### PR TITLE
Disable emphasis markdown

### DIFF
--- a/app/lib/govuk/markdown_renderer.rb
+++ b/app/lib/govuk/markdown_renderer.rb
@@ -8,6 +8,18 @@ module Govuk
       # No user input HTML please
     end
 
+    def emphasis(text)
+      # Disable feature
+    end
+
+    def double_emphasis(text)
+      # Disable feature
+    end
+
+    def triple_emphasis(text)
+      # Disable feature
+    end
+
     def list(content, list_type)
       case list_type
       when :ordered

--- a/spec/lib/govuk/markdown_renderer_spec.rb
+++ b/spec/lib/govuk/markdown_renderer_spec.rb
@@ -162,7 +162,7 @@ describe Govuk::MarkdownRenderer do
     end
   end
 
-  context "h6" do
+  describe "h6" do
     let(:markdown) do
       <<~MD
         ###### heading level 6
@@ -172,6 +172,54 @@ describe Govuk::MarkdownRenderer do
     it "renders correct HTML" do
       expected_html = <<~HTML
         <h3 class="govuk-heading-m">heading level 6</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe "em" do
+    let(:markdown) do
+      <<~MD
+        *emphasis*
+      MD
+    end
+
+    it "does not render emphasis tags" do
+      expected_html = <<~HTML
+        <p class="govuk-body">*emphasis*</p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe "strong" do
+    let(:markdown) do
+      <<~MD
+        **strong**
+      MD
+    end
+
+    it "does not render strong tags" do
+      expected_html = <<~HTML
+        <p class="govuk-body">**strong**</p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe "strong emphasis" do
+    let(:markdown) do
+      <<~MD
+        ***strong emphasis***
+      MD
+    end
+
+    it "does not render strong or emphasis tags" do
+      expected_html = <<~HTML
+        <p class="govuk-body">***strong emphasis***</p>
       HTML
 
       expect_equal_ignoring_ws(html, expected_html)


### PR DESCRIPTION
We don't want to allow providers to mark content in italics, bold or bold italic using markdown.

These are currently undocumented markdown features in Publish, but for any providers who know their markdown, they'll find that they currently work.

This will be consistent with how GOV.UK renders content.

Goes with https://github.com/DFE-Digital/find-teacher-training/pull/338

https://trello.com/c/4uABb34i/3519-disable-emphasis-markdown