### PR TITLE
[3467] Add "Request for PE" section to current cycle page

### DIFF
--- a/app/views/recruitment_cycles/_allocations.html.erb
+++ b/app/views/recruitment_cycles/_allocations.html.erb
@@ -1,9 +1,7 @@
 <% if @provider.accredited_body? %>
   <h2 class="govuk-heading-m">
-    <%= link_to raw("Request PE courses for 2021&thinsp;–&thinsp;2022"),
-                provider_recruitment_cycle_allocations_path(@provider.provider_code, year),
-                class: "govuk-link",
-                data: { qa: "request-allocations-link" } %>
+    <%= govuk_link_to raw("Request PE courses for 2021&thinsp;–&thinsp;2022"),
+                provider_recruitment_cycle_allocations_path(@provider.provider_code, year) %>
   </h2>
 
   <p class="govuk-body">

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -22,5 +22,8 @@
     <%= render partial: 'recruitment_cycles/courses_info', locals: { provider: @provider, year: params[:year] } %>
     <%= render partial: 'recruitment_cycles/locations_info', locals: { provider: @provider, year: params[:year] } %>
     <%= render partial: 'recruitment_cycles/courses_accredited_body', locals: { provider: @provider, year: params[:year] } %>
+    <% if @recruitment_cycle.current? %>
+      <%= render partial: 'recruitment_cycles/allocations', locals: { provider: @provider, year: params[:year] } %>
+    <% end %>
   </div>
 </div>

--- a/spec/site_prism/page_objects/page/organisations/recruitment_cycle.rb
+++ b/spec/site_prism/page_objects/page/organisations/recruitment_cycle.rb
@@ -11,6 +11,7 @@ module PageObjects
         element :locations_link, "a", text: "Locations"
         element :courses_link, "a", text: "Courses"
         element :courses_as_accredited_body_link, "a", text: "Courses as an accredited body"
+        element :request_for_pe_link, "a", text: "Request PE courses for"
       end
     end
   end

--- a/spec/views/recruitment_cycles/show_spec.rb
+++ b/spec/views/recruitment_cycles/show_spec.rb
@@ -30,6 +30,7 @@ describe "recruitment_cycles/show.html", type: :view do
         expect(recruitment_cycle_page).to have_courses_link
         expect(recruitment_cycle_page).to have_locations_link
         expect(recruitment_cycle_page).to have_courses_as_accredited_body_link
+        expect(recruitment_cycle_page).to have_request_for_pe_link
       end
     end
 
@@ -46,6 +47,7 @@ describe "recruitment_cycles/show.html", type: :view do
         expect(recruitment_cycle_page).to have_courses_link
         expect(recruitment_cycle_page).to have_locations_link
         expect(recruitment_cycle_page).to have_no_courses_as_accredited_body_link
+        expect(recruitment_cycle_page).to have_no_request_for_pe_link
       end
     end
   end
@@ -70,6 +72,7 @@ describe "recruitment_cycles/show.html", type: :view do
         expect(recruitment_cycle_page).to have_courses_link
         expect(recruitment_cycle_page).to have_locations_link
         expect(recruitment_cycle_page).to have_courses_as_accredited_body_link
+        expect(recruitment_cycle_page).to have_no_request_for_pe_link
       end
     end
 
@@ -86,6 +89,7 @@ describe "recruitment_cycles/show.html", type: :view do
         expect(recruitment_cycle_page).to have_courses_link
         expect(recruitment_cycle_page).to have_locations_link
         expect(recruitment_cycle_page).to have_no_courses_as_accredited_body_link
+        expect(recruitment_cycle_page).to have_no_request_for_pe_link
       end
     end
   end


### PR DESCRIPTION
### Context
#1193 needs to be merged first

### Changes proposed in this pull request
- Add "Requests for PE" to the current cycle so accredited body users can see their allocations
- Refactor the section header link to not include `data-qa`
### Guidance to review
Review last two commits.

#### Before
![image](https://user-images.githubusercontent.com/3441519/84911528-2c2b7680-b0b0-11ea-895f-8ab4dde48ea9.png)
#### After
![image](https://user-images.githubusercontent.com/3441519/84911591-406f7380-b0b0-11ea-8396-07e61d50c6c5.png)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
