### PR TITLE
[3602] - Fix accept terms process

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -184,6 +184,7 @@ private
     session[:auth_user]["state"] = user.state
     session[:auth_user]["associated_with_accredited_body"] = user.associated_with_accredited_body
     session[:auth_user]["notifications_configured"] = user.notifications_configured
+    session[:auth_user]["accepted_terms?"] = user.accept_terms_date_utc.present?
     session[:auth_user]["admin"] = user.admin
     session[:auth_user]["attributes"] = user.attributes
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,8 +16,7 @@ class UsersController < ApplicationController
 
   def accept_terms
     if params.require(:user)[:terms_accepted] == "1"
-      user.accept_terms_date_utc = Time.zone.now
-      UpdateUserService.call(user, "update")
+      User.member(current_user["user_id"]).accept_terms
       redirect_to page_after_accept_terms
     else
       @errors = { user_terms_accepted: ["You must accept the terms and conditions to continue"] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,8 @@ class User < Base
 
   custom_endpoint :accept_terms, on: :member, request_method: :patch
 
-  def self.member(id, state)
-    new(id: id, state: state)
+  def self.member(id)
+    new(id: id)
   end
 
   aasm do

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container">
-    <% if current_user.present? && current_user["admin"] %>
+    <% if current_user.present? && current_user["admin"] && current_user["accepted_terms?"] %>
       <div class="govuk-footer__navigation" id="admin">
         <div class="govuk-footer__section">
           <h2 class="govuk-footer__heading govuk-heading-m">Support tools</h2>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -85,6 +85,10 @@ describe ApplicationController, type: :controller do
           expect(controller.request.session[:auth_user][:provider_count]).to eq nil
         end
 
+        it "has set accept_terms?" do
+          expect(controller.request.session[:auth_user][:accept_terms?]).to eq nil
+        end
+
         describe "sentry contexts" do
           before do
             allow(Raven).to receive(:user_context)
@@ -119,6 +123,7 @@ describe ApplicationController, type: :controller do
                                   state: "new",
                                   admin: true,
                                   associated_with_accredited_body: false,
+                                  accept_terms_date_utc: Time.current,
                                   notifications_configured: false,
                                   attributes: {},
                                 ),

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -183,7 +183,7 @@ feature "Sign in", type: :feature do
   scenario "new inactive user accepts the terms and conditions page with rollover disabled" do
     allow(Settings).to receive(:rollover).and_return(false)
     user = build :user, :inactive, :new
-    update_request = stub_request(:patch, "#{Settings.manage_backend.base_url}/api/v2/users/#{user.id}")
+    update_request = stub_request(:patch, "#{Settings.manage_backend.base_url}/api/v2/users/#{user.id}/accept_terms")
 
     stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
 

--- a/spec/views/footer.html.erb_spec.rb
+++ b/spec/views/footer.html.erb_spec.rb
@@ -1,14 +1,27 @@
 require "rails_helper"
 
 describe "footer partial" do
-  scenario "shows access request link with count to admin users" do
-    access_requests = mock_access_requests
-    user = get_admin_user
+  context "admin user has accepted terms" do
+    scenario "shows access request link with count to admin users" do
+      access_requests = mock_access_requests
+      user = get_admin_user
 
-    page = render_footer_for user
+      page = render_footer_for user
 
-    expect(page.access_requests_link).to have_text("Access Requests (#{access_requests})")
-    expect(page).to have_organisations_link
+      expect(page.access_requests_link).to have_text("Access Requests (#{access_requests})")
+      expect(page).to have_organisations_link
+    end
+  end
+
+  context "admin user has not accepted terms" do
+    scenario "shows access request link with count to admin users" do
+      user = get_admin_user_who_has_not_accepted_terms
+
+      page = render_footer_for user
+
+      expect(page).to_not have_access_requests_link
+      expect(page).to_not have_organisations_link
+    end
   end
 
   scenario "doesn't show access request link to non-admin users" do
@@ -30,13 +43,18 @@ describe "footer partial" do
     get_user admin: true
   end
 
-  def get_user(admin: false)
+  def get_admin_user_who_has_not_accepted_terms
+    get_user admin: true, accepted_terms: false
+  end
+
+  def get_user(admin: false, accepted_terms: true)
     {
       "info" => {
         "first_name" => "bob",
         "last_name" => "bob",
       },
       "admin" => admin,
+      "accepted_terms?" => accepted_terms,
     }
   end
 


### PR DESCRIPTION
### Context
Currently users are unable to accept-terms (unauthorised)

### Changes proposed in this pull request
- This commit reverts back to the original behaviour for allowing users to accept terms. This is because the api users update endpoint contains a guard to check if the user has accepted terms.
- Additional fix added - access request count is displayed in footer only if user has accepted terms. I noticed when manually testing the fix for accept terms that if you are an admin user `admin: true` when you reach the accept terms page, the footer makes a direct API call that results in a 403 loop. See https://github.com/DFE-Digital/publish-teacher-training/blob/2fe9b92fbb7ade233ec563280de32fab04edebb2/app/views/layouts/_footer.html.erb#L9

An additional guard has been added to the footer so that it does not blow up if the user is admin and has not accepted terms.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
