### PR TITLE
[2943] Run javascripts tests as part of build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,14 @@ steps:
     failedTaskOnFailedTest: true
 
 - task: Docker@1
+  displayName: Run javascript tests
+  inputs:
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: yarn test
+    runInBackground: false
+
+- task: Docker@1
   displayName: Run ruby linter
   inputs:
     command: Run an image

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,36 +35,6 @@ steps:
     arguments: '--cache-from $(IMAGE_NAME):latest'
     addDefaultLabels: false
 
-- script: |
-    set -x
-    docker run --name test-run-image -d $(IMAGE_NAME)
-    docker exec test-run-image rake "parallel:spec[,, -O .azure_parallel]"
-    test_result=$?
-      if [ "$test_result" != "0" ]
-      then
-          echo "##vso[task.logissue type=error] Test task failed."
-          exit 1
-      fi
-    docker cp test-run-image:/app/rspec-output .
-    docker stop test-run-image
-    docker rm test-run-image
-  displayName: 'Run tests'
-
-- task: PublishTestResults@2
-  condition: succeededOrFailed()
-  inputs:
-    testRunner: JUnit
-    testResultsFiles: 'rspec-output/*.xml'
-    failedTaskOnFailedTest: true
-
-- task: Docker@1
-  displayName: Run javascript tests
-  inputs:
-    command: Run an image
-    imageName: $(IMAGE_NAME)
-    containerCommand: yarn test
-    runInBackground: false
-
 - task: Docker@1
   displayName: Run ruby linter
   inputs:
@@ -79,6 +49,36 @@ steps:
     command: Run an image
     imageName: $(IMAGE_NAME)
     containerCommand: scss-lint app/webpacker/stylesheets
+    runInBackground: false
+
+- script: |
+    set -x
+    docker run --name test-run-image -d $(IMAGE_NAME)
+    docker exec test-run-image rake "parallel:spec[,, -O .azure_parallel]"
+    test_result=$?
+      if [ "$test_result" != "0" ]
+      then
+          echo "##vso[task.logissue type=error] Test task failed."
+          exit 1
+      fi
+    docker cp test-run-image:/app/rspec-output .
+    docker stop test-run-image
+    docker rm test-run-image
+  displayName: 'Run ruby tests'
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testRunner: JUnit
+    testResultsFiles: 'rspec-output/*.xml'
+    failedTaskOnFailedTest: true
+
+- task: Docker@1
+  displayName: Run javascript tests
+  inputs:
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: yarn test
     runInBackground: false
 
 - task: Docker@1


### PR DESCRIPTION
### Context

- https://trello.com/c/angQ7t5X/2943-m-run-js-tests-as-part-of-the-ci-pipeline
- This runs the javascript tests as part of the build

### Changes proposed in this pull request

- Added task to CI to run js tests
- Linting now occurs before tests

### Guidance to review

- Added a failing js test
- Run in CI
- Build should fail

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally