### PR TITLE
[3051] Wizard for editing course modern languages

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -28,8 +28,9 @@ module Courses
     end
 
     def update
-      updated_subject_list = strip_non_language_subjects
-      updated_subject_list += selected_language_subjects
+      updated_subject_list = selected_language_subjects
+      updated_subject_list += selected_non_language_subjects
+
       if @course.update(subjects: updated_subject_list)
         flash[:success] = "Your changes have been saved"
         redirect_to(
@@ -63,15 +64,23 @@ module Courses
       [:modern_languages_subjects]
     end
 
-    def strip_non_language_subjects
-      @course.subjects.reject { |s| available_languages_ids.include?(s.id) }
-    end
-
     def selected_language_subjects
       language_ids = params.dig(:course, :language_ids)
       if language_ids.present?
         found_languages_ids = available_languages_ids & language_ids
         found_languages_ids.map { |id| Subject.new(id: id) }
+      else
+        []
+      end
+    end
+
+    def selected_non_language_subjects
+      ids = params.fetch(:course, {})[:subjects_ids]
+
+      if ids.present?
+        ids.map do |id|
+          Subject.new(id: id)
+        end
       else
         []
       end

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -75,14 +75,10 @@ module Courses
     end
 
     def selected_non_language_subjects
-      ids = params.fetch(:course, {})[:subjects_ids]
+      ids = params.dig(:course, :subjects_ids) || []
 
-      if ids.present?
-        ids.map do |id|
-          Subject.new(id: id)
-        end
-      else
-        []
+      ids.map do |id|
+        Subject.new(id: id)
       end
     end
 

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -12,19 +12,19 @@ module Courses
     end
 
     def update
-      if subjects_have_not_been_changed?
-        flash[:success] = "Your subject hasn't been changed"
+      if has_modern_languages_subject?
         redirect_to(
-          details_provider_recruitment_cycle_course_path(
+          modern_languages_provider_recruitment_cycle_course_path(
             @course.provider_code,
             @course.recruitment_cycle_year,
             @course.course_code,
+            course: { subjects_ids: selected_subject_ids },
           ),
         )
       elsif @course.update(subjects: selected_subjects)
         flash[:success] = "Your changes have been saved"
         redirect_to(
-          modern_languages_provider_recruitment_cycle_course_path(
+          details_provider_recruitment_cycle_course_path(
             @course.provider_code,
             @course.recruitment_cycle_year,
             @course.course_code,
@@ -37,6 +37,19 @@ module Courses
     end
 
   private
+
+    def has_modern_languages_subject?
+      selected_subjects.any? do |s|
+        s.id.to_s == modern_languages_subject.id.to_s
+      end
+    end
+
+    def modern_languages_subject
+      return @modern_languages_subject if @modern_languages_subject
+
+      hash = @course.meta[:edit_options][:modern_languages_subject]
+      @modern_languages_subject = Subject.new(hash)
+    end
 
     def subjects_have_not_been_changed?
       subjects_match?(selected_subjects, existing_non_language_subjects)
@@ -56,14 +69,16 @@ module Courses
       end
     end
 
-    def selected_subjects
-      selected_subject_ids = params
+    def selected_subject_ids
+      params
         .dig(:course)
         .slice(:master_subject_id, :subordinate_subject_id)
         .to_unsafe_h
         .values
         .select(&:present?)
+    end
 
+    def selected_subjects
       selected_subject_ids.map do |subject_id|
         subject_hash = find_subject(subject_id)
         Subject.new(subject_hash.to_h)

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -51,24 +51,6 @@ module Courses
       @modern_languages_subject = Subject.new(hash)
     end
 
-    def subjects_have_not_been_changed?
-      subjects_match?(selected_subjects, existing_non_language_subjects)
-    end
-
-    def subjects_match?(subject_array_a, subject_array_b)
-      return false if subject_array_a.length != subject_array_b.length
-
-      subject_array_a.zip(subject_array_b).all? do |subject_a, subject_b|
-        subject_a.present? && subject_b.present? && subject_a.id == subject_b.id
-      end
-    end
-
-    def existing_non_language_subjects
-      @course.subjects.select do |course_subject|
-        is_a_non_language_subject?(course_subject)
-      end
-    end
-
     def selected_subject_ids
       params
         .dig(:course)
@@ -88,12 +70,6 @@ module Courses
     def find_subject(subject_id)
       @course.meta[:edit_options][:subjects].find do |subject|
         subject[:id] == subject_id
-      end
-    end
-
-    def is_a_non_language_subject?(subject_to_find)
-      @course.meta[:edit_options][:subjects].any? do |subject|
-        subject[:id] == subject_to_find.id
       end
     end
 

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -214,6 +214,13 @@ class CourseDecorator < ApplicationDecorator
     meta["edit_options"]["subjects"].map { |subject| [subject["attributes"]["subject_name"], subject["id"]] }
   end
 
+  def selected_subject_ids
+    selectable_subject_ids = meta["edit_options"]["subjects"].map { |subject| subject["id"] }
+    selected_subject_ids = subjects.map(&:id)
+
+    selectable_subject_ids & selected_subject_ids
+  end
+
   def subject_present?(subject_to_find)
     subjects.map { |subject| subject["id"] }.include?(subject_to_find["id"])
   end

--- a/app/views/courses/modern_languages/_form_fields.html.erb
+++ b/app/views/courses/modern_languages/_form_fields.html.erb
@@ -10,6 +10,12 @@
     </legend>
     <%= render "shared/error_messages", error_keys: [:modern_languages_subjects] %>
 
+    <%= render 'shared/course_creation_hidden_fields',
+      form: form,
+      course_creation_params: params.fetch(:course, {}).slice(:subjects_ids),
+      except_keys: []
+    %>
+
     <div class="govuk-form-group" data-qa="course__languages">
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <% course.meta["edit_options"]["modern_languages"].each do |language| %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -12,7 +12,7 @@
     <%= render "shared/error_messages", error_keys: [:subjects] %>
     <div class="govuk-form-group">
       <%= form.label :master_subject_id, subject_input_label(@course), class: 'govuk-label' %>
-      <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, @course.subjects.first&.id), { include_blank: true }, data: { qa: 'course__master_subject' }, class: "govuk-select" %>
+      <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, course.selected_subject_ids.first), { include_blank: true }, data: { qa: 'course__master_subject' }, class: "govuk-select" %>
     </div>
 
     <% if course.level == "secondary" %>
@@ -29,7 +29,7 @@
             <div class="govuk-form-group">
               <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
               <span class="govuk-hint">For example ‘Physics with Mathematics’</span>
-              <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, @course.subjects.second&.id || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
+              <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, course.selected_subject_ids.second || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
             </div>
           </div>
         </details>

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -10,7 +10,7 @@ describe CourseDecorator do
   let(:subjects) { [english, mathematics] }
 
   let(:course) do
-    build :course,
+    build(:course,
           course_code: "A1",
           name: "Mathematics",
           qualification: "pgce_with_qts",
@@ -23,7 +23,7 @@ describe CourseDecorator do
           subjects: subjects,
           open_for_applications?: true,
           last_published_at: "2019-03-05T14:42:34Z",
-          recruitment_cycle: current_recruitment_cycle
+          recruitment_cycle: current_recruitment_cycle)
   end
   let(:start_date) { Time.zone.local(2019) }
   let(:site) { build(:site) }
@@ -31,11 +31,11 @@ describe CourseDecorator do
     build(:site_status, :full_time_and_part_time, site: site)
   end
 
-  let(:course_response) {
+  let(:course_response) do
     course.to_jsonapi(
       include: %i[sites provider accrediting_provider recruitment_cycle subjects],
     )
-  }
+  end
 
   let(:decorated_course) { course.decorate }
 
@@ -185,6 +185,25 @@ describe CourseDecorator do
         [english.subject_name, english.id],
         [mathematics.subject_name, mathematics.id],
       ])
+    end
+  end
+
+  describe "#selected_subject_ids" do
+    let(:selectable_subjects) { [english, mathematics] }
+    let(:subjects) { [biology, mathematics] }
+
+    let(:course) do
+      build(:course,
+            subjects: subjects,
+            edit_options: {
+            subjects: subjects.map do |subject|
+              subject.to_jsonapi[:data]
+            end,
+          })
+    end
+
+    it "returns ids for only subjects that are selectable" do
+      expect(decorated_course.selected_subject_ids).to match_array([biology.id, mathematics.id])
     end
   end
 

--- a/spec/features/courses/modern_languages/edit_spec.rb
+++ b/spec/features/courses/modern_languages/edit_spec.rb
@@ -57,7 +57,16 @@ feature "Edit course modern languages", type: :feature do
     scenario "can select multiple modern language subjects" do
       visit signin_path
 
-      visit(modern_languages_provider_recruitment_cycle_course_path(provider_code: provider.provider_code, recruitment_cycle_year: current_recruitment_cycle.year, code: course.course_code, course: { subjects_ids: [modern_languages_subject.id] }))
+      visit(
+        modern_languages_provider_recruitment_cycle_course_path(
+          provider_code: provider.provider_code,
+          recruitment_cycle_year: current_recruitment_cycle.year,
+          code: course.course_code,
+          course: {
+            subjects_ids: [modern_languages_subject.id],
+          },
+        ),
+      )
 
       patch_course_stub = set_patch_course_expectation do |subjects|
         expect(subjects).to match_array([
@@ -165,7 +174,9 @@ feature "Edit course modern languages", type: :feature do
       end
 
       it "takes user through wizard and saves subjects" do
-        expect(CGI.unescape(current_url)).to eql("http://www.example.com/organisations/#{provider.provider_code}/2020/courses/#{course.course_code}/modern-languages?course[subjects_ids][]=#{modern_languages_subject.id}")
+        modern_languages_uri = URI(current_url)
+        expect(modern_languages_uri.path).to eq("/organisations/#{provider.provider_code}/#{current_recruitment_cycle.year}/courses/#{course.course_code}/modern-languages")
+        expect(CGI.unescape(modern_languages_uri.query)).to eq("course[subjects_ids][]=#{modern_languages_subject.id}")
 
         patch_course_stub = set_patch_course_expectation do |subjects|
           expect(subjects).to match_array([

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -1,3 +1,0 @@
-describe Subject do
-  pending
-end

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -24,7 +24,7 @@ describe "heart beat requests" do
       end
 
       it "returns JSON" do
-        expect(response.content_type).to eq("application/json")
+        expect(response.media_type).to eq("application/json")
       end
 
       it "returns the expected response report" do


### PR DESCRIPTION
### Context

- When updating a published course to include modern languages it was not possible to select languages as part of the process

### Changes proposed in this pull request

- When changing subjects for a published course this now uses a wizard
- This allows for languages to be selected eg French, German
- Previously user could not select languages for the course
- An existing params mechanism is reused `course: { subjects_ids: [33] }`
- This query string is passed to wizard where it populates hidden fields
- This all this data is then sent to update endpoint
- Fix deprecation around `media_type`
- Removed un-needed pending test

### Guidance to review

- This PR depends on https://github.com/DFE-Digital/teacher-training-api/pull/1205 for the backend
- https://trello.com/c/8c9tBWQE/3051-m-make-editing-course-subjects-use-a-wizard
- For an existing course. Test both paths where course does and doesn't have modern languages
- Update to have modern languages with a selection of languages
- Course should now be updated correctly with new selection
- When editing a course with `Modern Languages` it should be pre-selected
- The previously chosen modern languages should also be pre-selected in the wizard 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally