### PR TITLE
[3339] Only list training providers without previous allocations

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -53,10 +53,7 @@ module Providers
     end
 
     def initial_request
-      all_training_providers = @provider.training_providers(
-        recruitment_cycle_year: @recruitment_cycle.year,
-      )
-      @training_providers_without_previous_allocations = all_training_providers
+      get_training_providers_without_previous_allocations
 
       if params[:training_provider_code]
         render "providers/allocations/places"
@@ -64,6 +61,22 @@ module Providers
     end
 
   private
+
+    def get_training_providers_without_previous_allocations
+      training_providers_with_previous_allocations = @provider.training_providers(
+        recruitment_cycle_year: @recruitment_cycle.year,
+        "filter[subjects]": PE_SUBJECT_CODE,
+        "filter[funding_type]": "fee",
+      )
+
+      @training_providers_without_previous_allocations =
+        @provider.training_providers(
+          recruitment_cycle_year: @recruitment_cycle.year,
+        ).reject do |provider|
+          training_providers_with_previous_allocations
+           .map(&:provider_code).include?(provider.provider_code)
+        end
+    end
 
     def build_training_provider
       @training_provider = Provider

--- a/app/views/providers/allocations/initial_request.html.erb
+++ b/app/views/providers/allocations/initial_request.html.erb
@@ -48,7 +48,9 @@
             %>
           </div>
         <% end %>
-        <div class="govuk-radios__divider">or</div>
+        <% if @training_providers_without_previous_allocations.present? %>
+          <div class="govuk-radios__divider">or</div>
+        <% end %>
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="find-organisation-not-listed-above" name="training_provider_code" type="radio" value="find-organisation">
           <%= label_tag "Find an organisation not listed above", nil, class: "govuk-label govuk-radios__label" %>

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -39,19 +39,10 @@ RSpec.feature "PE allocations" do
     )
     @training_provider = build(:provider)
     stub_api_v2_resource(@training_provider)
-    # to delete leter (all training providers)
     stub_api_v2_request(
       "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
       "#{@accredited_body.provider_code}/training_providers" \
       "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider]),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@accredited_body.provider_code}/training_providers" \
-      "?filter[funding_type]=-fee" \
-      "&filter[subjects]=-C6" \
-      "&recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
       resource_list_to_jsonapi([@training_provider]),
     )
   end


### PR DESCRIPTION
### Context
Only list training providers without previous allocations on the "Who are you requesting a course for?" page

**User story**
```
As an accredited body, 
I need to see all the organisations I accredit 
		  that didn't offer fee-funded PE last year, 
So that I can select one to request allocations on their behalf
```

We decided to implement it in Publish instead of adding negated filtering to the API. The controller action will make 2 API calls

Closes #1059

### Changes proposed in this pull request
* All organisations that have a course accredited by the accredited body last cycle **not including fee-funded PE** are listed
<kbd><img width="501" alt="Screenshot 2020-05-01 at 13 14 24" src="https://user-images.githubusercontent.com/38078064/80804666-baee3d80-8bad-11ea-82bd-375ee19e3b20.png"></kbd>


### Guidance to review
- go to `https://localhost:3000/organisations/B20/2020/allocations/request`
- training providers listed should be all training providers (listed here: https://localhost:3000/organisations/B20/2020/training-providers) 
except for the ones who offered PE fee-founded course (listed here: https://localhost:3000/organisations/B20/2020/allocations)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
