### PR TITLE
Use govuk-components helpers for links

### DIFF
--- a/app/components/course_level_component.html.erb
+++ b/app/components/course_level_component.html.erb
@@ -7,7 +7,7 @@
   </dd>
   <dd class="govuk-summary-list__actions">
     <% if changeable %>
-      <%= link_to new_provider_recruitment_cycle_courses_level_path(course.provider.provider_code, course.recruitment_cycle_year, params.to_unsafe_h.merge(goto_confirmation: true)), class: "govuk-link"  do %>
+      <%= govuk_link_to new_provider_recruitment_cycle_courses_level_path(course.provider.provider_code, course.recruitment_cycle_year, params.to_unsafe_h.merge(goto_confirmation: true)) do %>
         Change<span class="govuk-visually-hidden"> Level</span>
       <% end %>
     <% end %>

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -303,7 +303,7 @@ private
   end
 
   def edit_vacancy_link
-    h.link_to(h.vacancies_provider_recruitment_cycle_course_path(provider_code: object.provider_code, recruitment_cycle_year: object.recruitment_cycle_year, code: object.course_code), class: "govuk-link") do
+    h.govuk_link_to(h.vacancies_provider_recruitment_cycle_course_path(provider_code: object.provider_code, recruitment_cycle_year: object.recruitment_cycle_year, code: object.course_code)) do
       h.raw("Edit<span class=\"govuk-visually-hidden\"> vacancies for #{name_and_code}</span>")
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,9 +39,7 @@ module ApplicationHelper
                field: field.to_s,
              )
            end
-    tag.a error,
-          class: "govuk-link govuk-!-display-block",
-          href: href
+    govuk_link_to(error, href, class: "govuk-!-display-block")
   end
 
   def enrichment_summary_label(model, key, fields)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,17 +1,13 @@
 module OrganisationHelper
   def user_details(user, dfe_signin_deeplink: false)
     if dfe_signin_deeplink && user.sign_in_user_id.present?
-      link_to "#{user.first_name} #{user.last_name} <#{user.email}>",
-              "#{Settings.dfe_signin.user_search_url}/#{user.sign_in_user_id}/audit",
-              class: "govuk-link"
+      govuk_link_to "#{user.first_name} #{user.last_name} <#{user.email}>", "#{Settings.dfe_signin.user_search_url}/#{user.sign_in_user_id}/audit"
     else
       "#{user[:first_name]} #{user[:last_name]} <#{user[:email]}>"
     end
   end
 
   def provider_details(provider)
-    link_to "#{provider.provider_name} [#{provider.provider_code}]",
-            provider_path(provider.provider_code),
-            class: "govuk-link"
+    govuk_link_to "#{provider.provider_name} [#{provider.provider_code}]", provider_path(provider.provider_code)
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -36,8 +36,8 @@ module ViewHelper
     bat_contact_email_address.gsub("@", "<wbr>@").html_safe
   end
 
-  def bat_contact_mail_to(name = nil, subject: nil, link_class: "govuk-link", data: nil)
-    mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject, class: link_class, data: data
+  def bat_contact_mail_to(name = nil, **kwargs)
+    govuk_mail_to bat_contact_email_address, name || bat_contact_email_address_with_wrap, **kwargs
   end
 
   def enrichment_error_url(provider_code:, course:, field:)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,12 +1,8 @@
 module ViewHelper
   def course_creation_change_button(display_name, property_name, path)
-    link_to send(path, course.provider.provider_code, course.recruitment_cycle_year, params.to_unsafe_h.merge(goto_confirmation: true)), class: "govuk-link", data: { qa: "course__edit_#{property_name}_link" } do
+    govuk_link_to send(path, course.provider.provider_code, course.recruitment_cycle_year, params.to_unsafe_h.merge(goto_confirmation: true)), data: { qa: "course__edit_#{property_name}_link" } do
       raw("Change<span class=\"govuk-visually-hidden\"> #{display_name}</span>")
     end
-  end
-
-  def govuk_link_to(body, url = body, html_options = { class: "govuk-link" })
-    link_to body, url, html_options
   end
 
   def govuk_back_link_to(url)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -5,9 +5,9 @@ module ViewHelper
     end
   end
 
