### PR TITLE
[3340] start page

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,11 @@ class SessionsController < ApplicationController
   skip_before_action :request_login
 
   def new
-    redirect_to "/auth/dfe"
+    if Settings.features.signin_intercept
+      render
+    else
+      redirect_to "/auth/dfe"
+    end
   end
 
   def create

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<%= content_for :page_title, "Sign in" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m">You might have problems signing in</h2>
+        <p>Some of our users are having trouble signing in. We’re working on the problem now. If you can’t sign in, try again soon.</p>
+      </div>
+    </div>
+
+    <h1 class="govuk-heading-xl">
+      Sign in
+    </h1>
+
+    <p class="govuk-body-l">You must sign in to your account to manage your teacher training courses.</p>
+
+    <%= link_to "Sign in using DfE Sign-in", "/auth/dfe", class: "govuk-button" %>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Ask for an account</h2>
+    <p class="govuk-body">Don’t have an account? You can get one by emailing <%= bat_contact_mail_to %>. Please include the full names and email addresses of anyone who needs access.</p>
+  </div>
+</div>

--- a/app/webpacker/stylesheets/_banner.scss
+++ b/app/webpacker/stylesheets/_banner.scss
@@ -1,0 +1,53 @@
+.app-banner {
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(8, "bottom");
+  border: $govuk-border-width solid govuk-colour("blue");
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
+  }
+
+  &--missing-section {
+    border-width: 0 0 0 $govuk-border-width;
+    padding: govuk-spacing(2);
+    padding-left: govuk-spacing(3);
+    @include govuk-responsive-margin(4, "bottom");
+
+    .app-banner__message {
+      p {
+        @include govuk-typography-weight-bold;
+        color: govuk-colour("blue");
+        margin: 0;
+      }
+    }
+  }
+}
+
+.app-banner--info {
+  border-color: govuk-colour("blue");
+}
+
+.app-banner--success {
+  border-color: govuk-colour("green");
+}
+
+.app-banner--warning {
+  border-color: govuk-colour("red");
+
+  &.app-banner--missing-section {
+    .app-banner__message p {
+      color: govuk-colour("red");
+    }
+  }
+}
+
+.app-banner__message {
+  @include govuk-font($size: 19);
+}
+
+.app-banner__message *:last-child {
+  margin-bottom: 0;
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -22,6 +22,7 @@ $success-green: #00823b;
 @import "map";
 @import "admin-only";
 @import "patterns/pagination";
+@import "banner";
 
 .app-text-decoration-underline-dotted {
   text-decoration: underline dotted;

--- a/azure/template.json
+++ b/azure/template.json
@@ -164,6 +164,13 @@
       "metadata": {
           "description": "List of resource tags as a JSON object"
       }
+    },
+    "settingsFeaturesSigninIntercept": {
+      "type": "string",
+      "defaultValue": "false",
+      "metadata": {
+        "description": "when true, intercept the signin flow with an explanatory page; used when there are issues with DfE Sign-In"
+      }
     }
   },
   "variables": {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -62,3 +62,5 @@ log_level: info
 google:
   maps_api_key: replace_me
 use_ssl: true
+features:
+  signin_intercept: false

--- a/spec/features/sessions_signin_intercept_spec.rb
+++ b/spec/features/sessions_signin_intercept_spec.rb
@@ -1,0 +1,119 @@
+# coding: utf-8
+
+require "rails_helper"
+
+feature "sign-in interception" do
+  context "when the signin intercept feature is enabled" do
+    before do
+      given_the_signin_intercept_feature_is_enabled
+    end
+
+    context "unauthenticated user" do
+      it "redirects the user to the new session page" do
+        given_i_am_an_unauthenticated_user
+        when_i_visit_the_root_path
+        then_i_am_redirected_to_the_new_session_page
+      end
+    end
+
+    context "authenticated user" do
+      it "does not redirect the user" do
+        given_i_am_an_authenticated_user
+        when_i_visit_the_root_path
+        then_i_am_not_redirected_to_the_new_session_page
+      end
+    end
+  end
+
+  context "when signin intercept page feature is not enabled" do
+    before do
+      given_the_signin_intercept_feature_is_not_enabled
+    end
+
+    context "unauthenticated user" do
+      it "redirects the user to DfE signin" do
+        given_i_am_an_unauthenticated_user
+        when_i_visit_the_root_path
+        then_i_am_unauthorized
+      end
+    end
+
+    context "authenticated user" do
+      it "does not redirect the user" do
+        given_i_am_an_authenticated_user
+        when_i_visit_the_root_path
+        then_i_am_not_redirected_to_dfe_signin
+      end
+    end
+  end
+
+  def given_the_signin_intercept_feature_is_enabled
+    allow(Settings.features).to receive(:signin_intercept).and_return(true)
+  end
+
+  def given_the_signin_intercept_feature_is_not_enabled
+    allow(Settings.features).to receive(:signin_intercept).and_return(false)
+  end
+
+  def given_i_am_an_authenticated_user
+    stub_the_provider_index_requests
+    stub_omniauth
+    visit "/auth/dfe"
+  end
+
+  def given_i_am_an_unauthenticated_user
+    # suppress STDOUT error messages
+    OmniAuth.config.logger = Rails.logger
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:dfe] = :invalid_credentials
+    # oauth does this webfinger lookup 🤷 https://tools.ietf.org/html/rfc7033
+    stub_request(:get, "https://test-oidc.signin.education.gov.uk/.well-known/webfinger?rel=http://openid.net/specs/connect/1.0/issuer&resource=https://test-oidc.signin.education.gov.uk:443")
+      .to_return(status: 200, body: "", headers: {})
+  end
+
+  def when_i_visit_the_root_path
+    current_recruitment_cycle = build(:recruitment_cycle)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}",
+      current_recruitment_cycle.to_jsonapi,
+    )
+
+    visit root_path
+  end
+
+  def then_i_am_redirected_to_the_new_session_page
+    expect(page.current_path).to eq(signin_path)
+  end
+
+  def then_i_am_not_redirected_to_the_new_session_page
+    expect(page.current_path).to eq(root_path)
+  end
+
+  def then_i_am_unauthorized
+    # We wouldn't expect a user to see this but just testing that the user is
+    # redirected to signin doesn't seem to be possible so this at least tests
+    # that when signin_intercept is disabled the usual Signin OAuth based auth
+    # is still in place
+    expect(page.current_path).to eq("/401")
+  end
+
+  def then_i_am_not_redirected_to_dfe_signin
+    expect(page.current_path).to eq(root_path)
+  end
+
+  def stub_the_provider_index_requests
+    current_recruitment_cycle = build(:recruitment_cycle)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}",
+      current_recruitment_cycle.to_jsonapi,
+    )
+
+    provider1 = build(:provider)
+    provider2 = build(:provider)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}" \
+      "/providers?page[page]=1",
+      resource_list_to_jsonapi([provider1, provider2], meta: { count: 2 }),
+    )
+  end
+end


### PR DESCRIPTION
### Context

When Signin is unavailable we need to be able to display an alternative login interface/system. 

This was previously open as https://github.com/DFE-Digital/publish-teacher-training/pull/1061 which was approved.

### Changes proposed in this pull request

Add a start page that can be enabled with a feature flag. This start page will ultimately provide a magic link interface for users to login. (not included in this PR).

### Guidance to review

This is relatively straightforward but it turned out to be complex to add a test that when the feature isn't enabled we still redirect to DfE Signin. Turns out we don't have an explicit test for this (as far as I could see in any case). 

DfE Signin doesn't actually return to us when authentication fails but mocking failure out seemed to be the only way to test that it was included and we were redirecting when the user was unauthenticated and tried to access `root_path` We do implicitly test this in other tests as they fail if we don't stub out OAuth so there is coverage of a sort.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
