### PR TITLE
[3249] Allocations no path journey

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -17,8 +17,8 @@ module Providers
 
       @allocation_statuses = [
         { status: "YET TO REQUEST", status_colour: "grey" },
-        { status: "NOT REQUESTED", status_colour: "red" },
-        { status: "REQUESTED", status_colour: "green" },
+        { status: "NOT REQUESTED", status_colour: "red", requested: "no" },
+        { status: "REQUESTED", status_colour: "green", requested: "yes" },
       ]
     end
 

--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -40,7 +40,12 @@
                   </a>
                 </li>
                 <li class="govuk-summary-list__actions-list-item">
-                  <a class="govuk-link" href="#">
+                  <a class="govuk-link" data-qa="view-<%= allocation[:requested] %>-confirmation"
+                     href="<%= provider_recruitment_cycle_allocation_path(@provider.provider_code,
+                                                                          @provider.recruitment_cycle_year,
+                                                                          training_provider.provider_code,
+                                                                          requested: allocation[:requested])
+                  %>">
                     View&nbsp;confirmation<span class="govuk-visually-hidden"> for <%= training_provider.provider_name %></span>
                   </a>
                 </li>

--- a/app/views/providers/allocations/requests/_not_requested.html.erb
+++ b/app/views/providers/allocations/requests/_not_requested.html.erb
@@ -1,0 +1,28 @@
+<%= content_for :page_title, "Request Sent" %>
+
+<% training_provider_name = "Enfield County School for Girls" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl" data-qa="page-heading">
+      <span class="govuk-caption-xl"><%= training_provider_name %></span>
+      Thank you
+    </h1>
+    <p class="govuk-body">
+      You've confirmed that <%= training_provider_name %> will not be offering fee-funded
+      PE in 2021/22.
+    </p>
+
+    <h2 class="govuk-heading-m">What happens now?</h2>
+    <p class="govuk-body">
+      You don't need to do anything else. If you want to change this choice, you
+      have until 10 July to do so. If you have any questions, contact <%= bat_contact_mail_to %>.
+    </p>
+
+    <p class="govuk-body">
+      <%= link_to 'Return to Request PE courses for 2021/22',
+                  provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
+                  class: "govuk-link govuk-!-font-weight-bold" %>
+    </p>
+  </div>
+</div>

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7" data-qa="confirmation_panel">
+    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7" data-qa="page-heading">
       <h1 class="govuk-panel__title">Request sent</h1>
       <div class="govuk-panel__body">You’ve confirmed that Enfield School would like to offer PE in 2021/22</div>
     </div>

--- a/app/views/providers/allocations/show.html.erb
+++ b/app/views/providers/allocations/show.html.erb
@@ -1,5 +1,5 @@
 <% if @allocation.has_places? %>
   <%= render partial: "providers/allocations/requests/yes_requested" %>
 <% else %>
-  no path
+  <%= render partial: "providers/allocations/requests/not_requested" %>
 <% end %>

--- a/spec/features/providers/allocations_spec.rb
+++ b/spec/features/providers/allocations_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "PE allocations" do
     and_i_see_correct_breadcrumbs
   end
 
-  scenario "Accredited body updates PE allocations" do
+  scenario "Accredited body decides to request PE allocations" do
     given_accredited_body_exists
     given_training_provider_with_pe_fee_founded_course_exists
 
@@ -58,7 +58,31 @@ RSpec.feature "PE allocations" do
     then_i_click_yes
     then_i_click_continue
 
-    and_i_see_the_success_page
+    and_i_see_the_confirmation_page
+    and_i_see_the_corresponding_page_title("Request sent")
+  end
+
+  scenario "Accredited body decides not to request PE allocations" do
+    given_accredited_body_exists
+    given_training_provider_with_pe_fee_founded_course_exists
+
+    given_i_am_signed_in_as_an_admin
+
+    when_i_visit_my_organisations_page
+    and_i_click_request_pe_courses
+    then_i_see_the_pe_allocations_page
+
+    and_i_see_only_see_training_providers_offering_pe_fee_founded_courses
+    and_i_see_allocations_with_status_and_actions
+
+    and_i_click_confirm_choice
+    then_i_see_request_pe_allocations_page
+
+    then_i_click_no
+    then_i_click_continue
+
+    and_i_see_the_confirmation_page
+    and_i_see_the_corresponding_page_title("Thank you")
   end
 
   scenario "There is no PE allocations page for non accredited body" do
