### PR TITLE
[3623] No default course length

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -139,7 +139,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def other_course_length?
-    %w[OneYear TwoYears].exclude?(course.course_length)
+    %w[OneYear TwoYears].exclude?(course.course_length) && !course.course_length.nil?
   end
 
   def other_age_range?

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -20,7 +20,9 @@
         <%= f.label :course_length, 'Up to 2 years', value: 'TwoYears', class: 'govuk-label govuk-radios__label' %>
       </div>
       <div class="govuk-radios__item">
-        <%= f.radio_button :course_length, 'Other', class: 'govuk-radios__input', data: {"aria-controls" => "other-container" },
+        <%= f.radio_button :course_length, 'Other',
+          class: 'govuk-radios__input',
+          data: { "aria-controls" => "other-container" },
           checked: course.other_course_length?,
           aria: { describedby: @errors[:course_length] ? "course_length-error" : '' } %>
         <%= f.label :course_length, 'Other', value: 'Other', class: 'govuk-label govuk-radios__label' %>

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -589,4 +589,30 @@ describe CourseDecorator do
       end
     end
   end
+
+  describe "#other_course_length?" do
+    context "when course_length is a pre-defined value" do
+      let(:course) { build(:course, course_length: "OneYear") }
+
+      it "returns false" do
+        expect(decorated_course.other_course_length?).to be_falsey
+      end
+    end
+
+    context "when course_length is nil" do
+      let(:course) { build(:course, course_length: nil) }
+
+      it "returns false so there is no default value" do
+        expect(decorated_course.other_course_length?).to be_falsey
+      end
+    end
+
+    context "when course_length is user set" do
+      let(:course) { build(:course, course_length: "3 months") }
+
+      it "returns true" do
+        expect(decorated_course.other_course_length?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/lMuMuYoE/3623-m-when-creating-a-course-and-completing-course-fees-section-we-should-not-set-a-default-for-the-course-length
- A default course length is being set for the user which means less that accurate is being collected about the course

### Changes proposed in this pull request

- On first setting of course length we no longer set the default value
to other
- Instead the user can choose what value to select from the choice of
radios
- Before publication the user is forced to enter a value so the user
must enter the data
- This aims to collect more accurate data about the course

### Guidance to review

- https://s121d02-3623-ptt-as.azurewebsites.net/
- Create a course
- View/Edit the course in publish
- Under the `Description` tab, click `Course length and fees`
- Hit `Save` button
- Navigate back to this page
- The course length should not be `Other`
- Attempt to publish this course
- One of the reasons that prevent you from publishing should be that course length is missing and needs populating 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
