### PR TITLE
Small spacing and content fixes

### DIFF
--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -9,7 +9,7 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
   Who is the accredited body?
 </h1>
 
@@ -22,7 +22,7 @@
         @course.course_code),
       method: :put do |form| %>
 
-      <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_body">
+      <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__accredited_body">
         <% if provider.accredited_bodies.length > 0 %>
           <%= render partial: "provider_suggestion",
             collection: provider.accredited_bodies,

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
   Who is the accredited body?
 </h1>
 
@@ -18,7 +18,7 @@
                   method: :get do |form| %>
 
       <%= render "courses/new_fields_holder", form: form, except_keys: [:accrediting_provider_code] do |fields| %>
-        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_body">
+        <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__accredited_body">
           <% if provider.accredited_bodies.length > 0 %>
             <%= render partial: "provider_suggestion",
               collection: provider.accredited_bodies,

--- a/app/views/courses/age_range/_form_fields.html.erb
+++ b/app/views/courses/age_range/_form_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-radios" data-module="govuk-radios">
+<div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">
   <% @course.meta['edit_options']['age_range_in_years'].each do |value| %>
     <div class="govuk-radios__item">
       <%= form.radio_button :age_range_in_years, value, class: 'govuk-radios__input', data: {qa: "course__age_range_in_years_#{value}_radio"} %>

--- a/app/views/courses/applications_open/_form_fields.html.erb
+++ b/app/views/courses/applications_open/_form_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-form-group">
-  <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+  <div class="govuk-radios govuk-!-margin-top-2 govuk-radios--conditional" data-module="govuk-radios">
     <div class="govuk-radios__item">
       <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
             class: 'govuk-radios__input', data: { qa: 'applications_open_from' }

--- a/app/views/courses/applications_open/edit.html.erb
+++ b/app/views/courses/applications_open/edit.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl" id="applications_open_from-error">
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-2" id="applications_open_from-error">
   When will applications open?
 </h1>
 

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl" id="applications_open_from-error">
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-2" id="applications_open_from-error">
   When will applications open?
 </h1>
 

--- a/app/views/courses/apprenticeship/_form_fields.html.erb
+++ b/app/views/courses/apprenticeship/_form_fields.html.erb
@@ -8,7 +8,7 @@
 
     <%= render "shared/error_messages", error_keys: [:funding_type, :program_type] %>
 
-    <div class="govuk-radios" data-module="govuk-radios">
+    <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">
       <div class="govuk-radios__item">
         <%= form.radio_button :funding_type,
                 'apprenticeship',

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -13,7 +13,6 @@
         course_creation_params: @course_creation_params,
         except_keys: []
       %>
-      <hr class="govuk-section-break govuk-section-break--l">
       <div class="govuk-grid-row govuk-!-margin-bottom-9">
         <div class="govuk-grid-column-full">
           <dl class="govuk-summary-list govuk-!-margin-bottom-0" data-qa="course__details">

--- a/app/views/courses/fee_or_salary/_form_fields.html.erb
+++ b/app/views/courses/fee_or_salary/_form_fields.html.erb
@@ -4,11 +4,10 @@
       <h1 class="govuk-fieldset__heading">
         Is it fee paying or salaried?
       </h1>
-      <br>
     </legend>
 
     <%= render "shared/error_messages", error_keys: [:funding_type] %>
-    <div class="govuk-radios" data-module="govuk-radios">
+    <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">
       <div class="govuk-radios__item">
         <%= form.radio_button :funding_type,
                 'fee',

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -7,7 +7,7 @@
 </h1>
 <p class="govuk-body">Use this section to:</p>
 
-<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
   <li>write about each course</li>
   <li>preview and publish courses</li>
   <li>assign locations to a course</li>
@@ -19,7 +19,7 @@
     new_provider_recruitment_cycle_course_path(
       provider_code: @provider.provider_code,
       recruitment_cycle_year: @provider.recruitment_cycle_year),
-      class: "govuk-button govuk-!-margin-bottom-2") %>
+      class: "govuk-button govuk-!-margin-bottom-6") %>
 <% end %>
 
 <% if @self_accredited_courses %>