@@ -270,7 +294,11 @@ RSpec.feature "PE allocations" do
     allocations_new_page.continue_button.click
   end
 
-  def and_i_see_the_success_page
-    expect(allocations_show_page.confirmation_panel).to have_content("Request sent")
+  def and_i_see_the_confirmation_page
+    expect(allocations_show_page).to be_displayed
+  end
+
+  def and_i_see_the_corresponding_page_title(title)
+    expect(allocations_show_page.page_heading).to have_content(title)
   end
 end

--- a/spec/features/providers/allocations_spec.rb
+++ b/spec/features/providers/allocations_spec.rb
@@ -85,6 +85,44 @@ RSpec.feature "PE allocations" do
     and_i_see_the_corresponding_page_title("Thank you")
   end
 
+  scenario "Accredited body decides to view request PE allocations confirmation" do
+    given_accredited_body_exists
+    given_training_provider_with_pe_fee_founded_course_exists
+
+    given_i_am_signed_in_as_an_admin
+
+    when_i_visit_my_organisations_page
+    and_i_click_request_pe_courses
+    then_i_see_the_pe_allocations_page
+
+    and_i_see_only_see_training_providers_offering_pe_fee_founded_courses
+    and_i_see_allocations_with_status_and_actions
+
+    and_i_click_on_first_view_requested_confirmation
+
+    and_i_see_the_confirmation_page
+    and_i_see_the_corresponding_page_title("Request sent")
+  end
+
+  scenario "Accredited body decides to view request no PE allocations confirmation" do
+    given_accredited_body_exists
+    given_training_provider_with_pe_fee_founded_course_exists
+
+    given_i_am_signed_in_as_an_admin
+
+    when_i_visit_my_organisations_page
+    and_i_click_request_pe_courses
+    then_i_see_the_pe_allocations_page
+
+    and_i_see_only_see_training_providers_offering_pe_fee_founded_courses
+    and_i_see_allocations_with_status_and_actions
+
+    and_i_click_on_first_view_not_requested_confirmation
+
+    and_i_see_the_confirmation_page
+    and_i_see_the_corresponding_page_title("Thank you")
+  end
+
   scenario "There is no PE allocations page for non accredited body" do
     given_a_provider_exists
     given_i_am_signed_in_as_an_admin
@@ -300,5 +338,15 @@ RSpec.feature "PE allocations" do
 
   def and_i_see_the_corresponding_page_title(title)
     expect(allocations_show_page.page_heading).to have_content(title)
+  end
+
+  def and_i_click_on_first_view_requested_confirmation
+    stub_api_v2_resource(@training_provider)
+    allocations_page.view_requested_confirmation_links.first.click
+  end
+
+  def and_i_click_on_first_view_not_requested_confirmation
+    stub_api_v2_resource(@training_provider)
+    allocations_page.view_not_requested_confirmation_links.first.click
   end
 end

--- a/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/index_page.rb
@@ -12,6 +12,9 @@ module PageObjects
             element :status, "td[:nth-child(1)"
             element :actions, "td[:nth-child(2)"
           end
+
+          elements :view_requested_confirmation_links, '[data-qa="view-yes-confirmation"]'
+          elements :view_not_requested_confirmation_links, '[data-qa="view-no-confirmation"]'
         end
       end
     end

--- a/spec/site_prism/page_objects/page/providers/allocations/show_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/show_page.rb
@@ -3,9 +3,9 @@ module PageObjects
     module Providers
       module Allocations
         class ShowPage < PageObjects::Base
-          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations/show"
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations/{provider_code}"
 
-          element :confirmation_panel, ".govuk-panel--confirmation"
+          element :page_heading, '[data-qa="page-heading"]'
         end
       end
     end


### PR DESCRIPTION
### Context


closes #1032 

### Changes proposed in this pull request
- Adds a partial for when training provider decides not to request 
- wire up "View Confirmation" link to the show page.


### Guidance to review

- Visit https://s121d02-3249-ptt-as.azurewebsites.net/organisations/B20/2020/allocations
- Click "Confirm choice" 
	- select "no" and continue
    - Declined confirmation should appear

- view a "requested" confirmation
- view a "not requested"  confirmation

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
