### PR TITLE
[3575] Add pagination to organisation support page

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,8 +1,17 @@
 class OrganisationsController < ApplicationController
+  rescue_from "Pagy::OverflowError" do |_exception|
+    raise ActionController::RoutingError, "Not Found"
+  end
+
   def index
+    page = (params[:page] || 1).to_i
+    per_page = 10
+
     @organisations = Organisation
+      .order(:name)
       .includes(:providers, :users)
-      .all
-      .sort_by(&:name)
+      .page(page)
+
+    @pagy = Pagy.new(count: @organisations.meta.count, page: page, items: per_page)
   end
 end

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -16,3 +16,5 @@
     <%= render partial: "organisation", collection: @organisations %>
   </tbody>
 </table>
+
+<%= pagy_govuk_nav(@pagy).html_safe %>

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe OrganisationsController, type: :controller do
+  let(:current_user) do
+    {
+      user_id: 1,
+      uid: SecureRandom.uuid,
+      info: {
+        email: "dave@example.com",
+      },
+    }.with_indifferent_access
+  end
+
+  let(:user) { build(:user) }
+  let(:organisation_scope) { double }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_user)
+      .and_return(current_user)
+    allow(Organisation).to receive_message_chain("order.includes.page").and_return(double(meta: { count: 0 }))
+  end
+
+  context "requested page overflows" do
+    it "returns a 404" do
+      expect { get :index, params: { page: 2 } }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -20,9 +20,12 @@ feature "View organisations", type: :feature do
     stub_omniauth(user: user)
     stub_api_v2_resource(current_recruitment_cycle)
     stub_api_v2_resource(provider, include: "courses.accrediting_provider")
-    stub_api_v2_resource_collection([organisation], include: "providers,users")
     stub_api_v2_resource_collection([access_request], include: "requester")
     stub_api_v2_resource_collection([access_request])
+    stub_api_v2_request(
+      "/organisations?include=providers,users&page[page]=1&sort=name",
+      resource_list_to_jsonapi([organisation], include: "providers,users", meta: { count: 1 }),
+    )
   end
 
   describe "page header" do


### PR DESCRIPTION
### Context

The organisations support page loads all organisations and is consequently very slow and ties up the API for too long per request. This adds pagination which is supported in https://github.com/DFE-Digital/teacher-training-api/pull/1453

### Changes proposed in this pull request

Add pagination controls to the organisation support page (`/organisation-support-page`)

### Guidance to review

Requires https://github.com/DFE-Digital/teacher-training-api/pull/1453 so will not currently work in the review app until that is merged.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
