### PR TITLE
[3685] Persona login and dev auth

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Style/HashTransformValues:
   Enabled: false
 Rails/FindBy:
   Enabled: false
+Rails/ApplicationController:
+  Exclude:
+    - app/controllers/personas_controller.rb
 
 # rubocop-govuk 3.17.0 started to enforce this but no active record is actually in use
 # https://github.com/alphagov/rubocop-govuk/commit/c4a4329d5e44dc98b24f1d344a3532054b1539e0

--- a/README.md
+++ b/README.md
@@ -34,38 +34,7 @@ bundle
 bundle exec rake webpacker:compile
 ```
 
-### 3. Setup Basic Auth Login
-
-For local development, we rely on Basic Auth instead of DFE Sign-In, which can
-be enabled if required. This will require that you have a login in the database,
-this will be there if you have an account in production but if you don't yet, or
-don't want to use it, you can create a user locally with:
-
-```ruby
-# Optional, use if you don't already have an account.
-User.create(admin: true,
-            email: "john.smith@digital.education.gov.uk",
-            first_name: "John",
-            last_name: "Smith",
-            welcome_email_date_utc: Time.zone.now,
-            accept_terms_date_utc: Time.zone.now,
-            invite_date_utc: Time.zone.now,
-            state: "transitioned")
-```
-
-Then create the file `config/settings/development.local.yml` with the contents:
-
-```yaml
-authorised_users:
-  0:
-    first_name: [your first name, this will be updated in the db]
-    last_name: [your last name, this will be updated in the db]
-    email: [the email address to login with]
-    password: [the password you wish to use]
-```
-
-
-### 4. Run the server
+### 3. Run the server
 
 1. Run `bundle exec rails s` to launch the app on https://localhost:3000.
 
@@ -162,11 +131,27 @@ To track exceptions through Sentry, configure the `SENTRY_DSN` environment varia
 SENTRY_DSN=https://aaa:bbb@sentry.io/123 rails s
 ```
 
+## Basic auth
+
+Basic auth is enabled in non-production and non-local environments. The credentials can be found in the Confluence pages.
+
+## Persona login
+
+Persona login is availale in local development and non-production environments. This allows you to log in to existing anonymised accounts or pre-selected accounts identified by personas.
+
 ## Using DfE Sign-In
 
 Occasionally you may want to test the system integration with DfE Sign-In. In
 the dev environment the system is configured to use basic auth so you need to
 take a few extra steps to make it work with DfE Sign-In.
+
+### Disable developer auth
+
+The developer auth strategy supercedes DfE Sign-In and must be disabled first.
+
+In `config/settings/development.local.yml` set `developer_auth` to `false`
+
+The app must be rebooted in order for this change to take affect.
 
 ### Ensure You Have a DfE Sign-In Account
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Backend
 
+  before_action :http_basic_auth
   before_action :authenticate
   before_action :store_request_id
   before_action :request_login
@@ -34,17 +35,6 @@ class ApplicationController < ActionController::Base
   def current_user
     if is_authenticated?
       session[:auth_user]
-    elsif development_mode_auth?
-      user = authenticate_with_http_basic do |email, pass|
-        authorise_development_mode?(email, pass)
-      end
-      if user.present?
-        setup_development_mode_session(
-          email: user.email,
-          first_name: user.first_name,
-          last_name: user.last_name,
-        )
-      end
     end
   end
 
@@ -73,10 +63,6 @@ class ApplicationController < ActionController::Base
     @log_safe_current_user
   end
 
-  def development_mode_auth?
-    !Rails.env.production? && Settings.key?(:authorised_users)
-  end
-
   def magic_link_enabled?
     Settings.features.signin_intercept && Settings.features.signin_by_email && !Settings.features.dfe_signin
   end
@@ -101,16 +87,11 @@ class ApplicationController < ActionController::Base
   def request_login
     return if current_user.present?
 
-    if development_mode_auth?
-      logger.info("Doing development mode authentication")
-      request_http_basic_authentication("Development Mode")
-    else
-      logger.info("Authenticated user session not found " + {
-        redirect_back_to: request.path,
-      }.to_s)
-      session[:redirect_back_to] = request.path
-      redirect_to "/signin"
-    end
+    logger.info("Authenticated user session not found " + {
+      redirect_back_to: request.path,
+    }.to_s)
+    session[:redirect_back_to] = request.path
+    redirect_to "/signin"
   end
 
   def current_user_info
