### PR TITLE
[3644] age range validation

### DIFF
--- a/app/form_objects/age_range_form.rb
+++ b/app/form_objects/age_range_form.rb
@@ -1,0 +1,94 @@
+class AgeRangeForm
+  include ActiveModel::Model
+
+  attr_accessor :age_range_in_years, :presets
+  attr_reader :course_age_range_in_years_other_from,
+              :course_age_range_in_years_other_to
+
+  def course_age_range_in_years_other_from=(value)
+    @course_age_range_in_years_other_from = if value.present?
+                                              value.to_i
+                                            else
+                                              value
+                                            end
+  end
+
+  def course_age_range_in_years_other_to=(value)
+    @course_age_range_in_years_other_to = if value.present?
+                                            value.to_i
+                                          else
+                                            value
+                                          end
+  end
+
+  def initialize(args)
+    super
+
+    if process_custom_range?
+      self.course_age_range_in_years_other_from = extract_from_years
+      self.course_age_range_in_years_other_to = extract_to_years
+      self.age_range_in_years = "other"
+    end
+  end
+
+  validates :age_range_in_years, presence: { message: I18n.t("age_range.errors.missing_error") }
+  validates :course_age_range_in_years_other_from, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 46,
+    allow_blank: true,
+    message: I18n.t("age_range.errors.from_range", min: 0, max: 46),
+  }
+  validates :course_age_range_in_years_other_to, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 4,
+    less_than_or_equal_to: 50,
+    allow_blank: true,
+    message: I18n.t("age_range.errors.to_range", min: 4, max: 50),
+  }
+  validate :age_range_from_and_to_missing
+  validate :age_range_from_and_to_reversed
+  validate :age_range_spans_at_least_4_years
+
+private
+
+  def process_custom_range?
+    age_range_in_years.present? && age_range_in_years != "other" && !presets.include?(age_range_in_years)
+  end
+
+  def extract_from_years
+    age_range_in_years.split("_").first
+  end
+
+  def extract_to_years
+    age_range_in_years.split("_").last
+  end
+
+  def age_range_from_and_to_missing
+    if age_range_in_years == "other"
+      if course_age_range_in_years_other_from.blank?
+        errors.add(:course_age_range_in_years_other_from, I18n.t("age_range.errors.from_missing_error"))
+      end
+
+      if course_age_range_in_years_other_to.blank?
+        errors.add(:course_age_range_in_years_other_to, I18n.t("age_range.errors.to_missing_error"))
+      end
+    end
+  end
+
+  def age_range_from_and_to_reversed
+    if age_range_in_years == "other" && course_age_range_in_years_other_from.present? && course_age_range_in_years_other_to.present?
+      if course_age_range_in_years_other_from.to_i > course_age_range_in_years_other_to.to_i
+        errors.add(:course_age_range_in_years_other_from, I18n.t("age_range.errors.from_invalid_error"))
+      end
+    end
+  end
+
+  def age_range_spans_at_least_4_years
+    if age_range_in_years == "other"
+      if (course_age_range_in_years_other_to.to_i - course_age_range_in_years_other_from.to_i).abs < 4
+        errors.add(:course_age_range_in_years_other_to, I18n.t("age_range.errors.to_invalid_error"))
+      end
+    end
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -65,6 +65,7 @@ module ViewHelper
       course_length: base + (course.has_fees? ? "/fees" : "/salary") + "?display_errors=true#course_length_wrapper",
       salary_details: base + "/salary?display_errors=true#salary_details_wrapper",
       required_qualifications: base + "/requirements?display_errors=true#required_qualifications_wrapper",
+      age_range_in_years: base + "/age-range?display_errors=true",
     }.with_indifferent_access[field]
   end
 

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -3,25 +3,33 @@
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
-<%= render 'errors' %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
+    <%= form_with model: form_object,
+          scope: :course,
+          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
           url: age_range_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
           method: :put do |form| %>
 
