### PR TITLE
[1148] api migration implement publish maintenance mode and admin login only

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   rescue_from JsonApiClient::Errors::AccessDenied, with: :handle_access_denied
 
   include Pagy::Backend
+  include AdminOnlyMaintenanceMode
 
   before_action :http_basic_auth
   before_action :authenticate

--- a/app/controllers/concerns/admin_only_maintenance_mode.rb
+++ b/app/controllers/concerns/admin_only_maintenance_mode.rb
@@ -10,9 +10,6 @@ private
 
   def redirect_non_admins_in_maintenance_mode
     return unless Settings.features.maintenance_mode.enabled
-
-    flash[:notice] = simple_format(Settings.features.maintenance_mode.message)
-
     return if %w[sign_in sessions].include?(controller_name)
 
     unless current_user && current_user["admin"]

--- a/app/controllers/concerns/admin_only_maintenance_mode.rb
+++ b/app/controllers/concerns/admin_only_maintenance_mode.rb
@@ -1,5 +1,6 @@
 module AdminOnlyMaintenanceMode
   extend ActiveSupport::Concern
+  include ActionView::Helpers::TextHelper
 
   included do
     before_action :redirect_non_admins_in_maintenance_mode
@@ -10,7 +11,7 @@ private
   def redirect_non_admins_in_maintenance_mode
     return unless Settings.features.maintenance_mode.enabled
 
-    flash[:notice] = Settings.features.maintenance_mode.message
+    flash[:notice] = simple_format(Settings.features.maintenance_mode.message)
 
     return if %w[sign_in sessions].include?(controller_name)
 

--- a/app/controllers/concerns/admin_only_maintenance_mode.rb
+++ b/app/controllers/concerns/admin_only_maintenance_mode.rb
@@ -12,6 +12,10 @@ private
     return unless Settings.features.maintenance_mode.enabled
     return if %w[sign_in sessions].include?(controller_name)
 
+    redirect_if_non_admin
+  end
+
+  def redirect_if_non_admin
     unless current_user && current_user["admin"]
       redirect_to sign_in_path
     end

--- a/app/controllers/concerns/admin_only_maintenance_mode.rb
+++ b/app/controllers/concerns/admin_only_maintenance_mode.rb
@@ -1,0 +1,21 @@
+module AdminOnlyMaintenanceMode
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :redirect_non_admins_in_maintenance_mode
+  end
+
+private
+
+  def redirect_non_admins_in_maintenance_mode
+    return unless Settings.features.maintenance_mode.enabled
+
+    flash[:notice] = Settings.features.maintenance_mode.message
+
+    return if %w[sign_in sessions].include?(controller_name)
+
+    unless current_user && current_user["admin"]
+      redirect_to sign_in_path
+    end
+  end
+end

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -3,18 +3,36 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
+    <% if Settings.features.maintenance_mode.enabled %>
+      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <h3 class="govuk-notification-banner__heading">
+            <%= Settings.features.maintenance_mode.title %>
+          </h3>
+          <p class="govuk-body">
+            <%= Settings.features.maintenance_mode.body %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+
     <h1 class="govuk-heading-l">Sign in to Publish teaching training</h1>
 
     <p class="govuk-body-m"> Use DfE Sign-in to access your account.</p>
 
     <% if AuthenticationService.dfe_signin? %>
       <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe") %>
-    <% else %>    
+    <% else %>
       <%= govuk_link_to "Sign in using a Persona", "/personas", { class: "govuk-button" }  %>
     <% end %>
 
     <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to Publish teaching training email
-      <%= bat_contact_mail_to %>. 
+      <%= bat_contact_mail_to %>.
     </p>
-  </div>  
+  </div>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,7 +85,7 @@ features:
     show_next_cycle_allocation_recruitment_page: false
   maintenance_mode:
     enabled: false
-    message: "Closed for maintenance"
+    message: "This service will be unavailable from Thursday 4 March at 17:00 to Friday 5 March at 09:00, while we carry out maintenance.\n\nFind teacher training courses will still be available during this time. If you have any questions, contact us at becomingateacher@digital.education.gov.uk"
 
 authentication:
   mode: dfe_signin    # default authentication mode

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -83,6 +83,9 @@ features:
     # actually starting when it would be set to false
     has_current_cycle_started?: true
     show_next_cycle_allocation_recruitment_page: false
