### PR TITLE
[3666] Changing ' - '  to 'to' in line with GDS guidance

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -77,11 +77,11 @@ module BreadcrumbHelper
 
   def allocations_breadcrumb
     path = provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    provider_breadcrumb << ["Request PE courses for 2021/22", path]
+    provider_breadcrumb << ["Request PE courses for 2021 to 2022", path]
   end
 
   def allocations_closed_breadcrumb
     path = provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    provider_breadcrumb << ["PE courses for 2021/22", path]
+    provider_breadcrumb << ["PE courses for 2021 to 2022", path]
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -116,7 +116,7 @@ module ViewHelper
   end
 
   def show_legacy_courses_table?
-    # For the 2019/2020 cycle we transitioned mid-cycle
+    # For the 2019 to 2020 cycle we transitioned mid-cycle
     # In this year the course and site statuses aren't directly tied to the enrichment status
     # A course could appear on Find without any published content
     #

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -22,7 +22,7 @@ class RecruitmentCycle < Base
   end
 
   def year_range
-    "#{year} – #{year.to_i + 1}"
+    "#{year} to #{year.to_i + 1}"
   end
 
   def title

--- a/app/views/pages/performance_dashboard/_allocations_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_allocations_tab.html.erb
@@ -1,8 +1,8 @@
 <h3 class="govuk-heading-m">
-  PE Requests for 2021 – 2022
+  PE Requests for 2021 to 2022
 </h3>
 <%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "current" }%>
 <h3 class="govuk-heading-m">
-  PE Requests for 2020 – 2021
+  PE Requests for 2020 to 2021
 </h3>
 <%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "previous" }%>

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -8,7 +8,7 @@
 
     <p class="govuk-body">
       All your courses, locations and details have been copied over
-      from the current recruitment cycle (2020 - 2021). You can now
+      from the current recruitment cycle (2020 to 2021). You can now
       update them for 2021 – 2022.
     </p>
 

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">
-  <%= link_to "Current cycle (#{Settings.current_cycle} - #{Settings.current_cycle + 1})",
+  <%= link_to "Current cycle (#{Settings.current_cycle} to #{Settings.current_cycle + 1})",
               provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle),
               data: { qa: 'provider__courses__current_cycle' },
               class: "govuk-link" %>
@@ -15,7 +15,7 @@
 </ul>
 
 <h2 class="govuk-heading-m">
-  <%= link_to "Next cycle (#{Settings.current_cycle + 1} - #{Settings.current_cycle + 2})",
+  <%= link_to "Next cycle (#{Settings.current_cycle + 1} to #{Settings.current_cycle + 2})",
               provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle + 1),
               data: { qa: 'provider__courses__next_cycle' },
               class: "govuk-link" %>

--- a/app/views/providers/allocations/_allocation-request-closed-state.html.erb
+++ b/app/views/providers/allocations/_allocation-request-closed-state.html.erb
@@ -1,13 +1,13 @@
-<%= content_for :page_title, raw("PE courses for 2021&thinsp;–&thinsp;2022") %>
+<%= content_for :page_title, raw("PE courses for 2021 to 2022") %>
 <%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">PE courses for 2021&thinsp;–&thinsp;2022</h1>
+    <h1 class="govuk-heading-xl">PE courses for 2021 to 2022</h1>
 
     <% if @allocations_view.requested_allocations_statuses.any? || @allocations_view.not_requested_allocations_statuses.any? %>
       <p class="govuk-body">
-        You can no longer request fee-funded PE for 2021&thinsp;–&thinsp;2022. The request window closed on 10 July.
+        You can no longer request fee-funded PE for 2021 to 2022. The request window closed on 10 July.
       </p>
 
       <p class="govuk-body">
@@ -16,7 +16,7 @@
       </p>
 
       <p class="govuk-body">
-        Also included are current courses that were not requested for 2021&thinsp;–&thinsp;2022.
+        Also included are current courses that were not requested for 2021 to 2022.
       </p>
 
       <p class="govuk-body">
@@ -24,23 +24,23 @@
       </p>
 
       <%= render partial: "providers/allocations/allocation_report_closed_state", locals: {
-                 section_heading: "Courses for 2021&thinsp;–&thinsp;2022",
+                 section_heading: "Courses for 2021 to 2022",
                  allocations: @allocations_view.requested_allocations_statuses,
                  request_type: "repeat"} %>
 
       <%= render partial: "providers/allocations/allocation_report_closed_state", locals: {
-                 section_heading: "Courses not running in 2021&thinsp;–&thinsp;2022",
+                 section_heading: "Courses not running in 2021 to 2022",
                  allocations: @allocations_view.not_requested_allocations_statuses,
                  request_type: "repeat"} %>
     <% else %>
       <p class="govuk-body">
