### PR TITLE
1589 cleanup training providers

### DIFF
--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -17,7 +17,7 @@
     <ul class="govuk-list" data-qa="provider__training_providers_list">
       <% @providers.each do |provider| %>
       <h3 class="govuk-heading-m">
-        <%= link_to provider.provider_name, "#", class: "govuk-link" %>
+        <%= provider.provider_name %>
         <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block"> count of courses the accredited body certifies to be added</span>
       </h3>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
       get "/about", on: :member, to: "providers#about"
       put "/about", on: :member, to: "providers#update"
       post "/publish", on: :member, to: "providers#publish"
-      get "/training_providers", on: :member, to: "providers#training_providers"
+      get "/training-providers", on: :member, to: "providers#training_providers"
 
       resource :courses, only: %i[create] do
         resource :outcome, on: :member, only: %i[new], controller: "courses/outcome" do


### PR DESCRIPTION
### Context
Training providers

### Changes proposed in this pull request
- Update URL from `/training_providers` to `/training-providers`
- Remove link to the provider as it doesn't go anywhere yet

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
