### PR TITLE
[SPIKE][1757] Convert rollover interruptions pages to use cookies

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -123,23 +123,26 @@ private
       redirect_to accept_terms_path
     elsif user_state_to_redirect_paths[user_from_session.aasm.current_state]
       redirect_to user_state_to_redirect_paths[user_from_session.aasm.current_state]
+    elsif show_rollover_page?
+      redirect_to rollover_path
+    elsif show_rollover_recruitment_page?
+      redirect_to rollover_recruitment_path
     elsif use_redirect_back_to
       redirect_to session[:redirect_back_to] if session[:redirect_back_to].present?
       session.delete(:redirect_back_to)
     end
   end
 
+  def show_rollover_page?
+    FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") && !cookies[:accepted_rollover]
+  end
+
+  def show_rollover_recruitment_page?
+    FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page") && !cookies[:accepted_rollover_recruitment]
+  end
+
   def user_state_to_redirect_paths
-    if Settings.features.rollover.can_edit_current_and_next_cycles
-      {
-        new: transition_info_path,
-        transitioned: rollover_path,
-        rolled_over: rollover_path,
-        notifications_configured: rollover_path, # looping if notification re-configured
-      }
-    else
-      { new: transition_info_path }
-    end
+    { new: transition_info_path }
   end
 
   def authorise_development_mode?(email, password)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,17 +8,30 @@ class UsersController < ApplicationController
   end
 
   def accept_rollover
-    user.accept_rollover_screen!
-    session["auth_user"]["attributes"]["state"] = user.state
+    # If we really want to make sure that an invididual user has
+    # accepted the screen, we could add a user id in here if there
+    # are multuple accounts using the same machine?
+    #
+    # Users will however, have to endure the great hardship of accepting
+    # this for every different browser they use during the rollover period
+    cookies[:accepted_rollover] = {
+      value: true,
+      expires: 6.months.from_now,
+    }
     redirect_to root_path
   end
 
-  def accept_notifications_info
-    user.accept_notifications_screen!
-    session["auth_user"]["attributes"]["state"] = user.state
+  def accept_rollover_recruitment
+    cookies[:accepted_rollover_recruitment] = {
+      value: true,
+      expires: 6.months.from_now,
+    }
     redirect_to root_path
   end
 
+  # This terms screen is the only existing interrupt screen that doesn't use the state machine
+  # If we want to have data around how many users have accepted the rollover screens we could
+  # add timestamps like this, but it seems less important.
   def accept_terms
     if params.require(:user)[:terms_accepted] == "1"
       result = User.member(current_user["user_id"]).accept_terms

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,18 +13,14 @@ class User < Base
   aasm whiny_transitions: false do
     state :new, initial: true
     state :transitioned
+    # TODO:  Remove all these after migrating users all to "transitioned",
+    # we are replacing rolled over states and the notifications state is already gone
     state :rolled_over
     state :accepted_rollover_2021
     state :notifications_configured
 
     event :accept_transition_screen do
       transitions from: :new, to: :transitioned
-    end
-
-    event :accept_rollover_screen do
-      transitions from: %i[notifications_configured transitioned rolled_over], to: :accepted_rollover_2021 do
-        guard { FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") }
-      end
     end
   end
 

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -20,12 +20,8 @@
       <li>edit titles, outcomes and locations where necessary</li>
     </ul>
 
-    <%if FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page") %>
-      <%= link_to "Continue", rollover_recruitment_path,  class: "govuk-button" %>
-    <% else %>
-      <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
-        <%= f.submit "Continue", class: "govuk-button" %>
-      <% end %>
+    <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
+      <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -16,7 +16,7 @@
       to courses copied over from the current cycle and new courses added for 2021 to 2022.
     </p>
 
-    <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
+    <%= form_for :user, url: accept_rollover_recruitment_path, method: :patch do |f| %>
       <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,7 @@ Rails.application.routes.draw do
   get "/rollover", to: "pages#rollover", as: :rollover
   get "/rollover-recruitment", to: "pages#rollover_recruitment", as: :rollover_recruitment
   patch "/accept-rollover", to: "users#accept_rollover"
+  patch "/accept-rollover-recruitment", to: "users#accept_rollover_recruitment"
   get "/accept-terms", to: "pages#accept_terms"
   patch "/accept-terms", to: "users#accept_terms"
   get "/performance-dashboard", to: "pages#performance_dashboard", as: :performance_dashboard


### PR DESCRIPTION
### Context
This is a spike, so tests are missing and extra comments are added
For the purposes of review only. Do not merge.

https://trello.com/c/GgPy61jB/1757-spike-avoid-adding-acceptedrollover2022-user-state

### Changes proposed in this pull request
We want to avoid adding a new state for every time a user has to 
accept and interrupt screen. It is also likely that we will break
Apart the rollover and rollover-recruitment interrupt pages this year
as the allocations period ends before rollover begins. If we wanted
to have these two pages separate and maintain states, we could get
the user stuck in an infinite loop if we had both pages enabled
At the same time: 
 accepted_rollover -> accepted_rollover_recruitment -> accepted_rollover

This PR shows how we could use cookies to replace this mechanism. We
would lose the ability to query how many users have seen these screens
and accepted them. But we could add timestamps to the user and wipe
them after every rollover if that is something we really need. Since
We know rollover and allocations happen once a year, at roughly the same
time, using cookies with a 6 month expiry takes care of wiping for us.


### Guidance to review

Read the code comments. Try it out locally by enabling `rollover.can_edit_current_and_next_cycles` and `rollover.show_next_cycle_allocation_recruitment_page`, you should be greeted with these interrupt screens.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
