### PR TITLE
[1682] Show allocations section on Next Cycle page

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -31,6 +31,12 @@ class Provider < Base
     FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
   end
 
+  def from_previous_recruitment_cycle
+    Provider.where(recruitment_cycle_year: recruitment_cycle.year.to_i.pred)
+      .find(provider_code)
+      .first
+  end
+
 private
 
   def post_base_url

--- a/app/views/recruitment_cycles/_allocations.html.erb
+++ b/app/views/recruitment_cycles/_allocations.html.erb
@@ -1,7 +1,7 @@
-<% if @provider.accredited_body? %>
+<% if provider.accredited_body? %>
   <h2 class="govuk-heading-m">
     <%= govuk_link_to t("allocations_for_pe.#{Allocation.journey_mode}_state_link_text"),
-                      provider_recruitment_cycle_allocations_path(@provider.provider_code, year) %>
+                      provider_recruitment_cycle_allocations_path(provider.provider_code, year) %>
   </h2>
 
   <p class="govuk-body">

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -24,6 +24,8 @@
     <%= render partial: 'recruitment_cycles/courses_accredited_body', locals: { provider: @provider, year: params[:year] } %>
     <% if @recruitment_cycle.current? %>
       <%= render partial: 'recruitment_cycles/allocations', locals: { provider: @provider, year: params[:year] } %>
+    <% elsif @recruitment_cycle.next? %>
+      <%= render partial: 'recruitment_cycles/allocations', locals: { provider: @provider.from_previous_recruitment_cycle, year: (params[:year].to_i.pred) } %>
     <% end %>
   </div>
 </div>

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,12 +1,55 @@
-describe Provider do
-  describe "#publish" do
-    let(:provider) { build(:provider) }
+require "rails_helper"
 
+describe Provider do
+  let(:provider) { build(:provider) }
+
+  describe "#publish" do
     it "publishes" do
       publish_endpoint = stub_api_v2_request("/recruitment_cycles/#{provider.recruitment_cycle.year}/providers/#{provider.provider_code}/publish", {}, :post)
       RequestStore.store[:manage_courses_backend_token] = ""
       provider.publish
       expect(publish_endpoint).to have_been_requested
+    end
+  end
+
+  describe "#from_previous_recruitment_cycle" do
+    context "when the response from ttapi has some results" do
+      let(:organisation_response) { <<~JSON }
+         {
+           "data":[
+              {
+                 "id":"7",
+                 "type":"providers",
+                 "attributes":{
+                    "provider_code": "A06",
+                    "provider_name": "ACME"
+                 }
+              }
+           ],
+           "meta":{
+              "count":1
+           },
+           "jsonapi":{
+              "version":"1.0"
+           }
+        }
+      JSON
+
+      it "find a provider with the same code but previous recruitment cycle" do
+        cycle = Settings.current_cycle.pred
+        stub = stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v2/recruitment_cycles/#{cycle}/providers/#{provider.provider_code}")
+          .to_return(
+            status: 200,
+            body: organisation_response,
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          )
+
+        from_previous_cycle = provider.from_previous_recruitment_cycle
+        expect(stub).to have_been_requested
+        expect(from_previous_cycle).to be_a(Provider)
+        expect(from_previous_cycle.provider_code).to eq "A06"
+        expect(from_previous_cycle.provider_name).to eq "ACME"
+      end
     end
   end
 end

--- a/spec/views/recruitment_cycles/show_spec.rb
+++ b/spec/views/recruitment_cycles/show_spec.rb
@@ -61,7 +61,10 @@ describe "recruitment_cycles/show.html", type: :view do
     end
 
     describe "when accredited body user is viewing the next cycle" do
+      let(:current_year_provider) { build(:provider, :accredited_body) }
+
       before do
+        allow(accredited_body).to receive(:from_previous_recruitment_cycle).and_return(current_year_provider)
         assign(:provider, accredited_body)
         render template: "recruitment_cycles/show"
         recruitment_cycle_page.load(rendered)
@@ -73,13 +76,25 @@ describe "recruitment_cycles/show.html", type: :view do
         expect(recruitment_cycle_page).to have_courses_link
         expect(recruitment_cycle_page).to have_locations_link
         expect(recruitment_cycle_page).to have_courses_as_accredited_body_link
-        expect(recruitment_cycle_page).to have_no_request_for_pe_link
+        expect(recruitment_cycle_page).to have_request_for_pe_link
+        request_for_pe_link = recruitment_cycle_page.request_for_pe_link
+        expect(request_for_pe_link.text).to eq I18n.t("allocations_for_pe.open_state_link_text")
+        expect(request_for_pe_link[:href]).to eq(
+          provider_recruitment_cycle_allocations_path(
+            current_year_provider.provider_code,
+            current_recruitment_cycle.year,
+          ),
+        )
       end
     end
 
     describe "when training provider user is viewing the next cycle" do
+      let(:current_year_provider) { build(:provider) }
+
       before do
-        assign(:provider, build(:provider))
+        provider = build(:provider)
+        allow(provider).to receive(:from_previous_recruitment_cycle).and_return(current_year_provider)
+        assign(:provider, provider)
         render template: "recruitment_cycles/show"
         recruitment_cycle_page.load(rendered)
       end


### PR DESCRIPTION

### Context
https://trello.com/c/7ZSXSb0X/1682-ensure-allocations-exists-in-both-current-cycle-and-next-cycle-sections-in-publish-when-mid-rollover

We want to show the same allocations section (for the current cycle)
on the Next Cycle page for providers, as users get confused that it 
‘disappears’

### Changes proposed in this pull request

Show allocations section on the "Next Cycle" page for the "Current" cycle

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
