### PR TITLE
Authenticate with DockerHub before pulling image

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -188,6 +188,27 @@
       "metadata": {
         "description": "The publish provider page offers current and next rollover cycles when set to true."
       }
+    },
+    "dockerRegistryUrl": {
+      "type": "string",
+      "defaultValue": "https://index.docker.io",
+      "metadata": {
+          "description": "URL of the docker registry, eg: https://index.docker.io"
+      }
+    },
+    "dockerRegistryUsername": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+          "description": "Username to login to the docker registry"
+      }
+    },
+    "dockerRegistryPassword": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+          "description": "Password to login to the docker registry"
+      }
     }
   },
   "variables": {
@@ -371,6 +392,18 @@
               {
                 "name": "SETTINGS__FEATURES__DFE_SIGNIN",
                 "value": "[parameters('settingsFeaturesDfeSignin')]"
+              },
+              {
+                  "name": "DOCKER_REGISTRY_SERVER_URL",
+                  "value": "[parameters('dockerRegistryUrl')]"
+              },
+              {
+                  "name": "DOCKER_REGISTRY_SERVER_USERNAME",
+                  "value": "[parameters('dockerRegistryUsername')]"
+              },
+              {
+                  "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
+                  "value": "[parameters('dockerRegistryPassword')]"
               }
             ]
           },


### PR DESCRIPTION
### Context

see https://azure.github.io/AppService/2020/10/15/Docker-Hub-authenticated-pulls-on-App-Service.html

### Changes proposed in this pull request
configure App Service to authenticate with dockerhub using provided credentials 

Set in Azure Release pipelines. (done for QA)
```
-dockerRegistryUsername $(dockerRegistryUsername) -dockerRegistryPassword $(dockerRegistryPassword)
```
Update staging & production once/just before this is merged.

### Guidance to review
Changes have been tested in Find and Apply QA.

### Trello
https://trello.com/c/qG7Lio3h/365-pipeline-and-arm-template-changes-to-include-dockerhub-credentials-to-overcome-rate-limit

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
