### PR TITLE
Update copy on About this Course and requirements page

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -118,6 +118,12 @@ class Course < Base
     level == "further_education"
   end
 
+  def travel_to_work_areas
+    travel_to_work_areas = sites.map { |site| site.london_borough || site.travel_to_work_area }.uniq
+
+    travel_to_work_areas.to_sentence(last_word_connector: " and ")
+  end
+
 private
 
   def post_base_url

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,7 +4,7 @@ class Site < Base
   has_one :site_status
 
   properties :code, :location_name, :address1, :address2, :address3
-  properties :address4, :postcode, :latitude, :longitude
+  properties :address4, :postcode, :latitude, :longitude, :travel_to_work_area, :london_borough
 
   REGIONS = [
     ["London", :london],

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -108,6 +108,32 @@
           <li>how placement schools are selected</li>
         </ul>
 
+        <p class="govuk-body">We show guidance in this section. It tells candidates:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>what qualifications they need to teach in England</li>
+          <li>where to go to find out about international qualifications</li>
+          <li>why they might need to do a subject knowledge enhancement course</li>
+        </ul>
+
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              See the guidance
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <h3 class="govuk-heading-m">Where you will train</h3>
+            <% if @provider.provider_type == 'HEI' %>
+              <p class="govuk-body">You’ll be placed in schools for most of your course. This university is based in [show provider location(s)], and your school placements will be within commuting distance.</p>
+              <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
+              <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
+            <% else %>
+              <p class="govuk-body">This course has placement schools in [show provider location(s)]. Most of your time will be spent in the classroom with experienced teachers</p>
+              <p class="govuk-body">You'll be placed in different schools during your training. You can't pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
+            <% end %>
+          </div>
+        </details>
+
         <%= f.govuk_text_area :how_school_placements_work, label: { text: course.placements_heading, size:'s' }, max_words: 350, rows: 15 %>
 
         <%= f.govuk_submit "Save" %>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -115,7 +115,6 @@
           <li>why they might need to do a subject knowledge enhancement course</li>
         </ul>
 
-        <% binding.pry %>
         <details class="govuk-details" data-module="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
@@ -124,12 +123,12 @@
           </summary>
           <div class="govuk-details__text">
             <h3 class="govuk-heading-m">Where you will train</h3>
-            <% if @provider.provider_type == 'HEI' %>
-              <p class="govuk-body">You’ll be placed in schools for most of your course. This university is based in <%= @course.sites.map { |site| site.london_borough || site.travel_to_work_area }.join(", ") %>, and your school placements will be within commuting distance.</p>
+            <% if @provider.provider_type == 'university' %>
+              <p class="govuk-body">You’ll be placed in schools for most of your course. This university is based in <%= @course.travel_to_work_areas %>, and your school placements will be within commuting distance.</p>
               <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
               <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
             <% else %>
-              <p class="govuk-body">This course has placement schools in <%= @course.sites.map { |site| site.london_borough || site.travel_to_work_area }.join(", ") %>. Most of your time will be spent in the classroom with experienced teachers</p>
+              <p class="govuk-body">This course has placement schools in <%= @course.travel_to_work_areas %>. Most of your time will be spent in the classroom with experienced teachers.</p>
               <p class="govuk-body">You'll be placed in different schools during your training. You can't pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
             <% end %>
           </div>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -115,6 +115,7 @@
           <li>why they might need to do a subject knowledge enhancement course</li>
         </ul>
 
+        <% binding.pry %>
         <details class="govuk-details" data-module="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
@@ -124,11 +125,11 @@
           <div class="govuk-details__text">
             <h3 class="govuk-heading-m">Where you will train</h3>
             <% if @provider.provider_type == 'HEI' %>
-              <p class="govuk-body">You’ll be placed in schools for most of your course. This university is based in [show provider location(s)], and your school placements will be within commuting distance.</p>
+              <p class="govuk-body">You’ll be placed in schools for most of your course. This university is based in <%= @course.sites.map { |site| site.london_borough || site.travel_to_work_area }.join(", ") %>, and your school placements will be within commuting distance.</p>
               <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
               <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
             <% else %>
-              <p class="govuk-body">This course has placement schools in [show provider location(s)]. Most of your time will be spent in the classroom with experienced teachers</p>
+              <p class="govuk-body">This course has placement schools in <%= @course.sites.map { |site| site.london_borough || site.travel_to_work_area }.join(", ") %>. Most of your time will be spent in the classroom with experienced teachers</p>
               <p class="govuk-body">You'll be placed in different schools during your training. You can't pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
             <% end %>
           </div>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -32,6 +32,36 @@
         You could also say what happens if these requirements aren’t met.
       </p>
 
+      <p class="govuk-body">We show guidance in this section. It tells candidates:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>what qualifications they need to teach in England</li>
+        <li>where to go to find out about international qualifications</li>
+        <li>why they might need to do a subject knowledge enhancement course</li>
+      </ul>
+
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            See the guidance
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <h3 class="govuk-heading-m">Qualifications</h3>
+            <p class="govuk-body">To be a teacher in England you need:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>a degree or an equivalent qualification</li>
+              <li>English and Maths GCSEs at grade 4 (C) or above</li>
+              <li>For primary teaching, a science subject GCSE at grade 4 (C) or above</li>
+            </ul>
+            <p class="govuk-body">You can find out more about entry requirements, and how it works if you have studied overseas, at <%= link_to "Get Into Teaching", "https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher" %>.</p>
+
+            <h4 class="govuk-heading-s">Refreshing your subject knowledge</h4>
+            <p class="govuk-body">If you have the right qualities and qualifications to teach but need to refresh your subject knowledge, you might be asked to complete a <%= link_to "subject knowledge enhancement (SKE) course", "https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses" %>.</p>
+
+            <p class="govuk-body">You’ll find out if you need to complete an SKE course after the interview stage.</p>
+        </div>
+      </details>
+
       <%= f.govuk_text_area :required_qualifications, label: { text: 'Qualifications needed', size:'s' }, max_words: 100, rows: 10 %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     sequence(:id, &:to_s)
     sequence(:provider_code) { |n| "A#{n}" }
     provider_name { "ACME SCITT #{provider_code}" }
+    provider_type { "lead_school" }
     accredited_body? { false }
     can_add_more_sites? { true }
     courses { [] }

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -15,6 +15,8 @@ FactoryBot.define do
     latitude { nil }
     longitude { nil }
     recruitment_cycle_year { Settings.current_cycle }
+    travel_to_work_area { nil }
+    london_borough { nil }
 
     after :build do |course, evaluator|
       course.recruitment_cycle = evaluator.recruitment_cycle

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -153,4 +153,45 @@ describe Course do
       end
     end
   end
+
+  describe "#travel_to_work_areas" do
+    context "when there is a single travel to work area" do
+      let(:site1) { build(:site, travel_to_work_area: "Brighton") }
+      let(:course) { build(:course, sites: [site1]) }
+
+      it "returns that site" do
+        expect(course.travel_to_work_areas).to eq "Brighton"
+      end
+    end
+
+    context "when there is a london borough and travel to work area" do
+      let(:site1) { build(:site, london_borough: "Westminster", travel_to_work_area: "Test") }
+      let(:course) { build(:course, sites: [site1]) }
+
+      it "returns just the london borough" do
+        expect(course.travel_to_work_areas).to eq "Westminster"
+      end
+    end
+
+    context "when there are two  different travel sites" do
+      let(:site1) { build(:site, london_borough: "Westminster") }
+      let(:site2) { build(:site, travel_to_work_area: "Brighton") }
+      let(:course) { build(:course, sites: [site1, site2]) }
+
+      it "returns both sites with the correct format" do
+        expect(course.travel_to_work_areas).to eq "Westminster and Brighton"
+      end
+    end
+
+    context "when there is a mixture of more than two travel sites" do
+      let(:site1) { build(:site, london_borough: "Westminster") }
+      let(:site2) { build(:site, london_borough: "Southwark") }
+      let(:site3) { build(:site, travel_to_work_area: "Brighton") }
+      let(:course) { build(:course, sites: [site1, site2, site3]) }
+
+      it "returns all sites in the correct format" do
+        expect(course.travel_to_work_areas).to eq "Westminster, Southwark and Brighton"
+      end
+    end
+  end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -136,7 +136,7 @@ module Helpers
   end
 
   def stub_api_v2_build_course(params = {})
-    jsonapi_response = course.to_jsonapi(include: [:subjects, :sites, :provider, :accrediting_provider, provider: [:sites]])
+    jsonapi_response = course.to_jsonapi(include: [:subjects, :sites, :provider, :accrediting_provider, provider: %i[sites provider_type]])
     jsonapi_response[:data][:meta] = course.meta
     jsonapi_response[:data][:errors] = course_errors_to_json_api(course)
     stub_api_v2_request(

--- a/spec/support/serializers/provider_serializer.rb
+++ b/spec/support/serializers/provider_serializer.rb
@@ -16,5 +16,6 @@ class ProviderSerializer < JSONAPI::Serializable::Resource
              %i[courses sites users])
 
   attribute :recruitment_cycle
+  attribute :provider_type
   attribute :recruitment_cycle_year
 end


### PR DESCRIPTION
### Context

In order to keep the content on publish inline with recent updates on find this PR
tweaks the layout and copy of the about this course and requirements pages. 

### Changes proposed in this pull request
The requirements page has a details drop down added. The about page has a drop down
but it will render different information based on whether the course is at a uni
or a SCITT/Schools direct

### Guidance to review

Test still to be written. Currently blocked by TTW areas work.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