-  def govuk_back_link_to(url)
+  def govuk_back_link_to(url = :back, body = "Back")
     render GovukComponent::BackLink.new(
-      text: "Back",
+      text: body,
       href: url,
       classes: "govuk-!-display-none-print",
       html_attributes: {

--- a/app/views/access_requests/_access_request.html.erb
+++ b/app/views/access_requests/_access_request.html.erb
@@ -8,7 +8,7 @@
     &lt;<%= access_request.email_address %>&gt;
   </td>
   <td class="govuk-table__cell">
-    <%= link_to "Approve", confirm_access_request_path(access_request.id), class: "govuk-button govuk-!-margin-bottom-0", data: { qa: "access-request__approve" }%>
+    <%= govuk_link_to "Approve", confirm_access_request_path(access_request.id), button: true, class: "govuk-!-margin-bottom-0", data: { qa: "access-request__approve" } %>
   </td>
   <td class="govuk-table__cell" data-qa="access-request__organisation"><%= access_request.organisation %></td>
 </tr>

--- a/app/views/access_requests/index.html.erb
+++ b/app/views/access_requests/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <p class="govuk-body">
-  <%= link_to "Create and approve an access request manually", new_access_request_path, class: 'govuk-link', data: { qa: "create-access-request" } %>
+  <%= govuk_link_to "Create and approve an access request manually", new_access_request_path, data: { qa: "create-access-request" } %>
 </p>
 
 <table class="govuk-table">

--- a/app/views/access_requests/inform_publisher.html.erb
+++ b/app/views/access_requests/inform_publisher.html.erb
@@ -6,11 +6,11 @@
   Inform the publisher about the change to their access:
 
   <ol class="govuk-list govuk-list--number">
-    <li>Check whether <%= link_to "they already have a DfE Sign-in account", "#{Settings.dfe_signin.user_search_url}?criteria=#{@access_request.email_address}", class: "govuk-link", data: { qa: "dfe_signin_search_link" } %></li>
-    <li>In <%= link_to "GOV.UK Notify", Settings.notify.service_url, class: 'govuk-link', data: { qa: "notify_service_link" } %>, send an email to <strong><%= @recipient_email_address %></strong> using:
+    <li>Check whether <%= govuk_link_to "they already have a DfE Sign-in account", "#{Settings.dfe_signin.user_search_url}?criteria=#{@access_request.email_address}", data: { qa: "dfe_signin_search_link" } %></li>
+    <li>In <%= govuk_link_to "GOV.UK Notify", Settings.notify.service_url, data: { qa: "notify_service_link" } %>, send an email to <strong><%= @recipient_email_address %></strong> using:
       <ul class="govuk-list govuk-list--bullet">
-        <li>the <%= link_to "REGISTERED template", Settings.notify.registered_user_template_url, class: 'govuk-link', data: { qa: "registered_user_link" } %> if they have a DfE Sign-in account</li>
-        <li>the <%= link_to "UNREGISTERED template", Settings.notify.unregistered_user_template_url, class: 'govuk-link', data: { qa: "unregistered_user_link" } %> if they don’t</li>
+        <li>the <%= govuk_link_to "REGISTERED template", Settings.notify.registered_user_template_url, data: { qa: "registered_user_link" } %> if they have a DfE Sign-in account</li>
+        <li>the <%= govuk_link_to "UNREGISTERED template", Settings.notify.unregistered_user_template_url, data: { qa: "unregistered_user_link" } %> if they don’t</li>
       </ul>
   </ol>
 </p>

--- a/app/views/access_requests/inform_publisher.html.erb
+++ b/app/views/access_requests/inform_publisher.html.erb
@@ -16,5 +16,5 @@
 </p>
 
 <p class="govuk-body">
-  <%= link_to "Done", access_requests_path, class: "govuk-button govuk-!-margin-bottom-0", data: { qa: "done_link" } %>
+  <%= govuk_link_to "Done", access_requests_path, button: true, class: "govuk-!-margin-bottom-0", data: { qa: "done_link" } %>
 </p>

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "#{@errors && @errors.any? ? "Error: " : ""}Create an access request" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(access_requests_path) %>
 <% end %>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -34,7 +34,11 @@
       <%= form.govuk_submit t("ucas_contacts.#{@contact.type}.submit", default: "Save") %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_ucas_contacts_path(@provider.provider_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          provider_ucas_contacts_path(@provider.provider_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     </div>
   </div>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, t("ucas_contacts.#{@contact.type}.heading") %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_ucas_contacts_path(@provider.provider_code)) %>
 <% end %>

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -12,7 +12,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if @course.meta['edit_options']['show_is_send'] %>
-            <%= link_to send_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_is_send" } do %>
+            <%= govuk_link_to send_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_is_send" } do %>
               Change<span class="govuk-visually-hidden"> SEND</span>
             <% end %>
           <% end %>
@@ -28,7 +28,7 @@
             <%= course.sorted_subjects %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= link_to subjects_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_subjects_link" } do %>
+            <%= govuk_link_to subjects_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_subjects_link" } do %>
               Change<span class="govuk-visually-hidden"> subjects</span>
             <% end %>
           </dd>
@@ -44,7 +44,7 @@
             <%= course.age_range %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= link_to age_range_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_age_range_link" } do %>
+            <%= govuk_link_to age_range_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_age_range_link" } do %>
               Change<span class="govuk-visually-hidden"> age range</span>
             <% end %>
           </dd>
@@ -59,7 +59,7 @@
           <%= course.outcome %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to outcome_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
+          <%= govuk_link_to outcome_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_entry_requirements_link" } do %>
             Change<span class="govuk-visually-hidden"> outcome</span>
           <% end %>
         </dd>
@@ -74,7 +74,7 @@
           </dd>
           <dd class="govuk-summary-list__actions">
             <% if !course.is_published? %>
-              <%= link_to apprenticeship_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_apprenticeship_link" } do %>
+              <%= govuk_link_to apprenticeship_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_apprenticeship_link" } do %>
                 Change<span class="govuk-visually-hidden"> apprenticeship</span>
               <% end %>
             <% end %>
@@ -90,7 +90,7 @@
           </dd>
           <dd class="govuk-summary-list__actions">
             <% if !course.is_published? %>
-              <%= link_to fee_or_salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_funding_link" } do %>
+              <%= govuk_link_to fee_or_salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_funding_link" } do %>
                 Change<span class="govuk-visually-hidden"> fee or salary</span>
               <% end %>
             <% end %>
@@ -106,7 +106,7 @@
           <%= course.study_mode&.humanize %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to full_part_time_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_study_mode_link" } do %>
+          <%= govuk_link_to full_part_time_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_study_mode_link" } do %>
             Change<span class="govuk-visually-hidden"> full time of part time</span>
           <% end %>
         </dd>
@@ -132,7 +132,7 @@
           <% end %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_locations_link" } do %>
+          <%= govuk_link_to locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_locations_link" } do %>
             Change<span class="govuk-visually-hidden"> locations</span>
           <% end %>
         </dd>
@@ -148,7 +148,7 @@
           </dd>
           <dd class="govuk-summary-list__actions">
             <% unless course.is_published? %>
-              <%= link_to accredited_body_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" do %>
+              <%= govuk_link_to accredited_body_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) do %>
                 Change<span class="govuk-visually-hidden"> accredited body</span>
               <% end %>
             <% end %>
@@ -165,7 +165,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if @course.meta['edit_options']['show_applications_open'] %>
-            <%= link_to applications_open_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_open_applications_link" } do %>
+            <%= govuk_link_to applications_open_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_open_applications_link" } do %>
               Change<span class="govuk-visually-hidden"> applications open date</span>
             <% end %>
           <% end %>
@@ -181,7 +181,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if @course.meta['edit_options']['show_start_date'] %>
-            <%= link_to start_date_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_start_date_link" } do %>
+            <%= govuk_link_to start_date_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_start_date_link" } do %>
               Change<span class="govuk-visually-hidden"> start date</span>
             <% end %>
           <% end %>
@@ -206,7 +206,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if current_user["admin"] %>
-            <%= link_to title_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link" do %>
+            <%= govuk_link_to title_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) do %>
               Change<span class="govuk-visually-hidden"> course title</span>
             <% end %>
           <% end %>
@@ -246,7 +246,7 @@
             <% end %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= link_to entry_requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link", data: { qa: "course__edit_entry_requirements_link" } do %>
+            <%= govuk_link_to entry_requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__edit_entry_requirements_link" } do %>
               Change<span class="govuk-visually-hidden"> entry requirements</span>
             <% end %>
           </dd>

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -283,12 +283,9 @@
           <% end %>
         </ul>
 
-        <p class="govuk-body">
+        <p class="govuk-body govuk-!-margin-bottom-0">
           To request other changes to your basic details contact the Becoming a Teacher team:<br />
-          <%= bat_contact_mail_to bat_contact_email_address_with_wrap,
-            subject: "Edit #{course.name} (#{@provider.provider_code}/#{course.course_code})",
-            data: { qa: "course__contact_support" }
-          %>
+          <%= bat_contact_mail_to subject: "Edit #{course.name} (#{@provider.provider_code}/#{course.course_code})", data: { qa: "course__contact_support" } %>
         </p>
       </div>
     </aside>

--- a/app/views/courses/_course_table_row.html.erb
+++ b/app/views/courses/_course_table_row.html.erb
@@ -4,7 +4,7 @@
     <% if current_page?(provider_recruitment_cycle_courses_path(@provider.provider_code, course.recruitment_cycle_year)) %>
       <%= govuk_link_to "#{course.name_and_code}",
         provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-        class: "govuk-link govuk-heading-s govuk-!-margin-bottom-0"
+        class: "govuk-heading-s govuk-!-margin-bottom-0"
       %>
     <% else %>
     <span class="govuk-heading-s govuk-!-margin-0" data-qa="courses-table__course-name">

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
-  <%= link_to 'About this course', about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
+  <%= govuk_link_to "About this course", about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
   <%= enrichment_summary_item(:course, 'About this course', course.about_course, ['about_course']) %>
@@ -13,9 +13,9 @@
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
   <% if course.has_fees? %>
-    <%= link_to 'Course length and fees', fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
+    <%= govuk_link_to "Course length and fees", fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
   <% else %>
-    <%= link_to 'Course length and salary', salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
+    <%= govuk_link_to 'Course length and salary', salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
   <% end %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
@@ -32,7 +32,7 @@
 </dl>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">
-  <%= link_to 'Requirements and eligibility', requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link' %>
+  <%= govuk_link_to 'Requirements and eligibility', requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
 </h3>
 <dl class="govuk-summary-list govuk-summary-list--short">
   <%= enrichment_summary_item(:course, 'Qualifications needed', course.required_qualifications, ['required_qualifications']) %>

--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -22,10 +22,14 @@
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
     <h3 class="govuk-heading-m">Withdraw</h3>
     <p class="govuk-body">Remove this course from Find and close applications.</p>
-    <%= link_to 'Withdraw this course', withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link--destructive govuk-body", data: { qa: "course__withdraw-link" } %>
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      <%= govuk_link_to "Withdraw this course", withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive", data: { qa: "course__withdraw-link" } %>
+    </p>
   <% elsif course.new_and_not_running? %>
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
     <h3 class="govuk-heading-m govuk-visually-hidden">Delete</h3>
-    <%= link_to 'Delete this course', delete_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link--destructive govuk-body", data: { qa: "course__delete-link" } %>
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      <%= govuk_link_to 'Delete this course', delete_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive", data: { qa: "course__delete-link" } %>
+    </p>
   <% end %>
 </div>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -120,9 +120,15 @@
         <%= f.govuk_submit "Save" %>
 
         <p class="govuk-body">
-          <%= link_to 'Cancel changes',
-                      provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                      class: "govuk-link govuk-link--no-visited-state" %>
+          <%= govuk_link_to(
+            "Cancel changes",
+            provider_recruitment_cycle_course_path(
+              @provider.provider_code,
+              course.recruitment_cycle_year,
+              course.course_code
+            ),
+            class: "govuk-link--no-visited-state"
+          ) %>
         </p>
       <% end %>
     </div>

--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -61,12 +61,11 @@
                         class: "govuk-button govuk-!-margin-top-3", data: { qa: 'course__save' } %>
 
         <p class="govuk-body">
-          <%= link_to 'Cancel changes',
-            details_provider_recruitment_cycle_course_path(
-              course.provider_code,
-              course.recruitment_cycle_year,
-              course.course_code),
-            class: "govuk-link govuk-link--no-visited-state" %>
+          <%= govuk_link_to(
+            "Cancel changes",
+            details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+            class: "govuk-link--no-visited-state",
+          ) %>
         </p>
       <% end %>
     </div>

--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -1,10 +1,7 @@
 <%= content_for :page_title, "Who is the accredited body? – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(
-    details_provider_recruitment_cycle_course_path(
-      course.provider_code,
-      course.recruitment_cycle_year,
-      course.course_code)) %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Who is the accredited body?" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/accredited_body/search.html.erb
+++ b/app/views/courses/accredited_body/search.html.erb
@@ -1,10 +1,7 @@
 <%= content_for :page_title, "Organisation search" %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(
-    details_provider_recruitment_cycle_course_path(
-      course.provider_code,
-      course.recruitment_cycle_year,
-      course.course_code)) %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
 <%= render 'shared/errors' %>

