### PR TITLE
[2943] Add JS testing to Rake default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ Rake::Task["default"].clear
 task :default do
   cores = ENV["PARALLEL_CORES"]
   Rake::Task["parallel:spec"].invoke(cores)
+  Rake::Task["js_spec"].invoke
   Rake::Task["lint:ruby"].invoke
   Rake::Task["lint:scss"].invoke
   Rake::Task["brakeman"].invoke

--- a/lib/tasks/js_spec.rake
+++ b/lib/tasks/js_spec.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc "Run javascript tests"
+task js_spec: :environment do
+  system "yarn test"
+end

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "engines": {
     "node": "12.15.0"
   },
+  "scripts": {
+    "test": "jest"
+  },
   "dependencies": {
     "@rails/webpacker": "^5.1.1",
     "accessible-autocomplete": "^2.0.2",


### PR DESCRIPTION
Currently, we are not running javascript unit tests (Jest) as part of our
pipeline or as part of our standard development process. This commit adds
jest testing command to rake so that for the moment we will at least be
running some sort of JS testing locally before pushing to github.

The implementation was copied from Find.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
