### PR TITLE
[3149] Add course count on training providers page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -61,17 +61,13 @@ class ProvidersController < ApplicationController
   end
 
   def training_providers
-    if user_is_admin?
-      @training_providers = @provider.training_providers(recruitment_cycle_year: @recruitment_cycle.year)
+    @training_providers = @provider.training_providers(recruitment_cycle_year: @recruitment_cycle.year)
 
-      courses = Course.where(
-        recruitment_cycle_year: @recruitment_cycle.year,
-        accrediting_provider_code: @provider.provider_code,
-      )
-      @course_counts = courses.group_by(&:provider_code).transform_values(&:size)
-    else
-      redirect_to provider_path(@provider.provider_code)
-    end
+    courses = Course.where(
+      recruitment_cycle_year: @recruitment_cycle.year,
+      accrediting_provider_code: @provider.provider_code,
+    )
+    @course_counts = courses.group_by(&:provider_code).transform_values(&:size)
   end
 
   def training_provider_courses

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -27,7 +27,7 @@
                         class: "govuk-link govuk-!-font-weight-bold",
                         data: { qa: "link" } %>
             <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block" data-qa="course_count">
-              <%= "#{@course_counts[training_provider.provider_name]} course#{@course_counts[training_provider.provider_name] == 1 ? "" : "s"}" %>
+              <%= pluralize(@course_counts[training_provider.provider_code], "course") %>
             </span>
           </h3>
         </li>

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -26,6 +26,9 @@
                         ),
                         class: "govuk-link govuk-!-font-weight-bold",
                         data: { qa: "link" } %>
+            <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block" data-qa="course_count">
+              <%= "#{@course_counts[training_provider.provider_name]} course#{@course_counts[training_provider.provider_name] == 1 ? "" : "s"}" %>
+            </span>
           </h3>
         </li>
       <% end %>

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -39,50 +39,38 @@ feature "Get courses as an accredited body", type: :feature do
   end
 
   context "When the training provider has courses" do
-    context "as an admin user" do
-      it "can be reached from the provider show page" do
-        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
-        organisation_training_providers_page.training_providers.first.link.click
-        expect(current_path).to eq training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
-      end
-
-      it "should have the correct content" do
-        name_and_course_code = "#{course1.name} (#{course1.course_code})"
-        visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
-
-        expect(courses_as_an_accredited_body_page).to have_content("Training provider")
-        expect(courses_as_an_accredited_body_page).to have_content(training_provider2.provider_name)
-        expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.course_name.text).to eq("#{name_and_course_code} PGCE with QTS full time")
-        expect(courses_as_an_accredited_body_page).not_to have_link(name_and_course_code)
-        expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.find_link["href"]).to eq("#{Settings.search_ui.base_url}/course/#{training_provider2.provider_code}/#{course1.course_code}")
-        expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.vacancies.text).to eq("Yes")
-      end
-
-      it "doesn't show courses accredited by different accredited bodies" do
-        course_accreredited_by_a_different_body = "#{course2.name} (#{course2.course_code})"
-        visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
-
-        expect(courses_as_an_accredited_body_page).not_to have_content(course_accreredited_by_a_different_body)
-      end
-
-      it "should have the correct breadcrumbs" do
-        visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
-
-        within(".govuk-breadcrumbs") do
-          expect(page).to have_link(accrediting_body1.provider_name.to_s, href: "/organisations/#{accrediting_body1.provider_code}")
-          expect(page).to have_link("Courses as an accredited body", href: "/organisations/#{accrediting_body1.provider_code}/#{accrediting_body1.recruitment_cycle.year}/training-providers")
-          expect(page).to have_content("#{training_provider2.provider_name}’s courses")
-        end
-      end
+    it "can be reached from the provider show page" do
+      visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+      organisation_training_providers_page.training_providers.first.link.click
+      expect(current_path).to eq training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
     end
 
