### PR TITLE
Update base docker image to ruby:2.7.2-alpine3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine
+FROM ruby:2.7.2-alpine3.12
 ARG COMMIT_SHA
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \


### PR DESCRIPTION
### Context

alpine has released version 3.13 with an updated version of node which might cause version conflicts.

### Changes proposed in this pull request

use ruby:2.7.2-alpine3.12

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
