### PR TITLE
[1177] change secondary second subject hint to something that exists …

### DIFF
--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -27,7 +27,7 @@
 
           <div class="govuk-form-group">
             <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
-            <span class="govuk-hint">For example ‘Physics with Mathematics’</span>
+            <span class="govuk-hint">For example ‘Physics’</span>
             <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, course.selected_subject_ids.second || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
           </div>
         </div>


### PR DESCRIPTION
…on list

### Context

https://trello.com/c/IozUAkYb/1177-hint-text-suggests-an-option-thats-not-possible

### Changes proposed in this pull request

* Changed string to "Physics" which exists as a subject
* I could make it dynamic by choosing the first one from the dropdown list if we expect the list to change?

### Guidance to review

* Add new course, select secondary subject
* Click "Add a second subject (optional)" link

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
