### PR TITLE
[3479] Add users link to org show sidebar

### DIFF
--- a/app/controllers/providers/users_controller.rb
+++ b/app/controllers/providers/users_controller.rb
@@ -2,10 +2,10 @@ module Providers
   class UsersController < ApplicationController
     def index
       cycle_year = params.fetch(:year, Settings.current_cycle)
-      recruitment_cycle = RecruitmentCycle.find(cycle_year).first
+      @recruitment_cycle = RecruitmentCycle.find(cycle_year).first
 
       @provider = Provider.includes(:users)
-                    .where(recruitment_cycle_year: recruitment_cycle.year)
+                    .where(recruitment_cycle_year: @recruitment_cycle.year)
                     .find(params[:code])
                     .first
 

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -45,6 +45,11 @@ module BreadcrumbHelper
     recruitment_cycle_breadcrumb << ["About your organisation", path]
   end
 
+  def users_breadcrumb
+    path = details_provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year)
+    recruitment_cycle_breadcrumb << ["Users", path]
+  end
+
   def edit_site_breadcrumb
     path = edit_provider_recruitment_cycle_site_path(@provider.provider_code, @site.recruitment_cycle_year, @site.id)
     sites_breadcrumb << [@site_name_before_update, path]

--- a/app/views/providers/access_requests/new.html.erb
+++ b/app/views/providers/access_requests/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "#{@errors && @errors.any? ? "Error: " : ""}Request access for someone else" %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(provider_path(params[:code])) %>
+  <%= govuk_back_link_to(users_provider_path(params[:code])) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -44,8 +44,8 @@
       <% if @provider_view.show_notifications_link? %>
         <%= render partial: "providers/notifications_sign_up_link" %>
       <% end %>
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%= govuk_link_to "Request access", request_access_provider_path(code: @provider.provider_code) %></h2>
-      <p class="govuk-body">Request a DfE Sign-in account for others who manage your courses.</p>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%= govuk_link_to "Users", users_provider_path(code: @provider.provider_code) %></h2>
+      <p class="govuk-body">View users who manage your courses.</p>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%= govuk_link_to "UCAS contacts", provider_ucas_contacts_path(provider_code: @provider.provider_code) %></h2>
       <p class="govuk-body">Update or request UCAS contact details.</p>

--- a/app/views/providers/users/index.html.erb
+++ b/app/views/providers/users/index.html.erb
@@ -1,12 +1,13 @@
 <%= content_for :page_title, "Users" %>
+<%= content_for :before_content, render_breadcrumbs(:users) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Users</h1>
     <p class="govuk-body">
-      These users currently have access to this account. They can manage all your course and organisation details, including publishing, closing and withdrawing courses.
+      These users currently have access to this organisation. They can manage all your course and organisation details, including publishing, closing and withdrawing courses.
     </p>
-    <%= link_to "Invite user", request_access_provider_path(code: @provider.provider_code), class: "govuk-button" %>
+    <%= link_to "Request access for someone else", request_access_provider_path(code: @provider.provider_code), class: "govuk-button" %>
     <% @users.each do |user| %>
       <div>
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1">

--- a/spec/features/providers/index_spec.rb
+++ b/spec/features/providers/index_spec.rb
@@ -48,6 +48,7 @@ feature "View providers", type: :feature do
       expect(organisation_page).to have_link("Locations", href: "/organisations/A0/#{Settings.current_cycle}/locations")
       expect(organisation_page).to have_link("Courses", href: "/organisations/A0/#{Settings.current_cycle}/courses")
       expect(organisation_page).to have_link("UCAS contacts", href: "/organisations/A0/ucas-contacts")
+      expect(organisation_page).to have_link("Users", href: "/organisations/A0/users")
     end
 
     context "Rollover" do

--- a/spec/features/providers/user_spec.rb
+++ b/spec/features/providers/user_spec.rb
@@ -48,7 +48,7 @@ feature "Provider users page" do
   end
 
   def when_i_click_on_request_access
-    click_on("Invite user")
+    click_on("Request access for someone else")
   end
 
   def then_i_see_the_request_access_form


### PR DESCRIPTION
### Context
Display "users"

### Changes proposed in this pull request

![Screenshot 2020-06-04 at 12 15 40](https://user-images.githubusercontent.com/3071606/83750400-2b7cf400-a65d-11ea-8b62-e384aca05582.png)
![Screenshot 2020-06-04 at 12 15 43](https://user-images.githubusercontent.com/3071606/83750407-2cae2100-a65d-11ea-8648-4d18249c527a.png)

### Guidance to review
https://s121d02-3479-ptt-as.azurewebsites.net/
Go to any organisation page and click on the "users" link in the sidebar

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review