--- a/app/views/courses/accredited_body/search.html.erb
+++ b/app/views/courses/accredited_body/search.html.erb
@@ -61,12 +61,11 @@
 
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
-        details_provider_recruitment_cycle_course_path(
-        course.provider_code,
-        course.recruitment_cycle_year,
-        course.course_code),
-        class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -37,9 +37,11 @@
       %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
+        <%= govuk_link_to(
+          "Cancel changes",
           details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-          class: "govuk-link govuk-link--no-visited-state" %>
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Specify an age range – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Specify an age range" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/applications_open/edit.html.erb
+++ b/app/views/courses/applications_open/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "When will applications open? – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/applications_open/edit.html.erb
+++ b/app/views/courses/applications_open/edit.html.erb
@@ -14,7 +14,11 @@
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "When will applications open?" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/apprenticeship/edit.html.erb
+++ b/app/views/courses/apprenticeship/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Edit Apprenticeship – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/apprenticeship/edit.html.erb
+++ b/app/views/courses/apprenticeship/edit.html.erb
@@ -18,7 +18,11 @@
       %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -160,7 +160,7 @@
                     You can’t change this because you only have 1 location
                   </p>
                   <p class="govuk-!-margin-top-1">
-                  <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="<%= provider_locations_path %>">Manage your locations</a>
+                    <%= govuk_link_to "Manage your locations", provider_locations_path, target: "_blank", rel: "noopener noreferrer" %>
                   </p>
                 <% end %>
               </dd>

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -38,7 +38,11 @@
     <% end %>
 
     <p class="govuk-body govuk-!-margin-top-5">
-      <%= link_to 'Cancel', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= govuk_link_to(
+        "Cancel",
+        provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+        class: "govuk-link--no-visited-state",
+      ) %>
     </p>
   </div>
 </div>

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -21,9 +21,11 @@
       <%= form.submit "Save changes", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
+        <%= govuk_link_to(
+          "Cancel changes",
           details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-          class: "govuk-link govuk-link--no-visited-state" %>
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "GCSE requirements for applicants – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "GCSE requirements for applicants" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/fee_or_salary/edit.html.erb
+++ b/app/views/courses/fee_or_salary/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Is it fee paying or salaried? – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/fee_or_salary/edit.html.erb
+++ b/app/views/courses/fee_or_salary/edit.html.erb
@@ -16,7 +16,11 @@
       %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/fee_or_salary/new.html.erb
+++ b/app/views/courses/fee_or_salary/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Is it fee paying or salaried?" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -86,7 +86,11 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "What type of course?" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Pick all the languages for #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -25,9 +25,11 @@
       %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
+        <%= govuk_link_to(
+          "Cancel changes",
           details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-          class: "govuk-link govuk-link--no-visited-state" %>
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Pick all the languages for this course" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/outcome/edit.html.erb
+++ b/app/views/courses/outcome/edit.html.erb
@@ -22,9 +22,11 @@
       %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
+        <%= govuk_link_to(
+          "Cancel changes",
           details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-          class: "govuk-link govuk-link--no-visited-state" %>
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/outcome/edit.html.erb
+++ b/app/views/courses/outcome/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Pick a course outcome – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Pick a course outcome" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -48,7 +48,7 @@
   <% if @provider.website.present? %>
     <dt class="govuk-list--description__label">Website</dt>
     <dd data-qa="course__provider_website">
-      <%= link_to @provider.website, @provider.website, class: 'govuk-link' %>
+      <%= govuk_link_to @provider.website, @provider.website %>
     </dd>
   <% end %>
 </dl>
@@ -57,21 +57,21 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Contents</h2>
     <ul class="govuk-list govuk-list--dash course-contents govuk-!-margin-bottom-8">
-      <li><%= link_to 'About the course', '#section-about', class: 'govuk-link' %></li>
-      <li><%= link_to course.placements_heading, '#section-schools', class: 'govuk-link' %></li>
-      <li><%= link_to 'Entry requirements', '#section-entry', class: 'govuk-link' %></li>
-      <li><%= link_to 'About the training provider', '#section-about-provider', class: 'govuk-link' %></li>
+      <li><%= govuk_link_to "About the course", "#section-about" %></li>
+      <li><%= govuk_link_to course.placements_heading, "#section-schools" %></li>
+      <li><%= govuk_link_to "Entry requirements", "#section-entry" %></li>
+      <li><%= govuk_link_to "About the training provider", "#section-about-provider" %></li>
       <% if course.salaried? %>
-        <li><%= link_to 'Salary', '#section-salary', class: 'govuk-link' %></li>
+        <li><%= govuk_link_to "Salary", "#section-salary" %></li>
       <% end %>
-      <li><%= link_to 'Fees and financial support', '#section-fees-and-financial-support', class: 'govuk-link' %></li>
+      <li><%= govuk_link_to "Fees and financial support", "#section-fees-and-financial-support" %></li>
       <% if course.interview_process.present? %>
-        <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
+        <li><%= govuk_link_to "Interview process", "#section-interviews" %></li>
       <% end %>
-      <li><%= link_to 'Training with disabilities and other needs', '#section-train-with-disabilities', class: 'govuk-link' %></li>
-      <li><%= link_to 'Contact details', '#section-contact', class: 'govuk-link' %></li>
-      <li><%= link_to 'Support and advice', '#section-advice', class: 'govuk-link' %></li>
-      <li><%= link_to 'Apply', '#section-apply', class: 'govuk-link' %></li>
+      <li><%= govuk_link_to "Training with disabilities and other needs", "#section-train-with-disabilities" %></li>
+      <li><%= govuk_link_to "Contact details", "#section-contact" %></li>
+      <li><%= govuk_link_to "Support and advice", "#section-advice" %></li>
+      <li><%= govuk_link_to "Apply", "#section-apply" %></li>
     </ul>
 
     <%= render partial: 'courses/preview/about_course' %>

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -1,12 +1,9 @@
 <%= content_for :page_title, "Preview: #{course.name_and_code} with #{@provider.provider_name}" %>
 
 <% content_for :before_content do %>
-  <%= link_to "Back to course", provider_recruitment_cycle_course_path, class: "govuk-back-link" %>
+  <%= govuk_back_link_to(provider_recruitment_cycle_course_path, "Back to course") %>
 
-  <p class="govuk-body app-preview-banner">
-    This is a preview of a course:
-    <%= course.name_and_code %>.
-  </p>
+  <p class="govuk-body app-preview-banner">This is a preview of a course: <%= course.name_and_code %>.</p>
 <% end %>
 
 <h1 class="govuk-heading-xl">

--- a/app/views/courses/preview/_about_the_provider.html.erb
+++ b/app/views/courses/preview/_about_the_provider.html.erb
@@ -4,7 +4,7 @@
     <% if @provider.train_with_us.present? %>
       <%= markdown(@provider.train_with_us) %>
     <% else %>
-      <p class="app-missing-section">Please add details <%= link_to 'about your organisation', about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>.</p>
+      <p class="app-missing-section">Please add details <%= govuk_link_to 'about your organisation', about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>.</p>
     <% end %>
   </div>
 

--- a/app/views/courses/preview/_advice.html.erb
+++ b/app/views/courses/preview/_advice.html.erb
@@ -1,8 +1,8 @@
 <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
-<p class="govuk-body">For questions about this course you should contact the training provider using <%= link_to "the contact details above", "#contact_section", class: "govuk-link" %>.</p>
+<p class="govuk-body">For questions about this course you should contact the training provider using <%= govuk_link_to "the contact details above", "#contact_section" %>.</p>
 
 <h4 class="govuk-heading-m">Get support and advice about teaching</h4>
-<p class="govuk-body">Register with <%= link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/user/register', class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat", class: 'govuk-link' %>, from 8am to 8pm, Monday to Friday.</p>
+<p class="govuk-body">Register with <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/user/register' %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= govuk_link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat" %>, from 8am to 8pm, Monday to Friday.</p>
 
 <h4 class="govuk-heading-m">Website support</h4>
 <p class="govuk-body">If you have feedback or have had a problem using Find postgraduate teacher training you can <%= bat_contact_mail_to "contact us by email" %>.</p>

--- a/app/views/courses/preview/_contact_details.html.erb
+++ b/app/views/courses/preview/_contact_details.html.erb
@@ -6,7 +6,7 @@
       <% if @provider.email.present? %>
         <dt class="govuk-list--description__label">Email</dt>
         <dd data-qa="provider__email">
-          <%= mail_to @provider.email, @provider.email, title: "Send email to course contact", aria: { label: "Send email to course contact" }, class: "govuk-link" %>
+          <%= govuk_mail_to @provider.email, @provider.email, title: "Send email to course contact", aria: { label: "Send email to course contact" } %>
         </dd>
       <% end %>
 

--- a/app/views/courses/preview/_contact_details.html.erb
+++ b/app/views/courses/preview/_contact_details.html.erb
@@ -20,7 +20,7 @@
       <% if @provider.website.present? %>
         <dt class="govuk-list--description__label">Website</dt>
         <dd data-qa="provider__website">
-          <%= link_to @provider.website, @provider.website, class: "govuk-link" %>
+          <%= govuk_link_to @provider.website, @provider.website %>
         </dd>
       <% end %>
 

--- a/app/views/courses/preview/_train_with_disabilities.html.erb
+++ b/app/views/courses/preview/_train_with_disabilities.html.erb
@@ -4,7 +4,7 @@
     <% if @provider.train_with_disability.present? %>
       <%= markdown(@provider.train_with_disability) %>
     <% else %>
-      <p class="app-missing-section">Please add details about <%= link_to 'training with disabilities', about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>.</p>
+      <p class="app-missing-section">Please add details about <%= govuk_link_to "training with disabilities", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/preview/financial_support/_bursary.html.erb
+++ b/app/views/courses/preview/financial_support/_bursary.html.erb
@@ -12,14 +12,14 @@
   </ul>
 
   <p class="govuk-body">
-    You don’t have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out about <%= link_to "eligibility", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training", class: "govuk-link"%> and <%= link_to "how you’ll be paid", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid", class: "govuk-link"%>.
+    You don’t have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out about <%= govuk_link_to "eligibility", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training" %> and <%= govuk_link_to "how you’ll be paid", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid" %>.
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= govuk_link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans" %> - note that you'll have to apply for <%= govuk_link_to "undergraduate student finance", "https://www.gov.uk/student-finance" %>.
   </p>
 
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= link_to "outside the UK", "https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates", class: "govuk-link" %>.
+    Find out about financial support if you’re from <%= govuk_link_to "outside the UK", "https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" %>.
   </p>
 </div>

--- a/app/views/courses/preview/financial_support/_loan.html.erb
+++ b/app/views/courses/preview/financial_support/_loan.html.erb
@@ -1,8 +1,8 @@
 <div data-qa="course__loan_details">
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= govuk_link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans" %> - note that you'll have to apply for <%= govuk_link_to "undergraduate student finance", "https://www.gov.uk/student-finance" %>.
   </p>
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= link_to 'outside the UK', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates', class: 'govuk-link' %>.
+    Find out about financial support if you’re from <%= govuk_link_to "outside the UK", "https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" %>.
   </p>
 </div>

--- a/app/views/courses/preview/financial_support/_placeholder.html.erb
+++ b/app/views/courses/preview/financial_support/_placeholder.html.erb
@@ -1,3 +1,3 @@
 <%= govuk_inset_text do %>
-  <p class="govuk-body">Financial support for <%=course.cycle_range%> will be announced soon. Further information is available on <%= link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training", class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>.</p>
+  <p class="govuk-body">Financial support for <%=course.cycle_range%> will be announced soon. Further information is available on <%= govuk_link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training", rel: "noopener noreferrer", target: "_blank" %>.</p>
 <% end %>

--- a/app/views/courses/preview/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/preview/financial_support/_scholarship_and_bursary.html.erb
@@ -10,7 +10,7 @@
 
   <% if course.has_early_career_payments? %>
     <p class="govuk-body" data-qa="course__early_career_payment_details">
-      With a scholarship or bursary, you’ll also get early career payments of £2,000 in your second, third and fourth years of teaching (£3,000 in <%= link_to 'some areas of England', 'https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools', class: "govuk-link" %>).
+      With a scholarship or bursary, you’ll also get early career payments of £2,000 in your second, third and fourth years of teaching (£3,000 in <%= govuk_link_to "some areas of England", "https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools" %>).
     </p>
   <% end %>
 
@@ -23,14 +23,14 @@
   </p>
 
   <p class="govuk-body">
-    Find out how to <%= link_to "apply for a scholarship", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/scholarships", class: "govuk-link" %>. You don’t need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= link_to "how you’ll be paid", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid", class: "govuk-link" %>.
+    Find out how to <%= govuk_link_to "apply for a scholarship", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/scholarships" %>. You don’t need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= govuk_link_to "how you’ll be paid", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/how-you-will-be-paid" %>.
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= govuk_link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans" %> - note that you'll have to apply for <%= govuk_link_to "undergraduate student finance", "https://www.gov.uk/student-finance" %>.
   </p>
 
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= link_to "outside the UK", "https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates", class: "govuk-link" %>.
+    Find out about financial support if you’re from <%= govuk_link_to "outside the UK", "https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates" %>.
   </p>
 </div>

--- a/app/views/courses/request_change.html.erb
+++ b/app/views/courses/request_change.html.erb
@@ -9,6 +9,6 @@
 
     <p class="govuk-body">When the feature is ready, you'll be able to make the change yourself.</p>
 
-    <p class="govuk-body">Until then, contact the <%= bat_contact_mail_to name = 'Becoming A Teacher team', subject: "Edit #{course.name} (#{@provider_code}/#{course.course_code})" %>, who will make the change for you.</p>
+    <p class="govuk-body">Until then, contact the <%= bat_contact_mail_to "Becoming A Teacher team", subject: "Edit #{course.name} (#{@provider_code}/#{course.course_code})" %>, who will make the change for you.</p>
   </div>
 </div>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -80,9 +80,11 @@
       <%= f.govuk_submit "Save" %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
-                    provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                    class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -41,7 +41,11 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/send/edit.html.erb
+++ b/app/views/courses/send/edit.html.erb
@@ -18,7 +18,11 @@
       <%= form.submit course.is_running? ? "Save and publish changes" : "Save", class: "govuk-button", data: { qa: 'course__save' } %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/send/edit.html.erb
+++ b/app/views/courses/send/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Edit SEND – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -13,10 +13,7 @@
       <p class="govuk-body" data-error-message="Removing all locations would prevent people from applying to this course">
         Removing all locations would prevent people from applying to this course.
         If you want to close applications, you can
-        <%= link_to "edit the vacancies for this course",
-          vacancies_provider_recruitment_cycle_course_path(code: course.course_code),
-          class: "govuk-link"
-        %>.
+        <%= govuk_link_to "edit the vacancies for this course", vacancies_provider_recruitment_cycle_course_path(code: course.course_code) %>.
       </p>
     </div>
   </div>
@@ -29,7 +26,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body govuk-body govuk-!-margin-bottom-6"><%= link_to "Manage all your locations", provider_recruitment_cycle_sites_path(@provider.provider_code), class: "govuk-link", data: { qa: "course__manage_provider_locations_link" } %> to add to or edit this list.</p>
+    <p class="govuk-body govuk-body govuk-!-margin-bottom-6"><%= govuk_link_to "Manage all your locations", provider_recruitment_cycle_sites_path(@provider.provider_code), data: { qa: "course__manage_provider_locations_link" } %> to add to or edit this list.</p>
 
     <%= form_for course, url: locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :put do |f| %>
       <div class="govuk-form-group">
@@ -55,7 +52,11 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= link_to 'Cancel changes', details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= govuk_link_to(
+        "Cancel changes",
+        details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+        class: "govuk-link--no-visited-state",
+      ) %>
     </p>
   </div>
 </div>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Pick the locations for this course" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/start_date/edit.html.erb
+++ b/app/views/courses/start_date/edit.html.erb
@@ -19,9 +19,11 @@
       %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
+        <%= govuk_link_to(
+          "Cancel changes",
           details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-          class: "govuk-link govuk-link--no-visited-state" %>
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/start_date/edit.html.erb
+++ b/app/views/courses/start_date/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "When does the course start?" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "When does the course start?" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/status_panel/_unpublished.html.erb
+++ b/app/views/courses/status_panel/_unpublished.html.erb
@@ -3,7 +3,7 @@
 <p class="govuk-body">See how your unpublished changes look.</p>
 <p class="govuk-body">Preview your course to check for mistakes before publishing.</p>
 <p class="govuk-body">
-  <%= link_to 'Preview course', preview_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link', "data-qa": "course__preview-link" %>
+  <%= govuk_link_to "Preview course", preview_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
 </p>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/views/courses/status_panel/_withdrawn.html.erb
+++ b/app/views/courses/status_panel/_withdrawn.html.erb
@@ -17,5 +17,5 @@
 
 <h3 class="govuk-heading-m">Publish</h3>
 <p class="govuk-body">
-  If you need to republish this course contact the Becoming a Teacher team:<br /><%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Republish a withdrawn course" %>
+  If you need to republish this course contact the Becoming a Teacher team:<br /><%= bat_contact_mail_to subject: "Republish a withdrawn course" %>
 </p>

--- a/app/views/courses/status_panel/_withdrawn.html.erb
+++ b/app/views/courses/status_panel/_withdrawn.html.erb
@@ -10,7 +10,7 @@
 <h3 class="govuk-heading-m">Preview</h3>
 <p class="govuk-body">See how this course looked.</p>
 <p class="govuk-body">
-  <%= link_to 'Preview course', preview_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: 'govuk-link', "data-qa": "course__preview-link" %>
+  <%= govuk_link_to "Preview course", preview_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
 </p>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/views/courses/study_mode/edit.html.erb
+++ b/app/views/courses/study_mode/edit.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Full time or part time? – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/study_mode/edit.html.erb
+++ b/app/views/courses/study_mode/edit.html.erb
@@ -16,9 +16,11 @@
       %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
+        <%= govuk_link_to(
+          "Cancel changes",
           details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-          class: "govuk-link govuk-link--no-visited-state" %>
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Full time or part time?" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>

--- a/app/views/courses/subjects/edit.erb
+++ b/app/views/courses/subjects/edit.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Change subjects – #{course.name_and_code}" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>

--- a/app/views/courses/subjects/edit.erb
+++ b/app/views/courses/subjects/edit.erb
@@ -18,9 +18,11 @@
       %>
 
       <p class="govuk-body">
-        <%= link_to 'Cancel changes',
+        <%= govuk_link_to(
+          "Cancel changes",
           details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-          class: "govuk-link govuk-link--no-visited-state" %>
+          class: "govuk-link--no-visited-state",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -18,7 +18,7 @@
           <% if !current_user["admin"] && @course.level == "secondary" %>
             <h2 class="govuk-heading-m"> Adding a Physical education course?</h2>
             <p class="govuk-body-s">You’ll need to fill in a
-              <%= link_to "separate Google Form", add_course_url(current_user['info']['email'], @provider), class: "govuk-link", rel: "noopener noreferrer", target: "_blank" %>,
+              <%= govuk_link_to "separate Google Form", add_course_url(current_user['info']['email'], @provider), rel: "noopener noreferrer", target: "_blank" %>,
             as PE places are limited.</p>
           <% end %>
         </div>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,7 +1,9 @@
 <%= content_for :page_title, course.subject_page_title %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
+
 <%= render 'shared/errors' %>
 
 <div class="govuk-grid-row">

--- a/app/views/courses/title/edit.html.erb
+++ b/app/views/courses/title/edit.html.erb
@@ -30,9 +30,11 @@
           class: "govuk-button" %>
 
         <p class="govuk-body">
-          <%= link_to 'Cancel changes',
+          <%= govuk_link_to(
+            "Cancel changes",
             details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
-            class: "govuk-link govuk-link--no-visited-state" %>
+            class: "govuk-link--no-visited-state",
+          ) %>
         </p>
       <% end %>
     </div>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -32,7 +32,14 @@
       <% else %>
         <%= form.submit "Reopen applications", class: "govuk-button" %>
       <% end %>
-      <p class="govuk-body"><%= link_to "Cancel changes", provider_recruitment_cycle_courses_path(params[:provider_code]), class: "govuk-link govuk-link--no-visited-state" %></p>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(
+          "Cancel changes",
+          provider_recruitment_cycle_courses_path(params[:provider_code]),
+          class: "govuk-link--no-visited-state",
+        ) %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -36,7 +36,11 @@
     <% end %>
 
     <p class="govuk-body govuk-!-margin-top-5">
-      <%= link_to 'Cancel', provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= govuk_link_to(
+        "Cancel",
+        provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+        class: "govuk-link--no-visited-state",
+      ) %>
     </p>
   </div>
 </div>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">You are not permitted to see this page</h1>
     <p class="govuk-body">This page is restricted to certain users only.</p>
     <p class="govuk-body">
-      Contact us by email to request access: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses access request" %>
+      Contact us by email to request access: <%= bat_contact_mail_to subject: "Publish teacher training courses access request" %>
     </p>
   </div>
 </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
     <p class="govuk-body">Try again later.</p>
     <p class="govuk-body">
-      If you continue to see this error contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Problem with the service" %>
+      If you continue to see this error contact the Becoming a Teacher team: <%= bat_contact_mail_to subject: "Problem with the service" %>
     </p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -10,7 +10,7 @@
       If you pasted the web address, check you copied the entire address.
     </p>
     <p class="govuk-body">
-      If the web address is correct or you selected a link or button and you need to speak to someone about this problem, contact the Becoming a Teacher team: <%= bat_contact_mail_to bat_contact_email_address, subject: "Page not found" %>
+      If the web address is correct or you selected a link or button and you need to speak to someone about this problem, contact the Becoming a Teacher team: <%= bat_contact_mail_to subject: "Page not found" %>
     </p>
   </div>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -14,7 +14,7 @@
       <% end %>
       <h2 class="govuk-heading-m">Get support</h2>
       <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-        <li>Email: <%= bat_contact_mail_to bat_contact_email_address, subject: "Publish teacher training courses support", link_class: "govuk-footer__link" %></li>
+        <li>Email: <%= bat_contact_mail_to subject: "Publish teacher training courses support", class: "govuk-footer__link" %></li>
         <li class="govuk-!-margin-bottom-4">We respond within 5 working days, or one working day for more urgent queries</li>
         <li><%= link_to "How to publish teacher training courses", guidance_path, class: "govuk-footer__link" %></li>
         <li><%= link_to "Teacher Training Courses API documentation", "https://api.publish-teacher-training-courses.service.gov.uk", class: "govuk-footer__link" %></li>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -43,10 +43,14 @@
         } %>
       <% end %>
       <%= form.govuk_submit "Save" %>
+
       <p class="govuk-body">
-        <%= link_to "Cancel changes", @notifications_view.cancel_link_path,
-          class: "govuk-link",
-          id: "cancel-changes-link" %>
+        <%= govuk_link_to(
+          "Cancel changes",
+          @notifications_view.cancel_link_path,
+          class: "govuk-link--no-visited-state",
+          id: "cancel-changes-link",
+        ) %>
       </p>
     <% end %>
   </div>

--- a/app/views/pages/notifications_info.html.erb
+++ b/app/views/pages/notifications_info.html.erb
@@ -15,7 +15,7 @@
       <li>makes a change to an existing course </li>
     </ul>
     <p class="govuk-body">
-      <%= link_to "Sign up for notifications", notifications_path( start: true ), class:"govuk-button govuk-!-margin-bottom-0" %>
+      <%= govuk_link_to "Sign up for notifications", notifications_path(start: true), button: true %>
     </p>
     <p class="govuk-body">
       or

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -73,18 +73,17 @@
       <li>not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you</li>
     </ul>
     <p class="govuk-body">
-
-      If you need to contact us regarding any of the above, please do so via the DfE site at: <a href="https://www.gov.uk/contact-dfe" class="govuk-link">https://www.gov.uk/contact-dfe</a>.
+      If you need to contact us regarding any of the above, please do so via the DfE site at: <%= govuk_link_to "https://www.gov.uk/contact-dfe", "https://www.gov.uk/contact-dfe" %>.
     </p>
 
     <p class="govuk-body">
-      You can <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights" class="govuk-link">find out more about your data protection rights</a> on the Information Commissioner’s website.
+      You can <%= govuk_link_to "find out more about your data protection rights", "https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights" %> on the Information Commissioner’s website.
     </p>
 
     <h2 class="govuk-heading-l">The right to lodge a complaint</h2>
 
     <p class="govuk-body">
-      You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <a href="https://ico.org.uk/concerns/" class="govuk-link">https://ico.org.uk/concerns/</a>.
+      You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <%= govuk_link_to "https://ico.org.uk/make-a-complaint/", "https://ico.org.uk/make-a-complaint/" %></a>.
     </p>
     <h2 class="govuk-heading-l">Contact Info</h2>
 

--- a/app/views/pagy/_next_page.html.erb
+++ b/app/views/pagy/_next_page.html.erb
@@ -1,5 +1,5 @@
 <li class="pub-c-pagination__item pub-c-pagination__item--next">
-  <%= link_to "#{request.path}?page=#{pagy.next}", rel: 'next', class: "pub-c-pagination__link govuk-link" do %>
+  <%= govuk_link_to "#{request.path}?page=#{pagy.next}", rel: 'next', class: "pub-c-pagination__link" do %>
     <span class="pub-c-pagination__link-title">
       Next page
       <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">

--- a/app/views/pagy/_previous_page.html.erb
+++ b/app/views/pagy/_previous_page.html.erb
@@ -1,5 +1,5 @@
 <li class="pub-c-pagination__item pub-c-pagination__item--previous">
-  <%= link_to "#{request.path}?page=#{pagy.prev}", rel: 'prev', class: "pub-c-pagination__link govuk-link" do %>
+  <%= govuk_link_to "#{request.path}?page=#{pagy.prev}", rel: 'prev', class: "pub-c-pagination__link" do %>
     <span class="pub-c-pagination__link-title">
       <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
         <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -2,7 +2,9 @@
 
 <h1 class="govuk-heading-xl">Publish test users</h1>
 
-<%= link_to "Login as an anonymised user", "/auth/developer", class: 'govuk-link' %>
+<p class="govuk-body">
+  <%= govuk_link_to "Login as an anonymised user", "/auth/developer" %>
+</p>
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 

--- a/app/views/providers/_provider.html.erb
+++ b/app/views/providers/_provider.html.erb
@@ -1,6 +1,6 @@
 <li>
   <h2 class="govuk-heading-m">
-    <%= link_to provider.provider_name, provider_path(provider.provider_code), class: "govuk-link" %>
+    <%= govuk_link_to provider.provider_name, provider_path(provider.provider_code) %>
     <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block"><%= pluralize(provider.course_count, 'course') %></span>
   </h2>
 </li>

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -1,8 +1,11 @@
 <h2 class="govuk-heading-m">
-  <%= link_to "Current cycle (#{current_recruitment_cycle_period_text})",
-              provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle),
-              data: { qa: 'provider__courses__current_cycle' },
-              class: "govuk-link" %>
+  <%= govuk_link_to(
+    "Current cycle (#{current_recruitment_cycle_period_text})",
+    provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle),
+    data: {
+      qa: "provider__courses__current_cycle"
+    }
+   ) %>
 </h2>
 <p class="govuk-body">Use this section to:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
@@ -15,10 +18,13 @@
 </ul>
 
 <h2 class="govuk-heading-m">
-  <%= link_to "Next cycle (#{next_recruitment_cycle_period_text})",
-              provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle + 1),
-              data: { qa: 'provider__courses__next_cycle' },
-              class: "govuk-link" %>
+  <%= govuk_link_to(
+    "Next cycle (#{next_recruitment_cycle_period_text})",
+    provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle + 1),
+    data: {
+      qa: "provider__courses__next_cycle"
+    }
+  ) %>
 </h2>
 <p class="govuk-body">
   Courses for the next cycle will appear on Find postgraduate teacher training from October <%= Settings.current_cycle %>.

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -94,11 +94,13 @@
 
       <%= f.govuk_submit "Save and publish changes" %>
 
-      <div class="form-group">
-        <p class="govuk-body">
-          <%= govuk_link_to "Cancel changes", details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
-        </p>
-      </div>
+      <p class="govuk-body">
+        <%= govuk_link_to(
+          "Cancel changes",
+          details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+          class: "govuk-link--no-visited-state",
+        ) %>
+      </p>
     </div>
   </div>
 <% end %>

--- a/app/views/providers/access_requests/new.html.erb
+++ b/app/views/providers/access_requests/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "#{@errors && @errors.any? ? "Error: " : ""}Request access for someone else" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(users_provider_path(params[:code])) %>
 <% end %>

--- a/app/views/providers/allocations/_allocation_request_closed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_closed_state.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, raw("PE courses for #{next_allocation_cycle_period_text}") %>
+<%= content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
 <%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">
@@ -54,10 +54,7 @@
       Tell us what you think about this process
     </h2>
     <p class="govuk-body">
-      <%= link_to "Take part in our brief survey to help us improve Publish",
-                  "https://forms.gle/4EuNG8XGm3AqavRU9",
-                  class: "govuk-link govuk-!-font-weight-bold",
-                  target: "_blank" %>
-
+      <%= govuk_link_to "Take part in our brief survey to help us improve Publish", "https://forms.gle/4EuNG8XGm3AqavRU9", class: "govuk-!-font-weight-bold", target: "_blank" %>
+    </p>
   </div>
 </div>

--- a/app/views/providers/allocations/_allocation_request_open_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_open_state.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, raw("Request PE courses for #{next_allocation_cycle_period_text}") %>
+<%= content_for :page_title, "Request PE courses for #{next_allocation_cycle_period_text}" %>
 <%= content_for :before_content, render_breadcrumbs("allocations") %>
 
 <div class="govuk-grid-row">
@@ -91,9 +91,9 @@
       Tell us what you think about this process
     </h2>
     <p class="govuk-body">
-      <%= link_to "Take part in our brief survey to help us improve Publish",
+      <%= govuk_link_to "Take part in our brief survey to help us improve Publish",
                   "https://forms.gle/4EuNG8XGm3AqavRU9",
-                  class: "govuk-link govuk-!-font-weight-bold",
+                  class: "govuk-!-font-weight-bold",
                   target: "_blank" %>
   </div>
 </div>

--- a/app/views/providers/allocations/_allocation_request_open_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_open_state.html.erb
@@ -81,11 +81,14 @@
       We’ll need to know how many places each one would like to offer.
     </p>
 
-    <%= link_to "Choose an organisation",
-                initial_request_provider_recruitment_cycle_allocations_path(
-                  @provider.provider_code,
-                  @provider.recruitment_cycle_year),
-                class: "govuk-button govuk-!-margin-bottom-8" %>
+    <%= govuk_link_to(
+      "Choose an organisation",
+      initial_request_provider_recruitment_cycle_allocations_path(
+        @provider.provider_code,
+        @provider.recruitment_cycle_year
+      ),
+      button: true,
+     ) %>
 
     <h2 class="govuk-heading-m">
       Tell us what you think about this process

--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -26,13 +26,12 @@
         </td>
         <td class="govuk-table__cell">
           <% if allocation[:status] == AllocationsView::Status::YET_TO_REQUEST %>
-            <%= link_to "Confirm choice",
+            <%= govuk_link_to "Confirm choice",
                        new_repeat_request_provider_recruitment_cycle_allocation_path(
                           @provider.provider_code,
                           @provider.recruitment_cycle_year,
                           allocation[:training_provider_code]
-                       ),
-                        class: "govuk-link" %>
+                       ) %>
           <% else %>
             <ul class="govuk-summary-list__actions-list">
               <li class="govuk-summary-list__actions-list-item allocation-report__actions-list-item">

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -1,13 +1,15 @@
 <%= content_for :page_title, "Check your information before sending your request"%>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(initial_request_provider_recruitment_cycle_allocations_path(
-                          @provider.provider_code,
-                          @provider.recruitment_cycle_year,
-                          training_provider_code: params[:training_provider_code],
-                          number_of_places: params[:number_of_places],
-                          change: true,
-                          )) %>
+  <%= govuk_back_link_to(
+    initial_request_provider_recruitment_cycle_allocations_path(
+      @provider.provider_code,
+      @provider.recruitment_cycle_year,
+      training_provider_code: params[:training_provider_code],
+      number_of_places: params[:number_of_places],
+      change: true,
+    )
+  ) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -35,15 +35,14 @@
               <%= params[:number_of_places] %>
             </dd>
             <dd class="govuk-summary-list__actions">
-              <%= link_to "Change",
+              <%= govuk_link_to "Change",
                 initial_request_provider_recruitment_cycle_allocations_path(
                   @provider.provider_code,
                   @provider.recruitment_cycle_year,
                   training_provider_code: params[:training_provider_code],
                   number_of_places: params[:number_of_places],
                   change: true,
-                  ),
-                class: "govuk-link" %>
+                  ) %>
             </dd>
           </div>
         </dl>

