### PR TITLE
[3660] After accepting terms sync session data

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,8 @@ class UsersController < ApplicationController
 
   def accept_terms
     if params.require(:user)[:terms_accepted] == "1"
-      User.member(current_user["user_id"]).accept_terms
+      result = User.member(current_user["user_id"]).accept_terms
+      session["auth_user"]["attributes"]["accept_terms_date_utc"] = result.first.accept_terms_date_utc
       redirect_to page_after_accept_terms
     else
       @errors = { user_terms_accepted: ["You must accept the terms and conditions to continue"] }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe UsersController do
+  let(:user) { create(:user) }
+
+  let(:current_user) do
+    {
+      "user_id" => user.id,
+      "uid" => SecureRandom.uuid,
+    }
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+    allow(controller).to receive(:authenticate)
+    session["auth_user"] ||= {}
+    session["auth_user"]["attributes"] ||= {}
+  end
+
+  describe "#accept_terms" do
+    it "updates session with timestamp" do
+      stub_api_v2_request("/users/#{user.id}/accept_terms", user.to_jsonapi, :patch, 200)
+
+      put :accept_terms, params: { user: { terms_accepted: "1" } }
+      expect(session["auth_user"]["attributes"]["accept_terms_date_utc"]).to eql(user.as_json["attributes"]["accept_terms_date_utc"])
+    end
+
+    it "returns an error when terms haven't been accepted" do
+      put :accept_terms, params: { user: { terms_accepted: "0" } }
+      expect(response).to render_template("pages/accept_terms")
+    end
+  end
+end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -191,8 +191,10 @@ feature "Sign in", type: :feature do
 
   scenario "new inactive user accepts the terms and conditions page with rollover disabled" do
     allow(Settings).to receive(:rollover).and_return(false)
-    user = build :user, :inactive, :new
-    update_request = stub_request(:patch, "#{Settings.manage_backend.base_url}/api/v2/users/#{user.id}/accept_terms")
+    user = build(:user, :inactive, :new)
+    accepted_user = build(:user, user.attributes)
+    accepted_user.accept_terms_date_utc = 1.second.ago
+    stub_api_v2_request("/users/#{user.id}/accept_terms", accepted_user.to_jsonapi, :patch)
 
     stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
 
@@ -223,6 +225,5 @@ feature "Sign in", type: :feature do
     accept_terms_page.continue.click
 
     expect(transition_info_page).to be_displayed
-    expect(update_request).to have_been_made
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/sDVFcGD0/3660-update-session-when-user-accepts-terms
- After the user accepts term we keep the session in sync with this new data
- This is to make https://trello.com/c/IQbTVjZV/3638-m-all-interruptions-are-not-being-displayed-when-the-user-next-signs-in easier
- As we will now have a source of truth on whether or not the user has accepted terms or not

### Changes proposed in this pull request

- After the user accepts term we keep the session in sync with this new data
- This way we know when to display the terms page or not
- API also performs this check
- But now publish knows when to display the terms page
- Out of scope: there seem to other bits of hairy code working around the terms. We can change those to use this mechanism once merged 

### Guidance to review

- Depends on https://github.com/DFE-Digital/teacher-training-api/pull/1469
- No behavioural change
- Login as a new user who has not accepted terms
- Accept terms
- Should now be able to use publish like normal 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
