### PR TITLE
[3305] - Create org users page

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -23,8 +23,6 @@
 #                          installed the spring binstubs per the docs)
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
-
-# rubocop:disable Metrics/BlockLength
 group :red_green_refactor, halt_on_fail: true do
   guard :rspec, cmd: "bundle exec spring rspec", failed_mode: :keep do
     require "guard/rspec/dsl"
@@ -43,7 +41,7 @@ group :red_green_refactor, halt_on_fail: true do
     dsl.watch_spec_files_for(ruby.lib_files)
 
     # Rails files
-    rails = dsl.rails(view_extensions: %w(erb))
+    rails = dsl.rails(view_extensions: %w[erb])
     dsl.watch_spec_files_for(rails.app_files)
     dsl.watch_spec_files_for(rails.views)
 
@@ -73,4 +71,3 @@ group :red_green_refactor, halt_on_fail: true do
     watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/app/controllers/providers/users_controller.rb
+++ b/app/controllers/providers/users_controller.rb
@@ -1,0 +1,15 @@
+module Providers
+  class UsersController < ApplicationController
+    def index
+      cycle_year = params.fetch(:year, Settings.current_cycle)
+      recruitment_cycle = RecruitmentCycle.find(cycle_year).first
+
+      @provider = Provider.includes(:users)
+                    .where(recruitment_cycle_year: recruitment_cycle.year)
+                    .find(params[:code])
+                    .first
+
+      @users = @provider.users
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,7 +1,6 @@
 class Provider < Base
   belongs_to :recruitment_cycle, param: :recruitment_cycle_year
   has_many :users
-
   has_many :courses, param: :course_code
   has_many :sites
   has_one :allocation

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,5 +1,7 @@
 class Provider < Base
   belongs_to :recruitment_cycle, param: :recruitment_cycle_year
+  has_many :users
+
   has_many :courses, param: :course_code
   has_many :sites
   has_one :allocation

--- a/app/views/providers/users/index.html.erb
+++ b/app/views/providers/users/index.html.erb
@@ -1,0 +1,20 @@
+<%= content_for :page_title, "Users" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Users</h1>
+    <p class="govuk-body">
+      These users currently have access to this account. They can manage all your course and organisation details, including publishing, closing and withdrawing courses.
+    </p>
+    <%= link_to "Invite user", request_access_provider_path(code: @provider.provider_code), class: "govuk-button" %>
+    <% @users.each do |user| %>
+      <div>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
+          <%= user.first_name user.last_name %>
+        </h2>
+        <p class="govuk-body govuk-!-margin-bottom-0"><%= user.email %></p>
+      </div>
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,6 @@ Rails.application.routes.draw do
       patch "/alerts", on: :member, to: "ucas_contacts#update_alerts"
     end
 
-
     # TODO: Extract year constraint to future proof for future cycles
     resources :recruitment_cycles, param: :year, constraints: { year: /2020|2021/ }, path: "", only: :show do
       get "/details", on: :member, to: "providers#details"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,10 +52,13 @@ Rails.application.routes.draw do
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"
 
+    get "/users", on: :member, to: "providers/users#index"
+
     resource :ucas_contacts, path: "ucas-contacts", on: :member, only: %i[show] do
       get "/alerts", on: :member, to: "ucas_contacts#alerts"
       patch "/alerts", on: :member, to: "ucas_contacts#update_alerts"
     end
+
 
     # TODO: Extract year constraint to future proof for future cycles
     resources :recruitment_cycles, param: :year, constraints: { year: /2020|2021/ }, path: "", only: :show do

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       sites { [] }
       recruitment_cycle { build :recruitment_cycle }
       include_counts { [] }
+      users { [] }
     end
 
     sequence(:id, &:to_s)
@@ -77,6 +78,11 @@ FactoryBot.define do
       provider.courses = []
       evaluator.courses.each do |course|
         provider.courses << course
+      end
+
+      provider.users = []
+      evaluator.users.each do |user|
+        provider.users << user
       end
 
       provider.recruitment_cycle = evaluator.recruitment_cycle

