### PR TITLE
[3779] Fix copy course content

### DIFF
--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -9,18 +9,22 @@
 
 <%= form_with model: course,
               builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-              url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
-  <%= f.hidden_field :page, value: :requirements %>
+              url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) do |f| %>
   <%= f.govuk_error_summary "You’ll need to correct some information." %>
+<% end %>
 
-  <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-    Requirements and eligibility
-  </h1>
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+  Requirements and eligibility
+</h1>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: course,
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                  url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                  data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
+      <%= f.hidden_field :page, value: :requirements %>
       <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
 
       <p class="govuk-body">
@@ -59,13 +63,13 @@
                     provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                     class: "govuk-link govuk-link--no-visited-state" %>
       </p>
-    </div>
-
-    <aside class="govuk-grid-column-one-third">
-      <%= render partial: 'courses/related_sidebar',
-                          locals: {
-                            course: course,
-                            page_path: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) } %>
-    </aside>
+    <% end %>
   </div>
-<% end %>
+
+  <aside class="govuk-grid-column-one-third">
+    <%= render partial: 'courses/related_sidebar',
+                        locals: {
+                          course: course,
+                          page_path: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) } %>
+  </aside>
+</div>


### PR DESCRIPTION
### Context

- https://trello.com/c/aRTa0DRx/3779-copy-course-content-bug
- Fixes a regression that broke copy course content

### Changes proposed in this pull request

Based on the fix we applied here https://github.com/DFE-Digital/publish-teacher-training/pull/1283

- Previously there were 2 independent forms on the course requirements page
- A regression in the HTML markup caused these 2 forms to be nested and therefore invalid
- This change splits the forms so they are no longer nested
- A third non-submitable form has been added so if there are errors these can be rendered back to the user

### Guidance to review

- Login as admin or user with 2 courses
- Edit the course through the requirements page
- On the RHS use the copy content from another course feature
- Other course content should now be present on this course

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
