### PR TITLE
[3733] Age range display logic for FE courses

### DIFF
--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -64,21 +64,23 @@
               </dd>
             </div>
 
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Age range
-              </dt>
-              <dd class="govuk-summary-list__value" data-qa="course__age_range">
-                <%= course.age_range %>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <%= course_creation_change_button(
-                  "age range",
-                  "age_range",
-                  :new_provider_recruitment_cycle_courses_age_range_path
-                ) %>
-              </dd>
-            </div>
+            <% unless course.is_further_education? %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Age range
+                </dt>
+                <dd class="govuk-summary-list__value" data-qa="course__age_range">
+                  <%= course.age_range %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <%= course_creation_change_button(
+                    "age range",
+                    "age_range",
+                    :new_provider_recruitment_cycle_courses_age_range_path
+                  ) %>
+                </dd>
+              </div>
+            <% end %>
 
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -286,6 +286,20 @@ feature "Course confirmation", type: :feature do
       include_examples "goes to the edit page"
     end
 
+    context "age range showing" do
+      let(:level) { "primary" }
+      it "does show age range if course is primary" do
+        expect(course_confirmation_page.details).to have_age_range
+      end
+    end
+
+    context "age range not showing" do
+      let(:level) { "further_education" }
+      it "does not show age range if course is further education" do
+        expect(course_confirmation_page.details).to have_no_age_range
+      end
+    end
+
     context "study mode" do
       let(:destination_page) { PageObjects::Page::Organisations::Courses::NewStudyModePage.new }
 


### PR DESCRIPTION
### Context
* https://trello.com/c/H1d6Sd7Q/3733-age-range-should-not-be-displayed-in-the-check-your-answers-page-for-further-education-courses

When adding a new course accredited bodies/training providers do not need to specify an age range for Further Education courses. Therefore, on the 'Check your answers before confirming page', they do not need to see an empty age range field. 

### Changes proposed in this pull request
Removes the age range field on 'Check your answers before confirming page' for FE course but keeps it for Primary and Secondary courses. 

### Guidance to review

Add a new course for FE and Primary/Secondary to see change in age range display on confirmation page

https://s121d02-3733-ptt-as.azurewebsites.net/

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [x] Product Review
