### PR TITLE
[3442] Allow all providers to create a new course

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -13,10 +13,6 @@ module ProviderHelper
     govuk_link_to("Add a new course", new_provider_recruitment_cycle_course_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year), class: "govuk-button govuk-!-margin-bottom-2", **opts)
   end
 
-  def add_course_link(email, provider, is_current_cycle:, **opts)
-    link_to "Add a new course", add_course_url(email, provider, is_current_cycle: is_current_cycle), class: "govuk-button govuk-!-margin-bottom-2", rel: "noopener noreferrer", target: "_blank", **opts
-  end
-
   def google_form_url_for(settings, email, provider)
     settings.url + "&" +
       { settings.email_entry => email, settings.provider_code_entry => provider.provider_code }.to_query

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -9,10 +9,6 @@ module ProviderHelper
     end
   end
 
-  def create_course_link(provider, **opts)
-    govuk_link_to("Add a new course", new_provider_recruitment_cycle_course_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year), class: "govuk-button govuk-!-margin-bottom-2", **opts)
-  end
-
   def google_form_url_for(settings, email, provider)
     settings.url + "&" +
       { settings.email_entry => email, settings.provider_code_entry => provider.provider_code }.to_query

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -15,7 +15,11 @@
 </ul>
 
 <% if @provider.courses.count > 10 %>
-  <%= create_course_link(@provider, data: {qa: "course-create"} ) %>
+  <%= govuk_link_to("Add a new course",
+    new_provider_recruitment_cycle_course_path(
+      provider_code: @provider.provider_code,
+      recruitment_cycle_year: @provider.recruitment_cycle_year),
+      class: "govuk-button govuk-!-margin-bottom-2") %>
 <% end %>
 
 <% if @self_accredited_courses %>
@@ -35,4 +39,8 @@
   </section>
 <% end %>
 
-<%= create_course_link(@provider, data: {qa: "course-create"} ) %>
+<%= govuk_link_to("Add a new course",
+  new_provider_recruitment_cycle_course_path(
+    provider_code: @provider.provider_code,
+    recruitment_cycle_year: @provider.recruitment_cycle_year),
+    class: "govuk-button govuk-!-margin-bottom-2") %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -15,12 +15,7 @@
 </ul>
 
 <% if @provider.courses.count > 10 %>
-  <% if @provider.accredited_body? %>
-    <%= create_course_link(@provider, data: {qa: "course-create"} ) %>
-  <% else %>
-    <%= add_course_link(current_user['info']['email'], @provider, is_current_cycle: @recruitment_cycle.current?, data: {qa: "course-create-additional"}) %>
-    <p class="govuk-body-s govuk-!-margin-bottom-6">You’ll be taken to a Google Form to fill in your course details.</p>
-  <% end %>
+  <%= create_course_link(@provider, data: {qa: "course-create"} ) %>
 <% end %>
 
 <% if @self_accredited_courses %>
@@ -40,9 +35,4 @@
   </section>
 <% end %>
 
-<% if @provider.accredited_body? %>
-  <%= create_course_link(@provider, data: {qa: "course-create"} ) %>
-<% else %>
-  <%= add_course_link(current_user['info']['email'], @provider, is_current_cycle: @recruitment_cycle.current?, data: {qa: "course-create"}) %>
-  <p class="govuk-body-s">You’ll be taken to a Google Form to fill in your course details.</p>
-<% end %>
+<%= create_course_link(@provider, data: {qa: "course-create"} ) %>

--- a/spec/features/courses/index_spec.rb
+++ b/spec/features/courses/index_spec.rb
@@ -4,23 +4,20 @@ feature "courses page", type: :feature do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:courses_page) { PageObjects::Page::Organisations::CoursesPage.new }
   let(:new_level_page) { PageObjects::Page::Organisations::Courses::NewLevelPage.new }
+  let(:course) { build(:course, provider: provider) }
+  let(:provider) { build(:provider) }
 
-  context "as an accrediting provider" do
-    let(:course) { build(:course, provider: provider) }
-    let(:provider) { build(:provider, accredited_body?: true) }
+  scenario "links to the course creation page" do
+    stub_omniauth
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(provider, include: "courses.accrediting_provider")
 
-    scenario "links to the course creation page" do
-      stub_omniauth
-      stub_api_v2_resource(current_recruitment_cycle)
-      stub_api_v2_resource(provider, include: "courses.accrediting_provider")
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_build_course
 
-      stub_api_v2_resource(provider)
-      stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
-      stub_api_v2_build_course
-
-      courses_page.load_with_provider(provider)
-      courses_page.course_create.click
-      expect(new_level_page).to be_displayed
-    end
+    courses_page.load_with_provider(provider)
+    courses_page.course_create.click
+    expect(new_level_page).to be_displayed
   end
 end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -5,12 +5,6 @@ feature "View helpers", type: :helper do
   let(:html_escaped_version_of_email) { "ab%2Btest%40c.com" }
   let(:provider) { build(:provider) }
 
-  describe "#add_course_link" do
-    it "builds a link" do
-      expect(helper.add_course_link(email, provider, is_current_cycle: true)).to eq("<a class=\"govuk-button govuk-!-margin-bottom-2\" rel=\"noopener noreferrer\" target=\"_blank\" href=\"#{CGI.escapeHTML(helper.add_course_url(email, provider, is_current_cycle: true))}\">Add a new course</a>")
-    end
-  end
-
   describe "#add_course_url" do
     describe "for accredited bodies" do
       let(:provider) { build(:provider, accredited_body?: true) }

--- a/spec/site_prism/page_objects/page/organisations/courses_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses_page.rb
@@ -11,7 +11,7 @@ module PageObjects
         element :flash, ".govuk-success-summary"
         element :caption, ".govuk-caption-xl"
 
-        element :course_create, '[data-qa="course-create"]'
+        element :course_create, ".govuk-button", text: "Add a new course"
         element :course_create_additional, '[data-qa="course-create-additional"]'
 
         sections :courses_tables, '[data-qa="courses__table-section"]' do


### PR DESCRIPTION
### Context

**User story**
```
As a provider 
I need to publish a course and choose an accrediting body
So that I can recruit and have the course accredited by another provider
```
* If the accrediting body has opted-in to receive email notifications they are notified when a course is created - Done in #1111

### Changes proposed in this pull request
* ALL providers can now create courses i.e. no more google form

### Guidance to review
- Try to create a course for a provider that is not an accredited body

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
