### PR TITLE
[3461] Fix missing autocomplete functionality

### DIFF
--- a/app/views/providers/allocations/initial_request.html.erb
+++ b/app/views/providers/allocations/initial_request.html.erb
@@ -39,6 +39,7 @@
         <% else %>
           <%= hidden_field_tag "training_provider_code", "-1" %>
           <%= form.govuk_text_field :training_provider_query, label: { text: 'Find an organisation' } %>
+          <div id="provider-autocomplete" class="govuk-body"></div>
         <% end %>
       <% end %>
 

--- a/app/views/providers/allocations/pick_a_provider.html.erb
+++ b/app/views/providers/allocations/pick_a_provider.html.erb
@@ -40,6 +40,7 @@
 
           <div class="govuk-form-group">
             <%= form.govuk_text_field :training_provider_query, label: { text: 'Organisation name' } %>
+            <div id="provider-autocomplete" class="govuk-body"></div>
           </div>
 
           <%= form.govuk_submit "Search again" %>


### PR DESCRIPTION
During a demo we identified that the autocomplete was not enabled on
some of the provider search fields. This did not block the user from
completely their task as the progressive enhanced version was able to
allow them to complete it successfully.

## Before - "Who are you requesting a course for?" page
![old-bug-initial-search](https://user-images.githubusercontent.com/3441519/83187474-1fa5a500-a126-11ea-874e-05c951233583.gif)

## After - "Who are you requesting a course for?" page
![after-bug-initial](https://user-images.githubusercontent.com/3441519/83187618-567bbb00-a126-11ea-9c2a-de56a9fc2e5d.gif)



## Before - "Pick a provider" page
![old-bug-pick](https://user-images.githubusercontent.com/3441519/83188211-40222f00-a127-11ea-9450-fa83e772e667.gif)


## After - "Pick a provider" page

![after-bug-pick](https://user-images.githubusercontent.com/3441519/83188673-f7b74100-a127-11ea-99ef-24d0cb927463.gif)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
