### PR TITLE
[3040] Allow to remove languages once they have been selected

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -93,8 +93,8 @@ module Courses
     end
 
     def build_course_params
-      params[:course][:subjects_ids] += params[:course][:language_ids] if params[:course][:language_ids]
-      params[:course][:subjects_ids].uniq!
+      first_level_subject = params[:course][:subjects_ids].first
+      params[:course][:subjects_ids] = [first_level_subject, params[:course][:language_ids]].flatten if params[:course][:language_ids]
       params[:course].delete :language_ids
     end
   end

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -18,7 +18,8 @@ feature "new modern language", type: :feature do
   let(:modern_languages_subject) { build(:subject, :modern_languages) }
   let(:other_subject) { build(:subject, :mathematics) }
   let(:russian) { build(:subject, :russian) }
-  let(:modern_languages) { [russian] }
+  let(:french) { build(:subject, :french) }
+  let(:modern_languages) { [russian, french] }
   let(:subjects) { [modern_languages_subject] }
   let(:course) do
     build(:course,
@@ -89,6 +90,26 @@ feature "new modern language", type: :feature do
           provider_code: provider.provider_code,
           recruitment_cycle_year: recruitment_cycle.year,
           course: { subjects_ids: [modern_languages_subject.id, russian.id] },
+        ),
+      )
+    end
+
+    scenario "changing language selection" do
+      stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id])
+      build_course_with_selected_value_request
+      stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, french.id])
+      visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
+      new_modern_languages_page.language_checkbox("Russian").click
+      new_modern_languages_page.continue.click
+      next_step_page.back.click
+      new_modern_languages_page.language_checkbox("French").click
+      new_modern_languages_page.continue.click
+
+      expect(page).to have_current_path(
+        new_provider_recruitment_cycle_courses_age_range_path(
+          provider_code: provider.provider_code,
+          recruitment_cycle_year: recruitment_cycle.year,
+          course: { subjects_ids: [modern_languages_subject.id, french.id] },
         ),
       )
     end


### PR DESCRIPTION

### Context
It wasn't possible to remove languages once they have been selected.

### Changes proposed in this pull request
Stop adding `language_ids` into `subjects_ids`. Instead create a new array with the first level subject (eg Modern languages) and the most recent selection of languages, which will keep the selection up to date and won't permit duplications.
### Guidance to review

- Create a new secondary course: https://localhost:3000/organisations/2AT/2020/courses/level/new
- Select Modern Languages as the subject
- Select a language and Continue
- Press Back on the age range page
- Unselect the language, choose a different one and Continue
- Progress to the confirmation page
- Languages that were not selected should not appear

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
