### PR TITLE
[3509] Add error message when no option selected

### DIFF
--- a/app/controllers/providers/edit_initial_allocations_controller.rb
+++ b/app/controllers/providers/edit_initial_allocations_controller.rb
@@ -1,7 +1,7 @@
 module Providers
   class EditInitialAllocationsController < ApplicationController
     def do_you_want
-      if request.post?
+      if posted_with_params
         case params[:allocation][:request_type]
         when AllocationsView::RequestType::INITIAL
           redirect_to number_of_places_provider_recruitment_cycle_allocation_path(
@@ -19,11 +19,11 @@ module Providers
           )
         end
       else
-        render locals: {
-          training_provider: training_provider,
-          allocation: allocation,
-          provider: provider,
-        }
+        validate_if_post_request
+        render locals: { training_provider: training_provider,
+                         allocation: allocation,
+                         provider: provider,
+                         allocation_model: allocation_model }
       end
     end
 
@@ -108,6 +108,10 @@ module Providers
                                 .first
     end
 
+    def allocation_model
+      @allocation_model ||= ChangeInitialRequestForm.new
+    end
+
     def update
       allocation.number_of_places = params[:allocation][:number_of_places].to_i
       allocation.set_all_dirty!
@@ -120,6 +124,14 @@ module Providers
 
     def destroy
       allocation.destroy
+    end
+
+    def posted_with_params
+      request.post? && params[:allocation]
+    end
+
+    def validate_if_post_request
+      allocation_model.valid? if request.post?
     end
   end
 end

--- a/app/form_objects/change_initial_request_form.rb
+++ b/app/form_objects/change_initial_request_form.rb
@@ -1,0 +1,7 @@
+class ChangeInitialRequestForm
+  include ActiveModel::Model
+
+  attr_accessor :request_type
+
+  validates :request_type, presence: { message: "Select one option" }
+end

--- a/app/views/providers/edit_initial_allocations/do_you_want.html.erb
+++ b/app/views/providers/edit_initial_allocations/do_you_want.html.erb
@@ -13,11 +13,13 @@
                          training_provider.provider_code,
                   ),
                   method: :post,
-                  model: Allocation.new,
+                  model: allocation_model,
+                  scope: "allocation",
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <%= form.govuk_radio_buttons_fieldset(:old_department_id, legend: { size: 'xl', text: page_title },
+      <%= form.govuk_error_summary %>
+      <%= form.govuk_radio_buttons_fieldset(:request_type, legend: { size: 'xl', text: page_title },
                                             caption: { text: "#{training_provider.provider_name} ", size:'xl'}) do %>
-        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::INITIAL, label: { text: "Yes" } %>
+        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::INITIAL, label: { text: "Yes" }, link_errors: true %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
       <% end %>
       <%= hidden_field_tag :id, allocation.id %>

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -19,8 +19,10 @@ RSpec.feature "PE allocations" do
       and_i_click_change
 
       then_i_see_do_you_want_page
+      and_i_click_continue
+      then_i_see_an_error_message
 
-      when_i_select_yes
+      when_i_select_yes_with_error
       and_i_click_continue
       then_i_see_edit_number_of_places_page
 
@@ -239,8 +241,16 @@ RSpec.feature "PE allocations" do
     expect(find("h1")).to have_content("Do you want to request PE for this organisation?")
   end
 
+  def then_i_see_an_error_message
+    expect(page).to have_content("Select one option")
+  end
+
   def when_i_select_yes
     do_you_want_page.yes.click
+  end
+
+  def when_i_select_yes_with_error
+    choose "Yes"
   end
 
   def when_i_select_no


### PR DESCRIPTION
### Context
https://trello.com/c/lO5L7y4F/3509-s-editing-initial-allocation-causes-500-error-if-user-does-not-select-yes-or-no

### Changes proposed in this pull request
Add error messaging to editing initial allocations page

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
