### PR TITLE
[3594] Add setting to disable DfE Signin

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@ class SessionsController < ApplicationController
   skip_before_action :request_login
 
   def new
-    if FeatureService.enabled? :signin_intercept
+    if FeatureService.enabled?(:signin_intercept) || !FeatureService.enabled?(:dfe_signin)
       render
     else
       redirect_to "/auth/dfe"
@@ -10,6 +10,8 @@ class SessionsController < ApplicationController
   end
 
   def create
+    redirect_to signin_path and return unless FeatureService.enabled? :dfe_signin
+
     session[:auth_user] = HashWithIndifferentAccess.new(
       "uid" => auth_hash.dig("uid"),
       "info" => HashWithIndifferentAccess.new(

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -65,4 +65,5 @@ use_ssl: true
 features:
   signin_intercept: false
   signin_by_email: false
+  dfe_signin: true
 commit_sha_file: COMMIT_SHA

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe SessionsController, type: :controller do
+  context "signin is disabled" do
+    before do
+      allow(Settings.features).to receive(:dfe_signin)
+        .and_return(false)
+    end
+
+    describe "new" do
+      it "renders the new session page" do
+        get :new
+        expect(response).to render_template("sessions/new")
+      end
+    end
+
+    describe "create" do
+      it "redirects to /signin" do
+        get :create
+        expect(response).to redirect_to(signin_path)
+      end
+    end
+  end
+
+  context "signin is enabled" do
+    before do
+      allow(Settings.features).to receive(:dfe_signin)
+        .and_return(true)
+    end
+
+    describe "new" do
+      it "redirects to signin" do
+        get :new
+        expect(response).to redirect_to("/auth/dfe")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to be able to disable signin by DfE signin if there is a problem with the service.

### Changes proposed in this pull request

Adds a feature flag to disable signin via DfE signin.

When the feature is disabled an attempt to login via DfE signin renders the magic link signin page (`sessions#new`) or redirects to it if the user has actually come from signin already.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
