### PR TITLE
[3668] Refactor rollover settings and ensure review apps are inline with production user journeys

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   def accept_transition_info
     UpdateUserService.call(user, "accept_transition_screen!")
-    redirect_to Settings.rollover ? rollover_path : providers_path
+    redirect_to FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") ? rollover_path : providers_path
   end
 
   def accept_rollover

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -230,7 +230,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def return_start_date
-    if Settings.rollover
+    if FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
       start_date.presence || "September #{Settings.current_cycle + 1}"
     else
       start_date.presence || "September #{Settings.current_cycle}"

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -189,7 +189,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def current_cycle_and_open?
-    current_cycle? && Settings.current_cycle_open
+    current_cycle? && FeatureService.enabled?("rollover.has_current_cycle_started?")
   end
 
   def next_cycle?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -27,7 +27,7 @@ class Provider < Base
   end
 
   def rolled_over?
-    Settings.rollover
+    FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
   end
 
 private

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -14,7 +14,7 @@ class RecruitmentCycle < Base
   end
 
   def current_and_open?
-    current? && Settings.current_cycle_open
+    current? && FeatureService.enabled?("rollover.has_current_cycle_started?")
   end
 
   def next?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < Base
 
     event :accept_rollover_screen do
       transitions from: %i[transitioned rolled_over], to: :accepted_rollover_2021 do
-        guard { Settings.rollover }
+        guard { FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") }
       end
     end
 

--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -9,7 +9,9 @@ module FeatureService
     end
 
     def enabled?(feature_name)
-      Settings.features[feature_name]
+      segments = feature_name.to_s.split(".")
+
+      segments.reduce(Settings.features) { |config, segment| config[segment] }
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,7 +50,6 @@ environment:
   label: "Beta"
   selector_name: "beta"
 current_cycle: 2020
-current_cycle_open: true
 application_name: publish-teacher-training
 logstash:
   type: tcp
@@ -66,6 +65,10 @@ features:
   signin_by_email: false
   dfe_signin: true
   rollover:
+    # During rollover providers should be able to edit current & next recruitment cycle courses
     can_edit_current_and_next_cycles: true
+    # Normally a short period of time between rollover and the next cycle
+    # actually starting when it would be set to false
+    has_current_cycle_started?: true
 commit_sha_file: COMMIT_SHA
 allocations_state: closed

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,7 +49,6 @@ service_support:
 environment:
   label: "Beta"
   selector_name: "beta"
-rollover: false
 current_cycle: 2020
 current_cycle_open: true
 application_name: publish-teacher-training
@@ -66,5 +65,7 @@ features:
   signin_intercept: false
   signin_by_email: false
   dfe_signin: true
+  rollover:
+    can_edit_current_and_next_cycles: false
 commit_sha_file: COMMIT_SHA
 allocations_state: closed

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,6 +66,6 @@ features:
   signin_by_email: false
   dfe_signin: true
   rollover:
-    can_edit_current_and_next_cycles: false
+    can_edit_current_and_next_cycles: true
 commit_sha_file: COMMIT_SHA
 allocations_state: closed

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -7,3 +7,9 @@ search_ui:
 environment:
   label: "Test"
   selector_name: "test"
+features:
+  # Rollover is only enabled for a limited time each year so this explicitly
+  # sets it to false. If tests need to test when rollover is enabled then they
+  # should set the rollover setting in that test to true
+  rollover:
+    can_edit_current_and_next_cycles: false

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -582,7 +582,7 @@ describe CourseDecorator do
     context "during rollover" do
       let(:start_date) { nil }
 
-      before { allow(Settings).to receive(:rollover).and_return(true) }
+      before { allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true) }
 
       it "should return the September of the next cycle" do
         expect(decorated_course.return_start_date).to eq("September #{Settings.current_cycle + 1}")

--- a/spec/features/providers/about_spec.rb
+++ b/spec/features/providers/about_spec.rb
@@ -17,7 +17,7 @@ feature "View provider about", type: :feature do
   end
 
   before do
