### PR TITLE
[1730] change hardcoded recruitment cycle years

### DIFF
--- a/app/helpers/allocation_cycle_helper.rb
+++ b/app/helpers/allocation_cycle_helper.rb
@@ -1,0 +1,13 @@
+module AllocationCycleHelper
+  def current_allocation_cycle_period_text
+    "#{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}"
+  end
+
+  def next_allocation_cycle_period_text
+    "#{Settings.allocation_cycle_year + 1} to #{Settings.allocation_cycle_year + 2}"
+  end
+
+  def previous_allocation_cycle_period_text
+    "#{Settings.allocation_cycle_year - 1} to #{Settings.allocation_cycle_year}"
+  end
+end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -87,11 +87,11 @@ module BreadcrumbHelper
 
   def allocations_breadcrumb
     path = provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    provider_breadcrumb << ["Request PE courses for #{current_allocation_cycle_period_text}", path]
+    provider_breadcrumb << ["Request PE courses for #{next_allocation_cycle_period_text}", path]
   end
 
   def allocations_closed_breadcrumb
     path = provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    provider_breadcrumb << ["PE courses for #{current_allocation_cycle_period_text}", path]
+    provider_breadcrumb << ["PE courses for #{next_allocation_cycle_period_text}", path]
   end
 end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -87,11 +87,11 @@ module BreadcrumbHelper
 
   def allocations_breadcrumb
     path = provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    provider_breadcrumb << ["Request PE courses for 2021 to 2022", path]
+    provider_breadcrumb << ["Request PE courses for #{current_allocation_cycle_period_text}", path]
   end
 
   def allocations_closed_breadcrumb
     path = provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    provider_breadcrumb << ["PE courses for 2021 to 2022", path]
+    provider_breadcrumb << ["PE courses for #{current_allocation_cycle_period_text}", path]
   end
 end

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -1,0 +1,13 @@
+module RecruitmentCycleHelper
+  def current_recruitment_cycle_period_text
+    "#{Settings.current_cycle} to #{Settings.current_cycle + 1}"
+  end
+
+  def next_recruitment_cycle_period_text
+    "#{Settings.current_cycle + 1} to #{Settings.current_cycle + 2}"
+  end
+
+  def previous_recruitment_cycle_period_text
+    "#{Settings.current_cycle - 1} to #{Settings.current_cycle}"
+  end
+end

--- a/app/views/pages/performance_dashboard/_allocations_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_allocations_tab.html.erb
@@ -1,8 +1,8 @@
 <h3 class="govuk-heading-m">
-  PE Requests for 2021 to 2022
+  PE Requests for <%= current_allocation_cycle_period_text %>
 </h3>
 <%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "current" }%>
 <h3 class="govuk-heading-m">
-  PE Requests for 2020 to 2021
+  PE Requests for <%= previous_allocation_cycle_period_text %>
 </h3>
 <%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "previous" }%>

--- a/app/views/pages/performance_dashboard/_allocations_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_allocations_tab.html.erb
@@ -1,8 +1,8 @@
 <h3 class="govuk-heading-m">
-  PE Requests for <%= current_allocation_cycle_period_text %>
+  PE Requests for <%= next_allocation_cycle_period_text %>
 </h3>
 <%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "current" }%>
 <h3 class="govuk-heading-m">
-  PE Requests for <%= previous_allocation_cycle_period_text %>
+  PE Requests for <%= current_allocation_cycle_period_text %>
 </h3>
 <%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "previous" }%>

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -8,8 +8,8 @@
 
     <p class="govuk-body">
       All your courses, locations and details have been copied over
-      from the current recruitment cycle (2020 to 2021). You can now
-      update them for 2021 to 2022.
+      from the current recruitment cycle (<%= current_recruitment_cycle_period_text %>). You can now
+      update them for <%= next_recruitment_cycle_period_text %>.
     </p>
 
     <p class="govuk-body">You should:</p>

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -1,9 +1,9 @@
-<%= content_for :page_title, "Recruiting for the 2021 to 2022 cycle" %>
+<%= content_for :page_title, "Recruiting for the #{next_recruitment_cycle_period_text} cycle" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Recruiting for the <br>2021 to 2022 cycle
+      Recruiting for the <br><%= next_recruitment_cycle_period_text %> cycle
     </h1>
 
     <p class="govuk-body">
