### PR TITLE
[3699] Fix character counter on "About course" page

### DIFF
--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -54,7 +54,11 @@
           </span>
         </summary>
         <div class="govuk-details__text">
-          <p class="govuk-body">If you offer more than one course in the same subject - eg two Primary courses - it’s important to say how they differ (eg differences in teaching placements or in the focus of the training). Otherwise, applicants may be unable to decide between them.</p>
+          <p class="govuk-body">
+            If you offer more than one course in the same subject - eg two Primary courses - it’s important to say how
+            they differ (eg differences in teaching placements or in the focus of the training). Otherwise, applicants
+            may be unable to decide between them.
+          </p>
         </div>
       </details>
 
@@ -103,7 +107,9 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= link_to 'Cancel changes',
+                    provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                    class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -7,20 +7,21 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
-<%= render 'shared/errors' %>
+<%= form_with model: course,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+              url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+              data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
+  <%= f.hidden_field :page, value: :about %>
+  <%= f.govuk_error_summary "You’ll need to correct some information." %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-  About this course
-</h1>
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+    About this course
+  </h1>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-                  url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                  data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
-      <%= f.hidden_field :page, value: :about %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
       <p class="govuk-body">You should give a short, factual summary of the course.</p>
 
       <p class="govuk-body">Tell applicants:</p>
@@ -63,7 +64,6 @@
       </details>
 
       <%= f.govuk_text_area :about_course, label: { text: 'About this course', size:'s' }, max_words: 400, rows: 20 %>
-
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
@@ -111,13 +111,13 @@
                     provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                     class: "govuk-link govuk-link--no-visited-state" %>
       </p>
-    <% end %>
-  </div>
+    </div>
 
-  <aside class="govuk-grid-column-one-third">
-    <%= render partial: 'courses/related_sidebar',
-                        locals: {
-                          course: course,
-                          page_path: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) } %>
-  </aside>
-</div>
+    <aside class="govuk-grid-column-one-third">
+      <%= render partial: 'courses/related_sidebar',
+                          locals: {
+                            course: course,
+                            page_path: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) } %>
+    </aside>
+  </div>
+<% end %>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -58,12 +58,8 @@
         </div>
       </details>
 
-      <div id="about_course_wrapper" class="govuk-character-count" data-module="govuk-character-count" data-maxwords="400">
-        <%= render "shared/form_field",
-          form: f, field: :about_course, label: 'About this course', label_bold: true do |field, options| %>
-          <%= f.text_area field, options.merge(rows: 20, class: 'govuk-textarea govuk-js-character-count') %>
-        <% end %>
-      </div>
+      <%= f.govuk_text_area :about_course, label: { text: 'About this course', size:'s' }, max_words: 400, rows: 20 %>
+
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
@@ -77,12 +73,7 @@
         <li>whether they’ll have to sit any tests - if so, how can they prepare?</li>
       </ul>
 
-      <div id="interview_process_wrapper" class="govuk-character-count" data-module="govuk-character-count" data-maxwords="250">
-        <%= render "shared/form_field",
-          form: f, field: :interview_process, label: 'Interview process (optional)', label_bold: true do |field, options| %>
-          <%= f.text_area field, options.merge(rows: 15, class: 'govuk-textarea govuk-js-character-count') %>
-        <% end %>
-      </div>
+      <%= f.govuk_text_area :interview_process, label: { text: 'Interview process (optional)', size:'s' }, max_words: 250, rows: 15 %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
@@ -107,12 +98,7 @@
         <li>how placement schools are selected</li>
       </ul>
 
-      <div id="how_school_placements_work_wrapper" class="govuk-character-count" data-module="govuk-character-count" data-maxwords="350">
-        <%= render "shared/form_field",
-          form: f, field: :how_school_placements_work, label: course.placements_heading, label_bold: true do |field, options| %>
-          <%= f.text_area field, options.merge(rows: 15, class: 'govuk-textarea govuk-js-character-count') %>
-        <% end %>
-      </div>
+      <%= f.govuk_text_area :how_school_placements_work, label: { text: course.placements_heading, size:'s' }, max_words: 350, rows: 15 %>
 
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -104,7 +104,7 @@
 
       <%= f.govuk_text_area :how_school_placements_work, label: { text: course.placements_heading, size:'s' }, max_words: 350, rows: 15 %>
 
-      <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
+      <%= f.govuk_submit "Save" %>
 
       <p class="govuk-body">
         <%= link_to 'Cancel changes',

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -16,7 +16,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
+    <%= form_with model: course,
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                  url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                  data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
       <%= f.hidden_field :page, value: :about %>
       <p class="govuk-body">You should give a short, factual summary of the course.</p>
 

--- a/spec/site_prism/page_objects/page/organisations/course_about.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_about.rb
@@ -5,9 +5,9 @@ module PageObjects
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/about"
 
         element :enrichment_form, '[data-qa="enrichment-form"]'
-        element :about_textarea, "#course_about_course"
-        element :interview_process_textarea, "#course_interview_process"
-        element :how_school_placements_work_textarea, "#course_how_school_placements_work"
+        element :about_textarea, "#course-about-course-field"
+        element :interview_process_textarea, "#course-interview-process-field"
+        element :how_school_placements_work_textarea, "#course-how-school-placements-work-field"
       end
     end
   end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Switches the page to use GOV.UK Design System form builder
- Fixes styling issues where is any field had a validation error then all the fields were styled as having errors.
- Clicking on the Error summary should now take the user directly to the text area and set focus to it.

## Before
![image](https://user-images.githubusercontent.com/3441519/87854687-7603b880-c90b-11ea-8ff3-772412537b17.png)

## After
![image](https://user-images.githubusercontent.com/3441519/87854691-7bf99980-c90b-11ea-9138-5aefcf950ef5.png)

### Guidance to review

- Login as a user and try the following
- visit any courses "About page" and see how many words they have left for each textarea on the page
	- edit each text area and notice how the word counter below that text area updates as you add/remove words
- Attempt to add more words than each text area allows. 
	- clicking on the link in the error summary should take you directly to that field and it should have focus (yellow border) 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
