### PR TITLE
[1787] Update allocations interruption screen content for 2022-2023

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "rails", "~> 6.1"
 gem "puma", "~> 5.3"
 
 # Sidekiq for background worker
-gem 'sidekiq'
+gem "sidekiq"
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "webpacker"

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -3,19 +3,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Recruiting for the <br><%= next_recruitment_cycle_period_text %> cycle
+      Requesting permission to recruit for the <br><%= next_recruitment_cycle_period_text %> cycle
     </h1>
 
     <p class="govuk-body">
-      You do not need to request permission to recruit for any courses other
-      than fee-funded PE. Accredited bodies should request fee-funded PE by
-      <%= Settings.allocations_close_date.to_s(:govuk) %>.
-    </p>
-
+      You are now able to request permission to recruit for fee-funded PE for the <%= next_recruitment_cycle_period_text %> cycle.</p>
     <p class="govuk-body">
-      You can publish all other courses without requesting permission. This
-      applies to courses copied over from the current cycle and new courses
-      added for <%= next_recruitment_cycle_period_text %>.
+      You do not need to request permission to recruit in Publish for any courses other than fee-funded PE.
+      Accredited bodies should request fee-funded PE by <%= Settings.allocations_close_date.to_s(:govuk) %>.
     </p>
 
     <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -203,7 +203,7 @@ feature "Sign in", type: :feature do
             rollover_page.continue_link.click
 
             expect(rollover_recruitment_page).to be_displayed
-            expect(rollover_recruitment_page.title).to have_content("Recruiting for the #{Settings.current_cycle + 1} to #{Settings.current_cycle + 2} cycle")
+            expect(rollover_recruitment_page.title).to have_content("Requesting permission to recruit for the #{Settings.current_cycle + 1} to #{Settings.current_cycle + 2} cycle")
             rollover_recruitment_page.continue.click
 
             expect(root_page).to be_displayed


### PR DESCRIPTION
### Context

Updating the content on the interruptions screen in preparation for the next cycle.

### Guidance to review

- Navigate to `/rollover-recruitment`

### Screenshot

![image](https://user-images.githubusercontent.com/50492247/119806161-d83d2a80-bed9-11eb-8c0f-387e6cbad2bb.png)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
