### PR TITLE
[1481] Fix dup html ids on courses about view

### DIFF
--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -11,7 +11,7 @@
               builder: GOVUKDesignSystemFormBuilder::FormBuilder,
               url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
               data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
-  <%= f.hidden_field :page, value: :about %>
+  <%= f.hidden_field :page, value: :about, id: nil %>
   <%= f.govuk_error_summary "You’ll need to correct some information." %>
 <% end %>
 
@@ -26,7 +26,7 @@
                     builder: GOVUKDesignSystemFormBuilder::FormBuilder,
                     url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                     data: { qa: 'enrichment-form', module: 'form-check-leave' } do |f| %>
-        <%= f.hidden_field :page, value: :about %>
+        <%= f.hidden_field :page, value: :about, id: nil %>
 
         <p class="govuk-body">You should give a short, factual summary of the course.</p>
 


### PR DESCRIPTION
### Context

- https://trello.com/c/gDoyMfAx/1481-dup-ids-on-about-this-course-page

### Changes proposed in this pull request

- Don't generate ids for the hidden fields as they aren't used

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
