### PR TITLE
[2607] Remove Google  Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,16 +17,6 @@
     <%= favicon_link_tag asset_pack_path("media/images/govuk-apple-touch-icon-180x180.png"), rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
     <%= stylesheet_pack_tag "application", media: "all" %>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-112932657-2', 'auto');
-      ga('set', 'transport', 'beacon');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview')
-    </script>
-    <script>
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=


### PR DESCRIPTION
### Context
We now use Google Tag Manager

### Changes proposed in this pull request
Remove Google  Analytics

### Guidance to review
🚢 