### PR TITLE
[3226] - Fix error messages 

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -146,7 +146,7 @@ class CoursesController < ApplicationController
         redirect_to provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)
         flash[:success] = "#{@course.name} (#{@course.course_code}) has been withdrawn"
       else
-        flash[:error] = "Enter the course code (#{@course.course_code}) to withdraw this course"
+        flash[:error] = { id: "withdraw-error", message: "Enter the course code (#{@course.course_code}) to withdraw this course" }
         redirect_to withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)
       end
     else
@@ -164,7 +164,7 @@ class CoursesController < ApplicationController
       redirect_to provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)
       flash[:success] = "#{@course.name} (#{@course.course_code}) has been deleted"
     else
-      flash[:error] = "Enter the course code (#{@course.course_code}) to delete this course"
+      flash[:error] = { id: "delete-error", message: "Enter the course code (#{@course.course_code}) to delete this course" }
       redirect_to delete_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)
     end
   end

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -83,7 +83,7 @@ class ProvidersController < ApplicationController
     provider_query = params[:query]
 
     if provider_query.blank?
-      flash[:error] = "Training provider"
+      flash[:error] = { id: "provider-error", message: "Name or provider code" }
       return redirect_to organisations_path
     end
 

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -26,6 +26,11 @@
     <%= form_with model: @course, url: provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :delete do |f| %>
       <div class="govuk-form-group">
         <%= f.label 'confirm_course_code', 'Type in the course code to confirm', class: 'govuk-label' %>
+        <% if flash[:error] && flash[:error]["id"] == "delete-error" %>
+          <span class="govuk-error-message" id="delete-error" data-qa="course-delete-error">
+            <%= flash[:error]["message"] %>
+          </span>
+        <% end %>
         <%= f.text_field 'confirm_course_code', class: 'govuk-input govuk-input--width-5' %>
       </div>
       <hr class="govuk-section-break govuk-section-break--m">

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -24,6 +24,11 @@
     <%= form_with model: @course, url: withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :post do |f| %>
       <div class="govuk-form-group">
         <%= f.label 'confirm_course_code', 'Type in the course code to confirm', class: 'govuk-label' %>
+        <% if flash[:error] && flash[:error]["id"] == "withdraw-error" %>
+          <span class="govuk-error-message" id="withdraw-error" data-qa="course-withdraw-error">
+            <%= flash[:error]["message"] %>
+          </span>
+        <% end %>
         <%= f.text_field 'confirm_course_code', class: 'govuk-input govuk-input--width-5' %>
       </div>
       <hr class="govuk-section-break govuk-section-break--m">

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -3,12 +3,23 @@
     <% flash.each do |key, value| %>
         <% if key == "error" %>
           <div class="govuk-<%= key %>-summary" role="alert" aria-labelledby="<%= key %>-summary-heading" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="<%= key %>">
-            <h3 class="govuk-<%= key %>-summary__title" id="<%= key %>-summary-heading" data-error-message="<%= value %>"><%= value %></h3>
+            <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
+              You’ll need to correct some information.
+            </h2>
+            <div class="govuk-error-summary__body">
+              <ul class="govuk-list govuk-error-summary__list">
+                <li>
+                  <a href="#<%= value["id"] %>" data-qa="error__text">
+                    <%= value["message"] %>
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
         <% elsif key == "success_with_body" %>
           <div class="govuk-success-summary" role="alert" aria-labelledby="success-summary-heading" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="<%= key %>">
             <h3 class="govuk-success-summary__title" id="success-summary-heading" data-qa="flash__success__title"><%= value["title"] %></h3>
-            <p class="govuk-body" id="success-summary-body"data-qa="flash__success__body"><%= value["body"] %></h3>
+            <p class="govuk-body" id="success-summary-body"data-qa="flash__success__body"><%= value["body"] %></p>
           </div>
         <% else %>
           <div class="govuk-<%= key %>-summary" role="alert" aria-labelledby="<%= key %>-summary-heading" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="<%= key %>">

