### PR TITLE
[3414] Correctly pluralise allocation status

### DIFF
--- a/app/view_objects/allocations_view.rb
+++ b/app/view_objects/allocations_view.rb
@@ -1,4 +1,6 @@
 class AllocationsView
+  include ActionView::Helpers::TextHelper
+
   module Status
     REQUESTED = "REQUESTED".freeze
     NOT_REQUESTED = "NOT REQUESTED".freeze
@@ -101,7 +103,7 @@ private
       training_provider_code: training_provider.provider_code,
       status_colour: Colour::GREEN,
       requested: Requested::YES,
-      status: "#{matching_allocation.number_of_places} PLACES REQUESTED",
+      status: "#{pluralize(matching_allocation.number_of_places, 'place')} requested".upcase,
     }
 
     hash[:id] = matching_allocation.id if matching_allocation.id

--- a/spec/view_objects/allocations_view_spec.rb
+++ b/spec/view_objects/allocations_view_spec.rb
@@ -79,28 +79,42 @@ describe AllocationsView do
     subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).initial_allocation_statuses }
 
     context "Accredited body has requested an initial allocation for a training provider" do
-      let(:initial_allocation) do
-        build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 3)
+      context "more than 1 place requested" do
+        let(:initial_allocation) do
+          build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 3)
+        end
+
+        let(:repeat_allocation) do
+          build(:allocation, :repeat, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 4)
+        end
+
+        let(:allocations) { [initial_allocation, repeat_allocation] }
+
+        it {
+          is_expected.to eq([
+            {
+              training_provider_name: training_provider.provider_name,
+              training_provider_code: training_provider.provider_code,
+              status: "3 PLACES REQUESTED",
+              status_colour: AllocationsView::Colour::GREEN,
+              requested: AllocationsView::Requested::YES,
+              id: initial_allocation.id,
+            },
+          ])
+        }
       end
 
-      let(:repeat_allocation) do
-        build(:allocation, :repeat, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 4)
+      context "1 place requested" do
+        let(:initial_allocation) do
+          build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+        end
+
+        let(:allocations) { [initial_allocation] }
+
+        it "correctly pluralizes the status" do
+          expect(subject.first[:status]).to eq("1 PLACE REQUESTED")
+        end
       end
-
-      let(:allocations) { [initial_allocation, repeat_allocation] }
-
-      it {
-        is_expected.to eq([
-          {
-            training_provider_name: training_provider.provider_name,
-            training_provider_code: training_provider.provider_code,
-            status: "3 PLACES REQUESTED",
-            status_colour: AllocationsView::Colour::GREEN,
-            requested: AllocationsView::Requested::YES,
-            id: initial_allocation.id,
-          },
-        ])
-      }
     end
 
     context "Accredited body has not requested initial allocations for any training provider" do


### PR DESCRIPTION
### Context

Allocation status was pluralised incorrectly. When number of places is `1` the status should not be pluralised. 

### Changes proposed in this pull request
* **Before**<kbd> <img width="979" alt="Screenshot 2020-05-21 at 11 22 05" src="https://user-images.githubusercontent.com/38078064/82549991-c4881700-9b55-11ea-83a5-eb13f0c36fd6.png"></kbd>

* **After** <kbd><img width="981" alt="Screenshot 2020-05-21 at 11 21 31" src="https://user-images.githubusercontent.com/38078064/82550003-c81b9e00-9b55-11ea-84c0-15624e5ebf81.png"></kbd>

### Guidance to review
 -  create a new initial allocation with 1 place
 - view index page
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
