### PR TITLE
Open the secondary subject field when present

### DIFF
--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -16,24 +16,22 @@
     </div>
 
     <% if course.level == "secondary" %>
-      <div style="margin-bottom: -20px">
-        <details class="govuk-details" role="group" data-qa="course__subordinate_subject_accordion">
-          <summary class="govuk-details__summary" role="button">
-            <span class="govuk-details__summary-text">
-              Add a second subject (optional)
-            </span>
-          </summary>
-          <div class="govuk-details__text" id="details-content" aria-hidden="true">
-            <p>Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
+      <details class="govuk-details govuk-!-margin-top-6 govuk-!-margin-bottom-0" role="group" data-qa="course__subordinate_subject_accordion">
+        <summary class="govuk-details__summary" role="button">
+          <span class="govuk-details__summary-text">
+            Add a second subject (optional)
+          </span>
+        </summary>
+        <div class="govuk-details__text" id="details-content" aria-hidden="true">
+          <p>Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
 
-            <div class="govuk-form-group">
-              <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
-              <span class="govuk-hint">For example ‘Physics with Mathematics’</span>
-              <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, course.selected_subject_ids.second || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
-            </div>
+          <div class="govuk-form-group">
+            <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
+            <span class="govuk-hint">For example ‘Physics with Mathematics’</span>
+            <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, course.selected_subject_ids.second || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
           </div>
-        </details>
-      </div>
+        </div>
+      </details>
     <% end %>
   </fieldset>
 <% end %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <% if course.level == "secondary" %>
-      <details class="govuk-details govuk-!-margin-top-6 govuk-!-margin-bottom-0" role="group" data-qa="course__subordinate_subject_accordion" <% if course.selected_subject_ids.second %>open<% end %>>
+      <details class="govuk-details govuk-!-margin-top-6 govuk-!-margin-bottom-0" role="group" data-qa="course__subordinate_subject_details" <% if course.selected_subject_ids.second %>open<% end %>>
         <summary class="govuk-details__summary" role="button">
           <span class="govuk-details__summary-text">
             Add a second subject (optional)

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -22,8 +22,8 @@
             Add a second subject (optional)
           </span>
         </summary>
-        <div class="govuk-details__text" id="details-content" aria-hidden="true">
-          <p>Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
+        <div class="govuk-details__text" id="details-content">
+          <p class="govuk-body">Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
 
           <div class="govuk-form-group">
             <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <% if course.level == "secondary" %>
-      <details class="govuk-details govuk-!-margin-top-6 govuk-!-margin-bottom-0" role="group" data-qa="course__subordinate_subject_accordion">
+      <details class="govuk-details govuk-!-margin-top-6 govuk-!-margin-bottom-0" role="group" data-qa="course__subordinate_subject_accordion" <% if course.selected_subject_ids.second %>open<% end %>>
         <summary class="govuk-details__summary" role="button">
           <span class="govuk-details__summary-text">
             Add a second subject (optional)

--- a/spec/features/courses/subjects/edit_spec.rb
+++ b/spec/features/courses/subjects/edit_spec.rb
@@ -92,7 +92,7 @@ feature "Edit course subjects", type: :feature do
 
         subjects_page.subjects_fields.select(subjects.first.subject_name)
 
-        subjects_page.subordinate_subject_accordion.click
+        subjects_page.subordinate_subject_details.click
         subjects_page.subordinate_subject_fields.select(subjects.second.subject_name)
         subjects_page.save.click
         subjects_uri = URI(current_url)
@@ -246,7 +246,7 @@ feature "Edit course subjects", type: :feature do
         subjects_page.load_with_course(course)
 
         expect(subjects_page).to have_select("course_master_subject_id", selected: modern_languages_subject.subject_name)
-        subjects_page.subordinate_subject_accordion.click
+        subjects_page.subordinate_subject_details.click
         expect(subjects_page).to have_select("course_subordinate_subject_id", selected: nil)
       end
     end

