### PR TITLE
[1480] Remove id generation for persona fields

### DIFF
--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -14,9 +14,9 @@
 </p>
 
 <%= form_tag("/auth/developer/callback") do %>
-  <%= hidden_field_tag "email", "anonimized-user-10599@example.org" %>
-  <%= hidden_field_tag "first_name", "Course administrator" %>
-  <%= hidden_field_tag "last_name", "Anne" %>
+  <%= hidden_field_tag "email", "anonimized-user-10599@example.org", id: nil %>
+  <%= hidden_field_tag "first_name", "Course administrator", id: nil %>
+  <%= hidden_field_tag "last_name", "Anne", id: nil %>
 
   <%= submit_tag "Login as Anne", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
@@ -31,9 +31,9 @@
 </p>
 
 <%= form_tag("/auth/developer/callback") do %>
-  <%= hidden_field_tag "email", "anonimized-user-8847@example.org" %>
-  <%= hidden_field_tag "first_name", "ITT partnership manager" %>
-  <%= hidden_field_tag "last_name", "Susy" %>
+  <%= hidden_field_tag "email", "anonimized-user-8847@example.org", id: nil %>
+  <%= hidden_field_tag "first_name", "ITT partnership manager", id: nil %>
+  <%= hidden_field_tag "last_name", "Susy", id: nil %>
 
   <%= submit_tag "Login as Susy", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
@@ -56,9 +56,9 @@ Mary is a SCITT Business Support Coordinator who belongs to:
 </p>
 
 <%= form_tag("/auth/developer/callback") do %>
-  <%= hidden_field_tag "email", "anonimized-user-7839@example.org" %>
-  <%= hidden_field_tag "first_name", "Multi-org administrator" %>
-  <%= hidden_field_tag "last_name", "Mary" %>
+  <%= hidden_field_tag "email", "anonimized-user-7839@example.org", id: nil %>
+  <%= hidden_field_tag "first_name", "Multi-org administrator", id: nil %>
+  <%= hidden_field_tag "last_name", "Mary", id: nil %>
 
   <%= submit_tag "Login as Mary", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
@@ -74,9 +74,9 @@ Mary is a SCITT Business Support Coordinator who belongs to:
 </p>
 
 <%= form_tag("/auth/developer/callback") do %>
-  <%= hidden_field_tag "email", "becomingateacher+admin-integration-tests@digital.education.gov.uk" %>
-  <%= hidden_field_tag "first_name", "Support agent" %>
-  <%= hidden_field_tag "last_name", "Colin" %>
+  <%= hidden_field_tag "email", "becomingateacher+admin-integration-tests@digital.education.gov.uk", id: nil %>
+  <%= hidden_field_tag "first_name", "Support agent", id: nil %>
+  <%= hidden_field_tag "last_name", "Colin", id: nil %>
 
   <%= submit_tag "Login as Colin", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>


### PR DESCRIPTION
### Context

- https://trello.com/c/qmIVxhxq/1480-dup-ids-on-personas-page

These ids are not being used so we're just setting them to nil so they aren't set by the form helpers.

### Changes proposed in this pull request

<img width="545" alt="Screenshot 2021-04-19 at 16 21 04" src="https://user-images.githubusercontent.com/616080/115261102-3e8c9b80-a12b-11eb-9d64-a2f52e4f0178.png">

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
