### PR TITLE
[125] Make UCAS contacts updatable

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,0 +1,36 @@
+class ContactsController < ApplicationController
+  def edit
+    contact
+  end
+
+  def update
+    if contact.update(contact_params)
+      redirect_to provider_ucas_contacts_path(provider_code: params[:provider_code])
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def provider
+    raise "missing provider code" unless params[:provider_code]
+
+    @provider ||= begin
+                    Provider
+                      .includes(:contacts)
+                      .where(recruitment_cycle_year: Settings.current_cycle)
+                      .find(params[:provider_code])
+                      .first
+                  end
+  end
+
+  def contact
+    @contact ||= provider.contacts.find { |contact| contact.id == params[:id] }
+  end
+
+  def contact_params
+    params.require(:contact)
+      .permit(:id, :name, :email, :telephone, :permission_given)
+  end
+end

--- a/app/controllers/ucas_contacts_controller.rb
+++ b/app/controllers/ucas_contacts_controller.rb
@@ -4,6 +4,7 @@ class UcasContactsController < ApplicationController
     raise "missing provider code" unless provider_code
 
     @provider = Provider
+                  .includes(:contacts)
                   .where(recruitment_cycle_year: Settings.current_cycle)
                   .find(provider_code)
                   .first
@@ -11,7 +12,9 @@ class UcasContactsController < ApplicationController
     @provider.send_application_alerts = "none" unless @provider.send_application_alerts
   end
 
-  def show; end
+  def show
+    @ucas_contact_view = UcasContactView.new(provider: @provider)
+  end
 
   def alerts; end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,7 @@
+class Contact < Base
+  belongs_to :provider, param: :provider_code, shallow_path: true
+
+  def admin?
+    type == "admin"
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,7 @@ class Provider < Base
   has_many :sites
   has_one :allocation
   has_many :training_providers
+  has_many :contacts
 
   self.primary_key = :provider_code
 

--- a/app/view_objects/ucas_contact_view.rb
+++ b/app/view_objects/ucas_contact_view.rb
@@ -1,0 +1,22 @@
+class UcasContactView
+  CONTACT_TYPES = %i[admin fraud finance web_link utt].freeze
+  attr_reader :provider
+
+  def initialize(provider:)
+    @provider = provider
+  end
+
+  def contact(contact_type)
+    provider.contacts.find { |contact| contact.type.to_sym == contact_type.to_sym }
+  end
+
+  def contact_types
+    UcasContactView::CONTACT_TYPES
+  end
+
+  delegate :provider_code,
+           :gt12_contact,
+           :send_application_alerts,
+           :application_alert_contact,
+           to: :provider
+end

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -1,0 +1,41 @@
+<%= content_for :page_title, t("ucas_contacts.#{@contact.type}.heading") %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(provider_ucas_contacts_path(@provider.provider_code)) %>
+<% end %>
+
+<%= form_with model: @contact,
+  id: "contact_edit_form",
+  scope: :contact,
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+  url: provider_contact_path(@provider.provider_code, @contact.id),
+  method: :put do |form| %>
+
+  <%= form.govuk_error_summary "You’ll need to correct some information." %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl" data-qa="ucas_contacts__alerts__main_heading">
+        <%= t("ucas_contacts.#{@contact.type}.heading") %>
+      </h1>
+
+      <p class="govuk-body"><%= t("ucas_contacts.#{@contact.type}.purpose") %></p>
+
+      <% if @contact.admin? %>
+        <h2 class="govuk-heading-l">Request a change to your UCAS administrator</h2>
+        <p class="govuk-body" id="admin_subtext">Changes can take up to 7 days to process.</p>
+      <% end %>
+
+      <%= form.govuk_text_field :name, width: "three-quarters" %>
+      <%= form.govuk_email_field :email, label: { text: "Email address" }, width: "three-quarters" %>
+      <%= form.govuk_phone_field :telephone, width: "one-half" %>
+      <div class="govuk-form-group">
+        <%= form.govuk_check_box :permission_given,1,0, multiple: false, label: { text: "I give permission to share this email address with UCAS" }%>
+      </div>
+      <%= form.govuk_submit t("ucas_contacts.#{@contact.type}.submit", default: "Save") %>
+
+      <p class="govuk-body">
+        <%= link_to 'Cancel changes', provider_ucas_contacts_path(@provider.provider_code), class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/ucas_contacts/_contact.html.erb
+++ b/app/views/ucas_contacts/_contact.html.erb
@@ -1,0 +1,24 @@
+<div class="govuk-summary-list__row" data-qa="provider__<%=contact.type%>_contact">
+  <dt class="govuk-summary-list__key">
+    <%= heading %>
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">
+      <% if contact.present? %>
+        <%= contact.name %>
+        <%= contact.email %>
+        <%= contact.telephone %>
+      <% else %>
+        Information unknown
+      <% end %>
+    </p>
+    <p class="govuk-body-s">
+      <%= purpose %>
+    </p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to edit_provider_contact_path(@provider.provider_code, contact), class: "govuk-link" do %>
+      Change<span class="govuk-visually-hidden"> email alerts for new applications</span>
+    <% end %>
+  </dd>
+</div>

