### PR TITLE
[3022] Prevent duplicate subjects being added to school direct courses

### DIFF
--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -29,6 +29,7 @@ module Courses
           :sites_ids,
           :subjects_ids,
           :goto_confirmation,
+          :accrediting_provider_code,
         )
         .permit(
           :applications_open_from,

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -24,11 +24,6 @@
               collection: provider.accredited_bodies,
               locals: { form: fields }
             %>
-            <%= render 'shared/course_creation_hidden_fields',
-              form: fields,
-              course_creation_params: @course_creation_params,
-              except_keys: [:accrediting_provider_code]
-            %>
 
             <div class="govuk-radios__divider">or</div>
 


### PR DESCRIPTION
### Context

Courses were being created with duplicate of the subjects specified when they were made for a school direct.

### Changes proposed in this pull request

- Remove the hidden fields specified in the accrediting body view as they are provided by the course creation partial
- Additionally permit the `accrediting_provider_code` to prevent localhost from erroring

### Guidance to review

- Go to the course creation for a school direct
- Create a secondary course
- Specify one subject
- Go through to the confirmation page
- Ensure there's only copy of the subject

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
