### PR TITLE
[3466] Allocations no longer restricted to admins

### DIFF
--- a/app/controllers/provider_suggestions_controller.rb
+++ b/app/controllers/provider_suggestions_controller.rb
@@ -8,6 +8,15 @@ class ProviderSuggestionsController < ApplicationController
     render json: suggestions
   end
 
+  def suggest_any
+    return render(json: { error: "Bad request" }, status: :bad_request) if params_invalid?
+
+    sanitised_query = CGI.escape(params[:query])
+    suggestions = ProviderSuggestion.suggest_any(sanitised_query)
+      .map { |provider| { code: provider.provider_code, name: provider.provider_name } }
+    render json: suggestions
+  end
+
 private
 
   def params_invalid?

--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -4,7 +4,6 @@ module Providers
     before_action :build_provider
     before_action :build_training_provider, except: %i[index initial_request]
     before_action :require_provider_to_be_accredited_body!
-    before_action :require_admin_permissions!
 
     PE_SUBJECT_CODE = "C6".freeze
 
@@ -78,10 +77,10 @@ module Providers
   private
 
     def build_training_provider
-      @training_provider = Provider
-       .where(recruitment_cycle_year: @recruitment_cycle.year)
-       .find(params[:training_provider_code])
-       .first
+      return @training_provider if @training_provider
+
+      p = Provider.new(recruitment_cycle_year: @recruitment_cycle.year, provider_code: params[:training_provider_code])
+      @training_provider = p.show_any(recruitment_cycle_year: @recruitment_cycle.year).first
     end
 
     def build_provider
@@ -99,10 +98,6 @@ module Providers
 
     def require_provider_to_be_accredited_body!
       render "errors/not_found", status: :not_found unless @provider.accredited_body?
-    end
-
-    def require_admin_permissions!
-      render "errors/forbidden", status: :forbidden unless user_is_admin?
     end
   end
 end

--- a/app/controllers/providers/edit_initial_allocations_controller.rb
+++ b/app/controllers/providers/edit_initial_allocations_controller.rb
@@ -81,10 +81,10 @@ module Providers
   private
 
     def training_provider
-      @training_provider ||= Provider
-       .where(recruitment_cycle_year: recruitment_cycle.year)
-       .find(params[:training_provider_code])
-       .first
+      return @training_provider if @training_provider
+
+      p = Provider.new(recruitment_cycle_year: recruitment_cycle.year, provider_code: params[:training_provider_code])
+      @training_provider = p.show_any(recruitment_cycle_year: recruitment_cycle.year).first
     end
 
     def provider

--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -153,7 +153,7 @@ private
     return @training_providers_from_query if @training_providers_from_query
 
     query = params[:training_provider_query]
-    @training_providers_from_query ||= ProviderSuggestion.suggest(query)
+    @training_providers_from_query ||= ProviderSuggestion.suggest_any(query)
   end
 
   def training_providers_from_query_without_associated
@@ -206,10 +206,8 @@ private
     @training_provider ||= if params[:training_provider_code] == "-1"
                              training_providers_from_query.first
                            else
-                             Provider
-                               .where(recruitment_cycle_year: recruitment_cycle.year)
-                               .find(params[:training_provider_code])
-                               .first
+                             p = Provider.new(recruitment_cycle_year: recruitment_cycle.year, provider_code: params[:training_provider_code])
+                             p.show_any(recruitment_cycle_year: recruitment_cycle.year).first
                            end
   end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -8,6 +8,7 @@ class Provider < Base
   self.primary_key = :provider_code
 
   custom_endpoint :training_providers, on: :member, request_method: :get
+  custom_endpoint :show_any, on: :member, request_method: :get
 
   def publish
     post_request("/publish")

--- a/app/models/provider_suggestion.rb
+++ b/app/models/provider_suggestion.rb
@@ -4,4 +4,10 @@ class ProviderSuggestion < Base
       :request, :get, "/api/v2/providers/suggest?query=#{query}"
     )
   end
+
+  def self.suggest_any(query)
+    requestor.__send__(
+      :request, :get, "/api/v2/providers/suggest_any?query=#{query}"
+    )
+  end
 end

