### PR TITLE
[3017] Show list of courses by training providers to their accrediting body

### DIFF
--- a/app/views/courses/_course_table.html.erb
+++ b/app/views/courses/_course_table.html.erb
@@ -18,6 +18,6 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <%= render partial: 'course_table_row', collection: courses, as: :course %>
+    <%= render partial: 'courses/course_table_row', collection: courses, as: :course %>
   </tbody>
 </table>

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -1,9 +1,16 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell app-course-table__course-name" data-qa="courses-table__course">
-    <%= govuk_link_to "#{course.name_and_code}",
-      provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      class: "govuk-link govuk-heading-s govuk-!-margin-bottom-0"
-    %>
+
+    <% if current_page?(provider_recruitment_cycle_courses_path(@provider.provider_code, course.recruitment_cycle_year)) %>
+      <%= govuk_link_to "#{course.name_and_code}",
+        provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+        class: "govuk-link govuk-heading-s govuk-!-margin-bottom-0"
+      %>
+    <% else %>
+    <span class="govuk-heading-s govuk-!-margin-0" data-qa="courses-table__course-name">
+      <%= course.name_and_code %><br>
+    </span>
+    <% end %>
     <span class="govuk-body-s"><%= course.description %></span>
   </td>
   <% if show_legacy_courses_table? %>
@@ -25,7 +32,11 @@
   <% if @recruitment_cycle.current_and_open? %>
     <td class="govuk-table__cell" data-qa="courses-table__vacancies">
       <% if course.is_running? || course.is_withdrawn? %>
-        <%= course.vacancies %>
+        <% if current_page?(provider_recruitment_cycle_courses_path(@provider.provider_code, course.recruitment_cycle_year)) %>
+          <%= course.vacancies %>
+        <% else %>
+          <%= course.has_vacancies? ? "Yes" : "No" %>
+        <% end %>
       <% end %>
     </td>
   <% end %>

--- a/app/views/providers/training_provider_courses.html.erb
+++ b/app/views/providers/training_provider_courses.html.erb
@@ -1,0 +1,10 @@
+<%= content_for :page_title, provider.provider_name %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl">Training provider</span>
+  <%= @training_provider.provider_name %>
+</h1>
+
+<section data-qa="courses__table-section">
+  <%= render partial: 'courses/course_table', locals: { courses: @courses } %>
+</section>

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -15,11 +15,19 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <ul class="govuk-list" data-qa="provider__training_providers_list">
-      <% @providers.each do |provider| %>
-      <h3 class="govuk-heading-m">
-        <%= provider.provider_name %>
-        <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block">Courses will be added here shortly</span>
-      </h3>
+      <% @training_providers.each do |training_provider| %>
+        <li data-qa="training_provider">
+          <h3 class="govuk-heading-m">
+            <%= link_to training_provider.provider_name,
+                        training_provider_courses_provider_recruitment_cycle_path(
+                          provider.provider_code,
+                          provider.recruitment_cycle_year,
+                          training_provider.provider_code,
+                        ),
+                        class: "govuk-link govuk-!-font-weight-bold",
+                        data: { qa: "link" } %>
+          </h3>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,10 @@ Rails.application.routes.draw do
       post "/publish", on: :member, to: "providers#publish"
       get "/training-providers", on: :member, to: "providers#training_providers"
 
+      resource :training_providers, on: :member, param: :code, only: [], as: "" do
+        get "/:training_provider_code/courses", to: "providers#training_provider_courses", as: "training_provider_courses"
+      end
+
       resource :courses, only: %i[create] do
         resource :outcome, on: :member, only: %i[new], controller: "courses/outcome" do
           get "continue"

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -54,6 +54,9 @@ feature "Get courses as an accredited body", type: :feature do
 
         expect(courses_as_an_accredited_body_page).to have_content("Training provider")
         expect(courses_as_an_accredited_body_page).to have_content(training_provider2.provider_name)
