### PR TITLE
[3654] Changed 'school' to 'teaching' placements

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -97,7 +97,7 @@ class CoursesController < ApplicationController
       @copied_fields = [
         ["About the course", "about_course"],
         ["Interview process", "interview_process"],
-        ["How school placements work", "how_school_placements_work"],
+        ["How teaching placements work", "how_school_placements_work"],
       ].keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
     end
   end

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -13,7 +13,7 @@
 <dl class="govuk-summary-list govuk-summary-list--short">
   <%= enrichment_summary_item(:course,  'About this course', course.about_course, ['about_course']) %>
   <%= enrichment_summary_item(:course,  'Interview process (optional)', course.interview_process, ['interview_process']) %>
-  <%= enrichment_summary_item(:course,  'How school placements work', course.how_school_placements_work, ['how_school_placements_work']) %>
+  <%= enrichment_summary_item(:course,  'How teaching placements work', course.how_school_placements_work, ['how_school_placements_work']) %>
 </dl>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -51,7 +51,7 @@
           </span>
         </summary>
         <div class="govuk-details__text">
-          <p class="govuk-body">If you offer more than one course in the same subject - eg two Primary courses - it’s important to say how they differ (eg differences in school placements or in the focus of the training). Otherwise, applicants may be unable to decide between them.</p>
+          <p class="govuk-body">If you offer more than one course in the same subject - eg two Primary courses - it’s important to say how they differ (eg differences in teaching placements or in the focus of the training). Otherwise, applicants may be unable to decide between them.</p>
         </div>
       </details>
 
@@ -83,7 +83,7 @@
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
-      <h3 class="govuk-heading-l remove-top-margin">How school placements work</h3>
+      <h3 class="govuk-heading-l remove-top-margin">How teaching placements work</h3>
 
       <p class="govuk-body">
         Give applicants more information about the schools they’ll be teaching in. Tell them:
@@ -106,7 +106,7 @@
 
       <div id="how_school_placements_work_wrapper" class="govuk-character-count" data-module="govuk-character-count" data-maxwords="350">
         <%= render "shared/form_field",
-          form: f, field: :how_school_placements_work, label: 'How school placements work', label_bold: true do |field, options| %>
+          form: f, field: :how_school_placements_work, label: 'How teaching placements work', label_bold: true do |field, options| %>
           <%= f.text_area field, options.merge(rows: 15, class: 'govuk-textarea govuk-js-character-count') %>
         <% end %>
       </div>

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -55,7 +55,7 @@
       <% if course.interview_process.present? %>
         <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
       <% end %>
-      <li><%= link_to 'How school placements work', '#section-schools', class: 'govuk-link' %></li>
+      <li><%= link_to 'How teaching placements work', '#section-schools', class: 'govuk-link' %></li>
       <% if course.has_fees? %>
         <li><%= link_to 'Fees', '#section-fees', class: 'govuk-link' %></li>
       <% else %>

--- a/app/views/courses/preview/_about_schools.html.erb
+++ b/app/views/courses/preview/_about_schools.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-schools">How school placements work</h2>
+  <h2 class="govuk-heading-l" id="section-schools">How teaching placements work</h2>
   <div data-qa="course__about_schools">
     <% if course.how_school_placements_work.present? %>
       <%= markdown(course.how_school_placements_work) %>

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -17,7 +17,7 @@ feature "About course", type: :feature do
       provider: provider,
       about_course: "About course",
       interview_process: "Interview process",
-      how_school_placements_work: "How school placements work",
+      how_school_placements_work: "How teaching placements work",
       recruitment_cycle: current_recruitment_cycle,
     )
   end
@@ -65,7 +65,7 @@ feature "About course", type: :feature do
     )
 
     fill_in "About this course", with: "Something interesting about this course"
-    fill_in "How school placements work", with: "Something about how school placements work"
+    fill_in "How teaching placements work", with: "Something about how teaching placements work"
     click_on "Save"
 
     expect(about_course_page.flash).to have_content(
@@ -116,7 +116,7 @@ feature "About course", type: :feature do
             provider: provider,
             about_course: "Course 2 - About course",
             interview_process: "Course 2 - Interview process",
-            how_school_placements_work: "Course 2 - How school placements work"
+            how_school_placements_work: "Course 2 - How teaching placements work"
     end
 
     let(:course_3) do
@@ -147,7 +147,7 @@ feature "About course", type: :feature do
         "Your changes are not yet saved",
         "About the course",
         "Interview process",
-        "How school placements work",
+        "How teaching placements work",
       ].each do |name|
         expect(about_course_page.warning_message).to have_content(name)
       end
@@ -170,7 +170,7 @@ feature "About course", type: :feature do
 
       [
         "Interview process",
-        "How school placements work",
+        "How teaching placements work",
       ].each do |name|
         expect(about_course_page.warning_message).not_to have_content(name)
       end

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -22,7 +22,7 @@ feature "Preview course", type: :feature do
       other_requirements: "You will need three years of prior work experience, but not necessarily in an educational context.",
       about_accrediting_body: "Something great about the accredited body",
       interview_process: "Some helpful guidance about the interview process",
-      how_school_placements_work: "Some info about how school placements work",
+      how_school_placements_work: "Some info about how teaching placements work",
       about_course: "This is a course",
       required_qualifications: "You need some qualifications for this course",
       has_vacancies?: true,

--- a/spec/requests/courses/about_spec.rb
+++ b/spec/requests/courses/about_spec.rb
@@ -102,7 +102,7 @@ describe "Courses", type: :request do
       {
         page: "about",
         about_course: "Something about this course",
-        how_school_placements_work: "Something about how school placements work",
+        how_school_placements_work: "Something about how teaching placements work",
         interview_process: "Something about the interview process",
       }
     end


### PR DESCRIPTION
### Context
FE courses in Publish contain the following headers and links:

'How school placements work'

This should say:

'How teaching placements work'

### Changes proposed in this pull request
Copy-changing, replace 'school' with 'teaching' placements on various views

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [ ] Product Review
