### PR TITLE
Update TTAPI url config

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -9,7 +9,7 @@ dfe_signin:
 teacher_training_api:
   base_url: https://api.publish-teacher-training-courses.service.gov.uk
 search_ui:
-  base_url: https://find-postgraduate-teacher-training.education.gov.uk
+  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 environment:
   label: "Beta"
   selector_name: "beta"

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -4,7 +4,7 @@ dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   base_url: https://qa.publish-teacher-training-courses.service.gov.uk
 teacher_training_api:
-  base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
+  base_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -6,10 +6,9 @@ dfe_signin:
 teacher_training_api:
   base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
 search_ui:
-  base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 environment:
   label: "QA"
   selector_name: "qa"
 authentication:
   mode: persona   # none critical systems, ie localhost
-  

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -9,8 +9,7 @@ dfe_signin:
 teacher_training_api:
   base_url: https://api.staging.publish-teacher-training-courses.service.gov.uk
 search_ui:
-  base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 environment:
   label: "Staging"
   selector_name: "staging"
-

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -7,7 +7,7 @@ dfe_signin:
   base_url: https://staging.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://pp-support.signin.education.gov.uk/users
 teacher_training_api:
-  base_url: https://api.staging.publish-teacher-training-courses.service.gov.uk
+  base_url: https://teacher-training-api-prod.london.cloudapps.digital
 search_ui:
   base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 environment:


### PR DESCRIPTION
### Context
Test connection from Publish to TTAPI on PaaS before migrating TTAPI over to PaaS

### Changes proposed in this pull request

Point publish staging to https://teacher-training-api-prod.london.cloudapps.digital (TTAPI Paas Prod) for testing.
Update find urls

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