+        expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.course_name.text).to eq("#{name_and_course_code} PGCE with QTS full time")
+        expect(courses_as_an_accredited_body_page).not_to have_link(name_and_course_code)
+        expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.vacancies.text).to eq("Yes")
       end
 
       it "doesn't show courses accredited by different accredited bodies" do

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+feature "Get courses as an accredited body", type: :feature do
+  let(:organisation_training_providers_page) { PageObjects::Page::Organisations::TrainingProviders.new }
+  let(:courses_as_an_accredited_body_page) { PageObjects::Page::Organisations::OrganisationCoursesAsAnAccreditedBody.new }
+
+  let(:course1) { build :course, has_vacancies?: true }
+  let(:accrediting_body1) { build :provider, accredited_body?: true, courses: [course1] }
+
+  let(:course2) { build :course }
+  let(:accrediting_body2) { build :provider, accredited_body?: true, courses: [course2] }
+
+  let(:training_provider2) { build :provider, accredited_bodies: [accrediting_body1, accrediting_body2], courses: [course1, course2] }
+
+  let(:user) { build :user, :admin }
+  let(:access_request) { build :access_request }
+
+  before do
+    course1.accrediting_provider = accrediting_body1
+    stub_omniauth(user: user)
+    stub_api_v2_resource(accrediting_body1)
+    stub_api_v2_resource(accrediting_body2)
+    stub_api_v2_resource(training_provider2)
+    stub_api_v2_resource(accrediting_body1.recruitment_cycle)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{training_provider2.recruitment_cycle.year}/providers/" \
+      "#{training_provider2.provider_code}?include=courses.accrediting_provider",
+      training_provider2.to_jsonapi(include: :courses),
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
+      "#{accrediting_body1.provider_code}/courses?filter%5Baccrediting_provider%5D=#{accrediting_body1.provider_code}",
+      resource_list_to_jsonapi([course1]),
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
+      "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
+      resource_list_to_jsonapi([training_provider2, accrediting_body2]),
+    )
+    stub_api_v2_resource_collection([access_request])
+  end
+
+  context "When the training provider has courses" do
+    context "as an admin user" do
+      it "can be reached from the provider show page" do
+        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+        organisation_training_providers_page.training_providers.first.link.click
+        expect(current_path).to eq training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
+      end
+
+      it "should have the correct content" do
+        name_and_course_code = "#{course1.name} (#{course1.course_code})"
+        visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
+
+        expect(courses_as_an_accredited_body_page).to have_content("Training provider")
+        expect(courses_as_an_accredited_body_page).to have_content(training_provider2.provider_name)
+      end
+
+      it "doesn't show courses accredited by different accredited bodies" do
+        course_accreredited_by_a_different_body = "#{course2.name} (#{course2.course_code})"
+        visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
+
+        expect(courses_as_an_accredited_body_page).not_to have_content(course_accreredited_by_a_different_body)
+      end
+    end
+
+    context "as a non-admin user" do
+      let(:user) { build(:user) }
+
+      it "redirects to to the organisation show page" do
+        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+
+        expect(current_path).to eq provider_path(accrediting_body1.provider_code)
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/organisation_courses_as_an_accredited_body.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_courses_as_an_accredited_body.rb
@@ -1,0 +1,23 @@
+module PageObjects
+  module Page
+    module Organisations
+      class OrganisationCoursesAsAnAccreditedBody < CourseBase
+        set_url "/organisations/{provider_code}/training-providers/{training_provider_code}/courses"
+
+        sections :courses_tables, '[data-qa="courses__table-section"]' do
+          element :subheading, "h2"
+          sections :rows, "tbody tr" do
+            element :name, '[data-qa="courses-table__course"]'
+            element :course_name, "td.app-course-table__course-name"
+            element :ucas_status, '[data-qa="courses-table__ucas-status"]'
+            element :status, '[data-qa="courses-table__status"]'
+            element :on_find, '[data-qa="courses-table__findable"]'
+            element :find_link, '[data-qa="courses-table__findable"] a'
+            element :applications, '[data-qa="courses-table__applications"]'
+            element :vacancies, '[data-qa="courses-table__vacancies"]'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/training_providers.rb
+++ b/spec/site_prism/page_objects/page/organisations/training_providers.rb
@@ -4,7 +4,13 @@ module PageObjects
       class TrainingProviders < PageObjects::Base
         set_url "/organisations/{provider_code}/training-providers"
 
+        class TrainingProviderSection < SitePrism::Section
+          element :link, '[data-qa="link"]'
+          element :course_count, '[data-qa="course_count"]'
+        end
+
         element :training_providers_list, '[data-qa="provider__training_providers_list"]'
+        sections :training_providers, TrainingProviderSection, '[data-qa="training_provider"]'
       end
     end
   end


### PR DESCRIPTION
### Context
As an accrediting body
I want to see all the courses I accredit
So that I know what providers are running courses on our  behalf
### Changes proposed in this pull request
* There is a link on the "Courses as an Accredited Body" page for each of our training providers (this continues to only be visible to admins)
* On the training provider's course page, we can see the list of courses  provided by that training provider.
<img width="810" alt="courses_as_acc" src="https://user-images.githubusercontent.com/38078064/76872965-08fceb00-6865-11ea-8bdd-f005c3c7306b.png">

Out of scope of this PR:
- the course count text on the "Courses as an Accredited Body" page
- CSV download on the "Courses as an Accredited Body" page
- breadcrumbs

[Trello card](https://trello.com/c/NVngxJin/3017-m-show-list-of-courses-by-training-providers-to-their-accrediting-body)

### Guidance to review
- check if the links work for different providers eg https://localhost:3000/organisations/B20/2020/training-providers
- check if the listed courses are correct once you click the link

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
