### PR TITLE
[3203] - Add Provider search to Organisation Index page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -79,6 +79,22 @@ class ProvidersController < ApplicationController
     end
   end
 
+  def search
+    provider_query = params[:query]
+
+    if provider_query.blank?
+      flash[:error] = "Training provider"
+      return redirect_to organisations_path
+    end
+
+    provider_code = provider_query
+                      .split(" ")
+                      .last
+                      .gsub(/[()]/, "")
+
+    redirect_to provider_path(provider_code)
+  end
+
 private
 
   def provider_params

--- a/app/views/providers/_search.html.erb
+++ b/app/views/providers/_search.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with url: providers_search_path,
+                  method: :get do |form| %>
+      <%= form.label :query, {class: "govuk-label", for: "provider"} do %>
+        Search for an organisation
+        <span class="govuk-hint">Enter the name or provider code</span>
+        <% if flash[:error] && flash[:error] == "Training provider" %>
+          <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
+            <%= "Please enter the name or provider code" %>
+          </span>
+        <% end %>
+      <% end %>
+      <%= form.text_field :query,
+                          id: "provider",
+                          value: params[:query],
+                          class: "govuk-input govuk-!-width-two-thirds",
+                          data: {qa: "provider-search"} %>
+      <div id="provider-autocomplete" class="govuk-body govuk-!-width-two-thirds"></div>
+      <%= form.submit "Search", name: nil, class: "govuk-button", data: {qa: 'find-providers'} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -2,6 +2,10 @@
 
 <h1 class="govuk-heading-xl">Organisations</h1>
 
+<% if current_user.present? && current_user["admin"] %>
+  <%= render partial: "providers/search" %>
+<% end %>
+
 <ul class="govuk-list">
   <%= render partial: "providers/provider", collection: @providers %>
 </ul>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,7 +1,6 @@
-import {initAutocomplete, initProviderSearchAutocomplete} from "../scripts/autocomplete";
-
 require.context("govuk-frontend/govuk/assets");
 
