### PR TITLE
[55] Update cypress tests

### DIFF
--- a/end-to-end-tests/cypress/integration/organisations.js
+++ b/end-to-end-tests/cypress/integration/organisations.js
@@ -5,7 +5,7 @@ const baseUrl = Cypress.config().baseUrl;
 describe("login", function () {
   // NOTE: user only has one organisation associated so,
   //       it can not view a list of organisations
-  it("viewing B1T organisation details ", function () {
+  it("viewing organisation details ", function () {
     const params = {
       auth: {
         username: "admin",
@@ -18,11 +18,11 @@ describe("login", function () {
     cy.visit(params);
     cy.contains('Login as an anonymised user').click();
     cy.get('input#email')
-      .type('becomingateacher+integration-tests@digital.education.gov.uk');
+      .type('anonimized-user-10599@example.org');
     cy.get('form').submit();
 
-    cy.url().should('eq', `${baseUrl}organisations/B1T`);
-    cy.get('h1').contains('bat 1');
+    cy.url().should('eq', `${baseUrl}organisations/1A4`);
+    cy.get('h1').contains('School Direct');
     cy.get('footer').scrollIntoView({ duration: 100 });
   });
 });


### PR DESCRIPTION
### Context

- https://trello.com/c/cc7ehRNL/55-fix-cypress-tests
- Cypress tests for staging are currently broken when testing a user login

### Changes proposed in this pull request

- For some reason the original user did not get rolled over correctly
- Therefore they no longer belong to an organisation
- As a workaround we login into another valid anonymised user

### Guidance to review

- Update `end-to-end-tests/cypress.json` with `baseUrl` to `https://www.staging.publish-teacher-training-courses.service.gov.uk/`
- run `npx cypress run --env password=SEE_CONFLUENCE_PAGE`
- all tests should pass

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] ~Product Review~
