### PR TITLE
[3113] Fix modern languages step not showing

### DIFF
--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -98,7 +98,7 @@ module Courses
     end
 
     def has_modern_languages_subject?
-      modern_languages_subject_id = @course.meta[:edit_options][:modern_languages_subject][:id]
+      modern_languages_subject_id = @course.meta[:edit_options][:modern_languages_subject][:id].to_s
       @course.subjects.any? { |subject| subject[:id] == modern_languages_subject_id }
     end
 


### PR DESCRIPTION
### Context
The modern language step was not showing because the modern language subject id was an integer.

### Changes proposed in this pull request
Convert the modern language id to a string.

### Guidance to review
In tests ids in meta are strings, whereas in practice they are integers. I'm going to take some time to investigate this because it's come up a few times now. But this shouldn't block this PR, I can just open another one.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