--- a/app/views/ucas_contacts/_ucas_contact_list.html.erb
+++ b/app/views/ucas_contacts/_ucas_contact_list.html.erb
@@ -1,0 +1,31 @@
+<dl class="govuk-summary-list govuk-!-margin-top-6 govuk-!-margin-bottom-9 ucas-contact-list">
+  <% UcasContactView::CONTACT_TYPES.each do |contact_type| %>
+    <%- contact = ucas_contact_view.contact(contact_type) -%>
+    <div class="govuk-summary-list__row ucas-contact-list__row ucas-contact-list__row__<%=contact_type%>">
+      <dt class="govuk-summary-list__key">
+      <%= t("ucas_contacts.#{contact_type}.heading") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body">
+          <% if contact.present? %>
+            <%= contact.name %><br/>
+            <%= contact.email %><br/>
+            <%= contact.telephone %>
+          <% else %>
+            Information unknown
+          <% end %>
+        </p>
+        <p class="govuk-body-s">
+          <%= t("ucas_contacts.#{contact_type}.purpose") %>
+        </p>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <%- if contact.present? -%>
+          <%= link_to edit_provider_contact_path(ucas_contact_view.provider_code, contact.id), class: "govuk-link" do %>
+            Change<span class="govuk-visually-hidden"> email alerts for new applications</span>
+          <% end %>
+        <%- end -%>
+      </dd>
+    </div>
+  <% end %>
+</dl>

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -30,112 +30,7 @@
 
     <p class="govuk-body">UCAS will contact these people at your organisation:</p>
 
-    <dl class="govuk-summary-list govuk-!-margin-top-6 govuk-!-margin-bottom-9">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          UCAS Teacher Training (UTT) correspondent
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-body" data-qa="provider__utt_contact">
-            <% if @provider.utt_contact.present? %>
-              <%= @provider.utt_contact[:name] %>
-              <%= @provider.utt_contact[:email] %>
-              <%= @provider.utt_contact[:telephone] %>
-            <% else %>
-              Information unknown
-            <% end %>
-          </p>
-          <p class="govuk-body-s">
-            This person will receive the UCAS monthly bulletin, which includes information about deadlines for application decisions
-          </p>
-        </dd>
-        <dd class="govuk-summary-list__actions"></dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          web-link correspondent
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-body" data-qa="provider__web_link_contact">
-            <% if @provider.web_link_contact.present? %>
-              <%= @provider.web_link_contact[:name] %>
-              <%= @provider.web_link_contact[:email] %>
-              <%= @provider.web_link_contact[:telephone] %>
-            <% else %>
-              Information unknown
-            <% end %>
-          </p>
-          <p class="govuk-body-s">
-            This person will receive notices about UCAS systems and planned downtime
-          </p>
-        </dd>
-        <dd class="govuk-summary-list__actions"></dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Finance contact
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-body" data-qa="provider__finance_contact">
-            <% if @provider.finance_contact.present? %>
-              <%= @provider.finance_contact[:name] %>
-              <%= @provider.finance_contact[:email] %>
-              <%= @provider.finance_contact[:telephone] %>
-            <% else %>
-              Information unknown
-            <% end %>
-          </p>
-          <p class="govuk-body-s">
-            This person will receive invoices from UCAS for payment of fees
-          </p>
-        </dd>
-        <dd class="govuk-summary-list__actions"></dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Fraud contact
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-body" data-qa="provider__fraud_contact">
-            <% if @provider.fraud_contact.present? %>
-              <%= @provider.fraud_contact[:name] %>
-              <%= @provider.fraud_contact[:email] %>
-              <%= @provider.fraud_contact[:telephone] %>
-            <% else %>
-              Information unknown
-            <% end %>
-          </p>
-          <p class="govuk-body-s">
-            This person will receive alerts about fraudulent activity (for example when a plagiarised personal statement is detected)
-          </p>
-        </dd>
-        <dd class="govuk-summary-list__actions"></dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          UCAS Administrator
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-body" data-qa="provider__admin_contact">
-            <% if @provider.admin_contact.present? %>
-              <%= @provider.admin_contact[:name] %>
-              <%= @provider.admin_contact[:email] %>
-              <%= @provider.admin_contact[:telephone] %>
-            <% else %>
-              Information unknown
-            <% end %>
-          </p>
-          <p class="govuk-body-s">
-            This person is responsible for setting up and maintaining UCAS user accounts.
-          </p>
-        </dd>
-        <dd class="govuk-summary-list__actions"></dd>
-      </div>
-    </dl>
+    <%= render partial: "ucas_contact_list", locals: { ucas_contact_view: @ucas_contact_view } %>
 
     <hr class="govuk-section-break govuk-section-break--l" />
 
