### PR TITLE
Use GovukComponent::Details

### DIFF
--- a/app/views/courses/_entry_requirements.html.erb
+++ b/app/views/courses/_entry_requirements.html.erb
@@ -1,12 +1,5 @@
-<details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      <%= gcse_subject %> GCSE: <%= t("edit_options.entry_requirements.#{gcse_subject_code}.details_label") %>
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      <%= t("edit_options.entry_requirements.#{gcse_subject_code}.help") %>
-    </p>
-  </div>
-</details>
+<%= govuk_details(
+  summary: gcse_subject + " GCSE: " + t("edit_options.entry_requirements.#{gcse_subject_code}.details_label"),
+  description: t("edit_options.entry_requirements.#{gcse_subject_code}.help"),
+  classes: "govuk-!-margin-bottom-2",
+) %>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -47,27 +47,17 @@
 
         <p class="govuk-body">Remember to:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>make your content specific to this course - don’t repeat the descriptions you’ve used for other courses</li>
+          <li>make your content specific to this course – don’t repeat the descriptions you’ve used for other courses</li>
           <li>use short paragraphs (no more than five sentences each)</li>
-          <li>use bullet points where possible (to check formatting, use the 'preview' function after saving your content)</li>
+          <li>use bullet points where possible (to check formatting, use the ‘preview’ function after saving your content)</li>
           <li>spell out all acronyms the first time you use them, eg ITT, NQT, EAL, ICT (applicants may not be familiar with these terms)
           </li>
         </ul>
 
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Several courses in the same subject?
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <p class="govuk-body">
-              If you offer more than one course in the same subject - eg two Primary courses - it’s important to say how
-              they differ (eg differences in teaching placements or in the focus of the training). Otherwise, applicants
-              may be unable to decide between them.
-            </p>
-          </div>
-        </details>
+        <%= govuk_details(
+          summary: "Several courses in the same subject?",
+          description: "If you offer more than one course in the same subject – eg two Primary courses – it’s important to say how they differ (eg differences in teaching placements or in the focus of the training). Otherwise, applicants may be unable to decide between them.",
+        ) %>
 
         <%= f.govuk_text_area :about_course, label: { text: 'About this course', size:'s' }, max_words: 400, rows: 20 %>
 
@@ -115,22 +105,15 @@
           <li>why they might need to do a subject knowledge enhancement course</li>
         </ul>
 
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              See the guidance
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <h3 class="govuk-heading-m">Where you will train</h3>
-            <% if @provider.provider_type == 'university' %>
-              <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
-              <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
-            <% else %>
-              <p class="govuk-body">You'll be placed in different schools during your training. You can't pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
-            <% end %>
-          </div>
-        </details>
+        <%= govuk_details(summary: "See the guidance") do %>
+          <h3 class="govuk-heading-m">Where you will train</h3>
+          <% if @provider.provider_type == 'university' %>
+            <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
+            <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
+          <% else %>
+            <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
+          <% end %>
+        <% end %>
 
         <%= f.govuk_text_area :how_school_placements_work, label: { text: course.placements_heading, size:'s' }, max_words: 350, rows: 15 %>
 

--- a/app/views/courses/preview/qualification/_pgce.html.erb
+++ b/app/views/courses/preview/qualification/_pgce.html.erb
@@ -1,16 +1,5 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGCE</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      A postgraduate certificate in education (PGCE) is an academic qualification in education.
-    </p>
-    <p class="govuk-body">
-      It&rsquo;s recognised internationally, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-    <p class="govuk-body">
-      This course does not lead to qualified teacher status (QTS).
-    </p>
-  </div>
-</details>
+<%= govuk_details(summary: "PGCE") do %>
+  <p class="govuk-body">A postgraduate certificate in education (PGCE) is an academic qualification in education.</p>
+  <p class="govuk-body">It’s recognised internationally, though you should always check what qualifications are needed in the country you’d like to teach in.</p>
+  <p class="govuk-body">This course does not lead to qualified teacher status (QTS).</p>
+<% end %>