@@ -131,6 +112,14 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def http_basic_auth
+    if Settings.basic_auth
+      authenticate_or_request_with_http_basic do |name, password|
+        name == Settings.basic_auth_username && Digest::SHA512.hexdigest(password) == Settings.basic_auth_password_digest
+      end
+    end
+  end
 
   def check_interrupt_redirects(use_redirect_back_to: true)
     if !user_from_session.accepted_terms?

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,0 +1,12 @@
+if Settings.developer_auth
+  class PersonasController < ActionController::Base
+    layout "application"
+
+    def index; end
+
+    def current_user
+      session[:auth_user].presence
+    end
+    helper_method :current_user
+  end
+end

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,0 +1,81 @@
+<h1 class="govuk-heading-xl">Publish test users</h1>
+
+<%= link_to "Login as anonymised user", "/auth/developer", class: 'govuk-link' %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<h2 class="govuk-heading-l">Anne</h2>
+<strong class="govuk-tag govuk-tag--blue">Non-accredited</strong>
+
+<p class="govuk-body govuk-!-padding-top-5">
+  Anne is a course administrator who belongs to one school direct.
+</p>
+
+<%= form_tag("/auth/developer/callback") do %>
+  <%= hidden_field_tag "email", "anonimized-user-10599@example.org" %>
+  <%= hidden_field_tag "first_name", "Course administrator" %>
+  <%= hidden_field_tag "last_name", "Anne" %>
+
+  <%= submit_tag "Login as Anne", class: "govuk-button" %>
+<% end %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<h2 class="govuk-heading-l">Susy</h2>
+<strong class="govuk-tag govuk-tag--blue">Accredited</strong>
+<strong class="govuk-tag govuk-tag--blue">Non-accredited</strong>
+
+<p class="govuk-body govuk-!-padding-top-5">
+  Susy belongs to one accredited body.
+</p>
+
+<%= form_tag("/auth/developer/callback") do %>
+  <%= hidden_field_tag "email", "anonimized-user-8847@example.org" %>
+  <%= hidden_field_tag "first_name", "ITT partnership manager" %>
+  <%= hidden_field_tag "last_name", "Susy" %>
+
+  <%= submit_tag "Login Susy", class: "govuk-button" %>
+<% end %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<h2 class="govuk-heading-l">Mary</h2>
+
+<strong class="govuk-tag govuk-tag--blue">Multi-org</strong>
+<strong class="govuk-tag govuk-tag--blue">Accredited</strong>
+<strong class="govuk-tag govuk-tag--blue">Non-accredited</strong>
+
+<p class="govuk-body govuk-!-padding-top-5">
+Mary belongs to:
+  <ul class="govuk-list govuk-list--bullet">
+    <li>multiple accredited bodies, <strong>Suffolk and Norfolk Primary SCITT</strong> and <strong>Suffolk and Norfolk Secondary SCITT</strong></li>
+    <li>a school direct <strong>Thorpe St Andrew School and Sixth Form</strong> with courses accredited by <strong>Suffolk and Norfolk Secondary SCITT</strong></li>
+    <li>a school direct <strong>Thorpe St Andrew School and Sixth Form</strong> with courses also accredited by an organisation not associated with Mary</li>
+  </ul>
+</p>
+
+<%= form_tag("/auth/developer/callback") do %>
+  <%= hidden_field_tag "email", "anonimized-user-7839@example.org" %>
+  <%= hidden_field_tag "first_name", "Multi-org administrator" %>
+  <%= hidden_field_tag "last_name", "Mary" %>
+
+  <%= submit_tag "Login as Mary", class: "govuk-button" %>
+<% end %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<h2 class="govuk-heading-l">Colin</h2>
+
+<strong class="govuk-tag govuk-tag--blue">Support</strong>
+
+<p class="govuk-body govuk-!-padding-top-5">
+  Colin belongs to all organisations with adminstration access
+</p>
+
+<%= form_tag("/auth/developer/callback") do %>
+  <%= hidden_field_tag "email", "becomingateacher+admin-integration-tests@digital.education.gov.uk" %>
+  <%= hidden_field_tag "first_name", "Support agent" %>
+  <%= hidden_field_tag "last_name", "Colin" %>
+
+  <%= submit_tag "Login as Colin", class: "govuk-button" %>
+<% end %>

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "Publish test users" %>
+
 <h1 class="govuk-heading-xl">Publish test users</h1>
 
 <%= link_to "Login as anonymised user", "/auth/developer", class: 'govuk-link' %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,11 @@
+if Settings.developer_auth
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider :developer,
+             fields: %i[email first_name last_name],
+             uid_field: :email
+  end
+end
+
 module OmniAuth
   module Strategies
     class OpenIDConnect

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,11 @@ Rails.application.routes.draw do
   get :healthcheck, controller: :heartbeat
   get :sha, controller: :heartbeat
 