-    allow(Settings).to receive(:rollover).and_return(false)
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
     stub_omniauth
 
     stub_api_v2_request(

--- a/spec/features/providers/contact_spec.rb
+++ b/spec/features/providers/contact_spec.rb
@@ -9,7 +9,7 @@ feature "View provider contact", type: :feature do
   end
 
   before do
-    allow(Settings).to receive(:rollover).and_return(false)
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
     stub_omniauth
 
     stub_api_v2_request(

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -5,6 +5,7 @@ feature "View provider", type: :feature do
 
   before do
     allow(Settings).to receive(:current_cycle_open).and_return(true)
+    # allow(Settings.features).to receive(:can_edit_current_and_next_cycles).and_return(true)
     stub_omniauth
 
     stub_api_v2_resource(provider.recruitment_cycle)
@@ -79,7 +80,7 @@ feature "View provider", type: :feature do
     expect(breadcrumbs[0].text).to eq(provider.provider_name)
     expect(breadcrumbs[0]["href"]).to eq("/organisations/#{provider.provider_code}")
 
-    if Settings.rollover
+    if FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
       expect(breadcrumbs[1].text).to eq(provider.recruitment_cycle.title)
       expect(breadcrumbs[1]["href"]).to eq("/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}")
     end

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -4,8 +4,7 @@ feature "View provider", type: :feature do
   let(:org_detail_page) { PageObjects::Page::Organisations::OrganisationDetails.new }
 
   before do
-    allow(Settings).to receive(:current_cycle_open).and_return(true)
-    # allow(Settings.features).to receive(:can_edit_current_and_next_cycles).and_return(true)
+    allow(Settings.features.rollover).to receive(:has_current_cycle_started?).and_return(true)
     stub_omniauth
 
     stub_api_v2_resource(provider.recruitment_cycle)

--- a/spec/features/providers/index_spec.rb
+++ b/spec/features/providers/index_spec.rb
@@ -13,7 +13,7 @@ feature "View providers", type: :feature do
       "/recruitment_cycles/#{current_recruitment_cycle.year}",
       current_recruitment_cycle.to_jsonapi,
     )
-    allow(Settings).to receive(:rollover).and_return(rollover)
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(rollover)
   end
 
   context "with two providers" do

--- a/spec/features/providers/search_spec.rb
+++ b/spec/features/providers/search_spec.rb
@@ -25,7 +25,7 @@ feature "Search providers", type: :feature do
       resource_list_to_jsonapi([provider1, provider2], meta: { count: 2 }),
     )
 
-    allow(Settings).to receive(:rollover).and_return(rollover)
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(rollover)
 
     root_page.load
   end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -36,7 +36,7 @@ feature "Sign in", type: :feature do
 
   scenario "using DfE Sign-in" do
     user = build(:user)
-    allow(Settings).to receive(:rollover).and_return(true)
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
     stub_omniauth(user: user)
     stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
 
@@ -91,7 +91,7 @@ feature "Sign in", type: :feature do
         before do
           user_get_request
           user_update_request
-          allow(Settings).to receive(:rollover).and_return(true)
+          allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
         end
 
         scenario "new user accepts the transition info page" do
@@ -109,7 +109,7 @@ feature "Sign in", type: :feature do
 
       context "Roll over is disabled" do
         before do
-          allow(Settings).to receive(:rollover).and_return(false)
+          allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
         end
 
         scenario "new user accepts the transition info page" do
@@ -139,7 +139,7 @@ feature "Sign in", type: :feature do
       before do
         user_get_request
         user_update_request
-        allow(Settings).to receive(:rollover).and_return(true)
+        allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
       end
 
       scenario "new user accepts the rollover page" do
@@ -190,7 +190,7 @@ feature "Sign in", type: :feature do
   end
 
   scenario "new inactive user accepts the terms and conditions page with rollover disabled" do
-    allow(Settings).to receive(:rollover).and_return(false)
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
     user = build(:user, :inactive, :new)
     accepted_user = build(:user, user.attributes)
     accepted_user.accept_terms_date_utc = 1.second.ago

