### PR TITLE
3502 Add Code Climate test coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,7 +127,7 @@ group :test do
   gem "webmock"
 
   # Show test coverage %
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 
   # Make diffs of Ruby objects much more readable
   gem "super_diff"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    json (2.3.0)
     json-jwt (1.11.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -394,10 +395,11 @@ GEM
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
-    simplecov (0.18.5)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     site_prism (3.4.2)
       addressable (~> 2.5)
       capybara (~> 3.3)
@@ -510,7 +512,7 @@ DEPENDENCIES
   rubocop-govuk
   scss_lint-govuk
   sentry-raven
-  simplecov
+  simplecov (< 0.18)
   site_prism
   spring
   spring-commands-rspec

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,8 @@ steps:
           exit 1
       fi
     docker cp test-run-image:/app/rspec-output .
+    docker cp test-run-image:/app/coverage .
+
     docker stop test-run-image
     docker rm test-run-image
   displayName: 'Run ruby tests'
@@ -88,6 +90,22 @@ steps:
     imageName: $(IMAGE_NAME)
     containerCommand: rails brakeman
     runInBackground: false
+
+- script: |
+    set -x
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+    chmod +x ./cc-test-reporter
+
+    ./cc-test-reporter before-build
+    # As the tests were run in the docker container the paths to the coverage are prefixed with "/app/"
+    # So we need to replace it with the docker hosts current directory
+    sed "s|\"/app/|\"`pwd`/|g" coverage/.resultset.json -i
+    ./cc-test-reporter after-build
+  displayName: 'Publish Code Climate Test Coverage'
+  env:
+    CC_TEST_REPORTER_ID: $(ccReporterID)
+    AGENT_JOBSTATUS: $(Agent.JobStatus)
+    GIT_BRANCH: $(Build.SourceBranchName)
 
 - task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)


### PR DESCRIPTION
### Context
We need a way to surface code smells and test coverage. Code climate is used in API and Code Climate was configured to analysis this repo but it did not include the test coverage.
 
### Changes proposed in this pull request
- Sets simplecov version to 0.17.x so that code climates test reporter will work
- Add new script to the pipeline to push the test coverage score to code climate (This is only run if all our existing tasks pass.

### Guidance to review
I checked on Code Climate and can confirm that Code climate is receiving the requests sent to it

![image](https://user-images.githubusercontent.com/3441519/84235817-6617de00-aaee-11ea-8538-c2c7922b24cc.png)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
