### PR TITLE
Remove duplicate warning message js

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -14,23 +14,6 @@ window.initLocationsMap = initLocationsMap;
 const $form = document.querySelector('[data-module="form-check-leave"]');
 new FormCheckLeave($form).init();
 
-var $copyWarningMessage = document.querySelector(
-  '[data-copy-course="warning"]'
-);
-if ($copyWarningMessage) {
-  var $enrichmentForm = document.querySelector('[data-qa="enrichment-form"]');
-
-  if ($enrichmentForm) {
-    $enrichmentForm.addEventListener("submit", function() {
-      window.onbeforeunload = null;
-    });
-  }
-
-  window.onbeforeunload = function() {
-    return "You have unsaved changes, are you sure you want to leave?";
-  };
-}
-
 try {
   const $autocomplete = document.getElementById("provider-autocomplete");
   const $accredited_body_input = document.getElementById("course_accredited_body");


### PR DESCRIPTION
There is already a FormCheckLeave module which replicates the behaviour
which this code was using. I checked where this code might of been triggered
from and spotted that all the instances were being to setup to use the
FormCheckLeave module anyway.

https://github.com/DFE-Digital/publish-teacher-training/blob/1956e57d131c621a97b3b3eeec495b4662726547/app/webpacker/scripts/form-check-leave.js#L9-L27

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
