### PR TITLE
[3642] Amended log safe current user to be lean

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,10 +61,13 @@ class ApplicationController < ActionController::Base
 
   def log_safe_current_user(reload: false)
     if @log_safe_current_user.nil? || reload
-      @log_safe_current_user = current_user.dup
-      email = @log_safe_current_user["info"]&.fetch("email", "")
-      @log_safe_current_user.delete("info")
-      @log_safe_current_user["email_md5"] = Digest::MD5.hexdigest(email)
+      email = current_user["info"]&.fetch("email", "")
+
+      @log_safe_current_user = {
+        email_md5: Digest::MD5.hexdigest(email),
+        sign_in_user_id: current_user["uid"],
+        user_id: current_user["user_id"],
+      }
     end
     @log_safe_current_user
   end


### PR DESCRIPTION
### Context
Currently the log safe current user was logging way to much details

### Changes proposed in this pull request
Amended log safe current user to be lean

### Guidance to review
``` ruby
      {
        "email_md5"=>"email_md5", 
        "sign_in_user_id"=>"sign_in_user_id", 
        "user_id"=>"user_id"
      }
```

Configure from config/settings.yml or config/settings/development.local.yml
```yml
logstash:
  type: tcp
  host: # Our hostname here
  port: # Our port here
  ssl_enable: true
```
Logs will be much more compact see [kibana example](https://kibana.logit.io/app/kibana#/doc/8ac115c0-aac1-11e8-88ea-0383c11b333a/logstash-2020.07.24?id=xrzQgHMB9CPnJIZAXLuS&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1y,to:now)))


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
