### PR TITLE
[3251] Add check your information page and create initial allocation request

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -33,15 +33,21 @@ module Providers
         accredited_body_code: @provider.provider_code,
         provider_id: @training_provider.id,
         requested: requested?,
+        number_of_places: params[:number_of_places],
       )
 
-      redirect_to provider_recruitment_cycle_allocation_path(requested: params[:requested].downcase)
+      redirect_to provider_recruitment_cycle_allocation_path(
+        requested: (params[:requested].downcase unless initial_request?),
+        number_of_places: params[:number_of_places],
+      )
     end
 
     def show
       # TODO: temp until we retrieve the Allocation from the API
-      number_of_places = requested? ? 42 : 0
-      @allocation = Allocation.new(number_of_places: number_of_places)
+      @allocation = Allocation.new(
+        number_of_places: number_of_places,
+        request_type: (Allocation::RequestTypes::INITIAL if initial_request?),
+      )
     end
 
     def initial_request
@@ -81,7 +87,19 @@ module Providers
     end
 
     def requested?
-      params[:requested].downcase == "yes"
+      initial_request? || params[:requested].downcase == "yes"
+    end
+
+    def initial_request?
+      params[:number_of_places].present?
+    end
+
+    def number_of_places
+      if initial_request?
+        params[:number_of_places]
+      else
+        requested? ? 42 : 0
+      end
     end
   end
 end

--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -8,7 +8,9 @@ class InitialRequestFlow
   end
 
   def template
-    if number_of_places_page?
+    if check_your_information_page?
+      "providers/allocations/check_your_information"
+    elsif number_of_places_page?
       "providers/allocations/places"
     elsif blank_search_query? || empty_search_results?
       "providers/allocations/initial_request"
@@ -20,7 +22,7 @@ class InitialRequestFlow
   end
 
   def locals
-    if number_of_places_page?
+    if number_of_places_page? || check_your_information_page?
       {
         training_provider: training_provider,
       }
@@ -135,6 +137,10 @@ private
 
   def number_of_places_page?
     params[:training_provider_code].present? && params[:training_provider_code] != "-1"
+  end
+
+  def check_your_information_page?
+    params[:training_provider_code].present? && params[:places].present? && params[:training_provider_code] != "-1"
   end
 
   def training_provider

--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -11,7 +11,7 @@ class InitialRequestFlow
     if check_your_information_page?
       "providers/allocations/check_your_information"
     elsif number_of_places_page?
-      "providers/allocations/places"
+      "providers/allocations/number_of_places"
     elsif blank_search_query? || empty_search_results?
       "providers/allocations/initial_request"
     elsif pick_a_provider_page?
@@ -141,7 +141,7 @@ private
   end
 
   def check_your_information_page?
-    params[:training_provider_code].present? && params[:places].present? &&
+    params[:training_provider_code].present? && params[:number_of_places].present? &&
       params[:training_provider_code] != "-1" && !params[:change]
   end
 

--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -136,11 +136,13 @@ private
   end
 
   def number_of_places_page?
-    params[:training_provider_code].present? && params[:training_provider_code] != "-1"
+    params[:training_provider_code].present? && params[:training_provider_code] != "-1" ||
+      params[:change]
   end
 
   def check_your_information_page?
-    params[:training_provider_code].present? && params[:places].present? && params[:training_provider_code] != "-1"
+    params[:training_provider_code].present? && params[:places].present? &&
+      params[:training_provider_code] != "-1" && !params[:change]
   end
 
   def training_provider

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -11,6 +11,10 @@ class Allocation < Base
   property :request_type
 
   def has_places?
-    number_of_places.positive?
+    number_of_places.to_i.positive?
+  end
+
+  def initial_request?
+    request_type == Allocation::RequestTypes::INITIAL
   end
 end

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -28,9 +28,6 @@
                     ),
                     skip_enforcing_utf8: true do |form| %>
 
-      <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
-      <%= hidden_field_tag "number_of_places", params[:number_of_places] %>
-
       <fieldset class="govuk-fieldset">
         <%= legend %>
 
@@ -60,6 +57,8 @@
             </div>
           </dl>
         </div>
