### PR TITLE
[3286] Allocations when no training providers returned from the API

### DIFF
--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -15,7 +15,7 @@
   <tbody class="govuk-table__body">
   <% @training_providers.each do |training_provider| %>
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" data-qa="provider_name">
+      <th class="govuk-table__header" data-qa="provider-name">
         <%= training_provider.provider_name %>
       </th>
       <% allocation = @allocation_statuses.sample %>

--- a/app/views/providers/allocations/index.html.erb
+++ b/app/views/providers/allocations/index.html.erb
@@ -13,28 +13,36 @@
       Once you’ve made a request, you can change it before 10 July.
     </p>
 
-    <h2 class="govuk-heading-m">Request PE again in 2021/22</h2>
-    <p class="govuk-body">
-      These are the organisations currently offering fee-funded PE that you’re
-      listed as the accredited body for. Your own organisation will be included
-      if it’s offering its own courses.
-    </p>
+    <% unless @training_providers.empty? %>
+      <h2 class="govuk-heading-m" data-qa="request_again_header">Request PE again in 2021/22</h2>
+      <p class="govuk-body">
+        These are the organisations currently offering fee-funded PE that you’re
+        listed as the accredited body for. Your own organisation will be included
+        if it’s offering its own courses.
+      </p>
 
-    <p class="govuk-body">
-      Tell us if you’d like to run PE again. You won’t need to say how many places
-      you'd like to request - we'll allocate these based on current numbers. You'll
-      get confirmation of courses and numbers in September.
-    </p>
+      <p class="govuk-body">
+        Tell us if you’d like to run PE again. You won’t need to say how many places
+        you'd like to request - we'll allocate these based on current numbers. You'll
+        get confirmation of courses and numbers in September.
+      </p>
+    <% end %>
   </div>
 
-  <div class="govuk-grid-column-full">
-    <%= render partial: "providers/allocations/request_status", locals: {allocations: @allocations} %>
-  </div>
+    <% unless @training_providers.empty? %>
+      <div class="govuk-grid-column-full">
+        <%= render partial: "providers/allocations/request_status", locals: {allocations: @allocations} %>
+      </div>
+    <% end %>
 
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">Request new PE courses</h2>
+    <% unless @training_providers.empty? %>
+      <h2 class="govuk-heading-m">Request new PE courses</h2>
+    <% end %>
     <p class="govuk-body">
-      Request any PE courses for 2021/22 not offered in the current cycle.
+      <% unless @training_providers.empty? %>
+        Request any PE courses for 2021/22 not offered in the current cycle.
+      <% end %>
       Select the name of the organisation offering the course.
       You’ll be asked to give recruitment figures.
     </p>

--- a/app/views/providers/allocations/index.html.erb
+++ b/app/views/providers/allocations/index.html.erb
@@ -14,7 +14,7 @@
     </p>
 
     <% unless @training_providers.empty? %>
-      <h2 class="govuk-heading-m" data-qa="request_again_header">Request PE again in 2021/22</h2>
+      <h2 class="govuk-heading-m" data-qa="request-again-header">Request PE again in 2021/22</h2>
       <p class="govuk-body">
         These are the organisations currently offering fee-funded PE that you’re
         listed as the accredited body for. Your own organisation will be included

--- a/spec/features/allocations_spec.rb
+++ b/spec/features/allocations_spec.rb
@@ -20,6 +20,22 @@ RSpec.feature "PE allocations" do
     and_i_see_correct_breadcrumbs
   end
 
+  scenario "Accredited body views PE allocations page when training provider has no PE fee-founded course" do
+    given_accredited_body_exists
+    given_there_is_no_training_providers_with_pe_fee_founded_course
+    # once the feature is released it should be changed to
+    # given_i_am_signed_in_as_a_user_from_the_accredited_body
+    given_i_am_signed_in_as_an_admin
+
+    when_i_visit_my_organisations_page
+    and_i_click_request_pe_courses
+    then_i_see_the_pe_allocations_page
+
+    and_i_do_not_see_request_pe_again_section
+
+    and_i_see_correct_breadcrumbs
+  end
+
   scenario "There is no PE allocations page for non accredited body" do
     given_a_provider_exists
     given_i_am_signed_in_as_an_admin
@@ -62,6 +78,16 @@ RSpec.feature "PE allocations" do
       resource_list_to_jsonapi([@training_provider]),
     )
   end
+
+  def given_there_is_no_training_providers_with_pe_fee_founded_course
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accrediting_body.recruitment_cycle.year}/providers/" \
+      "#{@accrediting_body.provider_code}/training_providers" \
+      "?filter[funding_type]=fee" \
+      "&filter[subjects]=C6" \
+      "&recruitment_cycle_year=#{@accrediting_body.recruitment_cycle.year}",
+      resource_list_to_jsonapi([]),
+    )
   end
 
   def when_i_visit_my_organisations_page
@@ -86,6 +112,10 @@ RSpec.feature "PE allocations" do
 
   def and_i_see_allocations_with_status_and_actions
     expect(allocations_page).to have_rows
+  end
+
+  def and_i_do_not_see_request_pe_again_section
+    expect(allocations_page).not_to have_request_again_header
   end
 
   def and_i_see_correct_breadcrumbs

