### PR TITLE
Change ttapi endpoint from api2 to api

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -5,7 +5,7 @@ dfe_signin:
   base_url: https://www.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://support.signin.education.gov.uk/users
 manage_backend:
-  base_url: https://api2.publish-teacher-training-courses.service.gov.uk
+  base_url: https://api.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://find-postgraduate-teacher-training.education.gov.uk
 environment:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,7 +2,7 @@ dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   base_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
 manage_backend:
-  base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk
+  base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -5,7 +5,7 @@ dfe_signin:
   base_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://pp-support.signin.education.gov.uk/users
 manage_backend:
-  base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk
+  base_url: https://api.staging.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
 environment:


### PR DESCRIPTION
The api is now available on api.* endpoint and api2.* will be deprecated.

### Context

api2.* will be replaced by api.*.  Any references in the config to api2 needs updating to api.

### Changes proposed in this pull request

config/settings/production.yml
config/settings/staging.yml
config/settings/qa.yml

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
