### PR TITLE
[3484]- Create-rollover-application-environment

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -178,6 +178,13 @@
       "metadata": {
         "description": "true to offer the user the option to sign-in using a magic link sent to them by email"
       }
+    },
+    "rollover": {
+      "type": "string",
+      "defaultValue": "false",
+      "metadata": {
+        "description": "The publish provider page offers current and next rollover cycles when set to true."
+      }
     }
 
   },
@@ -346,6 +353,10 @@
               {
                 "name": "SETTINGS__LOGSTASH__PORT",
                 "value": "[parameters('logstashPort')]"
+              },
+              {
+                "name": "SETTINGS__ROLLOVER",
+                "value": "[parameters('rollover')]"
               }
             ]
           },


### PR DESCRIPTION
### Context

 The publish provider page offers current and next rollover cycles when rollover is set to true in Azure DevOps. The app must be deployed via rollback release pipeline for a rollover cycle to be displayed on the publish provider page. 

https://s121d04-rollover-ptt-as.azurewebsites.net/organisations/2AT

### Changes proposed in this pull request

https://dfe-ssp.visualstudio.com/Become-A-Teacher/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=297&path=FIND%20-%20Rollover

### Guidance to review

https://dfe-ssp.visualstudio.com/Become-A-Teacher/_releaseProgress?_a=release-environment-logs&releaseId=7207&environmentId=36635

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
