### PR TITLE
[3337] don't require SSL in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,32 +32,27 @@ bundle
 bundle exec rake webpacker:compile
 ```
 
-### 3. Configure DfE Sign-In
+### 3. Setup Basic Auth Login
 
-Create the following file and ask the team for the secret.
+For local development, we rely on Basic Auth instead of DFE Sign-In, which can
+be enabled if required. Create the file `config/settings/development.local.yml`
+with the contents:
 
-```
-# config/settings/development.local.yml
-dfe_signin:
-    secret: dfe_sign_in_test_server_client_secret_here
-```
-
-*If you don't have a sign-in account on test you can bypass sign-in by
-configuring basic auth instead.*
-
-
-### 4. Trust the TLS certificate
-
-Depending on your browser you may need to add the automatically generated SSL
-certificate to your OS keychain to make the browser trust the local site.
-
-On macOS:
-
-```bash
-sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain config/localhost/https/localhost.crt
+```yaml
+authorised_users:
+  0:
+    first_name: [your first name, this will be updated in the db]
+    last_name: [your last name, this will be updated in the db]
+    email: [the email address to login with]
+    password: [the password you wish to use]
 ```
 
-### 5. Run the server
+The email address has to exist in the users table of teacher-training-api, which
+means that you'll need to have an account on the production system (or add
+yourself by hand), but the password can be any non-secure local password you
+care to use.
+
+### 4. Run the server
 
 1. Run `bundle exec rails s` to launch the app on https://localhost:3000.
 
@@ -154,23 +149,48 @@ To track exceptions through Sentry, configure the `SENTRY_DSN` environment varia
 SENTRY_DSN=https://aaa:bbb@sentry.io/123 rails s
 ```
 
+## Using DfE Sign-In
 
-## Using Basic Auth Instead of DFE Sign-In
+Occasionally you may want to test the system integration with DfE Sign-In. In
+the dev environment the system is configured to use basic auth so you need to
+take a few extra steps to make it work with DfE Sign-In.
 
-For local development, you can disable reliance on DFE Sign-In by creating a
-file `config/settings/development.local.yml` with the contents:
+### Ensure You Have a DfE Sign-In Account
+
+You likely already have an account for certain environments, but you will need
+to ensure you have an account in the DfE Sign-In test environment to be able to
+login locally. Check with team members on how to do this.
+
+### Configure DfE Sign-In
+
+Create the following file and ask the team for the secret.
 
 ```yaml
-authorised_users:
-  0:
-    first_name: [your first name, this will be updated in the db]
-    last_name: [your last name, this will be updated in the db]
-    email: [the email address to login with]
-    password: [the password you wish to use]
+# config/settings/development.local.yml
+dfe_signin:
+    secret: dfe_sign_in_test_server_client_secret_here
 ```
 
-The email address has to exist in the users table of teacher-training-api, but
-the password can be any non-secure local password you care to use.
+### Trust the TLS certificate
+
+Depending on your browser you may need to add the automatically generated SSL
+certificate to your OS keychain to make the browser trust the local site.
+
+On macOS:
+
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain config/localhost/https/localhost.crt
+```
+
+### Run The Server in SSL Mode
+
+You'll have to configure the server to run in SSL mode by setting the
+environment variable `SETTINGS__USE_SSL`, for example, use this command to run
+the server:
+
+```bash
+SETTINGS__USE_SSL=1 rails s
+```
 
 ## Cypress
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,23 @@ bundle exec rake webpacker:compile
 ### 3. Setup Basic Auth Login
 
 For local development, we rely on Basic Auth instead of DFE Sign-In, which can
-be enabled if required. Create the file `config/settings/development.local.yml`
-with the contents:
+be enabled if required. This will require that you have a login in the database,
+this will be there if you have an account in production but if you don't yet, or
+don't want to use it, you can create a user locally with:
+
+```ruby
+# Optional, use if you don't already have an account.
+User.create(admin: true,
+            email: "john.smith@digital.education.gov.uk",
+            first_name: "John",
+            last_name: "Smith",
+            welcome_email_date_utc: Time.now,
+            accept_terms_date_utc: Time.now,
+            invite_date_utc: Time.now,
+            state: "transitioned")
+```
+
+Then create the file `config/settings/development.local.yml` with the contents:
 
 ```yaml
 authorised_users:
@@ -47,10 +62,6 @@ authorised_users:
     password: [the password you wish to use]
 ```
 
-The email address has to exist in the users table of teacher-training-api, which
-means that you'll need to have an account on the production system (or add
-yourself by hand), but the password can be any non-secure local password you
-care to use.
 
 ### 4. Run the server
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = Settings.use_ssl
 
   # Logging
   config.log_level = Settings.log_level

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,7 +32,7 @@ plugin :tmp_restart
 
 listen_port = ENV.fetch("PORT", 3000)
 
-if env == "development"
+if env == "development" && Settings.use_ssl
   cert = "#{Dir.pwd}/#{File.join('config', 'localhost', 'https', 'localhost.crt')}"
   key = "#{Dir.pwd}/#{File.join('config', 'localhost', 'https', 'localhost.key')}"
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,3 +61,4 @@ logstash:
 log_level: info
 google:
   maps_api_key: replace_me
+use_ssl: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -10,3 +10,4 @@ environment:
   label: "Development"
   selector_name: "development"
 log_level: debug
+use_ssl: false


### PR DESCRIPTION
### Context

Having to deal with SSL certificates is a pain.

### Changes proposed in this pull request

Skip SSL in local dev mode.

### Guidance to review

🚀 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
