### PR TITLE
[3686] Fix character count on Organisation "About" page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -99,7 +99,7 @@ class ProvidersController < ApplicationController
 private
 
   def provider_params
-    params.require(:provider).permit(
+    permitted_params = params.require(:provider).permit(
       :page,
       :train_with_us,
       :train_with_disability,
@@ -113,10 +113,31 @@ private
       :address4,
       :postcode,
       :region_code,
-      accredited_bodies: %i[provider_name provider_code description],
+      accredited_bodies_attributes: %i[provider_name provider_code description],
     ).to_h # Without this, accredited_bodies is an array of params objects
     # instead of an array of plain hashes and gets serialized incorrectly
     # on its way to the backend.
+    permitted_params.merge(accredited_bodies_param).except(:accredited_bodies_attributes)
+  end
+
+  def accredited_bodies_param
+    ab = params.require(:provider).except(
+      :page,
+      :train_with_us,
+      :train_with_disability,
+      :provider_name,
+      :email,
+      :telephone,
+      :website,
+      :address1,
+      :address2,
+      :address3,
+      :address4,
+      :postcode,
+      :region_code,
+    )
+      .permit(accredited_bodies_attributes: %i[provider_name provider_code description])
+    { accredited_bodies: ab[:accredited_bodies_attributes].to_h.map { |_k, v| v } }
   end
 
   def build_provider

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -137,7 +137,7 @@ private
       :region_code,
     )
       .permit(accredited_bodies_attributes: %i[provider_name provider_code description])
-    { accredited_bodies: ab[:accredited_bodies_attributes].to_h.map { |_k, v| v } }
+    { accredited_bodies: ab[:accredited_bodies_attributes].to_h.values }
   end
 
   def build_provider

--- a/app/decorators/provider_decorator.rb
+++ b/app/decorators/provider_decorator.rb
@@ -2,7 +2,9 @@ class ProviderDecorator < ApplicationDecorator
   delegate_all
 
   def accredited_bodies
-    object.accredited_bodies.sort_by { |provider| provider["provider_name"] }
+    object.accredited_bodies.sort_by { |provider| provider["provider_name"] }.map do |provider|
+      Provider.new(provider)
+    end
   end
 
   def website

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -61,7 +61,8 @@
         <h2 class="govuk-heading-l" id="accredited_bodies-error">About your accredited body</h2>
 
         <p id="about-training-provider-hint" class="govuk-body">
-          Tell applicants about your accredited body - you could mention their academic specialities and achievements. Be specific with the claims you make, and support with them evidence.
+          Tell applicants about your accredited body - you could mention their academic specialities and achievements.
+          Be specific with the claims you make, and support with them evidence.
         </p>
 
         <% provider.accredited_bodies.each_with_index do |provider,index| %>
@@ -95,7 +96,8 @@
         <li>mental health conditions</li>
       </ul>
       <p class="govuk-body">
-        If accessibility varies between locations, give details. It’s also useful for applicants to know how you’ve accommodated others with specific access needs in the past.
+        If accessibility varies between locations, give details. It’s also useful for applicants to know how
+        you’ve accommodated others with specific access needs in the past.
       </p>
 
       <%= f.govuk_text_area :train_with_disability,

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -4,61 +4,60 @@
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 <% end %>
 
-<%= render 'shared/errors' %>
+<%= form_with model: provider,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+              url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+              method: :put do |f| %>
+  <%= f.hidden_field :page, value: :about %>
+  <%= f.govuk_error_summary "You’ll need to correct some information." %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">
-        <%= @provider.provider_name %>
-      </span>
-      About your organisation
-    </h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">
+          <%= @provider.provider_name %>
+        </span>
+        About your organisation
+      </h1>
+    </div>
   </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">
-      Tell applicants why they should choose to train with you. Say:
-    </p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">
+        Tell applicants why they should choose to train with you. Say:
+      </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>who you are</li>
-      <li>who you work with</li>
-    </ul>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>who you are</li>
+        <li>who you work with</li>
+      </ul>
 
