### PR TITLE
[3250] Update the error copy for search field

### DIFF
--- a/app/form_objects/initial_request_form.rb
+++ b/app/form_objects/initial_request_form.rb
@@ -4,11 +4,9 @@ class InitialRequestForm
   attr_accessor :training_provider_code, :training_provider_query
 
   def add_no_results_error
-    support_email = "becomingateacher@digital.education.gov.uk"
-
     errors.add(:training_provider_query,
                "We couldn't find this organisation - please check your information and try again.
-                To add a new organisation to Publish, contact #{support_email}.")
+                To add a new organisation to Publish, contact #{Settings.service_support.contact_email_address}.")
   end
 
   def add_no_search_query_error

--- a/app/form_objects/initial_request_form.rb
+++ b/app/form_objects/initial_request_form.rb
@@ -4,7 +4,11 @@ class InitialRequestForm
   attr_accessor :training_provider_code, :training_provider_query
 
   def add_no_results_error
-    errors.add(:training_provider_query, "We couldn't find this provider, please check your input and try again")
+    support_email = "becomingateacher@digital.education.gov.uk"
+
+    errors.add(:training_provider_query,
+               "We couldn't find this organisation - please check your information and try again.
+                To add a new organisation to Publish, contact #{support_email}.")
   end
 
   def add_no_search_query_error

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -244,7 +244,8 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_see_error_message_that_no_providers_exist_for_search
-    expect(page).to have_content("We couldn't find this provider, please check your input and try again")
+    expect(page)
+      .to have_content("We couldn't find this organisation - please check your information and try again. To add a new organisation to Publish, contact becomingateacher@digital.education.gov.uk.")
   end
 
   def when_i_search_again_for_a_training_provider_that_does_not_exist


### PR DESCRIPTION
If the user is attempting to search for a provider which we do not have
on the system, we display an error message with some advice to contact
support to get the provider added.

### Context

### Changes proposed in this pull request

### Guidance to review

- Login as an accredited body user
- Go to request new allocation (https://s121d02-3250-ptt-as.azurewebsites.net/organisations/B20/2020/allocations/request) 
- Search for a provider who would not be on the system
	- Displays error message with hint text to contact support
- Try a search for the provider but do not type in the provider name
	- Error message saying you need to type in more information


![image](https://user-images.githubusercontent.com/3441519/81308091-4e75b180-9079-11ea-89c2-f1608bb9edd7.png)

![image](https://user-images.githubusercontent.com/3441519/81308427-ab716780-9079-11ea-9435-349a1a950727.png)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