--- a/app/views/providers/_search.html.erb
+++ b/app/views/providers/_search.html.erb
@@ -5,7 +5,7 @@
       <%= form.label :query, {class: "govuk-label", for: "provider"} do %>
         Search for an organisation
         <span class="govuk-hint">Enter the name or provider code</span>
-        <% if flash[:error] && flash[:error] == "Training provider" %>
+        <% if flash[:error] && flash[:error]["message"] == "Name or provider code" %>
           <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
             <%= "Please enter the name or provider code" %>
           </span>

--- a/spec/features/courses/destroy_spec.rb
+++ b/spec/features/courses/destroy_spec.rb
@@ -62,7 +62,11 @@ feature "Delete course", type: :feature do
       fill_in "Type in the course code to confirm", with: "Z"
       click_on "Yes I’m sure – delete this course"
 
-      expect(find(".govuk-error-summary")).to have_content(
+      expect(course_page.error_summary).to have_content(
+        "You’ll need to correct some information.",
+      )
+
+      expect(course_page.delete_error).to have_content(
         "Enter the course code (#{course.course_code}) to delete this course",
       )
     end

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -62,7 +62,11 @@ feature "Withdraw course", type: :feature do
       fill_in "Type in the course code to confirm", with: "Z"
       click_on "Yes I’m sure – withdraw this course"
 
-      expect(find(".govuk-error-summary")).to have_content(
+      expect(course_page.error_summary).to have_content(
+        "You’ll need to correct some information.",
+      )
+
+      expect(course_page.withdraw_error).to have_content(
         "Enter the course code (#{course.course_code}) to withdraw this course",
       )
     end

--- a/spec/features/providers/search_spec.rb
+++ b/spec/features/providers/search_spec.rb
@@ -51,7 +51,13 @@ feature "Search providers", type: :feature do
     it "displays an error" do
       root_page.find_providers.click
 
-      expect(root_page).to have_provider_error
+      expect(root_page.error_summary).to have_content(
+        "You’ll need to correct some information.",
+      )
+
+      expect(root_page.provider_error).to have_content(
+        "Please enter the name or provider code",
+      )
       expect(current_path).to eq("/")
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -25,6 +25,8 @@ module PageObjects
         element :publish, "[data-qa=course__publish]"
         element :success_summary, ".govuk-success-summary"
         element :error_summary, ".govuk-error-summary"
+        element :delete_error, "#delete-error"
+        element :withdraw_error, "#withdraw-error"
         element :status_panel, "[data-qa=course__status_panel]"
         element :withdraw_link, '[data-qa="course__withdraw-link"]'
         element :delete_link, '[data-qa="course__delete-link"]'

--- a/spec/site_prism/page_objects/page/root_page.rb
+++ b/spec/site_prism/page_objects/page/root_page.rb
@@ -5,6 +5,7 @@ module PageObjects
 
       element :provider_search, '[data-qa="provider-search"]'
       element :find_providers, '[data-qa="find-providers"]'
+      element :error_summary, ".govuk-error-summary"
       element :provider_error, '[data-qa="provider-error"]'
     end
   end


### PR DESCRIPTION
### Context
Following scenarios are not displaying error messages correctly i.e. not meeting GOVUK standards

- searching for a provider on the root page
- withdrawing a course
- deleting a course

Note that an error message audit for Publish is pending that may uncover more issues.

### Changes proposed in this pull request
- fixes the `_flash.html.erb` partial that all the above scenarios use
- pass in an `id` so that a book mark link can be created that links the top section to the _offending_ form field

### Searching providers
<img width="900" alt="search_providers" src="https://user-images.githubusercontent.com/5256922/78568031-70c9a480-7819-11ea-920e-277b192797c8.png">

### Withdrawing a course
<img width="914" alt="withdraw_a_course" src="https://user-images.githubusercontent.com/5256922/78568058-7a530c80-7819-11ea-9fec-3f5c9789bd4a.png">

### Destroying a course
<img width="1059" alt="delete" src="https://user-images.githubusercontent.com/5256922/78647210-26e0cd00-78b2-11ea-8e4c-165ce24e0b95.png">


### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
