### PR TITLE
[3332] - Add bad query encoding middleware

### DIFF
--- a/config/initializers/handle_bad_encoding.rb
+++ b/config/initializers/handle_bad_encoding.rb
@@ -1,0 +1,3 @@
+require "rack/handle_bad_encoding"
+
+Rails.application.config.middleware.use Rack::HandleBadEncoding

--- a/lib/rack/handle_bad_encoding.rb
+++ b/lib/rack/handle_bad_encoding.rb
@@ -1,0 +1,19 @@
+module Rack
+  class HandleBadEncoding
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      if env["REQUEST_PATH"] == "/providers/suggest"
+        begin
+          Rack::Utils.parse_nested_query(env["QUERY_STRING"].to_s)
+        rescue Rack::Utils::InvalidParameterError
+          env["QUERY_STRING"] = ""
+        end
+      end
+
+      @app.call(env)
+    end
+  end
+end

--- a/spec/lib/rack/handle_bad_encoding_spec.rb
+++ b/spec/lib/rack/handle_bad_encoding_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe Rack::HandleBadEncoding do
+  let(:app) { double }
+  let(:middleware) { described_class.new(app) }
+
+  context "request path is '/providers/suggest'" do
+    context "query does not contain invalid encodings" do
+      it "does not modify the query" do
+        expect(app).to receive(:call).with("REQUEST_PATH" => "/providers/suggest", "QUERY_STRING" => "query=ucl")
+        middleware.call(
+          "REQUEST_PATH" => "/providers/suggest",
+          "QUERY_STRING" => "query=ucl",
+        )
+      end
+    end
+
+    context "query is absent" do
+      it "does not modify the query" do
+        expect(app).to receive(:call).with("REQUEST_PATH" => "/providers/suggest")
+        middleware.call("REQUEST_PATH" => "/providers/suggest")
+      end
+    end
+
+    context "query contains invalid encodings" do
+      it "modifies the query" do
+        expect(app).to receive(:call).with(
+          "QUERY_STRING" => "",
+          "REQUEST_PATH" => "/providers/suggest",
+        )
+        middleware.call(
+          "QUERY_STRING" => "query=%2UCL%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
+          "REQUEST_PATH" => "/providers/suggest",
+        )
+      end
+    end
+  end
+
+  context "request path is not 'providers/suggest'" do
+    it "does not modify the query" do
+      expect(app).to receive(:call).with(
+        "QUERY_STRING" => "query=%2UCL%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
+        "REQUEST_PATH" => "/foo/bar",
+      )
+      middleware.call(
+        "QUERY_STRING" => "query=%2UCL%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
+        "REQUEST_PATH" => "/foo/bar",
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context
- Fix for Sentry issue: https://sentry.io/organizations/dfe-bat/issues/?project=1780060&referrer=slack
- Un-authed requests can be made to the 'providers/suggest' endpoint containing invalid encodings (this endpoint is accessed by the autocomplete). Rails does not handle this natively and exceptions bubble up


### Changes proposed in this pull request
- This new middleware intercepts the request and drops the query if the request path == `/providers/suggest` and the query contains invalid encodings
- Inspired by: https://jamescrisp.org/2018/05/28/fixing-invalid-query-parameters-invalid-encoding-in-a-rails-app/

### Guidance to review
- To view the error locally, comment out the `bad_query_encoding` initialiser, and make a request to `/providers/suggest` with a query containing invalid encodings e.g. `BLAH%%fjf%%BLAH` 
- To view the fix, uncomment the initialiser, restart the app, and send the same request.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
