### PR TITLE
[3100] Fix modern languages step always showing

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -6,7 +6,7 @@ module Courses
     include CourseBasicDetailConcern
 
     def new
-      return unless @course.meta[:edit_options][:modern_languages].nil?
+      return if has_modern_languages_subject?
 
       redirect_to next_step
     end
@@ -47,10 +47,10 @@ module Courses
     end
 
     def back
-      if @course.meta[:edit_options][:modern_languages].nil?
-        redirect_to @back_link_path
-      else
+      if has_modern_languages_subject?
         redirect_to new_provider_recruitment_cycle_courses_modern_languages_path(path_params)
+      else
+        redirect_to @back_link_path
       end
     end
 
@@ -95,6 +95,11 @@ module Courses
                   .where(provider_code: params[:provider_code])
                   .find(params[:code])
                   .first
+    end
+
+    def has_modern_languages_subject?
+      modern_languages_subject_id = @course.meta[:edit_options][:modern_languages_subject][:id]
+      @course.subjects.any? { |subject| subject[:id] == modern_languages_subject_id }
     end
 
     def build_course_params

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -238,6 +238,7 @@ feature "Course confirmation", type: :feature do
             subjects: [modern_languages_subject],
             age_range_in_years: [],
             modern_languages: [russian],
+            modern_languages_subject: modern_languages_subject,
         }
       end
       let(:course) do

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -19,9 +19,10 @@ feature "new modern language", type: :feature do
   let(:other_subject) { build(:subject, :mathematics) }
   let(:japanese) { build(:subject, :japanese) }
   let(:russian) { build(:subject, :russian) }
-  let(:modern_languages) { [russian, japanese] }
+  let(:modern_languages) { [russian] }
   let(:subjects) { [modern_languages_subject, other_subject] }
-  let(:selected_subjects) { [] }
+  let(:selected_subjects) { [modern_languages_subject] }
+
   let(:course) do
     build(:course,
           :new,
@@ -30,6 +31,7 @@ feature "new modern language", type: :feature do
           edit_options: {
             subjects: subjects,
             modern_languages: modern_languages,
+            modern_languages_subject: modern_languages_subject,
             age_range_in_years: %w[
                 11_to_16
                 11_to_18
@@ -136,7 +138,8 @@ feature "new modern language", type: :feature do
   end
 
   context "without modern language selected" do
-    let(:modern_languages) { nil }
+    let(:selected_subjects) { [other_subject, russian] }
+    let(:build_course_with_selected_value_request) { stub_api_v2_build_course(subjects_ids: [other_subject.id, russian.id]) }
 
     scenario "redirects to the next step" do
       stub_api_v2_build_course(subjects_ids: [other_subject.id])

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -57,6 +57,7 @@ feature "new course", type: :feature do
                   subjects: [build(:subject, subject_name: "Primary with Mathematics")],
                   gcse_subjects_required: %w[maths science english])
     model.meta[:edit_options][:subjects] = [english]
+    model.meta[:edit_options][:modern_languages_subject] = modern_languages
     model
   end
   let(:course_creation_request) do
@@ -259,6 +260,8 @@ feature "new course", type: :feature do
                       subjects: [build(:subject, subject_name: "Primary with Mathematics")],
                       gcse_subjects_required: %w[maths science english])
         model.meta[:edit_options][:subjects] = [english]
+        model.meta[:edit_options][:modern_languages_subject] = modern_languages
+
         model
       end
 
@@ -319,6 +322,8 @@ feature "new course", type: :feature do
                       gcse_subjects_required: %w[maths science english])
         model.meta[:edit_options][:subjects] = [modern_languages]
         model.meta[:edit_options][:modern_languages] = [russian]
+        model.meta[:edit_options][:modern_languages_subject] = modern_languages
+
         model
       end
 


### PR DESCRIPTION
### Context
The modern language subjects are now always given to publish, and this was historically used to distinguish between courses that needed the modern languages selection page and those that did not.

### Changes proposed in this pull request
Use the presence of the modern language subject to decide whether or not to show the modern languages page.

### Guidance to review
Similar issues may exist during modification of subjects in existing courses, this should be investigated and put into another card if applicable.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
