### PR TITLE
Use GovukComponent::Header

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -66,7 +66,7 @@ module ViewHelper
   end
 
   def header_environment_class
-    "app-header__container--#{Settings.environment.selector_name}"
+    "app-header--#{Settings.environment.selector_name}"
   end
 
   def beta_tag_environment_class

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,38 +1,14 @@
-<header class="govuk-header" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container <%= header_environment_class %>">
-    <div class="govuk-header__logo app-header__logo">
-      <%= link_to "/", class: "govuk-header__link govuk-header__link--homepage" do %>
-        <span class="govuk-header__logotype">
-          <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
-            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-            <image src="#{asset_pack_path(media/images/govuk-logotype-crown.png)}" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-          </svg>
-          <span class="govuk-header__logotype-text">
-            GOV.UK
-          </span>
-        </span>
-        <span class="govuk-header__product-name">
-          Publish teacher training courses
-        </span>
-      <% end %>
-    </div>
-    <div class="govuk-header__content app-header__content">
-      <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation" data-module="govuk-button">Menu</button>
-      <nav>
-        <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
-          <% if current_user.present? && current_user['associated_with_accredited_body'] %>
-            <li class="govuk-header__navigation-item <%= "govuk-header__navigation-item--active" if current_page?(notifications_path) %>">
-              <%= govuk_link_to "Notifications", notifications_path, class: "govuk-header__link" %>
-            </li>
-          <% end %>
-          <li class="govuk-header__navigation-item">
-            <% if current_user.present? %>
-              <%= link_to "Sign out", sign_out_path, class: "govuk-header__link" %>
-              <%= link_to "(#{current_user['info']['first_name']} #{current_user['info']['last_name']})", "#{Settings.dfe_signin.profile}", class: "govuk-header__link" %>
-            <% end %>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </div>
-</header>
+<%= govuk_header({
+  classes: "govuk-!-display-none-print app-header app-header--wide-logo #{header_environment_class}",
+  product_name: 'Publish teacher training courses',
+  logo_href: '/',
+  navigation_classes: 'govuk-header__navigation--end',
+}) do | component | %>
+  <% if current_user.present? && current_user['associated_with_accredited_body'] %>
+    <%= component.slot(:item, title: 'Notifications', href: notifications_path, active: current_page?(notifications_path)) %>
+  <% end %>
+  <% if current_user.present? %>
+    <%= component.slot(:item, title: 'Sign out', href: sign_out_path) %>
+    <%= component.slot(:item, title: "(#{current_user['info']['first_name']} #{current_user['info']['last_name']})", href: Settings.dfe_signin.profile) %>
+  <% end %>
+<% end %>

--- a/app/webpacker/stylesheets/_environments.scss
+++ b/app/webpacker/stylesheets/_environments.scss
@@ -18,22 +18,24 @@
   background: govuk-colour("purple");
 }
 
-.app-header__container--development {
-  border-bottom-color: govuk-colour("dark-grey");
-}
+.govuk-header__container {
+  .app-header--development & {
+    border-bottom-color: govuk-colour("dark-grey");
+  }
 
-.app-header__container--qa {
-  border-bottom-color: govuk-colour("orange");
-}
+  .app-header--qa & {
+    border-bottom-color: govuk-colour("orange");
+  }
 
-.app-header__container--review {
-  border-bottom-color: govuk-colour("purple");
-}
+  .app-header--review & {
+    border-bottom-color: govuk-colour("purple");
+  }
 
-.app-header__container--staging {
-  border-bottom-color: govuk-colour("red");
-}
+  .app-header--staging & {
+    border-bottom-color: govuk-colour("red");
+  }
 
-.app-header__container--sandbox {
-  border-bottom-color: govuk-colour("purple");
+  .app-header--sandbox & {
+    border-bottom-color: govuk-colour("purple");
+  }
 }

--- a/app/webpacker/stylesheets/_header.scss
+++ b/app/webpacker/stylesheets/_header.scss
@@ -1,8 +1,12 @@
-.app-header__logo {
-  width: auto;
-}
+.app-header--wide-logo {
+  @include govuk-media-query($from: desktop) {
+    .govuk-header__logo {
+      width: auto;
+    }
 
-.app-header__content {
-  width: auto;
-  float: right;
+    .govuk-header__content {
+      width: auto;
+      float: right;
+    }
+  }
 }

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -6,7 +6,7 @@ feature "View pages", type: :feature do
   scenario "Environment label and class are read from settings" do
     visit "/cookies"
     expect(find(".app-tag--#{Settings.environment.selector_name}")).to have_content(Settings.environment.label)
-    expect(page).to have_selector(".app-header__container--#{Settings.environment.selector_name}")
+    expect(page).to have_selector(".app-header--#{Settings.environment.selector_name}")
   end
 
   scenario "Navigate to /cookies" do


### PR DESCRIPTION
### Context

Following on from the doing the same on [_Find_](https://github.com/DFE-Digital/find-teacher-training/pulls?q=is%3Apr+label%3AComponents) and [_Apply_](https://github.com/DFE-Digital/apply-for-teacher-training/pulls?q=is%3Apr+label%3AComponents), I’m here to move _Publish_ over to using `govuk-components`. 👋 

### Changes proposed in this pull request

* Use `GovukComponent::Header` to render headers (via `govuk-components` `govuk_header` helper method).
* Use same naming conventions for header style modifiers as used on _Apply_

### Guidance to review

There should be no visual changes.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [x] Product Review