-    context "as a non-admin user" do
-      let(:user) { build(:user) }
+    it "should have the correct content" do
+      name_and_course_code = "#{course1.name} (#{course1.course_code})"
+      visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
 
-      it "redirects to to the organisation show page" do
-        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+      expect(courses_as_an_accredited_body_page).to have_content("Training provider")
+      expect(courses_as_an_accredited_body_page).to have_content(training_provider2.provider_name)
+      expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.course_name.text).to eq("#{name_and_course_code} PGCE with QTS full time")
+      expect(courses_as_an_accredited_body_page).not_to have_link(name_and_course_code)
+      expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.find_link["href"]).to eq("#{Settings.search_ui.base_url}/course/#{training_provider2.provider_code}/#{course1.course_code}")
+      expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.vacancies.text).to eq("Yes")
+    end
 
-        expect(current_path).to eq provider_path(accrediting_body1.provider_code)
+    it "doesn't show courses accredited by different accredited bodies" do
+      course_accreredited_by_a_different_body = "#{course2.name} (#{course2.course_code})"
+      visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
+
+      expect(courses_as_an_accredited_body_page).not_to have_content(course_accreredited_by_a_different_body)
+    end
+
+    it "should have the correct breadcrumbs" do
+      visit training_provider_courses_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year, training_provider2.provider_code)
+
+      within(".govuk-breadcrumbs") do
+        expect(page).to have_link(accrediting_body1.provider_name.to_s, href: "/organisations/#{accrediting_body1.provider_code}")
+        expect(page).to have_link("Courses as an accredited body", href: "/organisations/#{accrediting_body1.provider_code}/#{accrediting_body1.recruitment_cycle.year}/training-providers")
+        expect(page).to have_content("#{training_provider2.provider_name}’s courses")
       end
     end
   end

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -21,24 +21,14 @@ feature "Get courses as an accredited body", type: :feature do
     stub_api_v2_resource(accrediting_body1)
     stub_api_v2_resource(accrediting_body1.recruitment_cycle)
     stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/courses" \
+      "?filter[accrediting_provider_code]=#{accrediting_body1.provider_code}",
+      resource_list_to_jsonapi([course1]),
+     )
+    stub_api_v2_request(
       "/recruitment_cycles/#{training_provider2.recruitment_cycle.year}/providers/" \
       "#{training_provider2.provider_code}?include=courses.accrediting_provider",
       training_provider2.to_jsonapi(include: :courses),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
-      "#{accrediting_body1.provider_code}?include=courses.accrediting_provider",
-      accrediting_body1.to_jsonapi(include: :courses),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{accrediting_body2.recruitment_cycle.year}/providers/" \
-      "#{accrediting_body2.provider_code}?include=courses.accrediting_provider",
-      accrediting_body2.to_jsonapi(include: :courses),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
-      "#{accrediting_body1.provider_code}/courses?filter%5Baccrediting_provider%5D=#{accrediting_body1.provider_code}",
-      resource_list_to_jsonapi([course1]),
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -19,13 +19,21 @@ feature "Get courses as an accredited body", type: :feature do
     course1.accrediting_provider = accrediting_body1
     stub_omniauth(user: user)
     stub_api_v2_resource(accrediting_body1)
-    stub_api_v2_resource(accrediting_body2)
-    stub_api_v2_resource(training_provider2)
     stub_api_v2_resource(accrediting_body1.recruitment_cycle)
     stub_api_v2_request(
       "/recruitment_cycles/#{training_provider2.recruitment_cycle.year}/providers/" \
       "#{training_provider2.provider_code}?include=courses.accrediting_provider",
       training_provider2.to_jsonapi(include: :courses),
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
+      "#{accrediting_body1.provider_code}?include=courses.accrediting_provider",
+      accrediting_body1.to_jsonapi(include: :courses),
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body2.recruitment_cycle.year}/providers/" \
+      "#{accrediting_body2.provider_code}?include=courses.accrediting_provider",
+      accrediting_body2.to_jsonapi(include: :courses),
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -5,12 +5,12 @@ feature "Get training_providers", type: :feature do
   let(:organisation_training_providers_page) { PageObjects::Page::Organisations::TrainingProviders.new }
   let(:accrediting_body1) { build :provider, accredited_body?: true }
   let(:accrediting_body2) { build :provider, accredited_body?: true }
-  let(:course1) { build :course, accrediting_provider: accrediting_body1 }
-  let(:course2) { build :course, accrediting_provider: accrediting_body2 }
-  let(:training_provider1) { build :provider, accredited_bodies: [accrediting_body1, accrediting_body2], courses: [course1, course2] }
-  let(:course3) { build :course, accrediting_provider: accrediting_body1 }
-  let(:course4) { build :course, accrediting_provider: accrediting_body1 }
-  let(:training_provider2) { build :provider, accredited_bodies: [accrediting_body1], courses: [course3, course4] }
+  let(:training_provider1) { build :provider, accredited_bodies: [accrediting_body1, accrediting_body2] }
+  let(:course1) { build :course, accrediting_provider: accrediting_body1, provider: training_provider1 }
+  let(:course2) { build :course, accrediting_provider: accrediting_body2, provider: training_provider1 }
+  let(:training_provider2) { build :provider, accredited_bodies: [accrediting_body1] }
+  let(:course3) { build :course, accrediting_provider: accrediting_body1, provider: training_provider2 }
+  let(:course4) { build :course, accrediting_provider: accrediting_body1, provider: training_provider2 }
   let(:user) { build :user, :admin }
   let(:access_request) { build :access_request }
 
@@ -19,31 +19,16 @@ feature "Get training_providers", type: :feature do
     stub_api_v2_resource(accrediting_body1)
     stub_api_v2_resource(accrediting_body1.recruitment_cycle)
     stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/courses" \
+      "?filter[accrediting_provider_code]=#{accrediting_body1.provider_code}",
+      resource_list_to_jsonapi([course1, course3, course4]),
+     )
+    stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
       "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
       resource_list_to_jsonapi([training_provider1, training_provider2]),
     )
     stub_api_v2_resource_collection([access_request])
