### PR TITLE
[3617] Add allocations reporting numbers

### DIFF
--- a/app/services/performance_dashboard_service.rb
+++ b/app/services/performance_dashboard_service.rb
@@ -44,4 +44,20 @@ class PerformanceDashboardService
   def providers_accredited_bodies
     number_with_delimiter(@response["providers"]["training_providers"]["accredited_body"]["open"]["accredited_body"])
   end
+
+  def allocations_requests(recruitment_cycle)
+    number_with_delimiter(@response["allocations"][recruitment_cycle]["total"]["allocations"])
+  end
+
+  def allocations_number_of_places(recruitment_cycle)
+    number_with_delimiter(@response["allocations"][recruitment_cycle]["total"]["number_of_places"])
+  end
+
+  def allocations_accredited_bodies(recruitment_cycle)
+    number_with_delimiter(@response["allocations"][recruitment_cycle]["total"]["distinct_accredited_bodies"])
+  end
+
+  def allocations_providers(recruitment_cycle)
+    number_with_delimiter(@response["allocations"][recruitment_cycle]["total"]["distinct_providers"])
+  end
 end

--- a/app/views/pages/performance_dashboard.html.erb
+++ b/app/views/pages/performance_dashboard.html.erb
@@ -26,14 +26,18 @@
 <!--        Users-->
 <!--      </a>-->
 <!--    </li>-->
-<!--    <li class="govuk-tabs__list-item" role="presentation">-->
-<!--      <a class="govuk-tabs__tab" href="#allocations" id="tab_allocations" role="tab" aria-controls="allocations" aria-selected="false" tabindex="-1">-->
-<!--        Allocations-->
-<!--      </a>-->
-<!--    </li>-->
+    <li class="govuk-tabs__list-item" role="presentation">
+      <a class="govuk-tabs__tab" href="#allocations" id="tab_allocations" role="tab" aria-controls="allocations" aria-selected="false" tabindex="-1">
+        Allocations
+      </a>
+    </li>
   </ul>
   <div class="govuk-tabs__panel" id="providers" role="tabpanel" aria-labelledby="tab_providers">
     <h2 class="govuk-heading-l">Providers</h2>
     <%= render partial: "pages/performance_dashboard/providers_tab" %>
+  </div>
+  <div class="govuk-tabs__panel" id="allocations" role="tabpanel" aria-labelledby="tab_allocations">
+    <h2 class="govuk-heading-l">Allocations</h2>
+    <%= render partial: "pages/performance_dashboard/allocations_tab" %>
   </div>
 </div>

--- a/app/views/pages/performance_dashboard/_allocation_content.html.erb
+++ b/app/views/pages/performance_dashboard/_allocation_content.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-performance-dashboard app-performance-dashboard--secondary">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.total_providers %>
+      </div>
+      requests
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-performance-dashboard app-performance-dashboard--secondary">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.total_providers %>
+      </div>
+      number of places
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-performance-dashboard app-performance-dashboard--secondary">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.total_providers %>
+      </div>
+      accredited bodies
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-performance-dashboard app-performance-dashboard--secondary">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.total_providers %>
+      </div>
+      providers
+    </div>
+  </div>
+</div>

--- a/app/views/pages/performance_dashboard/_allocation_content.html.erb
+++ b/app/views/pages/performance_dashboard/_allocation_content.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-one-quarter">
     <div class="app-performance-dashboard app-performance-dashboard--secondary">
       <div class="app-performance-dashboard__title">
-        <%= @performance_data.total_providers %>
+        <%= @performance_data.allocations_requests(recruitment_cycle) %>
       </div>
       requests
     </div>
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-one-quarter">
     <div class="app-performance-dashboard app-performance-dashboard--secondary">
       <div class="app-performance-dashboard__title">
-        <%= @performance_data.total_providers %>
+        <%= @performance_data.allocations_number_of_places(recruitment_cycle) %>
       </div>
       number of places
     </div>
@@ -18,7 +18,7 @@
   <div class="govuk-grid-column-one-quarter">
     <div class="app-performance-dashboard app-performance-dashboard--secondary">
       <div class="app-performance-dashboard__title">
-        <%= @performance_data.total_providers %>
+        <%= @performance_data.allocations_accredited_bodies(recruitment_cycle) %>
       </div>
       accredited bodies
     </div>
@@ -26,7 +26,7 @@
   <div class="govuk-grid-column-one-quarter">
     <div class="app-performance-dashboard app-performance-dashboard--secondary">
       <div class="app-performance-dashboard__title">
-        <%= @performance_data.total_providers %>
+        <%= @performance_data.allocations_providers(recruitment_cycle) %>
       </div>
       providers
     </div>

--- a/app/views/pages/performance_dashboard/_allocations_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_allocations_tab.html.erb
@@ -1,0 +1,8 @@
+<h3 class="govuk-heading-m">
+  PE Requests for 2021 – 2022
+</h3>
+<%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "current" }%>
+<h3 class="govuk-heading-m">
+  PE Requests for 2020 – 2021
+</h3>
+<%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "previous" }%>

--- a/app/views/pages/performance_dashboard/_initial_performance_indicators.html.erb
+++ b/app/views/pages/performance_dashboard/_initial_performance_indicators.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-row govuk-!-margin-bottom-9">
+<div class="govuk-grid-row govuk-!-margin-bottom-3">
   <div class="govuk-grid-column-one-quarter">
     <h2 class="govuk-heading-m">Providers</h2>
     <div class="app-performance-dashboard app-performance-dashboard--kpi">

