### PR TITLE
[3205] Fix the link to the course on Find

### DIFF
--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -22,7 +22,11 @@
     <%= course.status_tag %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">
-    <%= course.on_find(@provider) %>
+    <% if @training_provider.present? %>
+      <%= course.on_find(@training_provider) %>
+    <% else %>
+      <%= course.on_find(@provider) %>
+    <% end %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__applications">
     <% if course.is_running? || course.is_withdrawn? %>

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -56,6 +56,7 @@ feature "Get courses as an accredited body", type: :feature do
         expect(courses_as_an_accredited_body_page).to have_content(training_provider2.provider_name)
         expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.course_name.text).to eq("#{name_and_course_code} PGCE with QTS full time")
         expect(courses_as_an_accredited_body_page).not_to have_link(name_and_course_code)
+        expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.find_link["href"]).to eq("#{Settings.search_ui.base_url}/course/#{training_provider2.provider_code}/#{course1.course_code}")
         expect(courses_as_an_accredited_body_page.courses_tables.first.rows.first.vacancies.text).to eq("Yes")
       end
 


### PR DESCRIPTION

### Context

Links to the courses on Find on Courses as accredited body page didn't work because they were created with accredited body code instead of training provider code.

The _course_table_row partial is shared between courses page and courses as an
accredited body page. The link was created using `@provider` code, however for
accredited body page it has to use `@training_provider`'s code.

### Changes proposed in this pull request
See below

### Guidance to review
- link on Find works correctly on /organisations/B20/2020/training-providers/2FY/courses 

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
