### PR TITLE
1056 basic smoke test

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,7 @@
+# This is to allow specs to be run in parallel without falling over
+# due to a subtle bug in bundler load paths
+# https://github.com/grosser/parallel_tests/issues/649
+# https://github.com/bundler/bundler/issues/5005#issuecomment-251025953
+# See discussion on https://github.com/DFE-Digital/teacher-training-api/pull/970
+---
+BUNDLE_DISABLE_EXEC_LOAD: "true"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.bundle
 log
 tmp
 .git

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,11 +19,7 @@ jobs:
           ruby-version: 2.7.2
 
       - name: install bundler and gems
-        run: |
-          gem install bundler
-          echo 'gem "httparty"' >> Gemfile
-          echo 'gem "rspec"' >> Gemfile
-          bundle
+        run: gem install bundler httparty rspec
 
       - uses: softprops/turnstyle@v1
         name: Wait for other runs
@@ -31,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
 
       - name: Smoke Tests ${{ github.event.inputs.environment }}
-        run: RAILS_ENV=${{ github.event.inputs.environment }} ./bin/bundle exec rspec spec/smoke --options ./.rspec_smoke 
+        run: RAILS_ENV=${{ github.event.inputs.environment }} bundle exec rspec spec/smoke --options ./.rspec_smoke 
 
       - name: 'Notify #twd_publish_register_tech on failure'
         if: failure()

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,15 +11,29 @@ jobs:
     name: smoke-tests-${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby 2.7.2
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+
+      - name: install bundler and gems
+        run: |
+          gem install bundler
+          echo 'gem "httparty"' >> Gemfile
+          echo 'gem "rspec"' >> Gemfile
+          bundle
+
       - uses: softprops/turnstyle@v1
         name: Wait for other runs
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
 
       - name: Smoke Tests ${{ github.event.inputs.environment }}
-        run: echo "Nothing to run yet 🚀"
+        run: RAILS_ENV=${{ github.event.inputs.environment }} ./bin/bundle exec rspec spec/smoke --options ./.rspec_smoke 
 
-      - name: 'Nofiy #twd_publish_register_tech on failure'
+      - name: 'Notify #twd_publish_register_tech on failure'
         if: failure()
         uses: rtCamp/action-slack-notify@master
         env:
@@ -28,5 +42,5 @@ jobs:
           SLACK_ICON_EMOJI: ':github-logo:'
           SLACK_USERNAME: Publish Teacher Training
           SLACK_TITLE: Smoke tests failure
-          SLACK_MESSAGE: ':alert: Smoke tests failure on ${{ github.event.inputs.environment }} :sadparrot:'
+          SLACK_MESSAGE: ':alert: Smoke tests failure on ${{ github.event.inputs.environment }} :fire:'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-# Ignore bundler config.
-/.bundle
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/.rspec_smoke
+++ b/.rspec_smoke
@@ -1,0 +1,2 @@
+--require spec_helper_smoke
+--format documentation 

--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,12 @@ group :development, :test do
   # Testing framework
   gem "rspec-its"
   gem "rspec-rails", "~> 4.0.2"
+
+  # Make HTTP requests fun again
+  gem "httparty"
+
+  # Smoketest, parallel spec
+  gem "rspec"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,9 @@ GEM
       rubocop (< 2.0)
     hashdiff (1.0.1)
     hashie (4.1.0)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.8.8)
       concurrent-ruby (~> 1.0)
@@ -233,11 +236,15 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.1104)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
     msgpack (1.4.2)
+    multi_xml (0.6.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.5)
@@ -510,6 +517,7 @@ DEPENDENCIES
   guard
   guard-rspec
   guard-rubocop
+  httparty
   json_api_client
   jsonapi-deserializable
   jsonapi-renderer
@@ -532,6 +540,7 @@ DEPENDENCIES
   rails_semantic_logger
   redcarpet
   request_store
+  rspec
   rspec-its
   rspec-rails (~> 4.0.2)
   rspec_junit_formatter

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -9,7 +9,7 @@ class HeartbeatController < ActionController::API
 
   def healthcheck
     checks = {
-      teacher_training_api: api_alive?,
+      teacher_training_api: api_ping?,
     }
 
     status = checks.values.all? ? :ok : :service_unavailable
@@ -22,8 +22,12 @@ class HeartbeatController < ActionController::API
 
 private
 
-  def api_alive?
-    response = Faraday.get("#{Settings.teacher_training_api.base_url}/healthcheck")
+  def api_ping?
+    api_alive?("/ping")
+  end
+
+  def api_alive?(path)
+    response = Faraday.get("#{Settings.teacher_training_api.base_url}#{path}")
     response.success?
   rescue StandardError
     false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,5 @@
