### PR TITLE
[2987] Don't duplicate modern languages when creating a course

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -94,6 +94,7 @@ module Courses
 
     def build_course_params
       params[:course][:subjects_ids] += params[:course][:language_ids] if params[:course][:language_ids]
+      params[:course][:subjects_ids].uniq!
       params[:course].delete :language_ids
     end
   end

--- a/spec/features/courses/accredited_body/new_spec.rb
+++ b/spec/features/courses/accredited_body/new_spec.rb
@@ -36,8 +36,10 @@ feature "Edit accredited body" do
 
     scenario "It displays the accredited bodies" do
       suggested_providers = new_accredited_body_page.suggested_accredited_bodies.map(&:text)
-      expect(suggested_providers[0]). to eq("#{accrediting_provider_1.provider_name} (#{accrediting_provider_1.provider_code})")
-      expect(suggested_providers[1]). to eq("#{accrediting_provider_2.provider_name} (#{accrediting_provider_2.provider_code})")
+      expect(suggested_providers).to include(
+        "#{accrediting_provider_1.provider_name} (#{accrediting_provider_1.provider_code})",
+        "#{accrediting_provider_2.provider_name} (#{accrediting_provider_2.provider_code})",
+      )
     end
 
     context "when selecting an accredited body" do

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -75,6 +75,24 @@ feature "new modern language", type: :feature do
       expect(build_course_with_selected_value_request).to have_been_requested.twice
     end
 
+    scenario "going back to Pick modern languages page" do
+      stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id])
+      build_course_with_selected_value_request
+      visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
+      new_modern_languages_page.language_checkbox("Russian").click
+      new_modern_languages_page.continue.click
+      next_step_page.back.click
+      new_modern_languages_page.continue.click
+
+      expect(page).to have_current_path(
+        new_provider_recruitment_cycle_courses_age_range_path(
+          provider_code: provider.provider_code,
+          recruitment_cycle_year: recruitment_cycle.year,
+          course: { subjects_ids: [modern_languages_subject.id, russian.id] },
+        ),
+      )
+    end
+
     scenario "does not redirect to the previous step" do
       stub_api_v2_build_course(subjects_ids: [other_subject.id])
       build_course_with_selected_value_request


### PR DESCRIPTION
### Context
The subject list contains duplicates of all the languages selected (1 per time you pressed continue).
This also causes a 500 server error if you try to submit

### Changes proposed in this pull request
Ensure modern languages are unique in the controller

### Guidance to review
1. Create a new secondary course: https://localhost:3000/organisations/2AT/2020/courses/level/new
2. Select Modern Languages as the subject
3. Select a few languages and **Continue**
4. Press **Back** on the age range page
5. Press **Continue** on the pick languages page
6. Repeat steps 4 & 5 as many times as you like
7. Progress to the confirmation page
Languages should only be listed once

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
