### PR TITLE
120 service status dashboard rollover tab

### DIFF
--- a/app/services/performance_dashboard_service.rb
+++ b/app/services/performance_dashboard_service.rb
@@ -84,4 +84,28 @@ class PerformanceDashboardService
   def users_active_30_days
     number_with_delimiter(@response["publish"]["users"]["recent_active_users"])
   end
+
+  def rollover_total
+    @response["rollover"]["total"]
+  end
+
+  def published_courses
+    number_with_delimiter(rollover_total["published_courses"])
+  end
+
+  def new_courses_published
+    number_with_delimiter(rollover_total["new_courses_published"])
+  end
+
+  def deleted_courses
+    number_with_delimiter(rollover_total["deleted_courses"])
+  end
+
+  def existing_courses_in_draft
+    number_with_delimiter(rollover_total["existing_courses_in_draft"])
+  end
+
+  def existing_courses_in_review
+    number_with_delimiter(rollover_total["existing_courses_in_review"])
+  end
 end

--- a/app/views/pages/performance_dashboard.html.erb
+++ b/app/views/pages/performance_dashboard.html.erb
@@ -31,6 +31,13 @@
         Allocations
       </a>
     </li>
+    <% if FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") %>
+      <li class="govuk-tabs__list-item" role="presentation">
+        <a class="govuk-tabs__tab" href="#rollover" id="tab_rollover" role="tab" aria-controls="rollover" aria-selected="false" tabindex="-1">
+          Rollover
+        </a>
+      </li>
+    <% end %>
   </ul>
   <div class="govuk-tabs__panel" id="providers" role="tabpanel" aria-labelledby="tab_providers">
     <h2 class="govuk-heading-l">Providers</h2>
@@ -45,5 +52,8 @@
   <div class="govuk-tabs__panel" id="allocations" role="tabpanel" aria-labelledby="tab_allocations">
     <h2 class="govuk-heading-l">Allocations</h2>
     <%= render partial: "pages/performance_dashboard/allocations_tab" %>
+  </div>
+  <div class="govuk-tabs__panel" id="rollover" role="tabpanel" aria-labelledby="tab_rollover">
+    <%= render partial: "pages/performance_dashboard/rollover_tab" %>
   </div>
 </div>

--- a/app/views/pages/performance_dashboard/_rollover_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_rollover_tab.html.erb
@@ -1,0 +1,49 @@
+<h2 class="govuk-heading-l">
+  Rollover
+</h2>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-1">
+  <div class="govuk-grid-column-full">
+    <div class="app-performance-dashboard app-performance-dashboard--primary">
+      <div class="app-performance-dashboard__title">
+        <%= @performance_data.published_courses %>
+      </div>
+      courses published for next cycle
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-performance-dashboard app-performance-dashboard--green">
+      <div class="app-performance-dashboard__title--small">
+        <%= @performance_data.new_courses_published %>
+      </div>
+      new courses published
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-performance-dashboard app-performance-dashboard--red">
+      <div class="app-performance-dashboard__title--small">
+        <%= @performance_data.deleted_courses %>
+      </div>
+      existing courses deleted
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-performance-dashboard app-performance-dashboard--secondary">
+      <div class="app-performance-dashboard__title--small">
+        <%= @performance_data.existing_courses_in_draft %>
+      </div>
+      existing courses in draft
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-performance-dashboard app-performance-dashboard--secondary">
+      <div class="app-performance-dashboard__title--small">
+        <%= @performance_data.existing_courses_in_review %>
+      </div>
+      existing courses in review
+    </div>
+  </div>
+</div>

--- a/spec/fixtures/performance-dashboard.json
+++ b/spec/fixtures/performance-dashboard.json
@@ -288,5 +288,14 @@
         "number_of_places": 1677
       }
     }
+  },
+  "rollover": {
+    "total": {
+      "published_courses": 2965,
+      "new_courses_published": 124,
+      "deleted_courses": 289,
+      "existing_courses_in_draft": 667,
+      "existing_courses_in_review": 14082
+    }
   }
 }

--- a/spec/services/performance_dashboard_service_spec.rb
+++ b/spec/services/performance_dashboard_service_spec.rb
@@ -141,6 +141,34 @@ describe PerformanceDashboardService do
     end
   end
 
+  describe "rollover data" do
+    let(:data) { service.call }
+
+    before do
+      data
+    end
+
+    it "returns a number of published courses" do
+      expect(data.published_courses).to eq("2,965")
+    end
+
+    it "returns a number of newly published courses" do
+      expect(data.new_courses_published).to eq("124")
+    end
+
+    it "returns a number of deleted courses" do
+      expect(data.deleted_courses).to eq("289")
+    end
+
+    it "returns a number of existing courses in draft" do
+      expect(data.existing_courses_in_draft).to eq("667")
+    end
+
+    it "returns a number of existing courses in review" do
+      expect(data.existing_courses_in_review).to eq("14,082")
+    end
+  end
+
   describe "when service fails to fetch data" do
     before do
       stub_request(:get, "http://localhost:3001/reporting.json")

--- a/spec/site_prism/page_objects/page/performance_dashboard_page.rb
+++ b/spec/site_prism/page_objects/page/performance_dashboard_page.rb
@@ -20,6 +20,10 @@ module PageObjects
       section :allocation_tab, "#allocations" do
         elements :recruitment_cycles, ".govuk-grid-row"
       end
+
+      section :rollover_tab, "#rollover" do
+        elements :data_sets, ".app-performance-dashboard"
+      end
     end
   end
 end

--- a/spec/views/pages/performance_dashboard.html.erb_spec.rb
+++ b/spec/views/pages/performance_dashboard.html.erb_spec.rb
@@ -21,7 +21,12 @@ describe "pages/performance_dashboard" do
                      allocations_accredited_bodies: "4,000",
                      users_active: "1,111",
                      users_not_active: "2,222",
-                     users_active_30_days: "3,333"
+                     users_active_30_days: "3,333",
+                     published_courses: "2000",
+                     new_courses_published: "1000",
+                     deleted_courses: "200",
+                     existing_courses_in_draft: "500",
+                     existing_courses_in_review: "5000"
 
     assign(:performance_data, service)
     render
@@ -53,6 +58,16 @@ describe "pages/performance_dashboard" do
   describe "allocations tab" do
     it "has two recruitment cycle years worth of data" do
       expect(performance_dashboard_page.allocation_tab.recruitment_cycles.length).to eq(2)
+    end
+  end
+
+  describe "rollover tab" do
+    before do
+      allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
+    end
+
+    it "has five sets of figures" do
+      expect(performance_dashboard_page.rollover_tab.data_sets.length).to eq(5)
     end
   end
 end


### PR DESCRIPTION
### Context
* https://trello.com/c/Fvyd6hPr/120-service-status-dashboard-rollover-tab
* https://trello.com/c/3C81CAYu/130-s-service-status-dashboard-rollover-data

This is the frontend PR/ticket for the new Rollover tab feature on the Performance Dashboard. 

### Changes proposed in this pull request
Using the new rollover data at the /reporting endpoint

<img width="1190" alt="Screenshot 2020-09-28 at 14 54 14" src="https://user-images.githubusercontent.com/58793682/94441292-7e456300-019a-11eb-9ef9-d351b90c8556.png">

Only when rollover settings are set to true then tab will show

### Guidance to review
For comparison with the prototype:
* https://publish-dashboard-prototype.herokuapp.com/with-tables#rollover

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [ ] Product Review