+      <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
+      <%= hidden_field_tag "number_of_places", params[:number_of_places] %>
 
       <%= form.submit "Send request", class: "govuk-button" %>
       <% end %>

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -1,0 +1,55 @@
+<%= content_for :page_title, "Check your information before sending your request"%>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(initial_request_provider_recruitment_cycle_allocations_path(
+                          @provider.provider_code,
+                          @provider.recruitment_cycle_year,
+                          training_provider_code: params[:training_provider_code],
+                          places: params[:places],
+                          )) %>
+<% end %>
+<% legend = capture do %>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
+            Check your information before sending your request
+        </h1>
+    </legend>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <%= form_with url: initial_request_provider_recruitment_cycle_allocations_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year,
+                  ),
+                skip_enforcing_utf8: true,
+                method: :get do |form| %>
+
+      <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
+      <%= hidden_field_tag "training_provider_code", params[:places] %>
+
+      <fieldset class="govuk-fieldset">
+        <%= legend %>
+
+        <%= render "shared/error_wrapper", error_keys: [:check_your_information], data_qa: "allocation__check_your_information" do %>
+
+        <div class="body-text">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Places requested
+              </dt>
+              <dd class="govuk-summary-list__value" id="number-of-places">
+                <%= params[:places] %>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+              </dd>
+            </div>
+          </dl>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -9,14 +9,6 @@
                           change: true,
                           )) %>
 <% end %>
-<% legend = capture do %>
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-        <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
-            Check your information before sending your request
-        </h1>
-    </legend>
-<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -28,40 +20,37 @@
                     ),
                     skip_enforcing_utf8: true do |form| %>
 
-      <fieldset class="govuk-fieldset">
-        <%= legend %>
+        <h1 class="govuk-heading-xl">
+            <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
+            Check your information before sending your request
+        </h1>
 
-        <%= render "shared/error_wrapper", error_keys: [:check_your_information], data_qa: "allocation__check_your_information" do %>
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Places requested
+            </dt>
+            <dd class="govuk-summary-list__value" id="number-of-places">
+              <%= params[:number_of_places] %>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to "Change",
+                initial_request_provider_recruitment_cycle_allocations_path(
+                  @provider.provider_code,
+                  @provider.recruitment_cycle_year,
+                  training_provider_code: params[:training_provider_code],
+                  number_of_places: params[:number_of_places],
+                  change: true,
+                  ),
+                class: "govuk-link" %>
+            </dd>
+          </div>
+        </dl>
 
-        <div class="body-text">
-          <dl class="govuk-summary-list">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Places requested
-              </dt>
-              <dd class="govuk-summary-list__value" id="number-of-places">
-                <%= params[:number_of_places] %>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-
-                <%= link_to "Change",
-                  initial_request_provider_recruitment_cycle_allocations_path(
-                    @provider.provider_code,
-                    @provider.recruitment_cycle_year,
-                    training_provider_code: params[:training_provider_code],
-                    number_of_places: params[:number_of_places],
-                    change: true,
-                    ),
-                  class: "govuk-link" %>
-              </dd>
-            </div>
-          </dl>
-        </div>
       <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
       <%= hidden_field_tag "number_of_places", params[:number_of_places] %>
 
       <%= form.submit "Send request", class: "govuk-button" %>
-      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -6,6 +6,7 @@
                           @provider.recruitment_cycle_year,
                           training_provider_code: params[:training_provider_code],
                           places: params[:places],
+                          change: true,
                           )) %>
 <% end %>
 <% legend = capture do %>
@@ -45,6 +46,16 @@
                 <%= params[:places] %>
               </dd>
               <dd class="govuk-summary-list__actions">
+
+                <%= link_to "Change",
+                  initial_request_provider_recruitment_cycle_allocations_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year,
+                    training_provider_code: params[:training_provider_code],
+                    places: params[:places],
+                    change: true,
+                    ),
+                  class: "govuk-link" %>
               </dd>
             </div>
           </dl>

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -18,7 +18,8 @@
                       params[:training_provider_code],
                       params[:number_of_places]
                     ),
-                    skip_enforcing_utf8: true do |form| %>
+                    skip_enforcing_utf8: true,
+                    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
         <h1 class="govuk-heading-xl">
             <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
@@ -50,7 +51,7 @@
       <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
       <%= hidden_field_tag "number_of_places", params[:number_of_places] %>
 
-      <%= form.submit "Send request", class: "govuk-button" %>
+      <%= form.govuk_submit "Send request" %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -31,7 +31,7 @@
             <dt class="govuk-summary-list__key">
               Places requested
             </dt>
-            <dd class="govuk-summary-list__value" id="number-of-places">
+            <dd class="govuk-summary-list__value">
               <%= params[:number_of_places] %>
             </dd>
             <dd class="govuk-summary-list__actions">

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -5,7 +5,7 @@
                           @provider.provider_code,
                           @provider.recruitment_cycle_year,
                           training_provider_code: params[:training_provider_code],
-                          places: params[:places],
+                          number_of_places: params[:number_of_places],
                           change: true,
                           )) %>
 <% end %>
@@ -20,16 +20,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-  <%= form_with url: initial_request_provider_recruitment_cycle_allocations_path(
-                    @provider.provider_code,
-                    @provider.recruitment_cycle_year,
-                  ),
-                skip_enforcing_utf8: true,
-                method: :get do |form| %>
+    <%= form_with url: provider_recruitment_cycle_allocation_path(
+                      @provider.provider_code,
+                      @provider.recruitment_cycle_year,
+                      params[:training_provider_code],
+                      params[:number_of_places]
+                    ),
+                    skip_enforcing_utf8: true do |form| %>
 
       <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
-      <%= hidden_field_tag "training_provider_code", params[:number_of_places] %>
+      <%= hidden_field_tag "number_of_places", params[:number_of_places] %>
 
       <fieldset class="govuk-fieldset">
         <%= legend %>
@@ -60,6 +60,8 @@
             </div>
           </dl>
         </div>
+
+      <%= form.submit "Send request", class: "govuk-button" %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -29,7 +29,7 @@
                 method: :get do |form| %>
 
       <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
-      <%= hidden_field_tag "training_provider_code", params[:places] %>
+      <%= hidden_field_tag "training_provider_code", params[:number_of_places] %>
 
       <fieldset class="govuk-fieldset">
         <%= legend %>
@@ -43,7 +43,7 @@
                 Places requested
               </dt>
               <dd class="govuk-summary-list__value" id="number-of-places">
-                <%= params[:places] %>
+                <%= params[:number_of_places] %>
               </dd>
               <dd class="govuk-summary-list__actions">
 
@@ -52,7 +52,7 @@
                     @provider.provider_code,
                     @provider.recruitment_cycle_year,
                     training_provider_code: params[:training_provider_code],
-                    places: params[:places],
+                    number_of_places: params[:number_of_places],
                     change: true,
                     ),
                   class: "govuk-link" %>

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -4,15 +4,6 @@
   <%= govuk_back_link_to(initial_request_provider_recruitment_cycle_allocations_path) %>
 <% end %>
 
-<% legend = capture do %>
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-        <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
-            How many places would you like to request?
-        </h1>
-    </legend>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
@@ -21,30 +12,34 @@
                     @provider.recruitment_cycle_year,
                   ),
                 skip_enforcing_utf8: true,
-                method: :get do |form| %>
+                method: :get,
+                builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
-      <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
+    <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
 
-      <fieldset class="govuk-fieldset">
-        <%= legend %>
+    <%= form.govuk_text_field :number_of_places,
+          label: {
+            text: "How many places would you like to request?",
+            size: "xl",
+            tag: "h1",
+          },
+          pattern: "[0-9]*",
+          inputmode: "numeric",
+          width: 10,
+          id: "number-of-places-input" do %>
 
-        <%= render "shared/error_wrapper", error_keys: [:number_of_places], data_qa: "allocation__places" do %>
+        <p class="govuk-body govuk-!-margin-bottom-4">
+          Say how many trainees the organisation would like to recruit
+          - make sure this number is as accurate as possible.
+        </p>
 
