### PR TITLE
[0195] Added a feature flag for a rollover recruitment page

### DIFF
--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -20,6 +20,12 @@
       <li>edit titles, outcomes and locations where necessary</li>
     </ul>
 
-    <%= link_to "Continue", rollover_recruitment_path,  class: "govuk-button" %>
+    <%if FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page") %>
+      <%= link_to "Continue", rollover_recruitment_path,  class: "govuk-button" %>
+    <% else %>
+      <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
+        <%= f.submit "Continue", class: "govuk-button" %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -78,6 +78,7 @@ features:
     # Normally a short period of time between rollover and the next cycle
     # actually starting when it would be set to false
     has_current_cycle_started?: true
+    show_next_cycle_allocation_recruitment_page: false
 commit_sha_file: COMMIT_SHA
 basic_auth: false
 basic_auth_username: admin

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -140,22 +140,48 @@ feature "Sign in", type: :feature do
         user_get_request
         user_update_request
         allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
+        allow(Settings.features.rollover).to receive(:show_next_cycle_allocation_recruitment_page).and_return(show_next_cycle_allocation_recruitment_page)
       end
 
-      scenario "new user accepts the rollover page" do
-        visit "/signin"
+      context "when show next cycle allocation recruitment page is set to true" do
+        let(:show_next_cycle_allocation_recruitment_page) { true }
+        scenario "new user accepts the rollover page" do
+          visit "/signin"
 
-        expect(rollover_page).to be_displayed
+          expect(rollover_page).to be_displayed
 
-        expect(rollover_page.title).to have_content("Prepare for the next cycle")
-        rollover_page.continue.click
+          expect(rollover_page.title).to have_content("Prepare for the next cycle")
+          expect(rollover_page).to_not have_continue_input_button
 
-        expect(rollover_recruitment_page).to be_displayed
-        expect(rollover_recruitment_page.title).to have_content("Recruiting for the 2021 to 2022 cycle")
-        rollover_recruitment_page.continue.click
+          rollover_page.continue_link.click
 
-        expect(root_page).to be_displayed
-        expect(user_update_request).to have_been_made
+          expect(rollover_recruitment_page).to be_displayed
+          expect(rollover_recruitment_page.title).to have_content("Recruiting for the 2021 to 2022 cycle")
+          rollover_recruitment_page.continue.click
+
+          expect(root_page).to be_displayed
+          expect(user_update_request).to have_been_made
+        end
+      end
+
+      context "when show next cycle allocation recruitment page is set to false" do
+        let(:show_next_cycle_allocation_recruitment_page) { false }
+
+        scenario "new user accepts the rollover page" do
+          visit "/signin"
+
+          expect(rollover_page).to be_displayed
+
+          expect(rollover_page.title).to have_content("Prepare for the next cycle")
+          expect(rollover_page).to_not have_continue_link
+
+          rollover_page.continue_input_button.click
+
+          expect(rollover_recruitment_page).to_not be_displayed
+
+          expect(root_page).to be_displayed
+          expect(user_update_request).to have_been_made
+        end
       end
     end
   end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -140,7 +140,8 @@ feature "Sign in", type: :feature do
         user_get_request
         user_update_request
         allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
-        allow(Settings.features.rollover).to receive(:show_next_cycle_allocation_recruitment_page).and_return(show_next_cycle_allocation_recruitment_page)
+        allow(Settings.features.rollover).to receive(:show_next_cycle_allocation_recruitment_page)
+          .and_return(show_next_cycle_allocation_recruitment_page)
       end
 
       context "when show next cycle allocation recruitment page is set to true" do

--- a/spec/site_prism/page_objects/page/rollover.rb
+++ b/spec/site_prism/page_objects/page/rollover.rb
@@ -4,7 +4,8 @@ module PageObjects
       set_url "/rollover"
 
       element :title, ".govuk-heading-xl"
-      element :continue, ".govuk-button", text: "Continue"
+      element :continue_link, ".govuk-button", text: "Continue"
+      element :continue_input_button, ".govuk-button[value=Continue]"
     end
   end
 end


### PR DESCRIPTION
### Context
The rollover recruitment page needs to be feature flagged.

### Changes proposed in this pull request
The rollover recruitment page be toggled.

### Guidance to review

https://s121d02-01-ptt-as.azurewebsites.net/


This affects the interruption page workflow
The rollover recruitment page contains dates that makes it no longer appropriate to be shown
:shipit: 
Affects new users or non-rollovered users

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
