### PR TITLE
3472 Remove admin only from notifications

### DIFF
--- a/app/views/providers/_notifications_sign_up_link.html.erb
+++ b/app/views/providers/_notifications_sign_up_link.html.erb
@@ -1,4 +1,4 @@
-<% if @provider.accredited_body? && current_user["admin"]%>
+<% if @provider.accredited_body? %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <%= govuk_link_to "Notifications", notifications_path, class: "govuk-link", data:{qa: "notifications-link"} %>
   </h2>

--- a/app/views/providers/_notifications_sign_up_link.html.erb
+++ b/app/views/providers/_notifications_sign_up_link.html.erb
@@ -1,11 +1,6 @@
 <% if @provider.accredited_body? && current_user["admin"]%>
-  <div class="app-admin-only__section">
-    <div class="app-admin-only__section-header">
-      <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
-    </div>
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-      <%= govuk_link_to "Notifications", notifications_path(provider_code: @provider.provider_code), class: "govuk-link", data:{qa: "notifications-link"} %>
-    </h2>
-    <p class="govuk-body">Get email notifications about your courses.</p>
-  </div>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+    <%= govuk_link_to "Notifications", notifications_path, class: "govuk-link", data:{qa: "notifications-link"} %>
+  </h2>
+  <p class="govuk-body">Get email notifications about your courses.</p>
 <% end %>

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -6,7 +6,7 @@ feature "Notifications", type: :feature do
 
   let(:provider) { build :provider }
   let(:access_request) { build :access_request }
-  let(:user) { build :user, :admin }
+  let(:user) { build :user }
 
   before do
     stub_omniauth(user: user)

--- a/spec/views/providers/show_spec.rb
+++ b/spec/views/providers/show_spec.rb
@@ -39,8 +39,8 @@ describe "providers/show" do
         expect(provider_show_page).to have_courses_as_accredited_body_link
       end
 
-      it "doesn't display the notification preferences" do
-        expect(provider_show_page).not_to have_notifications_preference_link
+      it "displays the notification preferences" do
+        expect(provider_show_page).to have_notifications_preference_link
       end
     end
   end


### PR DESCRIPTION
### Context

We are releasing the notification preferences feature to users so no longer need the 'Admin feature' flag.

### Changes proposed in this pull request

Revert the PRs that added the restriction and markup.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