--- a/app/webpacker/stylesheets/_performance-dashboard.scss
+++ b/app/webpacker/stylesheets/_performance-dashboard.scss
@@ -1,6 +1,7 @@
 .app-performance-dashboard {
   @include govuk-font($size: 19);
   @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(6, "bottom")
 }
 
 .app-performance-dashboard--primary {

--- a/spec/fixtures/performance-dashboard.json
+++ b/spec/fixtures/performance-dashboard.json
@@ -274,18 +274,18 @@
   "allocations": {
     "previous": {
       "total": {
-        "allocations": 433,
-        "distinct_accredited_bodies": 153,
-        "distinct_providers": 397,
+        "allocations": 1433,
+        "distinct_accredited_bodies": 1153,
+        "distinct_providers": 1397,
         "number_of_places": 1461
       }
     },
     "current": {
       "total": {
-        "allocations": 183,
-        "distinct_accredited_bodies": 86,
-        "distinct_providers": 180,
-        "number_of_places": 677
+        "allocations": 1183,
+        "distinct_accredited_bodies": 1186,
+        "distinct_providers": 1180,
+        "number_of_places": 1677
       }
     }
   }

--- a/spec/services/performance_dashboard_service_spec.rb
+++ b/spec/services/performance_dashboard_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe PerformanceDashboardService do
   let(:service) { described_class.new }
 
@@ -28,7 +30,7 @@ describe PerformanceDashboardService do
 
     it "returns a total of allocation for the current recruitment cycle year" do
       data = service.call
-      expect(data.total_allocations).to eq("183")
+      expect(data.total_allocations).to eq("1,183")
     end
   end
 
@@ -51,6 +53,52 @@ describe PerformanceDashboardService do
     it "returns a total of providers who are accredited bodies" do
       data = service.call
       expect(data.providers_accredited_bodies).to eq("1,930")
+    end
+  end
+
+  describe "allocations tab data" do
+    describe "current allocations" do
+      it "returns a total of allocations" do
+        data = service.call
+        expect(data.allocations_requests("current")).to eq("1,183")
+      end
+
+      it "returns a total of providers" do
+        data = service.call
+        expect(data.allocations_number_of_places("current")).to eq("1,677")
+      end
+
+      it "returns a total of accredited bodies" do
+        data = service.call
+        expect(data.allocations_accredited_bodies("current")).to eq("1,186")
+      end
+
+      it "returns a total number of places" do
+        data = service.call
+        expect(data.allocations_providers("current")).to eq("1,180")
+      end
+    end
+
+    describe "previous allocations" do
+      it "returns a total of allocations" do
+        data = service.call
+        expect(data.allocations_requests("previous")).to eq("1,433")
+      end
+
+      it "returns a total of providers" do
+        data = service.call
+        expect(data.allocations_number_of_places("previous")).to eq("1,461")
+      end
+
+      it "returns a total of accredited bodies" do
+        data = service.call
+        expect(data.allocations_accredited_bodies("previous")).to eq("1,153")
+      end
+
+      it "returns a total number of places" do
+        data = service.call
+        expect(data.allocations_providers("previous")).to eq("1,397")
+      end
     end
   end
 

--- a/spec/site_prism/page_objects/page/performance_dashboard_page.rb
+++ b/spec/site_prism/page_objects/page/performance_dashboard_page.rb
@@ -8,6 +8,10 @@ module PageObjects
       sections :primary_indicators, ".app-performance-dashboard--kpi" do
         element :section_heading, ".govuk-heading-m"
       end
+
+      section :allocation_tab, "#allocations" do
+        elements :recruitment_cycles, ".govuk-grid-row"
+      end
     end
   end
 end

--- a/spec/views/pages/performance_dashboard.html.erb_spec.rb
+++ b/spec/views/pages/performance_dashboard.html.erb_spec.rb
@@ -27,4 +27,10 @@ describe "pages/performance_dashboard" do
       expect(performance_dashboard_page.primary_indicators.length).to eq(4)
     end
   end
+
+  describe "allocations tab" do
+    it "has two recruitment cycle years worth of data" do
+      expect(performance_dashboard_page.allocation_tab.recruitment_cycles.length).to eq(2)
+    end
+  end
 end

--- a/spec/views/pages/performance_dashboard.html.erb_spec.rb
+++ b/spec/views/pages/performance_dashboard.html.erb_spec.rb
@@ -11,7 +11,11 @@ describe "pages/performance_dashboard" do
                      total_allocations: "300",
                      providers_published_courses: "3,400",
                      providers_unpublished_courses: "2,000",
-                     providers_accredited_bodies: "2,999"
+                     providers_accredited_bodies: "2,999",
+                     allocations_requests: "1,000",
+                     allocations_providers: "2,000",
+                     allocations_number_of_places: "3,000",
+                     allocations_accredited_bodies: "4,000"
 
     assign(:performance_data, service)
     render


### PR DESCRIPTION
### Context

https://trello.com/c/nRP7a83K/3617-add-users-reporting-numbers-into-dashboard
Adding another tab to the dashboard allocations 

![image](https://user-images.githubusercontent.com/25597009/86008632-f3c15c00-ba10-11ea-95df-bfe96f22fd23.png)

### Changes proposed in this pull request

* Add allocations tab to the dashboard
* Add allocations data methods to dashboard service

### Guidance to review

* go to https://s121d02-3617-ptt-as.azurewebsites.net/performance-dashboard
* click on allocations tab

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
