### PR TITLE
[3276] Add encoding for autocomplete queries

### DIFF
--- a/app/controllers/provider_suggestions_controller.rb
+++ b/app/controllers/provider_suggestions_controller.rb
@@ -1,7 +1,16 @@
 class ProviderSuggestionsController < ApplicationController
   def suggest
-    suggestions = ProviderSuggestion.suggest(params[:query])
+    return render(json: { error: "Bad request" }, status: :bad_request) if params_invalid?
+
+    sanitised_query = CGI.escape(params[:query])
+    suggestions = ProviderSuggestion.suggest(sanitised_query)
       .map { |provider| { code: provider.provider_code, name: provider.provider_name } }
     render json: suggestions
+  end
+
+private
+
+  def params_invalid?
+    params[:query].nil? || params[:query].length < 3
   end
 end

--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -1,5 +1,9 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 
+export const getPath = (endpoint,query) => {
+  return `${endpoint}?query=${query}`;
+}
+
 export const request = endpoint => {
   let xhr = null; // Hoist this call so that we can abort previous requests.
 
@@ -7,7 +11,7 @@ export const request = endpoint => {
     if (xhr && xhr.readyState !== XMLHttpRequest.DONE) {
       xhr.abort();
     }
-    const path = `${endpoint}?query=${query}`;
+    const path = getPath(endpoint, query);
 
     xhr = new XMLHttpRequest();
     xhr.addEventListener("load", evt => {

--- a/app/webpacker/scripts/autocomplete.spec.js
+++ b/app/webpacker/scripts/autocomplete.spec.js
@@ -1,4 +1,4 @@
-import {initAutocomplete, request} from "./autocomplete";
+import {initAutocomplete, getPath, request} from "./autocomplete";
 
 const abortMock = jest.fn();
 global.XMLHttpRequest = jest.fn(() => ({
@@ -29,6 +29,13 @@ describe("Autocomplete", () => {
     it("should instantiate an autocomplete", () => {
       expect(document.querySelector("#outer-container")).toMatchSnapshot();
     });
+  });
+
+  describe("getPath", () => {
+    it("should return a path", () => {
+      const path = getPath("/endpoint", "queryString");
+      expect(path).toBe("/endpoint?query=queryString")
+    })
   });
 
   describe("request", () => {

--- a/spec/fixtures/api_responses/provider-suggestions.json
+++ b/spec/fixtures/api_responses/provider-suggestions.json
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "id": "3",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A0",
+        "provider_name": "ACME SCITT 0",
+        "recruitment_cycle_year": "2020"
+      }
+    },
+    {
+      "id": "1",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A01",
+        "provider_name": "Acme SCITT",
+        "recruitment_cycle_year": "2020"
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/requests/provider_suggestions_spec.rb
+++ b/spec/requests/provider_suggestions_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe "/providers/suggest", type: :request do
+  let(:provider) { build(:provider) }
+
+  before do
+    stub_omniauth(provider: provider)
+    get(auth_dfe_callback_path)
+  end
+
+  context "when provider suggestion is blank" do
+    it "returns bad request (400)" do
+      get "/providers/suggest"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq("error" => "Bad request")
+    end
+  end
+  context "when provider suggestion is less than three characters" do
+    it "returns bad request (400)" do
+      get "/providers/suggest?query=St"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq("error" => "Bad request")
+    end
+  end
+  context "when provider suggestion query is valid" do
+    query = "Girls School"
+    query_with_unicode_character = "Girls%E2%80%99 School"
+
+    [query, query_with_unicode_character].each do |provider_query|
+      it "returns success (200) for query: '#{provider_query}'" do
+        provider_suggestions = stub_request(:get, "#{Settings.manage_backend.base_url}/api/v2/providers/suggest?query=#{provider_query}")
+                                 .to_return(
+                                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+                                   body: File.new("spec/fixtures/api_responses/provider-suggestions.json"),
+                                 )
+
+        get "/providers/suggest?query=#{provider_query}"
+
+        expect(provider_suggestions).to have_been_requested
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq(
+          [
+            {
+              "code" => "A0",
+              "name" => "ACME SCITT 0",
+            },
+            {
+              "code" => "A01",
+              "name" => "Acme SCITT",
+            },
+          ],
+         )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/4nSbRPzG/3276-s-publish-provider-autocomplete-not-encoding-request-correctly

### Changes proposed in this pull request

Changed the way the autocomplete generates the query string - now uses the encodeURIComponent function to help protect against unicode contamination. See this PR for a similar change on Find https://github.com/DFE-Digital/find-teacher-training/pull/204

### Guidance to review



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
