### PR TITLE
[1182] Handle JsonApiClient::Errors::ClientError for providers/suggest

### DIFF
--- a/app/controllers/provider_suggestions_controller.rb
+++ b/app/controllers/provider_suggestions_controller.rb
@@ -1,4 +1,6 @@
 class ProviderSuggestionsController < ApplicationController
+  rescue_from JsonApiClient::Errors::ClientError, with: :handle_error_request
+
   def suggest
     return render(json: { error: "Bad request" }, status: :bad_request) if params_invalid?
 
@@ -30,5 +32,9 @@ private
 
   def params_invalid?
     params[:query].nil? || params[:query].length < 3
+  end
+
+  def handle_error_request
+    render json: []
   end
 end

--- a/spec/requests/provider_suggestions_spec.rb
+++ b/spec/requests/provider_suggestions_spec.rb
@@ -16,6 +16,7 @@ describe "/providers/suggest", type: :request do
       expect(JSON.parse(response.body)).to eq("error" => "Bad request")
     end
   end
+
   context "when provider suggestion is less than three characters" do
     it "returns bad request (400)" do
       get "/providers/suggest?query=St"
@@ -24,6 +25,20 @@ describe "/providers/suggest", type: :request do
       expect(JSON.parse(response.body)).to eq("error" => "Bad request")
     end
   end
+
+  context "when the request raises an JsonApiClient::Errors::ClientError" do
+    let(:query) { "(Reach Academy Feltham" }
+
+    before do
+      stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v2/providers/suggest?query=#{query}").and_raise(JsonApiClient::Errors::ClientError)
+      get "/providers/suggest?query=#{query}"
+    end
+
+    it "returns an empty result set" do
+      expect(JSON.parse(response.body)).to eq([])
+    end
+  end
+
   context "when provider suggestion query is valid" do
     query = "Girls School"
     query_with_unicode_character = "Girls%E2%80%99 School"


### PR DESCRIPTION
### Context

- https://sentry.io/organizations/dfe-bat/issues/2244373584/?project=1407453&query=is%3Aunresolved

### Changes proposed in this pull request

- This PR handles the issue above when dodgy characters are attempted to be sent in the query which raises a `JsonApiClient::Errors::ClientError`. In this scenario it will return an empty result set and remove the error noise in Sentry.

### Guidance to review

- Fire up publish and attempt to search for an organisation from the admin search view
- If you remove the error handling code and attempt to search with `(Reach Academy Feltham` it'll raise it in the logs. Add it back in and it shouldn't raise it.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