-    stub_api_v2_request(
-      "/recruitment_cycles/#{training_provider1.recruitment_cycle.year}/providers/" \
-      "#{training_provider1.provider_code}?include=courses.accrediting_provider",
-      training_provider1.to_jsonapi(include: :courses),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{training_provider2.recruitment_cycle.year}/providers/" \
-      "#{training_provider2.provider_code}?include=courses.accrediting_provider",
-      training_provider2.to_jsonapi(include: :courses),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
-      "#{accrediting_body1.provider_code}?include=courses.accrediting_provider",
-      accrediting_body1.to_jsonapi(include: :courses),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{accrediting_body2.recruitment_cycle.year}/providers/" \
-      "#{accrediting_body2.provider_code}?include=courses.accrediting_provider",
-      accrediting_body2.to_jsonapi(include: :courses),
-    )
   end
 
   context "When the provider has training providers" do

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -3,46 +3,71 @@ require "rails_helper"
 feature "Get training_providers", type: :feature do
   let(:organisation_show_page) { PageObjects::Page::Organisations::OrganisationShow.new }
   let(:organisation_training_providers_page) { PageObjects::Page::Organisations::TrainingProviders.new }
-  let(:provider1) { build :provider, accredited_body?: true }
-  let(:provider2) { build :provider, accredited_bodies: [provider1] }
-  let(:provider3) { build :provider, accredited_bodies: [provider1] }
+  let(:accrediting_body1) { build :provider, accredited_body?: true }
+  let(:accrediting_body2) { build :provider, accredited_body?: true }
+  let(:course1) { build :course, accrediting_provider: accrediting_body1 }
+  let(:course2) { build :course, accrediting_provider: accrediting_body2 }
+  let(:training_provider1) { build :provider, accredited_bodies: [accrediting_body1, accrediting_body2], courses: [course1, course2] }
+  let(:course3) { build :course, accrediting_provider: accrediting_body1 }
+  let(:course4) { build :course, accrediting_provider: accrediting_body1 }
+  let(:training_provider2) { build :provider, accredited_bodies: [accrediting_body1], courses: [course3, course4] }
   let(:user) { build :user, :admin }
   let(:access_request) { build :access_request }
 
   before do
     stub_omniauth(user: user)
