### PR TITLE
Make notifications admin only

### DIFF
--- a/app/views/providers/_notifications_sign_up_link.html.erb
+++ b/app/views/providers/_notifications_sign_up_link.html.erb
@@ -1,4 +1,4 @@
-<% if @provider.accredited_body? %>
+<% if @provider.accredited_body? && current_user["admin"]%>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <%= govuk_link_to "Notifications", notifications_path, class: "govuk-link", data:{qa: "notifications-link"} %>
   </h2>

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -6,7 +6,7 @@ feature "Notifications", type: :feature do
 
   let(:provider) { build :provider }
   let(:access_request) { build :access_request }
-  let(:user) { build :user }
+  let(:user) { build :user, :admin }
 
   before do
     stub_omniauth(user: user)

--- a/spec/views/providers/show_spec.rb
+++ b/spec/views/providers/show_spec.rb
@@ -39,8 +39,8 @@ describe "providers/show" do
         expect(provider_show_page).to have_courses_as_accredited_body_link
       end
 
-      it "displays the notification preferences" do
-        expect(provider_show_page).to have_notifications_preference_link
+      it "doesn't display the notification preferences" do
+        expect(provider_show_page).not_to have_notifications_preference_link
       end
     end
   end


### PR DESCRIPTION
### Context

A [previous
PR](https://github.com/DFE-Digital/publish-teacher-training/pull/1118) was merged that released the notifications feature to all accredited body users. Unfortunately there is an issue with the notifications not being sent on course update.

### Changes proposed in this pull request

This reverts that PR (Couldn't easily git revert as there were conflicts) while we address the issue.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
