### PR TITLE
[3572] Course titles can be modified by admins

### DIFF
--- a/app/controllers/courses/title_controller.rb
+++ b/app/controllers/courses/title_controller.rb
@@ -1,0 +1,58 @@
+module Courses
+  class TitleController < ApplicationController
+    before_action :check_admin
+
+    def edit
+      render locals: { course: course }
+    end
+
+    def update
+      if course.update(course_params)
+        flash[:success] = "Your changes have been saved"
+
+        redirect_to(
+          details_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+          ),
+        )
+      else
+        @errors = course.errors.messages
+        render :edit, locals: { course: course }
+      end
+    end
+
+  private
+
+    def course
+      @course ||= Course
+        .where(recruitment_cycle_year: recruitment_cycle.year)
+        .where(provider_code: params[:provider_code])
+        .find(params[:code])
+        .first
+        .decorate
+    end
+
+    def course_params
+      params.require(:course).permit(:name)
+    end
+
+    def recruitment_cycle
+      return @recruitment_cycle if @recruitment_cycle
+
+      cycle_year = params.fetch(
+        :recruitment_cycle_year,
+        Settings.current_cycle,
+      )
+
+      @recruitment_cycle = RecruitmentCycle.find(cycle_year).first
+    end
+
+    def check_admin
+      unless user_is_admin?
+        render "errors/forbidden", status: :forbidden
+      end
+    end
+  end
+end

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -5,6 +5,7 @@ class Base < JsonApiClient::Resource
   class MCBConnection < JsonApiClient::Connection
     def run(request_method, path, params: nil, headers: {}, body: nil)
       authorization = "Bearer #{RequestStore.store[:manage_courses_backend_token]}"
