### PR TITLE
[3544] Adds and updates rollover interruption page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,5 +19,7 @@ class PagesController < ApplicationController
 
   def rollover; end
 
+  def rollover_recruitment; end
+
   def accept_terms; end
 end

--- a/app/views/pages/notifications_info.html.erb
+++ b/app/views/pages/notifications_info.html.erb
@@ -21,7 +21,7 @@
       or
     </p>
     <%= form_for :user, url: accept_notifications_info_path, method: :patch do |f| %>
-      <%= f.submit "Continue", class: "govuk-button", data: { qa: 'rollover__continue' } %>
+      <%= f.submit "Continue", class: "govuk-button"%>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -1,28 +1,25 @@
-<%= content_for :page_title, "Begin preparing for the next cycle" %>
+<%= content_for :page_title, "Prepare for the next cycle" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Begin preparing for the next cycle</h1>
-    <p class="govuk-body">All your courses, locations and details have been rolled over from the current cycle. You can now update them for the next recruitment cycle (2020 – 2021).</p>
-    <p class="govuk-body">You can:</p>
+    <h1 class="govuk-heading-xl">
+      Prepare for the next cycle
+    </h1>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>prepare your course descriptions</li>
-      <li>request new courses for the next cycle</li>
-      <li>delete courses you’re no longer running</li>
-    </ul>
-
-    <h2 class="govuk-heading-m">Changes to the professional skills test</h2>
-    <p class="govuk-body">In the next cycle candidates will not need to take a professional skills test.</p>
-
-    <p class="govuk-body govuk-!-margin-bottom-8">
-      <a class="govuk-link" href="https://www.gov.uk/government/news/changes-to-the-professional-skills-test-for-teachers" target="_blank">
-        View the announcement on GOV.UK
-      </a>
+    <p class="govuk-body">
+      All your courses, locations and details have been copied over
+      from the current recruitment cycle (2020 - 2021). You can now
+      update them for 2021 – 2022.
     </p>
 
-    <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
-      <%= f.submit "Continue", class: "govuk-button", data: { qa: 'rollover__continue' } %>
-    <% end %>
+    <p class="govuk-body">You should:</p>
+
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+      <li>add any new courses</li>
+      <li>delete courses you're no longer running</li>
+      <li>edit titles, outcomes and locations where necessary</li>
+    </ul>
+
+    <%= link_to "Continue", rollover_recruitment_path,  class: "govuk-button" %>
   </div>
 </div>

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -1,0 +1,23 @@
+<%= content_for :page_title, "Recruiting for the 2021 - 2022 cycle" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Recruiting for the <br>2021 - 2022 cycle
+    </h1>
+
+    <p class="govuk-body">
+      You do not need to request permission to recruit for any courses other than
+      fee-funded PE. Accredited bodies should request fee-funded PE by 10 July 2020.
+    </p>
+
+    <p class="govuk-body">
+      You can publish all other courses without requesting permission. This applies
+      to courses copied over from the current cycle and new courses added for 2021 - 2022.
+    </p>
+
+    <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
+      <%= f.submit "Continue", class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -229,6 +229,7 @@ Rails.application.routes.draw do
   get "/transition-info", to: "pages#transition_info", as: :transition_info
   patch "/accept-transition-info", to: "users#accept_transition_info"
   get "/rollover", to: "pages#rollover", as: :rollover
+  get "/rollover-recruitment", to: "pages#rollover_recruitment", as: :rollover_recruitment
   patch "/accept-rollover", to: "users#accept_rollover"
   get "/accept-terms", to: "pages#accept_terms"
   patch "/accept-terms", to: "users#accept_terms"

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 feature "Sign in", type: :feature do
-  let(:transition_info_page) { PageObjects::Page::TransitionInfo.new }
-  let(:notifications_info_page) { PageObjects::Page::NotificationsInfo.new }
-  let(:rollover_page)        { PageObjects::Page::Rollover.new }
-  let(:accept_terms_page)    { PageObjects::Page::AcceptTerms.new }
-  let(:organisations_page)   { PageObjects::Page::OrganisationsPage.new }
-  let(:root_page)            { PageObjects::Page::RootPage.new }
+  let(:transition_info_page)      { PageObjects::Page::TransitionInfo.new }
+  let(:notifications_info_page)   { PageObjects::Page::NotificationsInfo.new }
+  let(:rollover_page)             { PageObjects::Page::Rollover.new }
+  let(:rollover_recruitment_page) { PageObjects::Page::RolloverRecruitment.new }
+  let(:accept_terms_page)         { PageObjects::Page::AcceptTerms.new }
+  let(:organisations_page)        { PageObjects::Page::OrganisationsPage.new }
+  let(:root_page)                 { PageObjects::Page::RootPage.new }
   let(:providers) do
     [
       build(:provider, courses: [build(:course)]),
@@ -137,8 +138,12 @@ feature "Sign in", type: :feature do
 
         expect(rollover_page).to be_displayed
 
-        expect(rollover_page.title).to have_content("Begin preparing for the next cycle")
+        expect(rollover_page.title).to have_content("Prepare for the next cycle")
         rollover_page.continue.click
+
+        expect(rollover_recruitment_page).to be_displayed
+        expect(rollover_recruitment_page.title).to have_content("Recruiting for the 2021 - 2022 cycle")
+        rollover_recruitment_page.continue.click
 
         expect(root_page).to be_displayed
         expect(user_update_request).to have_been_made

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -172,7 +172,7 @@ feature "Sign in", type: :feature do
         expect(notifications_info_page).to be_displayed
 
         expect(notifications_info_page).to have_content("Get notifications about your courses")
-        rollover_page.continue.click
+        notifications_info_page.continue.click
 
         expect(root_page).to be_displayed
         expect(user_update_request).to have_been_made

--- a/spec/site_prism/page_objects/page/notifications_info.rb
+++ b/spec/site_prism/page_objects/page/notifications_info.rb
@@ -4,7 +4,7 @@ module PageObjects
       set_url "/notifications-info"
 
       element :title, "h1"
-      element :continue, "[data-qa=transition__continue]"
+      element :continue, ".govuk-button[value=Continue]"
     end
   end
 end

--- a/spec/site_prism/page_objects/page/rollover.rb
+++ b/spec/site_prism/page_objects/page/rollover.rb
@@ -3,8 +3,8 @@ module PageObjects
     class Rollover < PageObjects::Base
       set_url "/rollover"
 
-      element :title, "h1"
-      element :continue, "[data-qa=rollover__continue]"
+      element :title, ".govuk-heading-xl"
+      element :continue, ".govuk-button", text: "Continue"
     end
   end
 end

--- a/spec/site_prism/page_objects/page/rollover_recruitment.rb
+++ b/spec/site_prism/page_objects/page/rollover_recruitment.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module Page
+    class RolloverRecruitment < PageObjects::Base
+      set_url "/rollover-recruitment"
+
+      element :title, ".govuk-heading-xl"
+      element :continue, ".govuk-button[value=Continue]"
+    end
+  end
+end


### PR DESCRIPTION


### Context

### Changes proposed in this pull request
- Content updated for the existing rollover page
- a new recruitment reminder page is added to the flow
- state change should only happen after seeing rollover and recruitment
  reminder. (Will be done as a separate PR)

### Guidance to review
![image](https://user-images.githubusercontent.com/3441519/85553970-5fc05080-b61c-11ea-9704-aae849edf0b2.png)
![image](https://user-images.githubusercontent.com/3441519/85554003-664ec800-b61c-11ea-8deb-0a76b4b23873.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
