### PR TITLE
[3364] Add sorting to training provider courses

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -79,7 +79,10 @@ class ProvidersController < ApplicationController
     @courses = Course
       .where(recruitment_cycle_year: @recruitment_cycle.year)
       .where(provider_code: @training_provider.provider_code)
-      .where(accrediting_provider_code: @provider.provider_code).map(&:decorate)
+      .where(accrediting_provider_code: @provider.provider_code)
+      .map(&:decorate)
+
+    @courses.sort_by!(&:course_code)
   end
 
   def search


### PR DESCRIPTION
### Context

We updated the 'Courses as an accredited body' functionality to avoid 403 errors that some users were experiencing (these were due to using the providers endpoint to retrieve the courses)

Prior to the update introduced the results were sorted by course code.

### Changes proposed in this pull request

Add sorting to the course results. The API doesn't currently support this and there is no pagination so we can just sort in the frontend.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
