### PR TITLE
[3576] Preview tweaks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,8 @@ gem "rails_semantic_logger"
 # Kaminari, pagination templating
 gem "pagy"
 
+gem "rubypants"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,7 @@ GEM
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    rubypants (0.7.1)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -510,6 +511,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   rspec_junit_formatter
   rubocop-govuk
+  rubypants
   scss_lint-govuk
   sentry-raven
   simplecov (< 0.18)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,7 @@
 class CoursesController < ApplicationController
   decorates_assigned :course
+  decorates_assigned :provider
+
   before_action :initialise_errors
   before_action :build_recruitment_cycle
   before_action :build_courses, only: %i[index about requirements fees salary]

--- a/app/decorators/provider_decorator.rb
+++ b/app/decorators/provider_decorator.rb
@@ -4,4 +4,10 @@ class ProviderDecorator < ApplicationDecorator
   def accredited_bodies
     object.accredited_bodies.sort_by { |provider| provider["provider_name"] }
   end
+
+  def website
+    return if object.website.blank?
+
+    object.website.start_with?("http") ? object.website : ("http://" + object.website)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,16 @@ module ApplicationHelper
     options = { autolink: true, lax_spacing: true }
     markdown = Redcarpet::Markdown.new(render, options)
     markdown.render(source).html_safe
+
+    # Convert quotes to smart quotes
+    source_with_smart_quotes = smart_quotes(source)
+    markdown.render(source_with_smart_quotes).html_safe
+  end
+
+  def smart_quotes(string)
+    return "" if string.blank?
+
+    RubyPants.new(string, 2, ruby_pants_options).to_html
   end
 
   def enrichment_error_link(model, field, error)
@@ -66,5 +76,23 @@ module ApplicationHelper
     tag.div class: "govuk-summary-list__row" do
       enrichment_summary_label(model, key, fields) + enrichment_summary_value(value, fields)
     end
+  end
+
+private
+
+  # Use characters rather than HTML entities for smart quotes this matches how
+  # we write smart quotes in templates and allows us to use them in <title>
+  # elements
+  # https://github.com/jmcnevin/rubypants/blob/master/lib/rubypants.rb
+  def ruby_pants_options
+    {
+      double_left_quote: "“",
+      double_right_quote: "”",
+      single_left_quote: "‘",
+      single_right_quote: "’",
+      ellipsis: "…",
+      em_dash: "—",
+      en_dash: "–",
+    }
   end
 end

--- a/app/views/courses/preview/_advice.html.erb
+++ b/app/views/courses/preview/_advice.html.erb
@@ -2,10 +2,10 @@
 <p class="govuk-body">For questions about this course you should contact the training provider using <%= link_to "the contact details above", "#contact_section", class: "govuk-link" %>.</p>
 
 <h4 class="govuk-heading-m">Get support and advice about teaching</h4>
-<p class="govuk-body">Register with <%= link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/user/register', class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://ta-chat.education.gov.uk/chat/chatstart.aspx?domain=www.education.gov.uk&department=GetIntoTeaching%27,%27new_win%27,%27width=0,height=0%27);return%20false;%22&SID=1", class: 'govuk-link' %>, from 8am to 8pm, Monday to Friday.</p>
+<p class="govuk-body">Register with <%= link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/user/register', class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat", class: 'govuk-link' %>, from 8am to 8pm, Monday to Friday.</p>
 
 <h4 class="govuk-heading-m">Website support</h4>
 <p class="govuk-body">If you have feedback or have had a problem using Find postgraduate teacher training you can <%= bat_contact_mail_to "contact us by email" %>.</p>
 
 <h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
-<p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to "contact the Becoming a Teacher team", subject: "Edit #{course.name} (#{@provider_code}/#{course.course_code})" %></p>
+<p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to "contact us by email", subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>

--- a/app/views/courses/preview/_apply.html.erb
+++ b/app/views/courses/preview/_apply.html.erb
@@ -4,57 +4,54 @@
 
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
-  <p class="govuk-body">
-    <%= link_to 'Apply on the UCAS website', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do', class: 'govuk-link' %>. You’ll need to register with UCAS before you can apply.
-  </p>
-  <p class="govuk-body">
-    Visit Get into Teaching for <%= link_to 'guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply/apply', class: 'govuk-link' %>.
-  </p>
 
-  <p class="govuk-body">
-    When you apply you’ll need these codes for the Choices section of your application form:
-  </p>
-  <div class="govuk-inset-text">
-    <ul class="govuk-list">
-      <li class="govuk-!-margin-bottom-2">
-        Training provider code:
-        <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= @provider.provider_code %></span>
-      </li>
-      <li>
-        Training programme code:
-        <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= course.course_code %></span>
-      </li>
-    </ul>
-  </div>
-  <h3 class="govuk-heading-m">Choose a training location</h3>
-  <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
+  <% if @course.content_status == "rolled_over" || @course.has_vacancies? %>
+    <p class="govuk-body">
+      <%= link_to "Apply for this course", "#",
+                  class: "govuk-button govuk-button--start",
+                  data: { qa: 'course__apply_link' },
+                  rel: "nofollow" %>
+    </p>
 
-  <div id="locations-map" class="app-google-map" data-qa="course__locations_map"></div>
+    <h3 class="govuk-heading-m">Choose a training location</h3>
+    <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
 
