### PR TITLE
[48] Set staging allocations to confirmed

### DIFF
--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -13,3 +13,6 @@ environment:
   selector_name: "staging"
 basic_auth: true
 developer_auth: true
+features:
+  allocations:
+    state: confirmed


### PR DESCRIPTION
### Context

- https://trello.com/c/ZdQi6F25/48-import-final-allocation-numbers
- Allocations confirmed places has been imported into staging
- So testing of allocations in confirmed state can take place we need to enable the feature flag in staging

### Changes proposed in this pull request

- Set staging allocations state to confirmed

### Guidance to review

- Code review only otherwise only testable once deployed to staging

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] ~Tested by running locally~
- [ ] ~Product Review~
