### PR TITLE
[2856] Add info to loan text on preview page

### DIFF
--- a/app/views/courses/preview/financial_support/_bursary.html.erb
+++ b/app/views/courses/preview/financial_support/_bursary.html.erb
@@ -12,15 +12,14 @@
   </ul>
 
   <p class="govuk-body">
-    You don’t have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out about <%= link_to "eligibility", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training", class:"govuk-link"%> and <%= link_to "how you’ll be paid", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid", class:"govuk-link"%>.
+    You don’t have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out about <%= link_to "eligibility", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training", class: "govuk-link"%> and <%= link_to "how you’ll be paid", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid", class: "govuk-link"%>.
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study","https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class:"govuk-link" %>.
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
 
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= link_to "outside the UK", "https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates", class:"govuk-link" %>.
+    Find out about financial support if you’re from <%= link_to "outside the UK", "https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates", class: "govuk-link" %>.
   </p>
 </div>
-

--- a/app/views/courses/preview/financial_support/_loan.html.erb
+++ b/app/views/courses/preview/financial_support/_loan.html.erb
@@ -1,9 +1,8 @@
 <div data-qa="course__loan_details">
   <p class="govuk-body">
-    You may be eligible for a <%= link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans', class: 'govuk-link' %>
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
   <p class="govuk-body">
     Find out about financial support if you’re from <%= link_to 'outside the UK', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates', class: 'govuk-link' %>.
   </p>
 </div>
-

--- a/app/views/courses/preview/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/preview/financial_support/_scholarship_and_bursary.html.erb
@@ -27,7 +27,7 @@
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study","https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %>.
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
 
   <p class="govuk-body">


### PR DESCRIPTION
Co-authored-by: Aga Dufrat <aga.dufrat@digital.education.gov.uk>

### Context
To get a loan, postgrad teacher training applicants must apply for UNDERGRADUATE student finance.

The GOV.UK pages on student finance don't make this clear: https://www.gov.uk/student-finance and https://www.gov.uk/student-finance/new-fulltime-students. (These pages are linked to from the student finance pages on Get into Teaching).

We contacted GDS about this lack of clarity. As a result, they made an edit to this page: https://www.gov.uk/teacher-training-funding (under 'Postgraduates'). So it's clear there, at least, that postgrads need to apply for undergrad loans - but it's not clear anywhere else.

We should change the text on course pages in Find to address this. Currently we say "You may also be eligible for a loan while you study" and link to GiT: https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans (which then links to https://www.gov.uk/student-finance/new-fulltime-students).

We should add more detail to this text, and link to either the GiT page or the ultimate GOV.UK page.

### Changes proposed in this pull request
Change the text in the "Financial support" section of courses on Find, except for salaried courses. The new text should be:

You may also be eligible for a loan while you study - note that you'll have to apply for undergraduate student finance.

See the "Financial support" section here: https://www2.qa.find-postgraduate-teacher-training.service.gov.uk/course/T92/X130

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
