### PR TITLE
[1321] Allow course study mode to be updated to full time and part time

### DIFF
--- a/app/controllers/courses/study_mode_controller.rb
+++ b/app/controllers/courses/study_mode_controller.rb
@@ -3,11 +3,7 @@ module Courses
     include CourseBasicDetailConcern
 
     def update
-      if params[:course][:study_mode] == "full_time_or_part_time"
-        redirect_to request_change_provider_recruitment_cycle_course_path(params[:provider_code], params[:recruitment_cycle_year], params[:code])
-      else
-        super
-      end
+      super
     end
 
   private

--- a/spec/features/courses/study_mode/edit_spec.rb
+++ b/spec/features/courses/study_mode/edit_spec.rb
@@ -99,9 +99,8 @@ feature "Edit course study mode", type: :feature do
       choose("course_study_mode_full_time_or_part_time")
       click_on "Save"
 
-      expect(course_request_change_page).to be_displayed
-      expect(course_request_change_page.title).to have_content("Request a change to this course")
-      expect(update_course_stub).not_to have_been_requested
+      expect(update_course_stub).to have_been_requested
+      expect(course_details_page.flash).to have_content("Your changes have been saved")
     end
 
     scenario "It displays the correct title" do


### PR DESCRIPTION
### Context

- https://trello.com/c/6zJEvCGc/1321-allow-courses-to-be-changed-to-partime-and-fulltime-by-providers

### Changes proposed in this pull request

![fix](https://user-images.githubusercontent.com/616080/112351692-0461e280-8cc2-11eb-9656-713db01f2742.gif)

### Guidance to review

- Login via a persona, choose a provider/courses/course and update the study mode to full time or part time
- Assert your changes are saved

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
