### PR TITLE
[3383] Show initial allocations on index page

### DIFF
--- a/app/view_objects/allocations_view.rb
+++ b/app/view_objects/allocations_view.rb
@@ -33,9 +33,8 @@ class AllocationsView
   end
 
   def initial_allocation_statuses
-    statuses = @training_providers.map do |training_provider|
-      matching_allocation = find_matching_allocation(training_provider, initial_allocations)
-      build_initial_allocations(matching_allocation, training_provider)
+    statuses = initial_allocations.map do |allocation|
+      build_initial_allocations(allocation, allocation.provider)
     end
 
     statuses.compact
@@ -97,13 +96,17 @@ private
   def build_initial_allocations(matching_allocation, training_provider)
     return if matching_allocation.nil?
 
-    {
+    hash = {
       training_provider_name: training_provider.provider_name,
       training_provider_code: training_provider.provider_code,
       status_colour: Colour::GREEN,
       requested: Requested::YES,
       status: "#{matching_allocation.number_of_places} PLACES REQUESTED",
     }
+
+    hash[:id] = matching_allocation.id if matching_allocation.id
+
+    hash
   end
 
   def not_requested?(matching_allocation)

--- a/spec/view_objects/allocations_view_spec.rb
+++ b/spec/view_objects/allocations_view_spec.rb
@@ -82,9 +82,11 @@ describe AllocationsView do
       let(:initial_allocation) do
         build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 3)
       end
+
       let(:repeat_allocation) do
         build(:allocation, :repeat, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 4)
       end
+
       let(:allocations) { [initial_allocation, repeat_allocation] }
 
       it {
@@ -95,6 +97,7 @@ describe AllocationsView do
             status: "3 PLACES REQUESTED",
             status_colour: AllocationsView::Colour::GREEN,
             requested: AllocationsView::Requested::YES,
+            id: initial_allocation.id,
           },
         ])
       }


### PR DESCRIPTION
### Context

- Allocations index page were not showing newly create initial allocations
- This changes fixes that

### Changes proposed in this pull request

- https://trello.com/c/tZVaEdzD/3383-use-last-year-allocations
- Incorrect logic meant initial allocations were not showing on the
index page
- We now grab the initial allocations and iterate thru those instead

### Guidance to review

- 
### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
