### PR TITLE
[3734] Training providers cannot create further education courses

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -27,19 +27,21 @@
         </dd>
       </div>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= 'Subject'.pluralize(course.subjects.count) %>
-        </dt>
-        <dd class="govuk-summary-list__value" data-qa="course__subjects">
-          <%= course.sorted_subjects %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= link_to subjects_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_subjects_link" } do %>
-            Change<span class="govuk-visually-hidden"> subjects</span>
-          <% end %>
-        </dd>
-      </div>
+      <% unless course.is_further_education? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= 'Subject'.pluralize(course.subjects.count) %>
+          </dt>
+          <dd class="govuk-summary-list__value" data-qa="course__subjects">
+            <%= course.sorted_subjects %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to subjects_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_subjects_link" } do %>
+              Change<span class="govuk-visually-hidden"> subjects</span>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
 
       <% unless course.level == 'further_education' %>
         <div class="govuk-summary-list__row">

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -48,21 +48,23 @@
               </dd>
             </div>
 
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                <%= 'Subject'.pluralize(course.subjects.count) %>
-              </dt>
-              <dd class="govuk-summary-list__value" data-qa="course__subjects">
-                <%= course.sorted_subjects %>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <%= course_creation_change_button(
-                  "subjects",
-                  "subjects",
-                  :new_provider_recruitment_cycle_courses_subjects_path
-                ) %>
-              </dd>
-            </div>
+            <% unless course.is_further_education? %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  <%= 'Subject'.pluralize(course.subjects.count) %>
+                </dt>
+                <dd class="govuk-summary-list__value" data-qa="course__subjects">
+                  <%= course.sorted_subjects %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <%= course_creation_change_button(
+                      "subjects",
+                      "subjects",
+                      :new_provider_recruitment_cycle_courses_subjects_path
+                    ) %>
+                </dd>
+              </div>
+            <% end %>
 
             <% unless course.is_further_education? %>
               <div class="govuk-summary-list__row">

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -187,7 +187,7 @@
               </dd>
             </div>
 
-            <% unless @provider.accredited_body? %>
+            <% unless @provider.accredited_body? || course.is_further_education? %>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
                   Accredited body

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -99,6 +99,14 @@ feature "Course confirmation", type: :feature do
       end
     end
 
+    context "When new course is further education and provider is not accredited body" do
+      let(:provider) { build(:provider, accredited_body?: false) }
+      let(:level) { "further_education"}
+      it "shows further education course details on confirmation page" do
+        expect(course_confirmation_page.details.level.text).to eq("Further education")
+      end
+    end
+    
     context "When the course has nil fields" do
       let(:study_mode) { nil }
       let(:level) { nil }

--- a/spec/features/courses/confirmation_spec.rb
+++ b/spec/features/courses/confirmation_spec.rb
@@ -101,12 +101,12 @@ feature "Course confirmation", type: :feature do
 
     context "When new course is further education and provider is not accredited body" do
       let(:provider) { build(:provider, accredited_body?: false) }
-      let(:level) { "further_education"}
+      let(:level) { "further_education" }
       it "shows further education course details on confirmation page" do
         expect(course_confirmation_page.details.level.text).to eq("Further education")
       end
     end
-    
+
     context "When the course has nil fields" do
       let(:study_mode) { nil }
       let(:level) { nil }
@@ -243,6 +243,20 @@ feature "Course confirmation", type: :feature do
       end
 
       include_examples "goes to the edit page"
+    end
+
+    context "when course is primary or secondary" do
+      let(:level) { "primary" }
+      it "keeps subject field for non-FE courses" do
+        expect(course_confirmation_page.details).to have_subjects
+      end
+    end
+
+    context "when course is further education" do
+      let(:level) { "further_education" }
+      it "removes subject field for FE courses" do
+        expect(course_confirmation_page.details).to have_no_subjects
+      end
     end
 
     context "modern languages" do


### PR DESCRIPTION
### Context
* https://trello.com/c/xLKzxrwb/3734-s-training-providers-cannot-create-further-education-courses
* Non-accredited providers could not reach confirmation page when adding FE courses

### Changes proposed in this pull request
Logic to allow non-accredited providers to reach confirmation page
Subject field removed from confirmation page and basic details tab as there is nothing else to change the subject to and does not appear in course creation wizard

### Guidance to review

https://s121d02-3734-ptt-as.azurewebsites.net/

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [x] Product Review
