### PR TITLE
Fixes issue with rspec parallel xml outputs.

### DIFF
--- a/.azure_parallel
+++ b/.azure_parallel
@@ -1,4 +1,0 @@
---require spec_helper
---no-profile
---format RspecJunitFormatter
---out rspec-output/rspec-output<%= ENV['TEST_ENV_NUMBER'] %>.xml

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,2 +1,3 @@
 --format progress
 --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
+--require './spec/spec_helper.rb' --no-profile  --format RspecJunitFormatter --out rspec-output/rspec-output<%= ENV['TEST_ENV_NUMBER'] %>.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ steps:
 - script: |
     set -x
     docker run --name test-run-image -d $(IMAGE_NAME)
-    docker exec test-run-image rake "parallel:spec[,, -O .azure_parallel]"
+    docker exec test-run-image rake parallel:spec
     test_result=$?
 
     docker cp test-run-image:/app/rspec-output .


### PR DESCRIPTION
Our currently implementation seems not to be working anyway. To simplify
our process we are now using `.rspec_parallel` as a single config file
Azure should be able to use this output to report test coverage in azure.

### Context

### Changes proposed in this pull request
- Tested locally running `bundle exec rake parallel:spec` and inspected the logged out xm files found in `rspec-output`.
### Guidance to review
- view "Tests" tab for the azure job once it has been completed
![image](https://user-images.githubusercontent.com/3441519/89786024-30ee3300-db13-11ea-95eb-d1def01f3a45.png)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