--- a/spec/features/sites/index_spec.rb
+++ b/spec/features/sites/index_spec.rb
@@ -21,7 +21,7 @@ feature "View locations", type: :feature do
   let(:location_page) { PageObjects::Page::LocationPage.new }
 
   before do
-    allow(Settings).to receive(:rollover).and_return(false)
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
     user = build(:user)
     stub_omniauth(user: user, provider: provider)
 
@@ -80,7 +80,7 @@ feature "View locations", type: :feature do
 
   context "rollover" do
     it "it shows a list of locations" do
-      allow(Settings).to receive(:rollover).and_return(true)
+      allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
       root_page.load
       expect(organisation_page).to be_displayed(provider_code: provider_code)
       organisation_page.current_cycle.click

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -17,7 +17,7 @@ describe RecruitmentCycle do
 
       it "displays as the current cycle" do
         allow(Settings).to receive(:current_cycle).and_return(2020)
-        allow(Settings).to receive(:current_cycle_open).and_return(true)
+        allow(Settings.features.rollover).to receive(:has_current_cycle_started?).and_return(true)
         expect(recruitment_cycle.title).to eq("Current cycle (2020 to 2021)")
       end
     end
@@ -27,7 +27,7 @@ describe RecruitmentCycle do
 
       it "displays as the new cycle" do
         allow(Settings).to receive(:current_cycle).and_return(2020)
-        allow(Settings).to receive(:current_cycle_open).and_return(false)
+        allow(Settings.features.rollover).to receive(:has_current_cycle_started?).and_return(false)
         expect(recruitment_cycle.title).to eq("New cycle (2020 to 2021)")
       end
     end
@@ -37,7 +37,7 @@ describe RecruitmentCycle do
 
       it "displays as the new cycle" do
         allow(Settings).to receive(:current_cycle).and_return(2019)
-        allow(Settings).to receive(:current_cycle_open).and_return(false)
+        allow(Settings.features.rollover).to receive(:has_current_cycle_started?).and_return(false)
         expect(recruitment_cycle.title).to eq("Next cycle (2020 to 2021)")
       end
     end
@@ -47,7 +47,7 @@ describe RecruitmentCycle do
 
       it "displays as the previous cycle" do
         allow(Settings).to receive(:current_cycle).and_return(2020)
-        allow(Settings).to receive(:current_cycle_open).and_return(false)
+        allow(Settings.features.rollover).to receive(:has_current_cycle_started?).and_return(false)
         expect(recruitment_cycle.title).to eq("2019 to 2020")
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,7 +31,7 @@ describe User, type: :model do
       let(:rolled_over_user) { build(:user, :rolled_over) }
 
       before do
-        allow(Settings).to receive(:rollover).and_return(true)
+        allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
       end
 
       it "changes state from 'transitioned' to 'accepted_rollover_2021'" do
@@ -53,7 +53,7 @@ describe User, type: :model do
       let(:rolled_over_user) { create(:user, :rolled_over) }
 
       before do
-        allow(Settings).to receive(:rollover).and_return(false)
+        allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
       end
 
       it "raises and error when trying to change state from 'transitioned' to 'rolled_over'" do

--- a/spec/requests/recruitment_cycles_spec.rb
+++ b/spec/requests/recruitment_cycles_spec.rb
@@ -29,7 +29,7 @@ describe "Recruitment cycles" do
 
   describe "GET show" do
     it "redirects to the course index page" do
-      allow(Settings).to receive(:rollover).and_return(false)
+      allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
 
       get("/organisations/#{provider.provider_code}/#{current_recruitment_cycle.year}")
       expect(response).to redirect_to(provider_path(provider.provider_code))
@@ -40,7 +40,7 @@ describe "Recruitment cycles" do
 
     context "rollover" do
       it "renders the recruitment cycle page" do
-        allow(Settings).to receive(:rollover).and_return(true)
+        allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
 
         get("/organisations/#{provider.provider_code}/#{current_recruitment_cycle.year}")
         expect(response.body).to include("Current cycle")

