### PR TITLE
[3298] Create allocation thru API

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -26,8 +26,15 @@ module Providers
 
     def create
       if params.require(:requested) == "Yes"
+        Allocation.create(provider_code: @provider.provider_code,
+                                    provider_id: @training_provider.id)
+
         redirect_to provider_recruitment_cycle_allocation_path(requested: "yes")
       else
+        Allocation.create(provider_code: @provider.provider_code,
+                                    provider_id: @training_provider.id,
+                                    number_of_places: 0)
+
         redirect_to provider_recruitment_cycle_allocation_path(requested: "no")
       end
     end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,4 +1,6 @@
 class Allocation < Base
+  belongs_to :provider, param: :provider_code
+
   properties :number_of_places
 
   def has_places?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -2,6 +2,7 @@ class Provider < Base
   belongs_to :recruitment_cycle, param: :recruitment_cycle_year
   has_many :courses, param: :course_code
   has_many :sites
+  has_one :allocation
 
   self.primary_key = :provider_code
 

--- a/spec/features/providers/allocations_spec.rb
+++ b/spec/features/providers/allocations_spec.rb
@@ -16,7 +16,6 @@ RSpec.feature "PE allocations" do
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
     then_i_see_the_pe_allocations_page
-
     and_i_see_only_see_training_providers_offering_pe_fee_founded_courses
     and_i_see_allocations_with_status_and_actions
 
@@ -48,17 +47,14 @@ RSpec.feature "PE allocations" do
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
     then_i_see_the_pe_allocations_page
-
     and_i_see_only_see_training_providers_offering_pe_fee_founded_courses
     and_i_see_allocations_with_status_and_actions
 
-    and_i_click_confirm_choice
+    when_i_click_confirm_choice
     then_i_see_request_pe_allocations_page
 
-    then_i_click_yes
-    then_i_click_continue
-
-    and_i_see_the_confirmation_page
+    when_i_click_yes
+    and_i_click_continue
     and_i_see_the_corresponding_page_title("Request sent")
   end
 
@@ -71,15 +67,14 @@ RSpec.feature "PE allocations" do
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
     then_i_see_the_pe_allocations_page
-
     and_i_see_only_see_training_providers_offering_pe_fee_founded_courses
     and_i_see_allocations_with_status_and_actions
 
-    and_i_click_confirm_choice
+    when_i_click_confirm_choice
     then_i_see_request_pe_allocations_page
 
-    then_i_click_no
-    then_i_click_continue
+    when_i_click_no
+    and_i_click_continue
 
     and_i_see_the_confirmation_page
     and_i_see_the_corresponding_page_title("Thank you")
@@ -311,7 +306,7 @@ RSpec.feature "PE allocations" do
     expect(page).to have_content("You are not permitted to see this page")
   end
 
-  def and_i_click_confirm_choice
+  def when_i_click_confirm_choice
     stub_api_v2_resource(@training_provider)
     click_on "Confirm choice"
   end
@@ -320,15 +315,35 @@ RSpec.feature "PE allocations" do
     expect(find("h1")).to have_content("Do you want to request PE for this organisation?")
   end
 
-  def then_i_click_yes
+  def when_i_click_yes
+    stub_request(:post, "http://localhost:3001/api/v2/providers/#{@accrediting_body.provider_code}/allocations")
+      .with(
+        body: {
+          data: {
+            type: "allocations",
+            attributes: { provider_id: @training_provider.id },
+          },
+        }.to_json,
+      )
+
     allocations_new_page.yes.click
   end
 
-  def then_i_click_no
+  def when_i_click_no
+    stub_request(:post, "http://localhost:3001/api/v2/providers/#{@accrediting_body.provider_code}/allocations")
+      .with(
+        body: {
+          data: {
+            type: "allocations",
+            attributes: { provider_id: @training_provider.id, number_of_places: 0 },
+          },
+        }.to_json,
+      )
+
     allocations_new_page.no.click
   end
 
-  def then_i_click_continue
+  def and_i_click_continue
     allocations_new_page.continue_button.click
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/xZDgo5YV/3298-m-4d-create-allocation-request-action
- going thru yes and no journey should create an allocation in the api with the correct `number_of_places`

### Changes proposed in this pull request

- When accepting PE allocations call API to create allocation with
unspecified `number_of_places`
- When declining PE allocations call API to create allocation with zero
`number_of_places`

### Guidance to review

- wire up api from https://github.com/DFE-Digital/teacher-training-api/pull/1323
- or if merged, test on review app
- go thru yes journey
- allocation with 42 `number_of_places` should have been created
- go thru no journet
- allocation with 0 `number_of_places` should have been create
- NOTE: as endpoint is not idempotent it is possible to have more that one allocation where there should only be one

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