-      <%= render "shared/error_wrapper", error_keys: [:age_range_in_years], data_qa: "course__age_range_in_years" do %>
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-              Specify an age range
-            </h1>
-          </legend>
-          <%= render "shared/error_messages", error_keys: [:age_range_in_years] %>
-          <%= render 'form_fields', form: form %>
-        </fieldset>
+      <%= form.govuk_error_summary "You’ll need to correct some information." %>
+
+      <%= form.govuk_radio_buttons_fieldset(:age_range_in_years, legend: { size: 'xl', text: 'Specify an age range' }, caption: { text: course.name_and_code, size: 'xl' }) do %>
+        <% @course.meta['edit_options']['age_range_in_years'].each do |value| %>
+          <%= form.govuk_radio_button :age_range_in_years,
+            value,
+            label: { text: I18n.t("edit_options.age_range_in_years.#{value}.label") },
+            link_errors: true %>
+        <% end %>
+
+        <%= form.govuk_radio_divider %>
+
+        <%= form.govuk_radio_button :age_range_in_years, "other", label: { text: 'Another age range' } do %>
+          <p class="govuk-body">Enter an age range in years, for example: 5 to 11. The course must cover 4 or more school years.</p>
+
+          <%= form.govuk_text_field :course_age_range_in_years_other_from, label: { text: 'From' }, class: 'govuk-input govuk-input--width-2' %>
+
+          <%= form.govuk_text_field :course_age_range_in_years_other_to, label: { text: 'To' }, class: 'govuk-input govuk-input--width-2' %>
+        <% end %>
       <% end %>
 
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,9 +119,11 @@ en:
         label: "Get an email for each application you receive"
   age_range:
     errors:
-      missing_error: Choose an age range
+      missing_error: You need to pick an age range
       from_and_to_error: "Enter an age in both From and To"
       from_missing_error: "Enter an age in From"
       to_missing_error: "Enter an age in To"
       from_invalid_error: "Enter a valid age in From"
       to_invalid_error: "Enter a valid age in To"
+      from_range: "From age must be between %{min} and %{max}"
+      to_range: "To age must be between %{min} and %{max}"

--- a/spec/features/courses/age_range_in_years/edit_spec.rb
+++ b/spec/features/courses/age_range_in_years/edit_spec.rb
@@ -31,7 +31,7 @@ feature "Edit course age range in years", type: :feature do
     it "is not valid and returns error message" do
       age_range_in_years_page.save.click
 
-      expect(age_range_in_years_page.error_flash).to have_content("Choose an age range")
+      expect(age_range_in_years_page).to have_content("You need to pick an age range")
     end
   end
 
@@ -61,20 +61,19 @@ feature "Edit course age range in years", type: :feature do
     end
 
     scenario "presents a choice for each age range" do
-      expect(age_range_in_years_page).to have_age_range_fields
-      expect(age_range_in_years_page.age_range_fields)
-        .to have_selector('[for="course_age_range_in_years_11_to_16"]', text: "11 to 16")
-      expect(age_range_in_years_page.age_range_fields)
-        .to have_selector('[for="course_age_range_in_years_11_to_18"]', text: "11 to 18")
-      expect(age_range_in_years_page.age_range_fields)
-        .to have_selector('[for="course_age_range_in_years_14_to_19"]', text: "14 to 19")
-      expect(age_range_in_years_page.age_range_fields)
-        .to have_selector('[for="course_age_range_in_years_other"]', text: "Another age range")
+      expect(age_range_in_years_page)
+        .to have_selector('[for="course-age-range-in-years-11-to-16-field"]', text: "11 to 16")
+      expect(age_range_in_years_page)
+        .to have_selector('[for="course-age-range-in-years-11-to-18-field"]', text: "11 to 18")
+      expect(age_range_in_years_page)
+        .to have_selector('[for="course-age-range-in-years-14-to-19-field"]', text: "14 to 19")
+      expect(age_range_in_years_page)
+        .to have_selector('[for="course-age-range-in-years-other-field"]', text: "Another age range")
     end
 
     scenario "has the correct value selected" do
