### PR TITLE
[378] JWT long shelf life (serverside)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -247,11 +247,7 @@ private
     end
     # end of debugging
 
-    token = JWT.encode(
-      payload,
-      Settings.teacher_training_api.secret,
-      Settings.teacher_training_api.algorithm,
-    )
+    token = JWT::EncodeService.call(payload: payload)
 
     RequestStore.store[:manage_courses_backend_token] = token
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -2,11 +2,8 @@ class Session < Base
   class << self
     def create_by_magic(magic_link_token:, email:)
       payload = { email: email }
-      token = JWT.encode(
-        payload,
-        Settings.teacher_training_api.secret,
-        Settings.teacher_training_api.algorithm,
-      )
+      token = JWT::EncodeService.call(payload: payload)
+
       RequestStore.store[:manage_courses_backend_token] = token
       api_url = "#{site}sessions/create_by_magic"
 

--- a/app/services/jwt/encode_service.rb
+++ b/app/services/jwt/encode_service.rb
@@ -1,0 +1,43 @@
+module JWT
+  class EncodeService
+    class << self
+      def call(*args)
+        new(*args).call
+      end
+    end
+
+    def initialize(payload:)
+      @payload = payload
+    end
+
+    def call
+      JWT.encode(
+        data,
+        Settings.teacher_training_api.secret,
+        Settings.teacher_training_api.algorithm,
+      )
+    end
+
+  private
+
+    attr_reader :payload
+
+    def data
+      {
+        data: payload,
+        **claims,
+      }
+    end
+
+    def claims
+      now = Time.zone.now
+      {
+        aud: Settings.teacher_training_api.audience,
+        exp: (now + 5.minutes).to_i,
+        iat: now.to_i,
+        iss: Settings.teacher_training_api.issuer,
+        sub: Settings.teacher_training_api.subject,
+      }
+    end
+  end
+end

--- a/app/services/jwt/encode_service.rb
+++ b/app/services/jwt/encode_service.rb
@@ -1,10 +1,6 @@
 module JWT
   class EncodeService
-    class << self
-      def call(*args)
-        new(*args).call
-      end
-    end
+    include ServicePattern
 
     def initialize(payload:)
       @payload = payload

--- a/app/services/magic_link/generate_and_send_service.rb
+++ b/app/services/magic_link/generate_and_send_service.rb
@@ -15,11 +15,8 @@ module MagicLink
       payload = {
         email: @email,
       }
