### PR TITLE
Add age_range_in_years to the course preview page

### DIFF
--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -27,6 +27,12 @@
   <dd data-qa="course__qualifications">
     <%= render partial: 'courses/preview/qualification' %>
   </dd>
+
+  <% if course.age_range_in_years.present? %>
+    <dt class="govuk-list--description__label">Age range</dt>
+    <dd data-qa="course__age_range_in_years"><%= course.age_range_in_years.humanize %></dd>
+  <% end %>
+
   <% if course.length.present? %>
     <dt class="govuk-list--description__label">Course length</dt>
     <dd data-qa="course__length"><%= course.length %></dd>

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -11,6 +11,7 @@ feature "Preview course", type: :feature do
       course_length: "OneYear",
       applications_open_from: "2019-01-01T00:00:00Z",
       start_date: "2019-09-01T00:00:00Z",
+      age_range_in_years: "11_to_16",
       fee_uk_eu: "9250.0",
       fee_international: "9250.0",
       fee_details: "Optional fee details",
@@ -104,6 +105,10 @@ feature "Preview course", type: :feature do
 
     expect(preview_course_page.qualifications).to have_content(
       "PGCE with QTS",
+    )
+
+    expect(preview_course_page.age_range_in_years).to have_content(
+      "11 to 16",
     )
 
     expect(preview_course_page.funding_option).to have_content(

--- a/spec/site_prism/page_objects/page/organisations/course_preview.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_preview.rb
@@ -42,6 +42,7 @@ module PageObjects
         element :choose_a_training_location_table, "[data-qa=course__choose_a_training_location]"
         element :locations_map, "[data-qa=course__locations_map]"
         element :salary_details, "[data-qa=course__salary_details]"
+        element :age_range_in_years, "[data-qa=course__age_range_in_years]"
       end
     end
   end


### PR DESCRIPTION
### Context

This mirrors the changes made in this PR https://github.com/DFE-Digital/find-teacher-training/pull/777

Trello ticket https://trello.com/c/7GGhiNZp/3387-find-surface-age-range-metadata-from-publish

### Changes proposed in this pull request

- Adds age range in years to the course details section of the preview page 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