@@ -15,7 +15,7 @@
     <p class="govuk-body">
       You can publish all other courses without requesting permission. This
       applies to courses copied over from the current cycle and new courses
-      added for 2021 to 2022.
+      added for <%= next_recruitment_cycle_period_text %>.
     </p>
 
     <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">
-  <%= link_to "Current cycle (#{Settings.current_cycle} to #{Settings.current_cycle + 1})",
+  <%= link_to "Current cycle (#{current_recruitment_cycle_period_text})",
               provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle),
               data: { qa: 'provider__courses__current_cycle' },
               class: "govuk-link" %>
@@ -15,13 +15,13 @@
 </ul>
 
 <h2 class="govuk-heading-m">
-  <%= link_to "Next cycle (#{Settings.current_cycle + 1} to #{Settings.current_cycle + 2})",
+  <%= link_to "Next cycle (#{next_recruitment_cycle_period_text})",
               provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle + 1),
               data: { qa: 'provider__courses__next_cycle' },
               class: "govuk-link" %>
 </h2>
 <p class="govuk-body">
-  Courses for the next cycle will appear on Find postgraduate teacher training from October 2020.
+  Courses for the next cycle will appear on Find postgraduate teacher training from October <%= Settings.current_cycle %>.
   Use this section to:
 </p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">

--- a/app/views/providers/allocations/_allocation_report_confirmed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_report_confirmed_state.html.erb
@@ -1,5 +1,5 @@
 <table class="govuk-table ucas-info-table govuk-!-margin-bottom-8">
-  <caption class="govuk-visually-hidden">A list of confirmed allocations for 2021 to 2022</caption>
+  <caption class="govuk-visually-hidden">A list of confirmed allocations for <%= current_allocation_cycle_period_text %></caption>
   <thead class="govuk-table__head">
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="col">

--- a/app/views/providers/allocations/_allocation_report_confirmed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_report_confirmed_state.html.erb
@@ -1,5 +1,5 @@
 <table class="govuk-table ucas-info-table govuk-!-margin-bottom-8">
-  <caption class="govuk-visually-hidden">A list of confirmed allocations for <%= current_allocation_cycle_period_text %></caption>
+  <caption class="govuk-visually-hidden">A list of confirmed allocations for <%= next_allocation_cycle_period_text %></caption>
   <thead class="govuk-table__head">
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="col">

--- a/app/views/providers/allocations/_allocation_request_closed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_closed_state.html.erb
@@ -1,13 +1,13 @@
-<%= content_for :page_title, raw("PE courses for #{current_allocation_cycle_period_text}") %>
+<%= content_for :page_title, raw("PE courses for #{next_allocation_cycle_period_text}") %>
 <%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">PE courses for <%= current_allocation_cycle_period_text %></h1>
+    <h1 class="govuk-heading-xl">PE courses for <%= next_allocation_cycle_period_text %></h1>
 
     <% if @allocations_view.requested_allocations_statuses.any? || @allocations_view.not_requested_allocations_statuses.any? %>
       <p class="govuk-body">
-        You can no longer request fee-funded PE for <%= current_allocation_cycle_period_text %>.
+        You can no longer request fee-funded PE for <%= next_allocation_cycle_period_text %>.
         The request window closed on <%= Settings.allocations_close_date.to_s(:govuk_short) %>.
       </p>
 
@@ -18,7 +18,7 @@
       </p>
 
       <p class="govuk-body">
-        Also included are current courses that were not requested for <%= current_allocation_cycle_period_text %>.
+        Also included are current courses that were not requested for <%= next_allocation_cycle_period_text %>.
       </p>
 
       <p class="govuk-body">