-      expect(age_range_in_years_page.age_range_fields)
-        .to have_field("course_age_range_in_years_11_to_16", checked: true)
+      expect(age_range_in_years_page)
+        .to have_field("course-age-range-in-years-11-to-16-field", checked: true)
     end
 
     scenario "can be updated with a pre-determined age range" do
@@ -121,8 +120,14 @@ feature "Edit course age range in years", type: :feature do
         age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
-        expect(age_range_in_years_page.error_flash).to have_content(
-          "You’ll need to correct some information.\nEnter an age in both From and To",
+        expect(age_range_in_years_page).to have_content(
+          "You’ll need to correct some information.",
+        )
+        expect(age_range_in_years_page).to have_content(
+          "Enter an age in From",
+        )
+        expect(age_range_in_years_page).to have_content(
+          "Enter an age in To",
         )
       end
 
@@ -132,8 +137,11 @@ feature "Edit course age range in years", type: :feature do
         age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
-        expect(age_range_in_years_page.error_flash).to have_content(
-          "You’ll need to correct some information.\nEnter an age in To",
+        expect(age_range_in_years_page).to have_content(
+          "You’ll need to correct some information.",
+        )
+        expect(age_range_in_years_page).to have_content(
+          "Enter an age in To",
         )
       end
 
@@ -143,8 +151,11 @@ feature "Edit course age range in years", type: :feature do
         age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
-        expect(age_range_in_years_page.error_flash).to have_content(
-          "You’ll need to correct some information.\nEnter an age in From",
+        expect(age_range_in_years_page).to have_content(
+          "You’ll need to correct some information.",
+        )
+        expect(age_range_in_years_page).to have_content(
+          "Enter an age in From",
         )
       end
 
@@ -155,8 +166,11 @@ feature "Edit course age range in years", type: :feature do
         age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
-        expect(age_range_in_years_page.error_flash).to have_content(
-          "You’ll need to correct some information.\nEnter a valid age in From",
+        expect(age_range_in_years_page).to have_content(
+          "You’ll need to correct some information.",
+        )
+        expect(age_range_in_years_page).to have_content(
+          "Enter a valid age in From",
         )
       end
 
@@ -167,8 +181,11 @@ feature "Edit course age range in years", type: :feature do
         age_range_in_years_page.save.click
 
         expect(age_range_in_years_page).to be_displayed
-        expect(age_range_in_years_page.error_flash).to have_content(
-          "You’ll need to correct some information.\nEnter a valid age in To",
+        expect(age_range_in_years_page).to have_content(
+          "You’ll need to correct some information.",
+        )
+        expect(age_range_in_years_page).to have_content(
+          "Enter a valid age in To",
         )
       end
     end

--- a/spec/form_objects/age_range_form_spec.rb
+++ b/spec/form_objects/age_range_form_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe AgeRangeForm do
+  let(:preset_ranges) { %w[11_to_16 11_to_18 14_to_19] }
+
+  describe "#new" do
+    context "when a custom age_range" do
+      subject { described_class.new(age_range_in_years: "10_to_20", presets: preset_ranges) }
+
+      it "populates from and to and sets as other" do
+        expect(subject.age_range_in_years).to eql("other")
+        expect(subject.course_age_range_in_years_other_from).to eql(10)
+        expect(subject.course_age_range_in_years_other_to).to eql(20)
+      end
+    end
+
+    context "when a preset age_range" do
+      subject { described_class.new(age_range_in_years: "11_to_16", presets: preset_ranges) }
+
+      it "uses preset value" do
+        expect(subject.age_range_in_years).to eql("11_to_16")
+        expect(subject.course_age_range_in_years_other_from).to be_nil
+        expect(subject.course_age_range_in_years_other_to).to be_nil
+      end
+    end
+  end
+
+  describe "validations" do
+    context "when age_range_in_years not selected" do
+      subject { described_class.new(age_range_in_years: nil) }
+
+      it "is not valid" do
+        expect(subject.valid?).to be_falsey
+      end
+    end
+
+    context "when age_range_in_years is other" do
+      context "and from years is not present" do
+        subject do
+          described_class.new(age_range_in_years: "other",
+                              course_age_range_in_years_other_from: nil,
+                              course_age_range_in_years_other_to: "10",
+                              presets: preset_ranges)
+        end
+
+        it "is not valid" do
+          expect(subject.valid?).to be_falsey
+        end
+      end
+
+      context "and to years is not present" do
+        subject do
+          described_class.new(age_range_in_years: "other",
+                              course_age_range_in_years_other_from: "10",
+                              course_age_range_in_years_other_to: nil,
+                              presets: preset_ranges)
+        end
+
+        it "is not valid" do
+          expect(subject.valid?).to be_falsey
+        end
+      end
+    end
+
+    context "when from is bigger than to age" do
+      subject do
+        described_class.new(age_range_in_years: "other",
+                            course_age_range_in_years_other_from: "11",
+                            course_age_range_in_years_other_to: "10",
+                            presets: preset_ranges)
+      end
+
+      it "is not valid" do
+        expect(subject.valid?).to be_falsey
+      end
+    end
+
+    context "when custom age range is under 4 years" do
+      subject do
+        described_class.new(age_range_in_years: "other",
+                            course_age_range_in_years_other_from: "10",
+                            course_age_range_in_years_other_to: "11",
+                            presets: preset_ranges)
+      end
+
+      it "is not valid" do
+        expect(subject.valid?).to be_falsey
+      end
+    end
+
+    context "when from age is outside allowed range" do
+      subject do
+        described_class.new(age_range_in_years: "other",
+                            course_age_range_in_years_other_from: "47",
+                            course_age_range_in_years_other_to: "49",
+                            presets: preset_ranges)
+      end
+
+      it "is not valid" do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors[:course_age_range_in_years_other_from]).to include("From age must be between 0 and 46")
+      end
+    end
+
+    context "when from age is outside allowed range" do
+      subject do
+        described_class.new(age_range_in_years: "other",
+                            course_age_range_in_years_other_from: "10",
+                            course_age_range_in_years_other_to: "51",
+                            presets: preset_ranges)
+      end
+
+      it "is not valid" do
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors[:course_age_range_in_years_other_to]).to include("To age must be between 4 and 50")
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/course_age_range.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_age_range.rb
@@ -4,12 +4,11 @@ module PageObjects
       class CourseAgeRange < CourseBase
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/age-range"
 
-        element :age_range_fields, '[data-qa="course__age_range_in_years"]'
-        element :age_range_14_to_19, '[data-qa="course__age_range_in_years_14_to_19_radio"]'
-        element :age_range_other, '[data-qa="course__age_range_in_years_other_radio"]'
-        element :age_range_from_field, '[data-qa="course__age_range_in_years_other_from_input"]'
-        element :age_range_to_field, '[data-qa="course__age_range_in_years_other_to_input"]'
-        element :save, '[data-qa="course__save"]'
+        element :age_range_14_to_19, "#course-age-range-in-years-14-to-19-field"
+        element :age_range_other, "#course-age-range-in-years-other-field"
+        element :age_range_from_field, "#course-course-age-range-in-years-other-from-field"
+        element :age_range_to_field, "#course-course-age-range-in-years-other-to-field"
+        element :save, 'input[type="submit"]'
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/xsGZiaX2/3644-age-range-validation-message-link
- On attempt to publish with missing age range the error summary link would not navigate to the age range page so the user could fix the issue

### Changes proposed in this pull request

- On attempting to publish if age range is missing the validation summary link now goes to the age range page
- From this link on page load of the age range page errors are displayed to the user
- The age range page now uses a form object
- Validations have been moved from the controller to the form object
- The age range page now uses the gov uk formbuilder
- Browser side validations have been ported to publish side validations
- Site prism page objects no longer use data-qa references and now use ids
- Some validation messages have been improved but can still do with improvement but is outside the scope of this change

### Guidance to review

- https://s121d02-3644-ptt-as.azurewebsites.net/
- Login as an admin
- Find a rolled over course that does not have an age range eg `/organisations/17K/2021/courses`
- Attempt to publish the course
- Should see error summary with link to age range error
- Click on this error
- Should be take to age range page
- Errors should be displayed on this page on page load

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
