### PR TITLE
Deploy to QA env from qa branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - qa
   pull_request:
     branches:
       - master
@@ -83,7 +84,15 @@ jobs:
         with:
           workflow: Deploy
           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN  }}
-          inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "sha": "${{ github.sha }}"}'
+          inputs: '{"staging": "true", "production": "true", "sandbox": "true", "sha": "${{ github.sha }}"}'
+
+      - name: Trigger Deployment to QA
+        if: ${{ success() && github.ref == 'refs/heads/qa' }}
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Deploy
+          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN  }}
+          inputs: '{"qa": "true", "sha": "${{ github.sha }}"}'
 
       - name: 'Notify #twd_publish_register_tech on failure'
         if: ${{ failure() && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       qa:
         description: Deploy to qa?
-        default: 'true'
+        default: 'false'
         required: true
       staging:
         description: Deploy to staging?


### PR DESCRIPTION
### Context

Use `qa` env as a review environment untill we build review apps support on PaaS. 

### Changes proposed in this pull request

Stop deployment to `qa` from `master`
Deploy to `qa` for code pushes to `qa` branch.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
