### PR TITLE
[3463] Prefil number of places if param exists

### DIFF
--- a/app/views/providers/edit_initial_allocations/number_of_places.html.erb
+++ b/app/views/providers/edit_initial_allocations/number_of_places.html.erb
@@ -27,6 +27,7 @@
 
       <%= form.govuk_error_summary %>
       <%= form.govuk_text_field :number_of_places,
+          value: params[:number_of_places] || allocation.number_of_places,
           label: {
             text: "How many places would you like to request?",
             size: "xl",

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -29,6 +29,11 @@ RSpec.feature "PE allocations" do
       then_see_the_check_answers_page
       and_the_number_is_the_one_i_entered
 
+      when_i_click_change
+      then_i_see_edit_number_of_places_page
+      and_i_see_the_updated_number_of_places
+      and_i_click_continue
+
       when_i_click_send_request
       then_i_see_confirmation_page
     end
@@ -226,6 +231,10 @@ RSpec.feature "PE allocations" do
     click_on "Change"
   end
 
+  def when_i_click_change
+    click_on "Change"
+  end
+
   def then_i_see_do_you_want_page
     expect(find("h1")).to have_content("Do you want to request PE for this organisation?")
   end
@@ -278,6 +287,10 @@ RSpec.feature "PE allocations" do
 
   def and_the_number_is_the_one_i_entered
     expect(check_answers_page.number_of_places.text).to have_content("10")
+  end
+
+  def and_i_see_the_updated_number_of_places
+    expect(number_of_places_page.number_of_places_field.value).to have_content("10")
   end
 
   def when_i_click_send_request


### PR DESCRIPTION
### Context
https://trello.com/c/8JXumJFG/3463-s-change-link-on-check-your-answer-page-does-not-playback-the-correct-number-of-places-entered-on-how-many-places-would-you-like

### Changes proposed in this pull request
Specify number of places to be pre-filled if there's an existing param

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
