### PR TITLE
[3133] Dynamically display provider details

### DIFF
--- a/app/views/providers/allocations/requests/_not_requested.html.erb
+++ b/app/views/providers/allocations/requests/_not_requested.html.erb
@@ -1,15 +1,13 @@
 <%= content_for :page_title, "Request Sent" %>
 
-<% training_provider_name = "Enfield County School for Girls" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl" data-qa="page-heading">
-      <span class="govuk-caption-xl"><%= training_provider_name %></span>
+      <span class="govuk-caption-xl"><%= @training_provider.provider_name %> </span>
       Thank you
     </h1>
     <p class="govuk-body">
-      You've confirmed that <%= training_provider_name %> will not be offering fee-funded
+      You've confirmed that <%= @training_provider.provider_name %> will not be offering fee-funded
       PE in 2021/22.
     </p>
 

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -4,12 +4,14 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7" data-qa="page-heading">
       <h1 class="govuk-panel__title">Request sent</h1>
-      <div class="govuk-panel__body">You’ve confirmed that Enfield School would like to offer PE in 2021/22</div>
+      <p class="govuk-panel__body govuk-!-margin-bottom-0">
+        You’ve confirmed that <%= @training_provider.provider_name %> would like to offer PE in 2021/22
+      </p>
     </div>
     <h2 class="govuk-heading-m">What happens now?</h2>
     <p class="govuk-body">
       An email has been sent to
-      <%= mail_to 'admissions@uea.ac.uk', 'admissions@uea.ac.uk', class: 'govuk-link' %>
+      <%= mail_to @provider.email, @provider.email, class: 'govuk-link' %>
       confirming this choice and setting out next steps.
     </p>
     <p class="govuk-body">


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review
login as an admin and visit /organisations/S21/2020/allocations
check confirmations pages for request and not requested allocations.
Pages should playback the training provider name on the page.

FOr requested allocations, the page should display the Accredited bodies email address where the confirmation would have been sent to
 
### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
