### PR TITLE
disable-basic_auth_in_staging

### DIFF
--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -11,5 +11,5 @@ search_ui:
 environment:
   label: "Staging"
   selector_name: "staging"
-basic_auth: true
-developer_auth: true
+basic_auth: false
+developer_auth: false


### PR DESCRIPTION
### Context

Disable basic_auth in ./config/settings/staging.yml. This would allow DfE sign In

### Changes proposed in this pull request

Set basic_auth: to  false

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
