### PR TITLE
Update PaaS org name to dfe

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -7,7 +7,7 @@ data cloudfoundry_domain publish_service_gov_uk {
 }
 
 data cloudfoundry_org org {
-  name = "dfe-teacher-services"
+  name = "dfe"
 }
 
 data cloudfoundry_space space {


### PR DESCRIPTION
As part of the consolidation on other dfe services into PaaS,
there is the need rename the PaaS org name from "dfe-teacher-services" to "dfe"

### Context
As part of the consolidation on other dfe services into PaaS,
there is the need rename the PaaS org name from "dfe-teacher-services" to "dfe"

### Changes proposed in this pull request

data cloudfoundry_org org {
name = "dfe"
}


### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
