### PR TITLE
Slack alert on build failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,3 +84,15 @@ jobs:
           workflow: Deploy
           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN  }}
           inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "sha": "${{ github.sha }}"}'
+
+      - name: 'Notify #twd_publish_register_tech on failure'
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_publish_register_tech
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':github-logo:'
+          SLACK_USERNAME: Publish Teacher Training
+          SLACK_TITLE: Build Failure
+          SLACK_MESSAGE: ':alert: <!channel> Build failure'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,3 +130,15 @@ jobs:
           token:  ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: 'Notify #twd_publish_register_tech on failure'
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_publish_register_tech
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':github-logo:'
+          SLACK_USERNAME: Publish Teacher Training
+          SLACK_TITLE: Deployment Failure
+          SLACK_MESSAGE: ':alert: <!channel> Deploy to ${{ github.event.inputs.environment }} failed :fire:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -42,5 +42,5 @@ jobs:
           SLACK_ICON_EMOJI: ':github-logo:'
           SLACK_USERNAME: Publish Teacher Training
           SLACK_TITLE: Smoke tests failure
-          SLACK_MESSAGE: ':alert: Smoke tests failure on ${{ github.event.inputs.environment }} :fire:'
+          SLACK_MESSAGE: ':alert: <!channel> Smoke tests failure on ${{ github.event.inputs.environment }} :fire:'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

Alert `@channel` on build/deploy workflow failures

### Changes proposed in this pull request

Add action to alert slack channel on build/deployment workflow failures.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
