### PR TITLE
[3364] User getting 403 errors when viewing their training providers on the courses as an accredited body page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -76,14 +76,10 @@ class ProvidersController < ApplicationController
   end
 
   def training_provider_courses
-    if user_is_admin?
-      @courses = @training_provider.courses
-        .filter { |course| course[:accrediting_provider].present? }
-        .select { |course| course[:accrediting_provider][:provider_code] == @provider.provider_code }
-        .map(&:decorate)
-    else
-      redirect_to provider_path(@training_provider.provider_code)
-    end
+    @courses = @training_provider.courses
+      .filter { |course| course[:accrediting_provider].present? }
+      .select { |course| course[:accrediting_provider][:provider_code] == @provider.provider_code }
+      .map(&:decorate)
   end
 
   def search

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -76,10 +76,10 @@ class ProvidersController < ApplicationController
   end
 
   def training_provider_courses
-    @courses = @training_provider.courses
-      .filter { |course| course[:accrediting_provider].present? }
-      .select { |course| course[:accrediting_provider][:provider_code] == @provider.provider_code }
-      .map(&:decorate)
+    @courses = Course
+      .where(recruitment_cycle_year: @recruitment_cycle.year)
+      .where(provider_code: @training_provider.provider_code)
+      .where(accrediting_provider_code: @provider.provider_code).map(&:decorate)
   end
 
   def search

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Get courses as an accredited body", type: :feature do
+feature "get courses as an accredited body", type: :feature do
   let(:organisation_training_providers_page) { PageObjects::Page::Organisations::TrainingProviders.new }
   let(:courses_as_an_accredited_body_page) { PageObjects::Page::Organisations::OrganisationCoursesAsAnAccreditedBody.new }
 
@@ -12,7 +12,7 @@ feature "Get courses as an accredited body", type: :feature do
 
   let(:training_provider2) { build :provider, accredited_bodies: [accrediting_body1, accrediting_body2], courses: [course1, course2] }
 
-  let(:user) { build :user, :admin }
+  let(:user) { build :user }
   let(:access_request) { build :access_request }
 
   before do
@@ -38,7 +38,7 @@ feature "Get courses as an accredited body", type: :feature do
     stub_api_v2_resource_collection([access_request])
   end
 
-  context "When the training provider has courses" do
+  context "when the training provider has courses" do
     it "can be reached from the provider show page" do
       visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
       organisation_training_providers_page.training_providers.first.link.click

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -35,6 +35,11 @@ feature "get courses as an accredited body", type: :feature do
       "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
       resource_list_to_jsonapi([training_provider2, accrediting_body2]),
     )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/#{training_provider2.provider_code}" \
+      "/courses?filter[accrediting_provider_code]=#{accrediting_body1.provider_code}",
+      resource_list_to_jsonapi([course1]),
+    )
     stub_api_v2_resource_collection([access_request])
   end
 

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Get training_providers", type: :feature do
+feature "get training_providers", type: :feature do
   let(:organisation_show_page) { PageObjects::Page::Organisations::OrganisationShow.new }
   let(:organisation_training_providers_page) { PageObjects::Page::Organisations::TrainingProviders.new }
   let(:accrediting_body1) { build :provider, accredited_body?: true }
@@ -11,7 +11,7 @@ feature "Get training_providers", type: :feature do
   let(:training_provider2) { build :provider, accredited_bodies: [accrediting_body1] }
   let(:course3) { build :course, accrediting_provider: accrediting_body1, provider: training_provider2 }
   let(:course4) { build :course, accrediting_provider: accrediting_body1, provider: training_provider2 }
-  let(:user) { build :user, :admin }
+  let(:user) { build :user }
   let(:access_request) { build :access_request }
 
   before do
@@ -31,7 +31,7 @@ feature "Get training_providers", type: :feature do
     stub_api_v2_resource_collection([access_request])
   end
 
-  context "When the provider has training providers" do
+  context "when the provider has training providers" do
     it "can be reached from the provider show page" do
       visit provider_path(accrediting_body1.provider_code)
       organisation_show_page.courses_as_accredited_body_link.click


### PR DESCRIPTION
### Context

Users are getting 403 responses when trying to view courses as an accredited body.

### Changes proposed in this pull request

There were some remnants of this being an admin only feature left in the code. Remove them so as non-admin users don't get redirected or 403-ded

Change the way that we request courses from the API to avoid going through the provider#show endpoint and hitting the authorization failure.

NB: This requires https://github.com/DFE-Digital/teacher-training-api/pull/1354 to be merged

### Guidance to review

This needs to be reviewed as a non-admin user on the review app. I'm not sure whether we have a non-admin user that belongs to an accredited body so manual checking requires a bit of finagling in the console. I can pair on that bit if it helps.

We don't check authorization in the frontend as we rely on the API to enforce that so we should take a bit of extra care reviewing that too.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