--- a/spec/features/allocations_spec.rb
+++ b/spec/features/allocations_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "PE allocations" do
   end
 
   scenario "There is no PE allocations page for non accredited body" do
-    given_training_provider_exists
+    given_a_provider_exists
     given_i_am_signed_in_as_an_admin
 
     when_i_visit_training_providers_page
@@ -52,7 +52,16 @@ RSpec.feature "PE allocations" do
   end
 
   def given_training_provider_with_pe_fee_founded_course_exists
-    @training_provider1 = build(:provider)
+    @training_provider = build(:provider)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accrediting_body.recruitment_cycle.year}/providers/" \
+      "#{@accrediting_body.provider_code}/training_providers" \
+      "?filter[funding_type]=fee" \
+      "&filter[subjects]=C6" \
+      "&recruitment_cycle_year=#{@accrediting_body.recruitment_cycle.year}",
+      resource_list_to_jsonapi([@training_provider]),
+    )
+  end
   end
 
   def when_i_visit_my_organisations_page
@@ -64,14 +73,6 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_click_request_pe_courses
-    stub_api_v2_request(
-      "/recruitment_cycles/#{@accrediting_body.recruitment_cycle.year}/providers/" \
-      "#{@accrediting_body.provider_code}/training_providers" \
-      "?filter[funding_type]=fee" \
-      "&filter[subjects]=C6" \
-      "&recruitment_cycle_year=#{@accrediting_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider1]),
-    )
     click_on "Request PE courses for 2021/22"
   end
 
@@ -80,7 +81,7 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_see_only_see_training_providers_offering_pe_fee_founded_courses
-    expect(allocations_page.rows.first.provider_name.text).to eq(@training_provider1.provider_name)
+    expect(allocations_page.rows.first.provider_name.text).to eq(@training_provider.provider_name)
   end
 
   def and_i_see_allocations_with_status_and_actions
@@ -97,9 +98,9 @@ RSpec.feature "PE allocations" do
     end
   end
 
-  def given_training_provider_exists
-    @training_provider = build(:provider)
-    stub_api_v2_resource(@training_provider.recruitment_cycle)
+  def given_a_provider_exists
+    @provider = build(:provider)
+    stub_api_v2_resource(@provider.recruitment_cycle)
   end
 
   def there_is_no_request_pe_courses_link
@@ -107,16 +108,16 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_visit_training_providers_page
-    stub_api_v2_resource(@training_provider)
+    stub_api_v2_resource(@provider)
     stub_api_v2_resource_collection([build(:access_request)])
 
-    visit provider_path(@training_provider.provider_code)
-    expect(find("h1")).to have_content(@training_provider.provider_name.to_s)
+    visit provider_path(@provider.provider_code)
+    expect(find("h1")).to have_content(@provider.provider_name.to_s)
   end
 
   def and_i_cannot_access_pe_alloacations_page
-    allocations_page.load(provider_code: @training_provider.provider_code,
-                          recruitment_cycle_year: @training_provider.recruitment_cycle.year)
+    allocations_page.load(provider_code: @provider.provider_code,
+                          recruitment_cycle_year: @provider.recruitment_cycle.year)
     expect(page).to have_content("Page not found")
   end
 

--- a/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
@@ -5,10 +5,10 @@ module PageObjects
         class IndexPage < PageObjects::Base
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations"
 
-          element :request_again_header, '[data-qa="request_again_header"]'
+          element :request_again_header, '[data-qa="request-again-header"]'
 
           sections :rows, "tbody tr" do
-            element :provider_name, '[data-qa="provider_name"]'
+            element :provider_name, '[data-qa="provider-name"]'
             element :status, "td[:nth-child(1)"
             element :actions, "td[:nth-child(2)"
           end

--- a/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
@@ -5,6 +5,8 @@ module PageObjects
         class IndexPage < PageObjects::Base
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations"
 
+          element :request_again_header, '[data-qa="request_again_header"]'
+
           sections :rows, "tbody tr" do
             element :provider_name, '[data-qa="provider_name"]'
             element :status, "td[:nth-child(1)"


### PR DESCRIPTION
### Context
```
As an accredited body
I need not see extra content if there is no data or action available
So that I can stay focused on the actions I can take
```
Closes #1030 

### Changes proposed in this pull request
When the training providers don't have any PE fee-founded courses, 'Request PE again' section and some other elements of the text are not showing.


| PE fee-founded courses | No PE fee-founded courses | 
| ------------- |:-------------:| 
| <img width="424" alt="Screenshot 2020-04-21 at 18 26 56" src="https://user-images.githubusercontent.com/38078064/79894693-bda6a100-83fd-11ea-8ffa-161e867037d4.png">|<img width="507" alt="Screenshot 2020-04-21 at 18 19 01" src="https://user-images.githubusercontent.com/38078064/79894444-5f79be00-83fd-11ea-81d7-d202b4a21b19.png"> |


### Guidance to review
- `/organisations/2AT/2020/allocations` looks like the prototype https://allocations-alpha.herokuapp.com/pe-allocations-no-pe

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