-    stub_api_v2_resource(provider1)
-    stub_api_v2_resource(provider2)
-    stub_api_v2_resource(provider3)
-    stub_api_v2_resource(provider1.recruitment_cycle)
+    stub_api_v2_resource(accrediting_body1)
+    stub_api_v2_resource(accrediting_body1.recruitment_cycle)
     stub_api_v2_request(
-      "/recruitment_cycles/#{provider1.recruitment_cycle.year}/providers/" \
-      "#{provider1.provider_code}/training_providers?recruitment_cycle_year=#{provider1.recruitment_cycle.year}",
-      resource_list_to_jsonapi([provider2, provider3]),
+      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
+      "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
+      resource_list_to_jsonapi([training_provider1, training_provider2]),
     )
     stub_api_v2_resource_collection([access_request])
+    stub_api_v2_request(
+      "/recruitment_cycles/#{training_provider1.recruitment_cycle.year}/providers/" \
+      "#{training_provider1.provider_code}?include=courses.accrediting_provider",
+      training_provider1.to_jsonapi(include: :courses),
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{training_provider2.recruitment_cycle.year}/providers/" \
+      "#{training_provider2.provider_code}?include=courses.accrediting_provider",
+      training_provider2.to_jsonapi(include: :courses),
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
+      "#{accrediting_body1.provider_code}?include=courses.accrediting_provider",
+      accrediting_body1.to_jsonapi(include: :courses),
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body2.recruitment_cycle.year}/providers/" \
+      "#{accrediting_body2.provider_code}?include=courses.accrediting_provider",
+      accrediting_body2.to_jsonapi(include: :courses),
+    )
   end
 
   context "When the provider has training providers" do
     context "as an admin user" do
       it "can be reached from the provider show page" do
-        visit provider_path(provider1.provider_code)
+        visit provider_path(accrediting_body1.provider_code)
         organisation_show_page.courses_as_accredited_body_link.click
-        expect(current_path).to eq training_providers_provider_recruitment_cycle_path(provider1.provider_code, provider1.recruitment_cycle.year)
+        expect(current_path).to eq training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
       end
 
       it "should have the correct content" do
-        visit training_providers_provider_recruitment_cycle_path(provider1.provider_code, provider1.recruitment_cycle.year)
+        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
         expect(organisation_training_providers_page.title).to have_content("Courses as an accredited body")
-        expect(organisation_training_providers_page.training_providers_list).to have_content(provider2.provider_name)
-        expect(organisation_training_providers_page.training_providers_list).to have_content(provider3.provider_name)
+        expect(organisation_training_providers_page.training_providers_list).to have_content(training_provider1.provider_name)
+        expect(organisation_training_providers_page.training_providers.first.course_count.text).to have_content("1 course")
+        expect(organisation_training_providers_page.training_providers_list).to have_content(training_provider2.provider_name)
+        expect(organisation_training_providers_page.training_providers.second.course_count.text).to have_content("2 courses")
       end
 
       it "should have the correct breadcrumbs" do
-        visit training_providers_provider_recruitment_cycle_path(provider1.provider_code, provider1.recruitment_cycle.year)
+        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
 
         within(".govuk-breadcrumbs") do