@@ -149,8 +44,8 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <p class="govuk-body" data-qa="provider__gt12_contact">
-            <% if @provider.gt12_contact.present? %>
-              <%= @provider.gt12_contact %>
+            <% if @ucas_contact_view.gt12_contact.present? %>
+              <%= @ucas_contact_view.gt12_contact %>
             <% else %>
               Information unknown
             <% end %>
@@ -174,11 +69,11 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <p class="govuk-body" data-qa="provider__send_application_alerts">
-            <%= t("edit_options.send_application_alerts.#{@provider.send_application_alerts}.label") %>
+            <%= t("edit_options.send_application_alerts.#{@ucas_contact_view.send_application_alerts}.label") %>
           </p>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to alerts_provider_ucas_contacts_path(@provider.provider_code), class: "govuk-link", data: { qa: 'send_application_alerts__change' } do %>
+          <%= link_to alerts_provider_ucas_contacts_path(@ucas_contact_view.provider_code), class: "govuk-link", data: { qa: 'send_application_alerts__change' } do %>
             Change<span class="govuk-visually-hidden"> email alerts for new applications</span>
           <% end %>
         </dd>
@@ -189,15 +84,15 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <p class="govuk-body" data-qa="provider__application_alert_contact">
-            <% if @provider.application_alert_contact.present? %>
-              <%= @provider.application_alert_contact %>
+            <% if @ucas_contact_view.application_alert_contact.present? %>
+              <%= @ucas_contact_view.application_alert_contact %>
             <% else %>
               Information unknown
             <% end %>
           </p>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to alerts_provider_ucas_contacts_path(@provider.provider_code), class: "govuk-link", data: { qa: 'application_alert_contact__change' } do %>
+          <%= link_to alerts_provider_ucas_contacts_path(@ucas_contact_view.provider_code), class: "govuk-link", data: { qa: 'application_alert_contact__change' } do %>
             Change<span class="govuk-visually-hidden"> email alerts for new applications</span>
           <% end %>
         </dd>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,3 +134,20 @@ en:
     open_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses(ones without a salary) for the next recruitment cycle."
     closed_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses (ones without a salary) for the next recruitment cycle."
     confirmed_state_copy: "Use it to view the outcome of requests for fee-funded PE courses (ones without a salary) for the next recruitment cycle."
+  ucas_contacts:
+    admin:
+      heading: UCAS Administrator
+      purpose: This person is responsible for setting up and maintaining UCAS user accounts.
+      submit: Request changes
+    utt:
+      heading: UCAS Teacher Training (UTT) correspondent
+      purpose: This person will receive the UCAS monthly bulletin, which includes information about deadlines for application decisions.
+    web_link:
+      heading: UCAS web-link correspondent
+      purpose: This person will receive notices about UCAS systems and planned downtime.
+    fraud:
+      heading: Fraud contact
+      purpose: This person will receive alerts about fraudulent activity (for example when a plagiarised personal statement is detected).
+    finance:
+      heading: Finance contact
+      purpose: This person will receive invoices from UCAS for payment of fees.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
       patch "/alerts", on: :member, to: "ucas_contacts#update_alerts"
     end
 
+    resources :contacts, only: %i[edit update]
+
     # TODO: Extract year constraint to future proof for future cycles
     resources :recruitment_cycles, param: :year, constraints: { year: /2020|2021/ }, path: "", only: :show do
       get "/details", on: :member, to: "providers#details"

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     name { Faker::Name.name }
     telephone { Faker::Number.number(digits: 10).to_s }
     email { Faker::Internet.email }
