### PR TITLE
[1502] Add URN text field to the locations edit page

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -77,6 +77,7 @@ private
   def site_params
     params.require(:site).permit(
       :location_name,
+      :urn,
       :address1,
       :address2,
       :address3,

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -5,6 +5,13 @@
   <%= f.text_field field, options %>
 <% end %>
 
+<%= render "shared/form_field",
+  form: f, field: :urn, label: capture { %>
+    <h2 class="<%= cns("govuk-heading-m", "govuk-!-margin-bottom-0": @errors.present? && @errors[:urn]&.any?) %>">URN</h2>
+  <% } do |field, options| %>
+  <%= f.text_field field, options.merge(class: 'govuk-input govuk-input--width-10') %>
+<% end %>
+
 <h2 class="govuk-heading-m govuk-!-margin-top-8">Address</h2>
 
 <%= render "shared/form_field",
@@ -36,4 +43,3 @@
   form: f, field: :postcode do |field, options| %>
   <%= f.text_field field, options.merge(class: 'govuk-input govuk-input--width-10') %>
 <% end %>
-

--- a/spec/features/sites/new_spec.rb
+++ b/spec/features/sites/new_spec.rb
@@ -50,7 +50,7 @@ feature "Locations", type: :feature do
       fill_in "Town or city", with: "New town"
       fill_in "County", with: "New county"
       fill_in "Postcode", with: "SW1A 1AA"
-
+      fill_in "URN", with: "123456"
       click_on "Save"
 
       expect(page).to have_content("Your location has been created")


### PR DESCRIPTION
### Context

We are starting to collect URN numbers on all sites. This PR surfaces the field on the edit locations page.

### Changes proposed in this pull request

Add URN text field to the edit locations page

### Guidance to review

- Pull down the code and boot up the server
- Navigate to `...organisations/provider_code/2021/locations`
- Click on a location
- Enter a valid number in the URN box and save the changes
- Boot up the rails console and check that the change has been saved

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