--- a/app/views/recruitment_cycles/_allocations.html.erb
+++ b/app/views/recruitment_cycles/_allocations.html.erb
@@ -1,24 +1,19 @@
-<% if @provider.accredited_body? && current_user["admin"]%>
-  <div class="app-admin-only__section">
-    <div class="app-admin-only__section-header">
-      <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
-    </div>
-    <h2 class="govuk-heading-m">
-      <%= link_to raw("Request PE courses for 2021&thinsp;–&thinsp;2022"),
-                  provider_recruitment_cycle_allocations_path(@provider.provider_code, year),
-                  class: "govuk-link",
-                  data: { qa: "request-allocations-link" } %>
-    </h2>
+<% if @provider.accredited_body? %>
+  <h2 class="govuk-heading-m">
+    <%= link_to raw("Request PE courses for 2021&thinsp;–&thinsp;2022"),
+                provider_recruitment_cycle_allocations_path(@provider.provider_code, year),
+                class: "govuk-link",
+                data: { qa: "request-allocations-link" } %>
+  </h2>
 
-    <p class="govuk-body">
-      Only accredited bodies are able to see this section. Use it to request fee-funded PE courses
-      (ones without a salary) for the next recruitment cycle.
-    </p>
+  <p class="govuk-body">
+    Only accredited bodies are able to see this section. Use it to request fee-funded PE courses
+    (ones without a salary) for the next recruitment cycle.
+  </p>
 
-    <p class="govuk-body">This includes:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>your own courses</li>
-      <li>courses you’re the accredited body for (you must request these on behalf of training partners)</li>
-    </ul>
-  </div>
+  <p class="govuk-body">This includes:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>your own courses</li>
+    <li>courses you’re the accredited body for (you must request these on behalf of training partners)</li>
+  </ul>
 <% end %>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -74,7 +74,7 @@ try {
     initAutocomplete($autocomplete, $provider_input, provider_template);
   }
   if($autocomplete && $allocation_training_provider_input) {
-    initAutocomplete($autocomplete, $allocation_training_provider_input, provider_template);
+    initAutocomplete($autocomplete, $allocation_training_provider_input, provider_template, {path: "/providers/suggest_any"});
   }
 } catch (err) {
   console.error("Failed to initialise provider autocomplete:", err);

--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -31,7 +31,9 @@ export const request = endpoint => {
   };
 };
 