+    permission_given { true }
 
     trait :admin do
       type { "admin" }

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  factory :contact do
+    sequence(:id, &:to_s)
+    name { Faker::Name.name }
+    telephone { Faker::Number.number(digits: 10).to_s }
+    email { Faker::Internet.email }
+
+    trait :admin do
+      type { "admin" }
+    end
+
+    trait :utt do
+      type { "utt" }
+    end
+
+    trait :web_link do
+      type { "web_link" }
+    end
+
+    trait :fraud do
+      type { "fraud" }
+    end
+
+    trait :finance do
+      type { "finance" }
+    end
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -29,41 +29,6 @@ FactoryBot.define do
     recruitment_cycle_year { "2019" }
     last_published_at { Time.zone.local(2019).utc.iso8601 }
     content_status { "Published" }
-    utt_contact do
-      {
-        name: "utt_contact@acme-scitt.org",
-        email: "utt_contact@acme-scitt.org",
-        telephone: "utt_contact@acme-scitt.org",
-      }
-    end
-    web_link_contact do
-      {
-        name: "web_link_contact@acme-scitt.org",
-        email: "web_link_contact@acme-scitt.org",
-        telephone: "web_link_contact@acme-scitt.org",
-      }
-    end
-    finance_contact do
-      {
-        name: "finance_contact@acme-scitt.org",
-        email: "finance_contact@acme-scitt.org",
-        telephone: "finance_contact@acme-scitt.org",
-      }
-    end
-    fraud_contact do
-      {
-        name: "fraud_contact@acme-scitt.org",
-        email: "fraud_contact@acme-scitt.org",
-        telephone: "fraud_contact@acme-scitt.org",
-      }
-    end
-    admin_contact do
-      {
-        name: "admin_contact@acme-scitt.org",
-        email: "admin_contact@acme-scitt.org",
-        telephone: "admin_contact@acme-scitt.org",
-      }
-    end
     gt12_contact { "gt12_contact@acme-scitt.org" }
     application_alert_contact { "application_alert_contact@acme-scitt.org" }
     send_application_alerts { "all" }
@@ -83,6 +48,11 @@ FactoryBot.define do
       provider.users = []
       evaluator.users.each do |user|
         provider.users << user
+      end
+
+      provider.contacts = []
+      evaluator.contacts.each do |contact|
+        provider.contacts << contact
       end
 
       provider.recruitment_cycle = evaluator.recruitment_cycle

--- a/spec/features/providers/ucas_alerts_spec.rb
+++ b/spec/features/providers/ucas_alerts_spec.rb
@@ -14,7 +14,7 @@ feature "Edit UCAS email alerts", type: :feature do
 
   before do
     stub_omniauth
-    stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider, include: "contacts")
     visit alerts_provider_ucas_contacts_path(provider.provider_code)
   end
 

--- a/spec/features/providers/ucas_contacts_spec.rb
+++ b/spec/features/providers/ucas_contacts_spec.rb
@@ -3,15 +3,34 @@ require "rails_helper"
 feature "View provider UCAS contact", type: :feature do
   let(:org_ucas_contacts_page) { PageObjects::Page::Organisations::UcasContacts.new }
   let(:provider) do
-    build :provider,
-          provider_code: "A0",
-          send_application_alerts: nil
+    build(
+      :provider,
+      provider_code: "A0",
+      send_application_alerts: nil,
+      contacts: contacts,
+    )
+  end
+
+  let(:utt_contact) { build(:contact, :utt) }
+  let(:web_link_contact) { build(:contact, :web_link) }
+  let(:fraud_contact) { build(:contact, :fraud) }
+  let(:finance_contact) { build(:contact, :finance) }
+  let(:admin_contact) { build(:contact, :admin) }
+
+  let(:contacts) do
+    [
+      utt_contact,
+      web_link_contact,
+      fraud_contact,
+      finance_contact,
+      admin_contact,
+    ]
   end
 
   before do
     stub_omniauth
 
-    stub_api_v2_resource(provider)
+    stub_api_v2_resource(provider, include: "contacts")
   end
 
   scenario "viewing organisation UCAS contacts page" do
@@ -21,11 +40,12 @@ feature "View provider UCAS contact", type: :feature do
 
     expect(org_ucas_contacts_page.title).to have_content("UCAS contacts")
 
