### PR TITLE
Fail deploy job when smoke tests fail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,10 @@ jobs:
           timeoutSeconds:  300
           intervalSeconds: 15
 
+      - name: Stop when smoke tests fail
+        if: steps.wait_for_smoke_tests.outputs.conclusion == 'failure'
+        run: exit 1
+
       - name: Update ${{ matrix.environment }} status
         if: ${{ always() }}
         uses: bobheadxi/deployments@master


### PR DESCRIPTION
The fountainhead/actions-wait-for-check step does not fail
when the retrieved status check has failed.
We have to fail the job if the outcome is failure to prevent deploying to the next environment.