### PR TITLE
[3662] - Allow users to sign out when 'magic link' enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,6 +73,10 @@ class ApplicationController < ActionController::Base
     !Rails.env.production? && Settings.key?(:authorised_users)
   end
 
+  def magic_link_enabled?
+    Settings.features.signin_intercept && Settings.features.signin_by_email && !Settings.features.dfe_signin
+  end
+
   def authenticate
     if current_user.present?
       logger.info { "Authenticated user session found " + log_safe_current_user.to_s }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -77,7 +77,7 @@ class SessionsController < ApplicationController
 
   def signout
     if current_user.present?
-      if development_mode_auth?
+      if development_mode_auth? || magic_link_enabled?
         # Disappointingly, with HTTP basic auth it's trick to really log
         # someone out, since the browser just holds onto the user's username /
         # password and re-submits it until their session ends. So they'll just

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -64,5 +64,16 @@ describe "Sessions", type: :request do
         expect(session[:auth_user][:info][:email]).to eq email
       end
     end
+
+    describe "sign out" do
+      let(:email) { user.email }
+      let(:token) { SecureRandom.uuid }
+
+      it "destroys the session" do
+        get signout_path
+
+        expect(session[:auth_user]).to_not be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
When a user signs in via magic link and then attempts to sign out they receive an error. 
```
Error
invalid_request
unrecognized route or not allowed method (GET on /)
```

This is because the app is attempting to sign out of DFE signin.

### Changes proposed in this pull request
- Enable sign out if a user has signed in via 'magic link'.

### Guidance to review
- Sign in via magic link. To this add the following to your `development.local.yml`
```
features:
  signin_intercept: true
  signin_by_email: true
  dfe_signin: false
```
- Click 'sign out' in the header. You should be redirected to `/signin`.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
