### PR TITLE
Fix typo in Terms and Conditions

### DIFF
--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -17,7 +17,7 @@
     </p>
     <h3 class="govuk-heading-m">Information About Us</h3>
     <p class="govuk-body">
-      This Service is operated by [the Department for Education] (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
+      This Service is operated by the Department for Education (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
     </p>
     <p class="govuk-body">
       You can contact us using the following email address: <%= bat_contact_mail_to %>


### PR DESCRIPTION
### Context

Removes errant brackets around ‘Department of Education’ in Terms and Conditions.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
