### PR TITLE
[2919] Change holding message on 'Courses as an accrediting body' page

### DIFF
--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -18,7 +18,7 @@
       <% @providers.each do |provider| %>
       <h3 class="govuk-heading-m">
         <%= provider.provider_name %>
-        <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block"> count of courses the accredited body certifies to be added</span>
+        <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block">Courses will be added here shortly</span>
       </h3>
       <% end %>
     </ul>


### PR DESCRIPTION
### Context
We should change _'count of courses the accredited body certifies to be added'_ to _'Courses will be added here shortly'_ .

### Changes proposed in this pull request
| Before       | After          | 
| ------------- |:-------------:| 
| <img width="540" alt="text_before" src="https://user-images.githubusercontent.com/38078064/74157275-e9442880-4c0f-11ea-8388-86180f9dda0b.png"> | <img width="550" alt="text_after" src="https://user-images.githubusercontent.com/38078064/74157295-f103cd00-4c0f-11ea-94de-dd8fa8caba2c.png">
 
### Guidance to review

- visit an accrediting provider page eg https://localhost:3000/organisations/A60/2020/training-providers

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
