### PR TITLE
[3067] Remove selenium driver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,9 +119,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
 
-  gem "selenium-webdriver"
-
-  gem "webdrivers", "~> 4.2"
+  gem "webdrivers", "~> 4.0"
 
   # Add Junit formatter for rspec
   gem "rspec_junit_formatter"
@@ -139,7 +137,6 @@ group :test do
 
   # Allows assert_template in request specs
   gem "rails-controller-testing"
-
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,7 +501,6 @@ DEPENDENCIES
   rubocop
   rubocop-govuk
   scss_lint-govuk
-  selenium-webdriver
   sentry-raven
   simplecov
   site_prism
@@ -511,7 +510,7 @@ DEPENDENCIES
   super_diff
   tzinfo-data
   web-console (>= 3.3.0)
-  webdrivers (~> 4.2)
+  webdrivers (~> 4.0)
   webmock
   webpacker
 


### PR DESCRIPTION
As we using webdriver gem there is no need to include selenium driver gem.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
