### PR TITLE
[3544] Add copy to rollover provider show page.

### DIFF
--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -10,6 +10,7 @@
   <li>edit locations and vacancies in the current cycle</li>
   <% if @provider.accredited_body? %>
     <li>see which courses you're the accredited body for in the current cycle</li>
+    <li>view or make fee-funded PE course requests for in the next cycle</li>
   <% end %>
 </ul>
 

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -1,0 +1,23 @@
+<h2 class="govuk-heading-m">
+  <%= link_to "Current cycle (#{Settings.current_cycle} - #{Settings.current_cycle + 1})",
+              provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle),
+              data: { qa: 'provider__courses__current_cycle' },
+              class: "govuk-link" %>
+</h2>
+<p class="govuk-body">Use this section to:</p>
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+  <li>manage courses in the current cycle</li>
+  <li>edit locations and vacancies in the current cycle</li>
+</ul>
+
+<h2 class="govuk-heading-m">
+  <%= link_to "Next cycle (#{Settings.current_cycle + 1} - #{Settings.current_cycle + 2})",
+              provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle + 1),
+              data: { qa: 'provider__courses__next_cycle' },
+              class: "govuk-link" %>
+</h2>
+<p class="govuk-body">Use this section to:</p>
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+  <li>prepare courses for the next cycle</li>
+  <li>manage locations needed for the next cycle</li>
+</ul>

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -6,11 +6,11 @@
 </h2>
 <p class="govuk-body">Use this section to:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-  <li>manage courses in the current cycle</li>
-  <li>edit locations and vacancies in the current cycle</li>
+  <li>manage current courses</li>
+  <li>edit locations and vacancies for current courses</li>
   <% if @provider.accredited_body? %>
-    <li>see which courses you're the accredited body for in the current cycle</li>
-    <li>view or make fee-funded PE course requests for in the next cycle</li>
+    <li>see which courses you're currently the accredited body for</li>
+    <li>request PE courses for the next cycle (and view requests you've already made)</li>
   <% end %>
 </ul>
 
@@ -20,11 +20,14 @@
               data: { qa: 'provider__courses__next_cycle' },
               class: "govuk-link" %>
 </h2>
-<p class="govuk-body">Use this section to:</p>
+<p class="govuk-body">
+  Courses for the next cycle will appear on Find postgraduate teacher training from October 2020.
+  Use this section to:
+</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-  <li>prepare courses for the next cycle</li>
-  <li>manage locations needed for the next cycle</li>
+  <li>prepare your courses for the next cycle</li>
+  <li>manage locations for the next cycle</li>
   <% if @provider.accredited_body? %>
-    <li>see which courses you're the accredited body for in the next cycle</li>
+    <li>see which courses in the next cycle you're the accredited body for</li>
   <% end %>
 </ul>

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -8,6 +8,9 @@
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
   <li>manage courses in the current cycle</li>
   <li>edit locations and vacancies in the current cycle</li>
+  <% if @provider.accredited_body? %>
+    <li>see which courses you're the accredited body for in the current cycle</li>
+  <% end %>
 </ul>
 
 <h2 class="govuk-heading-m">
@@ -20,4 +23,7 @@
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
   <li>prepare courses for the next cycle</li>
   <li>manage locations needed for the next cycle</li>
+  <% if @provider.accredited_body? %>
+    <li>see which courses you're the accredited body for in the next cycle</li>
+  <% end %>
 </ul>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -8,29 +8,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @provider.rolled_over? %>
-      <h2 class="govuk-heading-m">
-        <%= link_to "Current cycle (#{Settings.current_cycle} - #{Settings.current_cycle + 1})",
-                          provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle),
-                          data: { qa: 'provider__courses__current_cycle' },
-                          class: "govuk-link" %>
-      </h2>
-      <p class="govuk-body">Use this section to:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-        <li>manage courses in the current cycle</li>
-        <li>edit locations and vacancies in the current cycle</li>
-      </ul>
-
-      <h2 class="govuk-heading-m">
-        <%= link_to "Next cycle (#{Settings.current_cycle + 1} - #{Settings.current_cycle + 2})",
-                          provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle + 1),
-                          data: { qa: 'provider__courses__next_cycle' },
-                          class: "govuk-link" %>
-      </h2>
-      <p class="govuk-body">Use this section to:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-        <li>prepare courses for the next cycle</li>
-        <li>manage locations needed for the next cycle</li>
-      </ul>
+      <%= render partial: 'show_during_rollover' %>
     <% else %>
       <%= render partial: 'recruitment_cycles/about_organisation', locals: { provider: @provider, year: Settings.current_cycle } %>
       <%= render partial: 'recruitment_cycles/courses_info', locals: { provider: @provider, year: Settings.current_cycle } %>


### PR DESCRIPTION
# Context
We added "Courses as accredited body" and "Requests for PE" feature during the last year. We need to tell users that they can still see this feature for either the current or next cycle.


# Changes proposed in this pull request
- Moves rollover content into a new partial
- adds copy relating to being able to view "Courses as accredited body" which is only shown if the provider is an accredited body 
- adds copy relating to being able to view/make request for pe but only for the current cycle
- updates some other copy after a content review.

## Before
![image](https://user-images.githubusercontent.com/3441519/84780623-b3f48080-afdd-11ea-979c-92b34b8e1f87.png)

## After
![image](https://user-images.githubusercontent.com/3441519/84790393-38003580-afe9-11ea-95cc-6ba733238504.png)



# Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
