### PR TITLE
3263 update accredited body courses csv

### DIFF
--- a/app/controllers/training_providers_courses_controller.rb
+++ b/app/controllers/training_providers_courses_controller.rb
@@ -9,15 +9,15 @@ class TrainingProvidersCoursesController < ApplicationController
       .where(recruitment_cycle_year: @recruitment_cycle.year, accrediting_provider_code: @provider.provider_code)
       .map do |c|
       {
-        provider_code: c.provider.provider_code,
-        provider_name: c.provider.provider_name,
-        course_code: c.course_code,
-        course_name: c.name,
-        study_mode: c.study_mode,
-        qualification: c.qualification,
-        content_status: c.content_status,
-        applications_open_from: c.applications_open_from,
-        has_vacancies: c.has_vacancies?,
+        "Provider code" => c.provider.provider_code,
+        "Provider" => c.provider.provider_name,
+        "Course code" => c.course_code,
+        "Course" => c.name,
+        "Study mode" => c.study_mode,
+        "Qualification" => c.qualification,
+        "Status" => c.content_status,
+        "Is it on Find?" => c.applications_open_from,
+        "Vacancies" => c.has_vacancies?,
       }
     end
 

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -11,6 +11,10 @@ class CourseDecorator < ApplicationDecorator
     content.html_safe
   end
 
+  def find_url(provider = object.provider)
+    h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
+  end
+
   def on_find(provider = object.provider)
     if object.findable?
       if current_cycle_and_open?

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -45,7 +45,7 @@
                       provider.recruitment_cycle_year,
                       format: :csv
                     ),
-                    class: "govuk-link govuk-!-font-weight-bold" %>
+                    class: "govuk-link govuk-body" %>
       </div>
   </aside>
 </div>

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -59,6 +59,10 @@ describe CourseDecorator do
     expect(decorated_course.is_send?).to eq("No")
   end
 
+  it "returns the Find URL" do
+    expect(decorated_course.find_url).to eq("#{Settings.search_ui.base_url}/course/#{provider.provider_code}/#{course.course_code}")
+  end
+
   it "returns course length" do
     expect(decorated_course.length).to eq("1 year")
   end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -90,7 +90,7 @@ describe "Providers", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to eq(
           <<~HEREDOC,
-            provider_code,provider_name,course_code,course_name,study_mode,qualification,content_status,applications_open_from,has_vacancies
+            Provider code,Provider,Course code,Course,Study mode,Qualification,Status,Is it on Find?,Vacancies
             #{course.provider.provider_code},#{course.provider.provider_name},#{course.course_code},#{course.name},#{course.study_mode},#{course.qualification},#{course.content_status},#{course.applications_open_from},#{course.has_vacancies?}
           HEREDOC
         )

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -72,6 +72,7 @@ describe "Providers", type: :request do
         training_provider = build(:provider)
         course = build(:course, provider: training_provider)
         accredited_provider = build(:provider, current_accredited_courses: [course])
+        decorated_course = course.decorate
         stub_api_v2_request("/recruitment_cycles/#{accredited_provider.recruitment_cycle.year}", accredited_provider.recruitment_cycle.to_jsonapi)
         stub_api_v2_resource(accredited_provider)
         stub_api_v2_request(
@@ -90,8 +91,8 @@ describe "Providers", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to eq(
           <<~HEREDOC,
-            Provider code,Provider,Course code,Course,Study mode,Qualification,Status,Is it on Find?,Vacancies
-            #{course.provider.provider_code},#{course.provider.provider_name},#{course.course_code},#{course.name},#{course.study_mode},#{course.qualification},#{course.content_status},#{course.applications_open_from},#{course.has_vacancies?}
+            Provider code,Provider,Course code,Course,Study mode,Qualification,Status,View on Find,Applications open from,Vacancies
+            #{course.provider.provider_code},#{course.provider.provider_name},#{course.course_code},#{course.name},#{decorated_course.study_mode.humanize},#{decorated_course.outcome},#{course.content_status.humanize},#{decorated_course.find_url},#{I18n.l(course.applications_open_from.to_date)},No
           HEREDOC
         )
       end


### PR DESCRIPTION
### Context
Improved accredited body courses csv

### Changes proposed in this pull request
- Humanize header names
- Add Find URL
- Add application open date
- Humanize study type, outcome and content status

### Guidance to review

- visit review app - https://s121d02-3263-ptt-as.azurewebsites.net/ - use incognito for different multiple logins
- find updated credentials on confluence https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/316407835/Find+and+Publish-+all+the+links#Review-Apps
- login as admin user
- Navigate to `/organisations/U80/2020/training-providers`

### Checklist
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [x] Product Review
