### PR TITLE
[3336] - Bug fix: state transition error

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -17,7 +17,7 @@ class NotificationsController < ApplicationController
       return
     end
 
-    unless user.notifications_configured
+    if user.may_accept_notifications_screen?
       UpdateUserService.call(user, "accept_notifications_screen!")
     end
 

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -16,7 +16,7 @@ describe NotificationsController, type: :controller do
   describe "UPDATE" do
     before do
       allow_any_instance_of(ApplicationController).to receive(:current_user)
-        .and_return(current_user)
+                                                        .and_return(current_user)
 
       user_notification_preferences = instance_double(UserNotificationPreferences)
       allow(user_notification_preferences).to receive(:update).and_return(user_notification_preferences)
@@ -54,8 +54,8 @@ describe NotificationsController, type: :controller do
       end
     end
 
-    context "user is not subscribed to notifications" do
-      let(:user) { build(:user, :rolled_over, id: 1, notifications_configured: false) }
+    context "user can transition state to 'notifications_configured'" do
+      let(:user) { build(:user, :rolled_over, id: 1, notifications_configured: false, associated_with_accredited_body: true) }
 
       it "calls the user update service" do
         expect(UpdateUserService)
@@ -76,25 +76,65 @@ describe NotificationsController, type: :controller do
       end
     end
 
-    context "user is subscribed to notifications" do
-      let(:user) { build(:user, :rolled_over, id: 1) }
+    context "user can not transition state to 'notifications configured'" do
+      context "user is not associated with accredited body" do
+        let(:user) do
+          build(
+            :user,
+            :rolled_over,
+            notifications_configured: false,
+            associated_with_accredited_body: false,
+            id: 1,
+          )
+        end
 
-      it "it does not call the user update service" do
-        expect(UpdateUserService)
-          .not_to receive(:call)
-                .with(instance_of(User), "accept_notifications_screen!")
+        it "it does not call the user update service" do
+          expect(UpdateUserService)
+            .not_to receive(:call)
+                      .with(instance_of(User), "accept_notifications_screen!")
 
-        provider_code = "A1"
-        params = {
-          user_notification_preferences: {
-            explicitly_enabled: true,
-            provider_code: provider_code,
-          },
-          id: current_user[:user_id],
-        }
+          provider_code = "A1"
+          params = {
+            user_notification_preferences: {
+              explicitly_enabled: true,
+              provider_code: provider_code,
+            },
+            id: current_user[:user_id],
+          }
 
-        put :update, params: params
-        expect(response).to redirect_to(provider_path(provider_code))
+          put :update, params: params
+          expect(response).to redirect_to(provider_path(provider_code))
+        end
+      end
+
+      context "user already has notifications configured" do
+        let(:user) do
+          build(
+            :user,
+            :rolled_over,
+            notifications_configured: true,
+            associated_with_accredited_body: true,
+            id: 1,
+          )
+        end
+
+        it "it does not call the user update service" do
+          expect(UpdateUserService)
+            .not_to receive(:call)
+                      .with(instance_of(User), "accept_notifications_screen!")
+
+          provider_code = "A1"
+          params = {
+            user_notification_preferences: {
+              explicitly_enabled: true,
+              provider_code: provider_code,
+            },
+            id: current_user[:user_id],
+          }
+
+          put :update, params: params
+          expect(response).to redirect_to(provider_path(provider_code))
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -56,7 +56,7 @@ describe User, type: :model do
   end
 
   describe "notifications_configured state event" do
-    context "user is associated with an accredited body and not subscribed to notifications" do
+    context "user is associated with an accredited body and does not have notifications configured" do
       let(:rolled_over_user) do
         build(
           :user,
@@ -66,7 +66,7 @@ describe User, type: :model do
         )
       end
 
-      it "changes state from 'rolled_over' to 'subscribed_to_notifications'" do
+      it "changes state from 'rolled_over' to 'notifications_configured'" do
         rolled_over_user.accept_notifications_screen!
 
         expect(rolled_over_user.notifications_configured?).to be true
@@ -74,17 +74,17 @@ describe User, type: :model do
       end
     end
 
-    context "user is not associated with an accredited body and subscribed to notifications" do
+    context "user is not associated with an accredited body and has notifications configured" do
       let(:rolled_over_user) { build(:user, :rolled_over, associated_with_accredited_body: false, notifications_configured: true) }
 
-      it "raises an error when trying to change state from 'rolled_over' to 'subscribed_to_notifications'" do
+      it "raises an error when trying to change state from 'rolled_over' to 'notifications_configured'" do
         expect { rolled_over_user.accept_notifications_screen! }.to raise_error(AASM::InvalidTransition)
         expect(update_request).not_to have_been_made
       end
     end
 
-    context "user is associated with an accredited body and subscribed to notifications" do
-      let(:rolled_over_user) { build(:user, :rolled_over, associated_with_accredited_body: true, notifications_configured: true) }
+    context "user is associated with an accredited body and has notifications configured" do
+      let(:rolled_over_user) { build(:user, :notifications_configured, associated_with_accredited_body: true, notifications_configured: true) }
 
       it "raises an error when trying to change state from 'rolled_over' to 'subscribed_to_notifications'" do
         expect { rolled_over_user.accept_notifications_screen! }.to raise_error(AASM::InvalidTransition)


### PR DESCRIPTION
### Context
- When a user updated their notification preferences after dismissing the notifications interruption screen, a state transition was accidentally being called. 

### Changes proposed in this pull request
- When a user updates their notifications preferences we now check if the user is 'allowed' to transition their state to 'notifications_configured'. If true then their state is transitioned and they will no longer see the notifications interruption screen

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
