### PR TITLE
Read COMMIT_SHA from ENV hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,9 @@ jobs:
         cache-from: |
           ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
           ${{ env.DOCKER_IMAGE}}:${{ env.DOCKER_IMAGE_TAG }}
-        build-args: BUILDKIT_INLINE_CACHE=1
+        build-args: |
+          BUILDKIT_INLINE_CACHE=1
+          COMMIT_SHA=paas-${{ github.sha }}
 
     - name: Trigger QA Deployment
       if: ${{ success() && github.ref == 'refs/heads/master' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2.7.2-alpine
+ARG COMMIT_SHA
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
@@ -26,5 +27,7 @@ RUN yarn install --frozen-lockfile
 ADD . $APP_HOME/
 
 RUN bundle exec rake assets:precompile
+
+ENV COMMIT_SHA=${COMMIT_SHA}
 
 CMD bundle exec rails server -b 0.0.0.0

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -4,7 +4,7 @@ class HeartbeatController < ActionController::API
   end
 
   def sha
-    render json: { sha: commit_sha }
+    render json: { sha: ENV["COMMIT_SHA"] }
   end
 
   def healthcheck
@@ -27,13 +27,5 @@ private
     response.success?
   rescue StandardError
     false
-  end
-
-  def commit_sha_path
-    Rails.root.join(Settings.commit_sha_file)
-  end
-
-  def commit_sha
-    File.read(commit_sha_path).strip
   end
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,6 @@ steps:
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
     echo '$(System.PullRequest.SourceBranch)'> $(build.artifactstagingdirectory)/prbranch.info
-    echo $(Build.SourceVersion) > COMMIT_SHA
   displayName: 'Set version number'
 
 - script: docker pull $(IMAGE_NAME):latest || true
@@ -33,7 +32,7 @@ steps:
     command: Build an image
     imageName: $(IMAGE_NAME)
     dockerFile: Dockerfile
-    arguments: '--cache-from $(IMAGE_NAME):latest'
+    arguments: '--cache-from $(IMAGE_NAME):latest --build-arg COMMIT_SHA=$(Build.SourceVersion)'
     addDefaultLabels: false
 
 - task: Docker@1

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -84,7 +84,6 @@ features:
     # actually starting when it would be set to false
     has_current_cycle_started?: true
     show_next_cycle_allocation_recruitment_page: false
-commit_sha_file: COMMIT_SHA
 basic_auth: false
 basic_auth_username: admin
 basic_auth_password_digest: "52785638ec464fd61f5c9b372797f1a7475225cabeb2b40b2d757eff9b337ff069b2314bb0c0611d44ca5d39c91906ab3415de0fbc36625b970e3c2c03d122da"

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -3,11 +3,9 @@ require "rails_helper"
 RSpec.describe HeartbeatController do
   describe "#sha" do
     around :each do |example|
-      File.open("COMMIT_SHA", "w") { |f| f.write "some-sha" }
+      ENV["COMMIT_SHA"] = "some-sha"
 
       example.run
-
-      File.delete("COMMIT_SHA")
     end
 
     it "returns sha" do


### PR DESCRIPTION
Set `COMMIT_SHA` as docker build argument

Stop writing to and reading COMMIT_SHA to a file.
Set COMMIT_SHA as build arg to docker build

`COMMIT_SHA` is prefixed with paas- in the app hosted in PaaS for identification while we are running on two platforms.

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review