-        <div class="govuk-form-group">
-          <%= label_tag :number_of_places, "Say how many trainees the organisation would like to recruit -
-            make sure this number is as accurate as possible.",
-            class: "govuk-label" %>
-            <%= number_field_tag :number_of_places,
-                    params[:number_of_places],
-                    min: 1,
-                    maxlength: 3,
-                    class: "govuk-input govuk-input--width-10",
-                    id: "number-of-places-input" %>
-        </div>
-      </fieldset>
-
-      <%= form.submit "Continue", class: "govuk-button", data: { qa: 'request_continue' } %>
-      <% end %>
     <% end %>
+
+    <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
+
+
+
+    <%= form.govuk_submit %>
+  <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -25,8 +25,7 @@
           },
           pattern: "[0-9]*",
           inputmode: "numeric",
-          width: 10,
-          id: "number-of-places-input" do %>
+          width: 10 do %>
 
         <p class="govuk-body govuk-!-margin-bottom-4">
           Say how many trainees the organisation would like to recruit

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -28,14 +28,14 @@
       <fieldset class="govuk-fieldset">
         <%= legend %>
 
-        <%= render "shared/error_wrapper", error_keys: [:places], data_qa: "allocation__places" do %>
+        <%= render "shared/error_wrapper", error_keys: [:number_of_places], data_qa: "allocation__places" do %>
 
         <div class="govuk-form-group">
-          <%= label_tag :places, "Say how many trainees the organisation would like to recruit -
+          <%= label_tag :number_of_places, "Say how many trainees the organisation would like to recruit -
             make sure this number is as accurate as possible.",
             class: "govuk-label" %>
-            <%= number_field_tag :places,
-                    params[:places],
+            <%= number_field_tag :number_of_places,
+                    params[:number_of_places],
                     min: 1,
                     maxlength: 3,
                     class: "govuk-input govuk-input--width-10",

--- a/app/views/providers/allocations/places.html.erb
+++ b/app/views/providers/allocations/places.html.erb
@@ -34,7 +34,12 @@
           <%= label_tag :places, "Say how many trainees the organisation would like to recruit -
             make sure this number is as accurate as possible.",
             class: "govuk-label" %>
-          <%= number_field_tag :places, nil, min: 1, maxlength: 3, class: "govuk-input govuk-input--width-10" %>
+            <%= number_field_tag :places,
+                    params[:places],
+                    min: 1,
+                    maxlength: 3,
+                    class: "govuk-input govuk-input--width-10",
+                    id: "number-of-places-input" %>
         </div>
       </fieldset>
 

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -16,7 +16,9 @@
     </p>
     <p class="govuk-body">
       In September we’ll let you know how many places we’ve allocated for this course.
-      This will be based on the current year’s recruitment figure of (INSERT FIGURE).
+      <% unless @allocation.initial_request? %>
+        This will be based on the current year’s recruitment figure of (INSERT FIGURE).
+      <% end %>
       If you have any questions, contact <%= bat_contact_mail_to %>
     </p>
     <p class="govuk-body">You have until 10 July to change this request.</p>

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -36,6 +36,9 @@ RSpec.feature "PE allocations" do
     and_i_click_continue
     then_i_see_check_your_information_page
     and_the_number_is_the_new_one
+
+    when_i_click_send_request
+    then_i_see_confirmation_page
   end
 
   scenario "Accredited body requests new PE allocations for new training provider" do
@@ -311,5 +314,22 @@ RSpec.feature "PE allocations" do
 
   def and_the_number_is_the_new_one
     expect(find("#number-of-places")).to have_content("3")
+  end
+
+  def when_i_click_send_request
+    stub_request(:post, "http://localhost:3001/api/v2/providers/#{@accredited_body.provider_code}/allocations")
+      .with(
+        body: {
+          data: {
+            type: "allocations",
+            attributes: { provider_id: @training_provider.id, request_type: "initial", number_of_places: "3" },
+          },
+        }.to_json,
+      )
+    click_on "Send request"
+  end
+
+  def then_i_see_confirmation_page
+    expect(find("h1")).to have_content("Request sent")
   end
 end

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 
 RSpec.feature "PE allocations" do
   let(:allocations_page) { PageObjects::Page::Providers::Allocations::IndexPage.new }
