### PR TITLE
[3159] Make 'other' option on applications open selectable

### DIFF
--- a/app/views/courses/applications_open/_form_fields.html.erb
+++ b/app/views/courses/applications_open/_form_fields.html.erb
@@ -16,8 +16,10 @@
             aria: { 'controls': 'other-container' },  data: { qa: 'applications_open_from_other' }
       %>
       <%= form.label :applications_open_from,
-            value: 'On a specific date',
-            class: 'govuk-label govuk-radios__label'
+            for: "course_applications_open_from_other",
+            value: "On a specific date",
+            class: "govuk-label govuk-radios__label",
+            data: { qa: "applications_open_field_from_other_label" }
       %>
     </div>
     <div class="govuk-radios__conditional <%=


### PR DESCRIPTION
### Context
The other option was not selectable, which reduced accessibility.

### Changes proposed in this pull request
Correct the `for=` attribute to match the radio button.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
