### PR TITLE
[3392] Integrate notifications endpoint

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,27 +1,36 @@
 class NotificationsController < ApplicationController
-  def index; end
+  def index
+    user_notification_preferences
+  end
 
-  def create
-    if params[:consent].nil?
-      # TODO: Better Error messages once wired up to API
-      flash[:error] = "Please select one option"
+  def update
+    if params[:user_notification_preferences][:explicitly_enabled].nil?
+      flash[:error] = {
+        id: "user-notification-preferences-explicitly-enabled-field",
+        message: "Please select one option",
+      }
       redirect_to notifications_path
       return
     end
 
-    if params.require(:consent).present?
-      flash[:success] = "Your notification preferences have been saved."
-      redirect_to redirect_to_path
-    end
+    user_notification_preferences.update(
+      enabled: params[:user_notification_preferences][:explicitly_enabled],
+    )
+    flash[:success] = "Your notification preferences have been saved."
+    redirect_to redirect_to_path
   end
 
 private
 
   def redirect_to_path
-    if params[:provider_code].present?
-      provider_path(params[:provider_code])
+    if params[:user_notification_preferences][:provider_code].present?
+      provider_path(params[:user_notification_preferences][:provider_code])
     else
       root_path
     end
+  end
+
+  def user_notification_preferences
+    @user_notification_preferences ||= UserNotificationPreferences.find(current_user["user_id"]).first
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,10 @@
 class NotificationsController < ApplicationController
   def index
-    user_notification_preferences
+    @notifications_view = NotificationsView.new(
+      request: request,
+      current_user: current_user,
+      user_notification_preferences: user_notification_preferences,
+    )
   end
 
   def update

--- a/app/models/user_notification_preferences.rb
+++ b/app/models/user_notification_preferences.rb
@@ -1,0 +1,12 @@
+class UserNotificationPreferences < Base
+  belongs_to :user, shallow_path: true
+
+  property :enabled
+  property :updated_at
+
+  def explicitly_enabled
+    return nil if updated_at.blank?
+
+    enabled
+  end
+end

--- a/app/view_objects/notifications_view.rb
+++ b/app/view_objects/notifications_view.rb
@@ -1,0 +1,40 @@
+class NotificationsView
+  ORGANISATION_URL_PATTERN = /\/organisations\/(\S+)\/?/.freeze
+
+  attr_reader :user_notification_preferences
+
+  def initialize(
+    request:,
+    current_user:,
+    user_notification_preferences:
+  )
+    @request = request
+    @current_user = current_user
+    @user_notification_preferences = user_notification_preferences
+  end
+
+  def user_id
+    current_user["user_id"]
+  end
+
+  def user_email
+    current_user["info"]["email"]
+  end
+
+  def cancel_link_path
+    return Rails.application.routes.url_helpers.root_path if ORGANISATION_URL_PATTERN.match(request.referer).nil?
+
+    URI(request.referer).path
+  end
+
+  def provider_code
+    matches = ORGANISATION_URL_PATTERN.match(request.referer)
+    return if matches.nil?
+
+    matches[1]
+  end
+
+private
+
+  attr_reader :request, :current_user
+end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -18,14 +18,27 @@
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with url:notifications_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_for @user_notification_preferences,
+      url: notification_path(current_user["user_id"]),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <%= form.hidden_field :provider_code, value: params[:provider_code] %>
-      <%= form.govuk_radio_buttons_fieldset(:consent,
-                                            legend: { size: "m", text: "Would you like to be notified?", tag: "span" }) do %>
+      <%= form.govuk_radio_buttons_fieldset(
+        :explitly_enabled,
+        legend: {
+          size: "m",
+          text: "Would you like to be notified?",
+          tag: "span" }) do %>
 
-        <%= form.govuk_radio_button :consent, "Yes",
-                                    label: { text: "Yes, send email notifications to #{current_user["info"]["email"]}" } %>
-        <%= form.govuk_radio_button :consent, "No", label: { text: "No" } %>
+        <%= form.govuk_radio_button :explicitly_enabled,
+          true,
+          label: {
+            text: "Yes, send email notifications to #{current_user["info"]["email"]}"
+        } %>
+        <%= form.govuk_radio_button :explicitly_enabled,
+          false,
+          label: {
+            text: "No"
+        } %>
       <% end %>
       <%= form.govuk_submit "Save" %>
     <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -18,10 +18,10 @@
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_for @user_notification_preferences,
-      url: notification_path(current_user["user_id"]),
+    <%= form_for @notifications_view.user_notification_preferences,
+      url: notification_path(@notifications_view.user_id),
       builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <%= form.hidden_field :provider_code, value: params[:provider_code] %>
