### PR TITLE
3204 Update tag component to be inline with GOV.UK Design System patterns

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,6 +1,6 @@
 class ApplicationDecorator < Draper::Decorator
   def status_tag
-    tag = h.content_tag(:div, status_tag_content.html_safe, class: "govuk-tag phase-tag--small #{status_tag_css_class}")
+    tag = h.content_tag(:div, status_tag_content.html_safe, class: "govuk-tag #{status_tag_css_class}")
     tag += unpublished_status_hint if object.has_unpublished_changes?
     tag.html_safe
   end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -21,12 +21,12 @@ private
 
   def status_tags
     {
-      published: { css_class: "phase-tag--published", content: "Published" },
-      withdrawn: { css_class: "phase-tag--withdrawn", content: "Withdrawn" },
-      empty: { css_class: "phase-tag--no-content", content: "Empty" },
-      draft: { css_class: "phase-tag--draft", content: "Draft" },
-      published_with_unpublished_changes: { css_class: "phase-tag--published",  content: "Published&nbsp;*" },
-      rolled_over: { css_class: "phase-tag--no-content", content: "Rolled over" },
+      published: { css_class: "govuk-tag--green app-phase-tag--published", content: "Published" },
+      withdrawn: { css_class: "govuk-tag--red app-phase-tag--withdrawn", content: "Withdrawn" },
+      empty: { css_class: "govuk-tag--grey app-phase-tag--no-content", content: "Empty" },
+      draft: { css_class: "govuk-tag--yellow app-phase-tag--draft", content: "Draft" },
+      published_with_unpublished_changes: { css_class: "govuk-tag--green app-phase-tag--published", content: "Published&nbsp;*" },
+      rolled_over: { css_class: "govuk-tag--grey app-phase-tag--no-content", content: "Rolled over" },
     }
   end
 

--- a/app/webpacker/stylesheets/_phase-tag.scss
+++ b/app/webpacker/stylesheets/_phase-tag.scss
@@ -1,22 +1,21 @@
-.phase-tag {
+// This is only needed when we use tags in the sidebar with a grey background. eg. Course details page
+// It adds a 1px solid border around the tag with a match colour of the text.
+// TODO Could be removed if we decide not to use grey background sections on pages
+
+.app-related .app-phase-tag {
   &--no-content {
-    background: govuk-colour("white");
-    border: 2px solid lighten(govuk-colour("dark-grey"), 10%);
-    color: govuk-colour("dark-grey");
-    margin-bottom: -1px;
-    margin-top: -1px;
+    border: 1px solid govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
   }
 
   &--draft {
-    background: govuk-colour("orange");
+    border: 1px solid govuk-shade(govuk-colour("yellow"), 65);
   }
 
   &--withdrawn {
-    background: govuk-colour("black");
-    color: govuk-colour("white");
+    border: 1px solid govuk-shade(govuk-colour("red"), 30);
   }
 
   &--published {
-    background: $button-colour;
+    border: 1px solid govuk-shade(govuk-colour("green"), 20);
   }
 }

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -12,9 +12,6 @@ $success-green: #00823b;
 
 @import "~govuk-frontend/govuk/all";
 
-// Not in design system:
-$button-colour: #00823b;
-
 @import "success-summary";
 @import "phase-tag";
 @import "course-tabs";


### PR DESCRIPTION
### Context
This brings status tags inline with [GOV.UK Design System](design-system.service.gov.uk/components/tag).
### Changes proposed in this pull request

### Guidance to review

#### List of courses - Before
<img width="1170" alt="Screenshot 2020-03-31 at 10 22 25" src="https://user-images.githubusercontent.com/3441519/78010126-e923f780-7339-11ea-9a20-6d62ed23c4f0.png">

#### List of courses - After
<img width="1170" alt="Screenshot 2020-03-31 at 10 20 06" src="https://user-images.githubusercontent.com/3441519/78010192-fe008b00-7339-11ea-8bfd-06f701249d5e.png">

#### Course details - Published - Before
<img width="1170" alt="Screenshot 2020-03-31 at 10 22 35" src="https://user-images.githubusercontent.com/3441519/78010354-2ee0c000-733a-11ea-950d-45029f788442.png">

#### Course details - Published - After
<img width="1170" alt="Screenshot 2020-03-31 at 10 20 36" src="https://user-images.githubusercontent.com/3441519/78010488-5172d900-733a-11ea-8db4-06f8dc2b2c72.png">

#### Course details - Draft - Before
<img width="1170" alt="Screenshot 2020-03-31 at 10 22 55" src="https://user-images.githubusercontent.com/3441519/78011056-02797380-733b-11ea-94ef-c4f9be4ce83a.png">



#### Course details - Draft - After
<img width="1170" alt="Screenshot 2020-03-31 at 10 20 53" src="https://user-images.githubusercontent.com/3441519/78010679-9139c080-733a-11ea-8f25-3185250d8e54.png">


#### Course details - Withdrawn - Before
<img width="1170" alt="Screenshot 2020-03-31 at 10 23 07" src="https://user-images.githubusercontent.com/3441519/78011075-086f5480-733b-11ea-8d2f-b7cc861022d1.png">



#### Course details - Withdrawn - After

<img width="1170" alt="Screenshot 2020-03-31 at 10 21 07" src="https://user-images.githubusercontent.com/3441519/78010719-9dbe1900-733a-11ea-9b47-af5914b64f47.png">


#### Course details - Rolled Over - Before
<img width="1170" alt="Screenshot 2020-03-31 at 10 23 20" src="https://user-images.githubusercontent.com/3441519/78010901-d231d500-733a-11ea-92e3-0f2924284471.png">


#### Course details - Rolled Over - After
<img width="1170" alt="Screenshot 2020-03-31 at 10 21 25" src="https://user-images.githubusercontent.com/3441519/78010750-a4e52700-733a-11ea-9cc4-a08dce6ecc45.png">


#### Course details - Empty - Before
<img width="1170" alt="Screenshot 2020-03-31 at 10 23 38" src="https://user-images.githubusercontent.com/3441519/78010921-d8c04c80-733a-11ea-82e1-3040d1cc39fb.png">


#### Course details - Empty - After
<img width="1170" alt="Screenshot 2020-03-31 at 10 21 45" src="https://user-images.githubusercontent.com/3441519/78010774-aa427180-733a-11ea-82df-5b06c402c986.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