-    <p class="govuk-body">
-      You could mention:
-    </p>
+      <p class="govuk-body">
+        You could mention:
+      </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>your key values</li>
-      <li>your specialisms</li>
-      <li>your past achievements (eg student successes, Ofsted ratings)</li>
-    </ul>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your key values</li>
+        <li>your specialisms</li>
+        <li>your past achievements (eg student successes, Ofsted ratings)</li>
+      </ul>
 
-    <p class="govuk-body">
-      Be specific with any claims you make, and support them with evidence. For example:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>don’t say “our students are some of the happiest in the country”</li>
-      <li>
-        do say “the Times Educational Supplement ranked our students as 4th
-        happiest in the country”
-      </li>
-    </ul>
-
-    <%= form_with model: provider,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-                  url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
-                  method: :put do |f| %>
-      <%= f.hidden_field :page, value: :about %>
+      <p class="govuk-body">
+        Be specific with any claims you make, and support them with evidence. For example:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>don’t say “our students are some of the happiest in the country”</li>
+        <li>
+          do say “the Times Educational Supplement ranked our students as 4th
+          happiest in the country”
+        </li>
+      </ul>
 
       <%= f.govuk_text_area :train_with_us, label: { text: 'Training with you', size:'s' }, max_words: 250, rows: 15 %>
 
       <% if provider.accredited_bodies.present? %>
-        <h2 class="govuk-heading-l" id="accredited_bodies-error">About your accredited body</h2>
+        <h2 class="govuk-heading-l">About your accredited body</h2>
 
         <p id="about-training-provider-hint" class="govuk-body">
           Tell applicants about your accredited body - you could mention their academic specialities and achievements.
@@ -94,12 +93,13 @@
       <hr class="govuk-section-break govuk-section-break--l">
       <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 2 hours.</p>
       <%= f.submit "Save and publish changes", class: "govuk-button" %>
-    <% end %>
 
-    <div class="form-group">
-      <p class="govuk-body">
-        <%= govuk_link_to "Cancel changes", details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
-      </p>
+
+      <div class="form-group">
+        <p class="govuk-body">
+          <%= govuk_link_to "Cancel changes", details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
+        </p>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -91,9 +91,8 @@
                             max_words: 250, rows: 15 %>
 
       <hr class="govuk-section-break govuk-section-break--l">
-      <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 2 hours.</p>
-      <%= f.submit "Save and publish changes", class: "govuk-button" %>
 
+      <%= f.submit "Save and publish changes", class: "govuk-button" %>
 
       <div class="form-group">
         <p class="govuk-body">

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -49,7 +49,10 @@
       </li>
     </ul>
 
-    <%= form_with model: @provider, url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year), method: :put do |f| %>
+    <%= form_with model: @provider,
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                  url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+                  method: :put do |f| %>
       <%= f.hidden_field :page, value: :about %>
 
       <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="250">

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -49,7 +49,7 @@
       </li>
     </ul>
 
-    <%= form_with model: @provider,
+    <%= form_with model: provider,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder,
                   url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
                   method: :put do |f| %>
@@ -65,23 +65,10 @@
           Be specific with the claims you make, and support with them evidence.
         </p>
 