+  maintenance_mode:
+    enabled: false
+    message: "Closed for maintenance"
 
 authentication:
   mode: dfe_signin    # default authentication mode

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,7 +85,8 @@ features:
     show_next_cycle_allocation_recruitment_page: false
   maintenance_mode:
     enabled: false
-    message: "This service will be unavailable from Thursday 4 March at 17:00 to Friday 5 March at 09:00, while we carry out maintenance.\n\nFind teacher training courses will still be available during this time. If you have any questions, contact us at becomingateacher@digital.education.gov.uk"
+    title: "This service will be unavailable from Thursday 4 March at 17:00 to Friday 5 March at 09:00, while we carry out maintenance."
+    body: "Find teacher training courses will still be available during this time. If you have any questions, contact us at becomingateacher@digital.education.gov.uk"
 
 authentication:
   mode: dfe_signin    # default authentication mode

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -235,7 +235,8 @@ feature "Sign in", type: :feature do
     describe "maintenance mode" do
       before do
         allow(Settings.features.maintenance_mode).to receive(:enabled).and_return(true)
-        allow(Settings.features.maintenance_mode).to receive(:message).and_return("Maintenance message")
+        allow(Settings.features.maintenance_mode).to receive(:title).and_return("Maintenance message title")
+        allow(Settings.features.maintenance_mode).to receive(:body).and_return("Maintenance message body")
       end
 
       describe "not signed in" do
@@ -243,7 +244,8 @@ feature "Sign in", type: :feature do
           visit "/"
           expect(page.current_path).to eq sign_in_path
           expect(page).to have_content("Sign in to Publish teaching training")
-          expect(page).to have_content("Maintenance message")
+          expect(page).to have_content("Maintenance message title")
+          expect(page).to have_content("Maintenance message body")
         end
       end
 
@@ -257,7 +259,8 @@ feature "Sign in", type: :feature do
 
           expect(page.current_path).to eq sign_in_path
           expect(page).to have_content("Sign in to Publish teaching training")
-          expect(page).to have_content("Maintenance message")
+          expect(page).to have_content("Maintenance message title")
+          expect(page).to have_content("Maintenance message body")
           expect(page).to have_content("Sign out (#{user.first_name} #{user.last_name})")
         end
       end
@@ -270,11 +273,11 @@ feature "Sign in", type: :feature do
           stub_api_v2_request("/access_requests", nil, :get)
 
           visit_dfe_sign_in(root_path)
-          # save_and_open_page
 
           expect(page.current_path).to eq root_path
           expect(page).to_not have_content("Sign in to Publish teaching training")
-          expect(page).to have_content("Maintenance message")
+          expect(page).to_not have_content("Maintenance message title")
+          expect(page).to_not have_content("Maintenance message body")
           expect(page).to have_content("Organisations")
           expect(page).to have_content("Sign out (#{user.first_name} #{user.last_name})")
         end

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -6,6 +6,9 @@ default: &default
   SETTINGS__FEATURES__SIGNIN_BY_EMAIL: false
   SETTINGS__FEATURES__SIGNIN_INTERCEPT: false
   SETTINGS__ROLLOVER: false
+  SETTINGS__FEATURES__MAINTENANCE_MODE__ENABLED: false
+  SETTINGS__FEATURES__MAINTENANCE_MODE__TITLE: "This service will be unavailable from Thursday 4 March at 17:00 to Friday 5 March at 09:00, while we carry out maintenance."
+  SETTINGS__FEATURES__MAINTENANCE_MODE__BODY: "Find teacher training courses will still be available during this time. If you have any questions, contact us at becomingateacher@digital.education.gov.uk"
 
 qa:
   <<: *default


### PR DESCRIPTION
### Context

https://trello.com/c/UobfcRmi/1148-api-migration-implement-publish-maintenance-mode-and-admin-login-only

### Changes proposed in this pull request

* Feature setting to enable maintenance mode, with a message.
* Admin users are able to sign in
* Non-admins redirected to sign in page
* Flash message is set on every page.

### Guidance to review