-          expect(page).to have_link(provider1.provider_name.to_s, href: "/organisations/#{provider1.provider_code}")
+          expect(page).to have_link(accrediting_body1.provider_name.to_s, href: "/organisations/#{accrediting_body1.provider_code}")
           expect(page).to have_content("Courses as an accredited body")
         end
       end
@@ -52,8 +77,8 @@ feature "Get training_providers", type: :feature do
       let(:user) { build(:user) }
 
       it "redirects to to the organisation show page" do
-        visit training_providers_provider_recruitment_cycle_path(provider1.provider_code, provider1.recruitment_cycle.year)
-        expect(current_path).to eq provider_path(provider1.provider_code)
+        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+        expect(current_path).to eq provider_path(accrediting_body1.provider_code)
       end
     end
   end

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -32,38 +32,27 @@ feature "Get training_providers", type: :feature do
   end
 
   context "When the provider has training providers" do
-    context "as an admin user" do
-      it "can be reached from the provider show page" do
-        visit provider_path(accrediting_body1.provider_code)
-        organisation_show_page.courses_as_accredited_body_link.click
-        expect(current_path).to eq training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
-      end
-
-      it "should have the correct content" do
-        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
-        expect(organisation_training_providers_page.title).to have_content("Courses as an accredited body")
-        expect(organisation_training_providers_page.training_providers_list).to have_content(training_provider1.provider_name)
-        expect(organisation_training_providers_page.training_providers.first.course_count.text).to have_content("1 course")
-        expect(organisation_training_providers_page.training_providers_list).to have_content(training_provider2.provider_name)
-        expect(organisation_training_providers_page.training_providers.second.course_count.text).to have_content("2 courses")
-      end
-
-      it "should have the correct breadcrumbs" do
-        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
-
-        within(".govuk-breadcrumbs") do
-          expect(page).to have_link(accrediting_body1.provider_name.to_s, href: "/organisations/#{accrediting_body1.provider_code}")
-          expect(page).to have_content("Courses as an accredited body")
-        end
-      end
+    it "can be reached from the provider show page" do
+      visit provider_path(accrediting_body1.provider_code)
+      organisation_show_page.courses_as_accredited_body_link.click
+      expect(current_path).to eq training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
     end
 
-    context "as a non-admin user" do
-      let(:user) { build(:user) }
+    it "should have the correct content" do
+      visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+      expect(organisation_training_providers_page.title).to have_content("Courses as an accredited body")
+      expect(organisation_training_providers_page.training_providers_list).to have_content(training_provider1.provider_name)
+      expect(organisation_training_providers_page.training_providers.first.course_count.text).to have_content("1 course")
+      expect(organisation_training_providers_page.training_providers_list).to have_content(training_provider2.provider_name)
+      expect(organisation_training_providers_page.training_providers.second.course_count.text).to have_content("2 courses")
+    end
 
-      it "redirects to to the organisation show page" do
-        visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
-        expect(current_path).to eq provider_path(accrediting_body1.provider_code)
+    it "should have the correct breadcrumbs" do
+      visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+
+      within(".govuk-breadcrumbs") do
+        expect(page).to have_link(accrediting_body1.provider_name.to_s, href: "/organisations/#{accrediting_body1.provider_code}")
+        expect(page).to have_content("Courses as an accredited body")
       end
     end
   end


### PR DESCRIPTION
### Context

As an accrediting body
I want to see all the courses I accredit
So that I know what providers are running courses on our behalf

### Changes proposed in this pull request
* The course count text appears on the "Courses as an Accredited Body" page for each training provider
  - only courses accredited by that specific accredited body are included

<kbd><img width="682" alt="Screenshot 2020-03-23 at 09 18 38" src="https://user-images.githubusercontent.com/38078064/77303838-830cf400-6ceb-11ea-912b-4b16bc8e2919.png"></kbd>

### Guidance to review
visit https://localhost:3000/organisations/B20/2020/training-providers

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
