### PR TITLE
Use GovukComponent::BackLink

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -10,7 +10,16 @@ module ViewHelper
   end
 
   def govuk_back_link_to(url)
-    govuk_link_to("Back", url, class: "govuk-back-link", data: { qa: "page-back" })
+    render GovukComponent::BackLink.new(
+      text: "Back",
+      href: url,
+      classes: "govuk-!-display-none-print",
+      html_attributes: {
+        data: {
+          qa: "page-back",
+        },
+      },
+    )
   end
 
   def search_ui_url(relative_path)

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -9,7 +9,7 @@ feature "View helpers", type: :helper do
 
   describe "#govuk_back_link_to" do
     it "returns an anchor tag with the govuk-back-link class" do
-      expect(helper.govuk_back_link_to("https://localhost:44364/organisations/A0")).to eq("<a class=\"govuk-back-link\" data-qa=\"page-back\" href=\"https://localhost:44364/organisations/A0\">Back</a>")
+      expect(helper.govuk_back_link_to("https://localhost:44364/organisations/A0")).to eq("<a class=\"govuk-back-link govuk-!-display-none-print\" data-qa=\"page-back\" href=\"https://localhost:44364/organisations/A0\">Back</a>\n")
     end
   end
 


### PR DESCRIPTION
### Context

Updates `govuk_back_link_to` helper to use `GovukComponent::BackLink` from `govuk-components`.

### Guidance to review

There should be no visual changes, although back links will no longer display when a page is printed.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