+
       super(
         request_method,
         path,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,6 +10,7 @@ class Course < Base
   property :maths, type: :string
   property :english, type: :string
   property :science, type: :string
+  property :name, type: :string
 
   self.primary_key = :course_code
 

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -200,8 +200,23 @@
         </dt>
         <dd class="govuk-summary-list__value" data-qa="course__name">
           <%= course.name %>
+
+          <% if current_user["admin"] %>
+            <div class="app-admin-only__section">
+              <div class="app-admin-only__section-header">
+                <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
+              </div>
+              Only admins can make changes
+            </div>
+          <% end %>
         </dd>
-        <dd class="govuk-summary-list__actions"></dd>
+        <dd class="govuk-summary-list__actions">
+          <% if current_user["admin"] %>
+            <%= link_to title_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" do %>
+              Change<span class="govuk-visually-hidden"> course title</span>
+            <% end %>
+          <% end %>
+        </dd>
       </div>
 
       <div class="govuk-summary-list__row">

--- a/app/views/courses/title/edit.html.erb
+++ b/app/views/courses/title/edit.html.erb
@@ -1,0 +1,40 @@
+<%= content_for :page_title, "Change course title – #{course.name_and_code}" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+<% end %>
+
+<%= render 'shared/errors' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-admin-only__section">
+      <div class="app-admin-only__section-header">
+        <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
+      </div>
+
+      <h1 class="govuk-heading-xl">
+        Change course title
+      </h1>
+
+      <%= form_with model: course,
+            url: title_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+            method: :put do |form| %>
+
+        <%= render "shared/form_field",
+          form: form, field: :name, label: "Course title" do |field, options| %>
+          <%= form.text_field field, class: "govuk-input govuk-!-width-two-thirds" %>
+        <% end %>
+
+        <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+          class: "govuk-button" %>
+
+        <p class="govuk-body">
+          <%= link_to 'Cancel changes',
+            details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+            class: "govuk-link govuk-link--no-visited-state" %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,9 @@ Rails.application.routes.draw do
         get "/publish", on: :member, to: "courses#details"
         post "/publish", on: :member, to: "courses#publish"
 
+        get "/title", on: :member, to: "courses/title#edit"
+        put "/title", on: :member, to: "courses/title#update"
+
         get "/entry-requirements", on: :member, to: "courses/entry_requirements#edit"
         put "/entry-requirements", on: :member, to: "courses/entry_requirements#update"
 

--- a/spec/controllers/courses/title_controller_spec.rb
+++ b/spec/controllers/courses/title_controller_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe Courses::TitleController do
+  let(:provider) { build(:provider) }
+  let(:course) { build(:course, provider: provider) }
+  let(:admin) do
+    {
+      user_id: 1,
+      uid: SecureRandom.uuid,
+      info: {
+        email: "dave@example.com",
+      },
+      admin: true,
+    }.with_indifferent_access
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+    stub_api_v2_resource(course.recruitment_cycle)
+    stub_api_v2_resource(course)
+  end
+
+  describe "#edit" do
+    context "when a non-admin" do
+      let(:current_user) do
+        {
+          user_id: 1,
+          uid: SecureRandom.uuid,
+          info: {
+            email: "dave@example.com",
+          },
+        }.with_indifferent_access
+      end
+
+      it "is forbidden" do
+        get :edit, params: {
+          provider_code: provider.provider_code,
+          recruitment_cycle_year: course.recruitment_cycle.year,
+          code: course.course_code,
+        }
+
+        expect(response).to be_forbidden
+        expect(response.body).to render_template("errors/forbidden")
+      end
+    end
+
+    context "when an admin" do
+      let(:current_user) { admin }
+
+      it "is accessible" do
+        get :edit, params: {
+          provider_code: provider.provider_code,
+          recruitment_cycle_year: course.recruitment_cycle.year,
+          code: course.course_code,
+        }
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:current_user) { admin }
+
+    it "updates the course title" do
+      stub_api_v2_resource(course, method: :patch) do |body|
+        expect(body["data"]["attributes"]["name"]).to eql("new course name")
+      end
+
+      put :update, params: {
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: course.recruitment_cycle.year,
+        code: course.course_code,
+        course: {
+          name: "new course name",
+        },
+      }
+    end
+
+    context "when title is blank" do
+      it "renders the form" do
+        errors = {
+          errors: [
+            {
+              "source": { "pointer": "/data/attributes/name" },
+              "title": "Title issue",
+              "detail": "Title cannot be blank",
+            },
+          ],
+        }
+
+        stub_api_v2_resource(course, jsonapi_response: errors, method: :patch)
+
+        put :update, params: {
+          provider_code: provider.provider_code,
+          recruitment_cycle_year: course.recruitment_cycle.year,
+          code: course.course_code,
+          course: {
+            name: "",
+          },
+        }
+
+        expect(subject).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -11,14 +11,14 @@ FactoryBot.define do
         # produce valid and usable objects.
 
         age_range_in_years = case level
-                             when :primary
+                             when "primary"
                                %w[
                                  3_to_7
                                  5_to_11
                                  7_to_11
                                  7_to_14
                                ]
-                             when :secondary
+                             when "secondary"
                                %w[
                                  11_to_16
                                  11_to_18
@@ -27,7 +27,7 @@ FactoryBot.define do
                              end
 
         qualifications = case level
-                         when :further_education
+                         when "further_education"
                            %w[pgce pgde]
                          else
                            %w[pgce_with_qts qts pgde_with_qts]
@@ -91,7 +91,7 @@ FactoryBot.define do
     funding_type { "fee" }
     applications_open_from { DateTime.new(2019).utc.iso8601 }
     is_send? { false }
-    level { :secondary }
+    level { "secondary" }
     about_course { nil }
     interview_process { nil }
     how_school_placements_work { nil }
@@ -148,9 +148,9 @@ FactoryBot.define do
 
       if evaluator.gcse_subjects_required_using_level
         course.gcse_subjects_required = case course.level
-                                        when :primary
+                                        when "primary"
                                           %w[maths english science]
-                                        when :secondary
+                                        when "secondary"
                                           %w[maths english]
                                         else
                                           []

--- a/spec/features/courses/age_range_in_years/new_spec.rb
+++ b/spec/features/courses/age_range_in_years/new_spec.rb
@@ -14,7 +14,7 @@ feature "new course age range", type: :feature do
       :course,
       :new,
       provider: provider,
-      level: :primary,
+      level: "primary",
       study_mode: "full_time_or_part_time",
       gcse_subjects_required_using_level: true,
       applications_open_from: "2019-10-09",
@@ -36,7 +36,7 @@ feature "new course age range", type: :feature do
       :course,
       :new,
       provider: provider,
-      level: :primary,
+      level: "primary",
     )
     stub_api_v2_new_resource(new_course)
     stub_api_v2_resource(recruitment_cycle)