+      <%= form.hidden_field :provider_code, value: @notifications_view.provider_code %>
       <%= form.govuk_radio_buttons_fieldset(
         :explitly_enabled,
         legend: {
@@ -32,7 +32,7 @@
         <%= form.govuk_radio_button :explicitly_enabled,
           true,
           label: {
-            text: "Yes, send email notifications to #{current_user["info"]["email"]}"
+            text: "Yes, send email notifications to #{@notifications_view.user_email}"
         } %>
         <%= form.govuk_radio_button :explicitly_enabled,
           false,
@@ -41,6 +41,11 @@
         } %>
       <% end %>
       <%= form.govuk_submit "Save" %>
+      <p class="govuk-body">
+        <%= link_to "Cancel changes", @notifications_view.cancel_link_path,
+          class: "govuk-link",
+          id: "cancel-changes-link" %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   root to: "providers#index"
   get "/organisations", to: redirect("/")
 
-  resources :notifications, path: "/notifications", controller: "notifications", only: %i[index create]
+  resources :notifications, path: "/notifications", controller: "notifications", only: %i[index update]
 
   resources :access_requests, path: "/access-requests", controller: "access_requests", only: %i[new index create] do
     member do

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+describe NotificationsController, type: :controller do
+  let(:current_user) do
+    {
+      user_id: 1,
+      uid: SecureRandom.uuid,
+      info: {
+        email: "dave@example.com",
+      },
+    }.with_indifferent_access
+  end
+
+  describe "UPDATE" do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user)
+        .and_return(current_user)
+
+      user_notification_preferences = instance_double(UserNotificationPreferences)
+      allow(user_notification_preferences).to receive(:update).and_return(user_notification_preferences)
+      allow(UserNotificationPreferences).to receive(:find).and_return([user_notification_preferences])
+    end
+
+    context "params[:provider_code] not present" do
+      it "redirects to the root path" do
+        params = {
+          user_notification_preferences: {
+            explicitly_enabled: true,
+          },
+          id: current_user[:user_id],
+        }
+
+        put :update, params: params
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "params[:provider_code] is present" do
+      it "redirects to the provider_path" do
+        provider_code = "A1"
+        params = {
+          user_notification_preferences: {
+            explicitly_enabled: true,
+            provider_code: provider_code,
+          },
+          id: current_user[:user_id],
+        }
+
+        put :update, params: params
+        expect(response).to redirect_to(provider_path(provider_code))
+      end
+    end
+  end
+end

--- a/spec/factories/user_notification_preferences.rb
+++ b/spec/factories/user_notification_preferences.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :user_notification_preferences do
+  end
+end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -31,23 +31,27 @@ feature "Notifications", type: :feature do
       then_i_should_see_notifications_link
     end
 
-    describe "User opting into notifications" do
+    describe "User sets notification preferences for the first time" do
       it "should allow the user to opt into notifications" do
+        given_a_user_has_never_set_their_preferences
         when_i_visit_accredited_body_page
         and_i_click_on_notifications_link
         then_the_notifications_page_is_displayed
-        and_i_opt_into_notifications
+        then_neither_radio_button_is_selected
+        and_i_select_yes
         and_save_my_choice
         then_i_should_see_my_preferences_have_been_saved
       end
     end
 
-    describe "User opting out of notifications" do
+    describe "User updates notification preferences" do
       it "should allow the user to opt into notifications" do
+        given_a_user_has_previously_set_their_preferences
         when_i_visit_accredited_body_page
         and_i_click_on_notifications_link
         then_the_notifications_page_is_displayed
-        and_i_opt_out_of_notifications
+        then_yes_radio_button_is_preselected
+        and_i_select_no
         and_save_my_choice
         then_i_should_see_my_preferences_have_been_saved
       end
@@ -55,6 +59,34 @@ feature "Notifications", type: :feature do
   end
 
 private
+
+  def given_a_user_has_never_set_their_preferences
+    notification = build(
+      :user_notification_preferences,
+      id: user.id,
+      updated_at: nil,
+      enabled: false,
+    )
+
+    stub_api_v2_request(
+      "/user_notification_preferences/#{user.id}",
+      resource_list_to_jsonapi([notification]),
+    )
+  end
+
+  def given_a_user_has_previously_set_their_preferences
+    notification = build(
+      :user_notification_preferences,
+      id: user.id,
+      updated_at: Time.zone.now,
+      enabled: true,
+    )
+
+    stub_api_v2_request(
+      "/user_notification_preferences/#{user.id}",
+      resource_list_to_jsonapi([notification]),
+    )
+  end
 
   def when_i_visit_providers_page
     visit provider_path(provider.provider_code)
