### PR TITLE
[3732] - update user notification opt in content

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -23,7 +23,7 @@ class NotificationsController < ApplicationController
       enabled: params[:user_notification_preferences][:explicitly_enabled],
     )
 
-    flash[:success] = "Your notification preferences have been saved."
+    flash[:success] = "Email notification preferences for #{user.email} have been saved."
 
     redirect_to redirect_to_path
   end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,21 +3,23 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl" data-qa="page-heading">
-      <span class="govuk-caption-xl">Manage notifications</span>
-      Changes to your courses as an accredited body
+      <span class="govuk-caption-xl">Notifications for accredited bodies</span>
+      Changes to courses
     </h1>
 
     <p class="govuk-body">
-      You can sign up for email notifications about these courses. We’ll tell you when a training provider:
+      We’ll tell you when a training provider:
     </p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
       <li>publishes a new course on Find postgraduate teacher training</li>
       <li>makes a change to an existing course</li>
+      <li>withdraws a course</li>
+      <li>changes the vacancy status of a course</li>
     </ul>
   </div>
 </div>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <%= form_for @notifications_view.user_notification_preferences,
       url: notification_path(@notifications_view.user_id),
       builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
@@ -25,14 +27,14 @@
       <%= form.govuk_radio_buttons_fieldset(
         :explitly_enabled,
         legend: {
-          size: "m",
-          text: "Would you like to be notified?",
+          size: "l",
+          text: "Would you like to receive email notifications?",
           tag: "span" }) do %>
 
         <%= form.govuk_radio_button :explicitly_enabled,
           true,
           label: {
-            text: "Yes, send email notifications to #{@notifications_view.user_email}"
+            text: "Yes, send me notifications"
         } %>
         <%= form.govuk_radio_button :explicitly_enabled,
           false,

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -9,7 +9,7 @@
     <p class="govuk-body">
       All your courses, locations and details have been copied over
       from the current recruitment cycle (2020 to 2021). You can now
-      update them for 2021 – 2022.
+      update them for 2021 to 2022.
     </p>
 
     <p class="govuk-body">You should:</p>

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -1,9 +1,9 @@
-<%= content_for :page_title, "Recruiting for the 2021 - 2022 cycle" %>
+<%= content_for :page_title, "Recruiting for the 2021 to 2022 cycle" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Recruiting for the <br>2021 - 2022 cycle
+      Recruiting for the <br>2021 to 2022 cycle
     </h1>
 
     <p class="govuk-body">
@@ -13,7 +13,7 @@
 
     <p class="govuk-body">
       You can publish all other courses without requesting permission. This applies
-      to courses copied over from the current cycle and new courses added for 2021 - 2022.
+      to courses copied over from the current cycle and new courses added for 2021 to 2022.
     </p>
 
     <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -161,7 +161,7 @@ private
   def then_i_should_see_my_preferences_have_been_saved
     expect(@put_request).to have_been_made
     expect(organisation_show_page)
-      .to have_content("Your notification preferences have been saved")
+      .to have_content("Email notification preferences for #{user.email} have been saved")
   end
 
   def then_yes_radio_button_is_preselected

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -151,7 +151,7 @@ feature "Sign in", type: :feature do
         rollover_page.continue.click
 
         expect(rollover_recruitment_page).to be_displayed
-        expect(rollover_recruitment_page.title).to have_content("Recruiting for the 2021 - 2022 cycle")
+        expect(rollover_recruitment_page.title).to have_content("Recruiting for the 2021 to 2022 cycle")
         rollover_recruitment_page.continue.click
 
         expect(root_page).to be_displayed


### PR DESCRIPTION
### Context
Copy updated to _notification preferences page_ and _notifications preferences saved success_ message.

### Changes proposed in this pull request

#### Notification preferences page

<img width="905" alt="updated_notification_preferences_page" src="https://user-images.githubusercontent.com/5256922/88929542-2cec2680-d272-11ea-8d3e-b7cd1ff9292b.png">

#### Notifications preferences success message

<img width="1145" alt="updated_notification_success_msg" src="https://user-images.githubusercontent.com/5256922/88929445-075f1d00-d272-11ea-86f9-b07efa23ad03.png">

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