--- a/spec/features/courses/subjects/edit_spec.rb
+++ b/spec/features/courses/subjects/edit_spec.rb
@@ -132,8 +132,7 @@ feature "Edit course subjects", type: :feature do
           subjects_page.load_with_course(course)
           edit_subject_stub = stub_api_v2_resource(course, method: :patch)
 
-          subjects_page.subjects_fields.select(subjects.first.subject_name)
-          subjects_page.subordinate_subject_accordion.click
+          subjects_page.master_subject_fields.select(subjects.first.subject_name)
           subjects_page.subordinate_subject_fields.select("")
           subjects_page.save.click
 
@@ -171,8 +170,7 @@ feature "Edit course subjects", type: :feature do
           subjects_page.load_with_course(course)
           edit_subject_stub = stub_api_v2_resource(course, method: :patch)
 
-          subjects_page.subjects_fields.select("")
-          subjects_page.subordinate_subject_accordion.click
+          subjects_page.master_subject_fields.select("")
           subjects_page.subordinate_subject_fields.select("")
           subjects_page.save.click
 
@@ -237,7 +235,6 @@ feature "Edit course subjects", type: :feature do
 
     scenario "it should automatically select the current subject" do
       subjects_page.load_with_course(course)
-      subjects_page.subordinate_subject_accordion.click
       expect(subjects_page).to have_select("course_subordinate_subject_id", selected: biology_subject.subject_name)
     end
 

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -79,7 +79,7 @@ feature "New course level", type: :feature do
       before do
         build_course_with_selected_value_request
         new_subjects_page.subjects_fields.select(english.subject_name).click
-        new_subjects_page.subordinate_subject_accordion.click
+        new_subjects_page.subordinate_subject_details.click
         new_subjects_page.subordinate_subjects_fields.select(biology.subject_name).click
         new_subjects_page.continue.click
       end
@@ -135,7 +135,7 @@ feature "New course level", type: :feature do
     let(:level) { :primary }
     scenario "Only displays the master subject field" do
       expect(new_subjects_page).to have_subjects_fields
-      expect(new_subjects_page).not_to have_subordinate_subject_accordion
+      expect(new_subjects_page).not_to have_subordinate_subject_details
     end
 
     context "Selecting master subject" do

--- a/spec/site_prism/page_objects/page/organisations/course_subjects.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_subjects.rb
@@ -6,7 +6,7 @@ module PageObjects
 
         element :subjects_fields, '[data-qa="course__subjects"]'
         element :master_subject_fields, '[data-qa="course__master_subject"]'
-        element :subordinate_subject_accordion, '[data-qa="course__subordinate_subject_accordion"]'
+        element :subordinate_subject_details, '[data-qa="course__subordinate_subject_details"]'
         element :subordinate_subject_fields, '[data-qa="course__subordinate_subjects"]'
         element :save, '[data-qa="course__save"]'
       end

--- a/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/new_subjects_page.rb
@@ -8,7 +8,7 @@ module PageObjects
           element :title, '[data-qa="page-heading"]'
           element :subjects_fields, '[data-qa="course__subjects"]'
           element :master_subject_fields, '[data-qa="course__master_subject"]'
-          element :subordinate_subject_accordion, '[data-qa="course__subordinate_subject_accordion"]'
+          element :subordinate_subject_details, '[data-qa="course__subordinate_subject_details"]'
           element :subordinate_subjects_fields, '[data-qa="course__subordinate_subjects"]'
           element :continue, '[data-qa="course__save"]'
           element :google_form_link, '[data-qa="course__google_form_link"]'


### PR DESCRIPTION
### Context

When editing a secondary course with multiple subjects, the second subject field is closed, even if a subject is selected.

- Open the details element when the second subject is present
- Remove inline styles, replace with classes
- Tweak spacing
- Fix naming of test variable

(Ignore whitespace when reviewing)

https://trello.com/c/RyXdo7Ry/3512-open-the-secondary-subject-field-when-present