### PR TITLE
[3508] Fix caption styling error

### DIFF
--- a/app/views/providers/allocations/edit.html.erb
+++ b/app/views/providers/allocations/edit.html.erb
@@ -7,7 +7,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @training_provider.provider_name %></span>
     <%= form_with url: provider_recruitment_cycle_allocation_path(
                     id: @allocation.id
                   ),
@@ -15,7 +14,8 @@
                   scope: "",
                   method: :patch,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <%= form.govuk_radio_buttons_fieldset(:old_department_id, legend: { size: 'xl', text: page_title }) do %>
+      <%= form.govuk_radio_buttons_fieldset(:old_department_id, legend: { size: 'xl', text: page_title },
+                                            caption: { text: "#{@training_provider.provider_name} ", size:'xl'}) do %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" } %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
       <% end %>

--- a/app/views/providers/allocations/new_repeat_request.html.erb
+++ b/app/views/providers/allocations/new_repeat_request.html.erb
@@ -17,9 +17,8 @@
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <%= form.govuk_error_summary %>
 
-      <span class="govuk-caption-xl"><%= @training_provider.provider_name %></span>
-
-      <%= form.govuk_radio_buttons_fieldset(:request_type, legend: { size: 'xl', text: page_title }) do %>
+      <%= form.govuk_radio_buttons_fieldset(:request_type, legend: { size: 'xl', text: page_title },
+                                            caption: { text: "#{@training_provider.provider_name} ", size:'xl'}) do %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" }, link_errors: true %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
       <% end %>

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -15,14 +15,13 @@
                 builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
     <%= form.govuk_error_summary %>
 
-    <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
-
     <%= form.govuk_text_field :number_of_places,
           label: {
             text: "How many places would you like to request?",
             size: "xl",
             tag: "h1",
           },
+          caption: { text: "#{training_provider.provider_name} ", size:'xl'},
           pattern: "[0-9]*",
           inputmode: "numeric",
           width: 10 do %>

--- a/app/views/providers/edit_initial_allocations/do_you_want.html.erb
+++ b/app/views/providers/edit_initial_allocations/do_you_want.html.erb
@@ -7,7 +7,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
     <%= form_with url: do_you_want_provider_recruitment_cycle_allocation_path(
                          provider.provider_code,
                          provider.recruitment_cycle_year,
@@ -16,7 +15,8 @@
                   method: :post,
                   model: Allocation.new,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <%= form.govuk_radio_buttons_fieldset(:old_department_id, legend: { size: 'xl', text: page_title }) do %>
+      <%= form.govuk_radio_buttons_fieldset(:old_department_id, legend: { size: 'xl', text: page_title },
+                                            caption: { text: "#{training_provider.provider_name} ", size:'xl'}) do %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::INITIAL, label: { text: "Yes" } %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
       <% end %>

--- a/app/views/providers/edit_initial_allocations/number_of_places.html.erb
+++ b/app/views/providers/edit_initial_allocations/number_of_places.html.erb
@@ -24,16 +24,15 @@
                     model: allocation,
                     method: :post,
                     builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+
       <%= form.govuk_error_summary %>
-
-      <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
-
-    <%= form.govuk_text_field :number_of_places,
+      <%= form.govuk_text_field :number_of_places,
           label: {
             text: "How many places would you like to request?",
             size: "xl",
             tag: "h1",
           },
+          caption: { text: "#{training_provider.provider_name} ", size:'xl'},
           pattern: "[0-9]*",
           inputmode: "numeric",
           width: 10 do %>
@@ -42,8 +41,7 @@
           Say how many places the organisation would like to offer for this
           course - make sure this number is as accurate as possible.
         </p>
-
-    <% end %>
+      <% end %>
 
     <%= hidden_field_tag "training_provider_code", params[:training_provider_code]  %>
 

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -383,7 +383,7 @@ RSpec.feature "PE allocations" do
   end
 
   def then_i_see_number_of_places_page
-    expect(number_of_places_page.header.text).to eq("How many places would you like to request?")
+    expect(number_of_places_page.header.text).to have_content("How many places would you like to request?")
   end
 
   def then_i_see_pick_a_provider_page


### PR DESCRIPTION
Previously the dfe govuk design system form builder did not support
captions and as a work around they were placed outside the label/heading.

This caused issues with error styling where the caption would not be include
in the error group.

Caption support reported and fixed https://github.com/DFE-Digital/govuk_design_system_formbuilder/issues/133

### Context

### Changes proposed in this pull request

### Guidance to review
Login as an accredited body user
Create/edit allocations and try force validation errors


# Before 
![image](https://user-images.githubusercontent.com/3441519/84122264-14a91980-aa30-11ea-8927-f31c88105ee1.png)
![image](https://user-images.githubusercontent.com/3441519/84122275-1a9efa80-aa30-11ea-9dca-a7b476daa9c4.png)

# After

![image](https://user-images.githubusercontent.com/3441519/84122292-2094db80-aa30-11ea-9be8-f326fbc5c59d.png)

![image](https://user-images.githubusercontent.com/3441519/84122311-28548000-aa30-11ea-9e1a-c2aa364be594.png)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