@@ -26,23 +26,23 @@
       </p>
 
       <%= render partial: "providers/allocations/allocation_report_closed_state", locals: {
-                 section_heading: "Courses for #{current_allocation_cycle_period_text}",
+                 section_heading: "Courses for #{next_allocation_cycle_period_text}",
                  allocations: @allocations_view.requested_allocations_statuses,
                  request_type: "repeat"} %>
 
       <%= render partial: "providers/allocations/allocation_report_closed_state", locals: {
-                 section_heading: "Courses not running in #{current_allocation_cycle_period_text}",
+                 section_heading: "Courses not running in #{next_allocation_cycle_period_text}",
                  allocations: @allocations_view.not_requested_allocations_statuses,
                  request_type: "repeat"} %>
     <% else %>
       <p class="govuk-body">
-        You did not request fee-funded PE for <%= current_allocation_cycle_period_text %>.
+        You did not request fee-funded PE for <%= next_allocation_cycle_period_text %>.
       </p>
 
       <p class="govuk-body">
         Your organisation, and any organisations you’re the accredited body for,
-        will not be offering this course - even if it’s being offered in <%= previous_allocation_cycle_period_text %>.
-        You can not run this course in <%= current_allocation_cycle_period_text %> without permission from the Department for Education.
+        will not be offering this course - even if it’s being offered in <%= current_allocation_cycle_period_text %>.
+        You can not run this course in <%= next_allocation_cycle_period_text %> without permission from the Department for Education.
       </p>
 
       <p class="govuk-body">

--- a/app/views/providers/allocations/_allocation_request_closed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_closed_state.html.erb
@@ -1,14 +1,14 @@
-<%= content_for :page_title, raw("PE courses for 2021 to 2022") %>
+<%= content_for :page_title, raw("PE courses for #{current_allocation_cycle_period_text}") %>
 <%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">PE courses for 2021 to 2022</h1>
+    <h1 class="govuk-heading-xl">PE courses for <%= current_allocation_cycle_period_text %></h1>
 
     <% if @allocations_view.requested_allocations_statuses.any? || @allocations_view.not_requested_allocations_statuses.any? %>
       <p class="govuk-body">
-        You can no longer request fee-funded PE for 2021 to 2022. The request
-        window closed on <%= Settings.allocations_close_date.to_s(:govuk_short) %>.
+        You can no longer request fee-funded PE for <%= current_allocation_cycle_period_text %>.
+        The request window closed on <%= Settings.allocations_close_date.to_s(:govuk_short) %>.
       </p>
 
       <p class="govuk-body">
@@ -18,8 +18,7 @@
       </p>
 
       <p class="govuk-body">
-        Also included are current courses that were not requested for 2021 to
-        2022.
+        Also included are current courses that were not requested for <%= current_allocation_cycle_period_text %>.
       </p>
 
       <p class="govuk-body">
@@ -27,24 +26,23 @@
       </p>
 
       <%= render partial: "providers/allocations/allocation_report_closed_state", locals: {
-                 section_heading: "Courses for 2021 to 2022",
+                 section_heading: "Courses for #{current_allocation_cycle_period_text}",
                  allocations: @allocations_view.requested_allocations_statuses,
                  request_type: "repeat"} %>
 
       <%= render partial: "providers/allocations/allocation_report_closed_state", locals: {
-                 section_heading: "Courses not running in 2021 to 2022",
+                 section_heading: "Courses not running in #{current_allocation_cycle_period_text}",
                  allocations: @allocations_view.not_requested_allocations_statuses,
                  request_type: "repeat"} %>
     <% else %>
       <p class="govuk-body">
-        You did not request fee-funded PE for 2021 to 2022.
+        You did not request fee-funded PE for <%= current_allocation_cycle_period_text %>.
       </p>
 
       <p class="govuk-body">
         Your organisation, and any organisations you’re the accredited body for,