-        <% provider.accredited_bodies.each_with_index do |provider,index| %>
-          <%= f.hidden_field "accredited_bodies[][provider_name]", value: provider["provider_name"], id: nil %>
-          <%= f.hidden_field "accredited_bodies[][provider_code]", value: provider["provider_code"], id: nil %>
-          <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="100">
-            <%= render "shared/form_field",
-              form: f,
-              field: "accredited_bodies[][description]",
-              label: "#{provider['provider_name']} (optional)",
-              id: "accredited_bodies[#{index}][description]",
-              label_bold: true do |field, options| %>
-              <%= f.text_area field, options.merge(
-                value: provider['description'],
-                rows: 10,
-                class: 'govuk-textarea govuk-js-character-count'
-              ) %>
-            <% end %>
-          </div>
+        <%= f.fields model: :accredited_bodies do |abf| %>
+          <%= abf.hidden_field :provider_name %>
+          <%= abf.hidden_field :provider_code %>
+          <%= abf.govuk_text_area :description, label: { text: "#{ abf.object.provider_name} (optional)", size:'s' }, max_words: 100, rows: 10 %>
         <% end %>
       <% end %>
 

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -92,7 +92,7 @@
 
       <hr class="govuk-section-break govuk-section-break--l">
 
-      <%= f.submit "Save and publish changes", class: "govuk-button" %>
+      <%= f.govuk_submit "Save and publish changes" %>
 
       <div class="form-group">
         <p class="govuk-body">

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -55,12 +55,7 @@
                   method: :put do |f| %>
       <%= f.hidden_field :page, value: :about %>
 
-      <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="250">
-        <%= render "shared/form_field",
-          form: f, field: :train_with_us, label: 'Training with you', label_bold: true do |field, options| %>
-          <%= f.text_area field, options.merge(rows: 15, class: 'govuk-textarea govuk-js-character-count') %>
-        <% end %>
-      </div>
+      <%= f.govuk_text_area :train_with_us, label: { text: 'Training with you', size:'s' }, max_words: 250, rows: 15 %>
 
       <% if provider.accredited_bodies.present? %>
         <h2 class="govuk-heading-l" id="accredited_bodies-error">About your accredited body</h2>
@@ -103,12 +98,9 @@
         If accessibility varies between locations, give details. It’s also useful for applicants to know how you’ve accommodated others with specific access needs in the past.
       </p>
 
-      <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="250">
-        <%= render "shared/form_field",
-          form: f, field: :train_with_disability, label: 'Training with disabilities and other needs', label_bold: true do |field, options| %>
-          <%= f.text_area field, options.merge(rows: 15, class: 'govuk-textarea govuk-js-character-count') %>
-        <% end %>
-      </div>
+      <%= f.govuk_text_area :train_with_disability,
+                            label: { text: 'Training with disabilities and other needs', size:'s' },
+                            max_words: 250, rows: 15 %>
 
       <hr class="govuk-section-break govuk-section-break--l">
       <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 2 hours.</p>

--- a/spec/features/providers/about_spec.rb
+++ b/spec/features/providers/about_spec.rb
@@ -74,8 +74,8 @@ feature "View provider about", type: :feature do
 
     fill_in "provider[train_with_us]", with: "Foo"
     fill_in "provider[train_with_disability]", with: "Bar"
-    fill_in "accredited_bodies[0][description]", with: "Baz"
-    fill_in "accredited_bodies[1][description]", with: "Qux"
+    fill_in "provider-accredited-bodies-attributes-0-description-field", with: "Baz"
+    fill_in "provider-accredited-bodies-attributes-1-description-field", with: "Qux"
     click_on "Save"
 
     expect(org_details_page.flash).to have_content(

--- a/spec/site_prism/page_objects/page/organisations/organisation_about.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_about.rb
@@ -6,8 +6,8 @@ module PageObjects
 
         element :title, ".govuk-heading-xl"
         element :caption, ".govuk-caption-xl"
-        element :train_with_us, "[data-qa=train_with_us]"
-        element :train_with_disability, "[data-qa=train_with_disability]"
+        element :train_with_us, "#provider-train-with-us-field"
+        element :train_with_disability, "#provider-train-with-disability-field"
         element :error_flash, ".govuk-error-summary"
       end
     end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Updates the form on the page to use GOV.UK Design System formbuilder
- Fixes issue where accredited body optional fields were displaying as errors if there were any validation errors for "training with us" and last text area "disabilities".
- removes old copy telling users it would take up to 2hrs for content to be updated on Find.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