-    expect(org_ucas_contacts_page.utt_contact).to have_content(provider.utt_contact[:name])
-    expect(org_ucas_contacts_page.web_link_contact).to have_content(provider.web_link_contact[:name])
-    expect(org_ucas_contacts_page.finance_contact).to have_content(provider.finance_contact[:name])
-    expect(org_ucas_contacts_page.fraud_contact).to have_content(provider.fraud_contact[:name])
-    expect(org_ucas_contacts_page.admin_contact).to have_content(provider.admin_contact[:name])
+    expect(org_ucas_contacts_page.utt_contact).to have_content(utt_contact.name)
+    expect(org_ucas_contacts_page.web_link_contact).to have_content(web_link_contact.name)
+    expect(org_ucas_contacts_page.finance_contact).to have_content(finance_contact.name)
+    expect(org_ucas_contacts_page.fraud_contact).to have_content(fraud_contact.name)
+    expect(org_ucas_contacts_page.admin_contact).to have_content(admin_contact.name)
+
     expect(org_ucas_contacts_page.gt12_contact).to have_content(provider.gt12_contact)
     expect(org_ucas_contacts_page.application_alert_contact).to have_content(provider.application_alert_contact)
     expect(org_ucas_contacts_page.send_application_alerts).to have_content("Don’t get an email")

--- a/spec/features/providers/update_ucas_contact_spec.rb
+++ b/spec/features/providers/update_ucas_contact_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+feature "update ucas contact" do
+  scenario "with valid params" do
+    given_i_am_a_provider_user
+    and_i_am_logged_in
+    and_my_provider_has_ucas_contacts
+    when_i_view_the_contacts
+    and_i_click_the_change_link_on_the_admin_contact
+    and_i_update_the_details
+    then_i_am_redirected_to_the_contacts_page
+    and_the_updated_details_are_visible
+  end
+
+  scenario "with invalid params" do
+    given_i_am_a_provider_user
+    and_i_am_logged_in
+    and_my_provider_has_ucas_contacts
+    when_i_view_the_contacts
+    and_i_click_the_change_link_on_the_admin_contact
+    and_i_update_the_details_with_invalid_params
+    then_i_am_not_redirected_to_the_contacts_page
+    and_an_error_message_is_displayed
+  end
+
+  def given_i_am_a_provider_user
+    provider
+  end
+
+  def and_i_am_logged_in
+    stub_omniauth
+  end
+
+  def and_my_provider_has_ucas_contacts
+    provider.contacts = []
+    contacts.each { |contact| provider.contacts << contact }
+  end
+
+  def when_i_view_the_contacts
+    stub_initial_provider_request
+
+    contacts_page.load(provider_code: provider.provider_code)
+  end
+
+  def and_i_click_the_change_link_on_the_admin_contact
+    contacts_page.admin_contact.change_link.click
+  end
+
+  def and_i_update_the_details
+    stub_updated_provider_request
+    stub_update_request
+    contacts_edit_page.name_field.set("John")
+    contacts_edit_page.email_field.set("john.cleese@bbc.co.uk")
+    contacts_edit_page.telephone_field.set("0790462876")
+    contacts_edit_page.submit_button.click
+  end
+
+  def and_i_update_the_details_with_invalid_params
+    stub_updated_provider_request
+    stub_invalid_update_request
+    contacts_edit_page.submit_button.click
+  end
+
+  def and_an_error_message_is_displayed
+    expect(contacts_edit_page.error_message).to be_visible
+  end
+
+  def then_i_am_redirected_to_the_contacts_page
+    expect(contacts_page).to be_displayed
+  end
+
+  def then_i_am_not_redirected_to_the_contacts_page
+    expect(contacts_page).not_to be_displayed
+  end
+
+  def and_the_updated_details_are_visible
+    expect(contacts_page.admin_contact.details).to have_content("John")
+    expect(contacts_page.admin_contact.details).to have_content("john.cleese@bbc.co.uk")
+    expect(contacts_page.admin_contact.details).to have_content("0790462876")
+  end
+
+  def provider
+    @provider ||= build(:provider, provider_code: "A0")
+  end
+
+  def contacts
+    @contacts ||= other_contacts + [admin_contact]
+  end
+
+  def admin_contact
+    @admin_contact ||= build(:contact, :admin)
+  end
+
+  def updated_contacts
+    @updated_contacts ||= begin
+                            admin_contact.name = "John"
+                            admin_contact.email = "john.cleese@bbc.co.uk"
+                            admin_contact.telephone = "0790462876"
+                            other_contacts + [admin_contact]
+                          end
+  end
+
+  def other_contacts
+    @other_contacts ||= [
+      build(:contact, :utt),
+      build(:contact, :web_link),
+      build(:contact, :fraud),
+      build(:contact, :finance),
+    ]
+  end
+
+  def contacts_page
+    @contacts_page ||= PageObjects::Page::Organisations::UcasContacts.new
+  end
+
+  def contacts_edit_page
+    @contacts_edit_page ||= PageObjects::Page::Organisations::UcasContactsEdit.new
+  end
+
+  def recruitment_cycle
+    @recruitment_cycle ||= build(:recruitment_cycle)
+  end
+
+  def stub_initial_provider_request
+    stub_api_v2_resource(provider, include: "contacts")
+  end
+
+  def stub_updated_provider_request
+    provider.contacts = []
+    updated_contacts.each { |contact| provider.contacts << contact }
+
+    stub_api_v2_resource(provider, include: "contacts")
+  end
+
+  def stub_update_request
+    stub_api_v2_request("/contacts/#{admin_contact.id}", admin_contact, :patch)
+  end
+
+  def stub_invalid_update_request
+    stub_api_v2_request("/contacts/#{admin_contact.id}", build(:error), :patch, 422)
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Contact do
+  describe "#admin?" do
+    subject { described_class.new(type: type).admin? }
+
+    context "type is 'admin'" do
+      let(:type) { "admin" }
+      it { is_expected.to be(true) }
+    end
+
+    context "type isn't admin" do
+      let(:type) { "utt" }
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/ucas_contacts.rb
+++ b/spec/site_prism/page_objects/page/organisations/ucas_contacts.rb
@@ -2,17 +2,25 @@ module PageObjects
   module Page
     module Organisations
       class UcasContacts < PageObjects::Base