--- a/spec/requests/recruitment_cycles_spec.rb
+++ b/spec/requests/recruitment_cycles_spec.rb
@@ -6,7 +6,7 @@ describe "Recruitment cycles" do
   let(:next_recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
 
   before do
-    allow(Settings).to receive(:current_cycle_open).and_return(true)
+    allow(Settings.features.rollover).to receive(:has_current_cycle_started?).and_return(true)
     stub_omniauth
     stub_api_v2_request(
       "/recruitment_cycles/#{current_recruitment_cycle.year}",

--- a/spec/services/feature_service_spec.rb
+++ b/spec/services/feature_service_spec.rb
@@ -1,18 +1,18 @@
 require "rails_helper"
 
 describe FeatureService do
-  let(:feature_enabled) { true }
+  let(:feature_value) { true }
 
   around(:each) do |example|
     old_value = Settings.features.rspec_testing
-    Settings.features.rspec_testing = feature_enabled
+    Settings.features.rspec_testing = feature_value
     example.run
     Settings.features.rspec_testing = old_value
   end
 
   describe ".require" do
     context "feature is enabled" do
-      let(:feature_enabled) { true }
+      let(:feature_value) { true }
 
       it "returns true" do
         response = FeatureService.require(:rspec_testing)
@@ -22,21 +22,37 @@ describe FeatureService do
     end
 
     context "feature is disabled" do
-      let(:feature_enabled) { false }
+      let(:feature_value) { false }
 
       it "raises an error" do
         expect { FeatureService.require(:rspec_testing) }
-          .to raise_error(
-            RuntimeError,
-            "Feature rspec_testing is disabled",
-          )
+          .to raise_error(RuntimeError, "Feature rspec_testing is disabled")
+      end
+    end
+
+    context "nested feature is enabled" do
+      let(:feature_value) { Config::Options.new nested: true }
+
+      it "returns true" do
+        response = FeatureService.require("rspec_testing.nested")
+
+        expect(response).to be_truthy
+      end
+    end
+
+    context "nested feature is disabled" do
+      let(:feature_value) { Config::Options.new nested: false }
+
+      it "raises an error" do
+        expect { FeatureService.require("rspec_testing.nested") }
+          .to raise_error(RuntimeError, "Feature rspec_testing.nested is disabled")
       end
     end
   end
 
   describe ".enabled?" do
     context "feature is enabled" do
-      let(:feature_enabled) { true }
+      let(:feature_value) { true }
 
       it "returns true" do
         response = FeatureService.enabled?(:rspec_testing)
@@ -46,10 +62,30 @@ describe FeatureService do
     end
 
     context "feature is disabled" do
-      let(:feature_enabled) { false }
+      let(:feature_value) { false }
 
       it "returns false" do
         response = FeatureService.enabled?(:rspec_testing)
+
+        expect(response).to be_falsey
+      end
+    end
+
+    context "nested feature is enabled" do
+      let(:feature_value) { Config::Options.new nested: true }
+
+      it "looks up the feature using dot-separated segments" do
+        response = FeatureService.enabled?("rspec_testing.nested")
+
+        expect(response).to be_truthy
+      end
+    end
+
+    context "nested feature is disabled" do
+      let(:feature_value) { Config::Options.new nested: false }
+
+      it "looks up the feature using dot-separated segments" do
+        response = FeatureService.enabled?("rspec_testing.nested")
 
         expect(response).to be_falsey
       end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Added support for nested features in Settings (Thank you @misaka)
- Renames `Settings.rollover` to `Settings.features.rollover.can_edit_current_and_next_cycles`
- Renames `Settings.current_cycle_open` to Settings.features.rollover.has_current_cycle_started?`
- Make `Settings.features.rollover.can_edit_current_and_next_cycles` default across all environments during rollover period 

### Guidance to review
- Easier to review commit by commit
- Review apps should now be operating in "Rollover" mode. 
- If you login as a single organisation user, you should see a page asking if you want to view/edit current/next cycle`
- If you login as a mult-organisation user, you should see a list of the organisations and if you click on one organisation, you should see a page asking if you want to view/edit current/next cycle`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
