### PR TITLE
[3433] - Add validations to "How many places would you like to request?" page

### DIFF
--- a/app/form_objects/initial_request_form.rb
+++ b/app/form_objects/initial_request_form.rb
@@ -1,11 +1,12 @@
 class InitialRequestForm
   include ActiveModel::Model
 
-  attr_accessor :training_provider_code, :training_provider_query
+  attr_accessor :training_provider_code, :training_provider_query, :number_of_places
 
   validates :training_provider_code, presence: { message: "Select or search for an organisation" }
   validates :training_provider_query, presence: { message: "You need to add some information", if: :provider_search? }
   validates :training_provider_query, length: { minimum: 2, message: "Please enter a minimum of two characters", if: :provider_search? }
+  validate :selected_number_of_places
 
   def add_no_results_error
     errors.add(
@@ -19,5 +20,17 @@ private
 
   def provider_search?
     training_provider_code == "-1"
+  end
+
+  def selected_number_of_places
+    return if number_of_places.nil?
+
+    errors.add(:number_of_places, "You must enter a number") unless number_of_places_valid?
+  end
+
+  def number_of_places_valid?
+    !number_of_places.empty? &&
+      !number_of_places.include?(".") &&
+      number_of_places.to_i.positive?
   end
 end

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -7,13 +7,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-  <%= form_with url: initial_request_provider_recruitment_cycle_allocations_path(
+  <%= form_with  model: form_object, scope: "", url: initial_request_provider_recruitment_cycle_allocations_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year,
                   ),
                 skip_enforcing_utf8: true,
-                method: :get,
                 builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form.govuk_error_summary %>
 
     <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
 

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -64,7 +64,6 @@ RSpec.feature "PE allocations" do
     then_i_see_pick_a_provider_page
 
     when_i_click_on_a_provider_from_search_results
-    and_i_click_continue
     then_i_see_number_of_places_page
     and_i_see_provider_name("Acme SCITT")
 
@@ -160,6 +159,107 @@ RSpec.feature "PE allocations" do
     and_i_click_continue
     then_i_see_the_request_new_pe_allocations_page
     and_i_see_error_message_that_my_search_query_must_contain_two_characters
+  end
+
+  context "Accredited body enters number of places" do
+    scenario "Accredited body submits form without specifying number of places" do
+      given_accredited_body_exists
+      given_the_accredited_body_has_an_allocation
+      given_there_is_a_training_provider_with_previous_allocations
+      # once the feature is released it should be changed to
+      # given_i_am_signed_in_as_a_user_from_the_accredited_body
+      given_i_am_signed_in_as_an_admin
+
+      when_i_visit_my_organisations_page
+      and_i_click_request_pe_courses
+      then_i_see_the_pe_allocations_page
+
+      when_i_click_choose_an_organisation_button
+      then_i_see_the_request_new_pe_allocations_page
+
+      and_i_choose_a_training_provider
+      and_i_click_continue
+      then_i_see_number_of_places_page
+
+      and_i_click_continue
+      then_i_see_number_of_places_page
+      and_i_see_error_message_that_i_must_enter_a_number
+    end
+
+    scenario "Accredited body enters '0'" do
+      given_accredited_body_exists
+      given_the_accredited_body_has_an_allocation
+      given_there_is_a_training_provider_with_previous_allocations
+      # once the feature is released it should be changed to
+      # given_i_am_signed_in_as_a_user_from_the_accredited_body
+      given_i_am_signed_in_as_an_admin
+
+      when_i_visit_my_organisations_page
+      and_i_click_request_pe_courses
+      then_i_see_the_pe_allocations_page
+
+      when_i_click_choose_an_organisation_button
+      then_i_see_the_request_new_pe_allocations_page
+
+      and_i_choose_a_training_provider
+      and_i_click_continue
+      then_i_see_number_of_places_page
+
+      when_i_fill_in_the_number_of_places_input_with_zero
+      and_i_click_continue
+      then_i_see_number_of_places_page
+      and_i_see_error_message_that_i_must_enter_a_number
+    end
+
+    scenario "Accredited body enters a float (1.1)" do
+      given_accredited_body_exists
+      given_the_accredited_body_has_an_allocation
+      given_there_is_a_training_provider_with_previous_allocations
+      # once the feature is released it should be changed to
+      # given_i_am_signed_in_as_a_user_from_the_accredited_body
+      given_i_am_signed_in_as_an_admin
+
+      when_i_visit_my_organisations_page
+      and_i_click_request_pe_courses
+      then_i_see_the_pe_allocations_page
+
+      when_i_click_choose_an_organisation_button
+      then_i_see_the_request_new_pe_allocations_page
+
+      and_i_choose_a_training_provider
+      and_i_click_continue
+      then_i_see_number_of_places_page
+
+      when_i_fill_in_the_number_of_places_input_with_a_float
+      and_i_click_continue
+      then_i_see_number_of_places_page
+      and_i_see_error_message_that_i_must_enter_a_number
+    end
+
+    scenario "Accredited body enters a non-numeric character" do
+      given_accredited_body_exists
+      given_the_accredited_body_has_an_allocation
+      given_there_is_a_training_provider_with_previous_allocations
+      # once the feature is released it should be changed to
+      # given_i_am_signed_in_as_a_user_from_the_accredited_body
+      given_i_am_signed_in_as_an_admin
+
+      when_i_visit_my_organisations_page
+      and_i_click_request_pe_courses
+      then_i_see_the_pe_allocations_page
+
+      when_i_click_choose_an_organisation_button
+      then_i_see_the_request_new_pe_allocations_page
+
+      and_i_choose_a_training_provider
+      and_i_click_continue
+      then_i_see_number_of_places_page
+
+      when_i_fill_in_the_number_of_places_input_with_a_letter
+      and_i_click_continue
+      then_i_see_number_of_places_page
+      and_i_see_error_message_that_i_must_enter_a_number
+    end
   end
 
   def given_accredited_body_exists
@@ -329,8 +429,24 @@ RSpec.feature "PE allocations" do
     expect(page).to have_content("Please enter a minimum of two characters")
   end
 
+  def and_i_see_error_message_that_i_must_enter_a_number
+    expect(page).to have_content("You must enter a number")
+  end
+
   def when_i_fill_in_the_number_of_places_input
     number_of_places_page.number_of_places_field.fill_in(with: "2")
+  end
+
+  def when_i_fill_in_the_number_of_places_input_with_a_letter
+    number_of_places_page.number_of_places_field.fill_in(with: "a")
+  end
+
+  def when_i_fill_in_the_number_of_places_input_with_zero
+    number_of_places_page.number_of_places_field.fill_in(with: "0")
+  end
+
+  def when_i_fill_in_the_number_of_places_input_with_a_float
+    number_of_places_page.number_of_places_field.fill_in(with: "1.1")
   end
 
   def then_i_see_check_your_information_page

--- a/spec/fixtures/api_responses/provider-suggestions.json
+++ b/spec/fixtures/api_responses/provider-suggestions.json
@@ -17,6 +17,15 @@
         "provider_name": "Acme SCITT",
         "recruitment_cycle_year": "2020"
       }
