### PR TITLE
[3607] Fixes bug with notification active link styling

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -21,7 +21,7 @@
       <nav>
         <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
           <% if current_user.present? && current_user['associated_with_accredited_body'] %>
-            <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active ? current_page?(notifications_path)" %>">
+            <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if current_page?(notifications_path) %>">
               <%= govuk_link_to "Notifications", notifications_path, class: "govuk-header__link" %>
             </li>
           <% end %>


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
Notification link in the header was being styled as the active link for every page. It should have only been active on the notifications page

![image](https://user-images.githubusercontent.com/3441519/85731654-99fc2180-b6f2-11ea-963c-607e3e35d1bb.png)


### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
