### PR TITLE
[33] Update allocation copy on the providers page

### DIFF
--- a/app/views/recruitment_cycles/_allocations.html.erb
+++ b/app/views/recruitment_cycles/_allocations.html.erb
@@ -1,12 +1,11 @@
 <% if @provider.accredited_body? %>
   <h2 class="govuk-heading-m">
-    <%= govuk_link_to "Request PE courses for 2021 to 2022",
-                provider_recruitment_cycle_allocations_path(@provider.provider_code, year) %>
+    <%= govuk_link_to t("allocations_for_pe.#{Allocation.journey_mode}_state_link_text"),
+                      provider_recruitment_cycle_allocations_path(@provider.provider_code, year) %>
   </h2>
 
   <p class="govuk-body">
-    Only accredited bodies are able to see this section. Use it to request fee-funded PE courses
-    (ones without a salary) for the next recruitment cycle.
+    <%= t("allocations_for_pe.#{Allocation.journey_mode}_state_copy") %>
   </p>
 
   <p class="govuk-body">This includes:</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,3 +127,10 @@ en:
       to_invalid_error: "Enter a valid age in To"
       from_range: "From age must be between %{min} and %{max}"
       to_range: "To age must be between %{min} and %{max}"
+  allocations_for_pe:
+    open_state_link_text: "Request PE courses for 2021 to 2022"
+    closed_state_link_text: "Request PE courses for 2021 to 2022"
+    confirmed_state_link_text: "View PE courses for 2021 to 2022"
+    open_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses(ones without a salary) for the next recruitment cycle."
+    closed_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses (ones without a salary) for the next recruitment cycle."
+    confirmed_state_copy: "Use it to view the outcome of requests for fee-funded PE courses (ones without a salary) for the next recruitment cycle."

--- a/spec/views/providers/show_spec.rb
+++ b/spec/views/providers/show_spec.rb
@@ -9,6 +9,7 @@ describe "providers/show" do
 
   before do
     view.extend(CurrentUserMethod)
+    allow(Allocation).to receive(:journey_mode).and_return("open")
     allow(view).to receive(:current_user).and_return({ "admin" => admin })
     assign(:provider, provider)
     render

--- a/spec/views/recruitment_cycles/show_spec.rb
+++ b/spec/views/recruitment_cycles/show_spec.rb
@@ -19,6 +19,7 @@ describe "recruitment_cycles/show.html", type: :view do
 
     describe "when accredited body user is viewing the current cycle" do
       before do
+        allow(Allocation).to receive(:journey_mode).and_return("open")
         assign(:provider, accredited_body)
         render template: "recruitment_cycles/show"
         recruitment_cycle_page.load(rendered)


### PR DESCRIPTION
We need to change the link and section copy for allocations depending
on the state of allocations. If its not "confirmed" then users should
be made to think that they could still request allocations but once
they have been confirmed then it could be "View" the confirmed
allocations.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
