### PR TITLE
Remove schools placement guidance

### DIFF
--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -124,11 +124,9 @@
           <div class="govuk-details__text">
             <h3 class="govuk-heading-m">Where you will train</h3>
             <% if @provider.provider_type == 'university' %>
-              <p class="govuk-body">You’ll be placed in schools for most of your course. This university is based in <%= @course.travel_to_work_areas %>, and your school placements will be within commuting distance.</p>
               <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
               <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
             <% else %>
-              <p class="govuk-body">This course has placement schools in <%= @course.travel_to_work_areas %>. Most of your time will be spent in the classroom with experienced teachers.</p>
               <p class="govuk-body">You'll be placed in different schools during your training. You can't pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
             <% end %>
           </div>

--- a/app/views/courses/preview/placement/_scitt.html.erb
+++ b/app/views/courses/preview/placement/_scitt.html.erb
@@ -1,2 +1,1 @@
-<p class="govuk-body">This course has placement schools in <%= course.travel_to_work_areas %>. Most of your time will be spent in the classroom with experienced teachers.</p>
 <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -69,7 +69,7 @@ feature "About course", type: :feature do
       expect(about_course_page.how_school_placements_work_textarea.value).to eq(
         course.how_school_placements_work,
       )
-      expect(page).to have_content("This course has placement schools in Westminster and Brighton.")
+      expect(page).to have_content("You'll be placed in different schools during your training.")
 
       fill_in "About this course", with: "Something interesting about this course"
       fill_in "How school placements work", with: "Something about how teaching placements work"
@@ -120,7 +120,7 @@ feature "About course", type: :feature do
       visit provider_recruitment_cycle_course_path(provider2.provider_code, course2.recruitment_cycle_year, course2.course_code)
       click_on "About this course"
 
-      expect(page).to have_content("This university is based in Westminster and Brighton,")
+      expect(page).to have_content("Universities can work with over 100 potential placement schools.")
     end
   end
 


### PR DESCRIPTION
### Context
We've received some concerns from providers about the new schools placement guidance on the Find course page

### Changes proposed in this pull request
- Offending paragraph removed from course preview and course create form guidance whilst further user testing is undertaken

### Trello
https://trello.com/c/lpBrddjm/3080-remove-school-placement-guidance-from-find-and-publish

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
