### PR TITLE
Change underscores in training_providers route path to dashes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
       post "/publish", on: :member, to: "providers#publish"
       get "/training-providers", on: :member, to: "providers#training_providers"
 
-      resource :training_providers, on: :member, param: :code, only: [], as: "" do
+      resource :training_providers, path: "/training-providers", on: :member, param: :code, only: [], as: "" do
         get "/:training_provider_code/courses", to: "providers#training_provider_courses", as: "training_provider_courses"
       end
 


### PR DESCRIPTION
### Context
Underscores can be confused with spaces if they are printed out with an underline beneath the URL.

### Changes proposed in this pull request
Update the route path.

### Guidance to review
The path should be `/organisations/W20/2020/training-providers/13A/courses`,
not `/organisations/W20/2020/training_providers/13A/courses`

Guidance to review
Should we set up redirects for the old URLs?

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
