### PR TITLE
[3054] Fix missing language selections when editing new course

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -99,7 +99,6 @@ module Courses
 
     def build_course_params
       params[:course][:subjects_ids] += params[:course][:language_ids] if params[:course][:language_ids]
-      params[:course][:subjects_ids].uniq!
       params[:course].delete :language_ids
     end
   end

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -98,8 +98,20 @@ module Courses
     end
 
     def build_course_params
+      build_new_course # to get languages edit_options
+      params[:course][:subjects_ids] = selected_non_language_subject_ids
       params[:course][:subjects_ids] += params[:course][:language_ids] if params[:course][:language_ids]
       params[:course].delete :language_ids
+    end
+
+    def non_language_subject_ids
+      @course.meta[:edit_options][:subjects].map do |subject|
+        subject["id"]
+      end
+    end
+
+    def selected_non_language_subject_ids
+      non_language_subject_ids & params[:course][:subjects_ids]
     end
   end
 end

--- a/app/views/courses/modern_languages/_form_fields.html.erb
+++ b/app/views/courses/modern_languages/_form_fields.html.erb
@@ -10,12 +10,6 @@
     </legend>
     <%= render "shared/error_messages", error_keys: [:modern_languages_subjects] %>
 
-    <%= render 'shared/course_creation_hidden_fields',
-      form: form,
-      course_creation_params: params.fetch(:course, {}).slice(:subjects_ids),
-      except_keys: []
-    %>
-
     <div class="govuk-form-group" data-qa="course__languages">
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <% course.meta["edit_options"]["modern_languages"].each do |language| %>

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -11,6 +11,13 @@
           url: modern_languages_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
           method: :put do |form| %>
       <%= render "shared/error_messages", error_keys: [:modern_languages_subjects] %>
+
+      <%= render 'shared/course_creation_hidden_fields',
+        form: form,
+        course_creation_params: params.fetch(:course, {}).slice(:subjects_ids),
+        except_keys: []
+      %>
+
       <%= render 'courses/modern_languages/form_fields', form: form %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -228,6 +228,40 @@ feature "Course confirmation", type: :feature do
       include_examples "goes to the edit page"
     end
 
+    context "modern languages" do
+      let(:subjects_page) { PageObjects::Page::Organisations::Courses::NewSubjectsPage.new }
+      let(:languages_page) { PageObjects::Page::Organisations::Courses::NewModernLanguagesPage.new }
+      let(:modern_languages_subject) { build(:subject, :modern_languages) }
+      let(:russian) { build(:subject, :russian) }
+      let(:edit_options) do
+        {
+            subjects: [modern_languages_subject],
+            age_range_in_years: [],
+            modern_languages: [russian],
+        }
+      end
+      let(:course) do
+        build(:course,
+              provider: provider,
+              sites: [site1, site2],
+              study_mode: study_mode,
+              level: level,
+              edit_options: edit_options,
+              subjects: [modern_languages_subject, russian])
+      end
+
+      before do
+        stub_api_v2_build_course(level: course.level,
+                                 subjects_ids: [modern_languages_subject.id])
+      end
+
+      it "keeps languages checked" do
+        course_confirmation_page.details.edit_subjects.click
+        subjects_page.continue.click
+        expect(languages_page.language_checkbox("Russian")).to be_checked
+      end
+    end
+
     context "age range" do
       let(:destination_page) { PageObjects::Page::Organisations::Courses::NewAgeRangePage.new }
 

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -104,24 +104,6 @@ feature "new modern language", type: :feature do
       expect(stub).to have_been_requested.twice
     end
 
-    scenario "going back to Pick modern languages page" do
-      stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id])
-      stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, russian.id])
-      visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
-      new_modern_languages_page.language_checkbox("Russian").click
-      new_modern_languages_page.continue.click
-      next_step_page.back.click
-      new_modern_languages_page.continue.click
-
-      expect(page).to have_current_path(
-        new_provider_recruitment_cycle_courses_age_range_path(
-          provider_code: provider.provider_code,
-          recruitment_cycle_year: recruitment_cycle.year,
-          course: { subjects_ids: [modern_languages_subject.id] }, # russian is missing because there's no real api to remember the choice
-        ),
-      )
-    end
-
     scenario "sends user back to course confirmation" do
       stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, russian.id])
       visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id, russian.id] }, goto_confirmation: true)

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -61,8 +61,6 @@ feature "new modern language", type: :feature do
   end
 
   context "with modern language selected" do
-    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, russian.id]) }
-
     scenario "presents the languages" do
       visit_modern_languages
       expect(new_modern_languages_page).to have_no_language_checkbox("Russian")
@@ -70,18 +68,18 @@ feature "new modern language", type: :feature do
 
     scenario "selecting a language" do
       stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id])