+  if Settings.developer_auth
+    post "/auth/developer/callback", to: "sessions#create"
+    get "/personas", to: "personas#index"
+  end
+
   # DfE Sign In
   get "/signin", to: "sessions#new", as: "signin"
   post "/send_magic_link", to: "sessions#send_magic_link"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -72,3 +72,7 @@ features:
     has_current_cycle_started?: true
 commit_sha_file: COMMIT_SHA
 allocations_state: closed
+basic_auth: false
+basic_auth_username: admin
+basic_auth_password_digest: "52785638ec464fd61f5c9b372797f1a7475225cabeb2b40b2d757eff9b337ff069b2314bb0c0611d44ca5d39c91906ab3415de0fbc36625b970e3c2c03d122da"
+developer_auth: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -11,3 +11,5 @@ environment:
   selector_name: "development"
 log_level: debug
 use_ssl: false
+basic_auth: false
+developer_auth: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -8,3 +8,5 @@ search_ui:
 environment:
   label: "QA"
   selector_name: "qa"
+basic_auth: true
+developer_auth: true

--- a/config/settings/research.yml
+++ b/config/settings/research.yml
@@ -6,3 +6,5 @@ manage_backend:
 environment:
   label: "QA"
   selector_name: "qa"
+basic_auth: true
+developer_auth: true

--- a/config/settings/rollover.yml
+++ b/config/settings/rollover.yml
@@ -6,3 +6,5 @@ manage_backend:
 environment:
   label: "Rollover"
   selector_name: "qa"
+basic_auth: true
+developer_auth: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -11,3 +11,5 @@ search_ui:
 environment:
   label: "Staging"
   selector_name: "staging"
+basic_auth: true
+developer_auth: true

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -47,10 +47,6 @@ describe ApplicationController, type: :controller do
     describe "#authenticate" do
       subject { controller.authenticate }
 
-      before do
-        disable_authorised_development_user
-      end
-
       context "user_id is not blank" do
         let(:user_id) { 666 }
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -69,5 +69,31 @@ describe SessionsController, type: :controller do
         expect(response).to redirect_to("/personas")
       end
     end
+
+    context "when using magic link" do
+      before do
+        allow(Settings.features).to receive(:signin_intercept).and_return(true)
+        allow(Settings.features).to receive(:signin_by_email).and_return(true)
+        allow(Settings.features).to receive(:dfe_signin).and_return(false)
+
+        session[:auth_user] = {
+          "uid" => "user@example.com",
+          "user_id" => "some-id",
+          "info" => {
+            "email" => "user@example.com",
+          },
+        }
+      end
+
+      it "resets the session" do
+        get :signout
+        expect(session[:auth_user]).to be_nil
+      end
+
+      it "redirects to /" do
+        get :signout
+        expect(response).to redirect_to("/")
+      end
+    end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -35,4 +35,39 @@ describe SessionsController, type: :controller do
       end
     end
   end
+
+  context "when developer auth is enabled" do
+    describe "#new" do
+      it "redirects to personas login" do
+        allow(Settings).to receive(:developer_auth).and_return(true)
+        get :new
+        expect(response).to redirect_to("/personas")
+      end
+    end
+  end
+
+  describe "#signout" do
+    context "when using developer auth" do
+      before do
+        session[:auth_user] = {
+          "provider" => "developer",
+          "uid" => "user@example.com",
+          "user_id" => "some-id",
+          "info" => {
+            "email" => "user@example.com",
+          },
+        }
+      end
+
+      it "resets the session" do
+        get :signout
+        expect(session[:auth_user]).to be_nil
+      end
+
+      it "redirects to /personas login page" do
+        get :signout
+        expect(response).to redirect_to("/personas")
+      end
+    end
+  end
 end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -1,43 +1,62 @@
 require "rails_helper"
 
 describe "authorisation", type: :request do
-  context "authorised_user defined in settings" do
-    let(:user) { build(:user, password: password) }
-    let(:password) { "password" }
-    let(:provider) { build :provider }
-    let(:recruitment_cycle) { build :recruitment_cycle }
-    let(:headers) { {} }
+  let(:basic_auth) { false }
 
-    before do
-      stub_api_v2_resource(recruitment_cycle)
-      stub_api_v2_resource_collection([provider])
-      stub_api_v2_resource(provider)
-    end
+  around :each do |example|
+    Settings.basic_auth = basic_auth
 
-    context "basic http authenticated" do
-      let(:headers) do
-        {
-          "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic
-                                    .encode_credentials(user.email, password),
-        }
-      end
+    example.run
 