+        class ContactDetail < SitePrism::Section
+          element :details, ".govuk-summary-list__value"
+          element :change_link, ".govuk-summary-list__actions a"
+        end
+
         set_url "/organisations/{provider_code}/ucas-contacts"
 
         element :flash, ".govuk-success-summary"
-        element :utt_contact, '[data-qa="provider__utt_contact"]'
-        element :web_link_contact, '[data-qa="provider__web_link_contact"]'
-        element :finance_contact, '[data-qa="provider__finance_contact"]'
-        element :fraud_contact, '[data-qa="provider__fraud_contact"]'
-        element :admin_contact, '[data-qa="provider__admin_contact"]'
-        element :gt12_contact, '[data-qa="provider__gt12_contact"]'
-        element :application_alert_contact, '[data-qa="provider__application_alert_contact"]'
-        element :send_application_alerts, '[data-qa="provider__send_application_alerts"]'
+        sections :contacts, ContactDetail, ".ucas-contact-list__row"
+        section :admin_contact, ContactDetail, ".ucas-contact-list__row__admin"
+        section :utt_contact, ContactDetail, ".ucas-contact-list__row__utt"
+        section :web_link_contact, ContactDetail, ".ucas-contact-list__row__web_link"
+        section :finance_contact, ContactDetail, ".ucas-contact-list__row__finance"
+        section :fraud_contact, ContactDetail, ".ucas-contact-list__row__fraud"
+
+        section :gt12_contact, ContactDetail, "[data-qa='provider__gt12_contact']"
+
+        element :application_alert_contact, "[data-qa='provider__application_alert_contact']"
+        element :send_application_alerts, "[data-qa='provider__send_application_alerts']"
         element :send_application_alerts_link, "a[data-qa=send_application_alerts__change]", text: "Change"
         element :application_alert_contact_link, "a[data-qa=application_alert_contact__change]", text: "Change"
       end

--- a/spec/site_prism/page_objects/page/organisations/ucas_contacts_edit.rb
+++ b/spec/site_prism/page_objects/page/organisations/ucas_contacts_edit.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module Page
+    module Organisations
+      class UcasContactsEdit < PageObjects::Base
+        set_url "/organisations/{provider_code}/ucas-contacts"
+
+        element :name_field, "#contact-name-field"
+        element :email_field, "#contact-email-field"
+        element :telephone_field, "#contact-telephone-field"
+        element :submit_button, "#contact_edit_form .govuk-button"
+        element :error_message, ".govuk-error-summary"
+        element :admin_subtext, "#admin_subtext"
+        element :admin_subheading, "#contact_edit_form h2"
+      end
+    end
+  end
+end