-        You did not request fee-funded PE for 2021&thinsp;–&thinsp;2022.
+        You did not request fee-funded PE for 2021 to 2022.
       </p>
 
       <p class="govuk-body">
         Your organisation, and any organisations you’re the accredited body for,
-        will not be offering this course - even if it’s being offered in 2020&thinsp;–&thinsp;2021.
-        You can not run this course in 2021&thinsp;–&thinsp;2022 without permission from the Department for Education.
+        will not be offering this course - even if it’s being offered in 2020 to 2021.
+        You can not run this course in 2021 to 2022 without permission from the Department for Education.
       </p>
 
       <p class="govuk-body">

--- a/app/views/providers/allocations/_allocation-request-open-state.html.erb
+++ b/app/views/providers/allocations/_allocation-request-open-state.html.erb
@@ -1,12 +1,12 @@
-<%= content_for :page_title, raw("Request PE courses for 2021&thinsp;–&thinsp;2022") %>
+<%= content_for :page_title, raw("Request PE courses for 2021 to 2022") %>
 <%= content_for :before_content, render_breadcrumbs("allocations") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Request PE courses for 2021&thinsp;–&thinsp;2022</h1>
+    <h1 class="govuk-heading-xl">Request PE courses for 2021 to 2022</h1>
 
     <p class="govuk-body">
-      You must request any fee-funded PE courses for 2021&thinsp;–&thinsp;2022 by 10 July 2020.
+      You must request any fee-funded PE courses for 2021 to 2022 by 10 July 2020.
       You do not need to request any other courses, including salaried PE.
     </p>
 
@@ -45,7 +45,7 @@
 
   <% if @allocations_view.initial_allocation_statuses.present? %>
     <div class="govuk-grid-column-full">
-      <h3 class="govuk-heading-m">New PE courses 2021&thinsp;–&thinsp;2022</h3>
+      <h3 class="govuk-heading-m">New PE courses 2021 to 2022</h3>
 
       <%= render partial: "providers/allocations/request_status", locals: {
         allocations: @allocations_view.initial_allocation_statuses,
@@ -63,7 +63,7 @@
 
     <p class="govuk-body">
       <% if @training_providers.present? %>
-        Request fee-funded PE for 2021&thinsp;–&thinsp;2022 for any organisations not currently offering this course.
+        Request fee-funded PE for 2021 to 2022 for any organisations not currently offering this course.
       <% else %>
         Select the name of the organisation(s) offering this course.
       <% end %>

--- a/app/views/providers/allocations/requests/_not_requested.html.erb
+++ b/app/views/providers/allocations/requests/_not_requested.html.erb
@@ -8,7 +8,7 @@
     </h1>
     <p class="govuk-body">
       You've confirmed that <%= @training_provider.provider_name %> will not be offering fee-funded
-      PE in 2021&thinsp;–&thinsp;2022.
+      PE in 2021 to 2022.
     </p>
 
     <h2 class="govuk-heading-m">What happens now?</h2>
@@ -22,7 +22,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to raw('Return to Request PE courses for 2021&thinsp;–&thinsp;2022'),
+      <%= link_to raw('Return to Request PE courses for 2021 to 2022'),
                   provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
                   class: "govuk-link govuk-!-font-weight-bold" %>
     </p>

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -5,7 +5,7 @@
     <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7" data-qa="page-heading">
       <h1 class="govuk-panel__title">Request sent</h1>
       <p class="govuk-panel__body govuk-!-margin-bottom-0">
-        You’ve confirmed that <%= @training_provider.provider_name %> would like to offer PE in 2021 &thinsp;–&thinsp; 2022.
+        You’ve confirmed that <%= @training_provider.provider_name %> would like to offer PE in 2021 to 2022.
       </p>
     </div>
     <h2 class="govuk-heading-m">What happens now?</h2>
@@ -19,7 +19,7 @@
     <p class="govuk-body">
       In September we'll let you know how many places we've allocated for this course.
       <% unless @allocation.initial_request? %>
-        This will be based on the organisation's allocation for 2020 - 2021.
+        This will be based on the organisation's allocation for 2020 to 2021.
       <% end %>
     </p>
 
@@ -28,7 +28,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to raw('Return to Request PE courses for 2021&thinsp;–&thinsp;2022'),
+      <%= link_to raw('Return to Request PE courses for 2021 to 2022'),
                   provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
                   class: "govuk-link govuk-!-font-weight-bold" %>
     </p>

--- a/app/views/recruitment_cycles/_allocations.html.erb
+++ b/app/views/recruitment_cycles/_allocations.html.erb
@@ -1,6 +1,6 @@
 <% if @provider.accredited_body? %>
   <h2 class="govuk-heading-m">
-    <%= govuk_link_to raw("Request PE courses for 2021&thinsp;–&thinsp;2022"),
+    <%= govuk_link_to "Request PE courses for 2021 to 2022",
                 provider_recruitment_cycle_allocations_path(@provider.provider_code, year) %>
   </h2>
 

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -139,7 +139,7 @@ feature "Preview course", type: :feature do
     )
 
     expect(preview_course_page).to have_content(
-      "The course fees for #{Settings.current_cycle} – #{Settings.current_cycle + 1} are as follows",
+      "The course fees for #{Settings.current_cycle} to #{Settings.current_cycle + 1} are as follows",
     )
 
     expect(preview_course_page.uk_fees).to have_content(

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -223,7 +223,7 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_click_request_pe_courses
-    click_on "Request PE courses for 2021 – 2022"
+    click_on "Request PE courses for 2021 to 2022"
   end
 
   def and_i_click_change

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -310,6 +310,10 @@ RSpec.feature "PE allocations" do
     stub_omniauth(user: user)
   end
 
+  def and_i_click_request_pe_courses
+    click_on "Request PE courses for 2021 to 2022"
+  end
+
   def when_i_visit_my_organisations_page
     stub_api_v2_resource(@accredited_body)
     stub_api_v2_resource_collection([build(:access_request)])
@@ -318,12 +322,8 @@ RSpec.feature "PE allocations" do
     expect(find("h1")).to have_content(@accredited_body.provider_name.to_s)
   end
 
-  def and_i_click_request_pe_courses
-    click_on "Request PE courses for 2021 – 2022"
-  end
-
   def then_i_see_the_pe_allocations_page
-    expect(find("h1")).to have_content("Request PE courses for 2021 – 2022")
+    expect(find("h1")).to have_content("Request PE courses for 2021 to 2022")
   end
 
   def when_i_click_choose_an_organisation_button

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -328,11 +328,11 @@ private
   end
 
   def and_i_click_request_pe_courses
-    click_on "Request PE courses for 2021 – 2022"
+    click_on "Request PE courses for 2021 to 2022"
   end
 
   def then_i_see_the_pe_allocations_page
-    expect(find("h1")).to have_content("Request PE courses for 2021 – 2022")
+    expect(find("h1")).to have_content("Request PE courses for 2021 to 2022")
   end
 
   def and_i_see_only_repeat_allocation_statuses
@@ -357,7 +357,7 @@ private
         @accredited_body.provider_name.to_s,
         href: "/organisations/#{@accredited_body.provider_code}",
       )
