### PR TITLE
[3771] fix cypress tests due to persona login changes

### DIFF
--- a/end-to-end-tests/README.md
+++ b/end-to-end-tests/README.md
@@ -1,0 +1,14 @@
+## Running tests
+
+For local development with UI:
+
+```sh
+npx cypress open
+```
+
+Headless via command line:
+
+```sh
+npx cypress run
+npx cypress run --env password="password-goes-here"
+```

--- a/end-to-end-tests/cypress/integration/_publicly_visible/index.js
+++ b/end-to-end-tests/cypress/integration/_publicly_visible/index.js
@@ -5,13 +5,11 @@
 // https://github.com/cypress-io/cypress/issues/5723
 // https://github.com/cypress-io/cypress/issues/781
 
-
 import publicly_visble_pages from "../../fixtures/publicly_visible/pages.json";
 
 const baseUrl = Cypress.config().baseUrl;
 
 describe("publicly visible pages", function () {
-
   publicly_visble_pages.forEach(publicly_visble_page => {
     describe(`${publicly_visble_page.pageType} pages`, function () {
       publicly_visble_page.pages.forEach(page => {
@@ -26,6 +24,10 @@ function canView(page) {
     const url = baseUrl + page.urlPath;
 
     const params = {
+      auth: {
+        username: "admin",
+        password: Cypress.env('password')
+      },
       method: 'GET',
       url: baseUrl + page.urlPath,
       failOnStatusCode: false
@@ -36,7 +38,7 @@ function canView(page) {
       .get(page.selector).contains(page.content);
 
     if(page.selector !== 'body') {
-      cy.get('footer').scrollIntoView({ duration: 2000 });
+      cy.get('footer').scrollIntoView({ duration: 100 });
     }
   };
 };

--- a/end-to-end-tests/cypress/integration/organisations.js
+++ b/end-to-end-tests/cypress/integration/organisations.js
@@ -5,12 +5,24 @@ const baseUrl = Cypress.config().baseUrl;
 describe("login", function () {
   // NOTE: user only has one organisation associated so,
   //       it can not view a list of organisations
-  it.skip("viewing B1T organisation details ", function () {
-    cy.signIn()
-      .visit(baseUrl);
+  it("viewing B1T organisation details ", function () {
+    const params = {
+      auth: {
+        username: "admin",
+        password: Cypress.env('password')
+      },
+      method: 'GET',
+      url: baseUrl
+    }
+
+    cy.visit(params);
+    cy.contains('Login as an anonymised user').click();
+    cy.get('input#email')
+      .type('becomingateacher+integration-tests@digital.education.gov.uk');
+    cy.get('form').submit();
 
     cy.url().should('eq', `${baseUrl}organisations/B1T`);
     cy.get('h1').contains('bat 1');
-    cy.get('footer').scrollIntoView({ duration: 2000 });
+    cy.get('footer').scrollIntoView({ duration: 100 });
   });
 });


### PR DESCRIPTION
### Context

- https://trello.com/b/fXA6ioZN/find-publish-sprint-board
- Fix cypress test in QA and staging
- This was due to change in basic auth details due to persona login change

### Changes proposed in this pull request

- Add basic README to give at least some hints on how to use the cypress tests
- Tweak cypress tests to be compatible with persona logins
- Speed up tests, now takes 100ms to scroll to the bottom of each page instead of 2 seconds

### Guidance to review

- See evidence of it passing https://dfe-ssp.visualstudio.com/Become-A-Teacher/_releaseProgress?_a=release-environment-logs&releaseId=8033&environmentId=46012

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] ~Product Review~
