### PR TITLE
[3383] Use last years allocation from API

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -29,25 +29,19 @@ module Providers
 
     def create
       # TODO: we need to add error handling here
-      AllocationServices::Create.call(
+
+      allocation = AllocationServices::Create.call(
         accredited_body_code: @provider.provider_code,
         provider_id: @training_provider.id,
-        requested: requested?,
+        request_type: params[:request_type],
         number_of_places: params[:number_of_places],
       )
 
-      redirect_to provider_recruitment_cycle_allocation_path(
-        requested: (params[:requested].downcase unless initial_request?),
-        number_of_places: params[:number_of_places],
-      )
+      redirect_to provider_recruitment_cycle_allocation_path(id: allocation.id)
     end
 
     def show
-      # TODO: temp until we retrieve the Allocation from the API
-      @allocation = Allocation.new(
-        number_of_places: number_of_places,
-        request_type: (Allocation::RequestTypes::INITIAL if initial_request?),
-      )
+      @allocation = Allocation.find(params[:id]).first
     end
 
     def initial_request
@@ -84,22 +78,6 @@ module Providers
 
     def require_admin_permissions!
       render "errors/forbidden", status: :forbidden unless user_is_admin?
-    end
-
-    def requested?
-      initial_request? || params[:requested].downcase == "yes"
-    end
-
-    def initial_request?
-      params[:number_of_places].present?
-    end
-
-    def number_of_places
-      if initial_request?
-        params[:number_of_places]
-      else
-        requested? ? 42 : 0
-      end
     end
   end
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -5,7 +5,7 @@ class Allocation < Base
     DECLINED = "declined".freeze
   end
 
-  belongs_to :provider, param: :provider_code
+  belongs_to :provider, param: :provider_code, shallow_path: true
 
   property :number_of_places
   property :request_type

--- a/app/services/allocation_services/create.rb
+++ b/app/services/allocation_services/create.rb
@@ -2,8 +2,8 @@ module AllocationServices
   class Create
     include ServicePattern
 
-    def initialize(requested:, accredited_body_code:, provider_id:, number_of_places: nil)
-      @requested = requested
+    def initialize(request_type:, accredited_body_code:, provider_id:, number_of_places: nil)
+      @request_type = request_type
       @accredited_body_code = accredited_body_code
       @provider_id = provider_id
       @number_of_places = number_of_places
@@ -15,7 +15,7 @@ module AllocationServices
 
   private
 
-    attr_reader :requested, :accredited_body_code, :provider_id, :number_of_places
+    attr_reader :request_type, :accredited_body_code, :provider_id, :number_of_places
 
     def create_params
       {
@@ -25,12 +25,6 @@ module AllocationServices
       }.tap do |params_to_return|
         params_to_return[:number_of_places] = number_of_places if number_of_places.present?
       end
-    end
-
-    def request_type
-      return Allocation::RequestTypes::REPEAT if requested && number_of_places.nil?
-      return Allocation::RequestTypes::INITIAL if requested && number_of_places.present?
-      return Allocation::RequestTypes::DECLINED unless requested
     end
   end
 end

--- a/app/view_objects/allocations_view.rb
+++ b/app/view_objects/allocations_view.rb
@@ -87,6 +87,10 @@ private
       allocation_status[:requested] = Requested::NO
     end
 
+    if matching_allocation&.id
+      allocation_status[:id] = matching_allocation.id
+    end
+
     allocation_status
   end
 

--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -40,12 +40,13 @@
                   Change<span class="govuk-visually-hidden"> request for <%= allocation[:training_provider_name] %></span>
                 </a>
               </li>
+
               <li class="govuk-summary-list__actions-list-item">
                 <a class="govuk-link" data-qa="view-<%= allocation[:requested] %>-confirmation"
                    href="<%= provider_recruitment_cycle_allocation_path(@provider.provider_code,
                                                                         @provider.recruitment_cycle_year,
                                                                         allocation[:training_provider_code],
-                                                                        requested: allocation[:requested])
+                                                                        id: allocation[:id])
                    %>">
                   View&nbsp;confirmation<span class="govuk-visually-hidden"> for <%= allocation[:training_provider_name] %></span>
                 </a>

--- a/app/views/providers/allocations/index.html.erb
+++ b/app/views/providers/allocations/index.html.erb
@@ -34,7 +34,9 @@
           allocations: @allocations_view.repeat_allocation_statuses,
           request_type: "repeat"
         } %>
+
         <h3 class="govuk-heading-m">New PE courses 2020/21</h3>
+
         <%= render partial: "providers/allocations/request_status", locals: {
           allocations: @allocations_view.initial_allocation_statuses,
           request_type: "initial"

--- a/app/views/providers/allocations/repeat_request.html.erb
+++ b/app/views/providers/allocations/repeat_request.html.erb
@@ -25,25 +25,20 @@
                   ) do |form| %>
       <fieldset class="govuk-fieldset">
         <%= legend %>
-        <% field = "requested"%>
+        <% field = "request_type" %>
 
         <%= render "shared/error_wrapper", error_keys: [field], data_qa: "allocation__#{field}" do %>