+  let(:number_of_places_page) { PageObjects::Page::Providers::Allocations::NumberOfPlacesPage.new }
+  let(:check_your_info_page) { PageObjects::Page::Providers::Allocations::CheckYourInformationPage.new }
+  let(:allocations_show_page) { PageObjects::Page::Providers::Allocations::ShowPage.new }
 
   scenario "Accredited body requests new PE allocations" do
     given_accredited_body_exists
@@ -238,7 +241,7 @@ RSpec.feature "PE allocations" do
   end
 
   def then_i_see_number_of_places_page
-    expect(find("h1")).to have_content("How many places would you like to request?")
+    expect(number_of_places_page.header.text).to eq("How many places would you like to request?")
   end
 
   def then_i_see_pick_a_provider_page
@@ -293,27 +296,27 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_fill_in_the_number_of_places_input
-    find_field(:number_of_places).fill_in(with: "2")
+    number_of_places_page.number_of_places_field.fill_in(with: "2")
   end
 
   def then_i_see_check_your_information_page
-    expect(find("h1")).to have_content("Check your information before sending your request")
+    expect(check_your_info_page.header.text).to have_content("Check your information before sending your request")
   end
 
   def and_the_number_is_the_one_i_entered
-    expect(find(".govuk-summary-list__value")).to have_content("2")
+    expect(check_your_info_page.number_of_places.text).to have_content("2")
   end
 
   def when_i_click_change
-    click_on "Change"
+    check_your_info_page.change_link.click
   end
 
   def when_i_change_the_number
-    find_field(:number_of_places).fill_in(with: "3")
+    number_of_places_page.number_of_places_field.fill_in(with: "3")
   end
 
   def and_the_number_is_the_new_one
-    expect(find(".govuk-summary-list__value")).to have_content("3")
+    expect(check_your_info_page.number_of_places.text).to eq("3")
   end
 
   def when_i_click_send_request
@@ -326,10 +329,10 @@ RSpec.feature "PE allocations" do
           },
         }.to_json,
       )
-    click_on "Send request"
+    check_your_info_page.send_request_button.click
   end
 
   def then_i_see_confirmation_page
-    expect(find("h1")).to have_content("Request sent")
+    expect(allocations_show_page.page_heading).to have_content("Request sent")
   end
 end

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -293,7 +293,7 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_fill_in_the_number_of_places_input
-    find("#number-of-places-input").fill_in(with: "2")
+    find_field(:number_of_places).fill_in(with: "2")
   end
 
   def then_i_see_check_your_information_page
@@ -301,7 +301,7 @@ RSpec.feature "PE allocations" do
   end
 
   def and_the_number_is_the_one_i_entered
-    expect(find("#number-of-places")).to have_content("2")
+    expect(find(".govuk-summary-list__value")).to have_content("2")
   end
 
   def when_i_click_change
@@ -309,11 +309,11 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_change_the_number
-    find("#number-of-places-input").fill_in(with: "3")
+    find_field(:number_of_places).fill_in(with: "3")
   end
 
   def and_the_number_is_the_new_one
-    expect(find("#number-of-places")).to have_content("3")
+    expect(find(".govuk-summary-list__value")).to have_content("3")
   end
 
   def when_i_click_send_request

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -309,7 +309,7 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_change_the_number
-    find("#number-of-places-input").fill_in(with: "3", currently_with: "2")
+    find("#number-of-places-input").fill_in(with: "3")
   end
 
   def and_the_number_is_the_new_one

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -28,6 +28,14 @@ RSpec.feature "PE allocations" do
     and_i_click_continue
     then_i_see_check_your_information_page
     and_the_number_is_the_one_i_entered
+
+    when_i_click_change
+    then_i_see_number_of_places_page
+
+    when_i_change_the_number
+    and_i_click_continue
+    then_i_see_check_your_information_page
+    and_the_number_is_the_new_one
   end
 
   scenario "Accredited body requests new PE allocations for new training provider" do
@@ -291,5 +299,17 @@ RSpec.feature "PE allocations" do
 
   def and_the_number_is_the_one_i_entered
     expect(find("#number-of-places")).to have_content("2")
