### PR TITLE
3620 add users reporting numbers into dashboard

### DIFF
--- a/app/services/performance_dashboard_service.rb
+++ b/app/services/performance_dashboard_service.rb
@@ -60,4 +60,16 @@ class PerformanceDashboardService
   def allocations_providers(recruitment_cycle)
     number_with_delimiter(@response["allocations"][recruitment_cycle]["total"]["distinct_providers"])
   end
+
+  def users_active
+    number_with_delimiter(@response["publish"]["users"]["total"]["active_users"])
+  end
+
+  def users_not_active
+    number_with_delimiter(@response["publish"]["users"]["total"]["non_active_users"])
+  end
+
+  def users_active_30_days
+    number_with_delimiter(@response["publish"]["users"]["recent_active_users"])
+  end
 end

--- a/app/views/pages/performance_dashboard.html.erb
+++ b/app/views/pages/performance_dashboard.html.erb
@@ -21,11 +21,11 @@
 <!--        Courses-->
 <!--      </a>-->
 <!--    </li>-->
-<!--    <li class="govuk-tabs__list-item" role="presentation">-->
-<!--      <a class="govuk-tabs__tab" href="#users" id="tab_users" role="tab" aria-controls="users" aria-selected="false" tabindex="-1">-->
-<!--        Users-->
-<!--      </a>-->
-<!--    </li>-->
+    <li class="govuk-tabs__list-item" role="presentation">
+      <a class="govuk-tabs__tab" href="#users" id="tab_users" role="tab" aria-controls="users" aria-selected="false" tabindex="-1">
+        Users
+      </a>
+    </li>
     <li class="govuk-tabs__list-item" role="presentation">
       <a class="govuk-tabs__tab" href="#allocations" id="tab_allocations" role="tab" aria-controls="allocations" aria-selected="false" tabindex="-1">
         Allocations
@@ -35,6 +35,9 @@
   <div class="govuk-tabs__panel" id="providers" role="tabpanel" aria-labelledby="tab_providers">
     <h2 class="govuk-heading-l">Providers</h2>
     <%= render partial: "pages/performance_dashboard/providers_tab" %>
+  </div>
+  <div class="govuk-tabs__panel" id="users" role="tabpanel" aria-labelledby="tab_users">
+    <%= render partial: "pages/performance_dashboard/users_tab" %>
   </div>
   <div class="govuk-tabs__panel" id="allocations" role="tabpanel" aria-labelledby="tab_allocations">
     <h2 class="govuk-heading-l">Allocations</h2>

--- a/app/views/pages/performance_dashboard/_users_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_users_tab.html.erb
@@ -1,0 +1,38 @@
+<h2 class="govuk-heading-l">Users</h2>
+<div class="govuk-grid-row govuk-!-margin-bottom-3">
+  <div class="govuk-grid-column-full">
+    <div class="app-performance-dashboard app-performance-dashboard--primary">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.total_users %>
+      </div>
+      registered
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <div class="app-performance-dashboard app-performance-dashboard--green">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.users_active %>
+      </div>
+      active
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="app-performance-dashboard app-performance-dashboard--red">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.users_not_active %>
+      </div>
+      not active
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="app-performance-dashboard app-performance-dashboard--secondary">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.users_active_30_days %>
+      </div>
+      active in the last 30 days
+    </div>
+  </div>
+</div>

--- a/spec/fixtures/performance-dashboard.json
+++ b/spec/fixtures/performance-dashboard.json
@@ -248,7 +248,7 @@
         "active_users": 1883,
         "non_active_users": 1167
       },
-      "recent_active_users": 708
+      "recent_active_users": 1708
     },
     "providers": {
       "total": {

--- a/spec/services/performance_dashboard_service_spec.rb
+++ b/spec/services/performance_dashboard_service_spec.rb
@@ -56,6 +56,28 @@ describe PerformanceDashboardService do
     end
   end
 
+  describe "users tab data" do
+    it "returns a total of users" do
+      data = service.call
+      expect(data.total_users).to eq("3,050")
+    end
+
+    it "returns a total of active users" do
+      data = service.call
+      expect(data.users_active).to eq("1,883")
+    end
+
+    it "returns a total of inactive users" do
+      data = service.call
+      expect(data.users_not_active).to eq("1,167")
+    end
+
+    it "returns a total of recently active users" do
+      data = service.call
+      expect(data.users_active_30_days).to eq("1,708")
+    end
+  end
+
   describe "allocations tab data" do
     describe "current allocations" do
       it "returns a total of allocations" do

--- a/spec/site_prism/page_objects/page/performance_dashboard_page.rb
+++ b/spec/site_prism/page_objects/page/performance_dashboard_page.rb
@@ -9,6 +9,10 @@ module PageObjects
         element :section_heading, ".govuk-heading-m"
       end
 
+      section :user_tab, "#users" do
+        elements :data_sets, ".app-performance-dashboard"
+      end
+
       section :allocation_tab, "#allocations" do
         elements :recruitment_cycles, ".govuk-grid-row"
       end

--- a/spec/views/pages/performance_dashboard.html.erb_spec.rb
+++ b/spec/views/pages/performance_dashboard.html.erb_spec.rb
@@ -15,7 +15,10 @@ describe "pages/performance_dashboard" do
                      allocations_requests: "1,000",
                      allocations_providers: "2,000",
                      allocations_number_of_places: "3,000",
-                     allocations_accredited_bodies: "4,000"
+                     allocations_accredited_bodies: "4,000",
+                     users_active: "1,111",
+                     users_not_active: "2,222",
+                     users_active_30_days: "3,333"
 
     assign(:performance_data, service)
     render
@@ -29,6 +32,12 @@ describe "pages/performance_dashboard" do
   describe "high level performance indicators" do
     it "has 4 sections" do
       expect(performance_dashboard_page.primary_indicators.length).to eq(4)
+    end
+  end
+
+  describe "users tab" do
+    it "has four user data results" do
+      expect(performance_dashboard_page.user_tab.data_sets.length).to eq(4)
     end
   end
 


### PR DESCRIPTION
### Context


https://trello.com/c/hgfaz71Z/3620-add-users-reporting-numbers-into-dashboard

Adding a users tab to the performance dashboard

### Changes proposed in this pull request

Adds a users tab to the dashboard

![image](https://user-images.githubusercontent.com/25597009/86014150-de9bfb80-ba17-11ea-8ac5-f6a5d3c44332.png)

### Guidance to review

* visit /performance-dashboard
* select users tab
 
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
