### PR TITLE
[3077] Fix provider code for support mailto link on course details page

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -51,8 +51,8 @@ module ViewHelper
     bat_contact_email_address.gsub("@", "<wbr>@").html_safe
   end
 
-  def bat_contact_mail_to(name = nil, subject: nil, link_class: "govuk-link")
-    mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject, class: link_class
+  def bat_contact_mail_to(name = nil, subject: nil, link_class: "govuk-link", data: nil)
+    mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject, class: link_class, data: data
   end
 
   def enrichment_error_url(provider_code:, course:, field:)

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -278,7 +278,13 @@
           <li>GCSE requirements</li>
         </ul>
 
-        <p class="govuk-body">To request other changes to your basic details contact the Becoming a Teacher team:<br /><%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Edit #{course.name} (#{@provider_code}/#{course.course_code})" %></p>
+        <p class="govuk-body">
+          To request other changes to your basic details contact the Becoming a Teacher team:<br />
+          <%= bat_contact_mail_to bat_contact_email_address_with_wrap,
+            subject: "Edit #{course.name} (#{@provider.provider_code}/#{course.course_code})",
+            data: { qa: "course__contact_support" }
+          %>
+        </p>
       </div>
     </aside>
   <% end %>

--- a/spec/features/courses/details_spec.rb
+++ b/spec/features/courses/details_spec.rb
@@ -103,6 +103,11 @@ feature "Course details", type: :feature do
     expect(course_details_page).to have_entry_requirements
   end
 
+  scenario "with the correct support email link" do
+    visit "/organisations/A0/#{course.recruitment_cycle.year}/courses/#{course.course_code}/details"
+    expect(course_details_page.contact_support.native.attributes["href"].value).to eq("mailto:becomingateacher@digital.education.gov.uk?subject=Edit%20#{course.name}%20%28A0%2F#{course.course_code}%29")
+  end
+
   context "When the course has nil fields" do
     let(:study_mode) { nil }
     let(:level) { nil }

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -131,8 +131,8 @@ feature "Course show", type: :feature do
   end
 
   describe "with a salaried course" do
-    let(:course) {
-      build :course,
+    let(:course) do
+      build(:course,
             :with_fees,
             funding_type: "salary",
             sites: [site],
@@ -144,8 +144,8 @@ feature "Course show", type: :feature do
             required_qualifications: "Foo",
             personal_qualities: "Foo",
             salary_details: "Foo",
-            other_requirements: "Foo"
-    }
+            other_requirements: "Foo")
+    end
 
     scenario "it shows the course show page" do
       expect(course_page.caption).to have_content(

--- a/spec/site_prism/page_objects/page/organisations/course_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_details.rb
@@ -32,6 +32,7 @@ module PageObjects
         element :level, "[data-qa=course__level]"
         element :entry_requirements, "[data-qa=course__entry_requirements]"
         element :allocations_info, "[data-qa=course__allocations_info]"
+        element :contact_support, "[data-qa=course__contact_support]"
       end
     end
   end


### PR DESCRIPTION
### Context
The mailto link on the course details page was not listing the provider code.

### Changes proposed in this pull request
Add a regression test and fix the issue.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