@@ -80,11 +112,53 @@ private
     expect(notifications_index_page).to be_displayed
   end
 
-  def and_i_opt_into_notifications
+  def and_i_select_yes
+    params = { "data" =>
+      { "id" => user.id.to_s,
+        "type" => "user_notification_preferences",
+        "attributes" => { "enabled" => "true" } } }.to_json
+
+    response_body =
+      { "_jsonapi" =>
+        { "data" =>
+          { "type" => "user_notification_preferences",
+            "id" => user.id.to_s,
+            "attributes" =>
+            { "enabled" => "true",
+              "updated_at" => "2020-05-20T10:00:00+01:00"  }  }  }  }
+
+    @put_request = stub_api_v2_request(
+      "/user_notification_preferences/#{user.id}",
+      response_body,
+      :patch,
+      200,
+      body: params,
+    )
     notifications_index_page.opt_in_radio.click
   end
 
-  def and_i_opt_out_of_notifications
+  def and_i_select_no
+    params = { "data" =>
+      { "id" => user.id.to_s,
+        "type" => "user_notification_preferences",
+        "attributes" => { "enabled" => "false" } } }.to_json
+
+    response_body =
+      { "_jsonapi" =>
+        { "data" =>
+          { "type" => "user_notification_preferences",
+            "id" => user.id.to_s,
+            "attributes" =>
+            { "enabled" => "false",
+              "updated_at" => "2020-05-20T10:00:00+01:00"  }  }  }  }
+
+    @put_request = stub_api_v2_request(
+      "/user_notification_preferences/#{user.id}",
+      response_body,
+      :patch,
+      200,
+      body: params,
+    )
     notifications_index_page.opt_out_radio.click
   end
 
@@ -93,7 +167,17 @@ private
   end
 
   def then_i_should_see_my_preferences_have_been_saved
+    expect(@put_request).to have_been_made
     expect(organisation_show_page)
       .to have_content("Your notification preferences have been saved")
+  end
+
+  def then_yes_radio_button_is_preselected
+    expect(notifications_index_page.opt_in_radio).to be_checked
+  end
+
+  def then_neither_radio_button_is_selected
+    expect(notifications_index_page.opt_in_radio).not_to be_checked
+    expect(notifications_index_page.opt_out_radio).not_to be_checked
   end
 end

--- a/spec/models/user_notification_preferences_spec.rb
+++ b/spec/models/user_notification_preferences_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe UserNotificationPreferences do
+  describe "#explictly_enabled" do
+    subject { UserNotificationPreferences.new(enabled: enabled, updated_at: updated_at).explicitly_enabled }
+
+    context "enabled == true" do
+      let(:enabled) { true }
+
+      context "updated_at is present" do
+        let(:updated_at) { Time.zone.now.to_s }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    context "enabled == false" do
+      let(:enabled) { false }
+
+      context "updated_at is empty" do
+        let(:updated_at) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "updated_at is present" do
+        let(:updated_at) { Time.zone.now.to_s }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/notifications/index_page.rb
+++ b/spec/site_prism/page_objects/page/notifications/index_page.rb
@@ -4,8 +4,8 @@ module PageObjects
       class IndexPage < PageObjects::Base
         set_url "/notifications"
 
-        element :opt_in_radio, "#consent-yes-field"
-        element :opt_out_radio, "#consent-no-field"
+        element :opt_in_radio, "#user-notification-preferences-explicitly-enabled-true-field"
+        element :opt_out_radio, "#user-notification-preferences-explicitly-enabled-field"
         element :save_button, "input[value=Save]"
       end
     end

--- a/spec/site_prism/page_objects/page/notifications/index_page.rb
+++ b/spec/site_prism/page_objects/page/notifications/index_page.rb
@@ -4,6 +4,7 @@ module PageObjects
       class IndexPage < PageObjects::Base
         set_url "/notifications"
 
+        element :cancel_changes_link, "#cancel-changes-link"
         element :opt_in_radio, "#user-notification-preferences-explicitly-enabled-true-field"
         element :opt_out_radio, "#user-notification-preferences-explicitly-enabled-field"
         element :save_button, "input[value=Save]"