--- a/spec/support/define_factory_jsonapi_render_methods.rb
+++ b/spec/support/define_factory_jsonapi_render_methods.rb
@@ -27,6 +27,7 @@ FactoryBot.define do
           Organisation: OrganisationSerializer,
           OrganisationUser: OrganisationUser,
           Allocation: AllocationSerializer,
+          Contact: ContactSerializer,
         },
         include: opts[:include],
       )

--- a/spec/support/resource_list_to_jsonapi.rb
+++ b/spec/support/resource_list_to_jsonapi.rb
@@ -19,6 +19,7 @@ def resource_list_to_jsonapi(resource_list, **opts)
       Organisation: OrganisationSerializer,
       Allocation: AllocationSerializer,
       UserNotificationPreferences: UserNotificationPreferencesSerializer,
+      Contact: ContactSerializer,
     },
     include: opts[:include],
     meta: opts[:meta],

--- a/spec/support/serializers/contact_serializer.rb
+++ b/spec/support/serializers/contact_serializer.rb
@@ -1,0 +1,11 @@
+class ContactSerializer < JSONAPI::Serializable::Resource
+  type "contacts"
+
+  belongs_to :provider
+
+  attribute :name
+  attribute :telephone
+  attribute :email
+  attribute :type
+  attribute :permission_given
+end

--- a/spec/support/serializers/provider_serializer.rb
+++ b/spec/support/serializers/provider_serializer.rb
@@ -10,6 +10,7 @@ class ProviderSerializer < JSONAPI::Serializable::Resource
   end
   has_many :sites
   has_many :users
+  has_many :contacts
 
   attributes(*FactoryBot.attributes_for("provider").keys -
              %i[courses sites users])

--- a/spec/view_objects/ucas_contact_view_spec.rb
+++ b/spec/view_objects/ucas_contact_view_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+describe UcasContactView do
+  let(:provider) { build(:provider) }
+
+  subject do
+    described_class.new(provider: provider)
+  end
+
+  describe "CONTACT_TYPES" do
+    let(:expected_contacts) { %i[admin fraud finance web_link utt] }
+
+    it "returns all UCAS contact types" do
+      expect(described_class::CONTACT_TYPES).to contain_exactly(*expected_contacts)
+    end
+
+    describe "#contact_types" do
+      it "returns CONTACT_TYPES" do
+        expect(subject.contact_types).to contain_exactly(*expected_contacts)
+      end
+    end
+  end
+
+  describe "#provider" do
+    it "returns the provider" do
+      expect(subject.provider).to eq(provider)
+    end
+  end
+
+  describe "#contact" do
+    let(:admin_contact) { build(:contact, :admin) }
+    let(:contacts) do
+      [
+        build(:contact, :utt),
+        admin_contact,
+        build(:contact, :fraud),
+      ]
+    end
+
+    before do
+      allow(provider).to receive(:contacts).and_return(contacts)
+    end
+
+    it "returns the requested contact" do
+      expect(subject.contact(:admin)).to eq(admin_contact)
+    end
+  end
+
+  describe "#provider_code" do
+    let(:provider) { build(:provider, provider_code: "1HO") }
+
+    it "returns the provider's code" do
+      expect(subject.provider_code).to eq("1HO")
+    end
+  end
+
+  describe "#gt12_contact" do
+    let(:provider) { build(:provider, gt12_contact: "test@example.com") }
+
+    it "returns the gt12_contact" do
+      expect(subject.gt12_contact).to eq("test@example.com")
+    end
+  end
+
+  describe "#send_application_alerts" do
+    let(:provider) { build(:provider, send_application_alerts: true) }
+
+    it "returns send_application_alerts" do
+      expect(subject.send_application_alerts).to eq(true)
+    end
+  end
+
+  describe "#application_alert_contact" do
+    let(:provider) { build(:provider, application_alert_contact: "test@example.com") }
+
+    it "returns the application_alert_contact" do
+      expect(subject.application_alert_contact).to eq("test@example.com")
+    end
+  end
+end

