### PR TITLE
[3032] Add a healthcheck endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,6 +136,8 @@ group :test do
 
   # Allows assert_template in request specs
   gem "rails-controller-testing"
+
+  gem "httparty"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,9 @@ GEM
       rubocop (~> 0.20)
     hashdiff (1.0.0)
     hashie (3.6.0)
+    httparty (0.18.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -218,11 +221,15 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    multi_xml (0.6.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.2)
@@ -468,6 +475,7 @@ DEPENDENCIES
   guard
   guard-rspec
   guard-rubocop
+  httparty
   json_api_client
   jsonapi-deserializable
   jsonapi-renderer

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,5 +1,28 @@
 class HealthChecksController < ActionController::API
+  include HTTParty
+
   def ping
     render body: "PONG"
+  end
+
+  def healthcheck
+    checks = {
+      teacher_training_api: api_alive?,
+    }
+
+    status = checks.values.all? ? :ok : :bad_gateway
+
+    render status: status, json: {
+      checks: checks,
+    }
+  end
+
+private
+
+  def api_alive?
+    response = HeartbeatController.get("#{Settings.teacher_training_api.base_url}/healthcheck")
+    response.success?
+  rescue StandardError
+    false
   end
 end

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -20,7 +20,7 @@ class HeartbeatController < ActionController::API
 private
 
   def api_alive?
-    response = HeartbeatController.get("#{Settings.teacher_training_api.base_url}/healthcheck")
+    response = HeartbeatController.get("#{Settings.manage_backend.base_url}/healthcheck")
     response.success?
   rescue StandardError
     false

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,4 +1,4 @@
-class HealthChecksController < ActionController::API
+class HeartbeatController < ActionController::API
   include HTTParty
 
   def ping

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
       via: %i[get post put]
   end
 
-  get :ping, controller: :health_checks
-  get :healthcheck, controller: :health_checks
+  get :ping, controller: :heartbeat
+  get :healthcheck, controller: :heartbeat
 
   # DfE Sign In
   get "/signin", to: "sessions#new", as: "signin"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
 
   get :ping, controller: :health_checks
+  get :healthcheck, controller: :health_checks
 
   # DfE Sign In
   get "/signin", to: "sessions#new", as: "signin"

--- a/spec/requests/health_checks_spec.rb
+++ b/spec/requests/health_checks_spec.rb
@@ -8,4 +8,85 @@ describe "health check requests" do
       expect(response.body).to eq "PONG"
     end
   end
+
+  describe "GET /healthcheck" do
+    let(:healthcheck_endpoint) { "http://localhost:3001/healthcheck" }
+
+    context "when everything is ok" do
+      before do
+        stub_request(:get, healthcheck_endpoint)
+          .to_return(status: 200)
+        get "/healthcheck"
+      end
+
+      it "returns HTTP success" do
+        expect(response.status).to eq(200)
+      end
+
+      it "returns JSON" do
+        expect(response.content_type).to eq("application/json")
+      end
+
+      it "returns the expected response report" do
+        expect(response.body).to eq({ checks: {
+          teacher_training_api: true,
+        } }.to_json)
+      end
+    end
+
+    context "when the api returns 502" do
+      before do
+        stub_request(:get, healthcheck_endpoint)
+          .to_return(status: 502)
+        get "/healthcheck"
+      end
+
+      it "returns status bad gateway" do
+        expect(response.status).to eq(502)
+      end
+
+      it "returns the expected response report" do
+        expect(response.body).to eq({ checks: {
+          teacher_training_api: false,
+        } }.to_json)
+      end
+    end
+
+    context "when the api times out" do
+      before do
+        stub_request(:get, healthcheck_endpoint)
+          .to_timeout
+        get "/healthcheck"
+      end
+
+      it "returns status bad gateway" do
+        expect(response.status).to eq(502)
+      end
+
+      it "returns the expected response report" do
+        expect(response.body).to eq({ checks: {
+          teacher_training_api: false,
+        } }.to_json)
+      end
+    end
+
+    context "when the api refuses the connection" do
+      before do
+        stub_request(:get, healthcheck_endpoint)
+          .to_raise(StandardError) # https://stackoverflow.com/questions/25552239/webmock-simulate-failing-api-no-internet-timeout/25559291#25559291
+        get "/healthcheck"
+      end
+
+      it "returns status bad gateway" do
+        expect(response.status).to eq(502)
+      end
+
+      it "returns the expected response report" do
+        expect(response.body).to eq({ checks: {
+          teacher_training_api: false,
+        } }.to_json)
+      end
+    end
+  end
+
 end

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -88,5 +88,4 @@ describe "heart beat requests" do
       end
     end
   end
-
 end

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "health check requests" do
+describe "heart beat requests" do
   describe "GET /ping" do
     it "returns PONG" do
       get "/ping"


### PR DESCRIPTION
This new `/healthcheck` endpoint checks whether the dependencies of this
service are up. By implication of having returned a 200 OK status you
can also tell that this service is up.

Failure of dependencies results in a 502 bad-gateway status and a json
body showing which dependencies failed.

Front-door will probably continue to check root `/` for a 200 status as
that doesn't have any dependencies currently, so no need for a ping
endpoint as well.

This code is based on
https://github.com/DFE-Digital/find-teacher-training/pull/159
