### PR TITLE
[3703] Add notice summary banner to course show page

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -24,6 +24,19 @@
   </div>
 <% end %>
 
+<% if course.age_range_in_years.nil? && !course.is_further_education? %>
+  <div class="app-notice-summary" role="alert" aria-labelledby="notice-summary-heading" tabindex="-1" data-module="govuk-error-summary">
+    <h3 class="app-notice-summary__title" id="notice-summary-heading">You need to provide some information before publishing this course</h3>
+    <p class="app-notice-summary__body" id="notice-summary-body">
+      <%= link_to age_range_provider_recruitment_cycle_course_path(@provider.provider_code,
+                                                                   course.recruitment_cycle_year,
+                                                                   course.course_code), class: "app-notice-summary__link" do %>
+        Specify an age range
+      <% end %>
+    </p>
+  </div>
+<% end %>
+
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl"><%= course.description %></span>
   <%= course.name_and_code %>

--- a/app/webpacker/stylesheets/_notice-summary.scss
+++ b/app/webpacker/stylesheets/_notice-summary.scss
@@ -1,0 +1,38 @@
+.app-notice-summary {
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(8, "bottom");
+
+  border: $govuk-border-width-narrow solid govuk-colour("blue");
+
+  &:focus {
+    outline: ($govuk-focus-width * 2) solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
+  }
+
+  *:last-child {
+    margin-bottom: 0;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    border: $govuk-border-width solid govuk-colour("blue");
+  }
+}
+
+.app-notice-summary__title {
+  @include govuk-font($size: 24, $weight: bold);
+  @include govuk-responsive-margin(4, "bottom");
+  margin-top: 0;
+}
+
+.app-notice-summary__body {
+  @include govuk-font($size: 19);
+}
+
+.app-notice-summary__link {
+  @include govuk-font($size: 19, $weight: bold);
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
+
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -13,6 +13,7 @@ $success-green: #00823b;
 @import "~govuk-frontend/govuk/all";
 
 @import "success-summary";
+@import "notice-summary";
 @import "phase-tag";
 @import "course-tabs";
 @import "currency-input";

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -343,6 +343,58 @@ feature "Course show", type: :feature do
           expect(course_page.error_summary).to have_content("About course can't be blank")
         end
       end
+
+      describe "age range notice summary" do
+        context "with primary" do
+          context "with age range set" do
+            let(:course) { build(:course, level: "primary", provider: provider, age_range_in_years: "7_to_11") }
+            it "should not display the banner" do
+              course_page.load(provider_code: provider.provider_code,
+                               recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
+              expect(course_page).to have_no_notice_summary_banner
+            end
+          end
+
+          context "with no age range set" do
+            let(:course) { build(:course, level: "primary", provider: provider, age_range_in_years: nil) }
+            it "should display the banner" do
+              course_page.load(provider_code: provider.provider_code,
+                               recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
+              expect(course_page).to have_notice_summary_banner
+            end
+          end
+        end
+
+        context "with secondary " do
+          context "with age range set" do
+            let(:course) { build(:course, level: "secondary", provider: provider, age_range_in_years: "7_to_11") }
+            it "should not display the banner" do
+              course_page.load(provider_code: provider.provider_code,
+                               recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
+              expect(course_page).to have_no_notice_summary_banner
+            end
+          end
+
+          context "with no age range set" do
+            let(:course) { build(:course, level: "secondary", provider: provider, age_range_in_years: nil) }
+            it "should display the banner" do
+              course_page.load(provider_code: provider.provider_code,
+                               recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
+              expect(course_page).to have_notice_summary_banner
+            end
+          end
+        end
+
+        context "with further eduction" do
+          let(:course) { build(:course, level: "secondar", provider: provider) }
+
+          scenario "no age range summary notice" do
+            course_page.load(provider_code: provider.provider_code,
+                             recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
+            expect(course_page).to have_no_notice_summary_banner
+          end
+        end
+      end
     end
   end
 end

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -30,6 +30,10 @@ module PageObjects
         element :status_panel, "[data-qa=course__status_panel]"
         element :withdraw_link, '[data-qa="course__withdraw-link"]'
         element :delete_link, '[data-qa="course__delete-link"]'
+
+        section :notice_summary_banner, ".app-notice-summary" do
+          element :age_range_link, ".app-notice-summary__link"
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
This banner will be used to help notify users in the service when they
are missing data and need to correct it before the can publish courses


### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/3441519/88774796-cb499080-d17b-11ea-96df-02fa9e845f17.png)

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
