### PR TITLE
Revert "Bump omniauth_openid_connect from 0.3.3 to 0.3.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    bindata (2.4.7)
+    bindata (2.4.4)
     bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -237,11 +237,11 @@ GEM
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth_openid_connect (0.3.4)
+    omniauth_openid_connect (0.3.3)
       addressable (~> 2.5)
       omniauth (~> 1.9)
       openid_connect (~> 1.1)
-    openid_connect (1.2.0)
+    openid_connect (1.1.8)
       activemodel
       attr_required (>= 1.0.0)
       json-jwt (>= 1.5.0)
@@ -271,13 +271,13 @@ GEM
     public_suffix (4.0.5)
     puma (4.3.5)
       nio4r (~> 2.0)
-    rack (2.0.9)
-    rack-oauth2 (1.12.0)
+    rack (2.2.2)
+    rack-oauth2 (1.10.1)
       activesupport
       attr_required
       httpclient
       json-jwt (>= 1.11.0)
-      rack (< 2.1)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -416,7 +416,7 @@ GEM
       attr_extras
       diff-lcs
       patience_diff
-    swd (1.2.0)
+    swd (1.1.2)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
@@ -429,7 +429,7 @@ GEM
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
-    validate_url (1.0.11)
+    validate_url (1.0.8)
       activemodel (>= 3.0.0)
       public_suffix
     web-console (4.0.2)


### PR DESCRIPTION
Reverts DFE-Digital/publish-teacher-training#1120

Backing this out as there is an [issue with 0.3.4](https://github.com/m0n9oose/omniauth_openid_connect/issues/59) which is preventing login with DfE Signin. 