--- a/app/views/providers/allocations/requests/_not_requested.html.erb
+++ b/app/views/providers/allocations/requests/_not_requested.html.erb
@@ -23,9 +23,10 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to raw("Return to Request PE courses for #{next_allocation_cycle_period_text}"),
-                  provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
-                  class: "govuk-link govuk-!-font-weight-bold" %>
+      <%= govuk_link_to(
+        "Return to Request PE courses for #{next_allocation_cycle_period_text}",
+        provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle)
+      ) %>
     </p>
   </div>
 </div>

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -33,9 +33,10 @@
     </p>
 
     <p class="govuk-body">
-      <%= link_to raw("Return to Request PE courses for #{next_allocation_cycle_period_text}"),
-                  provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
-                  class: "govuk-link govuk-!-font-weight-bold" %>
+      <%= govuk_link_to(
+        "Return to Request PE courses for #{next_allocation_cycle_period_text}",
+        provider_recruitment_cycle_allocations_path(@provider.provider_code, Settings.current_cycle),
+      ) %>
     </p>
   </div>
 </div>

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -118,10 +118,12 @@
       <%= f.submit "Save and publish changes", class: "govuk-button" %>
     <% end %>
 
-    <div class="form-group">
-      <p class="govuk-body">
-        <%= govuk_link_to "Cancel changes", details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
-      </p>
-    </div>
+    <p class="govuk-body">
+      <%= govuk_link_to(
+        "Cancel changes",
+        details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+        class: "govuk-link--no-visited-state",
+      ) %>
+    </p>
   </div>
 </div>

