### PR TITLE
[xxxx] Fix date on allocations requested page

### DIFF
--- a/app/helpers/allocation_cycle_helper.rb
+++ b/app/helpers/allocation_cycle_helper.rb
@@ -6,8 +6,4 @@ module AllocationCycleHelper
   def next_allocation_cycle_period_text
     "#{Settings.allocation_cycle_year + 1} to #{Settings.allocation_cycle_year + 2}"
   end
-
-  def previous_allocation_cycle_period_text
-    "#{Settings.allocation_cycle_year - 1} to #{Settings.allocation_cycle_year}"
-  end
 end

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -24,7 +24,7 @@
     <p class="govuk-body">
       In September we'll let you know how many places we've allocated for this course.
       <% unless @allocation.initial_request? %>
-        This will be based on the organisation's allocation for <%= previous_allocation_cycle_period_text %>.
+        This will be based on the organisation's allocation for <%= current_allocation_cycle_period_text %>.
       <% end %>
     </p>
 


### PR DESCRIPTION
### Context

We were showing the wrong date on the allocations requested page (the previous instead of the current cycle dates).

### Changes proposed in this pull request

How it was:

<img width="652" alt="Screenshot 2021-05-28 at 15 38 28" src="https://user-images.githubusercontent.com/18436946/120002074-5a0d8080-bfcc-11eb-944f-84be6d358c96.png">

How it is:

<img width="698" alt="Screenshot 2021-05-28 at 15 51 19" src="https://user-images.githubusercontent.com/18436946/120002280-904b0000-bfcc-11eb-86b8-77b9e2db11f8.png">


### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
