### PR TITLE
[3331] - Send request type from publish when creating updating an allocation

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -28,28 +28,20 @@ module Providers
     def new; end
 
     def create
-      if params.require(:requested) == "Yes"
-        Allocation.create(provider_code: @provider.provider_code,
-                          provider_id: @training_provider.id)
+      # TODO: we need to add error handling here
+      AllocationServices::Create.call(
+        accredited_body_code: @provider.provider_code,
+        provider_id: @training_provider.id,
+        requested: requested?,
+      )
 
-        redirect_to provider_recruitment_cycle_allocation_path(requested: "yes")
-      else
-        Allocation.create(provider_code: @provider.provider_code,
-                          provider_id: @training_provider.id,
-                          number_of_places: 0)
-
-        redirect_to provider_recruitment_cycle_allocation_path(requested: "no")
-      end
+      redirect_to provider_recruitment_cycle_allocation_path(requested: params[:requested].downcase)
     end
 
     def show
-      if params[:requested] == "yes"
-        @allocation = Allocation.new(number_of_places: 42)
-      end
-
-      if params[:requested] == "no"
-        @allocation = Allocation.new(number_of_places: 0)
-      end
+      # TODO: temp until we retrieve the Allocation from the API
+      number_of_places = requested? ? 42 : 0
+      @allocation = Allocation.new(number_of_places: number_of_places)
     end
 
   private
@@ -80,6 +72,10 @@ module Providers
 
     def require_admin_permissions!
       render "errors/forbidden", status: :forbidden unless user_is_admin?
+    end
+
+    def requested?
+      params[:requested].downcase == "yes"
     end
   end
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,7 +1,14 @@
 class Allocation < Base
+  module RequestTypes
+    INITIAL = "initial".freeze
+    REPEAT = "repeat".freeze
+    DECLINED = "declined".freeze
+  end
+
   belongs_to :provider, param: :provider_code
 
   property :number_of_places
+  property :request_type
 
   def has_places?
     number_of_places.positive?

--- a/app/services/allocation_services/create.rb
+++ b/app/services/allocation_services/create.rb
@@ -1,0 +1,36 @@
+module AllocationServices
+  class Create
+    include PublishService
+
+    def initialize(requested:, accredited_body_code:, provider_id:, number_of_places: nil)
+      @requested = requested
+      @accredited_body_code = accredited_body_code
+      @provider_id = provider_id
+      @number_of_places = number_of_places
+    end
+
+    def call
+      Allocation.create(create_params)
+    end
+
+  private
+
+    attr_reader :requested, :accredited_body_code, :provider_id, :number_of_places
+
+    def create_params
+      {
+        provider_code: accredited_body_code,
+        provider_id: provider_id,
+        request_type: request_type,
+      }.tap do |params_to_return|
+        params_to_return[:number_of_places] = number_of_places if number_of_places.present?
+      end
+    end
+
+    def request_type
+      return Allocation::RequestTypes::REPEAT if requested && number_of_places.nil?
+      return Allocation::RequestTypes::INITIAL if requested && number_of_places.present?
+      return Allocation::RequestTypes::DECLINED unless requested
+    end
+  end
+end

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -1,0 +1,21 @@
+module PublishService
+  def self.included(base)
+    base.extend ClassMethods
+    base.class_eval do
+      private_class_method :new
+    end
+  end
+
+  def call
+    raise NotImplementedError("#call must be implemented")
+  end
+
+  module ClassMethods
+    def call(**args)
+      return new.call if args.empty?
+
+      new(args).call
+    end
+  end
+end
+

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -18,4 +18,3 @@ module PublishService
     end
   end
 end
-

--- a/spec/features/providers/allocations_spec.rb
+++ b/spec/features/providers/allocations_spec.rb
@@ -350,7 +350,7 @@ RSpec.feature "PE allocations" do
         body: {
           data: {
             type: "allocations",
-            attributes: { provider_id: @training_provider.id },
+            attributes: { provider_id: @training_provider.id, request_type: "repeat" },
           },
         }.to_json,
       )
@@ -364,7 +364,7 @@ RSpec.feature "PE allocations" do
         body: {
           data: {
             type: "allocations",
-            attributes: { provider_id: @training_provider.id, number_of_places: 0 },
+            attributes: { provider_id: @training_provider.id, request_type: "declined" },
           },
         }.to_json,
       )

--- a/spec/services/allocation_services/create_spec.rb
+++ b/spec/services/allocation_services/create_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+module AllocationServices
+  describe Create do
+    describe ".call" do
+      let(:provider_id) { 1 }
+      let(:accredited_body_code) { "ABC" }
+      let(:number_of_places) { 10 }
+
+      context "requested: true" do
+        context "number_of_places provided" do
+          it "creates an initial request" do
+            expect(Allocation).to receive(:create)
+              .with(
+                provider_code: accredited_body_code,
+                provider_id: provider_id,
+                number_of_places: number_of_places,
+                request_type: Allocation::RequestTypes::INITIAL,
+              )
+
+            described_class.call(
+              requested: true,
+              accredited_body_code: accredited_body_code,
+              provider_id: provider_id,
+              number_of_places: number_of_places,
+            )
+          end
+        end
+
+        context "number_of_places not provided" do
+          it "creates a repeat request" do
+            expect(Allocation).to receive(:create)
+              .with(
+                provider_code: accredited_body_code,
+                provider_id: provider_id,
+                request_type: Allocation::RequestTypes::REPEAT,
+              )
+
+            described_class.call(
+              requested: true,
+              accredited_body_code: accredited_body_code,
+              provider_id: provider_id,
+            )
+          end
+        end
+      end
+
+      context "requested: false" do
+        it "creates a declined request" do
+          expect(Allocation).to receive(:create)
+            .with(
+              provider_code: accredited_body_code,
+              provider_id: provider_id,
+              request_type: Allocation::RequestTypes::DECLINED,
+            )
+
+          described_class.call(
+            requested: false,
+            accredited_body_code: accredited_body_code,
+            provider_id: provider_id,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
We have implemented `request_type` on the Allocation API endpoint.

### Changes proposed in this pull request
- Publish updated to pass in the `request_type` param when calling the Teacher Training API to create or update allocations

### Guidance to review

### Create

New requests should send:
`number_of_places: <whatevs>`

Re-requests should send:
`request_type: "repeat"`

No repeat allocation required should send:
`request_type: "decline"`

### Update

- Initial requests can update `number_of_places`
- Repeat and declined requests have the request type changed: repeat|declined


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
