### PR TITLE
[3455] Conditionally show notifications link on the organisations page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -10,10 +10,11 @@ class ProvidersController < ApplicationController
     page = (params[:page] || 1).to_i
     per_page = 10
 
-    @providers = Provider.where(recruitment_cycle_year: Settings.current_cycle)
-                         .page(page)
+    @providers = providers.page(page)
 
     @pagy = Pagy.new(count: @providers.meta.count, page: page, items: per_page)
+
+    @providers_view = ProvidersView.new(providers: providers)
 
     render "providers/no_providers", status: :forbidden if @providers.empty?
     redirect_to provider_path(@providers.first.provider_code) if @providers.size == 1

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -24,6 +24,8 @@ class ProvidersController < ApplicationController
       .where(recruitment_cycle_year: @recruitment_cycle.year)
       .find(params[:code])
       .first
+
+    @provider_view = ProviderView.new(provider: @provider, providers: providers)
   end
 
   def details
@@ -151,5 +153,9 @@ private
     cycle_year = params.fetch(:year, Settings.current_cycle)
 
     @recruitment_cycle = RecruitmentCycle.find(cycle_year).first
+  end
+
+  def providers
+    @providers ||= Provider.where(recruitment_cycle_year: Settings.current_cycle)
   end
 end

--- a/app/view_objects/provider_view.rb
+++ b/app/view_objects/provider_view.rb
@@ -1,0 +1,22 @@
+class ProviderView
+  def initialize(provider:, providers:)
+    @provider = provider
+    @providers = providers
+  end
+
+  def show_notifications_link?
+    accredited_body? && accredited_body_count == 1
+  end
+
+private
+
+  def accredited_body_count
+    providers.select(&:accredited_body?).count
+  end
+
+  def accredited_body?
+    provider.accredited_body?
+  end
+
+  attr_reader :provider, :providers
+end

--- a/app/view_objects/providers_view.rb
+++ b/app/view_objects/providers_view.rb
@@ -1,0 +1,17 @@
+class ProvidersView
+  def initialize(providers:)
+    @providers = providers
+  end
+
+  def show_notifications_link?
+    accredited_body_count > 1
+  end
+
+private
+
+  def accredited_body_count
+    providers.select(&:accredited_body?).count
+  end
+
+  attr_reader :providers
+end

--- a/app/views/providers/_notifications_sign_up_link.html.erb
+++ b/app/views/providers/_notifications_sign_up_link.html.erb
@@ -1,6 +1,4 @@
-<% if @provider.accredited_body? %>
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-    <%= govuk_link_to "Notifications", notifications_path, class: "govuk-link", data:{qa: "notifications-link"} %>
-  </h2>
-  <p class="govuk-body">Get email notifications about your courses.</p>
-<% end %>
+<h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+  <%= govuk_link_to "Notifications", notifications_path, class: "govuk-link", data:{qa: "notifications-link"} %>
+</h2>
+<p class="govuk-body">Get email notifications about your courses.</p>

--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -2,12 +2,24 @@
 
 <h1 class="govuk-heading-xl">Organisations</h1>
 
-<% if current_user.present? && current_user["admin"] %>
-  <%= render partial: "providers/search" %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if current_user.present? && current_user["admin"] %>
+      <%= render partial: "providers/search" %>
+    <% end %>
 
-<ul class="govuk-list">
-  <%= render partial: "providers/provider", collection: @providers %>
-</ul>
+    <ul class="govuk-list">
+      <%= render partial: "providers/provider", collection: @providers %>
+    </ul>
 
-<%= pagy_govuk_nav(@pagy).html_safe %>
+    <%= pagy_govuk_nav(@pagy).html_safe %>
+  </div>
+
+  <aside class="govuk-grid-column-one-third">
+    <div class="app-related">
+      <% if @providers_view.show_notifications_link? %>
+        <%= render partial: "providers/notifications_sign_up_link" %>
+      <% end %>
+    </div>
+  </aside>
+</div>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -41,7 +41,9 @@
   </div>
   <aside class="govuk-grid-column-one-third">
     <div class="app-related">
