### PR TITLE
[2842] Prevent guidance page 500ing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate
   before_action :store_request_id
+  before_action :request_login
 
   def not_found
     respond_with_error(template: "errors/not_found", status: :not_found, error_text: "Resource not found")
@@ -72,8 +73,13 @@ class ApplicationController < ActionController::Base
         Raven.user_context(id: current_user["user_id"])
         logger.debug { "User session set. " + log_safe_current_user(reload: true).to_s }
       end
+    end
+  end
 
-    elsif development_mode_auth?
+  def request_login
+    return if current_user.present?
+
+    if development_mode_auth?
       logger.info("Doing development mode authentication")
       request_http_basic_authentication("Development Mode")
     else
@@ -178,7 +184,7 @@ private
                        Settings.manage_backend.secret,
                        Settings.manage_backend.algorithm)
 
-   RequestStore.store[:manage_courses_backend_token] = token
+    RequestStore.store[:manage_courses_backend_token] = token
   end
 
   def assign_sentry_contexts

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -178,7 +178,7 @@ private
                        Settings.manage_backend.secret,
                        Settings.manage_backend.algorithm)
 
-    Thread.current[:manage_courses_backend_token] = token
+   RequestStore.store[:manage_courses_backend_token] = token
   end
 
   def assign_sentry_contexts

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token,
-                     :authenticate
+                     :request_login
 
   def not_found
     respond_to do |format|

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate, only: %i[guidance accessibility terms cookies privacy new_features]
+  skip_before_action :request_login, only: %i[guidance accessibility terms cookies privacy new_features]
 
   def accessibility; end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  skip_before_action :authenticate
+  skip_before_action :request_login
 
   def new
     redirect_to "/auth/dfe"

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -4,7 +4,7 @@ class Base < JsonApiClient::Resource
   # the user was first authenticated.
   class MCBConnection < JsonApiClient::Connection
     def run(request_method, path, params: nil, headers: {}, body: nil)
-      authorization = "Bearer #{Thread.current.fetch(:manage_courses_backend_token)}"
+      authorization = "Bearer #{RequestStore.store[:manage_courses_backend_token]}"
       super(
         request_method,
         path,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,15 +5,19 @@ describe ApplicationController, type: :controller do
     controller.response = response
   end
 
+  describe "#request_login" do
+    subject { controller.request_login }
+
+    context "user is unauthenticated" do
+      it { should redirect_to "/signin" }
+    end
+  end
+
   describe "#authenticate" do
     subject { controller.authenticate }
 
     before do
       disable_authorised_development_user
-    end
-
-    context "user is unauthenticated" do
-      it { should redirect_to "/signin" }
     end
 
     context "user is authenticated" do

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ErrorsController, type: :controller do
+describe ErrorsController, type: :controller do
   describe "GET #not_found" do
     it "returns not found" do
       get :not_found

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -4,7 +4,7 @@ describe Provider do
 
     it "publishes" do
       publish_endpoint = stub_api_v2_request("/recruitment_cycles/#{provider.recruitment_cycle.year}/providers/#{provider.provider_code}/publish", {}, :post)
-      Thread.current[:manage_courses_backend_token] = ""
+      RequestStore.store[:manage_courses_backend_token] = ""
       provider.publish
       expect(publish_endpoint).to have_been_requested
     end

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -5,7 +5,8 @@ describe RecruitmentCycle do
 
     it "returns the appropriate providers" do
       stub_api_v2_resource(recruitment_cycle, include: "providers")
-      Thread.current[:manage_courses_backend_token] = ""
+      RequestStore.store[:manage_courses_backend_token] = ""
+
       expect(RecruitmentCycle.current.id).to eq(recruitment_cycle.id)
     end
   end

--- a/spec/requests/not_found_spec.rb
+++ b/spec/requests/not_found_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "not found pages", type: :request do
+describe "not found pages", type: :request do
   it "returns a 404 for html" do
     get "/foo"
     expect(response).to have_http_status(404)


### PR DESCRIPTION
### Context
When https://www.publish-teacher-training-courses.service.gov.uk/guidance was visited by an admin user a 500 would occur because a request was being made to discover the number of access requests for the heading but this could not be done because the authentication procedure was not followed.  

### Changes proposed in this pull request
Use a safer method for storing the user token & move the redirection of the user to the login page into an individually skippable function.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
