### PR TITLE
Update footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,38 +1,29 @@
-<footer class="govuk-footer" role="contentinfo">
+<footer class="govuk-footer govuk-!-display-none-print" role="contentinfo">
   <div class="govuk-width-container">
-    <% if current_user.present? && current_user["admin"] && current_user["accepted_terms?"] %>
-      <div class="govuk-footer__navigation" id="admin">
-        <div class="govuk-footer__section">
-          <h2 class="govuk-footer__heading govuk-heading-m">Support tools</h2>
-          <ul class="govuk-footer__list">
-            <li class="govuk-footer__list-item">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <% if current_user.present? && current_user["admin"] && current_user["accepted_terms?"] %>
+          <h2 class="govuk-heading-m" id="admin">Support tools</h2>
+          <ul class="govuk-footer__inline-list govuk-!-margin-bottom-6">
+            <li class="govuk-footer__inline-list-item">
               <%= link_to "Access Requests (#{AccessRequest.return_count})", access_requests_path, class: "govuk-footer__link", data: { qa: "access_requests_link" } %>
             </li>
-            <li class="govuk-footer__list-item">
+            <li class="govuk-footer__inline-list-item">
               <%= link_to "Active users by organisation", organisations_support_page_path, class: "govuk-footer__link", data: { qa: "organisations_link" } %>
             </li>
           </ul>
-        </div>
-      </div>
-      <hr class="govuk-footer__section-break">
-    <% end %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds govuk-footer__content-container">
-        <p class="govuk-footer__content">
-          Contact the Becoming a Teacher team for support:
-          <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses support", link_class: "govuk-footer__link" %>
-        </p>
-      </div>
-    </div>
-    <div class="govuk-footer__meta">
-      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <% end %>
+        <h2 class="govuk-heading-m">Get support</h2>
+        <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
+          <li>Email: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses support", link_class: "govuk-footer__link" %></li>
+          <li class="govuk-!-margin-bottom-4">We respond within 5 working days, or one working day for more urgent queries</li>
+          <li><%= link_to "How to publish teacher training courses", guidance_path, class: "govuk-footer__link" %></li>
+          <li><%= link_to "Teacher Training Courses API documentation", "https://api.publish-teacher-training-courses.service.gov.uk", class: "govuk-footer__link" %></li>
+        </ul>
         <h2 class="govuk-visually-hidden">Support links</h2>
         <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
           <li class="govuk-footer__inline-list-item">
-            <%= bat_contact_mail_to "Give feedback", subject: "Publish teacher training courses feedback", link_class: "govuk-footer__link" %>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <%= link_to "Publishing guidance", guidance_path, class: "govuk-footer__link" %>
+            <%= link_to "Accessibility", accessibility_path, class: "govuk-footer__link" %>
           </li>
           <li class="govuk-footer__inline-list-item">
             <%= link_to "Cookies", cookies_path, class: "govuk-footer__link" %>
@@ -41,15 +32,15 @@
             <%= link_to "Privacy policy", privacy_path, class: "govuk-footer__link" %>
           </li>
           <li class="govuk-footer__inline-list-item">
-            <%= link_to "Accessibility", accessibility_path, class: "govuk-footer__link" %>
+            <%= link_to "Terms and conditions", terms_path, class: "govuk-footer__link" %>
           </li>
           <li class="govuk-footer__inline-list-item">
-            <%= link_to "Terms and conditions", terms_path, class: "govuk-footer__link" %>
+            <%= link_to "Service performance", performance_dashboard_path, class: "govuk-footer__link" %>
           </li>
         </ul>
       </div>
       <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+        <a class="govuk-footer__link govuk-footer__copyright-logo govuk-!-margin-bottom-1" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
       </div>
     </div>
   </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,8 +1,8 @@
-<%= content_for :page_title, "Terms and Conditions" %>
+<%= content_for :page_title, "Terms and conditions" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Terms and Conditions</h1>
+    <h1 class="govuk-heading-xl">Terms and conditions</h1>
     <h2 class="govuk-heading-l">Users of the Service</h2>
     <h3 class="govuk-heading-m">Using our website</h3>
     <p class="govuk-body">

--- a/end-to-end-tests/cypress/fixtures/publicly_visible/pages.json
+++ b/end-to-end-tests/cypress/fixtures/publicly_visible/pages.json
@@ -15,7 +15,7 @@
             {
                 "urlPath": "terms-conditions",
                 "selector": "h1",
-                "content": "Terms and Conditions"
+                "content": "Terms and conditions"
             },
             {
                 "urlPath": "privacy-policy",

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -16,7 +16,7 @@ feature "View pages", type: :feature do
 
   scenario "Navigate to /terms-conditions" do
     visit "/terms-conditions"
-    expect(find("h1")).to have_content("Terms and Conditions")
+    expect(find("h1")).to have_content("Terms and conditions")
   end
 
   scenario "Navigate to /privacy-policy" do


### PR DESCRIPTION
### Context

Design review of the footer on Publish found the following issues:

* Doesn’t show SLA or opening hours for support contact
* Link to guidance hidden among boilerplate links
* No heading to draw eye to contact details
* Support links don’t visually align with ‘© Crown Copyright’ text

See: https://trello.com/c/a3xUbZMt

### Changes proposed in this pull request

This PR fixes the above issues, updates the content to follow [recommended design pattern](https://design-system.service.gov.uk/patterns/contact-a-department-or-service-team/) for contact details, and aligns the design with the footers used on the other Becoming a teacher services, in particular that for Manage.

Also updates the title for ‘Terms and conditions’ page to use correct capitalisation format for titles.

#### Current footer

![publish-footer-old](https://user-images.githubusercontent.com/813383/91997485-0bc79b80-ed32-11ea-88e5-78f1be2038be.png)

#### Updated footer

![publish-footer-new](https://user-images.githubusercontent.com/813383/91997182-b7bcb700-ed31-11ea-919c-f384e3958ab2.png)

With admin support links:

![publish-footer-new-support](https://user-images.githubusercontent.com/813383/91997213-c2774c00-ed31-11ea-82e1-833655279e22.png)

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