--- a/spec/support/resource_list_to_jsonapi.rb
+++ b/spec/support/resource_list_to_jsonapi.rb
@@ -18,6 +18,7 @@ def resource_list_to_jsonapi(resource_list, **opts)
       AccessRequest: AccessRequestSerializer,
       Organisation: OrganisationSerializer,
       Allocation: AllocationSerializer,
+      UserNotificationPreferences: UserNotificationPreferencesSerializer,
     },
     include: opts[:include],
     meta: opts[:meta],

--- a/spec/support/serializers/user_notifications_preferences_serializer.rb
+++ b/spec/support/serializers/user_notifications_preferences_serializer.rb
@@ -1,0 +1,10 @@
+class UserNotificationPreferencesSerializer < JSONAPI::Serializable::Resource
+  type "user_notification_preferences"
+
+  belongs_to :user
+
+  attributes(*FactoryBot.attributes_for("user_notification_preferences").keys)
+
+  attribute :enabled
+  attribute :updated_at
+end

--- a/spec/view_objects/notifications_view_spec.rb
+++ b/spec/view_objects/notifications_view_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe NotificationsView do
+  subject do
+    described_class.new(
+      request: request,
+      current_user: current_user,
+      user_notification_preferences: user_notification_preferences,
+    )
+  end
+
+  let(:request) { double(referer: referer_url) }
+  let(:current_user) do
+    {
+      "user_id" => user_id,
+      "info" => {
+        "email" => user_email,
+      },
+    }
+  end
+  let(:user_id) { "123" }
+  let(:user_email) { "dave@example.com" }
+  let(:user_notification_preferences) { double }
+  let(:referer_url) { "https://www.example.com#{referer_path}" }
+  let(:referer_path) { "/organisations/B20" }
+
+  describe "#user_id" do
+    it "returns the current_user['user_id']" do
+      expect(subject.user_id).to eq(user_id)
+    end
+  end
+
+  describe "#user_email" do
+    it "returns the current_user['info']['email']" do
+      expect(subject.user_email).to eq(user_email)
+    end
+  end
+
+  describe "#cancel_link_path" do
+    context "referer is organisation page" do
+      it "returns the referer path" do
+        expect(subject.cancel_link_path).to eq(referer_path)
+      end
+    end
+
+    context "referer is not an organisation page" do
+      let(:referer_path) { "/interruption_screen_path" }
+
+      it "returns root_path" do
+        expect(subject.cancel_link_path).to eq(Rails.application.routes.url_helpers.root_path)
+      end
+    end
+  end
+
+  describe "#provider_code" do
+    context "referer is organisation page" do
+      it "returns the referer provider code" do
+        expect(subject.provider_code).to eq("B20")
+      end
+    end
+
+    context "referer is not an organisation page" do
+      let(:referer_path) { "/interruption_screen_path" }
+
+      it "returns nil" do
+        expect(subject.provider_code).to be_nil
+      end
+    end
+  end
+
+  describe "#user_notification_preferences" do
+    it "returns user_notification_preferences" do
+      expect(subject.user_notification_preferences).to eq(user_notification_preferences)
+    end
+  end
+end

--- a/spec/views/notifications/index_spec.rb
+++ b/spec/views/notifications/index_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "notifications/index" do
+  let(:notifications_index_page) { PageObjects::Page::Notifications::IndexPage.new }
+  let(:notifications_view) { instance_double(NotificationsView) }
+  let(:cancel_link_path) { "/organisations/B20" }
+
+  before do
+    allow(notifications_view).to receive(:user_id).and_return("123")
+    allow(notifications_view).to receive(:user_email)
+    allow(notifications_view).to receive(:user_notification_preferences).and_return(build(:user_notification_preferences))
+    allow(notifications_view).to receive(:provider_code)
+    allow(notifications_view).to receive(:cancel_link_path).and_return(cancel_link_path)
+    assign(:notifications_view, notifications_view)
+
+    render
+    notifications_index_page.load(rendered)
+  end
+
+  describe "cancel changes link" do
+    it "links to cancel link path" do
+      expect(notifications_index_page.cancel_changes_link["href"]).to eq(cancel_link_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We are adding a feature to enable a user (from an accredited body only at this stage) to enable/disable email notifications when a course that their accredited body ratifies is created or updated.

### Changes proposed in this pull request

Update the existing implementation to use the new API endpoint at `/user_notification_preferences`

### Guidance to review

Runs with [this API branch](https://github.com/DFE-Digital/teacher-training-api/pull/1369) which has yet to be approved/merged. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