--- a/app/views/providers/edit_initial_allocations/check_answers.html.erb
+++ b/app/views/providers/edit_initial_allocations/check_answers.html.erb
@@ -2,16 +2,16 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(
-        get_edit_initial_request_provider_recruitment_cycle_allocation_path(
-          provider.provider_code,
-          recruitment_cycle.year,
-          training_provider.provider_code,
-          number_of_places: params[:number_of_places],
-          request_type: params[:request_type],
-          next_step: "number_of_places",
-          id: allocation.id
-        )
-      ) %>
+    get_edit_initial_request_provider_recruitment_cycle_allocation_path(
+      provider.provider_code,
+      recruitment_cycle.year,
+      training_provider.provider_code,
+      number_of_places: params[:number_of_places],
+      request_type: params[:request_type],
+      next_step: "number_of_places",
+      id: allocation.id,
+    )
+  ) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/providers/edit_initial_allocations/check_answers.html.erb
+++ b/app/views/providers/edit_initial_allocations/check_answers.html.erb
@@ -41,7 +41,7 @@
             <%= params[:number_of_places] %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= link_to "Change",
+            <%= govuk_link_to "Change",
                         get_edit_initial_request_provider_recruitment_cycle_allocation_path(
                           provider.provider_code,
                           recruitment_cycle.year,
@@ -50,8 +50,7 @@
                           request_type: params[:request_type],
                           next_step: "number_of_places",
                           id: allocation.id
-                        ),
-                        class: "govuk-link" %>
+                        ) %>
           </dd>
         </div>
       </dl>

