### PR TITLE
[3402] Tweak Initial request form when there are no associated providers

### DIFF
--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -32,6 +32,7 @@ class InitialRequestFlow
       {
         training_providers: training_providers_without_associated,
         form_object: form_object,
+        provider: provider,
       }
     elsif pick_a_provider_page?
       {
@@ -41,6 +42,7 @@ class InitialRequestFlow
       {
         training_providers: training_providers_without_associated,
         form_object: form_object,
+        provider: provider,
       }
     end
   end

--- a/app/views/providers/allocations/initial_request.html.erb
+++ b/app/views/providers/allocations/initial_request.html.erb
@@ -1,14 +1,14 @@
 <%= content_for :page_title, "Who are you requesting a course for?"%>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>
+  <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path(provider.provider_code, provider.recruitment_cycle_year)) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: form_object, scope: "", url: initial_request_provider_recruitment_cycle_allocations_path(
-                      @provider.provider_code,
-                      @provider.recruitment_cycle_year,
+                      provider.provider_code,
+                      provider.recruitment_cycle_year,
                     ),
                      skip_enforcing_utf8: true,
                      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
@@ -21,19 +21,24 @@
           a lead school, or your own organisation if you’re offering it yourselves.
         </p>
 
-        <% training_providers.each do |training_provider| %>
-          <%= form.govuk_radio_button :training_provider_code,
-            training_provider.provider_code,
-            label: { text: training_provider.provider_name },
-            link_errors: true %>
-        <% end %>
-
-        <%= form.govuk_radio_divider %>
-
-        <%= form.govuk_radio_button :training_provider_code, "-1", label: { text: 'Find an organisation not listed above' } do %>
-          <%= form.govuk_text_field :training_provider_query, label: { text: 'Organisation name' } do %>
-            <div id="provider-autocomplete" class="govuk-body"></div>
+        <% if training_providers.present? %>
+          <% training_providers.each do |training_provider| %>
+            <%= form.govuk_radio_button :training_provider_code,
+              training_provider.provider_code,
+              label: { text: training_provider.provider_name },
+              link_errors: true %>
           <% end %>
+
+          <%= form.govuk_radio_divider %>
+
+          <%= form.govuk_radio_button :training_provider_code, "-1", label: { text: 'Find an organisation not listed above' } do %>
+            <%= form.govuk_text_field :training_provider_query, label: { text: 'Organisation name' } do %>
+              <div id="provider-autocomplete" class="govuk-body"></div>
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= hidden_field_tag "training_provider_code", "-1" %>
+          <%= form.govuk_text_field :training_provider_query, label: { text: 'Find an organisation' } %>
         <% end %>
       <% end %>
 

--- a/spec/views/providers/allocations/initial_request.html.erb_spec.rb
+++ b/spec/views/providers/allocations/initial_request.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "providers/allocations/initial_request.html.erb" do
+  context "when there are associated training providers" do
+    let(:provider) { build(:provider) }
+    let(:training_providers) { [build(:provider)] }
+    let(:form_object) { InitialRequestForm.new }
+
+    it "shows radio buttons" do
+      render template: "providers/allocations/initial_request.html.erb",
+             locals: {
+               provider: provider,
+               form_object: form_object,
+               training_providers: training_providers,
+             }
+
+      expect(rendered).to include("govuk-radios__item")
+    end
+  end
+
+  context "when there are no associated training providers" do
+    let(:provider) { build(:provider) }
+    let(:training_providers) { [] }
+    let(:form_object) { InitialRequestForm.new }
+
+    it "does not show radio buttons" do
+      render template: "providers/allocations/initial_request.html.erb",
+             locals: {
+               provider: provider,
+               form_object: form_object,
+               training_providers: training_providers,
+             }
+
+      expect(rendered).to_not include("govuk-radios__item")
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/6Znq0sUB/3402-when-there-are-no-associated-providers
- On the initial request journey on the first page when there are no associated providers the radio button divider would show and only one radio button with the provider search option

### Changes proposed in this pull request

- When there are no associated providers hide the radio buttons and only show the search field

### Guidance to review

- Create a new initial request for a provider that does not have any associated providers
- On the first page should not show radio buttons and only search field should be present in the form 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
