### PR TITLE
[3254] List only training providers that provide PE, fee-funded course

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -1,24 +1,30 @@
 module Providers
   class AllocationsController < ApplicationController
-    before_action :build_allocations
     before_action :build_recruitment_cycle
     before_action :build_provider
     before_action :build_training_provider, except: %i[index]
     before_action :require_provider_to_be_accredited_body!
     before_action :require_admin_permissions!
 
-    def index; end
+    PE_SUBJECT_CODE = "C6".freeze
+
+    def index
+      @training_providers = @provider.training_providers(
+        recruitment_cycle_year: @recruitment_cycle.year,
+        "filter[subjects]": PE_SUBJECT_CODE,
+        "filter[funding_type]": "fee",
+        )
+      # temporary placeholders
+      @allocation_statuses = [
+        { status: "NOT YET REQUESTED", status_colour: "grey" },
+        { status: "NOT REQUESTED", status_colour: "red" },
+        { status: "REQUESTED", status_colour: "green" },
+      ]
+    end
 
     def requests; end
 
   private
-
-    def build_allocations
-      @allocations = []
-      @allocations <<  { provider_name: "Enfield County School for Girls", status: "Confirm your choice", status_colour: "grey", action: "" }
-      @allocations <<  { provider_name: "London Academy", status: "NOT REQUESTED", status_colour: "red", action: "Change" }
-      @allocations <<  { provider_name: "University of East Anglia", status: "REQUESTED", status_colour: "green", action: "Change" }
-    end
 
     def build_training_provider
       @training_provider = Provider

--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -11,7 +11,7 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% @training_providers.each do | training_provider | %>
+  <% @training_providers.each do |training_provider| %>
     <tr class="govuk-table__row">
       <th class="govuk-table__header" data-qa="provider_name">
         <%= training_provider.provider_name %>

--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -11,18 +11,28 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% allocations.each do | allocation | %>
+  <% @training_providers.each do | training_provider | %>
     <tr class="govuk-table__row">
-      <th class="govuk-table__header">
-        <a class="govuk-link" href="#"><%= allocation[:provider_name] %></a>
+      <th class="govuk-table__header" data-qa="provider_name">
+        <%= training_provider.provider_name %>
       </th>
+      <% allocation = @allocation_statuses.sample %>
       <td class="govuk-table__cell">
         <span class="govuk-tag govuk-tag--<%= allocation[:status_colour] %>">
           <%= allocation[:status] %>
         </span>
       </td>
       <td class="govuk-table__cell">
-        <a class="govuk-link" href="#"><%= allocation[:action] %></a>
+        <% if allocation[:status] == "NOT YET REQUESTED" %>
+          <%= link_to "Confirm choice",
+          requests_provider_recruitment_cycle_allocation_path(
+            @provider.provider_code,
+            @provider.recruitment_cycle_year,
+            training_provider.provider_code),
+          class: "govuk-link" %>
+        <% else %>
+          <a class="govuk-link" href="#">Change</a>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/spec/features/allocations_spec.rb
+++ b/spec/features/allocations_spec.rb
@@ -3,14 +3,16 @@ require "rails_helper"
 RSpec.feature "PE allocations" do
   let(:allocations_page) { PageObjects::Page::Providers::Allocations::IndexPage.new }
 
-  scenario "Accredited provider views PE allocations page" do
+  scenario "Accredited body views PE allocations page" do
     given_accredited_body_exists
     given_training_provider_with_pe_fee_founded_course_exists
+    # once the feature is released it should be changed to
+    # given_i_am_signed_in_as_a_user_from_the_accredited_body
     given_i_am_signed_in_as_an_admin
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
-    then_i_see_the_pe_alloacations_page
+    then_i_see_the_pe_allocations_page
 
     and_i_see_only_see_training_providers_offering_pe_fee_founded_courses
     and_i_see_allocations_with_status_and_actions
@@ -73,7 +75,7 @@ RSpec.feature "PE allocations" do
     click_on "Request PE courses for 2021/22"
   end
 
-  def then_i_see_the_pe_alloacations_page
+  def then_i_see_the_pe_allocations_page
     expect(find("h1")).to have_content("Request PE courses for 2021/22")
   end
 

--- a/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
@@ -6,6 +6,7 @@ module PageObjects
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations"
 
           sections :rows, "tbody tr" do
+            element :provider_name, '[data-qa="provider_name"]'
             element :status, "td[:nth-child(1)"
             element :actions, "td[:nth-child(2)"
           end


### PR DESCRIPTION
### Context
```
Given I am on the "Request PE courses for 2020/21" page
When I view the list of training providers on that page
Then I see that the list of training providers is limited to those that offer courses I accredit
And the list of training providers is also limited to those that offer courses that have the subject physical education
And the list of training providers is also limited to those that offer courses that are fee-funded
```
### Changes proposed in this pull request
- Use the filtering on the v2 https://github.com/DFE-Digital/teacher-training-api/pull/1306 to list only training providers that provide PE, fee-funded course
- add a link to the Request form if the allocation status is "NOT YET REQUESTED".

<kbd><img width="644" alt="Screenshot 2020-04-14 at 16 20 30" src="https://user-images.githubusercontent.com/38078064/79243473-92f0a180-7e6d-11ea-9c5c-d9615c041e9d.png"></kbd>

### Guidance to review
Review app: https://s121d02-3254-ptt-as.azurewebsites.net/
- go to the allocations page eg. `https://s121d02-3254-ptt-as.azurewebsites.net/organisations/B20/2020/allocations`
- only training providers that provide PE, fee-funded course should be listed 
(for `B20` only 2 out of 7)
- when the status is "NOT YET REQUESTED", there is a "Confirm choice" link that takes you to the form.

Notes: 
- the statuses are not yet implemented so they are currently random, refresh the page to see different ones
- "Change" link is not implemented
- No tests for "Confirm choice" link. It's difficult to test due to the randomness. I ensure we have tests once both links are working.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
