### PR TITLE
[1483] Group radios inside fieldset

### DIFF
--- a/app/views/courses/applications_open/_form_fields.html.erb
+++ b/app/views/courses/applications_open/_form_fields.html.erb
@@ -1,27 +1,34 @@
 <div class="govuk-form-group">
   <div class="govuk-radios govuk-!-margin-top-2 govuk-radios--conditional" data-module="govuk-radios">
-    <div class="govuk-radios__item">
-      <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
-            class: 'govuk-radios__input', data: { qa: 'applications_open_from' }
-      %>
-      <%= form.label :applications_open_from, course.applications_open_from_message_for(@recruitment_cycle),
-            for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
-            class: 'govuk-label govuk-radios__label'
-      %>
-    </div>
-    <div class="govuk-radios__item">
-      <%= form.radio_button :applications_open_from, 'other',
-            class: 'govuk-radios__input',
-            checked: @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date,
-            aria: { 'controls': 'other-container' },  data: { qa: 'applications_open_from_other' }
-      %>
-      <%= form.label :applications_open_from,
-            for: "course_applications_open_from_other",
-            value: "On a specific date",
-            class: "govuk-label govuk-radios__label",
-            data: { qa: "applications_open_field_from_other_label" }
-      %>
-    </div>
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading" id="applications_open_from-error">
+          When will applications open?
+        </h1>
+      </legend>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
+              class: 'govuk-radios__input', data: { qa: 'applications_open_from' }
+        %>
+        <%= form.label :applications_open_from, course.applications_open_from_message_for(@recruitment_cycle),
+              for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
+              class: 'govuk-label govuk-radios__label'
+        %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :applications_open_from, 'other',
+              class: 'govuk-radios__input',
+              checked: @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date,
+              aria: { 'controls': 'other-container' },  data: { qa: 'applications_open_from_other' }
+        %>
+        <%= form.label :applications_open_from,
+              for: "course_applications_open_from_other",
+              value: "On a specific date",
+              class: "govuk-label govuk-radios__label",
+              data: { qa: "applications_open_field_from_other_label" }
+        %>
+      </div>
+    </fieldset>
     <div class="govuk-radios__conditional <%=
       "govuk-radios__conditional--hidden" unless @course.applications_open_from.present? && @course.applications_open_from  != @recruitment_cycle.application_start_date
     %>" id="other-container">

--- a/app/views/courses/applications_open/edit.html.erb
+++ b/app/views/courses/applications_open/edit.html.erb
@@ -5,10 +5,6 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-2" id="applications_open_from-error">
-  When will applications open?
-</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course, url: applications_open_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code), method: :put do |form| %>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -5,10 +5,6 @@
 
 <%= render 'shared/errors' %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-2" id="applications_open_from-error">
-  When will applications open?
-</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: continue_provider_recruitment_cycle_courses_applications_open_path(


### PR DESCRIPTION
### Context
https://trello.com/c/NBPYK2T3/1483-radio-elements-not-grouped-when-will-applications-open-page

### Changes proposed in this pull request

From accessibility audit. It is also required that the fieldset has a
legend so the page header must be put inside the fieldset legend for
1 question pages.

**Before**
<img width="1348" alt="Screenshot 2021-04-20 at 14 28 53" src="https://user-images.githubusercontent.com/823643/115404051-df8b5d00-a1e4-11eb-9a60-9657c6b95bcf.png">

**After**
<img width="1348" alt="Screenshot 2021-04-20 at 14 08 49" src="https://user-images.githubusercontent.com/823643/115404093-e87c2e80-a1e4-11eb-94bb-8b812b56a26a.png">

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
