### PR TITLE
[3399] - Initial allocation flow: provider search validation

### DIFF
--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -74,7 +74,7 @@ private
   end
 
   def training_provider_search?
-    params[:training_provider_code] == "-1" && params[:training_provider_query].present?
+    params[:training_provider_code] == "-1" && params[:training_provider_query].present? && params[:training_provider_query].size > 1
   end
 
   def one_search_result?
@@ -173,7 +173,7 @@ private
 
   def number_of_places_page?
     training_provider_selected? ||
-      (params[:training_provider_query].present? && one_search_result?) || params[:change]
+      (params[:training_provider_query].present? && params[:training_provider_query].size > 1 && one_search_result?) || params[:change]
   end
 
   def check_your_information_page?

--- a/app/form_objects/initial_request_form.rb
+++ b/app/form_objects/initial_request_form.rb
@@ -5,6 +5,7 @@ class InitialRequestForm
 
   validates :training_provider_code, presence: { message: "Select or search for an organisation" }
   validates :training_provider_query, presence: { message: "You need to add some information", if: :provider_search? }
+  validates :training_provider_query, length: { minimum: 2, message: "Please enter a minimum of two characters", if: :provider_search? }
 
   def add_no_results_error
     errors.add(

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -141,6 +141,27 @@ RSpec.feature "PE allocations" do
     and_i_see_error_message_that_i_must_add_more_info
   end
 
+  scenario "Accredited body searches for provider with string containing only one character" do
+    given_accredited_body_exists
+    given_the_accredited_body_has_an_allocation
+    given_there_is_a_training_provider_with_previous_allocations
+    # once the feature is released it should be changed to
+    # given_i_am_signed_in_as_a_user_from_the_accredited_body
+    given_i_am_signed_in_as_an_admin
+
+    when_i_visit_my_organisations_page
+    and_i_click_request_pe_courses
+    then_i_see_the_pe_allocations_page
+
+    when_i_click_choose_an_organisation_button
+    then_i_see_the_request_new_pe_allocations_page
+
+    when_i_search_for_a_training_provider_with_string_containing_one_character
+    and_i_click_continue
+    then_i_see_the_request_new_pe_allocations_page
+    and_i_see_error_message_that_my_search_query_must_contain_two_characters
+  end
+
   def given_accredited_body_exists
     @accredited_body = build(:provider, accredited_body?: true)
     stub_api_v2_resource(@accredited_body.recruitment_cycle)
@@ -295,8 +316,17 @@ RSpec.feature "PE allocations" do
     page.fill_in("training_provider_query", with: "")
   end
 
+  def when_i_search_for_a_training_provider_with_string_containing_one_character
+    page.choose("Find an organisation not listed above")
+    page.fill_in("training_provider_query", with: "x")
+  end
+
   def and_i_see_error_message_that_i_must_add_more_info
     expect(page).to have_content("You need to add some information")
+  end
+
+  def and_i_see_error_message_that_my_search_query_must_contain_two_characters
+    expect(page).to have_content("Please enter a minimum of two characters")
   end
 
   def when_i_fill_in_the_number_of_places_input

--- a/spec/form_objects/initial_request_form_spec.rb
+++ b/spec/form_objects/initial_request_form_spec.rb
@@ -19,5 +19,26 @@ RSpec.describe InitialRequestForm do
         expect(subject.errors[:training_provider_query]).to be_present
       end
     end
+
+    context "when search query contains only one character" do
+      subject do
+        described_class.new(training_provider_code: "-1", training_provider_query: "x")
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:training_provider_query]).to be_present
+      end
+    end
+
+    context "when search query contains more than one character" do
+      subject do
+        described_class.new(training_provider_code: "-1", training_provider_query: "ox")
+      end
+
+      it "is valid" do
+        expect(subject.valid?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
API has been updated to allow for two character provider searches. See https://github.com/DFE-Digital/teacher-training-api/pull/1378

### Changes proposed in this pull request
- During the initial allocation flow, a validation error is displayed on the form if the accredited body searches for a provider with a query string containing only one character

### Guidance to review
- Run this branch against https://github.com/DFE-Digital/teacher-training-api/pull/1378
- Request an initial allocation. Select other provider and enter a single character in the search field. Validation error should be displayed

### Notes
- Need some copy guidance on the error message
- I've followed the existing validation pattern for `blank_search_query`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
