### PR TITLE
[3589] - Skip signin redirect to interruption pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -140,6 +140,7 @@ private
     {
       transitioned: transition_info_path,
       rolled_over: rollover_path,
+      accepted_rollover_2021: rollover_path,
       notifications_configured: notifications_info_path,
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -124,6 +124,26 @@ class ApplicationController < ActionController::Base
 
 private
 
+  def redirect_to_correct_page(user, use_redirect_back_to: true)
+    if user&.accept_terms_date_utc.nil?
+      redirect_to accept_terms_path
+    elsif user.next_state
+      redirect_to user_state_to_redirect_paths[user.next_state]
+    elsif use_redirect_back_to
+      redirect_to session[:redirect_back_to] || root_path
+    else
+      redirect_to root_path
+    end
+  end
+
+  def user_state_to_redirect_paths
+    {
+      transitioned: transition_info_path,
+      rolled_over: rollover_path,
+      notifications_configured: notifications_info_path,
+    }
+  end
+
   def authorise_development_mode?(email, password)
     _, user = Settings.authorised_users.find do |_index, user|
       user.email == email && user.password == password

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,9 @@
 class PagesController < ApplicationController
   skip_before_action :request_login, only: %i[guidance accessibility terms cookies privacy performance_dashboard]
 
+  before_action :skip_already_transitioned_interruptions,
+                only: %i[transition_info rollover notifications_info]
+
   def accessibility; end
 
   def cookies; end
@@ -23,5 +26,14 @@ class PagesController < ApplicationController
 
   def performance_dashboard
     @performance_data = PerformanceDashboardService.call
+  end
+
+private
+
+  def skip_already_transitioned_interruptions
+    user = user_from_session
+    if redirect_path[user.next_state] != request.fullpath
+      redirect_to_correct_page(user, use_redirect_back_to: false)
+    end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -32,7 +32,7 @@ private
 
   def skip_already_transitioned_interruptions
     user = user_from_session
-    if redirect_path[user.next_state] != request.fullpath
+    if user_state_to_redirect_paths[user.next_state] != request.fullpath
       redirect_to_correct_page(user, use_redirect_back_to: false)
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,7 +14,9 @@ class PagesController < ApplicationController
 
   def guidance; end
 
-  def accredited_body_new_features; end
+  def new_features; end
+
+  def notifications_info; end
 
   def transition_info; end
 
@@ -31,7 +33,7 @@ class PagesController < ApplicationController
 private
 
   def skip_already_transitioned_interruptions
-    user = user_from_session
+    user = User.find(current_user["user_id"]).first
     if user_state_to_redirect_paths[user.next_state] != request.fullpath
       redirect_to_correct_page(user, use_redirect_back_to: false)
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -110,7 +110,7 @@ private
     request.env["omniauth.auth"]
   end
 
-  def redirect_to_correct_page(user)
+  def redirect_to_correct_page(user, use_redirect_back_to: true)
     if user&.accept_terms_date_utc.nil?
       redirect_to accept_terms_path
     elsif user.next_state

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -109,23 +109,4 @@ private
   def auth_hash
     request.env["omniauth.auth"]
   end
-
-  def redirect_to_correct_page(user, use_redirect_back_to: true)
-    if user&.accept_terms_date_utc.nil?
-      redirect_to accept_terms_path
-    elsif user.next_state
-      redirect_to redirect_path[user.next_state]
-    else
-      redirect_to session[:redirect_back_to] || root_path
-    end
-  end
-
-  def redirect_path
-    {
-      rolled_over: rollover_path,
-      accepted_rollover_2021: rollover_path,
-      notifications_configured: notifications_info_path,
-      transitioned: transition_info_path,
-    }
-  end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+describe PagesController, type: :controller do
+  context "user has state 'transitioned'" do
+    let(:current_user) do
+      {
+        user_id: 1,
+        uid: SecureRandom.uuid,
+        info: {
+          email: "dave@example.com",
+          state: "transitioned",
+        },
+      }.with_indifferent_access
+    end
+
+    let(:user) { build(:user, :transitioned, id: 1) }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user)
+                                                        .and_return(current_user)
+      stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
+    end
+
+    scenario "user visits '/transition-info'" do
+      get :transition_info
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "user has state 'rolled_over'" do
+    let(:current_user) do
+      {
+        user_id: 1,
+        uid: SecureRandom.uuid,
+        info: {
+          email: "dave@example.com",
+          state: "transitioned",
+        },
+      }.with_indifferent_access
+    end
+
+    let(:user) { build(:user, :transitioned, id: 1) }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user)
+                                                        .and_return(current_user)
+      stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
+    end
+
+    scenario "user visits '/rollover'" do
+      get :rollover
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "user has state 'rolled_over', is associated with an accredited body and does not have notifications configured" do
+    let(:current_user) do
+      {
+        user_id: 1,
+        uid: SecureRandom.uuid,
+        info: {
+          email: "dave@example.com",
+          state: "transitioned",
+          associated_with_accredited_body: true,
+          notifications_configured: false,
+        },
+      }.with_indifferent_access
+    end
+
+    let(:user) do
+      build(
+        :user,
+        :rolled_over,
+        id: 1,
+        associated_with_accredited_body: true,
+        notifications_configured: false,
+      )
+    end
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user)
+                                                        .and_return(current_user)
+      stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
+    end
+
+    scenario "user visits '/rollover'" do
+      get :rollover
+      expect(response).to redirect_to(notifications_info_path)
+    end
+  end
+
+  context "user has state 'notifications_configured'" do
+    let(:current_user) do
+      {
+        user_id: 1,
+        uid: SecureRandom.uuid,
+        info: {
+          email: "dave@example.com",
+          state: "transitioned",
+          associated_with_accredited_body: true,
+          notifications_configured: false,
+        },
+      }.with_indifferent_access
+    end
+
+    let(:user) do
+      build(
+        :user,
+        :notifications_configured,
+        id: 1,
+      )
+    end
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user)
+                                                        .and_return(current_user)
+      stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
+    end
+
+    scenario "user visits '/notification-info'" do
+      get :notifications_info
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/features/providers/index_spec.rb
+++ b/spec/features/providers/index_spec.rb
@@ -5,9 +5,10 @@ feature "View providers", type: :feature do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider_1) { build :provider, provider_code: "A0", include_counts: [:courses] }
   let(:rollover) { false }
