### PR TITLE
[3554] Fix rollover course create start date

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -230,7 +230,11 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def return_start_date
-    start_date.presence || "September #{Settings.current_cycle}"
+    if Settings.rollover
+      start_date.presence || "September #{Settings.current_cycle + 1}"
+    else
+      start_date.presence || "September #{Settings.current_cycle}"
+    end
   end
 
 private

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -573,8 +573,19 @@ describe CourseDecorator do
 
     context "when the course has no start date" do
       let(:start_date) { nil }
+
       it "should return the September of the current cycle" do
         expect(decorated_course.return_start_date).to eq("September #{Settings.current_cycle}")
+      end
+    end
+
+    context "during rollover" do
+      let(:start_date) { nil }
+
+      before { allow(Settings).to receive(:rollover).and_return(true) }
+
+      it "should return the September of the next cycle" do
+        expect(decorated_course.return_start_date).to eq("September #{Settings.current_cycle + 1}")
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/NJL3vOKK/3554-when-creating-a-course-in-the-next-recruitment-cycle-add-a-default-start-date
- During rollover course creation default start date is not set

### Changes proposed in this pull request

- During rollover on course creation set default start date for the next cycle

### Guidance to review

- Create a course in the next cycle
- On the course start page
- September of next cycle should be selected as the default

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
