### PR TITLE
[3440] Check for existing allocation then proceed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,5 @@ Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
   Enabled: false
+Rails/FindBy:
+  Enabled: false

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -5,10 +5,17 @@ class Allocation < Base
     DECLINED = "declined".freeze
   end
 
-  belongs_to :provider, param: :provider_code, shallow_path: true
+  belongs_to :provider, param: :provider_code, shallow_path: true # accredited_body
 
   property :number_of_places
   property :request_type
+
+  def self.for_provider_and_training_provider(recruitment_cycle:, provider:, training_provider:)
+    Allocation.where(recruitment_cycle_year: recruitment_cycle.year)
+              .where(provider_code: provider.provider_code)
+              .where(training_provider_code: training_provider.provider_code)
+              .first
+  end
 
   def has_places?
     number_of_places.to_i.positive?

--- a/app/views/providers/allocations/pick_a_provider.html.erb
+++ b/app/views/providers/allocations/pick_a_provider.html.erb
@@ -14,8 +14,18 @@
     <ul class="govuk-list govuk-list--bullet">
       <% training_providers.each do |training_provider| %>
         <li>
-          <%= govuk_link_to "#{training_provider.provider_name} (#{training_provider.provider_code})",
-            initial_request_provider_recruitment_cycle_allocations_path(training_provider_code: training_provider.provider_code) %>
+          <% allocation = Allocation.for_provider_and_training_provider(recruitment_cycle: @recruitment_cycle, provider: @provider, training_provider: training_provider) %>
+          <% if allocation.present? %>
+            <%= govuk_link_to "#{training_provider.provider_name} (#{training_provider.provider_code})",
+              edit_provider_recruitment_cycle_allocation_path(
+                @provider.provider_code,
+                @provider.recruitment_cycle_year,
+                training_provider.provider_code,
+                id: allocation.id) %>
+          <% else %>
+            <%= govuk_link_to "#{training_provider.provider_name} (#{training_provider.provider_code})",
+              initial_request_provider_recruitment_cycle_allocations_path(training_provider_code: training_provider.provider_code) %>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -235,6 +235,11 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_choose_a_training_provider
+    stub_api_v2_request(
+      "/providers/#{@accredited_body.provider_code}/allocations?filter[recruitment_cycle_year]=2020&filter[training_provider_code]=#{@training_provider.provider_code}&page[page]=1&page[per_page]=1",
+      resource_list_to_jsonapi([]),
+    )
+
     page.choose(@training_provider.provider_name)
   end
 
@@ -244,6 +249,15 @@ RSpec.feature "PE allocations" do
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                   body: File.new("spec/fixtures/api_responses/provider-suggestions.json"),
                 )
+
+    provider_codes = JSON.parse(File.read("spec/fixtures/api_responses/provider-suggestions.json")).dig("data").map { |p| p["attributes"]["provider_code"] }
+
+    provider_codes.each do |provider_code|
+      stub_api_v2_request(
+        "/providers/#{@accredited_body.provider_code}/allocations?filter[recruitment_cycle_year]=2020&filter[training_provider_code]=#{provider_code}&page[page]=1&page[per_page]=1",
+        resource_list_to_jsonapi([]),
+      )
+    end
 
     page.choose("Find an organisation not listed above")
     page.fill_in("training_provider_query", with: "ACME")


### PR DESCRIPTION
### Context

- https://trello.com/c/dtbw2raY/3440-stop-filtering-out-providers-from-provider-search-initial-allocation-request
- When searching for a provider for an allocation we now return providers that also have allocations
- As a result if one of these are selected we now take the user to modify the allocation

### Changes proposed in this pull request

- When creating a new allocation we now check if an allocation already
exists
- If yes, proceed to edit the existing allocation
- If now, proceed with the current journey to create the allocation

### Guidance to review

- Depends on https://github.com/DFE-Digital/teacher-training-api/pull/1388
- Create a new allocation. Search for a provider that already has an initial, repeat or allocation
- With Javascript the autocomplete will select the provider and on submit will take the user to edit the existing allocation
- Without Javascript the user is take to the pick a provider page where on clicking on the provider they are taken to the edit allocation page
- If the pick a provider page only contains one provider you will be redirected to edit the existing allocation

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
