### PR TITLE
[1809] Use interrupt page acknowledgements for rollover interrupt pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -210,7 +210,7 @@ private
     session[:auth_user]["attributes"] = user.attributes
 
     add_provider_count_cookie
-    add_interrupt_pages(user)
+    add_interrupt_pages
   end
 
   def user_from_session
@@ -226,10 +226,10 @@ private
     logger.error "Error setting the provider_count cookie: #{e.class.name}, #{e.message}"
   end
 
-  def add_interrupt_pages(user)
+  def add_interrupt_pages
     return unless FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") || FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page")
 
-    InterruptPageAcknowledgement.where(user_id: user.id, recruitment_cycle_year: Settings.current_cycle.next).all.each do |acknowledgement|
+    InterruptPageAcknowledgement.where(user_id: current_user["user_id"], recruitment_cycle_year: Settings.current_cycle.next).all.each do |acknowledgement|
       key = "accepted_#{acknowledgement.page}"
       session[:auth_user][key] = true
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -227,6 +227,8 @@ private
   end
 
   def add_interrupt_pages(user)
+    return unless FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") || FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page")
+
     InterruptPageAcknowledgement.where(user_id: user.id, recruitment_cycle_year: Settings.current_cycle.next).all.each do |acknowledgement|
       key = "accepted_#{acknowledgement.page}"
       session[:auth_user][key] = true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -229,7 +229,7 @@ private
   def add_interrupt_pages
     return unless FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") || FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page")
 
-    InterruptPageAcknowledgement.where(user_id: current_user["user_id"], recruitment_cycle_year: Settings.current_cycle.next).all.each do |acknowledgement|
+    InterruptPageAcknowledgement.where(user_id: current_user["user_id"], recruitment_cycle_year: Settings.current_cycle).all.each do |acknowledgement|
       key = "accepted_#{acknowledgement.page}"
       session[:auth_user][key] = true
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -123,23 +123,26 @@ private
       redirect_to accept_terms_path
     elsif user_state_to_redirect_paths[user_from_session.aasm.current_state]
       redirect_to user_state_to_redirect_paths[user_from_session.aasm.current_state]
+    elsif show_rollover_page?
+      redirect_to rollover_path
+    elsif show_rollover_recruitment_page?
+      redirect_to rollover_recruitment_path
     elsif use_redirect_back_to
       redirect_to session[:redirect_back_to] if session[:redirect_back_to].present?
       session.delete(:redirect_back_to)
     end
   end
 
+  def show_rollover_page?
+    FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") && !session[:auth_user]["accepted_rollover"]
+  end
+
+  def show_rollover_recruitment_page?
+    FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page") && !session[:auth_user]["accepted_rollover_recruitment"]
+  end
+
   def user_state_to_redirect_paths
-    if Settings.features.rollover.can_edit_current_and_next_cycles
-      {
-        new: transition_info_path,
-        transitioned: rollover_path,
-        rolled_over: rollover_path,
-        notifications_configured: rollover_path, # looping if notification re-configured
-      }
-    else
-      { new: transition_info_path }
-    end
+    { new: transition_info_path }
   end
 
   def authorise_development_mode?(email, password)
@@ -207,6 +210,7 @@ private
     session[:auth_user]["attributes"] = user.attributes
 
     add_provider_count_cookie
+    add_interrupt_pages(user)
   end
 
   def user_from_session
@@ -220,6 +224,13 @@ private
       Provider.where(recruitment_cycle_year: Settings.current_cycle).all.size
   rescue StandardError => e
     logger.error "Error setting the provider_count cookie: #{e.class.name}, #{e.message}"
+  end
+
+  def add_interrupt_pages(user)
+    InterruptPageAcknowledgement.where(user_id: user.id, recruitment_cycle_year: Settings.current_cycle.next).all.each do |acknowledgement|
+      key = "accepted_#{acknowledgement.page}"
+      session[:auth_user][key] = true
+    end
   end
 
   def add_token_to_connection

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,9 +9,9 @@ class UsersController < ApplicationController
 
   def accept_rollover
     InterruptPageAcknowledgement.create(
-      user_id: user.id,
+      user_id: current_user["user_id"],
       recruitment_cycle_year: Settings.current_cycle.next,
-      page: "rollover"
+      page: "rollover",
     )
     session["auth_user"]["accepted_rollover"] = true
     redirect_to root_path
