### PR TITLE
fixed subjects 500 error and added feature test

### DIFF
--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -91,13 +91,14 @@ module Courses
     end
 
     def build_course_params
-      selected_master = params[:course][:master_subject_id]
+      selected_master = nil
+      selected_master = params[:course][:master_subject_id] if params[:course][:master_subject_id].present?
       selected_subordinate = nil
       selected_subordinate = params[:course][:subordinate_subject_id] if params[:course][:subordinate_subject_id].present?
       previous_subject_selections = params[:course][:subjects_ids]
 
       params[:course][:subjects_ids] = []
-      params[:course][:subjects_ids] << selected_master
+      params[:course][:subjects_ids] << selected_master if selected_master
       params[:course][:subjects_ids] << selected_subordinate if selected_subordinate
       params[:course].delete(:master_subject_id)
       params[:course].delete(:subordinate_subject_id)

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -91,7 +91,6 @@ module Courses
     end
 
     def build_course_params
-      selected_master = nil
       selected_master = params[:course][:master_subject_id] if params[:course][:master_subject_id].present?
       selected_subordinate = nil
       selected_subordinate = params[:course][:subordinate_subject_id] if params[:course][:subordinate_subject_id].present?

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -155,6 +155,25 @@ feature "New course level", type: :feature do
       it_behaves_like "a course creation page"
     end
 
+    context "Not selecting master subject" do
+      let(:course) do
+        c = build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options)
+        c.errors.add(:subjects, "Invalid")
+        c
+      end
+      let(:selected_fields) { { subjects_ids: [""] } }
+      let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+      before do
+        build_course_with_selected_value_request
+      end
+
+      scenario "error flash" do
+        new_subjects_page.continue.click
+        expect(new_subjects_page.error_flash.text).to include("Subjects Invalid")
+      end
+    end
+
     context "Error handling" do
       let(:level) { :primary }
       let(:course) do

--- a/spec/features/courses/subjects/new_spec.rb
+++ b/spec/features/courses/subjects/new_spec.rb
@@ -157,9 +157,8 @@ feature "New course level", type: :feature do
 
     context "Not selecting master subject" do
       let(:course) do
-        c = build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options)
-        c.errors.add(:subjects, "Invalid")
-        c
+        build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options)
+         .tap { |course| course.errors.add(:subjects, "Invalid") }
       end
       let(:selected_fields) { { subjects_ids: [""] } }
       let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
@@ -177,9 +176,8 @@ feature "New course level", type: :feature do
     context "Error handling" do
       let(:level) { :primary }
       let(:course) do
-        c = build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options)
-        c.errors.add(:subjects, "Invalid")
-        c
+        build(:course, :new, provider: provider, level: level, gcse_subjects_required_using_level: true, edit_options: edit_options)
+         .tap { |course| course.errors.add(:subjects, "Invalid") }
       end
 
       before do


### PR DESCRIPTION
### Context

When a user tries to create a course, no matter the cycle, if they don't select a subject before submitting, they get a 500 error instead of a useful validation.

### Steps to reproduce

1. Go to the course table in either current or next cycle.
2. Click "Add a new course"
3. On the "What type of course?" page: Select either "Primary" or "Secondary", then "Continue"
4. On the "Pick a primary/secondary subject" page: Click "Continue" without selecting a subject
5. Admire the 500 error

### What should happen

User should see a validation error inviting them to choose a subject.

### Links

https://trello.com/c/7mVvxhKj/3641-500-error-when-no-subjects-selected-on-course-creation


### Changes proposed in this pull request

fixed subjects 500 error and added feature test

### Guidance to review



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
