### PR TITLE
[3409] Set cache control in assets header

### DIFF
--- a/config/initializers/assets_cache_header.rb
+++ b/config/initializers/assets_cache_header.rb
@@ -1,0 +1,8 @@
+# This will affect assets served from /app/assets
+Rails.application.config.static_cache_control = "public, max-age=31536000"
+
+# This will affect assets in /public, e.g. webpacker assets.
+Rails.application.config.public_file_server.headers = {
+  "Cache-Control" => "public, max-age=31536000",
+  "Expires" => 1.year.from_now.to_formatted_s(:rfc822),
+}


### PR DESCRIPTION
### Context
None of our assets were being cached by the browser because cache-control
was not being set. I set it to a 1 year because our assets use a cache
busting technique so if we were to update their content the filename would
be different and therefore the browser would fetch and use the updated
assets.

Reference:
mikerogers.io/2019/11/02/how-to-set-cache-control-headers-for-rails-webpacker-and-sprockets-assets.html

### Changes proposed in this pull request
visit https://s121d02-3409-ptt-as.azurewebsites.net/
Check asset headers and see if cache control is set to expire in a years time

![image](https://user-images.githubusercontent.com/3441519/83855968-c1258b80-a710-11ea-8e4b-b44d407f9874.png)

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