-        <% ["Yes", "No"].each_with_index do |value| %>
-          <% label = value %>
+          <% {"Yes" => Allocation::RequestTypes::REPEAT, "No" => Allocation::RequestTypes::DECLINED}.each do |k,v| %>
 
           <div class="govuk-radios__item">
             <%= form.radio_button field,
-                  value,
+                  v,
                   class: 'govuk-radios__input',
                   data: {
-                    'aria-describedby': "#{field}-#{value}-help"
+                    'aria-describedby': "#{field}-#{v}-help"
                   }
             %>
-            <%= form.label field,
-                  label,
-                  value: value,
-                  class: "govuk-label govuk-radios__label"
-            %>
+            <%= form.label "#{field}_#{v}", k, class: "govuk-label govuk-radios__label" %>
           </div>
         <% end %>
       </fieldset>

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -17,7 +17,7 @@
     <p class="govuk-body">
       In September we’ll let you know how many places we’ve allocated for this course.
       <% unless @allocation.initial_request? %>
-        This will be based on the current year’s recruitment figure of (INSERT FIGURE).
+        This will be based on the current year’s recruitment figure of <strong><%= @allocation.number_of_places %></strong>.
       <% end %>
       If you have any questions, contact <%= bat_contact_mail_to %>
     </p>

--- a/spec/features/requesting_new_allocations_spec.rb
+++ b/spec/features/requesting_new_allocations_spec.rb
@@ -176,6 +176,7 @@ RSpec.feature "PE allocations" do
       :allocation,
       accredited_body: @accredited_body,
       provider: @training_provider_with_allocation,
+      number_of_places: 2,
     )
 
     stub_api_v2_request(
@@ -323,15 +324,17 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_click_send_request
-    stub_request(:post, "http://localhost:3001/api/v2/providers/#{@accredited_body.provider_code}/allocations")
-      .with(
-        body: {
-          data: {
-            type: "allocations",
-            attributes: { provider_id: @training_provider.id, request_type: "initial", number_of_places: "3" },
-          },
-        }.to_json,
-      )
+    stub_api_v2_request(
+      "/providers/#{@accredited_body.provider_code}/allocations",
+      resource_list_to_jsonapi([@allocation]),
+      :post,
+    )
+
+    stub_api_v2_request(
+      "/allocations/#{@allocation.id}",
+      resource_list_to_jsonapi([@allocation]),
+    )
+
     check_your_info_page.send_request_button.click
   end
 

--- a/spec/services/allocation_services/create_spec.rb
+++ b/spec/services/allocation_services/create_spec.rb
@@ -19,10 +19,10 @@ module AllocationServices
               )
 
             described_class.call(
-              requested: true,
               accredited_body_code: accredited_body_code,
               provider_id: provider_id,
               number_of_places: number_of_places,
+              request_type: Allocation::RequestTypes::INITIAL,
             )
           end
         end
@@ -37,9 +37,9 @@ module AllocationServices
               )
 
             described_class.call(
-              requested: true,
               accredited_body_code: accredited_body_code,
               provider_id: provider_id,
+              request_type: Allocation::RequestTypes::REPEAT,
             )
           end
         end
@@ -55,9 +55,9 @@ module AllocationServices
             )
 
           described_class.call(
-            requested: false,
             accredited_body_code: accredited_body_code,
             provider_id: provider_id,
+            request_type: Allocation::RequestTypes::DECLINED,
           )
         end
       end

--- a/spec/site_prism/page_objects/page/providers/allocations/new_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/new_page.rb
@@ -5,8 +5,9 @@ module PageObjects
         class NewPage < PageObjects::Base
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations/{training_provider_code}/new"
 
-          element :yes, "#requested_yes"
-          element :no, "#requested_no"
+          element :form, "form"
+          element :yes, "#request_type_repeat"
+          element :no, "#request_type_declined"
           element :continue_button, "input[value='Continue']"
         end
       end

--- a/spec/view_objects/allocations_view_spec.rb
+++ b/spec/view_objects/allocations_view_spec.rb
@@ -26,6 +26,7 @@ describe AllocationsView do
             status: AllocationsView::Status::REQUESTED,
             status_colour: AllocationsView::Colour::GREEN,
             requested: AllocationsView::Requested::YES,
+            id: repeat_allocation.id,
           },
         ])
       }
@@ -46,6 +47,7 @@ describe AllocationsView do
             status: AllocationsView::Status::NOT_REQUESTED,
             status_colour: AllocationsView::Colour::RED,
             requested: AllocationsView::Requested::NO,
+            id: declined_allocation.id,
           },
         ])
       }


### PR DESCRIPTION
### Context

- https://trello.com/c/tZVaEdzD/3383-use-last-year-allocations
- Now that we have imported last years allocations we can start using them instead of dummy data

### Changes proposed in this pull request

- `request_type` now part of api and not via a virtual attribute
- Remove hard coded dummy data
- Confirmation page `number_of_places` placeholder now uses API data

### Guidance to review

- Depends on https://github.com/DFE-Digital/teacher-training-api/pull/1361
- Request a repeat allocation
- This allocation should have same number_of_places as previous allocation and can be seen on the confirmation page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] ~Product Review~
