### PR TITLE
[3756] Add "confirmed" state views for Allocations

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -10,7 +10,7 @@ class Allocation < Base
       "open" => "open",
       "closed" => "closed",
       "confirmed" => "confirmed",
-    }.fetch(Settings.allocations_state, "open")
+    }.fetch(Settings.features.allocations.state, "open")
   end
 
   belongs_to :provider, param: :provider_code, shallow_path: true # accredited_body

--- a/app/view_objects/allocations_view.rb
+++ b/app/view_objects/allocations_view.rb
@@ -53,6 +53,14 @@ class AllocationsView
     statuses.compact.sort_by! { |hsh| hsh[:training_provider_name] }
   end
 
+  def confirmed_allocation_places
+    statuses = confirmed_allocations.map do |allocation|
+      build_confirmed_allocations(allocation, allocation.provider)
+    end
+
+    statuses.compact.sort_by! { |hsh| hsh[:training_provider_name] }
+  end
+
   def not_requested_allocations_statuses
     statuses = filtered_training_providers.map do |training_provider|
       matching_allocation = find_matching_allocation(training_provider, not_requested_allocations)
@@ -82,6 +90,10 @@ private
   end
 
   def requested_allocations
+    @allocations.select { |allocation| allocation.request_type.in?([RequestType::INITIAL, RequestType::REPEAT]) }
+  end
+
+  def confirmed_allocations
     @allocations.select { |allocation| allocation.request_type.in?([RequestType::INITIAL, RequestType::REPEAT]) }
   end
 
@@ -141,6 +153,17 @@ private
     }
 
     hash[:id] = matching_allocation.id if matching_allocation.id
+
+    hash
+  end
+
+  def build_confirmed_allocations(allocation, training_provider)
+    return if allocation.nil?
+
+    hash = {
+      training_provider_name: training_provider.provider_name,
+      number_of_places: allocation.number_of_places,
+    }
 
     hash
   end

--- a/app/views/providers/allocations/_allocation-request-confirmed-state.html.erb
+++ b/app/views/providers/allocations/_allocation-request-confirmed-state.html.erb
@@ -1,0 +1,36 @@
+
+<%= content_for :page_title, "PE courses for 2021 to 2022" %>
+<%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"> Fee-funded PE courses for 2021 to 2022</h1>
+
+    <% if @allocations_view.confirmed_allocation_places.any? %>
+      <p class="govuk-body">
+        You requested fee-funded PE for the following organisations for 2021 to 2022.
+        These requests have been approved. Each organisation’s allocation is also included.
+      </p>
+
+      <p class="govuk-body">
+        If you have any questions, contact <%= bat_contact_mail_to %>.
+      </p>
+
+      <%= render partial: "providers/allocations/allocation_report_confirmed_state", locals: {
+                 confirmed_allocations: @allocations_view.confirmed_allocation_places
+               } %>
+    <% else %>
+      <p class="govuk-body">
+        You did not request fee-funded PE for 2021 to 2022.
+      </p>
+
+      <p class="govuk-body">
+        Any current courses that have not been requested will not be running in 2021 to 2022.
+      </p>
+
+      <p class="govuk-body">
+        If you have any questions, contact <%= bat_contact_mail_to %>.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/providers/allocations/_allocation_report_confirmed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_report_confirmed_state.html.erb
@@ -1,0 +1,25 @@
+<table class="govuk-table ucas-info-table govuk-!-margin-bottom-8">
+  <caption class="govuk-visually-hidden">A list of confirmed allocations for 2021 to 2022</caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col">
+      Organisation
+    </th>
+    <th class="govuk-table__header allocation-report__status" scope="col">
+      Number of Places
+    </th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% confirmed_allocations.each do |allocation| %>
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" data-qa="provider-name" scope="row">
+        <%= allocation[:training_provider_name] %>
+      </th>
+      <td class="govuk-table__cell">
+        <%= allocation[:number_of_places] %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,6 +61,12 @@ google:
   maps_api_key: replace_me
 use_ssl: true
 features:
+  allocations:
+    # Options:
+    # open - Users can make requests for allocations
+    # closed - Readonly - Users can see if they have or have not made request (does not show number of places)
+    # confirmed - final allocation places are displayed to users in a readonly state
+    state: closed
   signin_intercept: false
   signin_by_email: false
   dfe_signin: true
@@ -71,7 +77,6 @@ features:
     # actually starting when it would be set to false
     has_current_cycle_started?: true
 commit_sha_file: COMMIT_SHA
-allocations_state: closed
 basic_auth: false
 basic_auth_username: admin
 basic_auth_password_digest: "52785638ec464fd61f5c9b372797f1a7475225cabeb2b40b2d757eff9b337ff069b2314bb0c0611d44ca5d39c91906ab3415de0fbc36625b970e3c2c03d122da"

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,13 @@
 dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   base_url: https://localhost:3000
