### PR TITLE
Authenticate with DockerHub (PaaS)

### DIFF
--- a/.github/workflows/deploy-paas.yml
+++ b/.github/workflows/deploy-paas.yml
@@ -53,4 +53,6 @@ jobs:
         run: |
           terraform apply -var-file=${{ env.PAAS_TF_DIR }}/${{ env.TERRAFORM_VAR_FILE }} -auto-approve \
             ${{ env.PAAS_TF_DIR }}
-
+        env:
+          TF_VAR_DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          TF_VAR_DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/terraform/paas/resources.tf
+++ b/terraform/paas/resources.tf
@@ -4,6 +4,11 @@ resource cloudfoundry_app publish-training {
   docker_image = var.app.docker_image
   strategy     = "blue-green-v2"
 
+  docker_credentials = {
+    username = var.DOCKERHUB_USERNAME
+    password = var.DOCKERHUB_PASSWORD
+  }
+
   environment = {
     ASSETS_PRECOMPILE                                = var.app_env.ASSETS_PRECOMPILE
     RAILS_ENV                                        = var.app_env.RAILS_ENV

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -37,3 +37,11 @@ variable SETTINGS__DFE_SIGNIN__SECRET {
 variable SETTINGS__LOGSTASH__HOST {
   type = string
 }
+
+variable DOCKERHUB_USERNAME {
+  type = string
+}
+
+variable DOCKERHUB_PASSWORD {
+  type = string
+}


### PR DESCRIPTION
Authenticate with DockerHub to have increased rate limit.

### Context
See #1413 

### Changes proposed in this pull request

Authenticate with DockerHub before pulling image in PaaS.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