+  let(:user) { build(:user, :transitioned) }
 
   before do
-    stub_omniauth
+    stub_omniauth(user: user)
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}",
       current_recruitment_cycle.to_jsonapi,
@@ -60,6 +61,8 @@ feature "View providers", type: :feature do
           "/providers/#{provider_1.provider_code}",
           provider_response,
         )
+
+        stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
 
         visit provider_path(provider_1.provider_code)
 

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -69,6 +69,8 @@ feature "Sign in", type: :feature do
 
       context "Rollover is enabled" do
         let(:user) { build(:user, :new) }
+        let(:transitioned_user) { build(:user, :transitioned, id: user.id) }
+
         let(:user_update_request) do
           stub_request(
             :patch,
@@ -76,7 +78,14 @@ feature "Sign in", type: :feature do
           )
                                       .with(body: /"state":"transitioned"/)
         end
-        let(:user_get_request) { stub_api_v2_request("/users/#{user.id}", user.to_jsonapi) }
+
+        let(:user_get_request) do
+          stub_request(:get, "#{Settings.manage_backend.base_url}/api/v2/users/#{user.id}").to_return(
+            { body: user.to_jsonapi.to_json, headers: { 'Content-Type': "application/vnd.api+json" } },
+            { body: user.to_jsonapi.to_json, headers: { 'Content-Type': "application/vnd.api+json" } },
+            { body: transitioned_user.to_jsonapi.to_json, headers: { 'Content-Type': "application/vnd.api+json" } },
+          )
+        end
 
         before do
           user_get_request

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -38,6 +38,7 @@ feature "Sign in", type: :feature do
     user = build(:user)
     allow(Settings).to receive(:rollover).and_return(true)
     stub_omniauth(user: user)
+    stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
 
     visit root_path
 


### PR DESCRIPTION
### Context
If users try to visit to an interruption screen that they have previously actioned, and accept the interruption screen again they receive an an error as a result of the recent addition of the state machine to publish. This is most likely because these users have bookmarked the interruption pages.

### Changes proposed in this pull request
Before allowing a user to see an interruption screen we first check if their state is valid. If they already have the state transition that results from accepting the interruption screen then they are redirected to the next interruption screen and so on.

### Guidance for review
Set your user state to 'rolled_over' and try and visit the following interruption screens - `/transition-info`, `/rollover`. Rather than seeing flames you should be redirected. 

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
