### PR TITLE
[3578] Expose app sha at /sha

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -3,6 +3,10 @@ class HeartbeatController < ActionController::API
     render body: "PONG"
   end
 
+  def sha
+    render json: { sha: commit_sha }
+  end
+
   def healthcheck
     checks = {
       teacher_training_api: api_alive?,
@@ -23,5 +27,13 @@ private
     response.success?
   rescue StandardError
     false
+  end
+
+  def commit_sha_path
+    Rails.root.join(Settings.commit_sha_file)
+  end
+
+  def commit_sha
+    File.read(commit_sha_path).strip
   end
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ steps:
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
     echo '$(System.PullRequest.SourceBranch)'> $(build.artifactstagingdirectory)/prbranch.info
+    echo $(Build.SourceVersion) > COMMIT_SHA
   displayName: 'Set version number'
 
 - script: docker pull $(IMAGE_NAME):latest || true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
+  get :sha, controller: :heartbeat
 
   # DfE Sign In
   get "/signin", to: "sessions#new", as: "signin"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -65,3 +65,4 @@ use_ssl: true
 features:
   signin_intercept: false
   signin_by_email: false
+commit_sha_file: COMMIT_SHA

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe HeartbeatController do
+  describe "#sha" do
+    around :each do |example|
+      File.open("COMMIT_SHA", "w") { |f| f.write "some-sha" }
+
+      example.run
+
+      File.delete("COMMIT_SHA")
+    end
+
+    it "returns sha" do
+      get :sha
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)).to eql({ "sha" => "some-sha" })
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/w1Tsuu3M/3578-expose-commit-sha-as-sha
- We want to expose the application sha at /sha for debugging and integration reasons

### Changes proposed in this pull request

- Expose the commit sha as part of the azure build at `/sha`

### Guidance to review

- create a file named `COMMIT_SHA` in the root directory of the rails app
- enter a random string eg `hello-world`
- visit `/sha`
- should see json content `{"sha":"hello-world"}`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