-      it "considers the user logged in" do
-        stub_authorised_development_user(user) do
-          get "/organisations/#{provider.provider_code}", headers: headers
+    Settings.basic_auth = false
+  end
+
+  describe "basic auth" do
+    context "when enabled" do
+      let(:basic_auth) { true }
+
+      context "with correct details" do
+        let(:headers) do
+          {
+            "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic
+                                      .encode_credentials("admin", "secret"),
+          }
         end
 
-        expect(response).to be_successful
+        it "grants access" do
+          expect(Digest::SHA512).to receive(:hexdigest).with("secret").and_return("52785638ec464fd61f5c9b372797f1a7475225cabeb2b40b2d757eff9b337ff069b2314bb0c0611d44ca5d39c91906ab3415de0fbc36625b970e3c2c03d122da").at_least(:once)
+
+          get "/", headers: headers
+          expect(response).to redirect_to("/signin")
+          get "/signin", headers: headers
+          expect(response).to redirect_to("/auth/dfe")
+        end
+      end
+
+      context "with incorrect details" do
+        let(:headers) do
+          {
+            "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic
+                                      .encode_credentials("foo", "bar"),
+          }
+        end
+
+        it "denys access" do
+          get "/", headers: headers
+
+          expect(response).to have_http_status(401)
+        end
       end
     end
 
-    context "without basic http authentication" do
-      it "requests user login" do
-        stub_authorised_development_user(user) do
-          get "/organisations/#{provider.provider_code}", headers: headers
-        end
+    context "when disabled" do
+      let(:basic_auth) { false }
 
-        expect(response).to be_unauthorized
+      it "redirects to DfE signin" do
+        get "/"
+        expect(response).to redirect_to("/signin")
+        get "/signin"
+        expect(response).to redirect_to("/auth/dfe")
       end
     end
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -33,34 +33,6 @@ module Helpers
     )
     Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:dfe]
     stub_api_v2_request("/sessions", user.to_jsonapi, :post)
-
-    disable_authorised_development_user
-  end
-
-  def stub_authorised_development_user(user)
-    raise <<~EOMESSAGE unless block_given?
-      Can only stub authorised_user with a block, for example:
-
-        stub_authorised_development_user(user) do
-          get "/organisations"
-        end
-    EOMESSAGE
-
-    authorised_user = Config::Options.new(
-      email: user.email,
-      password: user.password,
-      first_name: user.first_name,
-      last_name: user.last_name,
-    )
-
-    stub_api_v2_request("/sessions", user.to_jsonapi, :post)
-
-    begin
-      Settings[:authorised_users] = [[0, authorised_user]]
-      yield
-    ensure
-      Settings.delete_field(:authorised_users)
-    end
   end
 
   def stub_api_v2_request(url_path, stub, method = :get, status = 200, token: nil, body: nil, &validate_request_body)
@@ -158,10 +130,6 @@ module Helpers
       url_for_build_course_with_params(params),
       jsonapi_response,
     )
-  end
-
-  def disable_authorised_development_user
-    allow(Settings).to receive(:key?).with(:authorised_users).and_return(false)
   end
 
 private


### PR DESCRIPTION
### Context

- https://trello.com/c/xA11zDVq/3685-m-persona-login
- Testing in review apps and other non-production environments was very difficult as only several user accounts were accessible

### Changes proposed in this pull request

- Remove previous basic auth mechanism which would take these details to a mapped list of allowed users
- Basic auth is now hard coded to simply prevent unknown user access
- Basic auth is now feature flagged and can be enabled/disabled via settings yaml
- Added OmniAuth developer auth strategy which is controlled via settings yaml
- Added persona login page (see screenshot below) which represent some pre-selected users from anonymised dataset
- These pre-selected users simply user the developer auth behind the scenes
- There is a link from persona page to developer auth so you can login as any user as long as their anonymised email address is known
- Updated README about these changes
- Confluence pages will be updated after this change is merged

![screencapture-qa-publish-teacher-training-courses-service-gov-uk-personas-2020-07-30-13_18_52](https://user-images.githubusercontent.com/92580/88921988-594e7580-d267-11ea-85da-cd96895fc984.png)

### Guidance to review

- visit review app https://s121d02-3685-ptt-as.azurewebsites.net/
- basic auth username is `admin`, password can be found on confluence page
- Should be able to login as different personas
- Signout should work and take you back to persona page
- Custom login should work you should be able to login as any anonymised user
- Not sure why code climate fails. It says total coverage has dropped but does not indicate where that is

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
