### PR TITLE
[1250] expose if accrediting_provider to provider endpoint

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -86,4 +86,8 @@ class Provider < ApplicationRecord
   def recruitment_cycle
     "2019"
   end
+
+  def accredited_body?
+    accrediting_provider == 'Y'
+  end
 end

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -3,7 +3,7 @@ module API
     class SerializableProvider < JSONAPI::Serializable::Resource
       type 'providers'
 
-      attributes :provider_code, :provider_name, :accrediting_provider, :opted_in
+      attributes :provider_code, :provider_name, :accredited_body?, :opted_in
 
       has_many :sites
 

--- a/spec/requests/api/v2/providers_spec.rb
+++ b/spec/requests/api/v2/providers_spec.rb
@@ -45,7 +45,7 @@ describe 'Providers API v2', type: :request do
               "provider_code" => provider.provider_code,
               "provider_name" => provider.provider_name,
               "opted_in" => true,
-              "accrediting_provider" => "N"
+              "accredited_body?" => false,
             },
             "relationships" => {
               "sites" => {
@@ -82,7 +82,7 @@ describe 'Providers API v2', type: :request do
               "provider_code" => provider.provider_code,
               "provider_name" => provider.provider_name,
               "opted_in" => true,
-              "accrediting_provider" => "N"
+              "accredited_body?" => false,
             },
             "relationships" => {
               "sites" => {
@@ -165,7 +165,7 @@ describe 'Providers API v2', type: :request do
             "provider_code" => provider.provider_code,
             "provider_name" => provider.provider_name,
             "opted_in" => true,
-            "accrediting_provider" => "N"
+            "accredited_body?" => false,
           },
           "relationships" => {
             "sites" => {
@@ -204,7 +204,7 @@ describe 'Providers API v2', type: :request do
                 "provider_code" => provider.provider_code,
                 "provider_name" => provider.provider_name,
                 "opted_in" => true,
-                "accrediting_provider" => "N"
+                "accredited_body?" => false,
               },
               "relationships" => {
                 "sites" => {

--- a/spec/serializers/api/v2/serializable_provider_spec.rb
+++ b/spec/serializers/api/v2/serializable_provider_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe API::V2::SerializableProvider do
-  let(:provider) { create :provider }
+  let(:provider) { create :provider, accrediting_provider: 'Y' }
   let(:resource) { API::V2::SerializableProvider.new object: provider }
 
   it 'sets type to providers' do
@@ -15,6 +15,6 @@ describe API::V2::SerializableProvider do
     should be_json.with_content(attributes: { provider_code: provider.provider_code,
                                               provider_name: provider.provider_name,
                                               opted_in: provider.opted_in,
-                                              accrediting_provider: provider.accrediting_provider })
+                                              accredited_body?: true })
   }
 end


### PR DESCRIPTION
### Context
Expose `accredited_body?` on provider endpoint

### Changes proposed in this pull request
- Add `accredited_body?` to provider endpoint
- Expand provider serializer spec

### Guidance to review
`/api/v2/providers`
