### PR TITLE
[2371] Allow accredited bodies to start creating new courses

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -9,8 +9,12 @@ module ProviderHelper
     end
   end
 
-  def add_course_link(email, provider, is_current_cycle:)
-    link_to "Add a new course", add_course_url(email, provider, is_current_cycle: is_current_cycle), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank"
+  def create_course_link(provider, **opts)
+    govuk_link_to("Add a new course", new_provider_recruitment_cycle_course_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year), class: "govuk-button govuk-!-margin-bottom-2", **opts)
+  end
+
+  def add_course_link(email, provider, is_current_cycle:, **opts)
+    link_to "Add a new course", add_course_url(email, provider, is_current_cycle: is_current_cycle), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank", **opts
   end
 
   def google_form_url_for(settings, email, provider)

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -15,8 +15,12 @@
 </ul>
 
 <% if @provider.courses.count > 10 %>
-  <%= add_course_link(current_user['info']['email'], @provider, is_current_cycle: @recruitment_cycle.current?) %>
-  <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
+  <% if @provider.accredited_body? %>
+    <%= create_course_link(@provider, data: {qa: "course-create"} ) %>
+  <% else %>
+    <%= add_course_link(current_user['info']['email'], @provider, is_current_cycle: @recruitment_cycle.current?, data: {qa: "course-create-additional"}) %>
+    <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
+  <% end %>
 <% end %>
 
 <% if @self_accredited_courses %>
@@ -36,5 +40,9 @@
   </section>
 <% end %>
 
-<%= add_course_link(current_user['info']['email'], @provider, is_current_cycle: @recruitment_cycle.current?) %>
-<p class="govuk-body-s">You’ll be taken to a Google Form to fill in your course details.</p>
+<% if @provider.accredited_body? %>
+  <%= create_course_link(@provider, data: {qa: "course-create"} ) %>
+<% else %>
+  <%= add_course_link(current_user['info']['email'], @provider, is_current_cycle: @recruitment_cycle.current?, data: {qa: "course-create"}) %>
+  <p class="govuk-body-s">You’ll be taken to a Google Form to fill in your course details.</p>
+<% end %>

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -1,93 +1,26 @@
 require "rails_helper"
 
-feature "View locations", type: :feature do
+feature "courses page", type: :feature do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
-  let(:sites) do
-    [
-      build(:site, location_name: "Main site 1"),
-      build(:site, location_name: "Main site 2"),
-      build(:site, location_name: "Main site 3"),
-    ]
-  end
+  let(:courses_page) { PageObjects::Page::Organisations::CoursesPage.new }
+  let(:new_level_page) { PageObjects::Page::Organisations::Courses::NewLevelPage.new }
 
-  let(:provider) do
-    build(:provider, sites: sites)
-  end
-  let(:provider_code) { provider.provider_code }
-  let(:site_response) { sites[0].to_jsonapi }
-  let(:root_page) { PageObjects::Page::RootPage.new }
-  let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
-  let(:locations_page) { PageObjects::Page::LocationsPage.new }
-  let(:location_page) { PageObjects::Page::LocationPage.new }
+  context "as an accrediting provider" do
+    let(:course) { build(:course, provider: provider) }
+    let(:provider) { build(:provider, accredited_body?: true) }
 
-  before do
-    allow(Settings).to receive(:rollover).and_return(false)
-    user = build(:user)
-    stub_omniauth(user: user)
+    scenario "links to the course creation page" do
+      stub_omniauth
+      stub_api_v2_resource(current_recruitment_cycle)
+      stub_api_v2_resource(provider, include: "courses.accrediting_provider")
 
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}",
-      resource_list_to_jsonapi(current_recruitment_cycle),
-    )
+      stub_api_v2_resource(provider)
+      stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
+      stub_api_v2_build_course
 
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers",
-      resource_list_to_jsonapi(provider, include: :sites),
-    )
-
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider_code}",
-      provider.to_jsonapi,
-    )
-
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider_code}?include=sites",
-      provider.to_jsonapi(include: :sites),
-    )
-
-    root_page.load
-    expect(organisation_page).to be_displayed(provider_code: provider_code)
-
-    organisation_page.locations.click
-  end
-
-  scenario "it shows a list of locations" do
-    expect(locations_page).to be_displayed(provider_code: provider_code)
-    expect(locations_page.title).to have_content("Locations")
-    expect(locations_page.locations.size).to eq(3)
-    expect(locations_page.locations.first).to have_hyperlink
-    expect(locations_page.locations.first.cell.text).to eq("Main site 1")
-    expect(locations_page).to have_add_a_location_link
-  end
-
-  scenario "it shows one location" do
-    stub_api_v2_request("/providers/#{provider_code}/sites/#{sites.first.id}", site_response)
-
-    expect(locations_page.locations.first).to have_hyperlink
-    locations_page.locations.first.hyperlink.click
-
-    expect(location_page).to be_displayed(provider_code: provider_code, site_id: sites[0].id)
-    expect(location_page.title).to have_content("Main site 1")
-  end
-
-  scenario "prompts users to add new locations" do
-    expect(locations_page).to have_add_a_location_link
-  end
-
-  context "rollover" do
-    it "it shows a list of locations" do
-      allow(Settings).to receive(:rollover).and_return(true)
-      root_page.load
-      expect(organisation_page).to be_displayed(provider_code: provider_code)
-      organisation_page.current_cycle.click
-      organisation_page.locations.click
-
-      expect(locations_page).to be_displayed(provider_code: provider_code)
-      expect(locations_page.title).to have_content("Locations")
-      expect(locations_page.locations.size).to eq(3)
+      courses_page.load_with_provider(provider)
+      courses_page.course_create.click
+      expect(new_level_page).to be_displayed
     end
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/courses_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses_page.rb
@@ -2,10 +2,17 @@ module PageObjects
   module Page
     module Organisations
       class CoursesPage < PageObjects::Base
+        def load_with_provider(provider)
+          self.load(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year)
+        end
+
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses"
 
         element :flash, ".govuk-success-summary"
         element :caption, ".govuk-caption-xl"
+
+        element :course_create, '[data-qa="course-create"]'
+        element :course_create_additional, '[data-qa="course-create-additional"]'
 
         sections :courses_tables, '[data-qa="courses__table-section"]' do
           element :subheading, "h2"


### PR DESCRIPTION
### Context

Create course is being enabled for accredited bodies

### Changes proposed in this pull request

Enable create course flow for accredited bodies

### Guidance to review

- Checkout this branch
- Go to an accredited body -> Create course should take you to the new flow
- Go to a non-accredited body -> Create course should take you to the google form

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
