### PR TITLE
[3653] On course publication render errors

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -174,11 +174,12 @@ class CoursesController < ApplicationController
   def publish
     if @course.publish
       flash[:success] = "Your course has been published."
+      redirect_to provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)
     else
-      flash[:error_summary] = @course.errors.messages
+      @errors = @course.errors.messages
+      build_course
+      render :show
     end
-
-    redirect_to provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)
   end
 
 private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,9 +45,9 @@ module ApplicationHelper
   end
 
   def enrichment_summary_label(model, key, fields)
-    if fields.select { |field| @errors&.key? field }.any?
+    if fields.select { |field| @errors&.key? field.to_sym }.any?
       errors = fields.map { |field|
-        @errors[field]&.map { |error| enrichment_error_link(model, field, error) }
+        @errors[field.to_sym]&.map { |error| enrichment_error_link(model, field, error) }
       }.flatten
       tag.dt class: "govuk-summary-list__key app-course-parts__fields__label--error" do
         [

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -59,13 +59,13 @@ module ViewHelper
     base = "/organisations/#{provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}"
 
     {
-      "about_course" => base + "/about?display_errors=true#about_course_wrapper",
-      "how_school_placements_work" => base + "/about?display_errors=true#how_school_placements_work_wrapper",
-      "fee_uk_eu" => base + "/fees?display_errors=true#fee_uk_eu_wrapper",
-      "course_length" => base + (course.has_fees? ? "/fees" : "/salary") + "?display_errors=true#course_length_wrapper",
-      "salary_details" => base + "/salary?display_errors=true#salary_details_wrapper",
-      "required_qualifications" => base + "/requirements?display_errors=true#required_qualifications_wrapper",
-    }[field]
+      about_course: base + "/about?display_errors=true#about_course_wrapper",
+      how_school_placements_work: base + "/about?display_errors=true#how_school_placements_work_wrapper",
+      fee_uk_eu: base + "/fees?display_errors=true#fee_uk_eu_wrapper",
+      course_length: base + (course.has_fees? ? "/fees" : "/salary") + "?display_errors=true#course_length_wrapper",
+      salary_details: base + "/salary?display_errors=true#salary_details_wrapper",
+      required_qualifications: base + "/requirements?display_errors=true#required_qualifications_wrapper",
+    }.with_indifferent_access[field]
   end
 
   def provider_enrichment_error_url(provider:, field:)

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -11,9 +11,9 @@
   <%= link_to 'About this course', about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item(:course,  'About this course', course.about_course, ['about_course']) %>
-  <%= enrichment_summary_item(:course,  'Interview process (optional)', course.interview_process, ['interview_process']) %>
-  <%= enrichment_summary_item(:course,  course.placements_heading, course.how_school_placements_work, ['how_school_placements_work']) %>
+  <%= enrichment_summary_item(:course, 'About this course', course.about_course, ['about_course']) %>
+  <%= enrichment_summary_item(:course, 'Interview process (optional)', course.interview_process, ['interview_process']) %>
+  <%= enrichment_summary_item(:course, course.placements_heading, course.how_school_placements_work, ['how_school_placements_work']) %>
 </dl>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
@@ -24,15 +24,15 @@
   <% end %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item(:course,  'Course length', course.length, ['course_length']) %>
+  <%= enrichment_summary_item(:course, 'Course length', course.length, ['course_length']) %>
 
   <% if course.has_fees? %>
-    <%= enrichment_summary_item(:course,  'Fee for UK and EU students', number_to_currency(course.fee_uk_eu), ['fee_uk_eu']) %>
-    <%= enrichment_summary_item(:course,  'Fee for international students (optional)', number_to_currency(course.fee_international), ['international_fees']) %>
-    <%= enrichment_summary_item(:course,  'Fee details (optional)', course.fee_details, ['fee_details']) %>
-    <%= enrichment_summary_item(:course,  'Financial support you offer (optional)', course.financial_support, ['financial_support']) %>
+    <%= enrichment_summary_item(:course, 'Fee for UK and EU students', number_to_currency(course.fee_uk_eu), ['fee_uk_eu']) %>
+    <%= enrichment_summary_item(:course, 'Fee for international students (optional)', number_to_currency(course.fee_international), ['international_fees']) %>
+    <%= enrichment_summary_item(:course, 'Fee details (optional)', course.fee_details, ['fee_details']) %>
+    <%= enrichment_summary_item(:course, 'Financial support you offer (optional)', course.financial_support, ['financial_support']) %>
   <% else %>