--- a/spec/views/contacts/_ucas_contact_list_spec.rb
+++ b/spec/views/contacts/_ucas_contact_list_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe "ucas_contact_list" do
+  let(:ucas_contact_view) { instance_double(UcasContactView, provider_code: "1XO") }
+  let(:contacts_page) { PageObjects::Page::Organisations::UcasContacts.new }
+
+  before do
+    allow(ucas_contact_view)
+      .to receive(:contact)
+      .and_return(nil)
+  end
+
+  def load_partial
+    render partial: "ucas_contacts/ucas_contact_list", locals: { ucas_contact_view: ucas_contact_view }
+    contacts_page.load(rendered)
+  end
+
+  context "provider has no contacts" do
+    before { load_partial }
+
+    it "renders five contacts rows" do
+      expect(contacts_page).to have_contacts(count: 5)
+    end
+  end
+
+  context "contact type is not present" do
+    before { load_partial }
+
+    it "renders 'Information unknown'" do
+      expect(contacts_page.admin_contact.details).to have_content("Information unknown")
+    end
+
+    it "doesn't render a change link" do
+      expect(contacts_page.admin_contact).to have_no_change_link
+    end
+  end
+
+  context "contact type is present" do
+    let(:admin_contact) { build(:contact, :admin, id: 1) }
+
+    before do
+      allow(ucas_contact_view)
+        .to receive(:contact)
+        .with(:admin)
+        .and_return(admin_contact)
+
+      load_partial
+    end
+
+    it "renders the contact details" do
+      expect(contacts_page.admin_contact.details).to have_content(admin_contact.name)
+    end
+
+    it "renders a change link" do
+      expect(contacts_page.admin_contact).to have_change_link
+    end
+  end
+end

--- a/spec/views/contacts/edit.html.erb_spec.rb
+++ b/spec/views/contacts/edit.html.erb_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe "contacts/edit" do
+  let(:contacts_edit_page) { PageObjects::Page::Organisations::UcasContactsEdit.new }
+
+  let(:contact) { build(:contact, id: 1, type: type) }
+  let(:provider) { build(:provider, provider_code: "1X0") }
+
+  before do
+    assign(:contact, contact)
+    assign(:provider, provider)
+
+    render
+    contacts_edit_page.load(rendered)
+  end
+
+  context "contact is an admin" do
+    let(:type) { "admin"  }
+
+    it "renders the admin subheading" do
+      expect(contacts_edit_page.admin_subheading.text).to eq("Request a change to your UCAS administrator")
+    end
+
+    it "renders the admin subtext" do
+      expect(contacts_edit_page.admin_subtext.text).to eq("Changes can take up to 7 days to process.")
+    end
+
+    it "renders the submit button with 'Request changes'" do
+      expect(contacts_edit_page.submit_button.value).to eq("Request changes")
+    end
+  end
+
+  context "contact isn't an admin" do
+    let(:type) { "utt" }
+
+    it "doesn't render the admin subheading" do
+      expect(contacts_edit_page.has_no_admin_subheading?).to be(true)
+    end
+
+    it "doesn't render the admin subtext" do
+      expect(contacts_edit_page.has_no_admin_subtext?).to be(true)
+    end
+
+    it "renders the submit button with 'Save'" do
+      expect(contacts_edit_page.submit_button.value).to eq("Save")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Users can't currently edit their UCAS contact details. Now they can 🥳 

### Changes proposed in this pull request

* Treat `Contact` as 'a thing' rather than an element on `Provider`
* Add update contact feature

### Guidance to review

* View an organisation that has UCAS contacts. 1XO is our favourite
* Click the edit link on one of the contacts
* Make a change
* Submit the form
* Rejoice

* The form should require all fields
* The form should require that permission is given with the checkbox
* The UCAS administrator form has extra copy and the submit button value is 'Request changes' rather than 'Save'

### Screenshots

![image](https://user-images.githubusercontent.com/50492247/94912769-134ca280-04a0-11eb-8f90-394453e94d1e.png)
![image](https://user-images.githubusercontent.com/50492247/94912780-19428380-04a0-11eb-92f4-274f790149b5.png)
![image](https://user-images.githubusercontent.com/50492247/94912794-1cd60a80-04a0-11eb-8f78-26abf31f0169.png)
![image](https://user-images.githubusercontent.com/50492247/94912809-20699180-04a0-11eb-8f73-25738d916a76.png)
![image](https://user-images.githubusercontent.com/50492247/94912820-22cbeb80-04a0-11eb-8e0f-191708114d36.png)
![image](https://user-images.githubusercontent.com/50492247/94912828-25c6dc00-04a0-11eb-9f7b-0980fdd48308.png)




### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