+    },
+    {
+      "id": "8",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "B01",
+        "provider_name": "Bar SCITT",
+        "recruitment_cycle_year": "2020"
+      }
     }
   ],
   "jsonapi": {

--- a/spec/form_objects/initial_request_form_spec.rb
+++ b/spec/form_objects/initial_request_form_spec.rb
@@ -40,5 +40,59 @@ RSpec.describe InitialRequestForm do
         expect(subject.valid?).to eq(true)
       end
     end
+
+    context "when number_of_places is empty" do
+      subject do
+        described_class.new(number_of_places: "")
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:number_of_places]).to be_present
+      end
+    end
+
+    context "when number_of_places is less than 1" do
+      subject do
+        described_class.new(number_of_places: "0")
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:number_of_places]).to be_present
+      end
+    end
+
+    context "when number_of_places is a letter" do
+      subject do
+        described_class.new(number_of_places: "a")
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:number_of_places]).to be_present
+      end
+    end
+
+    context "when number of places is a float" do
+      subject do
+        described_class.new(number_of_places: "1.1")
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:number_of_places]).to be_present
+      end
+    end
+
+    context "when all valid parameters are passed in" do
+      subject do
+        described_class.new(training_provider_code: "-1", training_provider_query: "ox", number_of_places: "2")
+      end
+
+      it "is valid" do
+        expect(subject.valid?).to eq(true)
+      end
+    end
   end
 end

--- a/spec/requests/provider_suggestions_spec.rb
+++ b/spec/requests/provider_suggestions_spec.rb
@@ -50,6 +50,10 @@ describe "/providers/suggest", type: :request do
               "code" => "A01",
               "name" => "Acme SCITT",
             },
+            {
+              "code" => "B01",
+              "name" => "Bar SCITT"
+            }
           ],
         )
       end

--- a/spec/requests/provider_suggestions_spec.rb
+++ b/spec/requests/provider_suggestions_spec.rb
@@ -52,8 +52,8 @@ describe "/providers/suggest", type: :request do
             },
             {
               "code" => "B01",
-              "name" => "Bar SCITT"
-            }
+              "name" => "Bar SCITT",
+            },
           ],
         )
       end


### PR DESCRIPTION
### Context
When the accredited body enters the number of places they require for an initial allocation, we can only accept positive integers greater than 0.

### Changes proposed in this pull request
Validation error shown on "How many places would you like to request page" if user enters the following values in the 'number of places' field:
- empty value (e.g "")
- 0
- non-integer (e.g. "a")

### Guidance to review
- Go to a provider's allocation page (e.g. `/organisations/K30/2020/allocations/) and select the 'initial allocation' flow. Once you reach the 'How many places would you like to request' page, please try and break it.
- Was considering using HTML `input=number` to handle some of the validation but apparently this has [fallen out of favour due to accessibility concerns](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/ ).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
