### PR TITLE
Remove rubocop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,9 +87,6 @@ group :development, :test do
 
   # Testing framework
   gem "rspec-rails", "~> 4.0.0.beta4"
-
-  # A Ruby static code analyzer and formatter
-  gem "rubocop", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -498,7 +498,6 @@ DEPENDENCIES
   request_store
   rspec-rails (~> 4.0.0.beta4)
   rspec_junit_formatter
-  rubocop
   rubocop-govuk
   scss_lint-govuk
   sentry-raven


### PR DESCRIPTION
### Context
- We are using the 'rubocop-govuk' gem so no need to also have the 'rubocop' gem.
- This will stop dependabot raising pr's for the rubocop gem.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
