### PR TITLE
[3714] Switch form to use GOV.UK Design System formbuilder

### DIFF
--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -16,7 +16,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course, url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
+    <%= form_with model: course,
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                  url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                  data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
       <%= f.hidden_field :page, value: :requirements %>
       <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
 

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -52,7 +52,7 @@
 
       <%= f.govuk_text_area :other_requirements, label: { text:  'Other requirements (optional)', size:'s' }, max_words: 100, rows: 10 %>
 
-      <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
+      <%= f.govuk_submit "Save" %>
 
       <p class="govuk-body">
         <%= link_to 'Cancel changes',

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -25,12 +25,7 @@
 
       <p class="govuk-body">State the minimum academic qualifications needed for this course. You could also say what happens if these requirements aren’t met.</p>
 
-      <div id="required_qualifications_wrapper" class="govuk-character-count" data-module="govuk-character-count" data-maxwords="100">
-        <%= render "shared/form_field",
-          form: f, field: :required_qualifications, label: 'Qualifications needed', label_bold: true do |field, options| %>
-          <%= f.text_area field, options.merge(rows: 10, class: 'govuk-textarea govuk-js-character-count') %>
-        <% end %>
-      </div>
+      <%= f.govuk_text_area :required_qualifications, label: { text: 'Qualifications needed', size:'s' }, max_words: 100, rows: 10 %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
@@ -39,12 +34,7 @@
       <p class="govuk-body">Tell applicants about the skills, motivation and experience you’re looking for (eg experience with children, a genuine passion for the subject, or a talent for public speaking).
       </p>
 
-      <div id="personal_qualities_wrapper" class="govuk-character-count" data-module="govuk-character-count" data-maxwords="100">
-        <%= render "shared/form_field",
-          form: f, field: :personal_qualities, label: 'Personal qualities (optional)', label_bold: true do |field, options| %>
-          <%= f.text_area field, options.merge(rows: 10, class: 'govuk-textarea govuk-js-character-count') %>
-        <% end %>
-      </div>
+      <%= f.govuk_text_area :personal_qualities, label: { text: 'Personal qualities (optional)', size:'s' }, max_words: 100, rows: 10 %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
@@ -53,12 +43,7 @@
       <p class="govuk-body">If applicants need any non-academic qualifications or documents, list them here (eg criminal record checks, or relevant work experience).
       </p>
 
-      <div id="other_requirements_wrapper" class="govuk-character-count" data-module="govuk-character-count" data-maxwords="100">
-        <%= render "shared/form_field",
-          form: f, field: :other_requirements, label: 'Other requirements (optional)', label_bold: true do |field, options| %>
-          <%= f.text_area field, options.merge(rows: 10, class: 'govuk-textarea govuk-js-character-count') %>
-        <% end %>
-      </div>
+      <%= f.govuk_text_area :other_requirements, label: { text:  'Other requirements (optional)', size:'s' }, max_words: 100, rows: 10 %>
 
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -7,20 +7,20 @@
 <%= render partial: 'courses/copy_content_warning',
                     locals: { copied_fields: @copied_fields } if params[:copy_from].present? %>
 
-<%= render 'shared/errors' %>
+<%= form_with model: course,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+              url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+              data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
+  <%= f.hidden_field :page, value: :requirements %>
+  <%= f.govuk_error_summary "You’ll need to correct some information." %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-  Requirements and eligibility
-</h1>
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+    Requirements and eligibility
+  </h1>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-                  url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                  data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
-      <%= f.hidden_field :page, value: :requirements %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
 
       <p class="govuk-body">
@@ -59,13 +59,13 @@
                     provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                     class: "govuk-link govuk-link--no-visited-state" %>
       </p>
-    <% end %>
-  </div>
+    </div>
 
-  <aside class="govuk-grid-column-one-third">
-    <%= render partial: 'courses/related_sidebar',
-                        locals: {
-                          course: course,
-                          page_path: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) } %>
-  </aside>
-</div>
+    <aside class="govuk-grid-column-one-third">
+      <%= render partial: 'courses/related_sidebar',
+                          locals: {
+                            course: course,
+                            page_path: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) } %>
+    </aside>
+  </div>
+<% end %>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -23,7 +23,10 @@
       <%= f.hidden_field :page, value: :requirements %>
       <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
 
-      <p class="govuk-body">State the minimum academic qualifications needed for this course. You could also say what happens if these requirements aren’t met.</p>
+      <p class="govuk-body">
+        State the minimum academic qualifications needed for this course.
+        You could also say what happens if these requirements aren’t met.
+      </p>
 
       <%= f.govuk_text_area :required_qualifications, label: { text: 'Qualifications needed', size:'s' }, max_words: 100, rows: 10 %>
 
@@ -31,7 +34,9 @@
 
       <h3 class="govuk-heading-l remove-top-margin">Personal qualities</h3>
 
-      <p class="govuk-body">Tell applicants about the skills, motivation and experience you’re looking for (eg experience with children, a genuine passion for the subject, or a talent for public speaking).
+      <p class="govuk-body">
+        Tell applicants about the skills, motivation and experience you’re looking for
+        (eg experience with children, a genuine passion for the subject, or a talent for public speaking).
       </p>
 
       <%= f.govuk_text_area :personal_qualities, label: { text: 'Personal qualities (optional)', size:'s' }, max_words: 100, rows: 10 %>
@@ -40,7 +45,9 @@
 
       <h3 class="govuk-heading-l remove-top-margin">Other requirements</h3>
 
-      <p class="govuk-body">If applicants need any non-academic qualifications or documents, list them here (eg criminal record checks, or relevant work experience).
+      <p class="govuk-body">
+        If applicants need any non-academic qualifications or documents, list them here
+        (eg criminal record checks, or relevant work experience).
       </p>
 
       <%= f.govuk_text_area :other_requirements, label: { text:  'Other requirements (optional)', size:'s' }, max_words: 100, rows: 10 %>
@@ -48,7 +55,9 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= link_to 'Cancel changes',
+                    provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                    class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>
   </div>

--- a/spec/site_prism/page_objects/page/organisations/course_requirements.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_requirements.rb
@@ -5,9 +5,9 @@ module PageObjects
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/requirements"
 
         element :enrichment_form, '[data-qa="enrichment-form"]'
-        element :required_qualifications, "#course_required_qualifications"
-        element :personal_qualities, "#course_personal_qualities"
-        element :other_requirements, "#course_other_requirements"
+        element :required_qualifications, "#course-required-qualifications-field"
+        element :personal_qualities, "#course-personal-qualities-field"
+        element :other_requirements, "#course-other-requirements-field"
       end
     end
   end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Switches the page to use GOV.UK Design System form builder
- Fixes styling issues where is any field had a validation error then all the fields were styled as having errors.
- Clicking on the Error summary should now take the user directly to the text area and set focus to it.
## Before
![image](https://user-images.githubusercontent.com/3441519/88403377-5fa2a480-cdc4-11ea-9c58-2677846761da.png)

## After
![image](https://user-images.githubusercontent.com/3441519/88403334-51548880-cdc4-11ea-9376-9953ed3e243c.png)

### With Errors
![image](https://user-images.githubusercontent.com/3441519/88403221-2b2ee880-cdc4-11ea-94d0-9d79458b56e2.png)


### Guidance to review
- go to https://s121d02-3714-ptt-as.azurewebsites.net/
- Login as a user and edit a course
- check the requirements page has word count
- try input more words than allowed 
- click on the link in the error at the top of the page. It should take to the form field that is invalid


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
