### PR TITLE
Fix install-fetch-config for non bash shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ production: ## Set DEPLOY_ENV to production
 	$(if $(CONFIRM_PRODUCTION), , $(error Production can only run with CONFIRM_PRODUCTION))
 
 install-fetch-config:
-	[[ ! -f bin/fetch_config.rb ]] \
+	[ ! -f bin/fetch_config.rb ] \
 		&& curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb \
 		&& chmod +x bin/fetch_config.rb \
 		|| true


### PR DESCRIPTION
### Context
Manage key vault secrets

### Changes proposed in this pull request
Use generic [ instead of bash [[

### Guidance to review
Run `make install-fetch-config`