### PR TITLE
[3340] Add start page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :request_login, only: %i[guidance accessibility terms cookies privacy new_features]
+  skip_before_action :request_login, only: %i[guidance accessibility terms cookies privacy new_features start]
 
   def accessibility; end
 
@@ -18,4 +18,6 @@ class PagesController < ApplicationController
   def rollover; end
 
   def accept_terms; end
+
+  def start; end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,11 @@ class SessionsController < ApplicationController
   skip_before_action :request_login
 
   def new
+    if Settings.features.start_page
+      render "pages/start"
+      return
+    end
+
     redirect_to "/auth/dfe"
   end
 

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,0 +1,26 @@
+<%= content_for :page_title, "Sign in" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m">You might have problems signing in</h2>
+        <p>Some of our users are having trouble signing in. We’re working on the problem now. If you can’t sign in, try again soon.</p>
+      </div>
+    </div>
+
+    <h1 class="govuk-heading-xl">
+      Sign in
+    </h1>
+
+    <p class="govuk-body-l">You must sign in to your account to manage your teacher training courses.</p>
+
+    <%= link_to "Sign in using DfE Sign-in", "/auth/dfe", class: "govuk-button" %>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Ask for an account</h2>
+    <p class="govuk-body">Don’t have an account? You can get one by emailing <%= bat_contact_mail_to %>. Please include the full names and email addresses of anyone who needs access.</p>
+  </div>
+</div>