-export const initAutocomplete = ($el, $input, inputValueTemplate) => {
+export const initAutocomplete = ($el, $input, inputValueTemplate, options = {}) => {
+  let path = options.path || "/providers/suggest";
+
   accessibleAutocomplete({
     element: $el,
     id: $input.id,
@@ -39,7 +41,7 @@ export const initAutocomplete = ($el, $input, inputValueTemplate) => {
     name: $input.name,
     defaultValue: $input.value,
     minLength: 3,
-    source: request("/providers/suggest"),
+    source: request(path),
     templates: {
       inputValue: inputValueTemplate,
       suggestion: result => result && `${result.name} (${result.code})`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,6 +233,7 @@ Rails.application.routes.draw do
   patch "/accept-terms", to: "users#accept_terms"
 
   get "/providers/suggest", to: "provider_suggestions#suggest"
+  get "/providers/suggest_any", to: "provider_suggestions#suggest_any"
   get "/providers/search", to: "providers#search"
   # redirect URL's from legacy c# app
   get "/organisation/:provider_code", to: redirect("/organisations/%{provider_code}", status: 301)

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_the_accredited_body_has_an_initial_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      # once the feature is released it should be changed to
-      # given_i_am_signed_in_as_a_user_from_the_accredited_body
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -39,9 +37,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_the_accredited_body_has_an_initial_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      # once the feature is released it should be changed to
-      # given_i_am_signed_in_as_a_user_from_the_accredited_body
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -60,9 +56,7 @@ RSpec.feature "PE allocations" do
           given_accredited_body_exists
           given_the_accredited_body_has_an_initial_allocation
           given_there_is_a_training_provider_with_previous_allocations
-          # once the feature is released it should be changed to
-          # given_i_am_signed_in_as_a_user_from_the_accredited_body
-          given_i_am_signed_in_as_an_admin
+          given_i_am_signed_in_as_a_user_from_the_accredited_body
 
           when_i_visit_my_organisations_page
           and_i_click_request_pe_courses
@@ -85,9 +79,7 @@ RSpec.feature "PE allocations" do
           given_accredited_body_exists
           given_the_accredited_body_has_an_initial_allocation
           given_there_is_a_training_provider_with_previous_allocations
-          # once the feature is released it should be changed to
-          # given_i_am_signed_in_as_a_user_from_the_accredited_body
-          given_i_am_signed_in_as_an_admin
+          given_i_am_signed_in_as_a_user_from_the_accredited_body
 
           when_i_visit_my_organisations_page
           and_i_click_request_pe_courses
@@ -110,9 +102,7 @@ RSpec.feature "PE allocations" do
           given_accredited_body_exists
           given_the_accredited_body_has_an_initial_allocation
           given_there_is_a_training_provider_with_previous_allocations
-          # once the feature is released it should be changed to
-          # given_i_am_signed_in_as_a_user_from_the_accredited_body
-          given_i_am_signed_in_as_an_admin
+          given_i_am_signed_in_as_a_user_from_the_accredited_body
 
           when_i_visit_my_organisations_page
           and_i_click_request_pe_courses
@@ -135,9 +125,7 @@ RSpec.feature "PE allocations" do
           given_accredited_body_exists
           given_the_accredited_body_has_an_initial_allocation
           given_there_is_a_training_provider_with_previous_allocations
-          # once the feature is released it should be changed to
-          # given_i_am_signed_in_as_a_user_from_the_accredited_body
-          given_i_am_signed_in_as_an_admin
+          given_i_am_signed_in_as_a_user_from_the_accredited_body
 
           when_i_visit_my_organisations_page
           and_i_click_request_pe_courses
@@ -179,16 +167,24 @@ RSpec.feature "PE allocations" do
       resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
     )
 
-    stub_api_v2_resource(@training_provider_with_allocation)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@training_provider_with_allocation.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([@training_provider_with_allocation]),
+    )
   end
 
-  def given_i_am_signed_in_as_an_admin
-    stub_omniauth(user: build(:user, :admin))
+  def user
+    @user ||= build(:user)
+  end
+
+  def given_i_am_signed_in_as_a_user_from_the_accredited_body
+    stub_omniauth(user: user)
   end
 
   def given_there_is_a_training_provider_with_previous_allocations
     @training_provider = build(:provider)
-    stub_api_v2_resource(@training_provider)
 
     @training_provider_with_fee_funded_pe = build(:provider)
 

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -10,9 +10,7 @@ RSpec.feature "PE allocations" do
     given_accredited_body_exists
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    # once the feature is released it should be changed to
-    # given_i_am_signed_in_as_a_user_from_the_accredited_body
-    given_i_am_signed_in_as_an_admin
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -48,9 +46,7 @@ RSpec.feature "PE allocations" do
     given_accredited_body_exists
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    # once the feature is released it should be changed to
-    # given_i_am_signed_in_as_a_user_from_the_accredited_body
-    given_i_am_signed_in_as_an_admin
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -77,9 +73,7 @@ RSpec.feature "PE allocations" do
     given_accredited_body_exists
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    # once the feature is released it should be changed to
-    # given_i_am_signed_in_as_a_user_from_the_accredited_body
-    given_i_am_signed_in_as_an_admin
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -98,9 +92,7 @@ RSpec.feature "PE allocations" do
     given_accredited_body_exists
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    # once the feature is released it should be changed to
-    # given_i_am_signed_in_as_a_user_from_the_accredited_body
-    given_i_am_signed_in_as_an_admin
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -123,9 +115,7 @@ RSpec.feature "PE allocations" do
     given_accredited_body_exists
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    # once the feature is released it should be changed to
-    # given_i_am_signed_in_as_a_user_from_the_accredited_body
-    given_i_am_signed_in_as_an_admin
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -144,9 +134,7 @@ RSpec.feature "PE allocations" do
     given_accredited_body_exists
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    # once the feature is released it should be changed to
-    # given_i_am_signed_in_as_a_user_from_the_accredited_body
-    given_i_am_signed_in_as_an_admin
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -166,9 +154,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_the_accredited_body_has_an_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      # once the feature is released it should be changed to
-      # given_i_am_signed_in_as_a_user_from_the_accredited_body
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -190,9 +176,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_the_accredited_body_has_an_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      # once the feature is released it should be changed to
-      # given_i_am_signed_in_as_a_user_from_the_accredited_body
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -215,9 +199,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_the_accredited_body_has_an_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      # once the feature is released it should be changed to
-      # given_i_am_signed_in_as_a_user_from_the_accredited_body
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -240,9 +222,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_the_accredited_body_has_an_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      # once the feature is released it should be changed to
-      # given_i_am_signed_in_as_a_user_from_the_accredited_body
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -263,13 +243,27 @@ RSpec.feature "PE allocations" do
   end
 
   def given_accredited_body_exists
-    @accredited_body = build(:provider, accredited_body?: true)
+    @accredited_body = build(:provider, accredited_body?: true, users: [user])
     stub_api_v2_resource(@accredited_body.recruitment_cycle)
+  end
+
+  def user
+    @user ||= build(:user)
+  end
+
+  def given_i_am_signed_in_as_a_user_from_the_accredited_body
+    stub_omniauth(user: user)
   end
 
   def given_there_is_a_training_provider_with_previous_allocations
     @training_provider = build(:provider)
-    stub_api_v2_resource(@training_provider)
+
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([@training_provider]),
+    )
 
     @training_provider_with_fee_funded_pe = build(:provider)
 
@@ -306,8 +300,12 @@ RSpec.feature "PE allocations" do
     )
   end
 
-  def given_i_am_signed_in_as_an_admin
-    stub_omniauth(user: build(:user, :admin))
+  def user
+    @user ||= build(:user)
+  end
+
+  def given_i_am_signed_in_as_a_user_from_the_accredited_body
+    stub_omniauth(user: user)
   end
 
   def when_i_visit_my_organisations_page
@@ -344,7 +342,7 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_search_for_a_training_provider
-    stub_request(:get, "#{Settings.manage_backend.base_url}/api/v2/providers/suggest?query=ACME")
+    stub_request(:get, "#{Settings.manage_backend.base_url}/api/v2/providers/suggest_any?query=ACME")
                 .to_return(
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                   body: File.new("spec/fixtures/api_responses/provider-suggestions.json"),
@@ -365,7 +363,13 @@ RSpec.feature "PE allocations" do
 
   def when_i_click_on_a_provider_from_search_results
     training_provider = build(:provider, provider_code: "A01", provider_name: "Acme SCITT")
-    stub_api_v2_resource(training_provider)
+
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([training_provider]),
+    )
 
     page.click_on("Acme SCITT")
   end
@@ -395,7 +399,7 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_search_for_a_training_provider_that_does_not_exist
-    stub_request(:get, "#{Settings.manage_backend.base_url}/api/v2/providers/suggest?query=donotexist")
+    stub_request(:get, "#{Settings.manage_backend.base_url}/api/v2/providers/suggest_any?query=donotexist")
                 .to_return(
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                   body: File.new("spec/fixtures/api_responses/empty-provider-suggestions.json"),
@@ -411,7 +415,7 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_search_again_for_a_training_provider_that_does_not_exist
-    stub_request(:get, "#{Settings.manage_backend.base_url}/api/v2/providers/suggest?query=donotexist")
+    stub_request(:get, "#{Settings.manage_backend.base_url}/api/v2/providers/suggest_any?query=donotexist")
                 .to_return(
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                   body: File.new("spec/fixtures/api_responses/empty-provider-suggestions.json"),

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -11,10 +11,7 @@ RSpec.feature "PE allocations" do
         given_accredited_body_exists
         given_training_provider_with_pe_fee_funded_course_exists
         given_the_accredited_body_has_requested_a_repeat_allocation
-
-        given_i_am_signed_in_as_an_admin
-        # once the feature is released it should be changed to
-        # given_i_am_signed_in_as_a_user_from_the_accredited_body
+        given_i_am_signed_in_as_a_user_from_the_accredited_body
 
         when_i_visit_my_organisations_page
         and_i_click_request_pe_courses
@@ -29,8 +26,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_training_provider_with_pe_fee_funded_course_exists
       given_the_accredited_body_has_not_requested_an_allocation
-
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -49,8 +45,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_training_provider_with_pe_fee_funded_course_exists
       given_the_accredited_body_has_not_requested_an_allocation
-
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -71,8 +66,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_training_provider_with_pe_fee_funded_course_exists
       given_the_accredited_body_has_requested_a_repeat_allocation
-
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -90,8 +84,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_training_provider_with_pe_fee_funded_course_exists
       given_the_accredited_body_has_declined_an_allocation
-
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -107,29 +100,19 @@ RSpec.feature "PE allocations" do
 
     scenario "There is no PE allocations page for non accredited body" do
       given_a_provider_exists
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_training_providers_page
       there_is_no_request_pe_courses_link
       and_i_cannot_access_pe_alloacations_page
     end
 
-    scenario "Non-admin user cannot views PE allocations page" do
-      given_accredited_body_exists
-      given_i_am_signed_in
-
-      when_i_visit_my_organisations_page
-      there_is_no_request_pe_courses_link
-      and_i_cannot_access_accredited_body_pe_allocations_page
-    end
-
     scenario "Accredited body views PE allocations request page for training provider" do
       given_accredited_body_exists
       given_training_provider_exists
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_pe_allocations_request_page
-
       then_i_see_the_pe_allocations_request_page
 
       and_i_see_back_link
@@ -144,10 +127,7 @@ RSpec.feature "PE allocations" do
         given_accredited_body_exists
         given_training_provider_with_pe_fee_funded_course_exists
         given_the_accredited_body_has_requested_an_initial_allocation
-
-        given_i_am_signed_in_as_an_admin
-        # once the feature is released it should be changed to
-        # given_i_am_signed_in_as_a_user_from_the_accredited_body
+        given_i_am_signed_in_as_a_user_from_the_accredited_body
 
         when_i_visit_my_organisations_page
         and_i_click_request_pe_courses
@@ -164,8 +144,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_training_provider_with_pe_fee_funded_course_exists
       given_the_accredited_body_has_declined_an_allocation
-
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -184,8 +163,7 @@ RSpec.feature "PE allocations" do
       given_accredited_body_exists
       given_training_provider_with_pe_fee_funded_course_exists
       given_the_accredited_body_has_requested_a_repeat_allocation
-
-      given_i_am_signed_in_as_an_admin
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -218,7 +196,13 @@ private
   def when_i_visit_pe_allocations_request_page
     stub_api_v2_resource(@accredited_body)
     stub_api_v2_resource(@accredited_body.recruitment_cycle)
-    stub_api_v2_resource(@training_provider)
+
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([@training_provider]),
+    )
 
     footer_stub_for_access_request_count
 
@@ -232,10 +216,6 @@ private
 
   def given_accredited_body_exists
     @accredited_body = build(:provider, accredited_body?: true)
-  end
-
-  def given_i_am_signed_in_as_an_admin
-    stub_omniauth(user: build(:user, :admin))
   end
 
   def when_i_visit_my_organisations_page
@@ -255,16 +235,16 @@ private
   end
 
   def given_accredited_body_exists
-    @accredited_body = build(:provider, accredited_body?: true)
+    @accredited_body = build(:provider, accredited_body?: true, users: [user])
     stub_api_v2_resource(@accredited_body.recruitment_cycle)
   end
 
-  def given_i_am_signed_in
-    stub_omniauth(user: build(:user))
+  def user
+    @user ||= build(:user)
   end
 
-  def given_i_am_signed_in_as_an_admin
-    stub_omniauth(user: build(:user, :admin))
+  def given_i_am_signed_in_as_a_user_from_the_accredited_body
+    stub_omniauth(user: user)
   end
 
   def given_training_provider_with_pe_fee_funded_course_exists
@@ -303,7 +283,12 @@ private
       "/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
       resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
     )
-    stub_api_v2_resource(@training_provider)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([@training_provider]),
+    )
     stub_api_v2_resource(@allocation)
   end
 
@@ -313,7 +298,14 @@ private
       "/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
       resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
     )
