### PR TITLE
[3454] Add validations to repeat allocations

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -25,29 +25,34 @@ module Providers
       )
     end
 
-    def new_repeat_request; end
+    def new_repeat_request
+      @allocation = RepeatRequestForm.new
+    end
 
     def edit
       @allocation = Allocation.find(params[:id]).first
     end
 
     def create
-      # TODO: we need to add error handling here
+      @allocation = RepeatRequestForm.new(request_type: params[:request_type])
 
-      allocation = AllocationServices::Create.call(
-        accredited_body_code: @provider.provider_code,
-        provider_id: @training_provider.id,
-        request_type: params[:allocation][:request_type],
-        number_of_places: params[:number_of_places],
-      )
-
-      redirect_to provider_recruitment_cycle_allocation_path(id: allocation.id)
+      if @allocation.valid?
+        allocation = AllocationServices::Create.call(
+          accredited_body_code: @provider.provider_code,
+          provider_id: @training_provider.id,
+          request_type: params[:request_type],
+          number_of_places: params[:number_of_places],
+        )
+        redirect_to provider_recruitment_cycle_allocation_path(id: allocation.id)
+      else
+        render :new_repeat_request
+      end
     end
 
     def update
       @allocation = Allocation.find(params[:id]).first
 
-      @allocation.request_type = params[:allocation][:request_type]
+      @allocation.request_type = params[:request_type]
 
       @allocation.save if @allocation.changed?
 

--- a/app/form_objects/repeat_request_form.rb
+++ b/app/form_objects/repeat_request_form.rb
@@ -1,0 +1,7 @@
+class RepeatRequestForm
+  include ActiveModel::Model
+
+  attr_accessor :request_type
+
+  validates :request_type, presence: { message: "Select one option" }
+end

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -47,7 +47,7 @@
             </dd>
           </div>
         </dl>
-      <%= hidden_field_tag "allocation[request_type]", AllocationsView::RequestType::INITIAL %>
+      <%= hidden_field_tag "request_type", AllocationsView::RequestType::INITIAL %>
       <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
       <%= hidden_field_tag "number_of_places", params[:number_of_places] %>
 

--- a/app/views/providers/allocations/edit.html.erb
+++ b/app/views/providers/allocations/edit.html.erb
@@ -12,6 +12,7 @@
                     id: @allocation.id
                   ),
                   model: @allocation,
+                  scope: "",
                   method: :patch,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <%= form.govuk_radio_buttons_fieldset(:old_department_id, legend: { size: 'xl', text: page_title }) do %>

--- a/app/views/providers/allocations/new_repeat_request.html.erb
+++ b/app/views/providers/allocations/new_repeat_request.html.erb
@@ -7,16 +7,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @training_provider.provider_name %></span>
     <%= form_with url: provider_recruitment_cycle_allocation_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year,
                     params[:training_provider_code]
                   ),
-                  scope: "allocation",
+                  model: @allocation,
+                  scope: "",
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <%= form.govuk_radio_buttons_fieldset(:allocation_fieldset, legend: { size: 'xl', text: page_title }) do %>
-        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" } %>
+      <%= form.govuk_error_summary %>
+
+      <span class="govuk-caption-xl"><%= @training_provider.provider_name %></span>
+
+      <%= form.govuk_radio_buttons_fieldset(:request_type, legend: { size: 'xl', text: page_title }) do %>
+        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" }, link_errors: true %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
       <% end %>
       <%= form.govuk_submit %>

--- a/spec/site_prism/page_objects/page/providers/allocations/new_page.rb
+++ b/spec/site_prism/page_objects/page/providers/allocations/new_page.rb
@@ -6,8 +6,8 @@ module PageObjects
           set_url "/organisations/{provider_code}/{recruitment_cycle_year}/allocations/{training_provider_code}/new"
 
           element :form, "form"
-          element :yes, "#allocation-request-type-repeat-field"
-          element :no, "#allocation-request-type-declined-field"
+          element :yes, "#request-type-repeat-field"
+          element :no, "#request-type-declined-field"
           element :continue_button, "input[value='Continue']"
         end
       end


### PR DESCRIPTION
Fixes an 500 error a user would get if they did not select yes/no.
This commit also removed the "allocation" namespace we added awhile ago.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