-        will not be offering this course - even if it’s being offered in 2020 to
-        2021. You can not run this course in 2021 to 2022 without permission
-        from the Department for Education.
+        will not be offering this course - even if it’s being offered in <%= previous_allocation_cycle_period_text %>.
+        You can not run this course in <%= current_allocation_cycle_period_text %> without permission from the Department for Education.
       </p>
 
       <p class="govuk-body">

--- a/app/views/providers/allocations/_allocation_request_confirmed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_confirmed_state.html.erb
@@ -1,14 +1,14 @@
 
-<%= content_for :page_title, "PE courses for #{current_allocation_cycle_period_text}" %>
+<%= content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
 <%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"> Fee-funded PE courses for <%= current_allocation_cycle_period_text %></h1>
+    <h1 class="govuk-heading-xl"> Fee-funded PE courses for <%= next_allocation_cycle_period_text %></h1>
 
     <% if @allocations_view.confirmed_allocation_places.any? %>
       <p class="govuk-body">
-        You requested fee-funded PE for the following organisations for <%= current_allocation_cycle_period_text %>.
+        You requested fee-funded PE for the following organisations for <%= next_allocation_cycle_period_text %>.
         These requests have been approved. Each organisation’s allocation is also included.
       </p>
 
@@ -21,11 +21,11 @@
                } %>
     <% else %>
       <p class="govuk-body">
-        You did not request fee-funded PE for <%= current_allocation_cycle_period_text %>.
+        You did not request fee-funded PE for <%= next_allocation_cycle_period_text %>.
       </p>
 
       <p class="govuk-body">
-        Any current courses that have not been requested will not be running in <%= current_allocation_cycle_period_text %>.
+        Any current courses that have not been requested will not be running in <%= next_allocation_cycle_period_text %>.
       </p>
 
       <p class="govuk-body">

--- a/app/views/providers/allocations/_allocation_request_confirmed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_confirmed_state.html.erb
@@ -1,14 +1,14 @@
 
-<%= content_for :page_title, "PE courses for 2021 to 2022" %>
+<%= content_for :page_title, "PE courses for #{current_allocation_cycle_period_text}" %>
 <%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"> Fee-funded PE courses for 2021 to 2022</h1>
+    <h1 class="govuk-heading-xl"> Fee-funded PE courses for <%= current_allocation_cycle_period_text %></h1>
 
     <% if @allocations_view.confirmed_allocation_places.any? %>
       <p class="govuk-body">
-        You requested fee-funded PE for the following organisations for 2021 to 2022.
+        You requested fee-funded PE for the following organisations for <%= current_allocation_cycle_period_text %>.
         These requests have been approved. Each organisation’s allocation is also included.
       </p>
 
@@ -21,11 +21,11 @@
                } %>
     <% else %>
       <p class="govuk-body">
-        You did not request fee-funded PE for 2021 to 2022.
+        You did not request fee-funded PE for <%= current_allocation_cycle_period_text %>.
       </p>
 
       <p class="govuk-body">
-        Any current courses that have not been requested will not be running in 2021 to 2022.
+        Any current courses that have not been requested will not be running in <%= current_allocation_cycle_period_text %>.
       </p>
 
       <p class="govuk-body">

--- a/app/views/providers/allocations/_allocation_request_open_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_open_state.html.erb
@@ -1,12 +1,12 @@
-<%= content_for :page_title, raw("Request PE courses for 2021 to 2022") %>
+<%= content_for :page_title, raw("Request PE courses for #{current_allocation_cycle_period_text}") %>
 <%= content_for :before_content, render_breadcrumbs("allocations") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Request PE courses for 2021 to 2022</h1>
+    <h1 class="govuk-heading-xl">Request PE courses for <%= current_allocation_cycle_period_text %></h1>
 
     <p class="govuk-body">
-      You must request any fee-funded PE courses for 2021 to 2022 by
+      You must request any fee-funded PE courses for <%= current_allocation_cycle_period_text %> by
       <%= Settings.allocations_close_date.to_s(:govuk) %>. You do not need to
       request any other courses, including salaried PE.
     </p>