--- a/app/views/providers/edit_initial_allocations/do_you_want.html.erb
+++ b/app/views/providers/edit_initial_allocations/do_you_want.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Do you want to request PE for this organisation?"%>
-<%= content_for :page_title, page_title%>
+<%= content_for :page_title, page_title %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>

--- a/app/views/providers/edit_initial_allocations/number_of_places.html.erb
+++ b/app/views/providers/edit_initial_allocations/number_of_places.html.erb
@@ -2,13 +2,13 @@
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(
-        get_edit_initial_request_provider_recruitment_cycle_allocation_path(
-          provider.provider_code,
-          recruitment_cycle.year,
-          training_provider.provider_code,
-          id: allocation.id
-        )
-      ) %>
+    get_edit_initial_request_provider_recruitment_cycle_allocation_path(
+      provider.provider_code,
+      recruitment_cycle.year,
+      training_provider.provider_code,
+      id: allocation.id,
+    )
+  ) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -29,7 +29,7 @@
 
       <h2 class="govuk-heading-s">Support and guidance</h2>
       <p class="govuk-body">If you have a question, or you’ve had a problem using Publish, you can email:</p>
-      <p class="govuk-body govuk-!-margin-bottom-0"><%= bat_contact_mail_to bat_contact_email_address_with_wrap, subject: "Support and guidance" %></p>
+      <p class="govuk-body govuk-!-margin-bottom-0"><%= bat_contact_mail_to subject: "Support and guidance" %></p>
     </div>
   </aside>
 </div>

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -18,14 +18,16 @@
       <% @training_providers.each do |training_provider| %>
         <li data-qa="training_provider">
           <h3 class="govuk-heading-m">