-      expect(page).to have_content("Request PE courses for 2021/22")
+      expect(page).to have_content("Request PE courses for 2021 to 2022")
     end
   end
 
@@ -367,7 +367,7 @@ private
   end
 
   def there_is_no_request_pe_courses_link
-    expect(page).not_to have_link("Request PE courses for 2021/22")
+    expect(page).not_to have_link("Request PE courses for 2021 to 2022")
   end
 
   def when_i_visit_training_providers_page

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -18,7 +18,7 @@ describe RecruitmentCycle do
       it "displays as the current cycle" do
         allow(Settings).to receive(:current_cycle).and_return(2020)
         allow(Settings).to receive(:current_cycle_open).and_return(true)
-        expect(recruitment_cycle.title).to eq("Current cycle (2020 – 2021)")
+        expect(recruitment_cycle.title).to eq("Current cycle (2020 to 2021)")
       end
     end
 
@@ -28,7 +28,7 @@ describe RecruitmentCycle do
       it "displays as the new cycle" do
         allow(Settings).to receive(:current_cycle).and_return(2020)
         allow(Settings).to receive(:current_cycle_open).and_return(false)
-        expect(recruitment_cycle.title).to eq("New cycle (2020 – 2021)")
+        expect(recruitment_cycle.title).to eq("New cycle (2020 to 2021)")
       end
     end
 
@@ -38,7 +38,7 @@ describe RecruitmentCycle do
       it "displays as the new cycle" do
         allow(Settings).to receive(:current_cycle).and_return(2019)
         allow(Settings).to receive(:current_cycle_open).and_return(false)
-        expect(recruitment_cycle.title).to eq("Next cycle (2020 – 2021)")
+        expect(recruitment_cycle.title).to eq("Next cycle (2020 to 2021)")
       end
     end
 
@@ -48,7 +48,7 @@ describe RecruitmentCycle do
       it "displays as the previous cycle" do
         allow(Settings).to receive(:current_cycle).and_return(2020)
         allow(Settings).to receive(:current_cycle_open).and_return(false)
-        expect(recruitment_cycle.title).to eq("2019 – 2020")
+        expect(recruitment_cycle.title).to eq("2019 to 2020")
       end
     end
   end


### PR DESCRIPTION
### Context

We need to change hyphens to 'to' because it's:
- better/easier for screenreaders to read out "to" than 'dashes'
- recommended in the GDS Style guide https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
- To be consistent with Apply

### Changes proposed in this pull request

- Replacing all `&thinsp;–&thinsp;` with ` to ` for year periods
- Replacing all `2020&thinsp;–&thinsp;2021` with  `2020 to 2021` 

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [ ] Product Review