-    <%= enrichment_summary_item(:course,  'Salary', course.salary_details, ['salary_details']) %>
+    <%= enrichment_summary_item(:course, 'Salary', course.salary_details, ['salary_details']) %>
   <% end %>
 </dl>
 
@@ -40,7 +40,7 @@
   <%= link_to 'Requirements and eligibility', requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
-  <%= enrichment_summary_item(:course,  'Qualifications needed', course.required_qualifications, ['qualifications']) %>
-  <%= enrichment_summary_item(:course,  'Personal qualities (optional)', course.personal_qualities, ['personal_qualities']) %>
-  <%= enrichment_summary_item(:course,  'Other requirements (optional)', course.other_requirements, ['other_requirements']) %>
+  <%= enrichment_summary_item(:course, 'Qualifications needed', course.required_qualifications, ['required_qualifications']) %>
+  <%= enrichment_summary_item(:course, 'Personal qualities (optional)', course.personal_qualities, ['personal_qualities']) %>
+  <%= enrichment_summary_item(:course, 'Other requirements (optional)', course.other_requirements, ['other_requirements']) %>
 </dl>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -340,16 +340,7 @@ feature "Course show", type: :feature do
           course_page.publish.click
 
           expect(page.title).to have_content("Error:")
-          expect(course_page).to be_displayed
           expect(course_page.error_summary).to have_content("About course can't be blank")
-        end
-
-        scenario "it deep links and persists errors" do
-          course_page.publish.click
-
-          click_link "About course can't be blank", match: :first
-
-          expect(about_course_page.error_flash).to have_content("About course can't be blank")
         end
       end
     end

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -54,9 +54,8 @@ describe "Courses" do
         post publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
       end
 
-      it "redirects to the course description page" do
-        expect(flash[:error_summary]).to eq(about_course: ["About course can't be blank"])
-        expect(response).to redirect_to(provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code))
+      it "displays errors" do
+        response.body.include?("About course can&#39;t be blank")
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -13,7 +13,7 @@ module PageObjects
         element :international_fees, "[data-qa=enrichment__international_fees]"
         element :fee_details, "[data-qa=enrichment__fee_details]"
         element :financial_support, "[data-qa=enrichment__financial_support]"
-        element :required_qualifications, "[data-qa=enrichment__qualifications]"
+        element :required_qualifications, "[data-qa=enrichment__required_qualifications]"
         element :personal_qualities, "[data-qa=enrichment__personal_qualities]"
         element :other_requirements, "[data-qa=enrichment__other_requirements]"
         element :has_vacancies, "[data-qa=course__has_vacancies]"


### PR DESCRIPTION
### Context

- https://trello.com/c/97e3BxBu/3653-missing-broken-error-summaries-when-trying-to-publish-a-course-in-rollover
- If adding large validation error messages publish would store these in the flash and therefore cookies have a chance of causing a cookie overflow

### Changes proposed in this pull request

- Previously on course publication any errors were stored in the flash
and shown on the next request after a redirect
- However we are using cookie based session store which has a limited
storage of 4kb
- Large error messages stored this way would cause the cookie to
overflow causing an error
- Instead we now render the same page on the request if validation fails
- This prevents the need to store data in the cookie
- `build_course` must be called again in controller as `JsonApiClient`
when calling `publish` removes associations needed for rendering

### Guidance to review

- Can be used with https://github.com/DFE-Digital/teacher-training-api/pull/1474
- Alternatively this change should be backwards compatible
- Publish a course with validation failing
- Should see validation messages in summary

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