-      <%= render partial: "providers/notifications_sign_up_link" %>
+      <% if @provider_view.show_notifications_link? %>
+        <%= render partial: "providers/notifications_sign_up_link" %>
+      <% end %>
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%= govuk_link_to "Request access", request_access_provider_path(code: @provider.provider_code) %></h2>
       <p class="govuk-body">Request a DfE Sign-in account for others who manage your courses.</p>
 

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 feature "Notifications", type: :feature do
   let(:organisation_show_page) { PageObjects::Page::Organisations::OrganisationShow.new }
   let(:notifications_index_page) { PageObjects::Page::Notifications::IndexPage.new }
+  let(:provider_view) { instance_double(ProviderView) }
 
-  let(:provider) { build :provider }
+  let(:provider) { build :provider, accredited_body?: true }
+  let(:providers) { [provider] }
   let(:access_request) { build :access_request }
   let(:user) { build :user }
 
@@ -15,21 +17,7 @@ feature "Notifications", type: :feature do
     stub_api_v2_resource_collection([access_request])
   end
 
-  context "When the provider is not an accredited body" do
-    it "does not have the notifications link" do
-      when_i_visit_providers_page
-      then_i_should_not_see_notifications_link
-    end
-  end
-
   context "When the provider is an accredited body" do
-    let(:provider) { build :provider, accredited_body?: true }
-
-    it "organisation page does have the notifications link" do
-      when_i_visit_accredited_body_page
-      then_i_should_see_notifications_link
-    end
-
     describe "User sets notification preferences for the first time" do
       it "should allow the user to opt into notifications" do
         given_a_user_has_never_set_their_preferences
@@ -87,20 +75,12 @@ private
     )
   end
 
-  def when_i_visit_providers_page
-    visit provider_path(provider.provider_code)
-  end
-
   def when_i_visit_accredited_body_page
-    when_i_visit_providers_page
+    visit provider_path(provider.provider_code)
   end
 
   def then_i_should_see_notifications_link
     expect(organisation_show_page).to have_notifications_preference_link
-  end
-
-  def then_i_should_not_see_notifications_link
-    expect(organisation_show_page).not_to have_notifications_preference_link
   end
 
   def and_i_click_on_notifications_link

--- a/spec/site_prism/page_objects/page/root_page.rb
+++ b/spec/site_prism/page_objects/page/root_page.rb
@@ -7,6 +7,7 @@ module PageObjects
       element :find_providers, '[data-qa="find-providers"]'
       element :error_summary, ".govuk-error-summary"
       element :provider_error, '[data-qa="provider-error"]'
+      element :notifications_preference_link, "[data-qa='notifications-link']"
     end
   end
 end

--- a/spec/view_objects/provider_view_spec.rb
+++ b/spec/view_objects/provider_view_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe ProviderView do
+  subject { described_class.new(provider: provider, providers: providers) }
+
+  describe "show_notifications_link?" do
+    context "provider is an accredited_body" do
+      context "one accredited body" do
+        let(:provider) { build(:provider, accredited_body?: true) }
+        let(:providers) { [provider] }
+        it "returns true" do
+          expect(subject.show_notifications_link?).to eq(true)
+        end
+      end
+
+      context "more than one accredited body" do
+        let(:provider) { build(:provider, accredited_body?: true) }
+        let(:providers) do
+          [
+            provider,
+            build(:provider, accredited_body?: true),
+          ]
+        end
+        it "returns false" do
+          expect(subject.show_notifications_link?).to eq(false)
+        end
+      end
+    end
+
+    context "provider is not an accredited_body" do
+      let(:provider) { build(:provider) }
+      let(:providers) { [provider] }
+
+      it "returns false" do
+        expect(subject.show_notifications_link?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/view_objects/providers_view_spec.rb
+++ b/spec/view_objects/providers_view_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe ProvidersView do
+  subject { described_class.new(providers: providers) }
+
+  describe "show_notifications_link?" do
+    context "one accredited body" do
+      let(:providers) { [build(:provider, :accredited_body)] }
+      it "returns false" do
+        expect(subject.show_notifications_link?).to eq(false)
+      end
+    end
+
+    context "more than one accredited body" do
+      let(:providers) do
+        [
+          build(:provider, :accredited_body),
+          build(:provider, :accredited_body),
+        ]
+      end
+      it "returns true" do
+        expect(subject.show_notifications_link?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/views/providers/index_spec.rb
+++ b/spec/views/providers/index_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe "providers/index" do
+  let(:provider_index_page) { PageObjects::Page::RootPage.new }
+  let(:pagy) { instance_double(Pagy) }
+  let(:providers_view) { instance_double(ProvidersView) }
+  let(:provider) { build(:provider, :accredited_body) }
+  let(:provider2) { build(:provider, :accredited_body) }
+
+  module CurrentUserMethod
+    def current_user; end
+  end
+
+  before do
+    view.extend(CurrentUserMethod)
+    allow(pagy).to receive(:prev)
+    allow(pagy).to receive(:next)
+    assign(:pagy, pagy)
+
+    assign(:providers, providers)
+    allow(provider).to receive(:course_count).and_return(1)
+    allow(provider2).to receive(:course_count).and_return(1)
+
+    allow(providers_view).to receive(:show_notifications_link?).and_return(notifications_link_boolean)
+    assign(:providers_view, providers_view)
+
+    render
+
+    provider_index_page.load(rendered)
+  end
+
+  context "one provider is an accredited body" do
+    let(:providers) { [provider] }
+    let(:notifications_link_boolean) { false }
+
+    it "doesn't display the notification preferences" do
+      expect(provider_index_page).not_to have_notifications_preference_link
+    end
+  end
+
+  context "more than one provider is an accredited body" do
+    let(:providers) do
+      [provider, provider2]
+    end
+    let(:notifications_link_boolean) { true }
+
+    it "displays the notification preferences" do
+      expect(provider_index_page).to have_notifications_preference_link
+    end
+  end
+end

--- a/spec/views/providers/show_spec.rb
+++ b/spec/views/providers/show_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "providers/show" do
   let(:provider_show_page) { PageObjects::Page::Organisations::OrganisationShow.new }
+  let(:provider_view) { instance_double(ProviderView) }
 
   module CurrentUserMethod
     def current_user; end
@@ -11,7 +12,8 @@ describe "providers/show" do
     view.extend(CurrentUserMethod)
     allow(view).to receive(:current_user).and_return({ "admin" => admin })
     assign(:provider, provider)
-
+    allow(provider_view).to receive(:show_notifications_link?).and_return(notifications_link_boolean)
+    assign(:provider_view, provider_view)
     render
 
     provider_show_page.load(rendered)
@@ -19,6 +21,7 @@ describe "providers/show" do
 
   context "provider is an accredited body" do
     let(:provider) { build(:provider, :accredited_body) }
+    let(:notifications_link_boolean) { true }
 
     context "user is an admin" do
       let(:admin) { true }
@@ -43,10 +46,21 @@ describe "providers/show" do
         expect(provider_show_page).to have_notifications_preference_link
       end
     end
+
+    context "more than one provider is an accredited body" do
+      let(:admin) { false }
+      let(:provider) { build(:provider, :accredited_body) }
+      let(:notifications_link_boolean) { false }
+
+      it "doesn't display the notification preferences" do
+        expect(provider_show_page).not_to have_notifications_preference_link
+      end
+    end
   end
 
   context "provider is not an accredited body" do
     let(:provider) { build(:provider) }
+    let(:notifications_link_boolean) { false }
 
     context "user is an admin" do
       let(:admin) { true }


### PR DESCRIPTION
### Context
Since turning notifications on enables them for all organisations the notifications link should appear on the organisations page if the user has more than one accredited body.

### Changes proposed in this pull request
When a user is associated with more than one accredited body display a notifications link in the right sidebar on the organisations index page (at`/`) and don't display it on the organisation show pages (e.g. `/organisations/T92`)

- <kbd><img width="791" alt="Screenshot 2020-05-28 at 14 46 29" src="https://user-images.githubusercontent.com/38078064/83411563-68a07680-a410-11ea-98a5-3f37b9c3bdee.png"></kbd>

### Guidance to review
- log in as a user with multiple accredited bodies 
  - visit root path
  - notifications link appears on the organisations page (index) `/`
  - notifications link does not appear on the providers page e.g. `/organisations/T92` 
- log in as a user with one accredited body 
  - notifications link appears on the providers page

_Note:_ There is still logic on the index and show page that can be moved to the new view objects. This will be done in a separate PR.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