-            <%= link_to training_provider.provider_name,
-                        training_provider_courses_provider_recruitment_cycle_path(
-                          provider.provider_code,
-                          provider.recruitment_cycle_year,
-                          training_provider.provider_code,
-                        ),
-                        class: "govuk-link govuk-!-font-weight-bold",
-                        data: { qa: "link" } %>
+            <%= govuk_link_to(
+              training_provider.provider_name,
+              training_provider_courses_provider_recruitment_cycle_path(
+                provider.provider_code,
+                provider.recruitment_cycle_year,
+                training_provider.provider_code,
+              ),
+              class: "govuk-!-font-weight-bold",
+              data: { qa: "link" }
+            ) %>
             <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block" data-qa="course_count">
               <%= pluralize(@course_counts[training_provider.provider_code], "course") %>
             </span>
@@ -39,13 +41,16 @@
       <div class="app-related" data-qa="download-section" >
         <h2 class="govuk-heading-m">Download</h2>
         <p class="govuk-body">Export all the courses you’re the accredited body for.</p>
-        <%= link_to "Download as a CSV file",
-                    download_training_providers_courses_provider_recruitment_cycle_path(
-                      provider.provider_code,
-                      provider.recruitment_cycle_year,
-                      format: :csv
-                    ),
-                    class: "govuk-link govuk-body" %>
+        <p class="govuk-body">
+          <%= govuk_link_to(
+            "Download as a CSV file",
+            download_training_providers_courses_provider_recruitment_cycle_path(
+              provider.provider_code,
+              provider.recruitment_cycle_year,
+              format: :csv
+            )
+          ) %>
+        </p>
       </div>
   </aside>
 </div>

--- a/app/views/providers/users/index.html.erb
+++ b/app/views/providers/users/index.html.erb
@@ -7,7 +7,7 @@
     <p class="govuk-body">
       These users currently have access to this organisation. They can manage all your course and organisation details, including publishing, closing and withdrawing courses.
     </p>
-    <%= link_to "Request access for someone else", request_access_provider_path(code: @provider.provider_code), class: "govuk-button" %>
+    <%= govuk_link_to "Request access for someone else", request_access_provider_path(code: @provider.provider_code), button: true %>
     <% @users.each do |user| %>
       <div>
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1">

--- a/app/views/sessions/magic_link_sent.html.erb
+++ b/app/views/sessions/magic_link_sent.html.erb
@@ -9,7 +9,7 @@
     </p>
     <p class="govuk-body">
       If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or
-      <%= link_to "try again", sign_in_path, class: "govuk-link" %>
+      <%= govuk_link_to "try again", sign_in_path %>
     </p>
   </div>
 </div>

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell" data-qa="provider__location-name">
-    <%= link_to site.location_name, edit_provider_recruitment_cycle_site_path(@provider.provider_code, site.recruitment_cycle_year, site.id), class: "govuk-link govuk-!-font-weight-bold" %>
+    <%= govuk_link_to site.location_name, edit_provider_recruitment_cycle_site_path(@provider.provider_code, site.recruitment_cycle_year, site.id), class: "govuk-!-font-weight-bold" %>
   </td>
   <td class="govuk-table__cell">
     <%= site.code %> <%= site.code == '-' ? '(dash)' : '' %>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -13,8 +13,13 @@
       <%= render 'form', f: f %>
       <%= f.submit "Save and publish changes", class: "govuk-button", data: { qa: 'location__publish-changes' } %>
     <% end %>
+
     <p class="govuk-body">
-      <%= link_to "Cancel changes", provider_recruitment_cycle_sites_path(@provider.provider_code), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= govuk_link_to(
+        "Cancel changes",
+        provider_recruitment_cycle_sites_path(@provider.provider_code),
+        class: "govuk-link--no-visited-state",
+      ) %>
     </p>
   </div>
 </div>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -36,7 +36,7 @@
       </tbody>
     </table>
     <% if @provider.can_add_more_sites? %>
-      <%= link_to "Add a location", new_provider_recruitment_cycle_site_path(@provider.provider_code), class: "govuk-button govuk-!-margin-bottom-2" %>
+      <%= govuk_link_to "Add a location", new_provider_recruitment_cycle_site_path(@provider.provider_code), button: true %>
     <% else %>
       <%= govuk_warning(text: "You can’t add any more locations as you’ve reached the maximum number of locations available.") %>
     <% end %>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -14,8 +14,13 @@
       <%= render 'form', f: f %>
       <%= f.submit "Save", class: "govuk-button", data: { qa: 'location__publish-changes' } %>
     <% end %>
+
     <p class="govuk-body">
-      <%= link_to "Cancel changes", provider_recruitment_cycle_sites_path(@provider[:provider_code]), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= govuk_link_to(
+        "Cancel changes",
+        provider_recruitment_cycle_sites_path(@provider[:provider_code]),
+        class: "govuk-link--no-visited-state",
+      ) %>
     </p>
   </div>
 </div>

--- a/app/views/ucas_contacts/_contact.html.erb
+++ b/app/views/ucas_contacts/_contact.html.erb
@@ -17,7 +17,7 @@
     </p>
   </dd>
   <dd class="govuk-summary-list__actions">