+features:
+  allocations:
+    # Options:
+    # open - Users can make requests for allocations
+    # closed - Readonly - Users can see if they have or have not made request (does not show number of places)
+    # confirmed - final allocation places are displayed to users in a readonly state
+    state: confirmed
 manage_backend:
   secret: secret
   base_url: http://localhost:3001

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -10,3 +10,6 @@ environment:
   selector_name: "qa"
 basic_auth: true
 developer_auth: true
+features:
+  allocations:
+    state: confirmed

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "PE allocations" do
   let(:allocations_show_page) { PageObjects::Page::Providers::Allocations::ShowPage.new }
 
   before do
-    allow(Settings).to receive(:allocations_state).and_return("open")
+    allow(Settings.features.allocations).to receive(:state).and_return("open")
   end
 
   context "updating an initial allocation" do

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "PE allocations" do
   let(:allocations_show_page) { PageObjects::Page::Providers::Allocations::ShowPage.new }
 
   before do
-    allow(Settings).to receive(:allocations_state).and_return("open")
+    allow(Settings.features.allocations).to receive(:state).and_return("open")
   end
 
   scenario "Accredited body requests new PE allocations" do

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "PE allocations" do
   let(:allocations_show_page) { PageObjects::Page::Providers::Allocations::ShowPage.new }
 
   before do
-    allow(Settings).to receive(:allocations_state).and_return("open")
+    allow(Settings.features.allocations).to receive(:state).and_return("open")
   end
 
   context "Repeat allocations" do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -4,28 +4,28 @@ RSpec.describe Allocation do
   describe ".journey_mode" do
     context "when allocation period is open" do
       it "returns 'open'" do
-        Settings.allocations_state = "open"
+        Settings.features.allocations.state = "open"
         expect(Allocation.journey_mode).to eq("open")
       end
     end
 
     context "when allocation period is closed" do
       it "returns 'closed'" do
-        Settings.allocations_state = "closed"
+        Settings.features.allocations.state = "closed"
         expect(Allocation.journey_mode).to eq("closed")
       end
     end
 
     context "when allocation period is confirmed" do
       it "returns 'closed'" do
-        Settings.allocations_state = "confirmed"
+        Settings.features.allocations.state = "confirmed"
         expect(Allocation.journey_mode).to eq("confirmed")
       end
     end
 
     context "when allocation period setting is invalid" do
       it "returns 'open by default'" do
-        Settings.allocations_state = "not_the_correct_state"
+        Settings.features.allocations.state = "not_the_correct_state"
         expect(Allocation.journey_mode).to eq("open")
       end
     end

--- a/spec/view_objects/allocations_view_spec.rb
+++ b/spec/view_objects/allocations_view_spec.rb
@@ -133,6 +133,50 @@ describe AllocationsView do
     end
   end
 
+  context "allocations are confirmed" do
+    describe "#confirmed_allocation_places" do
+      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).confirmed_allocation_places }
+      context "returns confirmed repeat and initial allocations with number of places" do
+        let(:confirmed_repeat_allocation) do
+          build(:allocation, :repeat, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+        end
+
+        let(:confirmed_initial_allocation) do
+          build(:allocation, :initial, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 2)
+        end
+
+        let(:allocations) { [confirmed_repeat_allocation, confirmed_initial_allocation] }
+
+        it {
+          is_expected.to eq([{ training_provider_name: training_provider.provider_name,
+                               number_of_places: confirmed_repeat_allocation.number_of_places },
+                             { training_provider_name: another_training_provider.provider_name,
+                               number_of_places: confirmed_initial_allocation.number_of_places }])
+        }
+      end
+
+      context "no confirmed declined allocations are returned" do
+        let(:confirmed_declined_allocation) do
+          build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0)
+        end
+
+        let(:allocations) { [confirmed_declined_allocation] }
+
+        it {
+          is_expected.to eq([])
+        }
+      end
+
+      context "no allocations are returned if their status is 'YET TO REQUEST'" do
+        let(:allocations) { [] }
+
+        it {
+          is_expected.to eq([])
+        }
+      end
+    end
+  end
+
   context "allocation period is closed" do
     describe "#requested_allocations" do
       subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).requested_allocations_statuses }


### PR DESCRIPTION
Moved Settings.allocations_state into the features namespace. Also added
comments around the different valid options.

We decided to keep `state` key as it could potentially be used by other
methods / backend business logic

### Context

https://trello.com/c/mAtodzq4/3756-s-implement-allocations-results-screen

### Changes proposed in this pull request

* Added allocations confirmed page templates
* Add view object method for returning only confirmed allocations
* Added tests for confirmed allocations view
* Changed allocation config settings naming
* Changed QA allocations feature state to confirmed for product review

### Guidance to review
- visit https://s121d02-3756-ptt-as.azurewebsites.net/ 
- login as a user of an accredited body
- view allocation page

![image](https://user-images.githubusercontent.com/25597009/90006759-6f116100-dc91-11ea-9625-7f8c25c6619d.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