--- a/app/views/courses/preview/qualification/_pgce_with_qts.html.erb
+++ b/app/views/courses/preview/qualification/_pgce_with_qts.html.erb
@@ -1,16 +1,5 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGCE with QTS</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
-    </p>
-    <p class="govuk-body">
-      It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-    <p class="govuk-body">
-      Many PGCE courses include credits that count toward a Master&rsquo;s degree.
-    </p>
-  </div>
-</details>
+<%= govuk_details(summary: "PGCE with QTS") do %>
+  <p class="govuk-body">A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.</p>
+  <p class="govuk-body">It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.</p>
+  <p class="govuk-body">Many PGCE courses include credits that count toward a Master’s degree.</p>
+<% end %>

--- a/app/views/courses/preview/qualification/_pgde.html.erb
+++ b/app/views/courses/preview/qualification/_pgde.html.erb
@@ -1,16 +1,5 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGDE</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).
-    </p>
-    <p class="govuk-body">
-      It&rsquo;s recognised internationally, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-    <p class="govuk-body">
-      This course does not lead to qualified teacher status (QTS).
-    </p>
-  </div>
-</details>
+<%= govuk_details(summary: "PGDE") do %>
+  <p class="govuk-body">A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).</p>
+  <p class="govuk-body">It’s recognised internationally, though you should always check what qualifications are needed in the country you’d like to teach in.</p>
+  <p class="govuk-body">This course does not lead to qualified teacher status (QTS).</p>
+<% end %>

--- a/app/views/courses/preview/qualification/_pgde_with_qts.html.erb
+++ b/app/views/courses/preview/qualification/_pgde_with_qts.html.erb
@@ -1,16 +1,5 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGDE with QTS</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
-    </p>
-    <p class="govuk-body">
-      It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-    <p class="govuk-body">
-      Many PGDE courses include credits towards a Master&rsquo;s degree.
-    </p>
-  </div>
-</details>
+<%= govuk_details(summary: "PGDE with QTS") do %>
+  <p class="govuk-body">A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.</p>
+  <p class="govuk-body">It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.</p>
+  <p class="govuk-body">Many PGDE courses include credits towards a Master’s degree.</p>
+<% end %>

--- a/app/views/courses/preview/qualification/_qts.html.erb
+++ b/app/views/courses/preview/qualification/_qts.html.erb
@@ -1,16 +1,5 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">QTS</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
-    </p>
-    <p class="govuk-body">
-      It may also allow you to teach in <%= link_to "the EU and EEA", "https://www.gov.uk/eu-eea", class: "govuk-link" %>, though this could change after 2020.
-    </p>
-    <p class="govuk-body">
-      If you&rsquo;re planning to teach overseas, you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-  </div>
-</details>
+<%= govuk_details(summary: "QTS") do %>
+  <p class="govuk-body">Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.</p>
+  <p class="govuk-body">It may also allow you to teach in <%= govuk_link_to "the EU and EEA", "https://www.gov.uk/eu-eea" %>, though this could change after 2020.</p>
+  <p class="govuk-body">If you’re planning to teach overseas, you should always check what qualifications are needed in the country you’d like to teach in.</p>
+<% end %>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -39,28 +39,19 @@
         <li>why they might need to do a subject knowledge enhancement course</li>
       </ul>
 
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            See the guidance
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <h3 class="govuk-heading-m">Qualifications</h3>
-            <p class="govuk-body">To be a teacher in England you need:</p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>a degree or an equivalent qualification</li>
-              <li>English and Maths GCSEs at grade 4 (C) or above</li>
-              <li>For primary teaching, a science subject GCSE at grade 4 (C) or above</li>
-            </ul>
-            <p class="govuk-body">You can find out more about entry requirements, and how it works if you have studied overseas, at <%= link_to "Get Into Teaching", "https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher" %>.</p>
-
-            <h4 class="govuk-heading-s">Refreshing your subject knowledge</h4>
-            <p class="govuk-body">If you have the right qualities and qualifications to teach but need to refresh your subject knowledge, you might be asked to complete a <%= link_to "subject knowledge enhancement (SKE) course", "https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses" %>.</p>
-
-            <p class="govuk-body">You’ll find out if you need to complete an SKE course after the interview stage.</p>
-        </div>
-      </details>
+      <%= govuk_details(summary: "See the guidance") do %>
+        <h3 class="govuk-heading-m">Qualifications</h3>
+        <p class="govuk-body">To be a teacher in England you need:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>a degree or an equivalent qualification</li>
+          <li>English and Maths GCSEs at grade 4 (C) or above</li>
+          <li>For primary teaching, a science subject GCSE at grade 4 (C) or above</li>
+        </ul>
+        <p class="govuk-body">You can find out more about entry requirements, and how it works if you have studied overseas, at <%= govuk_link_to "Get Into Teaching", "https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher" %>.</p>
+        <h4 class="govuk-heading-s">Refreshing your subject knowledge</h4>
+        <p class="govuk-body">If you have the right qualities and qualifications to teach but need to refresh your subject knowledge, you might be asked to complete a <%= govuk_link_to "subject knowledge enhancement (SKE) course", "https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses" %>.</p>
+        <p class="govuk-body">You’ll find out if you need to complete an SKE course after the interview stage.</p>
+      <% end %>
 
       <%= f.govuk_text_area :required_qualifications, label: { text: 'Qualifications needed', size:'s' }, max_words: 100, rows: 10 %>
 

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -16,22 +16,24 @@
     </div>
 
     <% if course.level == "secondary" %>