-    <%= link_to edit_provider_contact_path(@provider.provider_code, contact), class: "govuk-link" do %>
+    <%= govuk_link_to edit_provider_contact_path(@provider.provider_code, contact) do %>
       Change<span class="govuk-visually-hidden"> email alerts for new applications</span>
     <% end %>
   </dd>

--- a/app/views/ucas_contacts/_ucas_contact_list.html.erb
+++ b/app/views/ucas_contacts/_ucas_contact_list.html.erb
@@ -21,7 +21,7 @@
       </dd>
       <dd class="govuk-summary-list__actions">
         <%- if contact.present? -%>
-          <%= link_to edit_provider_contact_path(ucas_contact_view.provider_code, contact.id), class: "govuk-link" do %>
+          <%= govuk_link_to edit_provider_contact_path(ucas_contact_view.provider_code, contact.id) do %>
             Change<span class="govuk-visually-hidden"> email alerts for new applications</span>
           <% end %>
         <%- end -%>

--- a/app/views/ucas_contacts/alerts.html.erb
+++ b/app/views/ucas_contacts/alerts.html.erb
@@ -72,12 +72,14 @@
       <hr class="govuk-section-break govuk-section-break--l">
 
       <%= form.submit "Save", class: "govuk-button", data: { qa: 'course__save' } %>
-
     <% end %>
 
     <p class="govuk-body">
-      <%= link_to 'Cancel changes', provider_ucas_contacts_path(@provider.provider_code), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= govuk_link_to(
+        "Cancel changes",
+        provider_ucas_contacts_path(@provider.provider_code),
+        class: "govuk-link--no-visited-state",
+      ) %>
     </p>
-
   </div>
 </div>

--- a/app/views/ucas_contacts/alerts.html.erb
+++ b/app/views/ucas_contacts/alerts.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :page_title, "Email alerts for new applications" %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_ucas_contacts_path(@provider.provider_code)) %>
 <% end %>

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -15,7 +15,7 @@
 
       <p class="govuk-body">Some of the contacts below are labelled ‘Information unknown’. This is because UCAS doesn’t have permission under the <%= govuk_link_to "General Data Protection Regulation", "https://www.gov.uk/government/publications/guide-to-the-general-data-protection-regulation" %> (GDPR) to share these details with us.</p>
 
-      <p class="govuk-body">You can get hold of these details by contacting the UCAS Higher Education Provider Team (HEP Team) on 0344 984 1111 or at <%= mail_to "hep_team@ucas.ac.uk", "hep_team@ucas.ac.uk", class: "govuk-link" %>.</p>
+      <p class="govuk-body">You can get hold of these details by contacting the UCAS Higher Education Provider Team (HEP Team) on 0344 984 1111 or at <%= govuk_mail_to "hep_team@ucas.ac.uk", "hep_team@ucas.ac.uk" %>.</p>
 
       <p class="govuk-body">Alternatively you can choose new contacts and we will send them to UCAS to update.</p>
     <% end %>

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -13,7 +13,7 @@
     <%= govuk_inset_text do %>
       <h2 class="govuk-heading-m">What does ‘information unknown’ mean?</h2>
 
-      <p class="govuk-body">Some of the contacts below are labelled ‘Information unknown’. This is because UCAS doesn’t have permission under the <%= link_to "General Data Protection Regulation", "https://www.gov.uk/government/publications/guide-to-the-general-data-protection-regulation", class: "govuk-link" %> (GDPR) to share these details with us.</p>
+      <p class="govuk-body">Some of the contacts below are labelled ‘Information unknown’. This is because UCAS doesn’t have permission under the <%= govuk_link_to "General Data Protection Regulation", "https://www.gov.uk/government/publications/guide-to-the-general-data-protection-regulation" %> (GDPR) to share these details with us.</p>
 
       <p class="govuk-body">You can get hold of these details by contacting the UCAS Higher Education Provider Team (HEP Team) on 0344 984 1111 or at <%= mail_to "hep_team@ucas.ac.uk", "hep_team@ucas.ac.uk", class: "govuk-link" %>.</p>
 
@@ -73,7 +73,7 @@
           </p>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to alerts_provider_ucas_contacts_path(@ucas_contact_view.provider_code), class: "govuk-link", data: { qa: 'send_application_alerts__change' } do %>
+          <%= govuk_link_to alerts_provider_ucas_contacts_path(@ucas_contact_view.provider_code), data: { qa: 'send_application_alerts__change' } do %>
             Change<span class="govuk-visually-hidden"> email alerts for new applications</span>
           <% end %>
         </dd>
@@ -92,7 +92,7 @@
           </p>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to alerts_provider_ucas_contacts_path(@ucas_contact_view.provider_code), class: "govuk-link", data: { qa: 'application_alert_contact__change' } do %>
+          <%= govuk_link_to alerts_provider_ucas_contacts_path(@ucas_contact_view.provider_code), data: { qa: 'application_alert_contact__change' } do %>
             Change<span class="govuk-visually-hidden"> email alerts for new applications</span>
           <% end %>
         </dd>

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -103,7 +103,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="app-related">
       <h2 class="govuk-heading-m">Changing your contact details</h2>
-      <p class="govuk-body">To request changes to your UCAS contact details email the Becoming a Teacher team:<br><%= bat_contact_mail_to(bat_contact_email_address_with_wrap) %></p>
+      <p class="govuk-body">To request changes to your UCAS contact details email the Becoming a Teacher team:<br><%= bat_contact_mail_to %></p>
     </div>
   </div>
 </div>

--- a/app/webpacker/stylesheets/_link.scss
+++ b/app/webpacker/stylesheets/_link.scss
@@ -1,0 +1,5 @@
+.govuk-link {
+  &.app-link--destructive {
+    color: $govuk-error-colour;
+  }
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -26,6 +26,7 @@ $success-green: #00823b;
 @import "performance-dashboard";
 @import "banner";
 @import "tables";
+@import "link";
 
 .app-text-decoration-underline-dotted {
   text-decoration: underline dotted;
@@ -105,10 +106,6 @@ $success-green: #00823b;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.govuk-link--destructive {
-  color: $govuk-error-colour;
 }
 
 .govuk-list--dash {

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -1,12 +1,6 @@
 require "rails_helper"
 
 feature "View helpers", type: :helper do
-  describe "#govuk_link_to" do
-    it "returns an anchor tag with the govuk-link class" do
-      expect(helper.govuk_link_to("ACME SCITT", "https://localhost:44364/organisations/A0")).to eq("<a class=\"govuk-link\" href=\"https://localhost:44364/organisations/A0\">ACME SCITT</a>")
-    end
-  end
-
   describe "#govuk_back_link_to" do
     it "returns an anchor tag with the govuk-back-link class" do
       expect(helper.govuk_back_link_to("https://localhost:44364/organisations/A0")).to eq("<a class=\"govuk-back-link govuk-!-display-none-print\" data-qa=\"page-back\" href=\"https://localhost:44364/organisations/A0\">Back</a>\n")

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -7,6 +7,26 @@ feature "View helpers", type: :helper do
     end
   end
 
+  describe "#bat_contact_mail_to" do
+    context "with no link name" do
+      it "returns BAT contact email address with a word break in the link name" do
+        expect(helper.bat_contact_mail_to).to eq("<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk\">becomingateacher<wbr>@digital.education.gov.uk</a>")
+      end
+    end
+
+    context "with a link name" do
+      it "returns BAT contact email address with the link name" do
+        expect(helper.bat_contact_mail_to("Contact us")).to eq("<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk\">Contact us</a>")
+      end
+    end
+
+    context "with a subject" do
+      it "returns BAT contact email address with a mailto: subject query" do
+        expect(helper.bat_contact_mail_to(subject: "Feedback")).to eq("<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Feedback\">becomingateacher<wbr>@digital.education.gov.uk</a>")
+      end
+    end
+  end
+
   describe "#enrichment_error_url" do
     it "returns enrichment error URL" do
       course = Course.new(build(:course).attributes)


### PR DESCRIPTION
### Context

The `govuk-components` gem provides several helpers for outputting links with the `govuk-link` and related classes on them (one of which is similar to the `govuk_link_to` helper already in this application). We should use these helpers.

### Changes proposed in this pull request

* Remove `govuk_link_to` helper and tests (as replaced by one from `govuk-components`)
* Ensure web links use `govuk_link_to` helper, where relevant
* Ensure button links use `govuk_link_to` helper (with `button: true`)
* Ensure email links use `govuk_mail_to` helper
* Simplify and refactor `bat_contact_mail_to` helper, adding tests for it
* Refactor destructive link style (replace `govuk-link--destructive` with `govuk-link.app-link--destructive`)
* Tidy up back links (consistent whitespace, and allow `Back` text label to be overridden on course preview page)

### Guidance to review

Probably easiest to review each commit individually.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
