### PR TITLE
[2983] Fixed modern language issues whereby user cannot transverse from subject to modern language page

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -40,8 +40,6 @@ module CourseBasicDetailConcern
 
     if @errors.any?
       render :new
-    elsif params[:goto_confirmation].present?
-      redirect_to confirmation_provider_recruitment_cycle_courses_path(path_params)
     else
       redirect_to next_step
     end
@@ -145,27 +143,43 @@ private
     @meta_course_creation_params = params.slice(:goto_confirmation)
   end
 
-  def next_step
-    next_step = CourseCreationStepService.new.execute(current_step: current_step, course: @course)[:next]
-    next_page = course_creation_path_for(next_step)
+  def continue_step
+    params[:goto_confirmation] && !%i[subjects modern_languages].include?(current_step) ? :confirmation : CourseCreationStepService.new.execute(current_step: current_step, course: @course)[:next]
+  end
 
-    if next_page.nil?
-      raise "No path defined for next step: #{next_step}"
+  def next_step
+    continue_path = course_creation_path_for(continue_step)
+
+    if continue_path.nil?
+      raise "No path defined for continue step: #{continue_path}"
     end
 
-    next_page
+    continue_path
   end
 
   def path_params
-    { course: course_params }
+    path_params = { course: course_params }
+    path_params[:goto_confirmation] = params[:goto_confirmation] if params[:goto_confirmation]
+    path_params
+  end
+
+  def back_step
+    if params[:goto_confirmation]
+      if current_step == :modern_languages
+        :subjects
+      else
+        :confirmation
+      end
+    else
+      CourseCreationStepService.new.execute(current_step: current_step, course: @course)[:previous]
+    end
   end
 
   def build_back_link
-    previous_step = CourseCreationStepService.new.execute(current_step: current_step, course: @course)[:previous]
-    previous_path = course_back_path_for(previous_step)
+    previous_path = course_back_path_for(back_step)
 
     if previous_path.nil?
-      raise "No path defined for previous step: #{previous_step}"
+      raise "No path defined for back step: #{back_step}"
     end
 
     @back_link_path = previous_path

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -144,7 +144,7 @@ private
   end
 
   def continue_step
-    params[:goto_confirmation] && !%i[subjects modern_languages].include?(current_step) ? :confirmation : CourseCreationStepService.new.execute(current_step: current_step, course: @course)[:next]
+    params[:goto_confirmation] && !%i[subjects].include?(current_step) ? :confirmation : CourseCreationStepService.new.execute(current_step: current_step, course: @course)[:next]
   end
 
   def next_step

--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -144,7 +144,11 @@ private
   end
 
   def continue_step
-    params[:goto_confirmation] && !%i[subjects].include?(current_step) ? :confirmation : CourseCreationStepService.new.execute(current_step: current_step, course: @course)[:next]
+    if params[:goto_confirmation] && current_step != :subjects
+      :confirmation
+    else
+      CourseCreationStepService.new.execute(current_step: current_step, course: @course)[:next]
+    end
   end
 
   def next_step

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -5,14 +5,6 @@ module ViewHelper
     end
   end
 
-  def course_creation_back_button(back_path)
-    if params[:goto_confirmation]
-      govuk_back_link_to confirmation_provider_recruitment_cycle_courses_path(course: @course_creation_params)
-    else
-      govuk_back_link_to back_path
-    end
-  end
-
   def subject_page_title(course)
     if course.level == "primary"
       "Pick a primary subject"

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Who is the accredited body?" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Specify an age range" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "When will applications open?" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Is this a teaching apprenticeship?" %>
 
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "GCSE requirements for applicants" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/fee_or_salary/new.html.erb
+++ b/app/views/courses/fee_or_salary/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Is it fee paying or salaried?" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "What type of course?" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Pick modern languages" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Pick a course outcome" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Pick the locations for this course" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "When does the course start?" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Full time or part time?" %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -23,7 +23,7 @@
               Add a second subject (optional)
             </span>
           </summary>
-          <div class="govuk-details__text" id="details-content-c2b172cf-d259-4213-90bc-50d9d169a20f" aria-hidden="true">
+          <div class="govuk-details__text" id="details-content" aria-hidden="true">
             <p>Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
 
             <div class="govuk-form-group">

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, subject_page_title(@course) %>
 <% content_for :before_content do %>
-  <%= course_creation_back_button(@back_link_path) %>
+  <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 <%= render 'shared/errors' %>
 

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -14,7 +14,7 @@ feature "new modern language", type: :feature do
     PageObjects::Page::Organisations::Courses::NewAgeRangePage.new
   end
 
-  let(:provider) { build(:provider) }
+  let(:provider) { build(:provider, sites: [build(:site), build(:site)]) }
   let(:modern_languages_subject) { build(:subject, :modern_languages) }
   let(:other_subject) { build(:subject, :mathematics) }
   let(:russian) { build(:subject, :russian) }
@@ -22,7 +22,7 @@ feature "new modern language", type: :feature do
   let(:subjects) { [modern_languages_subject] }
   let(:course) do
     build(:course,
-          course_code: nil,
+          :new,
           provider: provider,
           edit_options: {
             subjects: subjects,
@@ -32,7 +32,11 @@ feature "new modern language", type: :feature do
                 11_to_18
                 14_to_19
               ],
-          })
+          },
+          accrediting_provider: build(:provider),
+          applications_open_from: "2019-10-09",
+          gcse_subjects_required: %w[maths science english],
+          start_date: "2019-10-09")
   end
   let(:recruitment_cycle) { build(:recruitment_cycle) }
 
@@ -91,6 +95,13 @@ feature "new modern language", type: :feature do
           course: { subjects_ids: [modern_languages_subject.id, russian.id] },
         ),
       )
+    end
+
+    scenario "sends user back to course confirmation" do
+      build_course_with_selected_value_request
+      visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id, russian.id] }, goto_confirmation: true)
+      new_modern_languages_page.continue.click
+      expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
     end
 
     scenario "does not redirect to the previous step" do

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -151,14 +151,21 @@ feature "New course level", type: :feature do
       end
     end
 
-    scenario "sends user back to course confirmation" do
+    # NOTE: modern langauges will send users to confirmation page
+    scenario "sends user to modern langauges" do
       stub_api_v2_build_course(subjects_ids: [english.id])
       visit_new_subjects_page(goto_confirmation: true)
 
       new_subjects_page.subjects_fields.select(english.subject_name).click
       new_subjects_page.continue.click
 
-      expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
+      expect(page).to have_current_path(
+        new_provider_recruitment_cycle_courses_modern_languages_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year,
+          course: { subjects_ids: [english.id] }, goto_confirmation: true,
+        ),
+      )
     end
   end
 


### PR DESCRIPTION


### Context
user cannot transerve from subject to modern language page

### Changes proposed in this pull request
Fixed modern language issues whereby user cannot transverse from subject to modern language page

Amended  usage of `goto_confirmation` to be in concern
Removed `course_creation_back_button` as it uses `goto_confirmation`
Amended `course_creation_back_button`to be just `govuk_back_link_to`

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
