### PR TITLE
[3472] Rename accrediting_provider_code

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -126,7 +126,7 @@ private
           :master_subject_id,
           :subordinate_subject_id,
           :funding_type,
-          :accrediting_provider_code,
+          :accredited_body_code,
           sites_ids: [],
           subjects_ids: [],
         )

--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -10,7 +10,7 @@ module Courses
     end
 
     def continue
-      other_selected_with_no_autocompleted_code = course_params[:accrediting_provider_code] == "other" && @autocompleted_provider_code.blank?
+      other_selected_with_no_autocompleted_code = course_params[:accredited_body_code] == "other" && @autocompleted_provider_code.blank?
 
       if other_selected_with_no_autocompleted_code
         redirect_to(
@@ -20,7 +20,7 @@ module Courses
           ),
         )
       else
-        params[:course][:accrediting_provider_code] = @autocompleted_provider_code if @autocompleted_provider_code.present?
+        params[:course][:accredited_body_code] = @autocompleted_provider_code if @autocompleted_provider_code.present?
         super
       end
     end
@@ -40,13 +40,13 @@ module Courses
 
     def update
       build_provider
-      code = update_course_params[:accrediting_provider_code]
+      code = update_course_params[:accredited_body_code]
       query = update_course_params[:accredited_body]
 
       @errors = errors_for_search_query(code, query)
       return render :edit if @errors.present?
 
-      if update_params[:accrediting_provider_code] == "other"
+      if update_params[:accredited_body_code] == "other"
         redirect_to_provider_search
       elsif @course.update(update_params)
         redirect_to_update_successful
@@ -75,7 +75,7 @@ module Courses
     end
 
     def error_keys
-      [:accrediting_provider_code]
+      [:accredited_body_code]
     end
 
     def redirect_to_provider_search
@@ -115,7 +115,7 @@ module Courses
       if code == "other" && query.length < 3
         errors = { accredited_body: ["Accredited body search too short, enter 2 or more characters"] }
       elsif code.blank?
-        errors = { accrediting_provider_code: ["Pick an accredited body"] }
+        errors = { accredited_body_code: ["Pick an accredited body"] }
       end
 
       errors
@@ -133,17 +133,17 @@ module Courses
     def update_course_params
       params.require(:course).permit(
         :autocompleted_provider_code,
-        :accrediting_provider_code,
+        :accredited_body_code,
         :accredited_body,
       )
     end
 
     def update_params
       autocompleted_code = update_course_params[:autocompleted_provider_code]
-      code = update_course_params[:accrediting_provider_code]
+      code = update_course_params[:accredited_body_code]
 
       {
-        accrediting_provider_code: autocompleted_code.presence || code,
+        accredited_body_code: autocompleted_code.presence || code,
       }
     end
   end

--- a/app/controllers/courses/applications_open_controller.rb
+++ b/app/controllers/courses/applications_open_controller.rb
@@ -29,7 +29,7 @@ module Courses
           :sites_ids,
           :subjects_ids,
           :goto_confirmation,
-          :accrediting_provider_code,
+          :accredited_body_code,
         )
         .permit(
           :applications_open_from,

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -217,7 +217,7 @@ private
         :start_date,
         :funding_type,
         :age_range_in_years,
-        :accrediting_provider_code,
+        :accredited_body_code,
         subjects_ids: [],
         sites_ids: [],
       )

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -78,7 +78,7 @@ class ProvidersController < ApplicationController
     @courses = Course
       .where(recruitment_cycle_year: @recruitment_cycle.year)
       .where(provider_code: @training_provider.provider_code)
-      .where(accrediting_provider_code: @provider.provider_code)
+      .where(accredited_body_code: @provider.provider_code)
       .map(&:decorate)
 
     @courses.sort_by!(&:name)

--- a/app/controllers/training_providers_courses_controller.rb
+++ b/app/controllers/training_providers_courses_controller.rb
@@ -7,7 +7,7 @@ class TrainingProvidersCoursesController < ApplicationController
 
   def index
     course_csv_rows = Course.includes(:provider)
