### PR TITLE
Allow using personal Azure credentials to run locally

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -34,10 +34,10 @@ provider azurerm {
   features {}
 
   skip_provider_registration = true
-  subscription_id            = local.azure_credentials.subscriptionId
-  client_id                  = local.azure_credentials.clientId
-  client_secret              = local.azure_credentials.clientSecret
-  tenant_id                  = local.azure_credentials.tenantId
+  subscription_id            = try(local.azure_credentials.subscriptionId, null)
+  client_id                  = try(local.azure_credentials.clientId, null)
+  client_secret              = try(local.azure_credentials.clientSecret, null)
+  tenant_id                  = try(local.azure_credentials.tenantId, null)
 }
 
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,7 +26,7 @@ variable key_vault_app_secret_name {}
 
 variable key_vault_infra_secret_name {}
 
-variable azure_credentials {}
+variable azure_credentials { default = null }
 
 #StatusCake
 variable statuscake_alerts {
@@ -37,12 +37,11 @@ variable statuscake_alerts {
 locals {
   cf_api_url = "https://api.london.cloud.service.gov.uk"
 
-
   paas_app_config                = yamldecode(file(var.paas_app_config_file))[var.paas_app_environment_config]
   app_secrets                    = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
   infra_secrets                  = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
   paas_app_environment_variables = merge(local.app_secrets, local.paas_app_config)
-  azure_credentials              = jsondecode(var.azure_credentials)
+  azure_credentials              = try(jsondecode(var.azure_credentials), null)
 
   dockerhub_credentials = {
     username = local.infra_secrets.DOCKERHUB_USERNAME


### PR DESCRIPTION
Until change, it was difficult to run terrafrom locally without specifying
the Service Principal credentials. But this can now be achieved by just using
the credential of the person running the script.

### Context

With the introduction of collecting secrets from Azure keyvault bu means of using a ServicePrincipal. If terraform is executed locally, the current terraform configuration will try to authenticate using the ServicePrincipal, instead of using the context of the person running the terraform command. This issue is more evident or pronounced when using the make file

### Changes proposed in this pull request

ignore the azure_credentials if it is not set

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
