### PR TITLE
[3563] Use TrainingProvider#show endpoint

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -8,10 +8,11 @@ module Providers
     PE_SUBJECT_CODE = "C6".freeze
 
     def index
-      @training_providers = @provider.training_providers(
+      @training_providers = TrainingProvider.where(
         recruitment_cycle_year: @recruitment_cycle.year,
-        "filter[subjects]": PE_SUBJECT_CODE,
-        "filter[funding_type]": "fee",
+        provider_code: @provider.provider_code,
+        subjects: PE_SUBJECT_CODE,
+        funding_type: "fee",
       )
 
       allocations = Allocation

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -69,7 +69,7 @@ class ProvidersController < ApplicationController
   end
 
   def training_providers
-    @training_providers = @provider.training_providers(recruitment_cycle_year: @recruitment_cycle.year)
+    @training_providers = TrainingProvider.where(recruitment_cycle_year: @recruitment_cycle.year, provider_code: @provider.provider_code)
     @training_providers.delete_if { |tp| tp.provider_code == @provider.provider_code }
     @course_counts = @training_providers.meta[:accredited_courses_counts]
   end
@@ -130,9 +130,8 @@ private
   end
 
   def build_training_provider
-    @training_provider = Provider
-      .includes(courses: [:accrediting_provider])
-      .where(recruitment_cycle_year: @recruitment_cycle.year)
+    @training_provider = TrainingProvider
+      .where(recruitment_cycle_year: @recruitment_cycle.year, provider_code: @provider.provider_code)
       .find(params[:training_provider_code])
       .first
   end

--- a/app/flows/initial_request_flow.rb
+++ b/app/flows/initial_request_flow.rb
@@ -117,17 +117,19 @@ private
   end
 
   def training_providers_with_fee_paying_pe_course
-    @training_providers_with_fee_paying_pe_course ||= provider.training_providers(
+    @training_providers_with_fee_paying_pe_course ||= TrainingProvider.where(
       recruitment_cycle_year: recruitment_cycle.year,
-      "filter[subjects]": PE_SUBJECT_CODE,
-      "filter[funding_type]": "fee",
+      provider_code: provider.provider_code,
+      subjects: PE_SUBJECT_CODE,
+      funding_type: "fee",
     )
   end
 
   def all_training_providers
     @all_training_providers ||=
-      provider.training_providers(
+      TrainingProvider.where(
         recruitment_cycle_year: recruitment_cycle.year,
+        provider_code: provider.provider_code,
       )
   end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -4,10 +4,10 @@ class Provider < Base
   has_many :courses, param: :course_code
   has_many :sites
   has_one :allocation
+  has_many :training_providers
 
   self.primary_key = :provider_code
 
-  custom_endpoint :training_providers, on: :member, request_method: :get
   custom_endpoint :show_any, on: :member, request_method: :get
 
   def publish

--- a/app/models/training_provider.rb
+++ b/app/models/training_provider.rb
@@ -1,0 +1,4 @@
+class TrainingProvider < Base
+  belongs_to :recruitment_cycle, param: :recruitment_cycle_year
+  belongs_to :provider, param: :provider_code
+end

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -199,15 +199,13 @@ RSpec.feature "PE allocations" do
       "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
       "#{@accredited_body.provider_code}/training_providers" \
       "?filter[funding_type]=fee" \
-      "&filter[subjects]=C6" \
-      "&recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
+      "&filter[subjects]=C6",
       resource_list_to_jsonapi([@training_provider_with_fee_funded_pe]),
     )
 
     stub_api_v2_request(
       "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@accredited_body.provider_code}/training_providers" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
+      "#{@accredited_body.provider_code}/training_providers",
       resource_list_to_jsonapi([@training_provider, @training_provider_with_fee_funded_pe, @training_provider_with_allocation]),
     )
   end

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -271,15 +271,13 @@ RSpec.feature "PE allocations" do
       "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
       "#{@accredited_body.provider_code}/training_providers" \
       "?filter[funding_type]=fee" \
-      "&filter[subjects]=C6" \
-      "&recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
+      "&filter[subjects]=C6",
       resource_list_to_jsonapi([@training_provider_with_fee_funded_pe]),
     )
 
     stub_api_v2_request(
       "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@accredited_body.provider_code}/training_providers" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
+      "#{@accredited_body.provider_code}/training_providers",
       resource_list_to_jsonapi([@training_provider, @training_provider_with_fee_funded_pe, @training_provider_with_allocation]),
     )
   end

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -253,8 +253,7 @@ private
       "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
       "#{@accredited_body.provider_code}/training_providers" \
       "?filter[funding_type]=fee" \
-      "&filter[subjects]=C6" \
-      "&recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
+      "&filter[subjects]=C6",
       resource_list_to_jsonapi([@training_provider]),
     )
   end
@@ -264,8 +263,7 @@ private
       "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
       "#{@accredited_body.provider_code}/training_providers" \
       "?filter[funding_type]=fee" \
-      "&filter[subjects]=C6" \
-      "&recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
+      "&filter[subjects]=C6",
       resource_list_to_jsonapi([]),
     )
   end

--- a/spec/features/providers/courses_as_an_accredited_body_spec.rb
+++ b/spec/features/providers/courses_as_an_accredited_body_spec.rb
@@ -26,13 +26,14 @@ feature "get courses as an accredited body", type: :feature do
       resource_list_to_jsonapi([course1]),
     )
     stub_api_v2_request(
-      "/recruitment_cycles/#{training_provider2.recruitment_cycle.year}/providers/" \
-      "#{training_provider2.provider_code}?include=courses.accrediting_provider",
+      "/recruitment_cycles/#{training_provider2.recruitment_cycle.year}" \
+      "/providers/#{accrediting_body1.provider_code}" \
+      "/training_providers/#{training_provider2.provider_code}",
       training_provider2.to_jsonapi(include: :courses),
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
-      "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
+      "#{accrediting_body1.provider_code}/training_providers",
       resource_list_to_jsonapi([training_provider2, accrediting_body2], { meta: { accredited_courses_counts: {} } }),
     )
     stub_api_v2_request(

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -25,7 +25,7 @@ feature "get training_providers", type: :feature do
     )
     stub_api_v2_request(
       "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
-      "#{accrediting_body1.provider_code}/training_providers?recruitment_cycle_year=#{accrediting_body1.recruitment_cycle.year}",
+      "#{accrediting_body1.provider_code}/training_providers",
       resource_list_to_jsonapi(
         [accrediting_body1, training_provider1, training_provider2],
         meta: {


### PR DESCRIPTION
### Context

- https://trello.com/c/6S5IQpl1/3563-accredited-bodies-cant-see-the-courses-they-accredit
- When viewing a training provider we are using the Provider#show endpoint which is only accessible to users that are associated with the provider via an organisation
- Switch to use a new endpoint that is accessible to users that are part of an accredited body on the provider

### Changes proposed in this pull request

- Previously using Provider#show endpoint which was only accessible if
the user was associated to that provider via an organisation
- Given a training provider TrainingProvider#show endpoint is accessible
to users that are part of any accredited body of the training provider
thru the courses they offer

### Guidance to review

- This change depends on https://github.com/DFE-Digital/teacher-training-api/pull/1431
- Login as a user of an accredited body e.g `anonimized-user-8916@example.org`
- Should be able to view accredited bodies
- Should be able to view courses of an accredited body

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
