### PR TITLE
[3192] Remove region select so users cannot edit

### DIFF
--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -37,7 +37,3 @@
   <%= f.text_field field, options.merge(class: 'govuk-input govuk-input--width-10') %>
 <% end %>
 
-<%= render "shared/form_field",
-  form: f, field: :region_code, label: "Region of UK" do |field, options| %>
-  <%= f.select field, Site::REGIONS, {}, options.merge(class: 'govuk-select') %>
-<% end %>

--- a/spec/features/sites/new_spec.rb
+++ b/spec/features/sites/new_spec.rb
@@ -50,7 +50,7 @@ feature "Locations", type: :feature do
       fill_in "Town or city", with: "New town"
       fill_in "County", with: "New county"
       fill_in "Postcode", with: "SW1A 1AA"
-      select "London", from: "Region of UK"
+
 
       click_on "Save"
 


### PR DESCRIPTION
### Context
Removing this form field as it is overridden by geocoding lookup.
It is no longer needed.

### Changes proposed in this pull request

### Guidance to review
#### Before
![image](https://user-images.githubusercontent.com/3441519/77678297-d8b1fc80-6f88-11ea-9821-6fdca51c9787.png)

#### After

![image](https://user-images.githubusercontent.com/3441519/77678308-dea7dd80-6f88-11ea-8f16-36b37c7f4b73.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
