### PR TITLE
Bump mimemagic to 0.3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN apk add --update --no-cache tzdata && \
     echo "Europe/London" > /etc/timezone
 
 RUN apk add --update --no-cache --virtual runtime-dependances \
- yarn \
- openssl-dev
+ yarn openssl-dev shared-mime-info
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.6)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
### Changes proposed in this pull request

Bump mimemagic to 0.3.9
Install `shared-mime-info` package.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
