### PR TITLE
[3678] - Course vacancies open (all locations)

### DIFF
--- a/app/controllers/courses/vacancies_controller.rb
+++ b/app/controllers/courses/vacancies_controller.rb
@@ -49,7 +49,7 @@ module Courses
         site_status.save
       end
 
-      @course.send_vacancies_updated_notification({ vacancies_filled: single_site_no_vacancies? })
+      send_vacancies_updated_notification(vacancies_filled: single_site_no_vacancies?)
     end
 
     def update_vacancies_for_multiple_sites
@@ -71,8 +71,8 @@ module Courses
         site_status.save
       end
 
-      @course.send_vacancies_updated_notification({ vacancies_filled: true }) if all_sites_have_no_vacancies?
-      @course.send_vacancies_updated_notification({ vacancies_filled: false }) if all_sites_have_vacancies?
+      send_vacancies_updated_notification(vacancies_filled: true) if all_sites_have_no_vacancies?
+      send_vacancies_updated_notification(vacancies_filled: false) if all_sites_have_vacancies?
     end
 
     def build_course
@@ -93,16 +93,25 @@ module Courses
     end
 
     def single_site_no_vacancies?
-      params[:change_vacancies_confirmation] == "no_vacancies_confirmation" && @course.has_vacancies? == true
+      params[:change_vacancies_confirmation] == "no_vacancies_confirmation" && @course.has_vacancies?
     end
 
     def all_sites_have_no_vacancies?
-      @course.has_vacancies? == true &&
+      @course.has_vacancies? &&
         (params[:course][:has_vacancies] == "false" || vacancy_statuses.all? { |v| v == "no_vacancies" })
     end
 
     def all_sites_have_vacancies?
       params[:course][:has_vacancies] == "true" && vacancy_statuses.all? { |v| v != "no_vacancies" }
+    end
+
+    def send_vacancies_updated_notification(vacancies_filled:)
+      @course.send_vacancies_updated_notification(
+        course_code: @course.course_code,
+        recruitment_cycle_year: @course.recruitment_cycle_year,
+        provider_code: params[:provider_code],
+        vacancies_filled: vacancies_filled,
+      )
     end
 
     def vacancy_statuses

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -27,9 +27,9 @@ class Base < JsonApiClient::Resource
 
 private
 
-  def post_request(path)
+  def post_request(path, attributes = {})
     post_options = {
-      body: { data: { attributes: {}, type: self.class.to_s.downcase } },
+      body: { data: { attributes: attributes, type: self.class.to_s.downcase } },
       params: request_params.to_params,
     }
 

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -27,9 +27,9 @@ class Base < JsonApiClient::Resource
 
 private
 
-  def post_request(path, attributes = {})
+  def post_request(path)
     post_options = {
-      body: { data: { attributes: attributes, type: self.class.to_s.downcase } },
+      body: { data: { attributes: {}, type: self.class.to_s.downcase } },
       params: request_params.to_params,
     }
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -26,8 +26,8 @@ class Course < Base
     post_request("/withdraw")
   end
 
-  def send_vacancies_filled_notification
-    post_request("/send_vacancies_filled_notification")
+  def send_vacancies_updated_notification(body = {})
+    post_request("/send_vacancies_updated_notification", body)
   end
 
   def self.build_new(params)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,6 +12,8 @@ class Course < Base
   property :science, type: :string
   property :name, type: :string
 
+  custom_endpoint :send_vacancies_updated_notification, on: :member, request_method: :post
+
   self.primary_key = :course_code
 
   def publish
@@ -24,10 +26,6 @@ class Course < Base
 
   def withdraw
     post_request("/withdraw")
-  end
-
-  def send_vacancies_updated_notification(body = {})
-    post_request("/send_vacancies_updated_notification", body)
   end
 
   def self.build_new(params)


### PR DESCRIPTION
### Context
Currently, subscribed users are only being notified if a course has no vacancies (all locations).

See associated API PR - https://github.com/DFE-Digital/teacher-training-api/pull/1483. This also has notification examples.

### Changes proposed in this pull request
- When a user updates course locations to from closed to open we want to trigger the vacancies updated notification. Specifically, the notification is triggered when a course has a single location and it is updated from closed to open, or when the course has multiple locations and all locations are changed to open.

### Guidance to review
- To run locally you will need to run this branch against  https://github.com/DFE-Digital/teacher-training-api/pull/1483 and have a Notify test key configured

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
