### PR TITLE
[3615] Age range now mandatory when updating

### DIFF
--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -45,6 +45,12 @@ module Courses
     end
 
     def build_errors
+      if no_selection?
+        return {
+          age_range_in_years: [t("age_range.errors.missing_error")],
+        }
+      end
+
       if age_range_from_and_to_missing?
         return {
           age_range_in_years: [t("age_range.errors.from_and_to_error")],
@@ -78,6 +84,10 @@ module Courses
           age_range_in_years_to: [t("age_range.errors.to_invalid_error")],
         }
       end
+    end
+
+    def no_selection?
+      age_range_param.blank?
     end
 
     def age_range_less_than_4?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,7 @@ en:
         label: "Get an email for each application you receive"
   age_range:
     errors:
+      missing_error: Choose an age range
       from_and_to_error: "Enter an age in both From and To"
       from_missing_error: "Enter an age in From"
       to_missing_error: "Enter an age in To"

--- a/spec/features/courses/age_range_in_years/edit_spec.rb
+++ b/spec/features/courses/age_range_in_years/edit_spec.rb
@@ -16,6 +16,25 @@ feature "Edit course age range in years", type: :feature do
     age_range_in_years_page.load_with_course(course)
   end
 
+  context "a course with no age range" do
+    let(:course) do
+      build(
+        :course,
+        age_range_in_years: nil,
+        edit_options: {
+          age_range_in_years: %w[11_to_16 11_to_18 14_to_19],
+        },
+        provider: provider,
+      )
+    end
+
+    it "is not valid and returns error message" do
+      age_range_in_years_page.save.click
+
+      expect(age_range_in_years_page.error_flash).to have_content("Choose an age range")
+    end
+  end
+
   context "a course with an age range of 11 to 16" do
     let(:course) do
       build(


### PR DESCRIPTION
### Context

- https://trello.com/c/4OdjeI1q/3615-make-age-range-a-required-field-for-courses-in-2020-cycle
- We want to improve data collected for courses
- Therefore age range is now mandatory when updating the age range

### Changes proposed in this pull request

- This is done with client side validation
- Cannot be easily done as an API side validation with the current
setup. Otherwise when updating another field this validation would be
triggered
- The codeclimate issue seems fine unless you can offer a better solution

### Guidance to review

- Find a course that has `age_range_in_years` set to `nil`
- Navigate to the edit the age range page for the course
- Attempt to save without entering an age range
- Should see validation message

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
