### PR TITLE
Use correct TTAPI staging url

### DIFF
--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -7,7 +7,7 @@ dfe_signin:
   base_url: https://staging.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://pp-support.signin.education.gov.uk/users
 teacher_training_api:
-  base_url: https://teacher-training-api-prod.london.cloudapps.digital
+  base_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 environment:


### PR DESCRIPTION
### Context

Publish Staging was pointing to TTAPI PaaS Prod

### Changes proposed in this pull request

Point publish staging to the correct prod url

### Guidance to review
To be merged once testing with TTAPI PaaS Prod is complete.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
