### PR TITLE
59 healthcheck statuscake

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "azurerm" {
+    container_name       = "tfstatestr"
+  }
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,4 @@
+provider statuscake {
+  username = var.sc_username
+  apikey   = var.sc_api_key
+}

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -1,0 +1,13 @@
+resource statuscake_test alert {
+  for_each =  var.alerts
+    
+  website_name  = each.value.website_name
+  website_url   = each.value.website_url
+  test_type     = each.value.test_type
+  check_rate    = each.value.check_rate
+  contact_group = each.value.contact_group
+  trigger_rate  = each.value.trigger_rate
+  custom_header = each.value.custom_header
+  status_codes  = each.value.status_codes
+  confirmations = 1
+}

--- a/terraform/terraform_prod.tfvars
+++ b/terraform/terraform_prod.tfvars
@@ -1,0 +1,12 @@
+alerts =  {
+prod-pubtt = {
+    website_name = "prod-publish-teacher-training"
+    website_url   = "https://www.publish-teacher-training-courses.service.gov.uk/ping" 
+    test_type     = "HTTP"
+    check_rate    = 60
+    contact_group = [151103]
+    trigger_rate  = 0
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
+  }
+}

--- a/terraform/terraform_qa.tfvars
+++ b/terraform/terraform_qa.tfvars
@@ -1,0 +1,12 @@
+alerts =  {
+qa-pubtt = {
+    website_name = "qa-publish-teacher-training"
+    website_url   = "https://www.qa.publish-teacher-training-courses.service.gov.uk/ping"
+    test_type     = "HTTP"
+    check_rate    = 60
+    contact_group = [151103]
+    trigger_rate  = 0
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
+  }
+}

--- a/terraform/terraform_staging.tfvars
+++ b/terraform/terraform_staging.tfvars
@@ -1,0 +1,12 @@
+alerts =  {
+staging-pubtt = {
+    website_name = "staging-publish-teacher-training"
+    website_url   = "https://www.staging.publish-teacher-training-courses.service.gov.uk/ping"
+    test_type     = "HTTP"
+    check_rate    = 60
+    contact_group = [151103]
+    trigger_rate  = 0
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "sc_username" {}
+variable "sc_api_key" {}
+variable "alerts" {
+  type = map
+}


### PR DESCRIPTION
### Context

Configured statuscake's Terraform pipeline to monitor Publish-teacher-training's website using Ping. 'healthcheck is not working at the moment' 

We have the status cakes. We have the /healthchecks. But /healthcheck on the API is returning false (Redis queues?).

API
* Figure out what is causing it to return false, fix it.

Publish
* Do we want to be using /ping or /healthcheck on API to determine our status? Sounds to me like it should be /ping, so this would need changing.


### Changes proposed in this pull request

Terraform:- configured statuscake's monitor url for each environment to */ping

### Guidance to review




### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