--- a/app/webpacker/stylesheets/_banner.scss
+++ b/app/webpacker/stylesheets/_banner.scss
@@ -1,0 +1,53 @@
+.app-banner {
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(8, "bottom");
+  border: $govuk-border-width solid govuk-colour("blue");
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
+  }
+
+  &--missing-section {
+    border-width: 0 0 0 $govuk-border-width;
+    padding: govuk-spacing(2);
+    padding-left: govuk-spacing(3);
+    @include govuk-responsive-margin(4, "bottom");
+
+    .app-banner__message {
+      p {
+        @include govuk-typography-weight-bold;
+        color: govuk-colour("blue");
+        margin: 0;
+      }
+    }
+  }
+}
+
+.app-banner--info {
+  border-color: govuk-colour("blue");
+}
+
+.app-banner--success {
+  border-color: govuk-colour("green");
+}
+
+.app-banner--warning {
+  border-color: govuk-colour("red");
+
+  &.app-banner--missing-section {
+    .app-banner__message p {
+      color: govuk-colour("red");
+    }
+  }
+}
+
+.app-banner__message {
+  @include govuk-font($size: 19);
+}
+
+.app-banner__message *:last-child {
+  margin-bottom: 0;
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -22,6 +22,7 @@ $success-green: #00823b;
 @import "map";
 @import "admin-only";
 @import "patterns/pagination";
+@import "banner";
 
 .app-text-decoration-underline-dotted {
   text-decoration: underline dotted;

--- a/azure/template.json
+++ b/azure/template.json
@@ -164,6 +164,13 @@
       "metadata": {
           "description": "List of resource tags as a JSON object"
       }
+    },
+    "settingsFeaturesStartPage": {
+      "type": "string",
+      "defaultValue": "false",
+      "metadata": {
+        "description": "true to automatically redirect unauthenticated users to DfE signin. false to display start page"
+      }
     }
   },
   "variables": {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get "/start", to: "pages#start", as: :start
   get "/accessibility", to: "pages#accessibility", as: :accessibility
   get "/cookies", to: "pages#cookies", as: :cookies
   get "/terms-conditions", to: "pages#terms", as: :terms

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -62,3 +62,5 @@ log_level: info
 google:
   maps_api_key: replace_me
 use_ssl: true
+features:
+  start_page: false

--- a/spec/features/start_page_spec.rb
+++ b/spec/features/start_page_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+describe "start page" do
+  context "when start page feature is enabled" do
+    before do
+      given_the_start_page_feature_is_enabled
+    end
+
+    context "unauthenticated user" do
+      it "redirects the user to the start page" do
+        given_i_am_an_unauthenticated_user
+        when_i_visit_the_root_path
+        then_i_am_redirected_to_the_start_page
+      end
+    end
+
+    context "authenticated user" do
+      it "does not redirect the user" do
+        given_i_am_an_authenticated_user
+        when_i_visit_the_root_path
+        then_i_am_not_redirected_to_the_start_page
+      end
+    end
+  end
+
+  context "when start page feature is not enabled" do
+    before do
+      given_the_start_page_feature_is_not_enabled
+    end
+
+    context "unauthenticated user" do
+      it "redirects the user to DfE signin" do
+        given_i_am_an_unauthenticated_user
+        when_i_visit_the_root_path
+        then_i_am_unauthorized
+      end
+    end
+
+    context "authenticated user" do
+      it "does not redirect the user" do
+        given_i_am_an_authenticated_user
+        when_i_visit_the_root_path
+        then_i_am_not_redirected_to_dfe_signin
+      end
+    end
+  end
+
+  def given_the_start_page_feature_is_enabled
+    allow(Settings.features).to receive(:start_page).and_return(true)
+  end
+
+  def given_the_start_page_feature_is_not_enabled
+    allow(Settings.features).to receive(:start_page).and_return(false)
+  end
+
+  def given_i_am_an_authenticated_user
+    stub_the_provider_index_requests
+    stub_omniauth
+    visit "/auth/dfe"
+  end
+
+  def given_i_am_an_unauthenticated_user
+    # suppress STDOUT error messages
+    OmniAuth.config.logger = Rails.logger
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:dfe] = :invalid_credentials
+    # oauth does this webfinger lookup 🤷 https://tools.ietf.org/html/rfc7033
+    stub_request(:get, "https://test-oidc.signin.education.gov.uk/.well-known/webfinger?rel=http://openid.net/specs/connect/1.0/issuer&resource=https://test-oidc.signin.education.gov.uk:443")
+      .to_return(status: 200, body: "", headers: {})
+  end
+
+  def when_i_visit_the_root_path
+    current_recruitment_cycle = build(:recruitment_cycle)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}",
+      current_recruitment_cycle.to_jsonapi,
+    )
+
+    visit root_path
+  end
+
+  def then_i_am_redirected_to_the_start_page
+    expect(page.current_path).to eq(signin_path)
+  end
+
+  def then_i_am_not_redirected_to_the_start_page
+    expect(page.current_path).to eq(root_path)
+  end
+
+  def then_i_am_unauthorized
+    # We wouldn't expect a user to see this but just testing that the user
+    # is redirected to signin doesn't seem to be possible so this at
+    # least tests that when start_page is disabled the usual Signin OAuth based
+    # auth is still in place
+    expect(page.current_path).to eq("/401")
+  end
+
+  def then_i_am_not_redirected_to_dfe_signin
+    expect(page.current_path).to eq(root_path)
+  end
+
+  def stub_the_provider_index_requests
+    current_recruitment_cycle = build(:recruitment_cycle)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}",
+      current_recruitment_cycle.to_jsonapi,
+    )
+
+    provider1 = build(:provider)
+    provider2 = build(:provider)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers?page[page]=1",
+      resource_list_to_jsonapi([provider1, provider2], meta: { count: 2 }),
+    )
+  end
+end


### PR DESCRIPTION
**UPDATE: we've decided not to merge this for now as the risk of deploying outweighs the benefits with DfE Signin currently responding. I'll leave open for now and we can merge if needed**

### Context

Signin is currently down and we need to display a message to users.

This implementation shows a page only in non-test enviroments. This was
necessary as a lot of tests break due to the flow change so this has to
be manually tested.

### Changes proposed in this pull request

* Render a start page when the user is not-authenticated that allows them to click to signin and more importantly at this point allows us to display a message.
* Maintain the old flow for tests 
* Update the signin link in the header to go directly to 'signin'

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
