### PR TITLE
3643 provider suggestion error

### DIFF
--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -10,9 +10,14 @@ module Courses
     end
 
     def continue
-      other_selected_with_no_autocompleted_code = course_params[:accredited_body_code] == "other" && @autocompleted_provider_code.blank?
+      code = course_params[:accredited_body_code]
+      query = @accredited_body
 
-      if other_selected_with_no_autocompleted_code
+      @errors = errors_for_search_query(code, query)
+
+      if @errors.present?
+        render :new
+      elsif other_selected_with_no_autocompleted_code?(code)
         redirect_to(
           search_new_provider_recruitment_cycle_courses_accredited_body_path(
             query: @accredited_body,
@@ -112,7 +117,7 @@ module Courses
     def errors_for_search_query(code, query)
       errors = {}
 
-      if code == "other" && query.length < 3
+      if other_selected_with_no_autocompleted_code?(code) && query.length < 2
         errors = { accredited_body: ["Accredited body search too short, enter 2 or more characters"] }
       elsif code.blank?
         errors = { accredited_body_code: ["Pick an accredited body"] }
@@ -145,6 +150,10 @@ module Courses
       {
         accredited_body_code: autocompleted_code.presence || code,
       }
+    end
+
+    def other_selected_with_no_autocompleted_code?(code)
+      code == "other" && @autocompleted_provider_code.blank?
     end
   end
 end

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -186,7 +186,7 @@ feature "Edit accredited body", type: :feature do
           expect(accredited_body_page).to be_displayed
           expect(accredited_body_page).to have_content("search too short")
 
-          fill_in "Name of accredited body", with: "AT"
+          fill_in "Name of accredited body", with: "A"
           click_on "Save and publish changes"
 
           expect(accredited_body_page).to be_displayed

--- a/spec/features/courses/accredited_body/new_spec.rb
+++ b/spec/features/courses/accredited_body/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Edit accredited body" do
+feature "New accredited body" do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider) { build(:provider, sites: [build(:site)]) }
   let(:course) { build(:course, provider: provider) }
@@ -108,6 +108,37 @@ feature "Edit accredited body" do
           end
 
           include_examples "a course creation page"
+        end
+
+        context "When not selecting an accredited body" do
+          let(:next_step_page) { PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new }
+          let(:selected_fields) { { level: "primary", accredited_body_code: "A01" } }
+          let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+          before do
+            build_course_with_selected_value_request
+            new_accredited_body_search_page.continue.click
+          end
+
+          scenario "it raises a validation error" do
+            expect(new_accredited_body_search_page).to have_content("Pick an accredited body")
+          end
+        end
+
+        context "When searching for an accredited body with fewer than two characters" do
+          let(:next_step_page) { PageObjects::Page::Organisations::Courses::NewEntryRequirementsPage.new }
+          let(:selected_fields) { { level: "primary", accredited_body_code: "A01" } }
+          let(:build_course_with_selected_value_request) { stub_api_v2_build_course(selected_fields) }
+
+          before do
+            build_course_with_selected_value_request
+            choose "other"
+            new_accredited_body_search_page.continue.click
+          end
+
+          scenario "it raises a validation error" do
+            expect(new_accredited_body_search_page).to have_content("Accredited body search too short, enter 2 or more characters")
+          end
         end
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/7MOribyu/3643-create-a-course-error-when-leaving-accredited-body-field-empty

To fix this issue we initially looked at the API to see what errors were being thrown. It turns out that for this particular endpoint, there aren't errors when a bad query is sent, and only a `bad request` status is thrown back, with no other information. This meant that Publish would send a bad query, and be unable to understand why it was bad - and so didn't load the error partial properly. 

We've got a couple of options here 
1. We can add validation to Publish that will prevent users from submitting searches that wouldn't meet the API's specifications. This prevents bad requests being sent to the API.
2. We can add proper error messaging to the API, which would allow us to send bad queries to the API, and it wouldn't just be throwing back unhelpful json. 
3. Both of these - we want helpful info for the users, but we also shouldn't be sending stuff to the API we know will cause an error. 
4. We remove the guards on the API that prevent searches with less than 3 characters from working - they don't seem to serve much of a purpose, and it would mean users who genuinely want to search for one or two char queries will be able to. 

### Changes proposed in this pull request

At the moment the changes proposed alter the validation on Publish, but we could go for other options outlined above. 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
