### PR TITLE
Use GovukComponent::InsetText

### DIFF
--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -17,7 +17,7 @@
         <div class="govuk-grid-column-full">
           <dl class="govuk-summary-list govuk-!-margin-bottom-0" data-qa="course__details">
             <%= render(CourseLevelComponent.new(course: course, changeable: true)) %>
-            
+
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
                 <abbr class="app-text-decoration-underline-dotted" title="Special educational needs and disability">SEND</abbr>
@@ -297,13 +297,13 @@
       <div data-qa="course__preview">
         <h2 class="govuk-heading-l">Preview</h2>
         <p class="govuk-body">See how this course will appear when it’s published on Find postgraduate teacher training:</p>
-        <div class="govuk-inset-text">
+        <%= govuk_inset_text do %>
           <h3 class="govuk-heading-m" data-qa="course__name">
             <span class="govuk-heading-s govuk-!-margin-bottom-0"><%= @provider.provider_name %></span>
             <%= course.name %>
           </h3>
           <p class="govuk-body" data-qa="course__description">Course: <%= course.description %></p>
-        </div>
+        <% end %>
       </div>
 
       <%= f.submit "Save new course",

--- a/app/views/courses/preview/financial_support/_placeholder.html.erb
+++ b/app/views/courses/preview/financial_support/_placeholder.html.erb
@@ -1,4 +1,3 @@
-<div class="govuk-inset-text">
+<%= govuk_inset_text do %>
   <p class="govuk-body">Financial support for <%=course.cycle_range%> will be announced soon. Further information is available on <%= link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training", class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>.</p>
-</div>
-
+<% end %>

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -10,7 +10,7 @@
 
     <p class="govuk-body">You can no longer change these contacts in NetUpdate, as NetUpdate has now been turned off.</p>
 
-    <div class="govuk-inset-text">
+    <%= govuk_inset_text do %>
       <h2 class="govuk-heading-m">What does ‘information unknown’ mean?</h2>
 
       <p class="govuk-body">Some of the contacts below are labelled ‘Information unknown’. This is because UCAS doesn’t have permission under the <%= link_to "General Data Protection Regulation", "https://www.gov.uk/government/publications/guide-to-the-general-data-protection-regulation", class: "govuk-link" %> (GDPR) to share these details with us.</p>
@@ -18,7 +18,7 @@
       <p class="govuk-body">You can get hold of these details by contacting the UCAS Higher Education Provider Team (HEP Team) on 0344 984 1111 or at <%= mail_to "hep_team@ucas.ac.uk", "hep_team@ucas.ac.uk", class: "govuk-link" %>.</p>
 
       <p class="govuk-body">Alternatively you can choose new contacts and we will send them to UCAS to update.</p>
-    </div>
+    <% end %>
 
     <hr class="govuk-section-break govuk-section-break--l" />
   </div>


### PR DESCRIPTION
### Context

Uses `GovukComponent::InsetText` to render footer component (via `govuk-components` `govuk_inset_text` helper method).

### Guidance to review

There should be no visual changes.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
