### PR TITLE
Point "View on Find" links to the correct sandbox domain

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -9,7 +9,7 @@ dfe_signin:
 teacher_training_api:
   base_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 search_ui:
-  base_url: https://sandbox.find-postgraduate-teacher-training.education.gov.uk
+  base_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 environment:
   label: "Sandbox"
   selector_name: "sandbox"


### PR DESCRIPTION
### Context

Clicking the "view on find" link in Sandbox takes you to eg

https://sandbox.find-postgraduate-teacher-training.education.gov.uk/course/EES/A233

When you really want to go to

https://sandbox.find-postgraduate-teacher-training.service.gov.uk/course/EES/A233

### Changes proposed in this pull request

Change the config so `search_ui_url` gets the correct domain when we use it to build the link.