### PR TITLE
[3422] Remove own provider from training providers

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -67,11 +67,13 @@ class ProvidersController < ApplicationController
 
   def training_providers
     @training_providers = @provider.training_providers(recruitment_cycle_year: @recruitment_cycle.year)
+    @training_providers.delete_if { |tp| tp.provider_code == @provider.provider_code }
 
     courses = Course.where(
       recruitment_cycle_year: @recruitment_cycle.year,
       accrediting_provider_code: @provider.provider_code,
     )
+
     @course_counts = courses.group_by(&:provider_code).transform_values(&:size)
   end
 

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -26,7 +26,7 @@ feature "get training_providers", type: :feature do
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
       "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
-      resource_list_to_jsonapi([training_provider1, training_provider2]),
+      resource_list_to_jsonapi([accrediting_body1, training_provider1, training_provider2]),
     )
     stub_api_v2_resource_collection([access_request])
   end
@@ -62,6 +62,12 @@ feature "get training_providers", type: :feature do
         expect(page).to have_link(accrediting_body1.provider_name.to_s, href: "/organisations/#{accrediting_body1.provider_code}")
         expect(page).to have_content("Courses as an accredited body")
       end
+    end
+
+    it "does not display itself as a training provider" do
+      visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+
+      expect(organisation_training_providers_page.training_providers_list).to_not have_content(accrediting_body1.provider_name)
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/Hwg5ZBqT/3422-accredited-bodies-should-be-able-to-request-pe-allocations
- The API has changed and now training providers returns itself if there offer their won courses
- There is a view in publish where we do not want the provider itself to be show and has therefore been removed on the frontend

### Changes proposed in this pull request

- There is an API change and now training providers list returns the
current provider if they themselves offer courses
- We don't want this in publish training providers page so has been
removed here

### Guidance to review

- Depends on https://github.com/DFE-Digital/teacher-training-api/pull/1374
- Find a provider that also has their own courses eg http://localhost:3000/organisations/2AT/2020/training-providers
- They should not see themselves on the training providers page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
