### PR TITLE
[379] Use Settings recruitment cycle in the routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :development, :test do
   gem "parallel_tests"
 
   # Testing framework
+  gem "rspec-its"
   gem "rspec-rails", "~> 4.0.1"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,9 @@ GEM
     rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -517,6 +520,7 @@ DEPENDENCIES
   rails_semantic_logger
   redcarpet
   request_store
+  rspec-its
   rspec-rails (~> 4.0.1)
   rspec_junit_formatter
   rubocop-govuk

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,8 +68,7 @@ Rails.application.routes.draw do
 
     resources :contacts, only: %i[edit update]
 
-    # TODO: Extract year constraint to future proof for future cycles
-    resources :recruitment_cycles, param: :year, constraints: { year: /2021|2022/ }, path: "", only: :show do
+    resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_cycle}|#{Settings.current_cycle + 1}/ }, path: "", only: :show do
       get "/details", on: :member, to: "providers#details"
       get "/contact", on: :member, to: "providers#contact"
       put "/contact", on: :member, to: "providers#update"

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe Settings do
+  describe "authentication" do
+    subject do
+      YAML.load_file(Rails.root.join("config/settings.yml"))
+    end
+
+    its(%w[current_cycle]) { should eq 2021 }
+  end
+end


### PR DESCRIPTION
### Context
We shouldn't need to hardcode the current/next recruitment cycle year.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
