### PR TITLE
[3229] add allocations request form page

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -3,7 +3,7 @@ module Providers
     before_action :build_allocations
     before_action :build_recruitment_cycle
     before_action :build_provider
-    before_action :build_training_provider
+    before_action :build_training_provider, except: %i[index]
     before_action :require_provider_to_be_accredited_body!
     before_action :require_admin_permissions!
 
@@ -21,12 +21,10 @@ module Providers
     end
 
     def build_training_provider
-      twip = Provider
+      @training_provider = Provider
        .where(recruitment_cycle_year: @recruitment_cycle.year)
        .find(params[:training_provider_code])
        .first
-
-      @training_provider = twip
     end
 
     def build_provider

--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -8,6 +8,7 @@ module Providers
     before_action :require_admin_permissions!
 
     def index; end
+
     def requests; end
 
   private
@@ -20,12 +21,12 @@ module Providers
     end
 
     def build_training_provider
-       twip = Provider
-        .where(recruitment_cycle_year: @recruitment_cycle.year)
-        .find(params[:training_provider_code])
-        .first
+      twip = Provider
+       .where(recruitment_cycle_year: @recruitment_cycle.year)
+       .find(params[:training_provider_code])
+       .first
 
-        @training_provider = twip
+      @training_provider = twip
     end
 
     def build_provider

--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -7,6 +7,7 @@ module Providers
     before_action :require_admin_permissions!
 
     def index; end
+    def requests; end
 
   private
 

--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -3,6 +3,7 @@ module Providers
     before_action :build_allocations
     before_action :build_recruitment_cycle
     before_action :build_provider
+    before_action :build_training_provider
     before_action :require_provider_to_be_accredited_body!
     before_action :require_admin_permissions!
 
@@ -16,6 +17,15 @@ module Providers
       @allocations <<  { provider_name: "Enfield County School for Girls", status: "Confirm your choice", status_colour: "grey", action: "" }
       @allocations <<  { provider_name: "London Academy", status: "NOT REQUESTED", status_colour: "red", action: "Change" }
       @allocations <<  { provider_name: "University of East Anglia", status: "REQUESTED", status_colour: "green", action: "Change" }
+    end
+
+    def build_training_provider
+       twip = Provider
+        .where(recruitment_cycle_year: @recruitment_cycle.year)
+        .find(params[:training_provider_code])
+        .first
+
+        @training_provider = twip
     end
 
     def build_provider

--- a/app/views/providers/allocations/requests.html.erb
+++ b/app/views/providers/allocations/requests.html.erb
@@ -28,7 +28,7 @@
         <%= legend %>
         <% field = "requested"%>
 
-        <%= render "shared/error_wrapper", error_keys: [field], data_qa: "allocations__#{field}" do %>
+        <%= render "shared/error_wrapper", error_keys: [field], data_qa: "allocation__#{field}" do %>
         <% ["Yes", "No"].each_with_index do |value| %>
           <% label = value %>
 

--- a/app/views/providers/allocations/requests.html.erb
+++ b/app/views/providers/allocations/requests.html.erb
@@ -1,0 +1,62 @@
+
+<% page_title = "Do you want to request PE for this organisation?"%>
+<%= content_for :page_title, page_title%>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>
+<% end %>
+
+
+<% legend = capture do %>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl">Enfield County School for Girls</span>
+            <%= page_title%>
+        </h1>
+    </legend>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <%= form_with url: requests_provider_recruitment_cycle_allocation_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year,
+                    params[:training_provider_code]
+                  ),
+                  method: :get do |form| %>
+      <fieldset class="govuk-fieldset">
+        <%= legend %>
+        <% field = "requested"%>
+
+        <%= render "shared/error_messages", error_keys: [field] %>
+
+
+        <% ["Yes", "No"].each_with_index do |value| %>
+          <% help = "#{value} means #{value.upcase}" %>
+          <% label = value %>
+
+          <div class="govuk-radios__item">
+            <%= form.radio_button field,
+                  value,
+                  class: 'govuk-radios__input',
+                  data: {
+                    'aria-describedby': "#{field}-#{value}-help"
+                  }
+            %>
+            <%= form.label field,
+                  label,
+                  value: value,
+                  class: "govuk-label govuk-radios__label"
+            %>
+            <span id="<%= "#{field}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
+              <%= help %>
+            </span>
+          </div>
+        <% end %>
+      </fieldset>
+
+      <%= form.submit "Continue", class: "govuk-button", data: { qa: 'request_continue' } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/providers/allocations/requests.html.erb
+++ b/app/views/providers/allocations/requests.html.erb
@@ -6,12 +6,11 @@
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>
 <% end %>
 
-
 <% legend = capture do %>
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
         <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl">Enfield County School for Girls</span>
