### PR TITLE
Admin only features should be marked as such

### DIFF
--- a/app/views/providers/_search.html.erb
+++ b/app/views/providers/_search.html.erb
@@ -1,23 +1,29 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with url: providers_search_path,
-                  method: :get do |form| %>
-      <%= form.label :query, {class: "govuk-label", for: "provider"} do %>
-        Search for an organisation
-        <span class="govuk-hint">Enter the name or provider code</span>
-        <% if flash[:error] && flash[:error]["message"] == "Name or provider code" %>
-          <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
-            <%= "Please enter the name or provider code" %>
-          </span>
+
+    <div class="app-admin-only__section">
+      <div class="app-admin-only__section-header">
+        <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
+      </div>
+      <%= form_with url: providers_search_path,
+                    method: :get do |form| %>
+        <%= form.label :query, {class: "govuk-label", for: "provider"} do %>
+          Search for an organisation
+          <span class="govuk-hint">Enter the name or provider code</span>
+          <% if flash[:error] && flash[:error]["message"] == "Name or provider code" %>
+            <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
+              <%= "Please enter the name or provider code" %>
+            </span>
+          <% end %>
         <% end %>
+        <%= form.text_field :query,
+                            id: "provider",
+                            value: params[:query],
+                            class: "govuk-input govuk-!-width-two-thirds",
+                            data: {qa: "provider-search"} %>
+        <div id="provider-autocomplete" class="govuk-body govuk-!-width-two-thirds"></div>
+        <%= form.submit "Search", name: nil, class: "govuk-button", data: {qa: 'find-providers'} %>
       <% end %>
-      <%= form.text_field :query,
-                          id: "provider",
-                          value: params[:query],
-                          class: "govuk-input govuk-!-width-two-thirds",
-                          data: {qa: "provider-search"} %>
-      <div id="provider-autocomplete" class="govuk-body govuk-!-width-two-thirds"></div>
-      <%= form.submit "Search", name: nil, class: "govuk-button", data: {qa: 'find-providers'} %>
-    <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### Context
The Autocomplete Search field on the organizations page is only for admin. When it was implemented the admin styling was not applied.

![image](https://user-images.githubusercontent.com/3441519/79974069-8e8d3f80-8490-11ea-901f-87c6e589fe85.png)

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
