### PR TITLE
[1797] Turn on settings required for rollover (in rollover environment)

### DIFF
--- a/config/settings/rollover.yml
+++ b/config/settings/rollover.yml
@@ -13,3 +13,11 @@ search_ui:
 environment:
   label: "Rollover"
   selector_name: "rollover"
+features:
+  rollover:
+    # During rollover providers should be able to edit current & next recruitment cycle courses
+    can_edit_current_and_next_cycles: true
+    # Normally a short period of time between rollover and the next cycle
+    # actually starting when it would be set to false
+    has_current_cycle_started?: false
+    show_next_cycle_allocation_recruitment_page: true


### PR DESCRIPTION
### Context

This PR turns on the required settings for rollover, in the rollover environment. 

As documented [here](https://github.com/DFE-Digital/publish-teacher-training/pull/1655/files)

### Guidance to review

- Navigate to `https://publish-teacher-training-rollover.london.cloudapps.digital/organisations`
- Choose a provider and click on it
- Check that the page displays links for both the current cycle, and next cycle 
- 🚢 


### Screenshot

![image](https://user-images.githubusercontent.com/50492247/119708000-b6996000-be53-11eb-9153-75059302f24f.png)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
