### PR TITLE
[3211] Use new course api endpoint

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,6 @@
 class Course < Base
   belongs_to :recruitment_cycle, through: :provider, param: :recruitment_cycle_year
-  belongs_to :provider, param: :provider_code
+  belongs_to :provider, param: :provider_code, shallow_path: true
   has_many :site_statuses
   has_many :sites, through: :site_statuses, source: :site
   has_many :subjects

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -204,23 +204,4 @@ feature "Edit course entry requirements", type: :feature do
       expect(update_course_stub).to have_been_requested
     end
   end
-
-  def stub_course_request
-    stub_api_v2_request(
-      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}/courses" \
-      "/#{course.course_code}",
-      course.to_jsonapi,
-    )
-  end
-
-  def stub_course_details_tab
-    stub_api_v2_request(
-      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/courses/#{course.course_code}" \
-      "?include=subjects,sites,provider.sites,accrediting_provider",
-      course.to_jsonapi(include: [:subjects, :sites, :accrediting_provider, :recruitment_cycle, provider: :sites]),
-    )
-  end
 end


### PR DESCRIPTION
### Context
The api can support `/api/v2/recruitment_cycles/2020/courses/*`, which was
added here https://github.com/DFE-Digital/teacher-training-api/pull/1288 so we
want the provider to be optional.

### Changes proposed in this pull request
Make provider a shallow_path on the Course model.

### Guidance to review
Tests are passing.
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
