### PR TITLE
[3707] Fix autocomplete clearing hidden input value

### DIFF
--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -47,6 +47,7 @@ export const initAutocomplete = ($el, $input, inputValueTemplate, options = {}) 
       suggestion: result => result && `${result.name} (${result.code})`
     },
     onConfirm: option => ($input.value = option ? option.code : ""),
+    confirmOnBlur: false,
     autoselect: true
   });
 


### PR DESCRIPTION
This fixes a bug with the autocomplete. As soon as the users tabbed
out of the autocomplete or clicked on the submit button or anything which
meant the autocomplete lost focus, the `onConfirm` method would run.  When
it is evaluated a second time the "option" variable is null so the hidden
text field has its value set to an empty string.

This doesn't address our tech debt as to why this autocomplete is different
from all the others the application has. I did do an investigation and it
would seem as though we added this hidden field so that we didn't have to
do another provider lookup from the backend. I'd say from a data integrity and
security POV we should do a lookup from the backend and not rely on the frontend
alone. A user could edit the value or submit some xss.

### Context

### Changes proposed in this pull request

### Guidance to review
- Login as admin user
- Create a new course for a training provider
- On the "Who is the accredited body" page search for a provider that is not already in partnership
  with the training provider you are creating the course for. 
	- Select the provider and submit the page
	    - expected to be taken to the UCAS apply page which asks for maths/english/science grades
- follow the rest of the process and make sure the course is shows the courses as being accredited by the accredited body you selected.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [x] Product Review
