### PR TITLE
[3398] validation no provider

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,2 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -61,7 +61,7 @@ module Providers
     def initial_request
       flow = InitialRequestFlow.new(params: params)
 
-      if request.post? && flow.redirect?
+      if request.post? && flow.valid? && flow.redirect?
         redirect_to flow.redirect_path
       else
         render flow.template, locals: flow.locals

--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -65,6 +65,8 @@ class InitialRequestFlow
     end
   end
 
+  delegate :valid?, to: :form_object
+
 private
 
   def training_provider_selected?
@@ -190,12 +192,6 @@ private
   end
 
   def blank_search_query?
-    return @blank_search_query if @blank_search_query
-
-    @blank_search_query = params[:training_provider_code] == "-1" && params[:training_provider_query].blank?
-
-    form_object.add_no_search_query_error if @blank_search_query
-
-    @blank_search_query
+    params[:training_provider_code] == "-1" && params[:training_provider_query].blank?
   end
 end

--- a/app/form_objects/initial_request_form.rb
+++ b/app/form_objects/initial_request_form.rb
@@ -3,6 +3,9 @@ class InitialRequestForm
 
   attr_accessor :training_provider_code, :training_provider_query
 
+  validates :training_provider_code, presence: { message: "Select or search for an organisation" }
+  validates :training_provider_query, presence: { message: "You need to add some information", if: :provider_search? }
+
   def add_no_results_error
     errors.add(
       :training_provider_query,
@@ -11,7 +14,9 @@ class InitialRequestForm
     )
   end
 
-  def add_no_search_query_error
-    errors.add(:training_provider_query, "You need to add some information")
+private
+
+  def provider_search?
+    training_provider_code == "-1"
   end
 end

--- a/app/views/providers/allocations/initial_request.html.erb
+++ b/app/views/providers/allocations/initial_request.html.erb
@@ -15,16 +15,17 @@
 
       <%= form.govuk_error_summary %>
 
-      <%= form.govuk_radio_buttons_fieldset(:training_provider, legend: { size: 'xl', text: 'Who are you requesting a course for?' }) do %>
+      <%= form.govuk_radio_buttons_fieldset(:training_provider_code, legend: { size: 'xl', text: 'Who are you requesting a course for?' }) do %>
         <p class="govuk-body">
           This should be the name of the organisation offering the course - eg
           a lead school, or your own organisation if you’re offering it yourselves.
         </p>
 
-        <% training_providers.each_with_index do |training_provider| %>
+        <% training_providers.each do |training_provider| %>
           <%= form.govuk_radio_button :training_provider_code,
             training_provider.provider_code,
-            label: { text: training_provider.provider_name } %>
+            label: { text: training_provider.provider_name },
+            link_errors: true %>
         <% end %>
 
         <%= form.govuk_radio_divider %>

--- a/spec/form_objects/initial_request_form_spec.rb
+++ b/spec/form_objects/initial_request_form_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe InitialRequestForm do
+  describe "validations" do
+    context "when no radio button selected" do
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:training_provider_code]).to be_present
+      end
+    end
+
+    context "when no search query provided" do
+      subject do
+        described_class.new(training_provider_code: "-1")
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:training_provider_query]).to be_present
+      end
+    end
+  end
+end

--- a/spec/requests/heartbeat_checks_spec.rb
+++ b/spec/requests/heartbeat_checks_spec.rb
@@ -24,7 +24,7 @@ describe "heartbeat checks requests" do
       end
 
       it "returns JSON" do
-        expect(response.content_type).to eq("application/json")
+        expect(response.media_type).to eq("application/json")
       end
 
       it "returns the expected response report" do


### PR DESCRIPTION
### Context

- https://trello.com/c/o5I1mnwd/3398-m-adding-validation-to-who-are-you-requesting-a-course-for-page
- There is missing validation on the first page of the initial request journey when the user does not select a radio option and continues

### Changes proposed in this pull request

- Add validation to initial request flow
- Fix deprecation warning when running test suite
- Added .rspec_parallel config to speed up local tests

### Guidance to review

- Create an initial allocation request
- On the first page do not select a radio option and continue
- Should see validation message

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