-    stub_api_v2_resource(@training_provider)
+
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([@training_provider]),
+    )
+
     stub_api_v2_resource(@allocation)
   end
 
@@ -398,7 +390,13 @@ private
   end
 
   def when_i_click_confirm_choice
-    stub_api_v2_resource(@training_provider)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([@training_provider]),
+    )
+
     click_on "Confirm choice"
   end
 
@@ -507,7 +505,13 @@ private
   end
 
   def and_i_click_on_first_view_requested_confirmation
-    stub_api_v2_resource(@training_provider)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([@training_provider]),
+    )
+
     stub_api_v2_request(
       "/allocations/#{@allocation.id}",
       resource_list_to_jsonapi([@allocation]),
@@ -516,7 +520,13 @@ private
   end
 
   def and_i_click_on_first_view_not_requested_confirmation
-    stub_api_v2_resource(@training_provider)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=2020",
+      resource_list_to_jsonapi([@training_provider]),
+    )
+
     stub_api_v2_request(
       "/allocations/#{@allocation.id}",
       resource_list_to_jsonapi([@allocation]),

--- a/spec/views/providers/show_spec.rb
+++ b/spec/views/providers/show_spec.rb
@@ -34,8 +34,8 @@ describe "providers/show" do
     context "user isn't an admin" do
       let(:admin) { false }
 
-      it "doesn't display the PE allocation link" do
-        expect(provider_show_page).not_to have_request_allocations_link
+      it "displays the PE allocation link" do
+        expect(provider_show_page).to have_request_allocations_link
       end
 
       it "displays the 'Courses as an accredited body' link" do


### PR DESCRIPTION
### Context

- https://trello.com/c/QpRrdwxL/3466-pre-launch-task-make-accredited-bodies-able-to-see-allocation-pages
- Allocations is currently feature flagged to admins only, this change removes that

### Changes proposed in this pull request

- Admin only restriction has been lifted
- Users of accredited bodies can access allocations

### Guidance to review

- Depends on https://github.com/DFE-Digital/teacher-training-api/pull/1394
- Access allocations as a user of an accredited body
- Should able to access allocations pages

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