-      token = JWT.encode(
-        payload,
-        Settings.teacher_training_api.secret,
-        Settings.teacher_training_api.algorithm,
-      )
+
+      token = JWT::EncodeService.call(payload: payload)
 
       post_url = "#{@site}users/generate_and_send_magic_link"
       response = Faraday.patch(

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,6 +18,10 @@ teacher_training_api:
   secret: <%= SecureRandom.base64 %>
   # URL of the API app (teacher-training-api)
   base_url: http://localhost:3001
+  issuer: "publish-teacher-training"
+  audience: "teacher-training-api"
+  subject: "access"
+
 search_ui:
   # URL of the C# search ui app (search-and-compare-ui)
   base_url: https://localhost:5000

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -1,11 +1,24 @@
 require "rails_helper"
 
 describe Settings do
-  describe "authentication" do
+  settings = YAML.load_file(Rails.root.join("config/settings.yml")).with_indifferent_access
+
+  subject do
+    settings
+  end
+
+  describe "settings.teacher_training_api" do
     subject do
-      YAML.load_file(Rails.root.join("config/settings.yml"))
+      settings[:teacher_training_api]
     end
 
-    its(%w[current_cycle]) { should eq 2021 }
+    its(%w[algorithm]) { should_not be_blank }
+    its(%w[secret]) { should_not be_blank }
+    its(%w[base_url]) { should_not be_blank }
+    its(%w[issuer]) { should_not be_blank }
+    its(%w[audience]) { should_not be_blank }
+    its(%w[subject]) { should_not be_blank }
   end
+
+  its(%w[current_cycle]) { should eq 2021 }
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -39,8 +39,8 @@ describe ApplicationController, type: :controller do
     before do
       allow(Base).to receive(:connection)
 
-      allow(JWT).to receive(:encode)
-        .with(payload, Settings.teacher_training_api.secret, Settings.teacher_training_api.algorithm)
+      allow(JWT::EncodeService).to receive(:call)
+        .with(payload: payload)
         .and_return("anything")
     end
 
@@ -65,8 +65,8 @@ describe ApplicationController, type: :controller do
           controller.authenticate
         end
 
-        it "has performed jwt encoding" do
-          expect(JWT).to have_received(:encode)
+        it "has performed jwt encoding service" do
+          expect(JWT::EncodeService).to have_received(:call)
         end
 
         it "has not called session create" do
@@ -168,8 +168,8 @@ describe ApplicationController, type: :controller do
           controller.authenticate
         end
 
-        it "has performed jwt encoding" do
-          expect(JWT).to have_received(:encode)
+        it "has performed jwt encoding service" do
+          expect(JWT::EncodeService).to have_received(:call)
         end
 
         it "has called session create" do

--- a/spec/services/jwt/encode_service_spec.rb
+++ b/spec/services/jwt/encode_service_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe JWT::EncodeService do
+  let(:email) { "bat@localhost" }
+  let(:payload) { { "email" => email } }
+  let(:now) { 1_605_093_071 }
+
+  let(:expected_token_values) do
+    {
+      "data" => payload,
+      **claims,
+    }
+  end
+
+  let(:claims) do
+    {
+      "aud" => Settings.teacher_training_api.audience,
+      "exp" => (now + 5.minutes).to_i,
+      "iat" => now.to_i,
+      "iss" => Settings.teacher_training_api.issuer,
+      "sub" => Settings.teacher_training_api.subject,
+    }
+  end
+
+  let(:decoded_token) do
+    JWT.decode(
+      subject,
+      Settings.teacher_training_api.secret,
+      false, # NOTE: do not verify, it is the client responsibilities
+    ).first
+  end
+
+  let(:static_decoded_token) do
+    token = "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImVtYWlsIjoiYmF0QGxvY2FsaG9zdCJ9LCJhdWQiOiJ0ZWFjaGVyLXRyYWluaW5nLWFwaSIsImV4cCI6MTYwNTA5MzM3MSwiaWF0IjoxNjA1MDkzMDcxLCJpc3MiOiJwdWJsaXNoLXRlYWNoZXItdHJhaW5pbmciLCJzdWIiOiJhY2Nlc3MifQ.njFc7S3opebXsOkkCM3UMCACfpxJmgsDIrvj2eJvBLY"
+    JWT.decode(
+      token,
+      Settings.teacher_training_api.secret,
+      false, # NOTE: do not verify, it is the client responsibilities
+    ).first
+  end
+
+  subject do
+    described_class.call(payload: payload)
+  end
+
+  describe "#call" do
+    before :each do
+      allow(Time).to receive(:zone)
+        .and_return(OpenStruct.new(now: now))
+    end
+
+    it "token values are equal" do
+      expect(decoded_token).to match(expected_token_values)
+      expect(static_decoded_token).to match(expected_token_values)
+    end
+  end
+end

--- a/spec/services/magic_link/generate_and_send_service_spec.rb
+++ b/spec/services/magic_link/generate_and_send_service_spec.rb
@@ -2,13 +2,18 @@ require "rails_helper"
 
 describe MagicLink::GenerateAndSendService do
   let(:email) { "bat@localhost" }
-  let(:site)  { "http://localhost:3000" }
+  let(:payload) { { email: email } }
+  let(:expected_token) { "expected_token" }
+  let(:site) { "http://localhost:3000" }
 
   describe "#call" do
     let(:response) { spy("Response", success?: true) }
 
     before :each do
       allow(Faraday).to receive(:patch).and_return(response)
+      allow(JWT::EncodeService).to receive(:call)
+        .with(payload: payload)
+        .and_return(expected_token)
     end
 
     it "makes a PATCH request to the API" do
@@ -36,12 +41,6 @@ describe MagicLink::GenerateAndSendService do
     end
 
     it "sets the Authorization header" do
-      expected_token = JWT.encode(
-        { email: email },
-        Settings.teacher_training_api.secret,
-        Settings.teacher_training_api.algorithm,
-      )
-
       described_class.call(email: email, site: site)
 
       expect(Faraday).to(


### PR DESCRIPTION
### Context
JWT long shelf life

### Changes proposed in this pull request
JWT tokens generated now has enough items of interest to enforce lifecycle termination due to

- expiration time
- mismatch
   - audience
   - issuer
   - subject

### Guidance to review
This is the server side of the service, and produces the JWT.

Should be reviewed alongside
https://github.com/DFE-Digital/teacher-training-api/pull/1644

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
