### PR TITLE
[34] Refactor google form url helper code to factor in next cycle

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,6 +1,6 @@
 module ProviderHelper
-  def add_course_url(email, provider, is_current_cycle:)
-    cycle_key = is_current_cycle ? "current_cycle" : "next_cycle"
+  def add_course_url(email, provider)
+    cycle_key = is_current_cycle(provider.recruitment_cycle_year) ? "current_cycle" : "next_cycle"
 
     if provider.accredited_body?
       google_form_url_for(Settings.google_forms[cycle_key].new_course_for_accredited_bodies, email, provider)
@@ -14,5 +14,9 @@ private
   def google_form_url_for(settings, email, provider)
     settings.url + "&" +
       { settings.email_entry => email, settings.provider_code_entry => provider.provider_code }.to_query
+  end
+
+  def is_current_cycle(cycle_year)
+    Settings.current_cycle == cycle_year.to_i
   end
 end

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -18,7 +18,7 @@
           <% if !current_user["admin"] && @course.level == "secondary" %>
             <h2 class="govuk-heading-m"> Adding a Physical education course?</h2>
             <p class="govuk-body-s">You’ll need to fill in a
-              <%= link_to "separate Google Form", add_course_url(current_user['info']['email'], @provider, is_current_cycle: true), class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>,
+              <%= link_to "separate Google Form", add_course_url(current_user['info']['email'], @provider), class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>,
             as PE places are limited.</p>
           <% end %>
         </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,11 +28,11 @@ notify:
 google_forms:
   next_cycle:
     new_course_for_accredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLScckkzOwt93FTZGgZCBRA6spAnSO06UKewD5N6P3moBhIpKiA/viewform?usp=pp_url
+      url: https://docs.google.com/forms/d/e/1FAIpQLSexQtIhIDiHM6vyy23OrJmeSoLTmLlw4y_2S3TI7FDQV2VcsQ/viewform?usp=pp_url
       email_entry: entry.957076544
       provider_code_entry: entry.1735563938
     new_course_for_unaccredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSeD1BwS11lYm4PJ8WZMRIU5U02h0z-T5WlC0aqycc1CHV-e0A/viewform?usp=pp_url
+      url: https://docs.google.com/forms/d/e/1FAIpQLSdmuYIBDGuESZJBKGVTIdEFntdcjX86J5u6yXTSFNpk18oJeA/viewform?usp=pp_url
       email_entry: entry.1033530353
       provider_code_entry: entry.158771972
   current_cycle:

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -3,38 +3,54 @@ require "rails_helper"
 feature "View helpers", type: :helper do
   let(:email) { "ab+test@c.com" }
   let(:html_escaped_version_of_email) { "ab%2Btest%40c.com" }
-  let(:provider) { build(:provider) }
+  let(:provider) { build(:provider, accredited_body?: accredited_body, recruitment_cycle: recruitment_cycle) }
 
   describe "#add_course_url" do
     describe "for accredited bodies" do
-      let(:provider) { build(:provider, accredited_body?: true) }
+      let(:accredited_body) { true }
 
-      it "returns correct google form for the current cycle" do
-        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to start_with(Settings.google_forms.current_cycle.new_course_for_accredited_bodies.url)
-        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to include(provider.attributes[:provider_code])
+      context "with current cycle" do
+        let(:recruitment_cycle) { build(:recruitment_cycle) }
+
+        it "returns correct google form for the current cycle" do
+          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.current_cycle.new_course_for_accredited_bodies.url)
+          expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
+          expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
+        end
       end
 
-      it "returns correct google form for the next cycle" do
-        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to start_with(Settings.google_forms.next_cycle.new_course_for_accredited_bodies.url)
-        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to include(provider.attributes[:provider_code])
+      context "with next cycle" do
+        let(:recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
+
+        it "returns correct google form for the next cycle" do
+          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.next_cycle.new_course_for_accredited_bodies.url)
+          expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
+          expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
+        end
       end
     end
 
     describe "for non-accredited bodies" do
-      let(:provider) { build(:provider, accredited_body?: false) }
+      let(:accredited_body) { false }
 
-      it "returns correct google form for the current cycle" do
-        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to start_with(Settings.google_forms.current_cycle.new_course_for_unaccredited_bodies.url)
-        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider, is_current_cycle: true)).to include(provider.attributes[:provider_code])
+      context "with current cycle" do
+        let(:recruitment_cycle) { build(:recruitment_cycle) }
+
+        it "returns correct google form for the current cycle" do
+          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.current_cycle.new_course_for_unaccredited_bodies.url)
+          expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
+          expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
+        end
       end
 
-      it "returns correct google form for the next cycle" do
-        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to start_with(Settings.google_forms.next_cycle.new_course_for_unaccredited_bodies.url)
-        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to include(html_escaped_version_of_email)
-        expect(helper.add_course_url(email, provider, is_current_cycle: false)).to include(provider.attributes[:provider_code])
+      context "with next cycle" do
+        let(:recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
+
+        it "returns correct google form for the next cycle" do
+          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.next_cycle.new_course_for_unaccredited_bodies.url)
+          expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
+          expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/M92Y7EQ3/34-s-update-the-next-cycle-google-forms-with-the-new-ones

### Changes proposed in this pull request

- Remove `is_current_cycle` which seemed to hard code the current cycle forcing the link to always render the google form for the current cycle
- Check the provider's currently selected recruitment cycle and render correct google form

### Guidance to review

- Fire up localhost
- Visit `http://localhost:3000/organisations/T92/2020/courses/subjects/new?course%5Bis_send%5D=0&course%5Blevel%5D=secondary`. Click the Google form URL, should show current google form for current cycle
- Visit `http://localhost:3000/organisations/T92/2021/courses/subjects/new?course%5Bis_send%5D=0&course%5Blevel%5D=secondary`. Click the Google form URL, should show google form for next cycle

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
