### PR TITLE
[3032] HTTParty is not a test only dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem "logstash-logger", "~> 0.26.1"
 # Semantic Logger makes logs pretty
 gem "rails_semantic_logger"
 
+# Make HTTP requests fun again
+gem "httparty"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]
@@ -137,7 +140,6 @@ group :test do
   # Allows assert_template in request specs
   gem "rails-controller-testing"
 
-  gem "httparty"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
As we are using httparty in a controller action, it should not have been
added to the test group.

### Context
Fixes uninitialized constand HeartbeatController::HTTParty error. 

![image](https://user-images.githubusercontent.com/3441519/75559762-ecc31680-5a3b-11ea-8917-317ea65bca74.png)

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