-  <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col">Location</th>
-        <th class="govuk-table__header" scope="col">Vacancies</th>
-        <th class="govuk-table__header" scope="col">Code</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% course.preview_site_statuses.each do |site_status| %>
+    <div id="locations-map" class="app-google-map" data-qa="course__locations_map"></div>
+
+    <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
+      <caption class="govuk-visually-hidden">Choose a training location - List of locations, vacancies and codes</caption>
+      <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <strong><%= site_status.site.location_name %></strong>
-            <br>
-            <%= site_status.site.full_address %>
-          </td>
-          <td class="govuk-table__cell">
-            <%= site_status.has_vacancies? ? 'Yes' : 'No' %>
-          </td>
-          <td class="govuk-table__cell"><%= site_status.site.code %></td>
+          <th class="govuk-table__header" scope="col">Location</th>
+          <th class="govuk-table__header" scope="col">Vacancies</th>
+          <th class="govuk-table__header" scope="col">Code</th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% course.preview_site_statuses.each do |site_status| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <strong><%= smart_quotes(site_status.site.location_name) %></strong>
+              <br>
+              <%= smart_quotes(site_status.site.full_address) %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= site_status.has_vacancies? ? 'Yes' : 'No' %>
+            </td>
+            <td class="govuk-table__cell"><%= site_status.site.code %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.
+      </strong>
+    </div>
+  <% end %>
 </div>
 
 <script>
@@ -62,10 +59,10 @@
     <% course.preview_site_statuses.each do |site_status| %>
       {
         "code": "<%= site_status.site.code %>",
-        "name": "<%= site_status.site.location_name %>",
-        "lat": "<%= site_status.site.latitude.present? ? site_status.site.latitude : @provider.latitude %>",
-        "lng": "<%= site_status.site.longitude.present? ? site_status.site.longitude : @provider.longitude %>",
-        "address": "<%= site_status.site.full_address %>",
+        "name": "<%= smart_quotes(site_status.site.location_name) %>",
+        "lat": "<%= site_status.site.latitude.present? ? site_status.site.latitude : course.provider.latitude %>",
+        "lng": "<%= site_status.site.longitude.present? ? site_status.site.longitude : course.provider.longitude %>",
+        "address": "<%= smart_quotes(site_status.site.full_address) %>",
         "vacancies": "<%= site_status.has_vacancies? ? "" : "No vacancies" %>"
       },
     <% end %>

--- a/spec/decorators/provider_decorator_spec.rb
+++ b/spec/decorators/provider_decorator_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ProviderDecorator do
+  let(:website) { "www.acmescitt.com" }
+
+  let(:provider) do
+    build(
+      :provider,
+      accredited_body?: false,
+      website: website,
+      address1: "1 Sample Road",
+      postcode: "W1 ABC",
+    )
+  end
+
+  subject { provider.decorate }
+
+  describe "#website" do
+    context "with website" do
+      it { expect(subject.website).to eq("http://www.acmescitt.com") }
+    end
+
+    context "without website" do
+      let(:website) { nil }
+
+      it { expect(subject.website).to eq(nil) }
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -49,4 +49,45 @@ RSpec.feature "View helpers", type: :helper do
         .to eq('<div class="govuk-summary-list__row"><dt class="govuk-summary-list__key">About course</dt><dd class="govuk-summary-list__value govuk-summary-list__value--truncate" data-qa="enrichment__about">Something about the course</dd></div>')
     end
   end
+
+  describe "#markdown" do
+    it "converts markdown to HTML" do
+      expect(helper.markdown("test")).to eq("<p class=\"govuk-body\">test</p>")
+    end
+
+    it "converts markdown lists to HTML lists" do
+      expect(helper.markdown("* test\n* another test")).to include("<li>test</li>")
+    end
+
+    it "ignores emphasis markdown" do
+      output = helper.markdown("This does not have *emphasis*\n**something important**\n***super***")
+      expect(output).to include("This does not have *emphasis*")
+      expect(output).to include("**something important**")
+      expect(output).to include("***super***")
+    end
+
+    it "converts quotes to smart quotes" do
+      output = helper.markdown("\"Wow -- what's this...\", O'connor asked.")
+      expect(output).to eq("<p class=\"govuk-body\">“Wow – what’s this…”, O’connor asked.</p>")
+    end
+
+    # Redcarpet fixes out of the box
+    it "fixes incorrect markdown links" do
+      output = helper.markdown("[Google] (https://www.google.com)")
+      expect(output).to include("<a href=\"https://www.google.com\" class=\"govuk-link\">Google</a>")
+    end
+  end
+
+  describe "#smart_quotes" do
+    it "converts quotes to smart quotes" do
+      output = helper.smart_quotes("\"Wow -- what's this...\", O'connor asked.")
+      expect(output).to include("“Wow – what’s this…”, O’connor asked.")
+    end
+
+    context "when nil" do
+      it "returns empty string" do
+        expect(helper.smart_quotes(nil)).to be_blank
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/lD6tJVsR/3576-s-publish-preview-functionality-should-match-find
- There are differences between the Publish preview functionality and how it will actually look on find. This change hopes to remove these differences

### Changes proposed in this pull request

- Links are now prefixed with `http` if there is no protocol specified. This is to prevent incorrect relative urls when they should be external links
- Smart quotes used when markdown is processed
- Markdown processor does some additional work to better render lists and bullet points to due incorrect markdown entered by users
-  Copy changes to the preview pages so it matches Find
- When a course is in `rolled_over` state and is being previewed we now show the "Apply section" as part of the preview

### Guidance to review

- Find a course in rolled over state and preview
- Compare with current version on Find
- These 2 pages should be near to identical

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
