### PR TITLE
[3543] Accept rollover for 2021

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -122,9 +122,10 @@ private
 
   def redirect_path
     {
-      transitioned: transition_info_path,
       rolled_over: rollover_path,
+      accepted_rollover_2021: rollover_path,
       notifications_configured: notifications_info_path,
+      transitioned: transition_info_path,
     }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < Base
     state :new, initial: true
     state :transitioned
     state :rolled_over
+    state :accepted_rollover_2021
     state :notifications_configured
 
     event :accept_transition_screen do
@@ -21,13 +22,13 @@ class User < Base
     end
 
     event :accept_rollover_screen do
-      transitions from: :transitioned, to: :rolled_over do
+      transitions from: %i[transitioned rolled_over], to: :accepted_rollover_2021 do
         guard { Settings.rollover }
       end
     end
 
     event :accept_notifications_screen do
-      transitions from: :rolled_over, to: :notifications_configured do
+      transitions from: %i[rolled_over accepted_rollover_2021], to: :notifications_configured do
         guard { associated_with_accredited_body }
         guard { !notifications_configured }
       end
@@ -35,8 +36,7 @@ class User < Base
   end
 
   def next_state
-    aasm
-        .states(permitted: true)
+    aasm.states(permitted: true)
         .map(&:name)
         .first
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
       state { "rolled_over" }
     end
 
+    trait :accepted_rollover_2021 do
+      state { "accepted_rollover_2021" }
+    end
+
     trait :notifications_configured do
       state { "notifications_configured" }
     end

--- a/spec/features/providers/index_spec.rb
+++ b/spec/features/providers/index_spec.rb
@@ -62,9 +62,9 @@ feature "View providers", type: :feature do
         )
 
         visit provider_path(provider_1.provider_code)
-        expect(find("h1")).to have_content(provider_1.provider_name.to_s)
-        expect(organisation_page).to have_current_cycle
-        expect(organisation_page).to have_next_cycle
+
+        expect(page.current_path).to eql("/rollover")
+        expect(find("h1")).to have_content("Prepare for the next cycle")
       end
     end
   end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -43,7 +43,7 @@ feature "Sign in", type: :feature do
 
     # Redirect to DfE Signin and come back
     expect(page).to have_content("Sign out (#{user.first_name} #{user.last_name})")
-    expect(root_page).to be_displayed
+    expect(page.current_path).to eql("/rollover")
   end
 
   describe "Interruption screens" do
@@ -122,8 +122,7 @@ feature "Sign in", type: :feature do
         stub_request(
           :patch,
           "#{Settings.manage_backend.base_url}/api/v2/users/#{user.id}",
-        )
-                                    .with(body: /"state":"rolled_over"/)
+        ).with(body: /"state":"accepted_rollover_2021"/)
       end
       let(:user_get_request) { stub_api_v2_request("/users/#{user.id}", user.to_jsonapi) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,15 +28,23 @@ describe User, type: :model do
   describe "rolled_over state event" do
     context "rollover is allowed" do
       let(:transitioned_user) { build(:user, :transitioned) }
+      let(:rolled_over_user) { build(:user, :rolled_over) }
 
       before do
         allow(Settings).to receive(:rollover).and_return(true)
       end
 
-      it "changes state from 'transitioned' to 'rolled_over'" do
+      it "changes state from 'transitioned' to 'accepted_rollover_2021'" do
         transitioned_user.accept_rollover_screen!
 
-        expect(transitioned_user.rolled_over?).to be true
+        expect(transitioned_user.accepted_rollover_2021?).to be true
+        expect(update_request).to have_been_made
+      end
+
+      it "changes state from 'rolled_over' to 'accepted_rollover_2021'" do
+        rolled_over_user.accept_rollover_screen!
+
+        expect(rolled_over_user.accepted_rollover_2021?).to be true
         expect(update_request).to have_been_made
       end
     end
@@ -66,10 +74,26 @@ describe User, type: :model do
         )
       end
 
+      let(:accepted_rollover_2021_user) do
+        build(
+          :user,
+          :accepted_rollover_2021,
+          associated_with_accredited_body: true,
+          notifications_configured: false,
+        )
+      end
+
       it "changes state from 'rolled_over' to 'notifications_configured'" do
         rolled_over_user.accept_notifications_screen!
 
         expect(rolled_over_user.notifications_configured?).to be true
+        expect(update_request).to have_been_made
+      end
+
+      it "changes state from 'accepted_rollover_2021' to 'notifications_configured'" do
+        accepted_rollover_2021_user.accept_notifications_screen!
+
+        expect(accepted_rollover_2021_user.notifications_configured?).to be true
         expect(update_request).to have_been_made
       end
     end


### PR DESCRIPTION
### Context

- https://trello.com/c/AMMShiva/3543-m-build-final-interruption-screen-for-roll-over
- When the user accepts rollover for 2021 we need to change state to keep track
- This adds a new state so we know user has accepted for the 2021 cycle

### Changes proposed in this pull request

- When a user now acknowledges rollover they are set the state of `accepted_rollover_2021`

### Guidance to review

- depends on https://github.com/DFE-Digital/publish-teacher-training/pull/1221
- this can be easily tested if the following is cherry picked https://github.com/DFE-Digital/publish-teacher-training/pull/1216
- navigate to /auth/developer
- login as different users some examples: admins, new, rolled_over, transitioned, those who have not accepted the terms
- on login should see correct screens
- logout will also work with the cherry picked branch
- login back in as the user
- should not see interrupt screens and should be sent to correct home page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