--- a/app/views/courses/modern_languages/_form_fields.html.erb
+++ b/app/views/courses/modern_languages/_form_fields.html.erb
@@ -10,7 +10,7 @@
     </legend>
     <%= render "shared/error_messages", error_keys: [:modern_languages_subjects] %>
 
-    <div class="govuk-form-group govuk-!-margin-top-6" data-qa="course__languages">
+    <div class="govuk-form-group govuk-!-margin-top-2" data-qa="course__languages">
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <% course.meta["edit_options"]["modern_languages"].each do |language| %>
           <div class="govuk-checkboxes__item">

--- a/app/views/courses/modern_languages/_form_fields.html.erb
+++ b/app/views/courses/modern_languages/_form_fields.html.erb
@@ -5,12 +5,12 @@
         <% if course.course_code %>
           <span class="govuk-caption-xl"><%= course.name_and_code %></span>
         <% end %>
-        Pick modern languages
+        Pick all the languages for this&nbsp;course
       </h1>
     </legend>
     <%= render "shared/error_messages", error_keys: [:modern_languages_subjects] %>
 
-    <div class="govuk-form-group" data-qa="course__languages">
+    <div class="govuk-form-group govuk-!-margin-top-6" data-qa="course__languages">
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <% course.meta["edit_options"]["modern_languages"].each do |language| %>
           <div class="govuk-checkboxes__item">

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Change modern languages – #{course.name_and_code}" %>
+<%= content_for :page_title, "Pick all the languages for #{course.name_and_code}" %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pick modern languages" %>
+<%= content_for :page_title, "Pick all the languages for this course" %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/send/edit.html.erb
+++ b/app/views/courses/send/edit.html.erb
@@ -5,11 +5,12 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">
-  Special educational needs and disability (SEND)
-</h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+      Special educational needs and disability (SEND)
+    </h1>
+
     <%= form_with model: course, url: send_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code), method: :put do |form| %>
 
       <%= render 'form_fields', form: form %>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -17,7 +17,7 @@
           </h1>
         </legend>
         <%= render "shared/error_messages", error_keys: [:sites] %>
-        <div class="govuk-form-group">
+        <div class="govuk-form-group govuk-!-margin-top-2">
           <div class="govuk-checkboxes">
             <%= fields.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sfields| %>
               <% site = sfields.object %>

--- a/app/views/courses/start_date/edit.html.erb
+++ b/app/views/courses/start_date/edit.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
   When does the course start?
 </h1>
 

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
   When does the course start?
 </h1>
 

--- a/app/views/courses/study_mode/_form_fields.html.erb
+++ b/app/views/courses/study_mode/_form_fields.html.erb
@@ -7,7 +7,7 @@
     </legend>
 
     <%= render "shared/error_messages", error_keys: [:study_modes] %>
-    <div class="govuk-radios" data-module="govuk-radios">
+    <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">
       <% @course.meta['edit_options']['study_modes'].each do |value| %>
         <div class="govuk-radios__item">
           <%= form.radio_button :study_mode,

--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -15,11 +15,11 @@
     <%= pagy_govuk_nav(@pagy).html_safe %>
   </div>
 
-  <aside class="govuk-grid-column-one-third">
-    <div class="app-related">
-      <% if @providers_view.show_notifications_link? %>
+  <% if @providers_view.show_notifications_link? %>
+    <aside class="govuk-grid-column-one-third">
+      <div class="app-related govuk-!-padding-bottom-1">
         <%= render partial: "providers/notifications_sign_up_link" %>
-      <% end %>
-    </div>
-  </aside>
+      </div>
+    </aside>
+  <% end %>
 </div>

--- a/app/views/shared/_edit_options_radio_buttons.html.erb
+++ b/app/views/shared/_edit_options_radio_buttons.html.erb
@@ -5,27 +5,28 @@
   <fieldset class="govuk-fieldset">
     <%= legend %>
     <%= render "shared/error_messages", error_keys: [field] %>