+publish_url: https://localhost:3000
+
 dfe_signin:
   # Our service name
   identifier: bats2

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,5 @@
+publish_url: https://localhost:3000 
+
 dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   base_url: https://localhost:3000

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,5 @@
+publish_url: https://www.publish-teacher-training-courses.service.gov.uk
+
 dfe_signin:
   issuer: https://oidc.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,8 +1,8 @@
-publish_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
+publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
-  base_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
+  base_url: https://qa.publish-teacher-training-courses.service.gov.uk
 teacher_training_api:
   base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
 search_ui:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,3 +1,5 @@
+publish_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
+
 dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   base_url: https://www.qa.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -1,3 +1,5 @@
+publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
+
 dfe_signin:
   issuer: https://oidc.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,10 +1,10 @@
-publish_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
+publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://pp-oidc.signin.education.gov.uk
   profile: https://pp-profile.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
-  base_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
+  base_url: https://staging.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://pp-support.signin.education.gov.uk/users
 teacher_training_api:
   base_url: https://api.staging.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,3 +1,5 @@
+publish_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
+
 dfe_signin:
   issuer: https://pp-oidc.signin.education.gov.uk
   profile: https://pp-profile.signin.education.gov.uk

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,5 @@
+publish_url: https://localhost:3000
+
 dfe_signin:
   base_url: https://localhost:3000
 teacher_training_api:

--- a/spec/requests/heartbeat_checks_spec.rb
+++ b/spec/requests/heartbeat_checks_spec.rb
@@ -10,7 +10,7 @@ describe "heartbeat checks requests" do
   end
 
   describe "GET /healthcheck" do
-    let(:healthcheck_endpoint) { "http://localhost:3001/healthcheck" }
+    let(:healthcheck_endpoint) { "http://localhost:3001/ping" }
 
     context "when everything is ok" do
       before do

--- a/spec/smoke/healthcheck_spec.rb
+++ b/spec/smoke/healthcheck_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper_smoke"
+
+describe "Publish Teacher Training Smoke Tests", :aggregate_failures, smoke: true do
+  let(:base_url) { Settings.publish_url }
+
+  subject(:response) { HTTParty.get(url) }
+
+  describe "GET #{Settings.publish_url}/healthcheck" do
+    let(:url) { "#{base_url}/healthcheck" }
+
+    it "returns HTTP success" do
+      expect(response.code).to eq(200)
+    end
+
+    it "returns JSON" do
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it "returns the expected response report" do
+      expect(response.body).to eq(
+        {
+          checks: {
+            teacher_training_api: true,
+          },
+        }.to_json,
+      )
+    end
+  end
+end

--- a/spec/smoke/healthcheck_spec.rb
+++ b/spec/smoke/healthcheck_spec.rb
@@ -28,4 +28,20 @@ describe "Publish Teacher Training Smoke Tests", :aggregate_failures, smoke: tru
       )
     end
   end
+
+  describe "GET #{Settings.publish_url}/ping" do
+    let(:url) { "#{base_url}/ping" }
+
+    it "returns HTTP success" do
+      expect(response.code).to eq(200)
+    end
+
+    it "returns HTML" do
+      expect(response.content_type).to eq("text/html")
+    end
+
+    it "returns the expected response report" do
+      expect(response.body).to eq("PONG")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,8 @@ end
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.filter_run_excluding smoke: true
+
   # Reduce noise in console when running specs in parallel
   config.silence_filter_announcements = true if ENV["TEST_ENV_NUMBER"]
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/spec_helper_smoke.rb
+++ b/spec/spec_helper_smoke.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] ||= "test"
+
+require "rspec"
+require "config"
+require "httparty"
+require "active_support/time"
+
+Config.load_and_set_settings(Config.setting_files("config", ENV["RAILS_ENV"]))


### PR DESCRIPTION
### Context
Smoke free

### Changes proposed in this pull request
Added missing smoky tests
Amended pub healthcheck calls api ping instead of calling api healthcheck

### Guidance to review

Required gems
```bash
  gem install bundler
  echo 'gem "httparty"' >> Gemfile
  echo 'gem "rspec"' >> Gemfile
  bundle
```

Only works for 
```bash
RAILS_ENV=production ./bin/bundle exec rspec  spec/smoke --options ./.rspec_smoke
RAILS_ENV=qa ./bin/bundle exec rspec  spec/smoke --options ./.rspec_smoke
RAILS_ENV=sandbox ./bin/bundle exec rspec  spec/smoke --options ./.rspec_smoke
RAILS_ENV=staging ./bin/bundle exec rspec  spec/smoke --options ./.rspec_smoke
```


Due to self cert SSL, it will __NOT__ work for as its

```bash
RAILS_ENV=development ./bin/bundle exec rspec  spec/smoke --options ./.rspec_smoke
RAILS_ENV=test ./bin/bundle exec rspec  spec/smoke --options ./.rspec_smoke
```

`./.rspec_smoke`is needed, as there is  a `./.rspec`



### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
