### PR TITLE
2830-Rename manage-courses

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 variables:
-  IMAGE_NAME: '$(dockerHubUserName)/manage-courses-frontend-poc'
+  IMAGE_NAME: '$(dockerHubUserName)/publish-teacher-training'
 
 steps:
 - script: |

--- a/config.sh
+++ b/config.sh
@@ -4,6 +4,6 @@ set -e
 # source this file to set up environment for use by other scripts
 
 DOCKER_REGISTRY_HOST="batdevcontainerregistry.azurecr.io"
-DOCKER_REGISTRY_IMAGE="manage-courses-frontend"
+DOCKER_REGISTRY_IMAGE="publish-teacher-training"
 
 export DOCKER_PATH="$DOCKER_REGISTRY_HOST/$DOCKER_REGISTRY_IMAGE"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ manage_backend:
   # Set this in the env! The below ensures that we are un-authenticatable if we
   # forget to do this in production.
   secret: <%= SecureRandom.base64 %>
-  # URL of the API app (manage-courses-backend)
+  # URL of the API app (teacher-training-api)
   base_url: http://localhost:3001
 search_ui:
   # URL of the C# search ui app (search-and-compare-ui)
@@ -52,7 +52,7 @@ environment:
 rollover: false
 current_cycle: 2020
 current_cycle_open: true
-application_name: manage-courses-frontend
+application_name: publish-teacher-training
 logstash:
   type: tcp
   host: # Our hostname here


### PR DESCRIPTION
### Context
Rename all references for manage-courses-frontend to publish-teacher-training

### Changes proposed in this pull request
Rename of docker hub repo isn't possible (https://success.docker.com/article/how-do-you-rename-a-docker-hub-repository).
A new repos have already been created automatically when this branch was committed.
dfedigital / publish-teacher-training


### Guidance to review
Please review to ensure no code is effected by this change.
Prior to merge with master all release pipeline and variable library needs updating.

### Checklist
https://trello.com/c/toDX7vbt/2830-rename-dockerhub-repos