-      build_course_with_selected_value_request
+      stub = stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, russian.id])
       visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
       new_modern_languages_page.language_checkbox("Russian").click
       new_modern_languages_page.continue.click
       # When rendering the next step an additional bulid course request will
       # fire off, so it will have been requested twice in total
-      expect(build_course_with_selected_value_request).to have_been_requested.twice
+      expect(stub).to have_been_requested.twice
     end
 
     scenario "going back to Pick modern languages page" do
       stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id])
-      build_course_with_selected_value_request
+      stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, russian.id])
       visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id] })
       new_modern_languages_page.language_checkbox("Russian").click
       new_modern_languages_page.continue.click
@@ -98,7 +96,7 @@ feature "new modern language", type: :feature do
     end
 
     scenario "sends user back to course confirmation" do
-      build_course_with_selected_value_request
+      stub_api_v2_build_course(subjects_ids: [modern_languages_subject.id, russian.id])
       visit_modern_languages(course: { subjects_ids: [modern_languages_subject.id, russian.id] }, goto_confirmation: true)
       new_modern_languages_page.continue.click
       expect(current_path).to eq confirmation_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
@@ -106,7 +104,6 @@ feature "new modern language", type: :feature do
 
     scenario "does not redirect to the previous step" do
       stub_api_v2_build_course(subjects_ids: [other_subject.id])
-      build_course_with_selected_value_request
       back_new_modern_languages_page.load(
         provider_code: provider.provider_code,
         recruitment_cycle_year: recruitment_cycle.year,
@@ -128,18 +125,15 @@ feature "new modern language", type: :feature do
 
   context "without modern language selected" do
     let(:modern_languages) { nil }
-    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(subjects_ids: [other_subject.id, russian.id]) }
 
     scenario "redirects to the next step" do
       stub_api_v2_build_course(subjects_ids: [other_subject.id])
-      build_course_with_selected_value_request
       visit_modern_languages(course: { subjects_ids: [other_subject.id] })
       expect(next_step_page).to be_displayed
     end
 
     scenario "redirects to the previous step" do
       stub_api_v2_build_course(subjects_ids: [other_subject.id])
-      build_course_with_selected_value_request
       back_new_modern_languages_page.load(
         provider_code: provider.provider_code,
         recruitment_cycle_year: recruitment_cycle.year,


### PR DESCRIPTION
### Context

#### What

Use the modern languages edit options to filter out languages to stop them from being replaced when changing the subjects.

#### Why

During course creation, when we reach the final review page and go to change the subjects, once we end up on the modern languages editing page the checked modern languages will be cleared.

#### Success

* Modern language edit option is used to filter modern languages from the regular subjects so that they are not replaced when changing the subjects

### Changes proposed in this pull request

* Cleanup - remove cause/workaround for duplicate `subjects_ids`
* Refactor spec - remove `build_course_with_selected_value_request`
* Fix missing language selections when editing new course, add test coverage for failure, update impacted code & tests

### Guidance to review

Read individual commit patches and messages.

repro:

* go through course creation as a Uni, stop at the "Check your answers" page
  * ready-made confirmation of new course: [on localhost](https://localhost:3000/organisations/A60/2020/courses/confirmation?course%5Bage_range_in_years%5D=11_to_18&course%5Bapplications_open_from%5D=2019-10-08&course%5Benglish%5D=must_have_qualification_at_application_time&course%5Bfunding_type%5D=fee&course%5Bis_send%5D=0&course%5Blevel%5D=secondary&course%5Bmaths%5D=equivalence_test&course%5Bqualification%5D=pgce_with_qts&course%5Bsites_ids%5D%5B%5D=11211035&course%5Bstart_date%5D=September+2020&course%5Bstudy_mode%5D=full_time&course%5Bsubjects_ids%5D%5B%5D=33&course%5Bsubjects_ids%5D%5B%5D=37) / [on qa](https://www.qa.publish-teacher-training-courses.service.gov.uk/organisations/A60/2020/courses/confirmation?course%5Bage_range_in_years%5D=11_to_18&course%5Bapplications_open_from%5D=2019-10-08&course%5Benglish%5D=must_have_qualification_at_application_time&course%5Bfunding_type%5D=fee&course%5Bis_send%5D=0&course%5Blevel%5D=secondary&course%5Bmaths%5D=equivalence_test&course%5Bqualification%5D=pgce_with_qts&course%5Bsites_ids%5D%5B%5D=11211035&course%5Bstart_date%5D=September+2020&course%5Bstudy_mode%5D=full_time&course%5Bsubjects_ids%5D%5B%5D=33&course%5Bsubjects_ids%5D%5B%5D=37)
* change languages 
* noticed the previously selected language(s) are not ticked any more

vids

* param goes missing at 302 https://youtu.be/oZpNO7KZ3WI

additional things to test

* back links
* editing an existing course

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally