### PR TITLE
[3433] - Add new 'number_of_places' validation

### DIFF
--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -84,7 +84,7 @@ class InitialRequestFlow
 private
 
   def valid_number_of_places?
-    params[:number_of_places] && !params[:number_of_places].include?(".") && params[:number_of_places].to_i.positive?
+    params[:number_of_places] && /\A\d+\z/.match?(params[:number_of_places]) && params[:number_of_places].to_i.positive?
   end
 
   def number_of_places_zero?

--- a/app/form_objects/initial_request_form.rb
+++ b/app/form_objects/initial_request_form.rb
@@ -29,7 +29,7 @@ private
 
   def number_of_places_valid?
     !number_of_places.empty? &&
-      !number_of_places.include?(".") &&
+      /\A\d+\z/.match?(number_of_places) &&
       number_of_places.to_i.positive?
   end
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -29,13 +29,6 @@ class Allocation < Base
     number_of_places.to_i.positive?
   end
 
-  def add_invalid_number_of_places_errors
-    errors.add(
-      :number_of_places,
-      "We could not find this organisation - please check your information and try ",
-    )
-  end
-
   def repeat_request?
     request_type == Allocation::RequestTypes::REPEAT
   end
@@ -48,7 +41,7 @@ private
 
   def number_of_places_valid?
     !number_of_places.to_s.empty? &&
-      !number_of_places.to_s.include?(".") &&
+      /\A\d+\z/.match?(number_of_places.to_s) &&
       number_of_places.to_i.positive?
   end
 end

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature "PE allocations" do
           and_i_click_continue
           then_i_see_edit_number_of_places_page
 
-          when_i_fill_in_the_number_of_places_input_with_a_letter
+          when_i_fill_in_the_number_of_places_input_with_a_letter_and_number
           and_i_click_continue
 
           then_i_see_edit_number_of_places_page
@@ -268,8 +268,8 @@ RSpec.feature "PE allocations" do
     number_of_places_page.number_of_places_field.fill_in(with: "1.1")
   end
 
-  def when_i_fill_in_the_number_of_places_input_with_a_letter
-    number_of_places_page.number_of_places_field.fill_in(with: "a")
+  def when_i_fill_in_the_number_of_places_input_with_a_letter_and_number
+    number_of_places_page.number_of_places_field.fill_in(with: "3a")
   end
 
   def when_i_fill_in_the_number_of_places_input_with_nothing

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -452,7 +452,7 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_fill_in_the_number_of_places_input_with_a_letter
-    number_of_places_page.number_of_places_field.fill_in(with: "a")
+    number_of_places_page.number_of_places_field.fill_in(with: "3a")
   end
 
   def when_i_fill_in_the_number_of_places_input_with_zero

--- a/spec/form_objects/initial_request_form_spec.rb
+++ b/spec/form_objects/initial_request_form_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe InitialRequestForm do
       end
     end
 
-    context "when number_of_places is a letter" do
+    context "when number_of_places contains a letter" do
       subject do
-        described_class.new(number_of_places: "a")
+        described_class.new(number_of_places: "3a")
       end
 
       it "returns an error" do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Allocation do
+  describe "validations" do
+    context "when number_of_places is empty" do
+      subject do
+        described_class.new(number_of_places: "", request_type: Allocation::RequestTypes::INITIAL)
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:number_of_places]).to be_present
+      end
+    end
+
+    context "when number_of_places is less than 1" do
+      subject do
+        described_class.new(number_of_places: "0", request_type: Allocation::RequestTypes::INITIAL)
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:number_of_places]).to be_present
+      end
+    end
+
+    context "when number_of_places contains a letter" do
+      subject do
+        described_class.new(number_of_places: "3a", request_type: Allocation::RequestTypes::INITIAL)
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:number_of_places]).to be_present
+      end
+    end
+
+    context "when number of places is a float" do
+      subject do
+        described_class.new(number_of_places: "1.1", request_type: Allocation::RequestTypes::INITIAL)
+      end
+
+      it "returns an error" do
+        subject.valid?
+        expect(subject.errors[:number_of_places]).to be_present
+      end
+    end
+
+    context "when number of places is valid" do
+      subject do
+        described_class.new(number_of_places: "2", request_type: Allocation::RequestTypes::INITIAL)
+      end
+
+      it "is valid" do
+        expect(subject.valid?).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Discovered that a combination of letter and number was still considered 'valid' when filling out the 'number of places' field when creating or updating an initial allocation

### Changes proposed in this pull request
- Adds regex to validate that 'number of places' only contains numbers
- Add Allocation model validation specs
- Remove unused code from Allocation model

### Guidance to review
When you fill out the 'number of places' field with a letter-number combination (e.g. '3a') you should now see a validation error.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
