### PR TITLE
[3521] Update copy and design on interruption page

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -11,7 +11,7 @@
       You can sign up for email notifications about these courses. We’ll tell you when a training provider:
     </p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-      <li>adds a new course</li>
+      <li>publishes a new course on Find postgraduate teacher training</li>
       <li>makes a change to an existing course</li>
     </ul>
   </div>

--- a/app/views/pages/accredited_body_new_features.html.erb
+++ b/app/views/pages/accredited_body_new_features.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Get notifications about your courses" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Get notifications about your courses</h1>

--- a/app/views/pages/accredited_body_new_features.html.erb
+++ b/app/views/pages/accredited_body_new_features.html.erb
@@ -9,11 +9,11 @@
       We'll tell you when a training provider:
     </p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>adds a new course</li>
+      <li>publishes a new course on Find postgraduate teacher training</li>
       <li>makes a change to an existing course </li>
     </ul>
     <p class="govuk-body">
-      <%= link_to "Sign up for notifications", notifications_path( start: true ), class:"govuk-button" %>
+      <%= link_to "Sign up for notifications", notifications_path( start: true ), class:"govuk-button govuk-!-margin-bottom-0" %>
     </p>
     <p class="govuk-body">
       or


### PR DESCRIPTION
### Context
### Changes proposed in this pull request
- Updates interruption page copy and spacing
- Updates notification page copy to mirror the interruption
- Add missing page title


#### Before - Interruption page

![image](https://user-images.githubusercontent.com/3441519/84354062-26b5c400-abb8-11ea-8579-5a5dd35f9c9d.png)

#### After - Interruption page
![image](https://user-images.githubusercontent.com/3441519/84354108-37663a00-abb8-11ea-8ce0-d3e749e468f9.png)


#### Before - Notification page
![image](https://user-images.githubusercontent.com/3441519/84354138-464cec80-abb8-11ea-8f39-b01af3dd5771.png)

#### After - Notification page

![image](https://user-images.githubusercontent.com/3441519/84354160-4baa3700-abb8-11ea-9db5-7044e387c99d.png)

 
### Guidance to review
Login as an accrediated body user and visit 
https://s121d02-3521-ptt-as.azurewebsites.net/accredited-body-new-features

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