@@ -79,7 +79,7 @@ feature "new course age range", type: :feature do
 
   context "Error handling" do
     let(:course) do
-      c = build(:course, provider: provider, level: :secondary, age_range_in_years: nil)
+      c = build(:course, provider: provider, level: "secondary", age_range_in_years: nil)
       c.errors.add(:age_range_in_years, "Invalid")
       c
     end

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -11,7 +11,7 @@ feature "Course confirmation", type: :feature do
   let(:site1) { build(:site, location_name: "Site one") }
   let(:site2) { build(:site, location_name: "Site two") }
   let(:study_mode) { "full_time" }
-  let(:level) { :secondary }
+  let(:level) { "secondary" }
   let(:course) do
     build(
       :course,

--- a/spec/features/courses/entry_requirements/new_spec.rb
+++ b/spec/features/courses/entry_requirements/new_spec.rb
@@ -6,7 +6,7 @@ feature "new course entry_requirements", type: :feature do
     PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new
   end
   let(:provider) { build(:provider, accredited_body?: true, sites: [build(:site)]) }
-  let(:level) { :further_education }
+  let(:level) { "further_education" }
   let(:course)  do
     build(
       :course,
@@ -31,7 +31,7 @@ feature "new course entry_requirements", type: :feature do
   end
 
   context "level primary" do
-    let(:level) { :primary }
+    let(:level) { "primary" }
     before do
       stub_api_v2_build_course(
         maths: "expect_to_achieve_before_training_begins",
@@ -79,7 +79,7 @@ feature "new course entry_requirements", type: :feature do
   end
 
   context "level secondary" do
-    let(:level) { :secondary }
+    let(:level) { "secondary" }
     before do
       stub_api_v2_build_course(
         maths: "expect_to_achieve_before_training_begins",
@@ -129,7 +129,7 @@ feature "new course entry_requirements", type: :feature do
   end
 
   context "Going back" do
-    let(:level) { :primary }
+    let(:level) { "primary" }
     before { visit_new_entry_requirements }
 
     context "With an accredited body" do
@@ -169,7 +169,7 @@ feature "new course entry_requirements", type: :feature do
       c = build(
         :course,
         provider: provider,
-        level: :primary,
+        level: "primary",
         gcse_subjects_required_using_level: true,
         maths: nil,
         english: nil,

--- a/spec/features/courses/new_spec.rb
+++ b/spec/features/courses/new_spec.rb
@@ -85,7 +85,7 @@ feature "new course", type: :feature do
 
   context "Beginning the course creation flow" do
     context "SCITT with single location" do
-      let(:level) { :primary }
+      let(:level) { "primary" }
 
       scenario "builds the new course on the API" do
         go_to_new_course_page_for_provider(provider)
@@ -183,7 +183,7 @@ feature "new course", type: :feature do
     end
 
     context "Further education provider with single location" do
-      let(:level) { :further_education }
+      let(:level) { "further_education" }
 
       scenario "creates the correct course" do
         # This is intended to be a test which will go through the entire flow
@@ -237,7 +237,7 @@ feature "new course", type: :feature do
 
   context "going backwards through the course creation flow" do
     context "with one site and no modern language subjects" do
-      let(:level) { :primary }
+      let(:level) { "primary" }
       let(:sites) { [site1] }
       let(:course_creation_params) do
         {
@@ -299,7 +299,7 @@ feature "new course", type: :feature do
     end
 
     context "with multiple sites and modern language subjects" do
-      let(:level) { :secondary }
+      let(:level) { "secondary" }
       let(:sites) { [site1, site2] }
       let(:course_creation_params) do
         {

--- a/spec/features/courses/outcome/edit_spec.rb
+++ b/spec/features/courses/outcome/edit_spec.rb
@@ -75,7 +75,7 @@ feature "Edit course outcome", type: :feature do
     let(:course) do
       build(
         :course,
-        level: :further_education,
+        level: "further_education",
         qualification: "pgde",
         provider: provider,
       )

--- a/spec/site_prism/page_objects/page/organisations/course_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_details.rb
@@ -33,6 +33,16 @@ module PageObjects
         element :entry_requirements, "[data-qa=course__entry_requirements]"
         element :allocations_info, "[data-qa=course__allocations_info]"
         element :contact_support, "[data-qa=course__contact_support]"
+
+        def title_detail
+          node = page.find_all("div.govuk-summary-list__row").find { |n| n.text.include?("Title") }
+          Detail.new(page, node)
+        end
+
+        class Detail < SitePrism::Section
+          element :value, "dd.govuk-summary-list__value"
+          element :actions, "dd.govuk-summary-list__actions"
+        end
       end
     end
   end

--- a/spec/views/courses/_basic_details_tab.html.erb_spec.rb
+++ b/spec/views/courses/_basic_details_tab.html.erb_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "courses/_basic_details_tab.html.erb" do
+  let(:provider) { build(:provider) }
+  let(:course) { build(:course, provider: provider).decorate }
+  let(:details_page) { PageObjects::Page::Organisations::CourseDetails.new }
+  let(:page) do
+    details_page.load(rendered)
+    details_page
+  end
+
+  before do
+    assign(:course, course)
+    assign(:provider, course.provider)
+    render partial: "courses/basic_details_tab", locals: { course: course, current_user: current_user }
+  end
+
+  describe "change link for course title" do
+    context "when not an admin" do
+      let(:current_user) do
+        { "admin" => false }
+      end
+
+      it "is not displayed" do
+        expect(page.title_detail.actions).to_not have_content("Change course title")
+      end
+
+      it "admin only help panel is not displayed" do
+        expect(page.title_detail.value).to_not have_content("Only admins can make changes")
+      end
+    end
+
+    context "when an admin" do
+      let(:current_user) do
+        { "admin" => true }
+      end
+
+      it "is displayed" do
+        expect(page.title_detail.actions).to have_content("Change course title")
+      end
+
+      it "admin only help panel is displayed" do
+        expect(page.title_detail.value).to have_content("Only admins can make changes")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/bKhHARtf/3572-m-make-course-title-editable
- This allows admins to modify course names via publish

### Changes proposed in this pull request

- Add a new controller and views only accessible to admins that allows the changing of course titles
- Added `Change` link from the course that is only visible to admins to be able navigate to the new controller and view
- Fix `Course` factory where `level` was return a symbol whereas the API actually returns a string
- CSS changes have not been applied and can be done later in another PR

### Guidance to review

- Depends on https://github.com/DFE-Digital/teacher-training-api/pull/1463
- https://s121d02-3572-ptt-as.azurewebsites.net
- Login as admin
- Find a course
- Should see change link for course title
- Click on link
- Should be taken to new page to change course title
- Change to the title to empty string ``
- Should see validation message
- Change title to `new course name`
- Course name should now be updated
- Logout
- Login as non-admin user
- Find a course
- Should not see change link for course title

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