-      <details class="govuk-details govuk-!-margin-top-6 govuk-!-margin-bottom-0" role="group" data-qa="course__subordinate_subject_details" <% if course.selected_subject_ids.second %>open<% end %>>
-        <summary class="govuk-details__summary" role="button">
-          <span class="govuk-details__summary-text">
-            Add a second subject (optional)
-          </span>
-        </summary>
-        <div class="govuk-details__text" id="details-content">
-          <p class="govuk-body">Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
+      <%= govuk_details(
+        summary: "Add a second subject (optional)",
+        classes: "govuk-!-margin-top-6 govuk-!-margin-bottom-0",
+        html_attributes: {
+          open: course.selected_subject_ids.second,
+          data: {
+            qa: "course__subordinate_subject_details"
+          }
+        }
+      ) do %>
+        <p class="govuk-body">Your first subject is the main one. It will appear first in the course title. It represents the bursary or scholarship available if applicable.</p>
 
-          <div class="govuk-form-group">
-            <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
-            <span class="govuk-hint">For example ‘Physics’</span>
-            <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, course.selected_subject_ids.second || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
-          </div>
+        <div class="govuk-form-group">
+          <%= form.label :subordinate_subject_id, 'Second subject (optional)', class: 'govuk-label' %>
+          <span class="govuk-hint">For example ‘Physics’</span>
+          <%= form.select :subordinate_subject_id, options_for_select(course.selectable_subjects, course.selected_subject_ids.second || nil), { include_blank: true }, data: { qa: 'course__subordinate_subjects' }, class: "govuk-select" %>
         </div>
-      </details>
+      <% end %>
     <% end %>
   </fieldset>
 <% end %>

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -13,132 +13,77 @@
     <h1 class="govuk-heading-xl">Guidance for Publish teacher training courses</h1>
 
     <h2 class="govuk-heading-l">New features</h2>
-
     <p class="govuk-body">We’re introducing a range of new features to Publish. These will allow you to:</p>
-
     <ul class="govuk-list govuk-list--bullet">
       <li>add and edit locations</li>
       <li>update the vacancy status of a course</li>
       <li>create new courses</li>
       <li>edit course details (eg titles, outcomes, and fee or salary status)</li>
     </ul>
-
     <p class="govuk-body">The first two features are available now. The others will be introduced soon.</p>
 
     <h3 class="govuk-heading-m">See the new features in these videos</h3>
 
-    <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/nxmtXGy1cCY?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe class="govuk-!-margin-bottom-4" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/nxmtXGy1cCY?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-    <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">Read a transcript of the video here</span>
-      </summary>
-      <div class="govuk-details__text">
-        <p class="govuk-body">In this video we'll show you how to change the vacancy status of a course in Publish teacher training courses. First we'll show you how to switch vacancies off for a course. And then we'll show you how to switch vacancies on.</p>
+    <%= govuk_details(summary: "Read a transcript of the video here") do %>
+      <p class="govuk-body">In this video we’ll show you how to change the vacancy status of a course in Publish teacher training courses. First we’ll show you how to switch vacancies off for a course. And then we’ll show you how to switch vacancies on.</p>
 
