### PR TITLE
1065 configure 2 instances of publish in prod

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -8,6 +8,7 @@ resource cloudfoundry_app web_app {
   timeout                    = 180
   strategy                   = "blue-green-v2"
   environment                = var.app_environment_variables
+  instances                  = var.web_app_instances
 
   dynamic "routes" {
     for_each = local.web_app_routes

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -3,7 +3,7 @@ cf_space                    = "bat-prod"
 paas_app_environment        = "prod"
 paas_app_environment_config = "prod"
 paas_web_app_host_name      = "www"
-paas_web_app_instances      = 1
+paas_web_app_instances      = 2
 paas_web_app_memory         = 512
 
 #StatusCake

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -3,7 +3,7 @@ cf_space                    = "bat-staging"
 paas_app_environment        = "staging"
 paas_app_environment_config = "staging"
 paas_web_app_host_name      = "staging"
-paas_web_app_instances      = 1
+paas_web_app_instances      = 2
 paas_web_app_memory         = 512
 
 #StatusCake


### PR DESCRIPTION
### Context
Publish is going live on paas

### Changes proposed in this pull request
Set paas web app instances to 2 in staging and prod
This is the minimum to avoid downtimes

### Guidance to review
Run deploy-plan

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