-      .where(recruitment_cycle_year: @recruitment_cycle.year, accrediting_provider_code: @provider.provider_code)
+      .where(recruitment_cycle_year: @recruitment_cycle.year, accredited_body_code: @provider.provider_code)
       .map(&:decorate)
       .map do |c|
       {

--- a/app/views/courses/accredited_body/_provider_suggestion.html.erb
+++ b/app/views/courses/accredited_body/_provider_suggestion.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-radios__item" data-qa="course__accredited_body_option">
-  <%= form.radio_button :accrediting_provider_code,
+  <%= form.radio_button :accredited_body_code,
     provider_suggestion["provider_code"],
     checked: provider_suggestion["provider_code"] == @course.accrediting_provider&.provider_code,
     class: 'govuk-radios__input' %>
-  <%= form.label :accrediting_provider_code,
+  <%= form.label :accredited_body_code,
     "#{provider_suggestion["provider_name"]} (#{provider_suggestion["provider_code"]})",
     value: provider_suggestion["provider_code"],
     class: 'govuk-label govuk-radios__label' %>

--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -32,14 +32,14 @@
           <div class="govuk-radios__divider">or</div>
 
           <div class="govuk-radios__item">
-            <%= form.radio_button :accrediting_provider_code,
+            <%= form.radio_button :accredited_body_code,
               'other',
               class: 'govuk-radios__input',
               data: { "aria-controls" => "other-container" },
               checked: @errors && @errors[:accredited_body]&.any?  %>
-            <%= form.label :accrediting_provider_code,
+            <%= form.label :accredited_body_code,
               "A new accredited body you’re working with",
-              for: 'course_accrediting_provider_code_other',
+              for: 'course_accredited_body_code_other',
               value: false,
               class: 'govuk-label govuk-radios__label' %>
           </div>
@@ -48,7 +48,7 @@
             <%= render "provider_search_field", form: form %>
           </div>
         <% else %>
-          <%= form.hidden_field :accrediting_provider_code, value: :other %>
+          <%= form.hidden_field :accredited_body_code, value: :other %>
           <%= render "provider_search_field", form: form %>
         <% end %>
       </div>

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -17,8 +17,8 @@
                   ),
                   method: :get do |form| %>
 
-      <%= render "courses/new_fields_holder", form: form, except_keys: [:accrediting_provider_code] do |fields| %>
-        <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__accredited_body">
+      <%= render "courses/new_fields_holder", form: form, except_keys: [:accredited_body_code] do |fields| %>
+        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_body">
           <% if provider.accredited_bodies.length > 0 %>
             <%= render partial: "provider_suggestion",
               collection: provider.accredited_bodies,
@@ -28,14 +28,14 @@
             <div class="govuk-radios__divider">or</div>
 
             <div class="govuk-radios__item">
-              <%= fields.radio_button :accrediting_provider_code,
+              <%= fields.radio_button :accredited_body_code,
                 'other',
                 class: 'govuk-radios__input',
                 data: { "aria-controls" => "other-container" },
                 checked: @errors && @errors[:accredited_body]&.any?  %>
-              <%= fields.label :accrediting_provider_code,
+              <%= fields.label :accredited_body_code,
                 "A new accredited body you’re working with",
-                for: 'course_accrediting_provider_code_other',
+                for: 'course_accredited_body_code_other',
                 value: false,
                 class: 'govuk-label govuk-radios__label' %>
             </div>
@@ -44,7 +44,7 @@
               <%= render "provider_search_field", form: fields %>
             </div>
           <% else %>
-            <%= fields.hidden_field :accrediting_provider_code, value: :other %>
+            <%= fields.hidden_field :accredited_body_code, value: :other %>
             <%= render "provider_search_field", form: fields %>
           <% end %>
         </div>

--- a/app/views/courses/accredited_body/search.html.erb
+++ b/app/views/courses/accredited_body/search.html.erb
@@ -32,13 +32,13 @@
           <div class="govuk-radios__divider">or</div>
 
           <div class="govuk-radios__item">
-            <%= form.radio_button :accrediting_provider_code,
+            <%= form.radio_button :accredited_body_code,
               'other',
               class: 'govuk-radios__input',
               data: { "aria-controls" => "other-container" } %>
-            <%= form.label :accrediting_provider_code,
+            <%= form.label :accredited_body_code,
               "Try another accrediting provider",
-              for: 'course_accrediting_provider_code_other',
+              for: 'course_accredited_body_code_other',
               value: false,
               class: 'govuk-label govuk-radios__label' %>
           </div>
@@ -52,12 +52,13 @@
 
         <p class="govuk-body">Try another search:</p>
 
-        <%= form.hidden_field :accrediting_provider_code, value: :other %>
+        <%= form.hidden_field :accredited_body_code, value: :other %>
         <%= render "provider_search_field", form: form %>
       <% end %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
         class: "govuk-button govuk-!-margin-top-3", data: { qa: 'course__save' } %>
+
 
       <p class="govuk-body">
         <%= link_to 'Cancel changes',

--- a/app/views/courses/accredited_body/search_new.html.erb
+++ b/app/views/courses/accredited_body/search_new.html.erb
@@ -18,7 +18,7 @@
       <%= render 'shared/course_creation_hidden_fields',
         form: form,
         course_creation_params: @course_creation_params,
-        except_keys: [:accrediting_provider_code]
+        except_keys: [:accredited_body_code]
       %>
 
       <% if @provider_suggestions.any? %>
@@ -29,13 +29,13 @@
           <div class="govuk-radios__divider">or</div>
 
           <div class="govuk-radios__item">
-            <%= form.radio_button :accrediting_provider_code,
+            <%= form.radio_button :accredited_body_code,
               'other',
               class: 'govuk-radios__input',
               data: { "aria-controls" => "other-container" } %>