--- a/spec/features/providers/user_spec.rb
+++ b/spec/features/providers/user_spec.rb
@@ -33,7 +33,7 @@ feature "Provider users page" do
   def when_i_visit_the_providers_user_page
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{@provider.provider_code}?include=users",
-      @provider.to_jsonapi(include: %i[users])
+      @provider.to_jsonapi(include: %i[users]),
     )
 
     visit "/organisations/#{@provider.provider_code}/users"
@@ -44,7 +44,7 @@ feature "Provider users page" do
   end
 
   def and_i_see_the_users_details
-    expect(provider_users_page.user_name).to have_content("#{@user.first_name @user.last_name}")
+    expect(provider_users_page.user_name).to have_content((@user.first_name @user.last_name).to_s)
   end
 
   def when_i_click_on_request_access

--- a/spec/features/providers/user_spec.rb
+++ b/spec/features/providers/user_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+feature "Provider users page" do
+  let(:provider_users_page) { PageObjects::Page::Providers::Users::IndexPage.new }
+  let(:new_access_request_page) { PageObjects::Page::Organisations::NewManualAccessRequestPage.new }
+
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+
+  scenario "View a provider's user page" do
+    given_a_provider_exists
+    given_i_am_signed_in_as_a_provider_user
+
+    when_i_visit_the_providers_user_page
+
+    then_i_see_the_provider_users_page
+    and_i_see_the_users_details
+
+    when_i_click_on_request_access
+
+    then_i_see_the_request_access_form
+  end
+
+  def given_a_provider_exists
+    @user = build(:user)
+    @provider = build(:provider, users: [@user])
+  end
+
+  def given_i_am_signed_in_as_a_provider_user
+    stub_api_v2_resource(@provider.recruitment_cycle)
+    stub_omniauth(user: @user)
+  end
+
+  def when_i_visit_the_providers_user_page
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/#{@provider.provider_code}?include=users",
+      @provider.to_jsonapi(include: %i[users])
+    )
+
+    visit "/organisations/#{@provider.provider_code}/users"
+  end
+
+  def then_i_see_the_provider_users_page
+    expect(provider_users_page.heading).to have_content("Users")
+  end
+
+  def and_i_see_the_users_details
+    expect(provider_users_page.user_name).to have_content("#{@user.first_name @user.last_name}")
+  end
+
+  def when_i_click_on_request_access
+    click_on("Invite user")
+  end
+
+  def then_i_see_the_request_access_form
+    expect(page.current_path).to eq("/organisations/#{@provider.provider_code}/request-access")
+  end
+end

--- a/spec/site_prism/page_objects/page/providers/users/index_page.rb
+++ b/spec/site_prism/page_objects/page/providers/users/index_page.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module Page
+    module Providers
+      module Users
+        class IndexPage < PageObjects::Base
+          set_url "/organisations/{provider_code}/users"
+
+          element :heading, "h1"
+          element :user_name, "h2", match: :first
+        end
+      end
+    end
+  end
+end

--- a/spec/support/serializers/provider_serializer.rb
+++ b/spec/support/serializers/provider_serializer.rb
@@ -9,9 +9,10 @@ class ProviderSerializer < JSONAPI::Serializable::Resource
     end
   end
   has_many :sites
+  has_many :users
 
   attributes(*FactoryBot.attributes_for("provider").keys -
-             %i[courses sites])
+             %i[courses sites users])
 
   attribute :recruitment_cycle
   attribute :recruitment_cycle_year


### PR DESCRIPTION
**Note** that API changes need to be merged / deployed first - https://github.com/DFE-Digital/teacher-training-api/pull/1360

### Context
As a provider
I need to see the other users that have access to my org
So that I can check the right people have access

### Changes proposed in this pull request
- Creation of new page that lists users that have access to a particular provider (organisation)

![users_page](https://user-images.githubusercontent.com/5256922/82022791-21329000-9685-11ea-9607-2b8d49929928.gif)

### Guidance to review
- This is dependent on API changes so you will need to test locally
- Run the API on branch `3305-return-user-association-from-provider`
- Visit a providers fancy new users page `/organisations/K30/users`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
