### PR TITLE
[3228] Add accrediting bodies allocation report

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -1,5 +1,6 @@
 module Providers
   class AllocationsController < ApplicationController
+    before_action :build_allocations
     before_action :build_recruitment_cycle
     before_action :build_provider
     before_action :require_provider_to_be_accredited_body!
@@ -8,6 +9,13 @@ module Providers
     def index; end
 
   private
+
+    def build_allocations
+      @allocations = []
+      @allocations <<  { provider_name: "Enfield County School for Girls", status: "Confirm your choice", status_colour: "grey", action: "" }
+      @allocations <<  { provider_name: "London Academy", status: "NOT REQUESTED", status_colour: "red", action: "Change" }
+      @allocations <<  { provider_name: "University of East Anglia", status: "REQUESTED", status_colour: "green", action: "Change" }
+    end
 
     def build_provider
       @provider = Provider

--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -1,0 +1,30 @@
+<table class="govuk-table ucas-info-table govuk-!-margin-bottom-8 ">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header subject-col">
+      Organisation
+    </th>
+    <th class="govuk-table__header status-col">
+      Status
+    </th>
+    <th class="govuk-table__header status-col"></th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% allocations.each do | allocation | %>
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">
+        <a class="govuk-link" href="#"><%= allocation[:provider_name] %></a>
+      </th>
+      <td class="govuk-table__cell">
+        <span class="govuk-tag govuk-tag--<%= allocation[:status_colour] %>">
+          <%= allocation[:status] %>
+        </span>
+      </td>
+      <td class="govuk-table__cell">
+        <a class="govuk-link" href="#"><%= allocation[:action] %></a>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/providers/allocations/index.html.erb
+++ b/app/views/providers/allocations/index.html.erb
@@ -1,11 +1,40 @@
 <%= content_for :page_title, "Request PE courses for 2021/22" %>
 <%= content_for :before_content, render_breadcrumbs("allocations") %>
 
-<h1 class="govuk-heading-xl">Request PE courses for 2021/22</h1>
+
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You need to request any fee-funded PE courses for 2021/22 by 10 July 2020. You do not need to request salaried PE courses.</p>
-    <p class="govuk-body">Once you’ve made a request, you can change it before 10 July.</p>
+    <h1 class="govuk-heading-xl">Request PE courses for 2021/22</h1>
+    <p class="govuk-body">
+      You need to request any fee-funded PE courses for 2021/22 by 10 July 2020.
+      You do not need to request salaried PE courses.
+    </p>
+    <p class="govuk-body">
+      Once you’ve made a request, you can change it before 10 July.
+    </p>
+
+    <h2 class="govuk-heading-m">Request PE again in 2021/22</h2>
+    <p class="govuk-body">
+      These are the organisations currently offering fee-funded PE that you’re
+      listed as the accredited body for. Your own organisation will be included
+      if it’s offering its own courses.
+    </p>
+
+    <p class="govuk-body">
+      Tell us if you’d like to request PE again. You won’t need to give recruitment
+      figures - these will be allocated based on the current year’s figures.
+      In September, you’ll receive confirmation of courses and numbers.
+    </p>
+
+    <%= render partial: "providers/allocations/request_status", locals: {allocations: @allocations} %>
+
+    <h2 class="govuk-heading-m">Request new PE courses</h2>
+    <p class="govuk-body">
+      Request any PE courses for 2021/22 not offered in the current cycle.
+      Select the name of the organisation offering the course.
+      You’ll be asked to give recruitment figures.
+    </p>
+
   </div>
 </div>

--- a/app/views/providers/allocations/index.html.erb
+++ b/app/views/providers/allocations/index.html.erb
@@ -3,7 +3,7 @@
 
 <h1 class="govuk-heading-xl">Request PE courses for 2021/22</h1>
 
-<div class="govuk-grid-row add-top-margin">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">You need to request any fee-funded PE courses for 2021/22 by 10 July 2020. You do not need to request salaried PE courses.</p>
     <p class="govuk-body">Once you’ve made a request, you can change it before 10 July.</p>

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-xl">UCAS contacts</h1>
 
-<div class="govuk-grid-row add-top-margin">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">These are contacts that were set in UCAS NetUpdate.</p>
 
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-<div class="govuk-grid-row add-top-margin">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Who will UCAS contact?</h2>
 

--- a/spec/features/allocations_spec.rb
+++ b/spec/features/allocations_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "PE allocations" do
+  let(:allocations_page) { PageObjects::Page::Providers::Allocations::IndexPage.new }
+
   scenario "Accredited provider views PE allocations page" do
     given_accredited_body_exists
     given_i_am_signed_in_as_an_admin
@@ -9,6 +11,7 @@ RSpec.feature "PE allocations" do
     and_i_click_request_pe_courses
     then_i_see_the_pe_alloacations_page
 
+    and_i_see_allocations_with_status_and_actions
     and_i_see_correct_breadcrumbs
   end
 
@@ -47,6 +50,19 @@ RSpec.feature "PE allocations" do
     stub_api_v2_resource(@accrediting_body)
     stub_api_v2_resource_collection([build(:access_request)])
 
+    @allocations = [{
+         provider_name: " Test 1",
+         status: "Good",
+         status_colour: "green",
+         action: "",
+       },
+                    {
+                      provider_name: " Test 2",
+                      status: "Good",
+                      status_colour: "red",
+                      action: "Change",
+                    }]
+
     visit provider_path(@accrediting_body.provider_code)
     expect(find("h1")).to have_content(@accrediting_body.provider_name.to_s)
   end
@@ -57,6 +73,10 @@ RSpec.feature "PE allocations" do
 
   def then_i_see_the_pe_alloacations_page
     expect(find("h1")).to have_content("Request PE courses for 2021/22")
+  end
+
+  def and_i_see_allocations_with_status_and_actions
+    expect(allocations_page).to have_rows
   end
 
   def and_i_see_correct_breadcrumbs
@@ -87,7 +107,8 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_cannot_access_pe_alloacations_page
-    visit provider_recruitment_cycle_allocations_path(@training_provider.provider_code, @training_provider.recruitment_cycle.year)
+    allocations_page.load(provider_code: @training_provider.provider_code,
+                          recruitment_cycle_year: @training_provider.recruitment_cycle.year)
     expect(page).to have_content("Page not found")
   end
 

--- a/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
@@ -1,0 +1,16 @@
+module PageObjects
+  module Page
+    module Providers
+      module Allocations
+        class IndexPage < PageObjects::Base
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations"
+
+          sections :rows, "tbody tr" do
+            element :status, "td[:nth-child(1)"
+            element :actions, "td[:nth-child(2)"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
Update copy of existing "Request PE courses for 2021/22" page.
### Guidance to review

Website: https://s121d02-3228-ptt-as.azurewebsites.net
- Login to the review app as an admin user
- Go to https://s121d02-3228-ptt-as.azurewebsites.net/organisations/O33
- Scroll to the admin feature at the bottom of the page
- View the requests for PE allocations
- Page loads and shows a table with three providers, their status and actions. 

At this moment, the list of providers is a static list and the links do not take the user to any particular part of the service.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
