### PR TITLE
[32] Changes 'for example' phrase to a valid date

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -210,7 +210,7 @@ class CourseDecorator < ApplicationDecorator
     else
       year = recruitment_cycle.year.to_i
       day_month = Date.parse(recruitment_cycle.application_start_date).strftime("%-d %B")
-      "On #{day_month} when applications for the #{year} – #{year + 1} cycle open"
+      "On #{day_month} when applications for the #{year} to #{year + 1} cycle open"
     end
   end
 

--- a/app/views/courses/applications_open/_form_fields.html.erb
+++ b/app/views/courses/applications_open/_form_fields.html.erb
@@ -31,7 +31,7 @@
             What date will applications open?
           </legend>
           <span class="govuk-hint">
-            For example, 31 10 <%= @recruitment_cycle.year %>
+            For example, 30 9 <%= @recruitment_cycle.year %>
           </span>
           <div class="govuk-date-input">
             <div class="govuk-date-input__item">


### PR DESCRIPTION
## Context
 * https://trello.com/c/d79wSVBk/32-check-that-the-when-will-applications-open-error-message-displays-the-correct-dates
* https://github.com/DFE-Digital/teacher-training-api/pull/1557

The 'for example' phrase was an invalid date. It needed to be between 13/10/2020 and 3/10/2021.

### Changes proposed in this pull request
For example phrase was changed to 30/9/2021 (just an arbitrary date) that is valid because it's within the date range for the 2020 to 2021 recuitment cycle. Also, a simple copy change to change the '-' to a 'to' in line with the rest of Publish for '2020 - 2021'. 

### Guidance to review
When adding a new course you see the change when the partial is rendered for the 'when will the applications open' page

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [X] Product Review
