### PR TITLE
[1484] Tab markup for accessibility

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -45,7 +45,7 @@
 <div class="course-tabs govuk-tabs">
   <h2 class="govuk-tabs__title">Contents</h2>
 
-  <ul class="govuk-tabs__list">
+  <ul class="govuk-tabs__list" role="tablist">
     <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
       <%=
         link_to "#description",
@@ -56,10 +56,10 @@
       <% end %>
     </li>
 
-    <li class="govuk-tabs__list-item">
+    <li class="govuk-tabs__list-item" role="presentation">
       <%=
         link_to details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-        class: "govuk-tabs__tab" do
+        class: "govuk-tabs__tab", role: 'tab', tabindex: '1', aria: { selected: false } do
       %>
         Basic details<br>
         <span class="govuk-body-s govuk-!-font-weight-regular pointer-events-none">Locations, outcome, subject</span>


### PR DESCRIPTION
### Context
https://trello.com/c/bkB21acy/1484-tab-list-markup-course-show-page

### Changes proposed in this pull request
* Adds role="tablist" to ul element
* Each list element has role "tab"
* Aria selected false to basic details tab which is not first selected on page load
* Tab index added so that tabs read as per screenshots below

### Guidance to review
Visit `organisations/1GT/2021/courses/28KJ/details` for example

<img width="558" alt="Screenshot 2021-04-26 at 12 32 17" src="https://user-images.githubusercontent.com/58793682/116075929-7c3d7700-a68b-11eb-93f7-589a7b9fe245.png">
<img width="536" alt="Screenshot 2021-04-26 at 12 30 25" src="https://user-images.githubusercontent.com/58793682/116075765-400a1680-a68b-11eb-9417-143a2516f758.png">

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
