### PR TITLE
[3341] - Optimise courses as an accredited body query

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -71,13 +71,7 @@ class ProvidersController < ApplicationController
   def training_providers
     @training_providers = @provider.training_providers(recruitment_cycle_year: @recruitment_cycle.year)
     @training_providers.delete_if { |tp| tp.provider_code == @provider.provider_code }
-
-    courses = Course.where(
-      recruitment_cycle_year: @recruitment_cycle.year,
-      accrediting_provider_code: @provider.provider_code,
-    )
-
-    @course_counts = courses.group_by(&:provider_code).transform_values(&:size)
+    @course_counts = @training_providers.meta[:accredited_courses_counts]
   end
 
   def training_provider_courses

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -33,7 +33,7 @@ feature "get courses as an accredited body", type: :feature do
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
       "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
-      resource_list_to_jsonapi([training_provider2, accrediting_body2]),
+      resource_list_to_jsonapi([training_provider2, accrediting_body2], { meta: { accredited_courses_counts: {} } }),
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/#{training_provider2.provider_code}" \

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -26,7 +26,15 @@ feature "get training_providers", type: :feature do
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
       "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
-      resource_list_to_jsonapi([accrediting_body1, training_provider1, training_provider2]),
+      resource_list_to_jsonapi(
+        [accrediting_body1, training_provider1, training_provider2],
+        meta: {
+          accredited_courses_counts: {
+            "#{training_provider1.provider_code}": "1",
+            "#{training_provider2.provider_code}": "2",
+          },
+        },
+      ),
     )
     stub_api_v2_resource_collection([access_request])
   end


### PR DESCRIPTION
### Context

“Courses as accredited body” page is extremely slow, 20-40sec Time to First Byte. This is because the API endpoint returning the list of training providers or course counts are extremely slow.

### Changes proposed in this pull request
- The V2 end point has been updated to calculated the accredited_body
course counts, resulting in faster load times - see https://github.com/DFE-Digital/teacher-training-api/pull/1400. Publish therefore needs to be updated to handle the new response.

### Guidance to review
See https://github.com/DFE-Digital/teacher-training-api/pull/1400 for guidance on running locally and manually testing the changes

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
