### PR TITLE
Make Admin section text inputs background white

### DIFF
--- a/app/webpacker/stylesheets/_admin-only.scss
+++ b/app/webpacker/stylesheets/_admin-only.scss
@@ -10,3 +10,7 @@
 .app-admin-only__section-header {
   @include govuk-responsive-padding(3, "bottom");
 }
+
+.app-admin-only__section .autocomplete__input, .app-admin-only__section .govuk-input {
+  background-color: govuk-colour("white");
+}

--- a/app/webpacker/stylesheets/_admin-only.scss
+++ b/app/webpacker/stylesheets/_admin-only.scss
@@ -7,10 +7,15 @@
   @include govuk-responsive-margin(8, "bottom");
 }
 
+.app-admin-only__section :last-child {
+  margin-bottom: 0;
+}
+
 .app-admin-only__section-header {
   @include govuk-responsive-padding(3, "bottom");
 }
 
-.app-admin-only__section .autocomplete__input, .app-admin-only__section .govuk-input {
+.app-admin-only__section .autocomplete__input,
+.app-admin-only__section .govuk-input {
   background-color: govuk-colour("white");
 }


### PR DESCRIPTION
### Context

#### Before
<img width="994" alt="Screenshot 2020-04-29 at 15 11 20" src="https://user-images.githubusercontent.com/3441519/80606108-cade1400-8a2b-11ea-9151-07bc0c55cb70.png">

#### After 
![image](https://user-images.githubusercontent.com/3441519/80720172-75216e80-8af4-11ea-9bfe-1e5669a9f75f.png)




