### PR TITLE
[3245] Allow multiple authorised_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,12 @@ For local development, you can disable reliance on DFE Sign-In by creating a
 file `config/settings/development.local.yml` with the contents:
 
 ```yaml
-authorised_user:
-  first_name: [your first name, this will be updated in the db]
-  last_name: [your last name, this will be updated in the db]
-  email: [the email address to login with]
-  password: [the password you wish to use]
+authorised_users:
+  0:
+    first_name: [your first name, this will be updated in the db]
+    last_name: [your last name, this will be updated in the db]
+    email: [the email address to login with]
+    password: [the password you wish to use]
 ```
 
 The email address has to exist in the users table of teacher-training-api, but

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -51,10 +51,10 @@ module Helpers
     stub_api_v2_request("/sessions", user.to_jsonapi, :post)
 
     begin
-      Settings[:authorised_user] = authorised_user
+      Settings[:authorised_users] = [[0, authorised_user]]
       yield
     ensure
-      Settings.delete_field(:authorised_user)
+      Settings.delete_field(:authorised_users)
     end
   end
 
@@ -157,7 +157,7 @@ module Helpers
   end
 
   def disable_authorised_development_user
-    allow(Settings).to receive(:key?).with(:authorised_user).and_return(false)
+    allow(Settings).to receive(:key?).with(:authorised_users).and_return(false)
   end
 
 private


### PR DESCRIPTION
### Context

- Can now login to review apps as a normal user and as an admin
- Previously could not login as admin

### Changes proposed in this pull request

- This now allows an array of authorised_users
- This means multiple users can be set for basic auth
- Allowing multiple users to bypass dfe signin
- This is used by the review apps
- Update README on how to set this up locally

### Guidance to review

- visit review app - https://s121d02-3245-ptt-as.azurewebsites.net/ -  use incognito for different multiple logins
- find updated credentials on confluence https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/316407835/Find+and+Publish-+all+the+links#Review-Apps
- login as normal user, should see app as normal user
- close window to logout
- new incognito window, https://s121d02-3245-ptt-as.azurewebsites.net/
- login as admin user, should be able to paginate through all organisations

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
