### PR TITLE
[972] Style the sandbox banner

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -77,6 +77,10 @@ module ViewHelper
     Settings.environment.label
   end
 
+  def sandbox_mode?
+    Settings.environment.selector_name == "sandbox"
+  end
+
   # Ad-hoc, informally specified, and bug-ridden Ruby implementation of half
   # of https://github.com/JedWatson/classnames.
   #

--- a/app/views/layouts/_beta-banner.html.erb
+++ b/app/views/layouts/_beta-banner.html.erb
@@ -3,6 +3,12 @@
     <strong class="govuk-tag govuk-phase-banner__content__tag <%= beta_tag_environment_class %>">
       <%= beta_banner_environment_label %>
     </strong>
-    <span class="govuk-phase-banner__text">This is a new service – your <%= bat_contact_mail_to "feedback", subject: "Publish teacher training courses feedback" %> will help us to improve it.</span>
+    <span class="govuk-phase-banner__text">
+    <% if sandbox_mode? %>
+      This is a <%= govuk_link_to "test version of Publish", root_path %> for providers and software vendors
+    <% else %>
+      This is a new service – your <%= bat_contact_mail_to "feedback", subject: "Publish teacher training courses feedback" %> will help us to improve it.
+    <% end %>
+    </span>
   </p>
 </div>

--- a/app/webpacker/stylesheets/_environments.scss
+++ b/app/webpacker/stylesheets/_environments.scss
@@ -10,6 +10,10 @@
   background: govuk-colour("red");
 }
 
+.app-tag--sandbox {
+  background: govuk-colour("purple");
+}
+
 .app-header__container--development {
   border-bottom-color: govuk-colour("dark-grey");
 }
@@ -20,4 +24,8 @@
 
 .app-header__container--staging {
   border-bottom-color: govuk-colour("red");
+}
+
+.app-header__container--sandbox {
+  border-bottom-color: govuk-colour("purple");
 }


### PR DESCRIPTION
### Context

https://trello.com/c/L1rjppxc/972-style-sandbox-banner-in-publish

### Changes proposed in this pull request

Adds purple styling to the sandbox banner and updates the text.

<img width="832" alt="Screenshot 2021-02-08 at 11 32 27" src="https://user-images.githubusercontent.com/18436946/107214856-6f9d7100-6a02-11eb-9e2b-429c09140eeb.png">

### Guidance to review

- Pull down the code
- Update your `development.yml` to think it's in sandbox mode, by copying from `sandbox.yml`:
```yml
environment:
  label: "Sandbox"
  selector_name: "sandbox"
```
- Check that the banner is styled correctly.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
