### PR TITLE
[3553] Fix accredited body viewing courses

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -144,7 +144,9 @@ private
   end
 
   def build_recruitment_cycle
-    cycle_year = params.fetch(:year, Settings.current_cycle)
+    # this is due to #training_provider_courses being nested as a route
+    # this causes the route param "year" to be prefixed
+    cycle_year = params[:recruitment_cycle_year] || params[:year] || Settings.current_cycle
 
     @recruitment_cycle = RecruitmentCycle.find(cycle_year).first
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/o78fXqgF/3553-fix-course-statuses-on-training-provider-course-list-for-accredited-body
- Accredited body viewing training provider courses would pull in courses from the current cycle and not the specified cycle. This is an issue during rollover

### Changes proposed in this pull request

- Accredited body viewing a training providers courses during rollover
would use the current cycle and not the cycle from the parameter
- This because this route is not restful and is nested
- As it is nested rails with prefix the param `year`
- So for the non restful route #training_provider_courses we must
consider both cases
- The better fix should be to move training providers to its own
resource and make everything restful

### Guidance to review

- Login as an accredited body user eg `anonimized-user-8916@example.org`
- View the courses of a training provider for both the current and next cycle
- Current cycle courses should be published
- Next cycle courses should be in rollover state

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
