### PR TITLE
[3573] Admins panel to update provider name

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -103,6 +103,7 @@ private
       :page,
       :train_with_us,
       :train_with_disability,
+      :provider_name,
       :email,
       :telephone,
       :website,

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -22,6 +22,24 @@
     <%= form_with model: @provider, url: contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year), method: :put do |f| %>
       <%= f.hidden_field :page, value: :contact %>
 
+      <% if current_user["admin"] %>
+        <div class="app-admin-only__section">
+          <div class="app-admin-only__section-header">
+            <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
+          </div>
+
+          <%= render "shared/form_field",
+            form: f,
+            field: :provider_name,
+            label: "Provider name" do |field, options| %>
+            <span class="govuk-hint">
+              The marketing name of the provider
+            </span>
+            <%= f.text_field field, options.merge(class: 'govuk-input govuk-!-width-two-thirds') %>
+          <% end %>
+        </div>
+      <% end %>
+
       <%= render "shared/form_field",
         form: f, field: :email, label: "Email address" do |field, options| %>
         <span class="govuk-hint">

--- a/spec/views/providers/contact.html.erb_spec.rb
+++ b/spec/views/providers/contact.html.erb_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "providers/contact.html.erb" do
+  before do
+    assign(:provider, build(:provider))
+  end
+
+  context "when not an admin" do
+    before do
+      controller.singleton_class.class_eval do
+      protected
+
+        def current_user
+          { "admin" => false }
+        end
+        helper_method :current_user
+      end
+    end
+
+    it "cannot see provider_name field" do
+      render
+
+      expect(rendered).to_not include("Provider name")
+    end
+  end
+
+  context "when an admin" do
+    before do
+      controller.singleton_class.class_eval do
+      protected
+
+        def current_user
+          { "admin" => true }
+        end
+        helper_method :current_user
+      end
+    end
+
+    it "can see provider_name field" do
+      render
+
+      expect(rendered).to include("Provider name")
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/KXiJdzYT/3573-m-make-provider-name-editable
- Admin users of publish want to be able to update provider names for convenience

### Changes proposed in this pull request

- In the contact details page admins can see the `provider_name` field
- Non-admins cannot see this field
- The API determines if the user is allowed update this field or not

### Guidance to review

- https://s121d02-3573-ptt-as.azurewebsites.net/
- This change depends on https://github.com/DFE-Digital/teacher-training-api/pull/1461
- Login in a non-admin
- Navigate to contact page of a provider
- Should not see admin panel with `provider_name` field
- Logout
- Login as admin
- Navigate to contact page of a provider
- Should see an admin panel with the `provider_name` field
- Change the `provider_name` to something else
- Submit form
- Navigate to provider
- Provider name should now be updated to new value

### Screenshots

![image](https://user-images.githubusercontent.com/92580/86257019-e7740500-bbb0-11ea-8c32-2d344b078e85.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