@@ -54,7 +54,7 @@
 
   <% if @allocations_view.initial_allocation_statuses.present? %>
     <div class="govuk-grid-column-full">
-      <h3 class="govuk-heading-m">New PE courses 2021 to 2022</h3>
+      <h3 class="govuk-heading-m">New PE courses <%= current_allocation_cycle_period_text %></h3>
 
       <%= render partial: "providers/allocations/request_status", locals: {
         allocations: @allocations_view.initial_allocation_statuses,
@@ -72,7 +72,7 @@
 
     <p class="govuk-body">
       <% if @training_providers.present? %>
-        Request fee-funded PE for 2021 to 2022 for any organisations not
+        Request fee-funded PE for <%= current_allocation_cycle_period_text %> for any organisations not
         currently offering this course.
       <% else %>
         Select the name of the organisation(s) offering this course.

--- a/app/views/providers/allocations/_allocation_request_open_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_open_state.html.erb
@@ -1,12 +1,12 @@
-<%= content_for :page_title, raw("Request PE courses for #{current_allocation_cycle_period_text}") %>
+<%= content_for :page_title, raw("Request PE courses for #{next_allocation_cycle_period_text}") %>
 <%= content_for :before_content, render_breadcrumbs("allocations") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Request PE courses for <%= current_allocation_cycle_period_text %></h1>
+    <h1 class="govuk-heading-xl">Request PE courses for <%= next_allocation_cycle_period_text %></h1>
 
     <p class="govuk-body">
-      You must request any fee-funded PE courses for <%= current_allocation_cycle_period_text %> by
+      You must request any fee-funded PE courses for <%= next_allocation_cycle_period_text %> by
       <%= Settings.allocations_close_date.to_s(:govuk) %>. You do not need to
       request any other courses, including salaried PE.
     </p>
@@ -54,7 +54,7 @@
 
   <% if @allocations_view.initial_allocation_statuses.present? %>
     <div class="govuk-grid-column-full">
-      <h3 class="govuk-heading-m">New PE courses <%= current_allocation_cycle_period_text %></h3>
+      <h3 class="govuk-heading-m">New PE courses <%= next_allocation_cycle_period_text %></h3>
 
       <%= render partial: "providers/allocations/request_status", locals: {
         allocations: @allocations_view.initial_allocation_statuses,
@@ -72,7 +72,7 @@
 
     <p class="govuk-body">
       <% if @training_providers.present? %>
-        Request fee-funded PE for <%= current_allocation_cycle_period_text %> for any organisations not
+        Request fee-funded PE for <%= next_allocation_cycle_period_text %> for any organisations not
         currently offering this course.
       <% else %>
         Select the name of the organisation(s) offering this course.

--- a/app/views/providers/allocations/requests/_not_requested.html.erb
+++ b/app/views/providers/allocations/requests/_not_requested.html.erb
@@ -8,7 +8,7 @@
     </h1>
     <p class="govuk-body">
       You've confirmed that <%= @training_provider.provider_name %> will not be
-      offering fee-funded PE in <%= current_allocation_cycle_period_text %>.
+      offering fee-funded PE in <%= next_allocation_cycle_period_text %>.
     </p>
 
     <h2 class="govuk-heading-m">What happens now?</h2>
@@ -23,7 +23,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to raw("Return to Request PE courses for #{current_allocation_cycle_period_text}"),
+      <%= link_to raw("Return to Request PE courses for #{next_allocation_cycle_period_text}"),
                   provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
                   class: "govuk-link govuk-!-font-weight-bold" %>
     </p>

--- a/app/views/providers/allocations/requests/_not_requested.html.erb
+++ b/app/views/providers/allocations/requests/_not_requested.html.erb
@@ -8,7 +8,7 @@
     </h1>
     <p class="govuk-body">
       You've confirmed that <%= @training_provider.provider_name %> will not be
-      offering fee-funded PE in 2021 to 2022.
+      offering fee-funded PE in <%= current_allocation_cycle_period_text %>.
     </p>
 
     <h2 class="govuk-heading-m">What happens now?</h2>
@@ -23,7 +23,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to raw('Return to Request PE courses for 2021 to 2022'),
+      <%= link_to raw("Return to Request PE courses for #{current_allocation_cycle_period_text}"),
                   provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
                   class: "govuk-link govuk-!-font-weight-bold" %>
     </p>

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(
       title: "Request sent",
-      body: "You’ve confirmed that #{@training_provider.provider_name} would like to offer PE in #{current_allocation_cycle_period_text}.",
+      body: "You’ve confirmed that #{@training_provider.provider_name} would like to offer PE in #{next_allocation_cycle_period_text}.",
       classes: "govuk-!-margin-bottom-6",
       html_attributes: {
         data: {
@@ -33,7 +33,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to raw("Return to Request PE courses for #{current_allocation_cycle_period_text}"),
+      <%= link_to raw("Return to Request PE courses for #{next_allocation_cycle_period_text}"),
                   provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
                   class: "govuk-link govuk-!-font-weight-bold" %>
     </p>

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(
       title: "Request sent",
-      body: "You’ve confirmed that #{@training_provider.provider_name} would like to offer PE in 2021 to 2022.",
+      body: "You’ve confirmed that #{@training_provider.provider_name} would like to offer PE in #{current_allocation_cycle_period_text}.",
       classes: "govuk-!-margin-bottom-6",
       html_attributes: {
         data: {
@@ -24,7 +24,7 @@
     <p class="govuk-body">
       In September we'll let you know how many places we've allocated for this course.
       <% unless @allocation.initial_request? %>
-        This will be based on the organisation's allocation for 2020 to 2021.
+        This will be based on the organisation's allocation for <%= previous_allocation_cycle_period_text %>.
       <% end %>
     </p>
 
@@ -33,7 +33,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to raw('Return to Request PE courses for 2021 to 2022'),
+      <%= link_to raw("Return to Request PE courses for #{current_allocation_cycle_period_text}"),
                   provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
                   class: "govuk-link govuk-!-font-weight-bold" %>
     </p>

--- a/app/views/recruitment_cycles/_allocations.html.erb
+++ b/app/views/recruitment_cycles/_allocations.html.erb
@@ -1,7 +1,6 @@
 <% if provider.accredited_body? %>
   <h2 class="govuk-heading-m">
-    <% period = (Allocation.journey_mode == "confirmed" ? current_recruitment_cycle_period_text : current_allocation_cycle_period_text) %>
-    <%= govuk_link_to t("allocations_for_pe.#{Allocation.journey_mode}_state_link_text", period: period),
+    <%= govuk_link_to t("allocations_for_pe.#{Allocation.journey_mode}_state_link_text", period: next_allocation_cycle_period_text),
                       provider_recruitment_cycle_allocations_path(provider.provider_code, year) %>
   </h2>
 

--- a/app/views/recruitment_cycles/_allocations.html.erb
+++ b/app/views/recruitment_cycles/_allocations.html.erb
@@ -1,6 +1,7 @@
 <% if provider.accredited_body? %>
   <h2 class="govuk-heading-m">
-    <%= govuk_link_to t("allocations_for_pe.#{Allocation.journey_mode}_state_link_text"),
+    <% period = (Allocation.journey_mode == "confirmed" ? current_recruitment_cycle_period_text : current_allocation_cycle_period_text) %>
+    <%= govuk_link_to t("allocations_for_pe.#{Allocation.journey_mode}_state_link_text", period: period),
                       provider_recruitment_cycle_allocations_path(provider.provider_code, year) %>
   </h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,9 +132,9 @@ en:
       from_range: "From age must be between %{min} and %{max}"
       to_range: "To age must be between %{min} and %{max}"
   allocations_for_pe:
-    open_state_link_text: "Request PE courses for 2021 to 2022"
-    closed_state_link_text: "Request PE courses for 2021 to 2022"
-    confirmed_state_link_text: "View PE courses for 2021 to 2022"
+    open_state_link_text: "Request PE courses for %{period}"
+    closed_state_link_text: "Request PE courses for %{period}"
+    confirmed_state_link_text: "View PE courses for %{period}"
     open_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses(ones without a salary) for the next recruitment cycle."
     closed_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses (ones without a salary) for the next recruitment cycle."
     confirmed_state_copy: "Use it to view the outcome of requests for fee-funded PE courses (ones without a salary) for the next recruitment cycle."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,6 +57,7 @@ environment:
   label: "Beta"
   selector_name: "beta"
 current_cycle: 2021
+allocation_cycle_year: 2021
 # `financial_support_placeholder_cycle` the cycle year value should be
 # omitted if placeholder is not required otherwise it should be the
 # new/next cycle.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,12 +57,12 @@ environment:
   label: "Beta"
   selector_name: "beta"
 current_cycle: 2021
-allocation_cycle_year: 2021
+allocation_cycle_year: 2020
+allocations_close_date: 2021-07-02
 # `financial_support_placeholder_cycle` the cycle year value should be
 # omitted if placeholder is not required otherwise it should be the
 # new/next cycle.
 financial_support_placeholder_cycle:
-allocations_close_date: 2021-07-02
 application_name: publish-teacher-training
 logstash:
   type: tcp

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -7,8 +7,8 @@ environment:
   selector_name: "review"
 authentication:
   mode: persona
+allocation_cycle_year: 2020
 allocations_close_date: 2021-07-02
-allocation_cycle_year: 2021
 features:
   allocations:
     state: open

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -8,6 +8,7 @@ environment:
 authentication:
   mode: persona
 allocations_close_date: 2021-07-02
+allocation_cycle_year: 2021
 features:
   allocations:
     state: open

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -223,7 +223,7 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_click_request_pe_courses
-    click_on "Request PE courses for 2021 to 2022"
+    click_on "Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}"
   end
 
   def and_i_click_change

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -222,8 +222,12 @@ RSpec.feature "PE allocations" do
     expect(find("h1")).to have_content(@accredited_body.provider_name.to_s)
   end
 
+  def next_allocation_cycle_period_text
+    "#{Settings.allocation_cycle_year + 1} to #{Settings.allocation_cycle_year + 2}"
+  end
+
   def and_i_click_request_pe_courses
-    click_on "Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}"
+    click_on "Request PE courses for #{next_allocation_cycle_period_text}"
   end
 
   def and_i_click_change

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -310,8 +310,12 @@ RSpec.feature "PE allocations" do
     signed_in_user(user: user)
   end
 
+  def next_allocation_cycle_period_text
+    "#{Settings.allocation_cycle_year + 1} to #{Settings.allocation_cycle_year + 2}"
+  end
+
   def and_i_click_request_pe_courses
-    click_on "Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}"
+    click_on "Request PE courses for #{next_allocation_cycle_period_text}"
   end
 
   def when_i_visit_my_organisations_page
@@ -323,7 +327,7 @@ RSpec.feature "PE allocations" do
   end
 
   def then_i_see_the_pe_allocations_page
-    expect(find("h1")).to have_content("Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}")
+    expect(find("h1")).to have_content("Request PE courses for #{next_allocation_cycle_period_text}")
   end
 
   def when_i_click_choose_an_organisation_button

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -311,7 +311,7 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_click_request_pe_courses
-    click_on "Request PE courses for 2021 to 2022"
+    click_on "Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}"
   end
 
   def when_i_visit_my_organisations_page
@@ -323,7 +323,7 @@ RSpec.feature "PE allocations" do
   end
 
   def then_i_see_the_pe_allocations_page
-    expect(find("h1")).to have_content("Request PE courses for 2021 to 2022")
+    expect(find("h1")).to have_content("Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}")
   end
 
   def when_i_click_choose_an_organisation_button

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -291,12 +291,16 @@ private
     expect(find("h1")).to have_content(@accredited_body.provider_name.to_s)
   end
 
+  def next_allocation_cycle_period_text
+    "#{Settings.allocation_cycle_year + 1} to #{Settings.allocation_cycle_year + 2}"
+  end
+
   def and_i_click_request_pe_courses
-    click_on "Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}"
+    click_on "Request PE courses for #{next_allocation_cycle_period_text}"
   end
 
   def then_i_see_the_pe_allocations_page
-    expect(find("h1")).to have_content("Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}")
+    expect(find("h1")).to have_content("Request PE courses for #{next_allocation_cycle_period_text}")
   end
 
   def and_i_see_only_repeat_allocation_statuses
@@ -321,7 +325,7 @@ private
         @accredited_body.provider_name.to_s,
         href: "/organisations/#{@accredited_body.provider_code}",
       )
-      expect(page).to have_content("Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}")
+      expect(page).to have_content("Request PE courses for #{next_allocation_cycle_period_text}")
     end
   end
 

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -292,11 +292,11 @@ private
   end
 
   def and_i_click_request_pe_courses
-    click_on "Request PE courses for 2021 to 2022"
+    click_on "Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}"
   end
 
   def then_i_see_the_pe_allocations_page
-    expect(find("h1")).to have_content("Request PE courses for 2021 to 2022")
+    expect(find("h1")).to have_content("Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}")
   end
 
   def and_i_see_only_repeat_allocation_statuses
@@ -321,7 +321,7 @@ private
         @accredited_body.provider_name.to_s,
         href: "/organisations/#{@accredited_body.provider_code}",
       )
-      expect(page).to have_content("Request PE courses for 2021 to 2022")
+      expect(page).to have_content("Request PE courses for #{Settings.allocation_cycle_year} to #{Settings.allocation_cycle_year + 1}")
     end
   end
 

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -203,7 +203,7 @@ feature "Sign in", type: :feature do
             rollover_page.continue_link.click
 
             expect(rollover_recruitment_page).to be_displayed
-            expect(rollover_recruitment_page.title).to have_content("Recruiting for the 2021 to 2022 cycle")
+            expect(rollover_recruitment_page.title).to have_content("Recruiting for the #{Settings.current_cycle + 1} to #{Settings.current_cycle + 2} cycle")
             rollover_recruitment_page.continue.click
 
             expect(root_page).to be_displayed

--- a/spec/views/recruitment_cycles/show_spec.rb
+++ b/spec/views/recruitment_cycles/show_spec.rb
@@ -58,6 +58,7 @@ describe "recruitment_cycles/show.html", type: :view do
       view.extend(CurrentUserMethod)
       allow(view).to receive(:params).and_return({ year: next_recruitment_cycle.year })
       assign(:recruitment_cycle, next_recruitment_cycle)
+      allow(Settings.features.allocations).to receive(:state).and_return("open")
     end
 
     describe "when accredited body user is viewing the next cycle" do
@@ -78,7 +79,8 @@ describe "recruitment_cycles/show.html", type: :view do
         expect(recruitment_cycle_page).to have_courses_as_accredited_body_link
         expect(recruitment_cycle_page).to have_request_for_pe_link
         request_for_pe_link = recruitment_cycle_page.request_for_pe_link
-        expect(request_for_pe_link.text).to eq I18n.t("allocations_for_pe.open_state_link_text")
+        period = "#{Settings.allocation_cycle_year + 1} to #{Settings.allocation_cycle_year + 2}"
+        expect(request_for_pe_link.text).to eq I18n.t("allocations_for_pe.open_state_link_text", period: period)
         expect(request_for_pe_link[:href]).to eq(
           provider_recruitment_cycle_allocations_path(
             current_year_provider.provider_code,


### PR DESCRIPTION
### Context

https://trello.com/c/bUofqbav/1730-allocations-change-hardcoded-2021-22-to-2022-23

### Changes proposed in this pull request

* replaced hardcoded recruitment cycle year with helpers
* New settings for allocation year added `Settings.allocation_cycle_year`
* `Settings.allocation_cycle_year` should match correctly to ttapi's `Settings.allocation_cycle_year`

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
