### PR TITLE
Deploy publish app to rollover environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           workflow: Deploy
           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN  }}
-          inputs: '{"staging": "true", "production": "true", "sandbox": "true", "sha": "${{ github.sha }}"}'
+          inputs: '{"staging": "true", "production": "true", "sandbox": "true", "rollover": "true", "sha": "${{ github.sha }}"}'
 
       - name: Trigger Deployment to QA
         if: ${{ success() && github.ref == 'refs/heads/qa' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ on:
         description: Deploy to sandbox?
         default: 'false'
         required: true
+      rollover:
+        description: Deploy to rollover?
+        default: 'false'
+        required: true
       sha:
         description: Commit sha to be deployed
         required: true

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ ruby 2.7.2
 yarn 1.22.5
 nodejs 12.18.4
 bundler 2.1.4
+terraform 0.13.5

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,13 @@ sandbox: ## Set DEPLOY_ENV to sandbox
 	$(eval space=bat-prod)
 	$(eval paas_env=sandbox)
 
+.PHONY: rollover
+rollover: ## Set DEPLOY_ENV to sandbox
+	$(eval DEPLOY_ENV=rollover)
+	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-test)
+	$(eval space=bat-staging)
+	$(eval paas_env=rollover)
+
 .PHONY: production
 production: ## Set DEPLOY_ENV to production
 	$(eval DEPLOY_ENV=production)

--- a/config/environments/rollover.rb
+++ b/config/environments/rollover.rb
@@ -1,0 +1,1 @@
+require Rails.root.join("config/environments/production")

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -34,3 +34,8 @@ review:
   <<: *default
   RAILS_ENV: review
   RACK_ENV: review
+
+rollover:
+  <<: *default
+  RAILS_ENV: rollover
+  RACK_ENV: rollover

--- a/terraform/workspace_variables/rollover.sh
+++ b/terraform/workspace_variables/rollover.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121t01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=PUBLISH-APP-SECRETS-ROLLOVER
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-ROLLOVER

--- a/terraform/workspace_variables/rollover.tfvars
+++ b/terraform/workspace_variables/rollover.tfvars
@@ -1,0 +1,22 @@
+#PaaS
+cf_space                    = "bat-staging"
+paas_app_environment        = "rollover"
+paas_app_environment_config = "rollover"
+paas_web_app_host_name      = "rollover"
+paas_web_app_instances      = 1
+paas_web_app_memory         = 512
+
+#StatusCake
+statuscake_alerts = {
+  sandbox-pubtt = {
+    website_name   = "publish-teacher-training-rollover"
+    website_url    = "https://publish-teacher-training-rollover.london.cloudapps.digital/ping"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [151103]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+}
+
+key_vault_resource_group    = "s121t01-shared-rg"

--- a/terraform/workspace_variables/rollover_backend.tfvars
+++ b/terraform/workspace_variables/rollover_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s121t01-ptt-rg"
+storage_account_name = "s121t01pttterraform"
+container_name       = "rollover-paas-tfstate"
+key                  = "terraform.tfstate"


### PR DESCRIPTION
### Context

Deploy app to `rollover` environment

### Changes proposed in this pull request

Terraform config for rollover,

`rollover`  deploys to `bat-staging` space.

`make rollover` commands to view and edit app secrets.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