@@ -19,9 +19,9 @@ class UsersController < ApplicationController
 
   def accept_rollover_recruitment
     InterruptPageAcknowledgement.create(
-      user_id: user.id,
+      user_id: current_user["user_id"],
       recruitment_cycle_year: Settings.current_cycle.next,
-      page: "rollover_recruitment"
+      page: "rollover_recruitment",
     )
     session["auth_user"]["accepted_rollover_recruitment"] = true
     redirect_to root_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   def accept_rollover
     InterruptPageAcknowledgement.create(
       user_id: current_user["user_id"],
-      recruitment_cycle_year: Settings.current_cycle.next,
+      recruitment_cycle_year: Settings.current_cycle,
       page: "rollover",
     )
     session["auth_user"]["accepted_rollover"] = true
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
   def accept_rollover_recruitment
     InterruptPageAcknowledgement.create(
       user_id: current_user["user_id"],
-      recruitment_cycle_year: Settings.current_cycle.next,
+      recruitment_cycle_year: Settings.current_cycle,
       page: "rollover_recruitment",
     )
     session["auth_user"]["accepted_rollover_recruitment"] = true

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,17 +8,28 @@ class UsersController < ApplicationController
   end
 
   def accept_rollover
-    user.accept_rollover_screen!
-    session["auth_user"]["attributes"]["state"] = user.state
+    InterruptPageAcknowledgement.create(
+      user_id: user.id,
+      recruitment_cycle_year: Settings.current_cycle.next,
+      page: "rollover"
+    )
+    session["auth_user"]["accepted_rollover"] = true
     redirect_to root_path
   end
 
-  def accept_notifications_info
-    user.accept_notifications_screen!
-    session["auth_user"]["attributes"]["state"] = user.state
+  def accept_rollover_recruitment
+    InterruptPageAcknowledgement.create(
+      user_id: user.id,
+      recruitment_cycle_year: Settings.current_cycle.next,
+      page: "rollover_recruitment"
+    )
+    session["auth_user"]["accepted_rollover_recruitment"] = true
     redirect_to root_path
   end
 
+  # This terms screen is the only existing interrupt screen that doesn't use the state machine
+  # If we want to have data around how many users have accepted the rollover screens we could
+  # add timestamps like this, but it seems less important.
   def accept_terms
     if params.require(:user)[:terms_accepted] == "1"
       result = User.member(current_user["user_id"]).accept_terms

--- a/app/models/interrupt_page_acknowledgement.rb
+++ b/app/models/interrupt_page_acknowledgement.rb
@@ -1,0 +1,4 @@
+class InterruptPageAcknowledgement < Base
+  belongs_to :recruitment_cycle, param: :recruitment_cycle_year
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,6 @@ class User < Base
   aasm whiny_transitions: false do
     state :new, initial: true
     state :transitioned
-    # TODO:  Remove all these after migrating users all to "transitioned",
-    # we are replacing rolled over states and the notifications state is already gone
     state :rolled_over
     state :accepted_rollover_2021
     state :notifications_configured

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,18 +13,14 @@ class User < Base
   aasm whiny_transitions: false do
     state :new, initial: true
     state :transitioned
+    # TODO:  Remove all these after migrating users all to "transitioned",
+    # we are replacing rolled over states and the notifications state is already gone
     state :rolled_over
     state :accepted_rollover_2021
     state :notifications_configured
 
     event :accept_transition_screen do
       transitions from: :new, to: :transitioned