+import {initAutocomplete} from "../scripts/autocomplete";
 import "../stylesheets/application.scss";
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import { initAll } from "govuk-frontend";
@@ -64,14 +63,14 @@ try {
   const $autocomplete = document.getElementById("provider-autocomplete");
   const $accredited_body_input = document.getElementById("course_accredited_body");
   const $provider_input = document.getElementById("provider");
+  const accredited_body_template = result => result && result.name;
+  const provider_template = result => result && `${result.name} (${result.code})`;
 
-  if ($autocomplete) {
-    if($accredited_body_input) {
-      initAutocomplete($autocomplete, $accredited_body_input);
-    }
-    if($provider_input) {
-      initProviderSearchAutocomplete($autocomplete, $provider_input);
-    }
+  if ($autocomplete && $accredited_body_input) {
+    initAutocomplete($autocomplete, $accredited_body_input, accredited_body_template);
+  }
+  if($autocomplete && $provider_input) {
+    initAutocomplete($autocomplete, $provider_input, provider_template);
   }
 } catch (err) {
   console.error("Failed to initialise provider autocomplete:", err);

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,3 +1,5 @@
+import {initAutocomplete, initProviderSearchAutocomplete} from "../scripts/autocomplete";
+
 require.context("govuk-frontend/govuk/assets");
 
 import "../stylesheets/application.scss";
@@ -5,7 +7,6 @@ import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import { initAll } from "govuk-frontend";
 import FormCheckLeave from "scripts/form-check-leave";
 import { triggerFormAnalytics } from "scripts/form-error-tracking";
-import initAutocomplete from "scripts/autocomplete";
 import initLocationsMap from "scripts/locations-map";
 
 initAll();
@@ -61,9 +62,16 @@ if (typeof ga === "function") {
 
 try {
   const $autocomplete = document.getElementById("provider-autocomplete");
-  const $input = document.getElementById("course_accredited_body");
+  const $accredited_body_input = document.getElementById("course_accredited_body");
+  const $provider_input = document.getElementById("provider");
+
   if ($autocomplete) {
-    initAutocomplete($autocomplete, $input);
+    if($accredited_body_input) {
+      initAutocomplete($autocomplete, $accredited_body_input);
+    }
+    if($provider_input) {
+      initProviderSearchAutocomplete($autocomplete, $provider_input);
+    }
   }
 } catch (err) {
   console.error("Failed to initialise provider autocomplete:", err);

--- a/app/webpacker/scripts/__snapshots__/autocomplete.spec.js.snap
+++ b/app/webpacker/scripts/__snapshots__/autocomplete.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Autocomplete initAutocomplete should instantiate an autocomplete 1`] = 
           
   <input
     id="old-input"
-    name="course[accrediting_provider_code]"
+    name="course[autocompleted_provider_code]"
     type="hidden"
   />
   
@@ -17,30 +17,40 @@ exports[`Autocomplete initAutocomplete should instantiate an autocomplete 1`] = 
     id="autocomplete-container"
   >
     <div
-      aria-expanded="false"
       class="autocomplete__wrapper"
-      role="combobox"
     >
       <div
-        aria-atomic="true"
-        aria-live="polite"
-        role="status"
         style="border: 0px; height: 1px; margin-bottom: -1px; margin-right: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
       >
-        Type in 3 or more characters for results.
-        <span>
-          ,,
-        </span>
+        <div
+          aria-atomic="true"
+          aria-live="polite"
+          id="input__status--A"
+          role="status"
+        >
+          
+        </div>
+        <div
+          aria-atomic="true"
+          aria-live="polite"
+          id="input__status--B"
+          role="status"
+        >
+          
+        </div>
       </div>
       
       <input
+        aria-autocomplete="both"
+        aria-describedby="input__assistiveHint"
+        aria-expanded="false"
         aria-owns="input__listbox"
         autocomplete="off"
         class="autocomplete__input autocomplete__input--default"
         id="input"
         name=""
         placeholder=""
-        role="textbox"
+        role="combobox"
         type="text"
       />
       
@@ -51,6 +61,12 @@ exports[`Autocomplete initAutocomplete should instantiate an autocomplete 1`] = 
       >
         
       </ul>
+      <span
+        id="input__assistiveHint"
+        style="display: none;"
+      >
+        When autocomplete results are available use up and down arrows to review and enter to select.  Touch device users, explore by touch or with swipe gestures.
+      </span>
     </div>
   </div>
   

--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -27,7 +27,7 @@ export const request = endpoint => {
   };
 };
 
-const initAutocomplete = ($el, $input) => {
+export const initAutocomplete = ($el, $input) => {
   accessibleAutocomplete({
     element: $el,
     id: $input.id,
@@ -50,4 +50,25 @@ const initAutocomplete = ($el, $input) => {
   $input.type = "hidden";
 };
 
-export default initAutocomplete;
+export const initProviderSearchAutocomplete = ($el, $input) => {
+  accessibleAutocomplete({
+    element: $el,
+    id: $input.id,
+    showNoOptionsFound: true,
+    name: $input.name,
+    defaultValue: $input.value,
+    minLength: 3,
+    source: request("/providers/suggest"),
+    templates: {
+      inputValue: result => result && `${result.name} (${result.code})`,
+      suggestion: result => result && `${result.name} (${result.code})`
+    },
+    onConfirm: option => ($input.value = option ? option.code : ""),
+    autoselect: true
+  });
+
+  // Hijack the original input to submit the selected provider_code.
+  $input.id = `old-${$input.id}`;
+  $input.name = "course[autocompleted_provider_code]";
+  $input.type = "hidden";
+};

--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -27,7 +27,7 @@ export const request = endpoint => {
   };
 };
 
-export const initAutocomplete = ($el, $input) => {
+export const initAutocomplete = ($el, $input, inputValueTemplate) => {
   accessibleAutocomplete({
     element: $el,
     id: $input.id,
@@ -37,30 +37,7 @@ export const initAutocomplete = ($el, $input) => {
     minLength: 3,
     source: request("/providers/suggest"),
     templates: {
-      inputValue: result => result && result.name,
-      suggestion: result => result && `${result.name} (${result.code})`
-    },
-    onConfirm: option => ($input.value = option ? option.code : ""),
-    autoselect: true
-  });
-
-  // Hijack the original input to submit the selected provider_code.
-  $input.id = `old-${$input.id}`;
-  $input.name = "course[autocompleted_provider_code]";
-  $input.type = "hidden";
-};
-
-export const initProviderSearchAutocomplete = ($el, $input) => {
-  accessibleAutocomplete({
-    element: $el,
-    id: $input.id,
-    showNoOptionsFound: true,
-    name: $input.name,
-    defaultValue: $input.value,
-    minLength: 3,
-    source: request("/providers/suggest"),
-    templates: {
-      inputValue: result => result && `${result.name} (${result.code})`,
+      inputValue: inputValueTemplate,
       suggestion: result => result && `${result.name} (${result.code})`
     },
     onConfirm: option => ($input.value = option ? option.code : ""),

--- a/app/webpacker/scripts/autocomplete.spec.js
+++ b/app/webpacker/scripts/autocomplete.spec.js
@@ -1,4 +1,4 @@
-import initAutocomplete, { request } from "./autocomplete";
+import {initAutocomplete, request} from "./autocomplete";
 
 const abortMock = jest.fn();
 global.XMLHttpRequest = jest.fn(() => ({

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,7 +198,7 @@ Rails.application.routes.draw do
   patch "/accept-terms", to: "users#accept_terms"
 
   get "/providers/suggest", to: "provider_suggestions#suggest"
-
+  get "/providers/search", to: "providers#search"
   # redirect URL's from legacy c# app
   get "/organisation/:provider_code", to: redirect("/organisations/%{provider_code}", status: 301)
   get "/organisation/:provider_code/details", to: redirect("/organisations/%{provider_code}/details", status: 301)

--- a/spec/features/providers/search_spec.rb
+++ b/spec/features/providers/search_spec.rb
@@ -63,7 +63,7 @@ feature "Search providers", type: :feature do
       stub_api_v2_request(
         "/recruitment_cycles/#{current_recruitment_cycle.year}" \
         "/providers/#{provider_code}",
-        {}, :get, 404,
+        {}, :get, 404
       )
 
       root_page.provider_search.fill_in(with: "Unknown Provider (#{provider_code})")

--- a/spec/features/providers/search_spec.rb
+++ b/spec/features/providers/search_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+feature "Search providers", type: :feature do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:rollover) { false }
+  let(:provider1) { build(:provider, provider_code: "A0", include_counts: [:courses]) }
+  let(:provider2) { build(:provider, provider_code: "A1", include_counts: [:courses]) }
+  let(:root_page) { PageObjects::Page::RootPage.new }
+  let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
+  let(:user) { build :user, :admin }
+  let(:access_request) { build :access_request }
+
+  before do
+    stub_omniauth(user: user)
+    stub_api_v2_resource_collection([access_request])
+
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}",
+      current_recruitment_cycle.to_jsonapi,
+    )
+
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+        "/providers",
+      resource_list_to_jsonapi([provider1, provider2]),
+    )
+
+    allow(Settings).to receive(:rollover).and_return(rollover)
+
+    root_page.load
+  end
+
+  context "Searching for a known provider" do
+    it "redirects to the provider page" do
+      provider_response = provider1.to_jsonapi(include: %i[courses accrediting_provider])
+
+      stub_api_v2_request(
+        "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+        "/providers/#{provider1.provider_code}",
+        provider_response,
+      )
+
+      root_page.provider_search.fill_in(with: provider1.provider_code)
+      root_page.find_providers.click
+
+      expect(current_path).to eq("/organisations/#{provider1.provider_code}")
+    end
+  end
+
+  context "Blank provider search" do
+    it "displays an error" do
+      root_page.find_providers.click
+
+      expect(root_page).to have_provider_error
+      expect(current_path).to eq("/")
+    end
+  end
+
+  context "Searching for an unknown provider" do
+    it "redirects to 'not found'" do
+      provider_code = "234"
+
+      stub_api_v2_request(
+        "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+        "/providers/#{provider_code}",
+        {}, :get, 404,
+      )
+
+      root_page.provider_search.fill_in(with: "Unknown Provider (#{provider_code})")
+      root_page.find_providers.click
+
+      expect(current_path).to eq("/organisations/#{provider_code}")
+      expect(organisation_page).to have_not_found
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/organisation_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_page.rb
@@ -8,7 +8,7 @@ module PageObjects
         element :courses, "[data-qa=provider__courses]", text: "Courses"
         element :current_cycle, "[data-qa=provider__courses__current_cycle]", text: "Current cycle"
         element :next_cycle, "[data-qa=provider__courses__next_cycle]", text: "Next cycle"
-
+        element :not_found, 'h1', text: "Page not found"
         section :pagination, ".pub-c-pagination" do
           element :next_page, ".pub-c-pagination__link-title"
         end

--- a/spec/site_prism/page_objects/page/organisations/organisation_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_page.rb
@@ -8,7 +8,7 @@ module PageObjects
         element :courses, "[data-qa=provider__courses]", text: "Courses"
         element :current_cycle, "[data-qa=provider__courses__current_cycle]", text: "Current cycle"
         element :next_cycle, "[data-qa=provider__courses__next_cycle]", text: "Next cycle"
-        element :not_found, 'h1', text: "Page not found"
+        element :not_found, "h1", text: "Page not found"
         section :pagination, ".pub-c-pagination" do
           element :next_page, ".pub-c-pagination__link-title"
         end

--- a/spec/site_prism/page_objects/page/root_page.rb
+++ b/spec/site_prism/page_objects/page/root_page.rb
@@ -2,6 +2,10 @@ module PageObjects
   module Page
     class RootPage < OrganisationsPage
       set_url "/"
+
+      element :provider_search, '[data-qa="provider-search"]'
+      element :find_providers, '[data-qa="find-providers"]'
+      element :provider_error, '[data-qa="provider-error"]'
     end
   end
 end


### PR DESCRIPTION
### Context
Both org#index pages have a big hit on our API. We should had search then pagination to improve the performance (and UX)

### Changes proposed in this pull request
- Add ability to search by provider name or provider code. Includes autocomplete functionality. This is available to admin users only

![provider_search](https://user-images.githubusercontent.com/5256922/78368738-fd772700-75bb-11ea-9595-5780bf3ca794.gif)

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
