### PR TITLE
Use GovukComponent::Warning

### DIFF
--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -1,10 +1,5 @@
 <% if course.is_withdrawn? %>
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      This course has been withdrawn
-    </strong>
-  </div>
+  <%= govuk_warning(text: "This course has been withdrawn.") %>
 <% end %>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">

--- a/app/views/courses/preview/_apply.html.erb
+++ b/app/views/courses/preview/_apply.html.erb
@@ -44,13 +44,7 @@
       </tbody>
     </table>
   <% else %>
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.
-      </strong>
-    </div>
+    <%= govuk_warning(text: "You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.") %>
   <% end %>
 </div>
 

--- a/app/views/courses/request_change.html.erb
+++ b/app/views/courses/request_change.html.erb
@@ -5,13 +5,7 @@
 </h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        We're still working on this feature.
-      </strong>
-    </div>
+    <%= govuk_warning(text: "We’re still working on this feature.") %>
 
     <p class="govuk-body">When the feature is ready, you'll be able to make the change yourself.</p>
 

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -18,14 +18,11 @@
 
     <p class="govuk-body">You can assign locations to a course from the ‘Basic details’ tab on the course page.</p>
 
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        You are limited to 37 locations by UCAS Apply.<br>
-        <span class="govuk-!-font-weight-regular">Each location has a single character code.</span>
-      </strong>
-    </div>
+    <% content_for :warning_text do %>
+      You are limited to 37 locations by UCAS Apply.<br>
+      <span class="govuk-!-font-weight-regular">Each location has a single character code.</span>
+    <% end %>
+    <%= govuk_warning(text: content_for(:warning_text)) %>
 
     <table class="govuk-table app-table--vertical-align-middle">
       <thead class="govuk-table__head">
@@ -41,13 +38,7 @@
     <% if @provider.can_add_more_sites? %>
       <%= link_to "Add a location", new_provider_recruitment_cycle_site_path(@provider.provider_code), class: "govuk-button govuk-!-margin-bottom-2" %>
     <% else %>
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning</span>
-          You can’t add any more locations as you’ve reached the maximum number of locations available
-        </strong>
-      </div>
+      <%= govuk_warning(text: "You can’t add any more locations as you’ve reached the maximum number of locations available.") %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context

Uses `GovukComponent::Warning` to render warning text components (via `govuk-components` `govuk_warning` helper method).

### Guidance to review

There should be no visual changes.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
