### PR TITLE
[1589] Add an accredited provider's training providers' page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -59,6 +59,14 @@ class ProvidersController < ApplicationController
     redirect_to details_provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year)
   end
 
+  def training_providers
+    if @current_user["admin"]
+      @providers = @provider.training_providers(recruitment_cycle_year: @recruitment_cycle.year)
+    else
+      redirect_to provider_path(@provider.provider_code)
+    end
+  end
+
 private
 
   def provider_params

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -59,4 +59,9 @@ module BreadcrumbHelper
     path = provider_ucas_contacts_path(@provider.provider_code)
     provider_breadcrumb << ["UCAS contacts", path]
   end
+
+  def training_providers_breadcrumb
+    path = provider_ucas_contacts_path(@provider.provider_code)
+    provider_breadcrumb << ["Training providers", path]
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,8 @@ class Provider < Base
 
   self.primary_key = :provider_code
 
+  custom_endpoint :training_providers, on: :member, request_method: :get
+
   def publish
     post_request("/publish")
   end

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -34,7 +34,7 @@
     <% else %>
       <%= render partial: 'recruitment_cycles/about_organisation', locals: { provider: @provider, year: Settings.current_cycle } %>
       <%= render partial: 'recruitment_cycles/courses_info', locals: { provider: @provider, year: Settings.current_cycle } %>
-      <%= render partial: 'recruitment_cycles/courses_accredited_body', locals: { provider: @provider } %>
+      <%= render partial: 'recruitment_cycles/courses_accredited_body', locals: { provider: @provider, year: Settings.current_cycle } %>
       <%= render partial: 'recruitment_cycles/locations_info', locals: { provider: @provider, year: Settings.current_cycle } %>
     <% end %>
   </div>

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -1,0 +1,26 @@
+<%= content_for :page_title, "Courses as an accredited body" %>
+<%= content_for :before_content, render_breadcrumbs(:training_providers) %>
+
+<h1 class="govuk-heading-xl">
+  Courses as an accredited body
+</h1>
+
+<p class="govuk-body">Use this section to:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>see who lists you as their accredited body</li>
+  <li>see which courses you’re the accredited body for</li>
+</ul>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-6">Training providers</h2>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <ul class="govuk-list" data-qa="provider__training_providers_list">
+      <% @providers.each do |provider| %>
+      <h3 class="govuk-heading-m">
+        <%= link_to provider.provider_name, "#", class: "govuk-link" %>
+        <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block"> count of courses the accredited body certifies to be added</span>
+      </h3>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/recruitment_cycles/_courses_accredited_body.html.erb
+++ b/app/views/recruitment_cycles/_courses_accredited_body.html.erb
@@ -1,10 +1,16 @@
 <% if @provider.accredited_body? && current_user["admin"]%>
   <div class="govuk-!-margin-bottom-8">
-    <h2 class="govuk-heading-m"><%= link_to "Courses as an accredited body","#", class: "govuk-link", data: { qa: 'courses_as_accredited_body_link' } %></h2>
-      <p class="govuk-body">Use this section to:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-        <li>see who lists you as their accredited body</li>
-        <li>see which courses you’re the accredited body for</li>
-      </ul>
-    </div>
-  <% end %>
+    <h2 class="govuk-heading-m">
+      <%= link_to "Courses as an accredited body",
+                  training_providers_provider_recruitment_cycle_path(@provider.provider_code, year),
+                  class: "govuk-link",
+                  data: { qa: 'courses_as_accredited_body_link' } %>
+    </h2>
+
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+      <li>see who lists you as their accredited body</li>
+      <li>see which courses you’re the accredited body for</li>
+    </ul>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,9 +45,9 @@ Rails.application.routes.draw do
     get "/courses/:course_code/delete", to: redirect("/organisations/%{provider_code}/#{Settings.current_cycle}/courses/%{course_code}/delete")
     get "/courses/:course_code/preview", to: redirect("/organisations/%{provider_code}/#{Settings.current_cycle}/courses/%{course_code}/preview")
 
-
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"
+
 
     resource :ucas_contacts, path: "ucas-contacts", on: :member, only: %i[show] do
       get "/alerts", on: :member, to: "ucas_contacts#alerts"
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
       get "/about", on: :member, to: "providers#about"
       put "/about", on: :member, to: "providers#update"
       post "/publish", on: :member, to: "providers#publish"
+      get "/training_providers", on: :member, to: "providers#training_providers"
 
       resource :courses, only: %i[create] do
         resource :outcome, on: :member, only: %i[new], controller: "courses/outcome" do

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+feature "Get training_providers", type: :feature do
+  let(:organisation_show_page) { PageObjects::Page::Organisations::OrganisationShow.new }
+  let(:organisation_training_providers_page) { PageObjects::Page::Organisations::TrainingProviders.new }
+  let(:provider1) { build :provider, accredited_body?: true }
+  let(:provider2) { build :provider, accredited_bodies: [provider1] }
+  let(:provider3) { build :provider, accredited_bodies: [provider1] }
+  let(:user) { build :user, :admin }
+  let(:access_request) { build :access_request }
+
+  before do
+    stub_omniauth(user: user)
+    stub_api_v2_resource(provider1)
+    stub_api_v2_resource(provider2)
+    stub_api_v2_resource(provider3)
+    stub_api_v2_resource(provider1.recruitment_cycle)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{provider1.recruitment_cycle.year}/providers/" \
+      "#{provider1.provider_code}/training_providers?recruitment_cycle_year=#{provider1.recruitment_cycle.year}",
+      resource_list_to_jsonapi([provider2, provider3]),
+    )
+    stub_api_v2_resource_collection([access_request])
+  end
+
+  context "When the provider has training providers" do
+    context "as an admin user" do
+      it "can be reached from the provider show page" do
+        visit provider_path(provider1.provider_code)
+        organisation_show_page.courses_as_accredited_body_link.click
+        expect(current_path).to eq training_providers_provider_recruitment_cycle_path(provider1.provider_code, provider1.recruitment_cycle.year)
+      end
+
+      it "should have the correct content" do
+        visit training_providers_provider_recruitment_cycle_path(provider1.provider_code, provider1.recruitment_cycle.year)
+        expect(organisation_training_providers_page.title).to have_content("Courses as an accredited body")
+        expect(organisation_training_providers_page.training_providers_list).to have_content(provider2.provider_name)
+        expect(organisation_training_providers_page.training_providers_list).to have_content(provider3.provider_name)
+      end
+    end
+
+    context "as a non-admin user" do
+      let(:user) { build(:user) }
+
+      it "redirects to to the organisation show page" do
+        visit training_providers_provider_recruitment_cycle_path(provider1.provider_code, provider1.recruitment_cycle.year)
+        expect(current_path).to eq provider_path(provider1.provider_code)
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/training_providers.rb
+++ b/spec/site_prism/page_objects/page/organisations/training_providers.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Organisations
+      class TrainingProviders < PageObjects::Base
+        set_url "/organisations/{provider_code}/training-providers"
+
+        element :training_providers_list, '[data-qa="provider__training_providers_list"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

**Follow on PR from #858** 

This PR adds a page that list's training providers for an accrediting provider. 

There will be an additional PR once the backend work is completed which will allow a user to click onto one of these providers and see the courses for the training provider that the accrediting provider validates the qualification.
 
### Changes proposed in this pull request

- Adds a page which lists the training providers for an accredited provider
- Redirects non-admin users back to their org page (this will be removed at a later date)

### Guidance to review

- The course count section on the page will be fixed once the backend work mentioned above is provided.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
