### PR TITLE
[1680] Remove view allocation confirmation link

### DIFF
--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -54,17 +54,6 @@
                                     ) %>
                 <% end %>
               </li>
-
-              <li class="govuk-summary-list__actions-list-item">
-                <a class="govuk-link" data-qa="view-<%= allocation[:requested] %>-confirmation"
-                   href="<%= provider_recruitment_cycle_allocation_path(@provider.provider_code,
-                                                                        @provider.recruitment_cycle_year,
-                                                                        allocation[:training_provider_code],
-                                                                        id: allocation[:id])
-                   %>">
-                  View&nbsp;confirmation<span class="govuk-visually-hidden"> for <%= allocation[:training_provider_name] %></span>
-                </a>
-              </li>
             </ul>
           <% end %>
         </td>

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -66,42 +66,6 @@ RSpec.feature "PE allocations" do
       and_i_see_the_corresponding_page_title("Thank you")
     end
 
-    scenario "Accredited body decides to view request PE allocations confirmation" do
-      given_accredited_body_exists
-      given_training_provider_with_pe_fee_funded_course_exists
-      given_the_accredited_body_has_requested_a_repeat_allocation
-      given_i_am_signed_in_as_a_user_from_the_accredited_body
-
-      when_i_visit_my_organisations_page
-      and_i_click_request_pe_courses
-
-      then_i_see_the_pe_allocations_page
-      and_i_see_only_repeat_allocation_statuses
-
-      and_i_click_on_first_view_requested_confirmation
-
-      and_i_see_the_confirmation_page
-      and_i_see_the_corresponding_page_title("Request sent")
-    end
-
-    scenario "Accredited body decides to view request no PE allocations confirmation" do
-      given_accredited_body_exists
-      given_training_provider_with_pe_fee_funded_course_exists
-      given_the_accredited_body_has_declined_an_allocation
-      given_i_am_signed_in_as_a_user_from_the_accredited_body
-
-      when_i_visit_my_organisations_page
-      and_i_click_request_pe_courses
-
-      then_i_see_the_pe_allocations_page
-      and_i_see_only_repeat_allocation_statuses
-
-      and_i_click_on_first_view_not_requested_confirmation
-
-      and_i_see_the_confirmation_page
-      and_i_see_the_corresponding_page_title("Thank you")
-    end
-
     scenario "There is no PE allocations page for non accredited body" do
       given_a_provider_exists
       given_i_am_signed_in_as_a_user_from_the_accredited_body


### PR DESCRIPTION
### Context

- https://trello.com/c/BoYsQbKJ/1680-m-delete-view-confirmation-links

### Changes proposed in this pull request

- Removes the link allowing users to view allocations confirmation as required in the ticket above

<img width="1035" alt="Screenshot 2021-05-14 at 12 09 19" src="https://user-images.githubusercontent.com/616080/118263541-53e8b180-b4ae-11eb-8389-66eed697dcac.png">

### Guidance to review

The removed code.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
