### PR TITLE
[3392] Don't pass provider_code in the query string

### DIFF
--- a/app/views/providers/_notifications_sign_up_link.html.erb
+++ b/app/views/providers/_notifications_sign_up_link.html.erb
@@ -1,6 +1,6 @@
 <% if @provider.accredited_body? %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-    <%= govuk_link_to "Notifications", notifications_path(provider_code: @provider.provider_code), class: "govuk-link", data:{qa: "notifications-link"} %>
+    <%= govuk_link_to "Notifications", notifications_path, class: "govuk-link", data:{qa: "notifications-link"} %>
   </h2>
   <p class="govuk-body">Get email notifications about your courses.</p>
 <% end %>


### PR DESCRIPTION

We are using `request.referer` to get the provider_code on the notifications page so we don't need to pass it in the query string.