-    <% @course.meta['edit_options'][key].each_with_index do |value| %>
-      <% help = t("edit_options.#{key}.#{value}.help") %>
-      <% label = t("edit_options.#{key}.#{value}.label") %>
-
-      <div class="govuk-radios__item">
-        <%= form.radio_button field,
-              value,
-              class: 'govuk-radios__input',
-              data: {
-                'aria-describedby': "#{field}-#{value}-help"
-              }
-        %>
-        <%= form.label field,
-              label,
-              value: value,
-              class: "govuk-label govuk-radios__label #{"govuk-!-font-weight-bold" if bold_labels}"
-        %>
-        <span id="<%= "#{field}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
-          <%= help %>
-        </span>
-      </div>
-    <% end %>
+    <div class="govuk-radios govuk-!-margin-top-2">
+      <% @course.meta['edit_options'][key].each_with_index do |value| %>
+        <% help = t("edit_options.#{key}.#{value}.help") %>
+        <% label = t("edit_options.#{key}.#{value}.label") %>
+        <div class="govuk-radios__item">
+          <%= form.radio_button field,
+                value,
+                class: 'govuk-radios__input',
+                data: {
+                  'aria-describedby': "#{field}-#{value}-help"
+                }
+          %>
+          <%= form.label field,
+                label,
+                value: value,
+                class: "govuk-label govuk-radios__label #{"govuk-!-font-weight-bold" if bold_labels}"
+          %>
+          <span id="<%= "#{field}-#{value}-help" %>" class="govuk-hint govuk-radios__hint">
+            <%= help %>
+          </span>
+        </div>
+      <% end %>
+    </div>
   </fieldset>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,9 +52,9 @@ en:
         help: "You will consider applicants with a pending GCSE. But UCAS will block applications from anyone who needs to take an equivalency test."
         details_label: "Taking the GCSE"
       equivalence_test:
-        label: "3: Equivalency test"
+        label: "3: Equivalency test (most flexible)"
         help: "You will consider applicants who need to take an equivalency test, as well as those with a pending GCSE."
-        details_label: "Equivalency test"
+        details_label: "Equivalency test (most flexible)"
       not_required:
         details_label: "No requirement"
         help: "You will receive applications from candidates who will not have a grade C (or 4) or above."

--- a/spec/features/courses/modern_languages/new_spec.rb
+++ b/spec/features/courses/modern_languages/new_spec.rb
@@ -66,8 +66,8 @@ feature "new modern language", type: :feature do
     scenario "It displays the correct title" do
       visit_modern_languages
 
-      expect(page.title).to start_with("Pick modern languages")
-      expect(new_modern_languages_page.title.text).to eq("Pick modern languages")
+      expect(page.title).to start_with("Pick all the languages")
+      expect(new_modern_languages_page.title.text).to eq("Pick all the languages for this course")
     end
   end
 


### PR DESCRIPTION
### Context

- Stop spacing from jumping around in new course journey
- Fix spacing on "Add course" button at the top of the courses list
- Indicate that the equivalency test option is the "most flexible" option
- Don't show an empty grey box on providers list
- Update modern languages page titles to match design ("Pick all the languages for this course" vs "Pick modern languages")

## Spacing in new course journey

Compare:
 https://bat-design-history.netlify.app/images/publish-teacher-training-courses/new-course-wizard-available/pick-the-locations-for-this-course.png
with
https://bat-design-history.netlify.app/images/publish-teacher-training-courses/new-course-wizard-available/when-will-applications-open.png

Some pages don't have legends in the right place, making them inconsistent. For now classes have been used to keep pages consistent rather than refactoring those pages.

## Add course spacing

| Before | After |
|--|--|
|![Screen Shot 2020-06-09 at 12 18 12](https://user-images.githubusercontent.com/319055/84141610-56938900-aa4b-11ea-8ffc-426a8313838e.png)|![Screen Shot 2020-06-09 at 12 17 18](https://user-images.githubusercontent.com/319055/84141614-585d4c80-aa4b-11ea-8ac4-abed9ab0a36a.png)|

## Provider list grey box bug

![Screen Shot 2020-06-09 at 12 20 08](https://user-images.githubusercontent.com/319055/84141762-9490ad00-aa4b-11ea-92f6-82021ef6ebf0.png)

https://trello.com/c/yUAtTYiR/3514-spacing-and-content-fixes