+  end
+
+  def when_i_click_change
+    click_on "Change"
+  end
+
+  def when_i_change_the_number
+    find("#number-of-places-input").fill_in(with: "3", currently_with: "2")
+  end
+
+  def and_the_number_is_the_new_one
+    expect(find("#number-of-places")).to have_content("3")
   end
 end

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -23,6 +23,11 @@ RSpec.feature "PE allocations" do
     and_i_choose_a_training_provider
     and_i_click_continue
     then_i_see_number_of_places_page
+
+    when_i_fill_in_the_number_of_places_input
+    and_i_click_continue
+    then_i_see_check_your_information_page
+    and_the_number_is_the_one_i_entered
   end
 
   scenario "Accredited body requests new PE allocations for new training provider" do
@@ -48,6 +53,11 @@ RSpec.feature "PE allocations" do
     and_i_click_continue
     then_i_see_number_of_places_page
     and_i_see_provider_name("Acme SCITT")
+
+    when_i_fill_in_the_number_of_places_input
+    and_i_click_continue
+    then_i_see_check_your_information_page
+    and_the_number_is_the_one_i_entered
   end
 
   scenario "Accredited body requests new PE allocations for training provider they can't find on first page" do
@@ -269,5 +279,17 @@ RSpec.feature "PE allocations" do
 
   def and_i_see_error_message_that_i_must_add_more_info
     expect(page).to have_content("You need to add some information")
+  end
+
+  def when_i_fill_in_the_number_of_places_input
+    find("#number-of-places-input").fill_in(with: "2")
+  end
+
+  def then_i_see_check_your_information_page
+    expect(find("h1")).to have_content("Check your information before sending your request")
+  end
+
+  def and_the_number_is_the_one_i_entered
+    expect(find("#number-of-places")).to have_content("2")
   end
 end

--- a/spec/site_prism/page_objects/page/providers/allocations/check_your_information_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/check_your_information_page.rb
@@ -1,0 +1,16 @@
+module PageObjects
+  module Page
+    module Providers
+      module Allocations
+        class CheckYourInformationPage < PageObjects::Base
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations/request"
+
+          element :header, "h1"
+          element :number_of_places, "dd.govuk-summary-list__value"
+          element :change_link, "dd.govuk-summary-list__actions a"
+          element :send_request_button, "input[value='Send request']"
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/providers/allocations/number_of_places_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/number_of_places_page.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module Page
+    module Providers
+      module Allocations
+        class NumberOfPlacesPage < PageObjects::Base
+          set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations/request"
+
+          element :header, "h1"
+          element :number_of_places_field, "#number-of-places-field"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
As an accredited body, 
I need to review my number before submitting, 
So that I know it is right

```
Given I am on the "How many places would you like to request?" page
When I input a number into the box and click continue
Then I should move to the "Check your information before sending your request" page 

Given I am on the "Check your information before sending your request" page 
When I review the number and click "submit"
Then I should move to the "Request sent confirmation" page 

Given I am on the "Check your information before sending your request" page 
When I click "change" beside the number
Then I should move back to the "How many places would you like to request?" page
```
Closes #1085
### Changes proposed in this pull request
- add "Check your information" page <kbd>
<img width="488" alt="Screenshot 2020-05-07 at 16 38 48" src="https://user-images.githubusercontent.com/38078064/81315194-e7a8c600-9081-11ea-9e25-732d7ed9afdb.png"></kbd>
- user is able to change the number of places by either clicking Change or Back
- clicking "Send request" 
  - creates an allocation with request_type is "initial" and number of number of places chosen by the user
  - redirects to confirmation page <kbd>
<img width="489" alt="Screenshot 2020-05-07 at 16 39 13" src="https://user-images.githubusercontent.com/38078064/81315953-e330dd00-9082-11ea-9d7f-bb7d821ac6dd.png"></kbd>


### Guidance to review
- go to http://localhost:3000/organisations/B20/2020/allocations/request
- go through the form
- change number of places
- when you click "Send request"
	- you are taken to the confirmation page
	- allocation exists in the API  (look at `Allocation.last` in the API's console)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
