### PR TITLE
3507 financial support section displaying incorrect information for provider

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -116,7 +116,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def salaried?
-    object.funding_type == "salary"
+    object.funding_type == "salary" || object.funding_type == "apprenticeship"
   end
 
   def apprenticeship?

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -171,7 +171,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def funding_option
-    if object.funding_type == "salary"
+    if salaried?
       "Salary"
     elsif excluded_from_bursary?
       "Student finance if you’re eligible"

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -260,6 +260,12 @@ describe CourseDecorator do
         it { is_expected.to eq("Salary") }
       end
 
+      context "Apprenticeship" do
+        let(:course) { build :course, funding_type: "apprenticeship" }
+
+        it { is_expected.to eq("Salary") }
+      end
+
       context "Bursary and Scholarship" do
         let(:mathematics) { build(:subject, :mathematics, scholarship: "2000", bursary_amount: "3000") }
         let(:course) { build :course, subjects: [mathematics] }

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -238,8 +238,14 @@ describe CourseDecorator do
         it { is_expected.to be_salaried }
       end
 
-      context "course is not salaried" do
+      context "course is an apprenticeship with salary" do
         let(:course) { build :course, funding_type: "apprenticeship" }
+
+        it { is_expected.to be_salaried }
+      end
+
+      context "course is not salaried" do
+        let(:course) { build :course, :with_fees }
 
         it { is_expected.to_not be_salaried }
       end


### PR DESCRIPTION
### Context
financial information for apprenticeships

### Changes proposed in this pull request
Fix financial information

### Guidance to review
Ported from https://github.com/DFE-Digital/find-teacher-training

https://github.com/DFE-Digital/find-teacher-training/pull/59
https://github.com/DFE-Digital/find-teacher-training/pull/321

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
