### PR TITLE
3054 modifying a modern language course during course creation should keep modern languages checked

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -49,12 +49,19 @@ private
 
   def build_new_course
     add_custom_age_range_into_params if params.dig("course", "age_range_in_years") == "other"
+    add_subjects_ids if params.dig("previous", "subjects_ids").is_a?(Array) && current_step == :subjects
 
     @course = Course.build_new(
       recruitment_cycle_year: params[:recruitment_cycle_year],
       provider_code: params[:provider_code],
       course: course_params.to_unsafe_hash,
     )
+  end
+
+  def add_subjects_ids
+    if params["previous"]["modern_language_subject_id"].in?(params["course"]["subjects_ids"])
+      params["course"]["subjects_ids"] = params["previous"]["subjects_ids"]
+    end
   end
 
   def add_custom_age_range_into_params

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -11,6 +11,13 @@
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
+
+      <%= params.dig("course", "subjects_ids")%>
+      <% if params.dig("course", "subjects_ids").is_a?(Array) %>
+        <% params.dig("course", "subjects_ids").each do |array_value| %>
+          <%= hidden_field(:previous, :subjects_ids, multiple: true, value: array_value) %>
+        <% end %>
+      <% end %>
       <%= render "courses/new_fields_holder", form: form, except_keys: [] do |fields| %>
         <%= render 'form_fields', form: fields %>
 

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -11,10 +11,9 @@
                     @provider.recruitment_cycle_year
                   ),
                   method: :get do |form| %>
-
-      <%= params.dig("course", "subjects_ids")%>
-      <% if params.dig("course", "subjects_ids").is_a?(Array) %>
-        <% params.dig("course", "subjects_ids").each do |array_value| %>
+      <% if @course[:meta][:edit_options][:modern_language_subject][:id].to_s.in?(params.dig("course", "subjects_ids") || [])%>
+          <%= hidden_field(:previous, :modern_language_subject_id, value: @course[:meta][:edit_options][:modern_language_subject][:id]) %>
+        <% params["course"]["subjects_ids"].each do |array_value| %>
           <%= hidden_field(:previous, :subjects_ids, multiple: true, value: array_value) %>
         <% end %>
       <% end %>


### PR DESCRIPTION
### Context
:confounded: 
everything is going to be broken
### Changes proposed in this pull request
add hidden fields for previous subject ids selected if available for when the subject ids contains the `modern language id`

### Guidance to review
subject page
on `GET` set the hidden fields 
on `Post` back fill the subjects id if it contains `modern language id`
to serve the modern languages page
### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
