### PR TITLE
[3147] Add breadcrumbs on courses as accredited body pages

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -64,4 +64,9 @@ module BreadcrumbHelper
     path = training_providers_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
     provider_breadcrumb << ["Courses as an accredited body", path]
   end
+
+  def training_provider_courses_breadcrumb
+    path = training_provider_courses_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year, @training_provider.provider_code)
+    training_providers_breadcrumb << ["#{@training_provider.provider_name}’s courses", path]
+  end
 end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -61,7 +61,7 @@ module BreadcrumbHelper
   end
 
   def training_providers_breadcrumb
-    path = provider_ucas_contacts_path(@provider.provider_code)
-    provider_breadcrumb << ["Training providers", path]
+    path = training_providers_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    provider_breadcrumb << ["Courses as an accredited body", path]
   end
 end

--- a/app/views/providers/training_provider_courses.html.erb
+++ b/app/views/providers/training_provider_courses.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, provider.provider_name %>
+<%= content_for :before_content, render_breadcrumbs(:training_provider_courses) %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">Training provider</span>

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -65,6 +65,16 @@ feature "Get courses as an accredited body", type: :feature do
 
         expect(courses_as_an_accredited_body_page).not_to have_content(course_accreredited_by_a_different_body)
       end
+
+      it "should have the correct breadcrumbs" do
+        visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
+
+        within(".govuk-breadcrumbs") do
+          expect(page).to have_link(accrediting_body1.provider_name.to_s, href: "/organisations/#{accrediting_body1.provider_code}")
+          expect(page).to have_link("Courses as an accredited body", href: "/organisations/#{accrediting_body1.provider_code}/#{accrediting_body1.recruitment_cycle.year}/training-providers")
+          expect(page).to have_content("#{training_provider2.provider_name}’s courses")
+        end
+      end
     end
 
     context "as a non-admin user" do

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -37,6 +37,15 @@ feature "Get training_providers", type: :feature do
         expect(organisation_training_providers_page.training_providers_list).to have_content(provider2.provider_name)
         expect(organisation_training_providers_page.training_providers_list).to have_content(provider3.provider_name)
       end
+
+      it "should have the correct breadcrumbs" do
+        visit training_providers_provider_recruitment_cycle_path(provider1.provider_code, provider1.recruitment_cycle.year)
+
+        within(".govuk-breadcrumbs") do
+          expect(page).to have_link(provider1.provider_name.to_s, href: "/organisations/#{provider1.provider_code}")
+          expect(page).to have_content("Courses as an accredited body")
+        end
+      end
     end
 
     context "as a non-admin user" do


### PR DESCRIPTION
### Context
Breadcrumbs navigation needed updating on the Training providers page and breadcrumbs had to be added to the Training provider courses page

### Changes proposed in this pull request

- Training providers page <img width="664" alt="Screenshot 2020-03-18 at 08 48 49" src="https://user-images.githubusercontent.com/38078064/76985728-90fff500-6938-11ea-8f6a-d75e97fccb10.png">
- Training provider courses page <img width="659" alt="Screenshot 2020-03-18 at 08 49 18" src="https://user-images.githubusercontent.com/38078064/76985734-93fae580-6938-11ea-887e-1ad07077b9ec.png">

### Guidance to review
- Breadcrumbs are showing on the 
  - Training providers page eg path `/organisations/W20/2020/training-providers`
  - Training provider courses eg path `/organisations/W20/2020/training-providers/13A/courses`
- All breadcrumbs links work correctly 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
