### PR TITLE
976 validate secrets in the pipeline 2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,15 +72,24 @@ jobs:
           DEPLOY_ENV:   ${{ matrix.environment }}
           DOCKER_IMAGE: ${{ format('dfedigital/publish-teacher-training:paas-{0}', github.event.inputs.sha) }}
 
-      - name: Download app secrets file
-        working-directory: terraform/workspace_variables
-        run: echo $APP_SECRETS | base64 -d >> app_secrets.yml
-        env:
-          APP_SECRETS: ${{ secrets[format('APP_SECRETS_{0}', env.DEPLOY_ENV)] }}
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets[format('AZURE_CREDENTIALS_{0}', env.DEPLOY_ENV)] }}
+
+      - name: Validate Azure key vault secrets
+        run: |
+          wget https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb
+          chmod +x fetch_config.rb
+          . "terraform/workspace_variables/${DEPLOY_ENV}.sh"
+          ./fetch_config.rb -s "azure-key-vault-secret:${TF_VAR_key_vault_name}/${TF_VAR_key_vault_app_secret_name}" -d quiet \
+            && echo Data in "${TF_VAR_key_vault_name}/${TF_VAR_key_vault_app_secret_name}" looks valid
+          ./fetch_config.rb -s "azure-key-vault-secret:${TF_VAR_key_vault_name}/${TF_VAR_key_vault_infra_secret_name}" -d quiet \
+            && echo Data in "${TF_VAR_key_vault_name}/${TF_VAR_key_vault_infra_secret_name}" looks valid
 
       - name: Terraform init, plan & apply
         working-directory: terraform
         run: |
+          . "workspace_variables/${DEPLOY_ENV}.sh"
           terraform init -backend-config workspace_variables/${{ env.DEPLOY_ENV }}_backend.tfvars
           terraform plan -var-file workspace_variables/${{ env.DEPLOY_ENV }}.tfvars -out tfplan
           terraform apply -auto-approve -input=false "tfplan"

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ terraform.tfstate.d/
 ./*.tfstate
 lock.json
 **/.terraform/
+
+bin/fetch_config.rb

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	echo "        make review APP_NAME=<APP_NAME> deploy-plan IMAGE_TAG=GIT_REF PASSCODE=<CF_SSO_CODE>"
 	echo "  Delete a review app"
 	echo ""
-	echo "        make review APP_NAME=<APP_NAME> destory IMAGE_TAG=GIT_REF PASSCODE=<CF_SSO_CODE>"
+	echo "        make review APP_NAME=<APP_NAME> destroy IMAGE_TAG=GIT_REF PASSCODE=<CF_SSO_CODE>"
 	echo "Examples:"
 	echo "  Deploy an pre-built image to qa"
 	echo ""

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	echo "        make review APP_NAME=<APP_NAME> deploy-plan IMAGE_TAG=GIT_REF PASSCODE=<CF_SSO_CODE>"
 	echo "  Delete a review app"
 	echo ""
-	echo "        make review APP_NAME=<APP_NAME> destory IMAGE_TAG=GIT_REF PASSCODE=<CF_SSO_CODE>"	
+	echo "        make review APP_NAME=<APP_NAME> destory IMAGE_TAG=GIT_REF PASSCODE=<CF_SSO_CODE>"
 	echo "Examples:"
 	echo "  Deploy an pre-built image to qa"
 	echo ""
@@ -64,6 +64,23 @@ production: ## Set DEPLOY_ENV to production
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-production)
 	$(if $(CONFIRM_PRODUCTION), , $(error Production can only run with CONFIRM_PRODUCTION))
 
