### PR TITLE
[2873] Prevent multiple course creations via JS

### DIFF
--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -319,7 +319,10 @@
 
       <%= f.submit "Save new course",
         class: "govuk-button",
-        data: { qa: 'course__save' } %>
+        "data-prevent-double-click" => true,
+        "data-module" => "govuk-button",
+        data: { qa: 'course__save' }
+      %>
        <p class="govuk-body">Saving this course will not publish it.</p>
     <% end %>
   </div>


### PR DESCRIPTION
### Context

In certain circumstances, it was possible to spam click the button and create multiple courses. To prevent this as a stop-gap before preventing it more on the API we want to disable the button via javascript from sending multiple submissions.

### Changes proposed in this pull request

- Add the prevent double click from the design system to the button

### Guidance to review

- Make a course
- Spam that click button

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
