### PR TITLE
3535 remove leftover ga code

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,9 +19,6 @@
   </head>
 
   <body class="govuk-template__body <%= content_for(:body_classes) %>">
-    <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WCZDP65" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -5,7 +5,6 @@ import "../stylesheets/application.scss";
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import { initAll } from "govuk-frontend";
 import FormCheckLeave from "scripts/form-check-leave";
-import { triggerFormAnalytics } from "scripts/form-error-tracking";
 import initLocationsMap from "scripts/locations-map";
 
 initAll();
@@ -30,33 +29,6 @@ if ($copyWarningMessage) {
   window.onbeforeunload = function() {
     return "You have unsaved changes, are you sure you want to leave?";
   };
-}
-
-if (typeof ga === "function") {
-  const $formErrorSummary = document.querySelector(
-    '[data-ga-event-form="error"]'
-  );
-  const $formSuccessSummary = document.querySelector(
-    '[data-ga-event-form="success"]'
-  );
-
-  if ($formErrorSummary) {
-    const $formErrorMessages = $formErrorSummary.querySelectorAll(
-      "[data-error-message]"
-    );
-
-    triggerFormAnalytics("form", "form-submitted", "form-error");
-
-    $formErrorMessages.forEach(function($errorMessage) {
-      triggerFormAnalytics(
-        "form",
-        "form-error-message",
-        $errorMessage.getAttribute("data-error-message")
-      );
-    });
-  } else if ($formSuccessSummary) {
-    triggerFormAnalytics("form", "form-submitted", "form-success");
-  }
 }
 
 try {

--- a/app/webpacker/scripts/form-error-tracking.js
+++ b/app/webpacker/scripts/form-error-tracking.js
@@ -1,7 +1,0 @@
-export function triggerFormAnalytics(category, action, label) {
-  ga("send", "event", {
-    eventCategory: category,
-    eventAction: action,
-    eventLabel: label
-  });
-}


### PR DESCRIPTION
### Context
Removes code which was missed off https://github.com/DFE-Digital/publish-teacher-training/pull/926.

For Publish we do not use GA or GTM at all and do not offer the option to accept GA cookies

### Changes proposed in this pull request
- Removes obsolete JS that relied on GA. As we are no longer loading in GA, none of this code would ever be run.
- Remove mentions of GTM.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