-        <h2 class="govuk-heading-m">To switch vacancies off</h2>
+      <h2 class="govuk-heading-m">To switch vacancies off</h2>
+      <p class="govuk-body">First, scroll down to the Courses section on your Organisation Overview page.</p>
+      <p class="govuk-body">The Courses section now contains an option allowing you to manage vacancies. Click through.</p>
+      <p class="govuk-body">Here – on the Courses page – you’ll see the courses table.</p>
+      <p class="govuk-body">This shows: your course title and code; its publication status (including whether it’s live on the Find tool); whether candidates can currently apply to it; and finally, whether it still has vacancies.</p>
+      <p class="govuk-body">To turn vacancies off, scroll down to the course you’d like to update. And then click the Edit option in the Vacancies column.</p>
+      <p class="govuk-body">This takes you through to the Edit Vacancies page for this course.</p>
+      <p class="govuk-body">Here, you’re given two options. You can confirm that the course has no vacancies. Or you can confirm that there are still vacancies for this course.</p>
+      <p class="govuk-body">If there are no longer any vacancies – if you’re no longer recruiting candidates – click the upper box.</p>
+      <p class="govuk-body">Once you click ‘Publish changes’, this course will be closed to applications. Changes will be published immediately to Find.</p>
+      <p class="govuk-body">Click ‘Publish changes’. You’ll see that the vacancy status of the course has now been updated – a message will tell you that the changes you’ve just made have been published.</p>
+      <p class="govuk-body">If you now go back to the main Courses page, you’ll see that the Vacancies column has been updated too. This course is no longer accepting applications.</p>
 
-        <p class="govuk-body">First, scroll down to the Courses section on your Organisation Overview page.</p>
+      <h2 class="govuk-heading-m">To switch vacancies on</h2>
+      <p class="govuk-body">Scroll down the Courses page to the courses table. And select the relevant course.</p>
+      <p class="govuk-body">As you can see in the Vacancies column, this course currently doesn’t have any vacancies.</p>
+      <p class="govuk-body">Click ‘Edit’.</p>
+      <p class="govuk-body">As before, you’re given two options. Click the lower box to confirm there are vacancies. You’ll see a drop down list – this shows the locations related to this course. Tick those locations that still have vacancies. If any location doesn’t have vacancies, untick it.</p>
+      <p class="govuk-body">Once you’ve confirmed that there are vacancies, click ‘Publish changes’ to open the course to new applications.</p>
+      <p class="govuk-body">You’ll see a message confirming that the vacancy status of this course has now been updated – the changes you’ve made have now been published.</p>
+      <p class="govuk-body">If you go back to the main Courses page, you’ll see that the Vacancies column has been updated in the course table. Candidates will now be able to apply for this course through Find.</p>
+    <% end %>
 
-        <p class="govuk-body">The Courses section now contains an option allowing you to manage vacancies. Click through.</p>
+    <iframe class="govuk-!-margin-bottom-4" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/W_zhfemKiYM?rel=" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-        <p class="govuk-body">Here - on the Courses page - you'll see the courses table.</p>
+    <%= govuk_details(summary: "Read a transcript of the video here") do %>
+      <p class="govuk-body">In this video we’ll show you how to add and edit locations in Publish teacher training courses.</p>
+      <p class="govuk-body">Once you’ve signed in to Publish, go to your Organisation overview page. Click on the Locations section. Note that you can’t add or edit locations in the Courses section.</p>
+      <p class="govuk-body">You’ll see a list of your locations – this includes ones associated with your current courses, as well as with courses that aren’t currently running.</p>
+      <p class="govuk-body">A location is anywhere that candidates can choose when applying for a course. It’s usually where training takes place.</p>
+      <p class="govuk-body">However, it could also be a main address that represents a number of training sites.</p>
+      <p class="govuk-body">In this video, first of all we’ll show you how to change the details for a location. Then, we’ll show you how to add a new location – and assign it to one of your courses.</p>
 
