### PR TITLE
3629 Add notification call for no vacancies

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -25,6 +25,10 @@ class Course < Base
     post_request("/withdraw")
   end
 
+  def send_vacancies_filled_notification
+    post_request("/send_vacancies_filled_notification")
+  end
+
   def self.build_new(params)
     response = connection.run(:get, "#{Course.site}build_new_course?#{params.to_query}")
 


### PR DESCRIPTION
Co-authored-by: Toby Retallick <toby.retallick@gmail.com>

### Context

https://trello.com/c/5q8MIq3C/3629-duplicate-notification-emails-sent-out-to-accredited-provider

User got sent 10 emails! This PR is the publish side of things, and introduces a change where an API call is made to send a notification once a course has no vacancies left. https://github.com/DFE-Digital/teacher-training-api/pull/1465

### Changes proposed in this pull request

* Add API call to send notification after a course has no remaining vacancies

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
