### PR TITLE
[2859] Use new modern languages attribute for errors

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -60,7 +60,7 @@ module Courses
   private
 
     def error_keys
-      [:subjects]
+      [:modern_languages_subjects]
     end
 
     def strip_non_language_subjects

--- a/app/views/courses/modern_languages/_form_fields.html.erb
+++ b/app/views/courses/modern_languages/_form_fields.html.erb
@@ -1,17 +1,31 @@
-<div class="govuk-form-group" data-qa="course__languages">
-  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-    <% course.meta["edit_options"]["modern_languages"].each do |language| %>
-      <div class="govuk-checkboxes__item">
-        <%= form.check_box :language_ids,
-          { checked: course.subject_present?(language),
-            class: 'govuk-checkboxes__input',
-            multiple: true,
-            data: { qa: "checkbox_language_#{language["attributes"]["subject_name"]}" }
-          }, language["id"], nil %>
-        <%= form.label "language_ids_#{language["id"]}",
-          language["attributes"]["subject_name"],
-          class: 'govuk-label govuk-checkboxes__label' %>
+<%= render "shared/error_wrapper", error_keys: [:modern_languages_subjects], data_qa: "course__modern_languages_subjects" do %>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading" data-qa="page-heading">
+        <% if course.course_code %>
+          <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+        <% end %>
+        Pick modern languages
+      </h1>
+    </legend>
+    <%= render "shared/error_messages", error_keys: [:modern_languages_subjects] %>
+
+    <div class="govuk-form-group" data-qa="course__languages">
+      <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+        <% course.meta["edit_options"]["modern_languages"].each do |language| %>
+          <div class="govuk-checkboxes__item">
+            <%= form.check_box :language_ids,
+              { checked: course.subject_present?(language),
+                class: 'govuk-checkboxes__input',
+                multiple: true,
+                data: { qa: "checkbox_language_#{language["attributes"]["subject_name"]}" }
+              }, language["id"], nil %>
+            <%= form.label "language_ids_#{language["id"]}",
+              language["attributes"]["subject_name"],
+              class: 'govuk-label govuk-checkboxes__label' %>
+          </div>
+        <% end %>
       </div>
-    <% end %>
-  </div>
-</div>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -10,20 +10,8 @@
     <%= form_with model: course,
           url: modern_languages_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
           method: :put do |form| %>
-      <div
-        class="<%= classnames("govuk-form-group", "govuk-form-group--error": @errors && @errors[:subjects]&.any?) %>"
-        data-qa="course__modern_languages_section">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-              Change modern languages
-            </h1>
-          </legend>
-          <%= render "shared/error_messages", error_keys: [:subjects] %>
-          <%= render 'courses/modern_languages/form_fields', form: form %>
-        </fieldset>
-      </div>
+      <%= render "shared/error_messages", error_keys: [:modern_languages_subjects] %>
+      <%= render 'courses/modern_languages/form_fields', form: form %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
         class: "govuk-button", data: { qa: 'course__save' }

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -1,13 +1,10 @@
 <%= content_for :page_title, "Pick modern languages" %>
 <% content_for :before_content do %>
-  <% course_creation_back_button(@back_link_path) %>
+  <%= course_creation_back_button(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">
-  Pick modern languages
-</h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: continue_provider_recruitment_cycle_courses_modern_languages_path(

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,5 +1,4 @@
 <%= render "shared/error_wrapper", error_keys: [:subjects], data_qa: "course__subjects" do %>
-
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading" data-qa="page-heading">

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -14,7 +14,6 @@ feature "new modern language", type: :feature do
     PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
   end
 
-  let(:course) { build(:course, :new, provider: provider) }
   let(:provider) { build(:provider) }
   let(:modern_languages_subject) { build(:subject, :modern_languages) }
   let(:other_subject) { build(:subject, :mathematics) }
@@ -23,6 +22,7 @@ feature "new modern language", type: :feature do
   let(:subjects) { [modern_languages_subject] }
   let(:course) do
     build(:course,
+          course_code: nil,
           provider: provider,
           edit_options: {
             subjects: subjects,

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -88,11 +88,11 @@ feature "new modern language", type: :feature do
 
     context "Error handling" do
       scenario do
-        course.errors.add(:subjects, "Invalid")
+        course.errors.add(:modern_languages_subjects, "Invalid")
         stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id])
         visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
         new_modern_languages_page.continue.click
-        expect(new_modern_languages_page.error_flash.text).to include("Subjects Invalid")
+        expect(new_modern_languages_page.error_flash.text).to include("Modern languages subjects Invalid")
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_modern_languages_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_modern_languages_page.rb
@@ -6,6 +6,7 @@ module PageObjects
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/modern-languages/new{?query*}"
 
           element :languages_fields, '[data-qa="course__languages"]'
+          element :title, '[data-qa="page-heading"]'
 
           def language_checkbox(name)
             languages_fields.find("[data-qa=\"checkbox_language_#{name}\"]")


### PR DESCRIPTION
### Context
Users cannot create modern language courses because the subjects attribute triggers an error once the modern language subject is selected preventing the user from proceeding.
 
### Changes proposed in this pull request
Watch the `modern_languages_subjects` attribute for errors instead of the subjects attribute (which is no longer used for modern language errors)

### Guidance to review
Requires: https://github.com/DFE-Digital/teacher-training-api/pull/1159

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