-        <p class="govuk-body">This shows: your course title and code; its publication status (including whether it's live on the Find tool); whether candidates can currently apply to it; and finally, whether it still has vacancies.</p>
+      <h2 class="govuk-heading-m">1.</h2>
+      <p class="govuk-body">To change location details, click on the location you’d like to edit.</p>
+      <p class="govuk-body">You’ll be taken to a page showing the name and address of this location. Make your changes in the relevant fields.</p>
+      <p class="govuk-body">When you’ve finished, click ‘save and publish changes’. Alternatively, click ‘cancel changes’ if you don’t wish to make any edits.</p>
+      <p class="govuk-body">You’ll be taken back to the main Locations page. Any changes you make will be published immediately to Find postgraduate teacher training courses.</p>
+      <p class="govuk-body">They’ll also be updated in UCAS Apply within two hours.</p>
 
-        <p class="govuk-body">To turn vacancies off, scroll down to the course you'd like to update. And then click the Edit option in the Vacancies column.</p>
+      <h2 class="govuk-heading-m">2.</h2>
+      <p class="govuk-body">To add a new location, click the green ‘Add a location’ button on the Locations page. Note that you can only enter 37 locations in total. </p>
+      <p class="govuk-body">Fill in the name and address of the location, including the full postcode. You should also specify a region. A UCAS code will automatically be generated for this location. Click Save.</p>
 
-        <p class="govuk-body">This takes you through to the Edit Vacancies page for this course.</p>
-
-        <p class="govuk-body">Here, you’re given two options. You can confirm that the course has no vacancies. Or you can confirm that there are still vacancies for this course.</p>
-
-        <p class="govuk-body">If there are no longer any vacancies - if you’re no longer recruiting candidates - click the upper box.</p>
-
-        <p class="govuk-body">Once you click 'Publish changes', this course will be closed to applications. Changes will be published immediately to Find.</p>
-
-        <p class="govuk-body">Click 'Publish changes'. You'll see that the vacancy status of the course has now been updated - a message will tell you that the changes you've just made have been published.</p>
-
-        <p class="govuk-body">If you now go back to the main Courses page, you'll see that the Vacancies column has been updated too. This course is no longer accepting applications.</p>
-
-        <h2 class="govuk-heading-m">To switch vacancies on</h2>
-
-        <p class="govuk-body">Scroll down the Courses page to the courses table. And select the relevant course.</p>
-
-        <p class="govuk-body">As you can see in the Vacancies column, this course currently doesn't have any vacancies.</p>
-
-        <p class="govuk-body">Click 'Edit'.</p>
-
-        <p class="govuk-body">As before, you’re given two options. Click the lower box to confirm there are vacancies. You'll see a drop down list - this shows the locations related to this course. Tick those locations that still have vacancies. If any location doesn't have vacancies, untick it.</p>
-
-        <p class="govuk-body">Once you've confirmed that there are vacancies, click 'Publish changes' to open the course to new applications.</p>
-
-        <p class="govuk-body">You'll see a message confirming that the vacancy status of this course has now been updated - the changes you've made have now been published.</p>
-
-        <p class="govuk-body">If you go back to the main Courses page, you'll see that the Vacancies column has been updated in the course table. Candidates will now be able to apply for this course through Find.</p>
-      </div>
-    </details>
-
-    <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/W_zhfemKiYM?rel=" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-    <details class="govuk-details govuk-!-margin-top-4">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">Read a transcript of the video here</span>
-      </summary>
-      <div class="govuk-details__text">
-        <p class="govuk-body">In this video we’ll show you how to add and edit locations in Publish teacher training courses.</p>
-
-        <p class="govuk-body">Once you’ve signed in to Publish, go to your Organisation overview page. Click on the Locations section. Note that you can’t add or edit locations in the Courses section.</p>
-
-        <p class="govuk-body">You’ll see a list of your locations - this includes ones associated with your current courses, as well as with courses that aren’t currently running.</p>
-
-        <p class="govuk-body">A location is anywhere that candidates can choose when applying for a course. It’s usually where training takes place.</p>
-
-        <p class="govuk-body"> However, it could also be a main address that represents a number of training sites.</p>
-
-        <p class="govuk-body">In this video, first of all we’ll show you how to change the details for a location. Then, we’ll show you how to add a new location - and assign it to one of your courses.</p>
-
-        <h2 class="govuk-heading-m">1.</h2>
-
-        <p class="govuk-body">To change location details, click on the location you’d like to edit.</p>
-
-        <p class="govuk-body">You’ll be taken to a page showing the name and address of this location. Make your changes in the relevant fields.</p>
-
-        <p class="govuk-body">When you’ve finished, click ‘save and publish changes’. Alternatively, click ‘cancel changes’ if you don’t wish to make any edits.</p>
-
-        <p class="govuk-body">You’ll be taken back to the main Locations page. Any changes you make will be published immediately to Find postgraduate teacher training courses.</p>
-
-        <p class="govuk-body">They’ll also be updated in UCAS Apply within two hours.</p>
-
-        <h2 class="govuk-heading-m">2.</h2>
-
-        <p class="govuk-body">To add a new location, click the green ‘Add a location’ button on the Locations page. Note that you can only enter 37 locations in total. </p>
-
-        <p class="govuk-body">Fill in the name and address of the location, including the full postcode. You should also specify a region. A UCAS code will automatically be generated for this location. Click Save.</p>
-
-        <h2 class="govuk-heading-m">3.</h2>
-
-        <p class="govuk-body">Once you’ve added your location, you can assign it to a course. This will allow candidates to select it during the application process.</p>
-
-        <p class="govuk-body">To assign your location to a course, go back to the main page for your organisation. Scroll down to Courses.</p>
-
-        <p class="govuk-body">Though you can only edit your locations in the Locations section, you can only assign them to a course in Courses.</p>
-
-        <p class="govuk-body">On the Courses page, select the course you’d like to add the location to.</p>
-
-        <p class="govuk-body">On the course page, click the ‘Basic details’ tab.</p>
-
-        <p class="govuk-body">You’ll see a Locations option. The table sets out the locations that candidates can currently choose from when applying for this course.</p>
-
-        <p class="govuk-body">To add your new location, click ‘Change’. Here you’ll see a list of all your existing locations. There are ticks next to those currently assigned to this course. </p>
-
-        <p class="govuk-body">Tick the one you’d like to add. Click ‘save and publish changes’.</p>
-
-        <p class="govuk-body">You’ll be taken back to the ‘Basic details’ table. The location has now been added to this course.</p>
-
-        <p class="govuk-body">It will be published immediately to Find postgraduate teacher training - and to UCAS Apply within two hours.</p>
-
-      </div>
-    </details>
-
+      <h2 class="govuk-heading-m">3.</h2>
+      <p class="govuk-body">Once you’ve added your location, you can assign it to a course. This will allow candidates to select it during the application process.</p>
+      <p class="govuk-body">To assign your location to a course, go back to the main page for your organisation. Scroll down to Courses.</p>
+      <p class="govuk-body">Though you can only edit your locations in the Locations section, you can only assign them to a course in Courses.</p>
+      <p class="govuk-body">On the Courses page, select the course you’d like to add the location to.</p>
+      <p class="govuk-body">On the course page, click the ‘Basic details’ tab.</p>
+      <p class="govuk-body">You’ll see a Locations option. The table sets out the locations that candidates can currently choose from when applying for this course.</p>
+      <p class="govuk-body">To add your new location, click ‘Change’. Here you’ll see a list of all your existing locations. There are ticks next to those currently assigned to this course. </p>
+      <p class="govuk-body">Tick the one you’d like to add. Click ‘save and publish changes’.</p>
+      <p class="govuk-body">You’ll be taken back to the ‘Basic details’ table. The location has now been added to this course.</p>
+      <p class="govuk-body">It will be published immediately to Find postgraduate teacher training – and to UCAS Apply within two hours.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -24,7 +24,7 @@
 
     <h3 class="govuk-heading-m">See the new features in these videos</h3>
 
-    <iframe class="govuk-!-margin-bottom-4" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/nxmtXGy1cCY?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe class="govuk-!-margin-bottom-4" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/nxmtXGy1cCY?rel=0" title="Video: Editing vacancies" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
     <%= govuk_details(summary: "Read a transcript of the video here") do %>
       <p class="govuk-body">In this video we’ll show you how to change the vacancy status of a course in Publish teacher training courses. First we’ll show you how to switch vacancies off for a course. And then we’ll show you how to switch vacancies on.</p>
@@ -52,7 +52,7 @@
       <p class="govuk-body">If you go back to the main Courses page, you’ll see that the Vacancies column has been updated in the course table. Candidates will now be able to apply for this course through Find.</p>
     <% end %>
 
-    <iframe class="govuk-!-margin-bottom-4" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/W_zhfemKiYM?rel=" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe class="govuk-!-margin-bottom-4" width="100%" height="315" src="https://www.youtube-nocookie.com/embed/W_zhfemKiYM?rel=" title="Video: Adding and assigning locations" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
     <%= govuk_details(summary: "Read a transcript of the video here") do %>
       <p class="govuk-body">In this video we’ll show you how to add and edit locations in Publish teacher training courses.</p>

--- a/app/views/providers/allocations/pick_a_provider.html.erb
+++ b/app/views/providers/allocations/pick_a_provider.html.erb
@@ -32,35 +32,26 @@
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-    <details class="govuk-details" role="group">
-      <summary class="govuk-details__summary" role="button">
-        <span class="govuk-details__summary-text">Try another provider</span>
-      </summary>
+    <%= govuk_details(summary: "Try another provider") do %>
+      <%= form_with url: initial_request_provider_recruitment_cycle_allocations_path(
+                      @provider.provider_code,
+                      @provider.recruitment_cycle_year,
+                      training_provider_code: params[:training_provider_code]
+                    ),
+                    skip_enforcing_utf8: true,
+                    method: :get,
+                    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+        <%= form.hidden_field :training_provider_code, value: "-1" %>
 
-      <div class="govuk-details__text">
-        <%= form_with url: initial_request_provider_recruitment_cycle_allocations_path(
-                        @provider.provider_code,
-                        @provider.recruitment_cycle_year,
-                        training_provider_code: params[:training_provider_code]
-                      ),
-                      skip_enforcing_utf8: true,
-                      method: :get,
-                      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-          <%= form.hidden_field :training_provider_code, value: "-1" %>
+        <div class="govuk-form-group">
+          <%= form.govuk_text_field :training_provider_query, label: { text: 'Organisation name' } %>
+          <div id="provider-autocomplete" class="govuk-body"></div>
+        </div>
 
-          <div class="govuk-form-group">
-            <%= form.govuk_text_field :training_provider_query, label: { text: 'Organisation name' } %>
-            <div id="provider-autocomplete" class="govuk-body"></div>
-          </div>
+        <%= form.govuk_submit "Search again" %>
+      <% end %>
+    <% end %>
 
-          <%= form.govuk_submit "Search again" %>
-        <% end %>
-      </div>
-    </details>
-
-    <p class="govuk-body">
-      To add a new provider to Publish, you should contact
-      <%= bat_contact_mail_to %>
-    </p>
+    <p class="govuk-body">To add a new provider to Publish, you should contact <%= bat_contact_mail_to %></p>
   </div>
 </div>

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -69,7 +69,7 @@ feature "About course", type: :feature do
       expect(about_course_page.how_school_placements_work_textarea.value).to eq(
         course.how_school_placements_work,
       )
-      expect(page).to have_content("You'll be placed in different schools during your training.")
+      expect(page).to have_content("You’ll be placed in different schools during your training.")
 
       fill_in "About this course", with: "Something interesting about this course"
       fill_in "How school placements work", with: "Something about how teaching placements work"


### PR DESCRIPTION
### Context

Uses `GovukComponent::Details` to render details component (via `govuk-components` `govuk_details` helper method).

Also… adds the `title` attribute to the YouTube video frames - good accessibility catch by SonorCloud.

### Guidance to review

There should be no visual or behavioural changes. Have removed some whitespace between paragraphs, and updated and straight quotes to use smart quotes inside where spotted inside any details content.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
