### PR TITLE
[2864] Return to the courses list when navigating back from the new level page

### DIFF
--- a/app/services/course_creation_step_service.rb
+++ b/app/services/course_creation_step_service.rb
@@ -30,6 +30,7 @@ class CourseCreationStepService
 
   def school_direct_workflow_steps
     %i[
+      courses_list
       level
       subjects
       modern_languages
@@ -48,6 +49,7 @@ class CourseCreationStepService
 
   def uni_or_scitt_workflow_steps
     %i[
+      courses_list
       level
       subjects
       modern_languages
@@ -65,6 +67,7 @@ class CourseCreationStepService
 
   def further_education_workflow_steps
     %i[
+      courses_list
       level
       outcome
       full_or_part_time

--- a/spec/features/courses/level/new_spec.rb
+++ b/spec/features/courses/level/new_spec.rb
@@ -61,6 +61,22 @@ feature "New course level", type: :feature do
     end
   end
 
+  context "Navigating backwards" do
+    let(:course_list_page) { PageObjects::Page::Organisations::CoursesPage.new }
+
+    before do
+      stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    end
+
+    it "Returns to the course list page" do
+      visit_new_level_page
+
+      new_level_page.back.click
+
+      expect(course_list_page).to be_displayed
+    end
+  end
+
   context "Error handling" do
     before do
       stub_api_v2_build_course(is_send: 0)

--- a/spec/services/course_creation_step_service_spec.rb
+++ b/spec/services/course_creation_step_service_spec.rb
@@ -151,6 +151,10 @@ describe CourseCreationStepService do
       let(:level) { "primary" }
       let(:provider) { build(:provider, accredited_body?: false) }
 
+      context "Current step: Level" do
+        include_examples "previous step", :level, :courses_list
+      end
+
       context "Current step: Modern languages" do
         include_examples "previous step", :modern_languages, :subjects
       end
@@ -187,6 +191,10 @@ describe CourseCreationStepService do
     context "SCITT Provider" do
       let(:level) { "primary" }
       let(:provider) { build(:provider, accredited_body?: true) }
+
+      context "Current step: Level" do
+        include_examples "previous step", :level, :courses_list
+      end
 
       context "Current step: Subjects" do
         include_examples "previous step", :subjects, :level
@@ -236,6 +244,10 @@ describe CourseCreationStepService do
     context "Further education" do
       let(:provider) { build(:provider) }
       let(:level) { "further_education" }
+
+      context "Current step: Level" do
+        include_examples "previous step", :level, :courses_list
+      end
 
       context "Current step: Outcome" do
         include_examples "previous step", :outcome, :level


### PR DESCRIPTION
### Context

Course creation had an issue where if you went back from the new level page, it took you to the confirmation page

### Changes proposed in this pull request
- Reimplement the back link connection to the courses list

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
