### PR TITLE
[3390] Update notification page copy

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -4,14 +4,16 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl" data-qa="page-heading">
       <span class="govuk-caption-xl">Manage notifications</span>
-      Changes to courses as an accredited body
+      Changes to your courses as an accredited body
     </h1>
 
     <p class="govuk-body">
-      Receive notifications about courses that you’re the accredited body for.
-      You’ll be told about any new courses added and updated about changes to
-      existing courses.
+      You can sign up for email notifications about these courses. We’ll tell you when a training provider:
     </p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+      <li>adds a new course</li>
+      <li>makes a change to an existing course</li>
+    </ul>
   </div>
 </div>
 <div class="govuk-grid-row">
@@ -22,7 +24,7 @@
                                             legend: { size: "m", text: "Would you like to be notified?", tag: "span" }) do %>
 
         <%= form.govuk_radio_button :consent, "Yes",
-                                    label: { text: "Yes, send notifications to #{current_user["info"]["email"]}" } %>
+                                    label: { text: "Yes, send email notifications to #{current_user["info"]["email"]}" } %>
         <%= form.govuk_radio_button :consent, "No", label: { text: "No" } %>
       <% end %>
       <%= form.govuk_submit "Save" %>

--- a/app/views/providers/_notifications_sign_up_link.html.erb
+++ b/app/views/providers/_notifications_sign_up_link.html.erb
@@ -6,6 +6,6 @@
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
       <%= govuk_link_to "Notifications", notifications_path(provider_code: @provider.provider_code), class: "govuk-link", data:{qa: "notifications-link"} %>
     </h2>
-    <p class="govuk-body">Receive notifications about courses that you’re the accredited body for.</p>
+    <p class="govuk-body">Get email notifications about your courses.</p>
   </div>
 <% end %>


### PR DESCRIPTION
### Context

There is a concern that we aren't being clear enough that the notifications we are about launch are email notifications.

We have decided to make minor copy updates to included the phrase "email'.

What does success look like?
The following are updated to match attached designs and prototype

- Copy under Notifications heading in the sidebar (design attached)
- Copy and radio button label on the Manage Notifications page (prototype link attached)

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
