### PR TITLE
[3500] Fix accredited body searches

### DIFF
--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -33,7 +33,7 @@ module Courses
       build_provider
       build_previous_course_creation_params
       @query = params[:query]
-      @provider_suggestions = ProviderSuggestion.suggest(@query)
+      @provider_suggestions = ProviderSuggestion.suggest_any_accredited_body(@query)
     rescue JsonApiClient::Errors::ClientError => e
       @errors = e
     end
@@ -59,7 +59,7 @@ module Courses
     def search
       build_course
       @query = params[:query]
-      @provider_suggestions = ProviderSuggestion.suggest(@query)
+      @provider_suggestions = ProviderSuggestion.suggest_any_accredited_body(@query)
     rescue JsonApiClient::Errors::ClientError => e
       @errors = e
     end

--- a/app/controllers/provider_suggestions_controller.rb
+++ b/app/controllers/provider_suggestions_controller.rb
@@ -17,6 +17,15 @@ class ProviderSuggestionsController < ApplicationController
     render json: suggestions
   end
 
+  def suggest_any_accredited_body
+    return render(json: { error: "Bad request" }, status: :bad_request) if params_invalid?
+
+    sanitised_query = CGI.escape(params[:query])
+    suggestions = ProviderSuggestion.suggest_any_accredited_body(sanitised_query)
+      .map { |provider| { code: provider.provider_code, name: provider.provider_name } }
+    render json: suggestions
+  end
+
 private
 
   def params_invalid?

--- a/app/models/provider_suggestion.rb
+++ b/app/models/provider_suggestion.rb
@@ -10,4 +10,10 @@ class ProviderSuggestion < Base
       :request, :get, "/api/v2/providers/suggest_any?query=#{query}"
     )
   end
+
+  def self.suggest_any_accredited_body(query)
+    requestor.__send__(
+      :request, :get, "/api/v2/providers/suggest_any?query=#{query}&filter[only_accredited_body]=true"
+    )
+  end
 end

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -23,7 +23,7 @@ try {
   const provider_template = result => result && `${result.name} (${result.code})`;
 
   if ($autocomplete && $accredited_body_input) {
-    initAutocomplete($autocomplete, $accredited_body_input, accredited_body_template);
+    initAutocomplete($autocomplete, $accredited_body_input, accredited_body_template, {path: "/providers/suggest_any_accredited_body"});
   }
   if($autocomplete && $provider_input) {
     initAutocomplete($autocomplete, $provider_input, provider_template);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,7 @@ Rails.application.routes.draw do
 
   get "/providers/suggest", to: "provider_suggestions#suggest"
   get "/providers/suggest_any", to: "provider_suggestions#suggest_any"
+  get "/providers/suggest_any_accredited_body", to: "provider_suggestions#suggest_any_accredited_body"
   get "/providers/search", to: "providers#search"
   # redirect URL's from legacy c# app
   get "/organisation/:provider_code", to: redirect("/organisations/%{provider_code}", status: 301)

--- a/spec/controllers/provider_suggestions_controller_spec.rb
+++ b/spec/controllers/provider_suggestions_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe ProviderSuggestionsController do
+  let(:current_user) do
+    {
+      user_id: 1,
+      uid: SecureRandom.uuid,
+      info: {
+        email: "dave@example.com",
+      },
+    }.with_indifferent_access
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+  end
+
+  describe "#suggest_any" do
+    it "suggests accredited bodies only" do
+      stub = stub_request(:get, "http://localhost:3001/api/v2/providers/suggest_any")
+        .with(query: { query: "foo" })
+        .to_return(
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          body: File.read(Rails.root.join("spec/fixtures/api_responses/provider-suggestions.json")),
+        )
+
+      get :suggest_any, params: { query: "foo" }
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#suggest_any_accredited_body" do
+    it "suggests accredited bodies only" do
+      stub = stub_request(:get, "http://localhost:3001/api/v2/providers/suggest_any")
+        .with(query: { query: "foo", filter: { only_accredited_body: "true" } })
+        .to_return(
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          body: File.read(Rails.root.join("spec/fixtures/api_responses/provider-suggestions.json")),
+        )
+
+      get :suggest_any_accredited_body, params: { query: "foo" }
+
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -203,7 +203,7 @@ feature "Edit accredited body", type: :feature do
 
   def searching_returns_some_results
     stub_api_v2_request(
-      "/providers/suggest?query=ACME",
+      "/providers/suggest_any?query=ACME&filter[only_accredited_body]=true",
       resource_list_to_jsonapi([
         build(:provider_suggestion, provider_name: "ACME 1", provider_code: "A01"),
         build(:provider_suggestion, provider_name: "ACME 2"),
@@ -215,7 +215,7 @@ feature "Edit accredited body", type: :feature do
 
   def searching_returns_no_results
     stub_api_v2_request(
-      "/providers/suggest?query=ACME",
+      "/providers/suggest_any?query=ACME&filter[only_accredited_body]=true",
       resource_list_to_jsonapi([]),
     )
   end

--- a/spec/features/courses/accredited_body/new_spec.rb
+++ b/spec/features/courses/accredited_body/new_spec.rb
@@ -124,20 +124,13 @@ private
 
   def searching_returns_some_results
     stub_api_v2_request(
-      "/providers/suggest?query=ACME",
+      "/providers/suggest_any?query=ACME&filter[only_accredited_body]=true",
       resource_list_to_jsonapi([
         build(:provider_suggestion, provider_name: "ACME 1", provider_code: "A01"),
         build(:provider_suggestion, provider_name: "ACME 2"),
         build(:provider_suggestion, provider_name: "ACME 3"),
         build(:provider_suggestion, provider_name: "ACME 4"),
       ]),
-    )
-  end
-
-  def searching_returns_no_results
-    stub_api_v2_request(
-      "/providers/suggest?query=ACME",
-      resource_list_to_jsonapi([]),
     )
   end
 end

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -20,7 +20,7 @@ describe "Courses" do
         build(:recruitment_cycle)
         provider1 = build(:provider, provider_name: "asd")
         provider2 = build(:provider, provider_name: "aoe")
-        stub_api_v2_request("/providers/suggest?query=a", resource_list_to_jsonapi([provider1, provider2]))
+        stub_api_v2_request("/providers/suggest_any?query=a&filter[only_accredited_body]=true", resource_list_to_jsonapi([provider1, provider2]))
         get(accredited_body_search_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code, query: "a"))
         expect(response.body).to include("asd")
         expect(response.body).to include("aoe")


### PR DESCRIPTION
### Context

- https://trello.com/c/OO8AqZZe/3500-course-creation-accredited-body-search
- Previously was only searching a very small subset or providers

### Changes proposed in this pull request

- Use modified api endpoint to search all accredited bodies for suggestions

### Guidance to review

- note sure about the code climate failure given that overall test coverage has not dropped
- depends on https://github.com/DFE-Digital/teacher-training-api/pull/1425
- create a new course as user `anonimized-user-8272@example.org`
- on the page to select accredited body perform a search
- should run search and return relevant accredited bodies
- should work for non-js version

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