-            <%= page_title%>
+            <span class="govuk-caption-xl"><%= @training_provider.provider_name %></span>
+            <%= page_title %>
         </h1>
     </legend>
 <% end %>
@@ -51,7 +50,7 @@
       </fieldset>
 
       <%= form.submit "Continue", class: "govuk-button", data: { qa: 'request_continue' } %>
-    <% end %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/requests.html.erb
+++ b/app/views/providers/allocations/requests.html.erb
@@ -29,11 +29,8 @@
         <%= legend %>
         <% field = "requested"%>
 
-        <%= render "shared/error_messages", error_keys: [field] %>
-
-
+        <%= render "shared/error_wrapper", error_keys: [field], data_qa: "allocations__#{field}" do %>
         <% ["Yes", "No"].each_with_index do |value| %>
-          <% help = "#{value} means #{value.upcase}" %>
           <% label = value %>
 
           <div class="govuk-radios__item">
@@ -49,14 +46,12 @@
                   value: value,
                   class: "govuk-label govuk-radios__label"
             %>
-            <span id="<%= "#{field}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
-              <%= help %>
-            </span>
           </div>
         <% end %>
       </fieldset>
 
       <%= form.submit "Continue", class: "govuk-button", data: { qa: 'request_continue' } %>
+    <% end %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,7 +184,12 @@ Rails.application.routes.draw do
       resources :sites, path: "locations", on: :member, except: %i[destroy show]
 
       scope module: "providers" do
-        resources :allocations, only: [:index]
+        resources :allocations, only: [:index], on: :member, param: :training_provider_code do
+          member do
+            post :requests
+            get :requests
+          end
+        end
       end
     end
   end

--- a/spec/features/allocations_request_spec.rb
+++ b/spec/features/allocations_request_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.feature "PE allocations request" do
+  scenario "Accredited body views PE allocations request page for training provider" do
+    given_accredited_body_exists
+    given_training_provider_exists
+    given_i_am_signed_in_as_an_admin
+
+    when_i_visit_pe_alloacations_request_page
+
+    then_i_see_the_pe_alloacations_request_page
+
+    and_i_see_back_link
+    and_i_see_training_provider_name
+    and_i_see_request_form
+  end
+
+  def and_i_see_request_form
+    request_form = find '[data-qa="allocation__requested"]'
+
+    expect(request_form.find("#requested_no")).to_not be_checked
+    expect(request_form.find("#requested_yes")).to_not be_checked
+  end
+
+  def and_i_see_training_provider_name
+    expect(find("h1")).to have_content(@training_provider.provider_name)
+  end
+
+  def then_i_see_the_pe_alloacations_request_page
+    expect(page.title).to have_content("Do you want to request PE for this organisation?")
+    expect(find("h1")).to have_content("Do you want to request PE for this organisation?")
+  end
+
+  def when_i_visit_pe_alloacations_request_page
+    stub_api_v2_resource(@accrediting_body)
+    stub_api_v2_resource(@accrediting_body.recruitment_cycle)
+    stub_api_v2_resource(@training_provider)
+
+    footer_stub_for_access_request_count
+
+    visit requests_provider_recruitment_cycle_allocation_path(@accrediting_body.provider_code, @accrediting_body.recruitment_cycle.year, @training_provider.provider_code)
+  end
+
+  def footer_stub_for_access_request_count
+    stub_api_v2_resource_collection([build(:access_request)])
+  end
+
+  def given_accredited_body_exists
+    @accrediting_body = build(:provider, accredited_body?: true)
+  end
+
+  def given_i_am_signed_in_as_an_admin
+    stub_omniauth(user: build(:user, :admin))
+  end
+
+  def when_i_visit_my_organisations_page
+    visit provider_path(@accrediting_body.provider_code)
+    expect(find("h1")).to have_content(@accrediting_body.provider_name.to_s)
+  end
+
+  def and_i_see_back_link
+    expect(page).to have_link(
+      "Back",
+      href: "/organisations/#{@accrediting_body.provider_code}/2020/allocations",
+    )
+  end
+
+  def given_training_provider_exists
+    @training_provider = build(:provider)
+  end
+end


### PR DESCRIPTION
### Context
The request form page

### Changes proposed in this pull request
Add the request form page

### Guidance to review
Just the page is done

Log in as admin and navigate directly to the request form page

```https://s121d02-3229-ptt-as.azurewebsites.net/organisations/B1T/2020/allocations/#{provider_code}/requests```

replace `#{provider_code}` with a proper one.

ie

https://s121d02-3229-ptt-as.azurewebsites.net/organisations/B1T/2020/allocations/E14/requests
https://s121d02-3229-ptt-as.azurewebsites.net/organisations/B1T/2020/allocations/M20/requests

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