-            <%= form.label :accrediting_provider_code,
+            <%= form.label :accredited_body_code,
               "Try another accrediting provider",
-              for: 'course_accrediting_provider_code_other',
+              for: 'course_accredited_body_code_other',
               value: false,
               class: 'govuk-label govuk-radios__label' %>
           </div>
@@ -49,7 +49,7 @@
 
         <p class="govuk-body">Try another search:</p>
 
-        <%= form.hidden_field :accrediting_provider_code, value: :other %>
+        <%= form.hidden_field :accredited_body_code, value: :other %>
         <%= render "provider_search_field", form: form %>
       <% end %>
 

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-id_selector = ->(code) { "course_accrediting_provider_code_#{code.downcase}" }
+id_selector = ->(code) { "course_accredited_body_code_#{code.downcase}" }
 for_selector = ->(code) { "[for=\"#{id_selector.call(code)}\"]" }
 
 feature "Edit accredited body", type: :feature do
@@ -149,7 +149,7 @@ feature "Edit accredited body", type: :feature do
           course_code: course.course_code,
           type: "courses",
           attributes: {
-            accrediting_provider_code: accrediting_provider_1.provider_code,
+            accredited_body_code: accrediting_provider_1.provider_code,
           },
         },
       }.to_json)

--- a/spec/features/courses/accredited_body/new_spec.rb
+++ b/spec/features/courses/accredited_body/new_spec.rb
@@ -49,7 +49,7 @@ feature "Edit accredited body" do
 
     context "when selecting an accredited body" do
       let(:next_step_page) { PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new }
-      let(:selected_fields) { { level: "primary", accrediting_provider_code: accrediting_provider_1.provider_code } }
+      let(:selected_fields) { { level: "primary", accredited_body_code: accrediting_provider_1.provider_code } }
       let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
 
       before do
@@ -85,7 +85,7 @@ feature "Edit accredited body" do
     context "Searching for a new accredited body" do
       context "with some results" do
         before do
-          stub_api_v2_build_course(level: "primary", accrediting_provider_code: "other")
+          stub_api_v2_build_course(level: "primary", accredited_body_code: "other")
           searching_returns_some_results
           choose "A new accredited body you’re working with"
           fill_in "Name of accredited body", with: "ACME"
@@ -98,7 +98,7 @@ feature "Edit accredited body" do
 
         context "When selecting an accredited body" do
           let(:next_step_page) { PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new }
-          let(:selected_fields) { { level: "primary", accrediting_provider_code: "A01" } }
+          let(:selected_fields) { { level: "primary", accredited_body_code: "A01" } }
           let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
 
           before do

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -22,7 +22,7 @@ feature "get courses as an accredited body", type: :feature do
     stub_api_v2_resource(accrediting_body1.recruitment_cycle)
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/courses" \
-      "?filter[accrediting_provider_code]=#{accrediting_body1.provider_code}",
+      "?filter[accredited_body_code]=#{accrediting_body1.provider_code}",
       resource_list_to_jsonapi([course1]),
     )
     stub_api_v2_request(
@@ -37,7 +37,7 @@ feature "get courses as an accredited body", type: :feature do
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/#{training_provider2.provider_code}" \
-      "/courses?filter[accrediting_provider_code]=#{accrediting_body1.provider_code}",
+      "/courses?filter[accredited_body_code]=#{accrediting_body1.provider_code}",
       resource_list_to_jsonapi([course1]),
     )
     stub_api_v2_resource_collection([access_request])

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -20,7 +20,7 @@ feature "get training_providers", type: :feature do
     stub_api_v2_resource(accrediting_body1.recruitment_cycle)
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/courses" \
-      "?filter[accrediting_provider_code]=#{accrediting_body1.provider_code}",
+      "?filter[accredited_body_code]=#{accrediting_body1.provider_code}",
       resource_list_to_jsonapi([course1, course3, course4]),
     )
     stub_api_v2_request(

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -87,7 +87,7 @@ describe "Providers", type: :request do
         stub_api_v2_resource(accredited_provider)
         stub_api_v2_request(
           "/recruitment_cycles/#{accredited_provider.recruitment_cycle.year}/courses" \
-          "?filter[accrediting_provider_code]=#{accredited_provider.provider_code}&include=provider",
+          "?filter[accredited_body_code]=#{accredited_provider.provider_code}&include=provider",
           resource_list_to_jsonapi([course], include: :provider),
         )
 


### PR DESCRIPTION
**NB: This must be deployed with https://github.com/DFE-Digital/teacher-training-api/pull/1407 in an out-of-hours deploy as there may be a few seconds of incompatibility between publish and the api during the deploy.**

### Context

This is the correct naming and is necessary for compatibility with
https://github.com/DFE-Digital/teacher-training-api/pull/1407

### Changes proposed in this pull request

Rename `accrediting_provider_code` -> `accredited_body_code`

### Guidance to review

This needs to be tested with https://github.com/DFE-Digital/teacher-training-api/pull/1407

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
