### PR TITLE
[3818] Use confirmed allocation numbers from API

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -16,6 +16,7 @@ class Allocation < Base
   belongs_to :provider, param: :provider_code, shallow_path: true # accredited_body
 
   property :number_of_places
+  property :confirmed_number_of_places
   property :request_type
 
   validate :selected_number_of_places, if: :initial_request?

--- a/app/view_objects/allocations_view.rb
+++ b/app/view_objects/allocations_view.rb
@@ -163,6 +163,7 @@ private
     hash = {
       training_provider_name: training_provider.provider_name,
       number_of_places: allocation.number_of_places,
+      confirmed_number_of_places: allocation.confirmed_number_of_places,
     }
 
     hash

--- a/app/views/providers/allocations/_allocation_report_confirmed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_report_confirmed_state.html.erb
@@ -17,7 +17,7 @@
         <%= allocation[:training_provider_name] %>
       </th>
       <td class="govuk-table__cell">
-        <%= allocation[:number_of_places] %>
+        <%= allocation[:confirmed_number_of_places] %>
       </td>
     </tr>
   <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -62,11 +62,9 @@ google:
 use_ssl: true
 features:
   allocations:
-    # Options:
-    # open - Users can make requests for allocations
-    # closed - Readonly - Users can see if they have or have not made request (does not show number of places)
-    # confirmed - final allocation places are displayed to users in a readonly state
-    state: closed
+    # state: open # Users can make requests for allocations
+    state: closed # Readonly - Users can see if they have or have not made request (does not show number of places)
+    # state: confirmed # final allocation places are displayed to users in a readonly state
   signin_intercept: false
   signin_by_email: false
   dfe_signin: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,11 +3,9 @@ dfe_signin:
   base_url: https://localhost:3000
 features:
   allocations:
-    # Options:
-    # open - Users can make requests for allocations
-    # closed - Readonly - Users can see if they have or have not made request (does not show number of places)
-    # confirmed - final allocation places are displayed to users in a readonly state
-    state: confirmed
+    # state: open # Users can make requests for allocations
+    # state: closed # Readonly - Users can see if they have or have not made request (does not show number of places)
+    state: confirmed # final allocation places are displayed to users in a readonly state
 teacher_training_api:
   secret: secret
   base_url: http://localhost:3001

--- a/spec/view_objects/allocations_view_spec.rb
+++ b/spec/view_objects/allocations_view_spec.rb
@@ -136,22 +136,31 @@ describe AllocationsView do
   context "allocations are confirmed" do
     describe "#confirmed_allocation_places" do
       subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).confirmed_allocation_places }
+
       context "returns confirmed repeat and initial allocations with number of places" do
         let(:confirmed_repeat_allocation) do
-          build(:allocation, :repeat, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+          build(:allocation, :repeat, accredited_body: accredited_body,
+                                      provider: training_provider,
+                                      number_of_places: 1,
+                                      confirmed_number_of_places: 3)
         end
 
         let(:confirmed_initial_allocation) do
-          build(:allocation, :initial, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 2)
+          build(:allocation, :initial, accredited_body: accredited_body,
+                                       provider: another_training_provider,
+                                       number_of_places: 2,
+                                       confirmed_number_of_places: 4)
         end
 
         let(:allocations) { [confirmed_repeat_allocation, confirmed_initial_allocation] }
 
         it {
           is_expected.to eq([{ training_provider_name: training_provider.provider_name,
-                               number_of_places: confirmed_repeat_allocation.number_of_places },
+                               number_of_places: confirmed_repeat_allocation.number_of_places,
+                               confirmed_number_of_places: confirmed_repeat_allocation.confirmed_number_of_places },
                              { training_provider_name: another_training_provider.provider_name,
-                               number_of_places: confirmed_initial_allocation.number_of_places }])
+                               number_of_places: confirmed_initial_allocation.number_of_places,
+                               confirmed_number_of_places: confirmed_initial_allocation.confirmed_number_of_places }])
         }
       end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/sAOGBGQF/3818-backend-allocation-for-final-numbers
- For confirmed allocation numbers we must use the correct data from the API

### Changes proposed in this pull request

- Frontend changes to use confirmed allocation numbers from API
- API changes must be rolled out first before this change is released

### Guidance to review

- Depends on https://github.com/DFE-Digital/teacher-training-api/pull/1537
- Test in unison with https://github.com/DFE-Digital/teacher-training-api/pull/1537
- Find a provider with allocations eg B20
- Modify one of their allocations in the rails console and set confirmed_number_of_places to 123
- View the allocation via publisher web interface. Should see 123
- The other unset allocation should be blank i.e. the app does not throw an error

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