-    end
-
-    event :accept_rollover_screen do
-      transitions from: %i[notifications_configured transitioned rolled_over], to: :accepted_rollover_2021 do
-        guard { FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") }
-      end
     end
   end
 

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -20,12 +20,8 @@
       <li>edit titles, outcomes and locations where necessary</li>
     </ul>
 
-    <%if FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page") %>
-      <%= link_to "Continue", rollover_recruitment_path,  class: "govuk-button" %>
-    <% else %>
-      <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
-        <%= f.submit "Continue", class: "govuk-button" %>
-      <% end %>
+    <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
+      <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -13,7 +13,7 @@
       Accredited bodies should request fee-funded PE by <%= Settings.allocations_close_date.to_s(:govuk) %>.
     </p>
 
-    <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
+    <%= form_for :user, url: accept_rollover_recruitment_path, method: :patch do |f| %>
       <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,7 @@ Rails.application.routes.draw do
   get "/rollover", to: "pages#rollover", as: :rollover
   get "/rollover-recruitment", to: "pages#rollover_recruitment", as: :rollover_recruitment
   patch "/accept-rollover", to: "users#accept_rollover"
+  patch "/accept-rollover-recruitment", to: "users#accept_rollover_recruitment"
   get "/accept-terms", to: "pages#accept_terms"
   patch "/accept-terms", to: "users#accept_terms"
   get "/performance-dashboard", to: "pages#performance_dashboard", as: :performance_dashboard

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 describe ApplicationController, type: :controller do
+  let(:acknowledgements_response) { "{}" }
+
   before do
+    stub_interrupt_page_acknowledgements(acknowledgements_response)
     controller.response = response
   end
 
@@ -37,8 +40,6 @@ describe ApplicationController, type: :controller do
     end
 
     before do
-      allow(Base).to receive(:connection)
-
       allow(JWT::EncodeService).to receive(:call)
         .with(payload: payload)
         .and_return("anything")
@@ -129,6 +130,26 @@ describe ApplicationController, type: :controller do
       end
 
       context "user_id is blank" do
+        let(:acknowledgements_response) { <<~JSON }
+               {
+                 "data":[
+                    {
+                       "id":"7",
+                       "type":"interrupt_page_acknowledgements",
+                       "attributes":{
+                          "page": "lovely_page"
+                       }
+                    }
+                 ],
+                 "meta":{
+                    "count":1
+                 },
+                 "jsonapi":{
+                    "version":"1.0"
+                 }
+              }
+        JSON
+
         let(:user_id) { 999 }
 
         let(:session) do
@@ -191,6 +212,11 @@ describe ApplicationController, type: :controller do
             .to eq 2
         end
 
+        it "sets acknowleged pages" do
+          expect(controller.request.session[:auth_user]["accepted_lovely_page"])
+            .to eq true
+        end
+
         describe "sentry contexts" do
           before do
             allow(Sentry).to receive(:set_user)
@@ -232,6 +258,86 @@ describe ApplicationController, type: :controller do
             expect(controller.log_safe_current_user(reload: true)[:sign_in_user_id]).to be_eql(sign_in_user_id)
           end
         end
+      end
+    end
+
+    describe "redirects" do
+      let(:user_id) { 666 }
+      let(:session) {
+        {
+          auth_user: {
+            "info" => user_info,
+            "user_id" => user_id,
+            "uid" => sign_in_user_id,
+          },
+          id: user_id,
+          state: "transitioned",
+          admin: true,
+          associated_with_accredited_body: false,
+          accept_terms_date_utc: Time.zone.now,
+          notifications_configured: false,
+          first_name: user_first_name,
+          last_name: user_last_name,
+          email: user_email,
+        }
+      }
+
+      let(:current_user) do
+        {
+          user_id: user_id,
+          uid: sign_in_user_id,
+          info: user_info,
+          attributes: session
+        }.with_indifferent_access
+      end
+
+      controller do
+        def index
+          render plain: "Hello World"
+        end
+      end
+
+      before do
+        allow(controller).to receive(:current_user).and_return(current_user)
+        allow(Session).to receive(:create)
+
+        controller.request.session = session
+        controller.authenticate
+      end
+
+      context "user has accepted rollover page", 'feature_rollover.can_edit_current_and_next_cycles': true do
+        let(:session) {
+          super().tap do |s|
+            s[:auth_user]["accepted_rollover"] = true
+          end
+        }
+
+        it "does not redirect" do
+          get :index
+          expect(response.code).to eq "200"
+        end
+      end
+
+      context "user has not accepted rollover page" do
+        context "flag on", 'feature_rollover.can_edit_current_and_next_cycles': true do
+          it "redirects" do
+            get :index
+            expect(response).to redirect_to "/rollover"
+          end
+        end
+
+        context "flag off" do
+          it "does not redirect" do
+            get :index
+            expect(response.code).to eq "200"
+          end
+        end
+      end
+
+      context "user has accepted rollover_recruitment page" do
+      end
+
+      context "user has not accepted rollover_recruitment page" do
       end
     end
   end
@@ -282,5 +388,12 @@ describe ApplicationController, type: :controller do
 
       expect(RequestStore.store).to eq(request_id: request_uuid)
     end
+  end
+
+
+  def stub_interrupt_page_acknowledgements(body)
+    url =  /http:\/\/localhost:3001\/api\/v2\/recruitment_cycles\/#{Settings.current_cycle.next}\/users\/\d+\/interrupt_page_acknowledgements/
+    stub_request(:get, url)
+      .to_return(status: 200, body: body, headers: {'Content-Type'=>'application/vnd.api+json'})
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,7 +4,7 @@ describe ApplicationController, type: :controller do
   let(:acknowledgements_response) { "{}" }
 
   before do
-    stub_interrupt_page_acknowledgements(acknowledgements_response)
+    stub_interrupt_acknowledgements(acknowledgements_response)
     controller.response = response
   end
 
@@ -212,7 +212,7 @@ describe ApplicationController, type: :controller do
             .to eq 2
         end
 
-        it "sets acknowleged pages" do
+        it "sets acknowledges pages", 'feature_rollover.can_edit_current_and_next_cycles': true do
           expect(controller.request.session[:auth_user]["accepted_lovely_page"])
             .to eq true
         end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -414,7 +414,7 @@ describe ApplicationController, type: :controller do
   end
 
   def stub_interrupt_page_acknowledgements(body)
-    url = /http:\/\/localhost:3001\/api\/v2\/recruitment_cycles\/#{Settings.current_cycle.next}\/users\/\d+\/interrupt_page_acknowledgements/
+    url = /http:\/\/localhost:3001\/api\/v2\/recruitment_cycles\/#{Settings.current_cycle}\/users\/\d+\/interrupt_page_acknowledgements/
     stub_request(:get, url)
       .to_return(status: 200, body: body, headers: { "Content-Type" => "application/vnd.api+json" })
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -32,8 +32,38 @@ RSpec.describe UsersController do
   end
 
   describe "#accept_rollover_recruitment" do
+    it "creates the acknowledgement and redirects" do
+      stub_request(:post, "http://localhost:3001/api/v2/recruitment_cycles/#{Settings.current_cycle.next}/users/#{user.id}/interrupt_page_acknowledgements")
+        .with(
+          body: {
+            data: {
+              type: "interrupt_page_acknowledgements",
+              attributes: {
+                page: "rollover_recruitment",
+              },
+            },
+          }.to_json,
+        )
+      put :accept_rollover_recruitment
+      expect(response).to redirect_to(root_path)
+    end
   end
 
   describe "#accept_rollover" do
+    it "creates the acknowledgement and redirects" do
+      stub_request(:post, "http://localhost:3001/api/v2/recruitment_cycles/#{Settings.current_cycle.next}/users/#{user.id}/interrupt_page_acknowledgements")
+        .with(
+          body: {
+            data: {
+              type: "interrupt_page_acknowledgements",
+              attributes: {
+                page: "rollover",
+              },
+            },
+          }.to_json,
+        )
+      put :accept_rollover
+      expect(response).to redirect_to(root_path)
+    end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UsersController do
 
   describe "#accept_rollover_recruitment" do
     it "creates the acknowledgement and redirects" do
-      stub_request(:post, "http://localhost:3001/api/v2/recruitment_cycles/#{Settings.current_cycle.next}/users/#{user.id}/interrupt_page_acknowledgements")
+      stub_request(:post, "http://localhost:3001/api/v2/recruitment_cycles/#{Settings.current_cycle}/users/#{user.id}/interrupt_page_acknowledgements")
         .with(
           body: {
             data: {
@@ -51,7 +51,7 @@ RSpec.describe UsersController do
 
   describe "#accept_rollover" do
     it "creates the acknowledgement and redirects" do
-      stub_request(:post, "http://localhost:3001/api/v2/recruitment_cycles/#{Settings.current_cycle.next}/users/#{user.id}/interrupt_page_acknowledgements")
+      stub_request(:post, "http://localhost:3001/api/v2/recruitment_cycles/#{Settings.current_cycle}/users/#{user.id}/interrupt_page_acknowledgements")
         .with(
           body: {
             data: {

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -30,4 +30,10 @@ RSpec.describe UsersController do
       expect(response).to render_template("pages/accept_terms")
     end
   end
+
+  describe "#accept_rollover_recruitment" do
+  end
+
+  describe "#accept_rollover" do
+  end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -84,14 +84,12 @@ feature "Sign in", type: :feature do
 
     scenario "using DfE Sign-in" do
       user = build(:user, :transitioned)
-      allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
       stub_omniauth(user: user)
       stub_api_v2_request("/users/#{user.id}", user.to_jsonapi)
 
       visit_dfe_sign_in(root_path)
 
       expect(page).to have_content("Sign out (#{user.first_name} #{user.last_name})")
-      expect(page.current_path).to eql("/rollover")
     end
 
     describe "Interruption screens" do
@@ -106,7 +104,7 @@ feature "Sign in", type: :feature do
             :patch,
             "#{Settings.teacher_training_api.base_url}/api/v2/users/#{user.id}",
           )
-                                      .with(body: /"state":"transitioned"/)
+            .with(body: /"state":"transitioned"/)
         end
         let(:user_get_request) { stub_api_v2_request("/users/#{user.id}", user.to_jsonapi) }
 
@@ -115,119 +113,16 @@ feature "Sign in", type: :feature do
           user_update_request
         end
 
-        context "Rollover is enabled" do
-          let(:user) { build(:user, :new) }
-          let(:transitioned_user) { build(:user, :transitioned, id: user.id) }
+        scenario "new user accepts the transition info page" do
+          visit_dfe_sign_in("/signin")
 
-          let(:user_update_request) do
-            stub_request(
-              :patch,
-              "#{Settings.teacher_training_api.base_url}/api/v2/users/#{user.id}",
-            )
-                                        .with(body: /"state":"transitioned"/)
-          end
+          expect(transition_info_page).to be_displayed
+          expect(transition_info_page.title).to have_content("Important new features")
 
-          let(:user_get_request) do
-            stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v2/users/#{user.id}").to_return(
-              { body: user.to_jsonapi.to_json, headers: { 'Content-Type': "application/vnd.api+json" } },
-              { body: user.to_jsonapi.to_json, headers: { 'Content-Type': "application/vnd.api+json" } },
-              { body: transitioned_user.to_jsonapi.to_json, headers: { 'Content-Type': "application/vnd.api+json" } },
-            )
-          end
+          transition_info_page.continue.click
 
-          before do
-            user_get_request
-            user_update_request
-            allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
-          end
-
-          scenario "new user accepts the transition info page" do
-            visit_dfe_sign_in("/signin")
-
-            expect(transition_info_page).to be_displayed
-            expect(transition_info_page.title).to have_content("Important new features")
-
-            transition_info_page.continue.click
-
-            expect(rollover_page).to be_displayed
-            expect(user_update_request).to have_been_made
-          end
-        end
-
-        context "Roll over is disabled" do
-          before do
-            allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
-          end
-
-          scenario "new user accepts the transition info page" do
-            visit_dfe_sign_in("/signin")
-
-            expect(transition_info_page).to be_displayed
-            expect(transition_info_page.title).to have_content("Important new features")
-
-            transition_info_page.continue.click
-
-            expect(root_page).to be_displayed
-            expect(user_update_request).to have_been_made
-          end
-        end
-      end
-
-      describe "rollover screen" do
-        let(:user) { build(:user, :transitioned) }
-        let(:user_update_request) do
-          stub_request(
-            :patch,
-            "#{Settings.teacher_training_api.base_url}/api/v2/users/#{user.id}",
-          ).with(body: /"state":"accepted_rollover_2021"/)
-        end
-        let(:user_get_request) { stub_api_v2_request("/users/#{user.id}", user.to_jsonapi) }
-
-        before do
-          user_get_request
-          user_update_request
-          allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
-          allow(Settings.features.rollover).to receive(:show_next_cycle_allocation_recruitment_page)
-            .and_return(show_next_cycle_allocation_recruitment_page)
-        end
-
-        context "when show next cycle allocation recruitment page is set to true" do
-          let(:show_next_cycle_allocation_recruitment_page) { true }
-          scenario "new user accepts the rollover page" do
-            visit_dfe_sign_in("/signin")
-            expect(rollover_page).to be_displayed
-
-            expect(rollover_page.title).to have_content("Prepare for the next cycle")
-            expect(rollover_page).to_not have_continue_input_button
-
-            rollover_page.continue_link.click
-
-            expect(rollover_recruitment_page).to be_displayed
-            expect(rollover_recruitment_page.title).to have_content("Requesting permission to recruit for the #{Settings.current_cycle + 1} to #{Settings.current_cycle + 2} cycle")
-            rollover_recruitment_page.continue.click
-
-            expect(root_page).to be_displayed
-            expect(user_update_request).to have_been_made
-          end
-        end
-
-        context "when show next cycle allocation recruitment page is set to false" do
-          let(:show_next_cycle_allocation_recruitment_page) { false }
-
-          scenario "new user accepts the rollover page" do
-            visit_dfe_sign_in("/signin")
-            expect(rollover_page).to be_displayed
-
-            expect(rollover_page.title).to have_content("Prepare for the next cycle")
-            expect(rollover_page).to_not have_continue_link
-
-            rollover_page.continue_input_button.click
-
-            expect(rollover_recruitment_page).to_not be_displayed
-
-            expect(root_page).to be_displayed
-            expect(user_update_request).to have_been_made
-          end
+          expect(root_page).to be_displayed
+          expect(user_update_request).to have_been_made
         end
       end
     end

--- a/spec/features/sites/index_spec.rb
+++ b/spec/features/sites/index_spec.rb
@@ -19,10 +19,10 @@ feature "View locations", type: :feature do
   let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
   let(:locations_page) { PageObjects::Page::LocationsPage.new }
   let(:location_page) { PageObjects::Page::LocationPage.new }
+  let(:user) { build(:user) }
 
   before do
     allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
-    user = build(:user)
     signed_in_user(user: user, provider: provider)
 
     stub_api_v2_request(
@@ -47,6 +47,8 @@ feature "View locations", type: :feature do
       "/providers/#{provider_code}?include=sites",
       provider.to_jsonapi(include: :sites),
     )
+
+    stub_interrupt_acknowledgements
 
     root_page.load
 
@@ -81,6 +83,7 @@ feature "View locations", type: :feature do
   context "rollover" do
     it "it shows a list of locations" do
       allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
+      signed_in_user(user: user, provider: provider)
       root_page.load
       expect(organisation_page).to be_displayed(provider_code: provider_code)
       organisation_page.current_cycle.click

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,44 +25,6 @@ describe User, type: :model do
     end
   end
 
-  describe "rolled_over state event" do
-    context "rollover is allowed" do
-      let(:transitioned_user) { build(:user, :transitioned) }
-      let(:rolled_over_user) { build(:user, :rolled_over) }
-
-      before do
-        allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
-      end
-
-      it "changes state from 'transitioned' to 'accepted_rollover_2021'" do
-        transitioned_user.accept_rollover_screen!
-
-        expect(transitioned_user.accepted_rollover_2021?).to be true
-        expect(update_request).to have_been_made
-      end
-
-      it "changes state from 'rolled_over' to 'accepted_rollover_2021'" do
-        rolled_over_user.accept_rollover_screen!
-
-        expect(rolled_over_user.accepted_rollover_2021?).to be true
-        expect(update_request).to have_been_made
-      end
-    end
-
-    context "rollover is not allowed" do
-      let(:rolled_over_user) { create(:user, :rolled_over) }
-
-      before do
-        allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
-      end
-
-      it "raises and error when trying to change state from 'transitioned' to 'rolled_over'" do
-        expect { rolled_over_user.accept_rollover_screen! }.to_not raise_error
-        expect(update_request).not_to have_been_made
-      end
-    end
-  end
-
   describe "#next_state" do
     let(:new_user) { create(:user, :new) }
 

--- a/spec/requests/recruitment_cycles_spec.rb
+++ b/spec/requests/recruitment_cycles_spec.rb
@@ -37,15 +37,6 @@ describe "Recruitment cycles" do
       get("/organisations/#{provider.provider_code}/#{next_recruitment_cycle.year}")
       expect(response).to redirect_to(provider_path(provider.provider_code))
     end
-
-    context "rollover" do
-      it "renders the recruitment cycle page" do
-        allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
-
-        get("/organisations/#{provider.provider_code}/#{current_recruitment_cycle.year}")
-        expect(response.body).to include("Current cycle")
-      end
-    end
   end
 
   describe "when visiting a cycle year that doesn’t exist" do

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,25 +1,38 @@
-RSpec.configure do |configure|
+RSpec.configure do |config|
   # Allow examples to be tagged with "feature :some_feature". This will turn that
   # feature just for the duration of that test.
-  configure.around :each do |example|
+  normalise_feature_name = ->(feature) { feature.to_s.delete_prefix("feature_").to_sym }
+
+  settings_has_key = lambda do |feature_name|
+    segments = feature_name.to_s.split(".")
+    final_key = segments.last
+    segments[0..-2].reduce(Settings.features) { |settings, segment| settings[segment] }.key? final_key.to_sym
+  end
+
+  set_feature = lambda do |feature_name, value|
+    segments = feature_name.to_s.split(".")
+    final_key = segments.last
+    segments[0..-2].reduce(Settings.features) { |settings, segment| settings[segment] }[final_key.to_sym] = value
+  end
+
+  config.around :each do |example|
     original_features = {}
+    features = example.metadata.keys.grep(/^feature_.*/)
 
-    example.metadata.keys.grep(/^feature_.*/) do |metadata_key|
-      feature = metadata_key.to_s.delete_prefix("feature_")
-
-      if Settings.features.key? feature
-        original_features[feature] = Settings.features[feature]
+    features.each do |metadata_key|
+      feature = normalise_feature_name.call(metadata_key)
+      if settings_has_key.call(feature)
+        original_features[feature] = FeatureService.enabled?(feature)
       end
 
-      Settings.features[feature] = example.metadata[metadata_key]
+      set_feature.call(feature, example.metadata[metadata_key])
     end
 
     example.run
 
-    Array[*example.metadata[:feature]].each do |feature|
-      if original_features.key? feature
-        Settings.features[feature] = original_features[feature]
-      end
+    features.each do |metadata_key|
+      feature = normalise_feature_name.call(metadata_key)
+      set_feature.call(feature, original_features[feature])
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -77,7 +77,7 @@ module Helpers
         }
       JSON
 
-    stub_request(:get, /http:\/\/localhost:3001\/api\/v2\/recruitment_cycles\/#{Settings.current_cycle.next}\/users\/\d+\/interrupt_page_acknowledgements/)
+    stub_request(:get, /http:\/\/localhost:3001\/api\/v2\/recruitment_cycles\/#{Settings.current_cycle}\/users\/\d+\/interrupt_page_acknowledgements/)
       .to_return(
         body: body,
         headers: {


### PR DESCRIPTION
### Context
https://trello.com/c/ztZfy8sZ/1809-avoid-adding-acceptedrollover2022-user-state

### Changes proposed in this pull request

- Replaces the old mechanism for determining when to show interrupt pages based on user state
- Breaks apart the 2 rollover interrupt pages so they can be turned on independently 
- Calls a new endpoint on TTAPI for creating acknowledgements for interrupt pages per user/page type/recruitment cycle: https://github.com/DFE-Digital/teacher-training-api/pull/1942

### Guidance to review

Run locally in combination with https://github.com/DFE-Digital/teacher-training-api/pull/1942

- Check that the pages do not show up when rollover flags are off
- Create a new recruitment cycle on TTAPI (for the next year after the one you have set for current)
- Turn on `rollover.can_edit_current_and_next_cycles` and `rollover.show_next_cycle_allocation_recruitment_page` independently to check each page in isolation.
- Sign out and sign in again to verify that the acknowledgement is persisted

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
