### PR TITLE
Revert healthCheckPath

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -323,9 +323,6 @@
           "http20Enabled": {
             "value": true
           },
-          "healthCheckPath": {
-            "value": "/ping"
-          },
           "appServiceAppSettings": {
             "value": [
               {
@@ -371,10 +368,6 @@
               {
                 "name": "WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION",
                 "value": "0"
-              },
-              {
-                "name": "WEBSITE_HEALTHCHECK_MAXPINGFAILURES",
-                "value": "5"
               },
               {
                 "name": "SETTINGS__LOGSTASH__HOST",


### PR DESCRIPTION
Reverts #1498
This is causing slow response times, so revering this until further investigation.

### Context
#1498 is causing slow response times (as seen under Response time metrics )in Azure Portal.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