+install-fetch-config:
+	[[ ! -f bin/fetch_config.rb ]] \
+		&& curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb \
+		&& chmod +x bin/fetch_config.rb \
+		|| true
+
+set-azure-account:
+	az account set -s ${AZ_SUBSCRIPTION} && az account show
+
+edit-app-secrets: install-fetch-config set-azure-account
+	. terraform/workspace_variables/$(DEPLOY_ENV).sh && bin/fetch_config.rb -s azure-key-vault-secret:$${TF_VAR_key_vault_name}/$${TF_VAR_key_vault_app_secret_name} \
+		-e -d azure-key-vault-secret:$${TF_VAR_key_vault_name}/$${TF_VAR_key_vault_app_secret_name} -f yaml
+
+edit-infra-secrets: install-fetch-config set-azure-account
+	. terraform/workspace_variables/$(DEPLOY_ENV).sh && bin/fetch_config.rb -s azure-key-vault-secret:$${TF_VAR_key_vault_name}/$${TF_VAR_key_vault_infra_secret_name} \
+		-e -d azure-key-vault-secret:$${TF_VAR_key_vault_name}/$${TF_VAR_key_vault_infra_secret_name} -f yaml
+
 deploy-init:
 	$(eval export TF_DATA_DIR=./terraform/.terraform)
 	$(if $(IMAGE_TAG), , $(error Missing environment variable "IMAGE_TAG"))
@@ -75,10 +92,13 @@ deploy-init:
 	echo "🚀 DEPLOY_ENV is $(DEPLOY_ENV)"
 
 deploy-plan: deploy-init
-	terraform plan -var-file=terraform/workspace_variables/$(DEPLOY_ENV).tfvars terraform
+	. terraform/workspace_variables/$(DEPLOY_ENV).sh \
+		&& terraform plan -var-file=terraform/workspace_variables/$(DEPLOY_ENV).tfvars terraform
 
 deploy: deploy-init
-	terraform apply -var-file=terraform/workspace_variables/$(DEPLOY_ENV).tfvars -auto-approve terraform
+	. terraform/workspace_variables/$(DEPLOY_ENV).sh \
+		&& terraform apply -var-file=terraform/workspace_variables/$(DEPLOY_ENV).tfvars -auto-approve terraform
 
 destroy: deploy-init
-	terraform destroy -var-file=terraform/workspace_variables/$(DEPLOY_ENV).tfvars terraform
+	. terraform/workspace_variables/$(DEPLOY_ENV).sh \
+		&& terraform destroy -var-file=terraform/workspace_variables/$(DEPLOY_ENV).tfvars terraform

--- a/terraform/workspace_variables/production.sh
+++ b/terraform/workspace_variables/production.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121p01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=PUBLISH-APP-SECRETS-PRODUCTION
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-PRODUCTION

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -19,7 +19,4 @@ statuscake_alerts = {
   }
 }
 
-key_vault_name              = "s121p01-shared-kv-01"
 key_vault_resource_group    = "s121p01-shared-rg"
-key_vault_app_secret_name   = "PUBLISH-APP-SECRETS-PRODUCTION"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"

--- a/terraform/workspace_variables/qa.sh
+++ b/terraform/workspace_variables/qa.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121d01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=PUBLISH-APP-SECRETS-QA
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-QA

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -20,7 +20,4 @@ statuscake_alerts = {
 }
 
 #vault
-key_vault_name              = "s121d01-shared-kv-01"
 key_vault_resource_group    = "s121d01-shared-rg"
-key_vault_app_secret_name   = "PUBLISH-APP-SECRETS-QA"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-QA"

--- a/terraform/workspace_variables/sandbox.sh
+++ b/terraform/workspace_variables/sandbox.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121p01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=PUBLISH-APP-SECRETS-SANDBOX
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-SANDBOX

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -19,7 +19,4 @@ statuscake_alerts = {
   }
 }
 
-key_vault_name              = "s121p01-shared-kv-01"
 key_vault_resource_group    = "s121p01-shared-rg"
-key_vault_app_secret_name   = "PUBLISH-APP-SECRETS-SANDBOX"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"

--- a/terraform/workspace_variables/staging.sh
+++ b/terraform/workspace_variables/staging.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121t01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=PUBLISH-APP-SECRETS-STAGING
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-STAGING

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -20,7 +20,4 @@ statuscake_alerts = {
 }
 
 #vault
-key_vault_name              = "s121t01-shared-kv-01"
 key_vault_resource_group    = "s121t01-shared-rg"
-key_vault_app_secret_name   = "PUBLISH-APP-SECRETS-STAGING"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"


### PR DESCRIPTION
### Context

Validate the screte yaml file before it is saved. As is when a secret-file (yaml file) is not well formed and a `yamldecode` is attempted by Terraform. This would course terraform to fail and spilling out the contents of the secret-file in plain text in the logs.

### Changes proposed in this pull request

Add `fetch_config.rb` as part of the terraform deploy process. 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
