### PR TITLE
[3655] Close allocations

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,3 +67,4 @@ features:
   signin_by_email: false
   dfe_signin: true
 commit_sha_file: COMMIT_SHA
+allocations_state: closed

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -11,4 +11,3 @@ environment:
   selector_name: "development"
 log_level: debug
 use_ssl: false
-allocations_state: closed

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -11,4 +11,3 @@ search_ui:
 environment:
   label: "Beta"
   selector_name: "beta"
-allocations_state: open

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -8,4 +8,3 @@ search_ui:
 environment:
   label: "QA"
   selector_name: "qa"
-allocations_state: closed

--- a/config/settings/research.yml
+++ b/config/settings/research.yml
@@ -6,4 +6,3 @@ manage_backend:
 environment:
   label: "QA"
   selector_name: "qa"
-allocations_state: open

--- a/config/settings/rollover.yml
+++ b/config/settings/rollover.yml
@@ -6,4 +6,3 @@ manage_backend:
 environment:
   label: "Rollover"
   selector_name: "qa"
-allocations_state: open

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -11,4 +11,3 @@ search_ui:
 environment:
   label: "Staging"
   selector_name: "staging"
-allocations_state: open

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -7,4 +7,3 @@ search_ui:
 environment:
   label: "Test"
   selector_name: "test"
-allocations_state: open

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -7,6 +7,10 @@ RSpec.feature "PE allocations" do
   let(:confirm_deletion_page) { PageObjects::Page::Providers::Allocations::EditInitialAllocations::ConfirmDeletionPage.new }
   let(:allocations_show_page) { PageObjects::Page::Providers::Allocations::ShowPage.new }
 
+  before do
+    allow(Settings).to receive(:allocations_state).and_return("open")
+  end
+
   context "updating an initial allocation" do
     scenario "changing the number of places for an allocation" do
       given_accredited_body_exists

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -6,6 +6,10 @@ RSpec.feature "PE allocations" do
   let(:check_your_info_page) { PageObjects::Page::Providers::Allocations::CheckYourInformationPage.new }
   let(:allocations_show_page) { PageObjects::Page::Providers::Allocations::ShowPage.new }
 
+  before do
+    allow(Settings).to receive(:allocations_state).and_return("open")
+  end
+
   scenario "Accredited body requests new PE allocations" do
     given_accredited_body_exists
     given_the_accredited_body_has_an_allocation

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature "PE allocations" do
   let(:allocations_new_page) { PageObjects::Page::Providers::Allocations::NewPage.new }
   let(:allocations_show_page) { PageObjects::Page::Providers::Allocations::ShowPage.new }
 
+  before do
+    allow(Settings).to receive(:allocations_state).and_return("open")
+  end
+
   context "Repeat allocations" do
     context "Accredited body has previously requested a repeat allocation for a training provider" do
       scenario "Accredited body views PE allocations page" do


### PR DESCRIPTION
### Context
We told accredited bodies that "you have from Monday 1 June until midday on Friday 10 July to request any fee-funded PE, early years initial teacher training (EYITT) and undergraduate courses for 2021/22".
### Changes proposed in this pull request
Changed allocation state settings to closed
### Guidance to review
Merge after merging a previous PR #1245 ?
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
