### PR TITLE
Use GovukComponent::Tag

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,36 +1,36 @@
 class ApplicationDecorator < Draper::Decorator
   def status_tag
-    tag = h.tag.div(status_tag_content.html_safe, class: "govuk-tag #{status_tag_css_class}")
+    tag = h.govuk_tag(text: status_text.html_safe, colour: status_colour)
     tag += unpublished_status_hint if object.has_unpublished_changes?
     tag.html_safe
   end
 
 private
 
-  def status_tag_content
-    return status_tags[:withdrawn][:content] if object.ucas_status == "not_running"
+  def status_text
+    return status_tags[:withdrawn][:text] if object.ucas_status == "not_running"
 
-    status_tags[object.content_status.to_sym][:content]
+    status_tags[object.content_status.to_sym][:text]
   end
 
-  def status_tag_css_class
-    return status_tags[:withdrawn][:css_class] if object.ucas_status == "not_running"
+  def status_colour
+    return status_tags[:withdrawn][:colour] if object.ucas_status == "not_running"
 
-    status_tags[object.content_status.to_sym][:css_class]
+    status_tags[object.content_status.to_sym][:colour]
   end
 
   def status_tags
     {
-      published: { css_class: "govuk-tag--green app-phase-tag--published", content: "Published" },
-      withdrawn: { css_class: "govuk-tag--red app-phase-tag--withdrawn", content: "Withdrawn" },
-      empty: { css_class: "govuk-tag--grey app-phase-tag--no-content", content: "Empty" },
-      draft: { css_class: "govuk-tag--yellow app-phase-tag--draft", content: "Draft" },
-      published_with_unpublished_changes: { css_class: "govuk-tag--green app-phase-tag--published", content: "Published&nbsp;*" },
-      rolled_over: { css_class: "govuk-tag--grey app-phase-tag--no-content", content: "Rolled over" },
+      published: { text: "Published", colour: "green" },
+      withdrawn: { text: "Withdrawn", colour: "red" },
+      empty: { text: "Empty", colour: "grey" },
+      draft: { text: "Draft", colour: "yellow" },
+      published_with_unpublished_changes: { text: "Published&nbsp;*", colour: "green" },
+      rolled_over: { text: "Rolled over", colour: "grey" },
     }
   end
 
   def unpublished_status_hint
-    h.tag.div("*&nbsp;Unpublished&nbsp;changes".html_safe, class: "govuk-body govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-top-1")
+    h.tag.span("*&nbsp;Unpublished&nbsp;changes".html_safe, class: "govuk-body-s govuk-!-display-block govuk-!-margin-bottom-0 govuk-!-margin-top-1")
   end
 end

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -198,7 +198,7 @@
           <% if current_user["admin"] %>
             <div class="app-admin-only__section">
               <div class="app-admin-only__section-header">
-                <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
+                <%= govuk_tag(text: "Admin feature", colour: "purple") %>
               </div>
               Only admins can make changes
             </div>

--- a/app/views/courses/_status_panel.html.erb
+++ b/app/views/courses/_status_panel.html.erb
@@ -1,8 +1,8 @@
 <div class="app-related">
   <h3 class="govuk-heading-m">Status</h3>
-  <div class="govuk-!-margin-bottom-6" data-qa="course__content-status">
+  <p class="govuk-body" data-qa="course__content-status">
     <%= course.status_tag %>
-  </div>
+  </p>
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
     <% if @recruitment_cycle.current_and_open? %>Is it<% else %>Will it be<% end %> on <abbr class="app-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
   </h3>

--- a/app/views/courses/title/edit.html.erb
+++ b/app/views/courses/title/edit.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="app-admin-only__section">
       <div class="app-admin-only__section-header">
-        <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
+        <%= govuk_tag(text: "Admin feature", colour: "purple") %>
       </div>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -9,9 +9,12 @@
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
 <h2 class="govuk-heading-l">Anne</h2>
-<strong class="govuk-tag govuk-tag--blue">School Direct</strong>
 
-<p class="govuk-body govuk-!-padding-top-5">
+<p class="govuk-body">
+  <%= govuk_tag(text: "School Direct", colour: "blue") %>
+</p>
+
+<p class="govuk-body">
   Anne is a course administrator who belongs to one school direct.
 </p>
 
@@ -19,16 +22,18 @@
   <%= hidden_field_tag "email", "anonimized-user-10599@example.org", id: nil %>
   <%= hidden_field_tag "first_name", "Course administrator", id: nil %>
   <%= hidden_field_tag "last_name", "Anne", id: nil %>
-
   <%= submit_tag "Login as Anne", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
 <h2 class="govuk-heading-l">Susy</h2>
-<strong class="govuk-tag govuk-tag--blue">Accredited Body</strong>
 
-<p class="govuk-body govuk-!-padding-top-5">
+<p class="govuk-body">
+  <%= govuk_tag(text: "Accredited body", colour: "blue") %>
+</p>
+
+<p class="govuk-body">
   Susy is a SCITT service manager who belongs to one accredited body.
 </p>
 
@@ -36,7 +41,6 @@
   <%= hidden_field_tag "email", "anonimized-user-8847@example.org", id: nil %>
   <%= hidden_field_tag "first_name", "ITT partnership manager", id: nil %>
   <%= hidden_field_tag "last_name", "Susy", id: nil %>
-
   <%= submit_tag "Login as Susy", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
 
@@ -44,24 +48,26 @@
 
 <h2 class="govuk-heading-l">Mary</h2>
 
-<strong class="govuk-tag govuk-tag--blue">Multi-org</strong>
-<strong class="govuk-tag govuk-tag--blue">Accredited Body</strong>
-<strong class="govuk-tag govuk-tag--blue">School Direct</strong>
-
-<p class="govuk-body govuk-!-padding-top-5">
-Mary is a SCITT Business Support Coordinator who belongs to:
-  <ul class="govuk-list govuk-list--bullet">
-    <li>multiple accredited bodies, <strong>Suffolk and Norfolk Primary SCITT</strong> and <strong>Suffolk and Norfolk Secondary SCITT</strong></li>
-    <li>a school direct <strong>Thorpe St Andrew School and Sixth Form</strong> with courses accredited by <strong>Suffolk and Norfolk Secondary SCITT</strong></li>
-    <li>a school direct <strong>Thorpe St Andrew School and Sixth Form</strong> with courses also accredited by an organisation not associated with Mary</li>
-  </ul>
+<p class="govuk-body">
+  <%= govuk_tag(text: "Multi-org", colour: "blue") %>
+  <%= govuk_tag(text: "Accredited body", colour: "blue") %>
+  <%= govuk_tag(text: "School Direct", colour: "blue") %>
 </p>
+
+<p class="govuk-body">
+  Mary is a SCITT Business Support Coordinator who belongs to:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>multiple accredited bodies, <strong>Suffolk and Norfolk Primary SCITT</strong> and <strong>Suffolk and Norfolk Secondary SCITT</strong></li>
+  <li>a school direct <strong>Thorpe St Andrew School and Sixth Form</strong> with courses accredited by <strong>Suffolk and Norfolk Secondary SCITT</strong></li>
+  <li>a school direct <strong>Thorpe St Andrew School and Sixth Form</strong> with courses also accredited by an organisation not associated with Mary</li>
+</ul>
 
 <%= form_tag("/auth/developer/callback") do %>
   <%= hidden_field_tag "email", "anonimized-user-7839@example.org", id: nil %>
   <%= hidden_field_tag "first_name", "Multi-org administrator", id: nil %>
   <%= hidden_field_tag "last_name", "Mary", id: nil %>
-
   <%= submit_tag "Login as Mary", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
 
@@ -69,9 +75,11 @@ Mary is a SCITT Business Support Coordinator who belongs to:
 
 <h2 class="govuk-heading-l">Colin</h2>
 
-<strong class="govuk-tag govuk-tag--blue">Admin</strong>
+<p class="govuk-body">
+  <%= govuk_tag(text: "Admin", colour: "blue") %>
+</p>
 
-<p class="govuk-body govuk-!-padding-top-5">
+<p class="govuk-body">
   Colin is a DfE support agent who has administrator access to all organisations.
 </p>
 
@@ -79,6 +87,5 @@ Mary is a SCITT Business Support Coordinator who belongs to:
   <%= hidden_field_tag "email", "becomingateacher+admin-integration-tests@digital.education.gov.uk", id: nil %>
   <%= hidden_field_tag "first_name", "Support agent", id: nil %>
   <%= hidden_field_tag "last_name", "Colin", id: nil %>
-
   <%= submit_tag "Login as Colin", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>

--- a/app/views/providers/_search.html.erb
+++ b/app/views/providers/_search.html.erb
@@ -3,7 +3,7 @@
 
     <div class="app-admin-only__section">
       <div class="app-admin-only__section-header">
-        <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
+        <%= govuk_tag(text: "Admin feature", colour: "purple") %>
       </div>
       <%= form_with url: providers_search_path,
                     method: :get do |form| %>

--- a/app/views/providers/allocations/_allocation_report_closed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_report_closed_state.html.erb
@@ -21,9 +21,7 @@
           <%= allocation[:training_provider_name] %>
         </th>
         <td class="govuk-table__cell">
-            <span class="govuk-tag govuk-tag--<%= allocation[:status_colour] %>">
-              <%= allocation[:status] %>
-            </span>
+          <%= govuk_tag(text: allocation[:status], colour: allocation[:status_colour]) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/providers/allocations/_request_status.html.erb
+++ b/app/views/providers/allocations/_request_status.html.erb
@@ -20,9 +20,7 @@
           <%= allocation[:training_provider_name] %>
         </th>
         <td class="govuk-table__cell">
-            <span class="govuk-tag govuk-tag--<%= allocation[:status_colour] %>">
-              <%= allocation[:status] %>
-            </span>
+          <%= govuk_tag(text: allocation[:status], colour: allocation[:status_colour]) %>
         </td>
         <td class="govuk-table__cell">
           <% if allocation[:status] == AllocationsView::Status::YET_TO_REQUEST %>

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -24,7 +24,7 @@
       <% if current_user["admin"] %>
         <div class="app-admin-only__section">
           <div class="app-admin-only__section-header">
-            <strong class="govuk-tag govuk-tag--purple">Admin Feature</strong>
+            <%= govuk_tag(text: "Admin feature", colour: "purple") %>
           </div>
 
           <%= render "shared/form_field",

--- a/app/webpacker/stylesheets/_phase-tag.scss
+++ b/app/webpacker/stylesheets/_phase-tag.scss
@@ -2,20 +2,20 @@
 // It adds a 1px solid border around the tag with a match colour of the text.
 // TODO Could be removed if we decide not to use grey background sections on pages
 
-.app-related .app-phase-tag {
-  &--no-content {
+.app-related {
+  .govuk-tag--grey {
     border: 1px solid govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
   }
 
-  &--draft {
+  .govuk-tag--yellow {
     border: 1px solid govuk-shade(govuk-colour("yellow"), 65);
   }
 
-  &--withdrawn {
+  .govuk-tag--red {
     border: 1px solid govuk-shade(govuk-colour("red"), 30);
   }
 
-  &--published {
+  .govuk-tag--green {
     border: 1px solid govuk-shade(govuk-colour("green"), 20);
   }
 }

--- a/app/webpacker/stylesheets/_related.scss
+++ b/app/webpacker/stylesheets/_related.scss
@@ -1,8 +1,12 @@
-// This is only needed when we use tags in the sidebar with a grey background. eg. Course details page
-// It adds a 1px solid border around the tag with a match colour of the text.
-// TODO Could be removed if we decide not to use grey background sections on pages
-
 .app-related {
+  background-color: govuk-colour("light-grey");
+  padding: govuk-spacing(4);
+
+  .govuk-select {
+    background: govuk-colour("white");
+  }
+
+  // Add a 1px solid border around tags which match colour of the text
   .govuk-tag--grey {
     border: 1px solid govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
   }

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -13,7 +13,6 @@ $success-green: #00823b;
 @import "~govuk-frontend/govuk/all";
 
 @import "advice";
-@import "phase-tag";
 @import "currency-input";
 @import "notification-banner";
 @import "definition-list";
@@ -23,20 +22,12 @@ $success-green: #00823b;
 @import "patterns/pagination";
 @import "tabs";
 @import "performance-dashboard";
+@import "related";
 @import "tables";
 @import "link";
 
 .app-text-decoration-underline-dotted {
   text-decoration: underline dotted;
-}
-
-.app-related {
-  background-color: govuk-colour("light-grey");
-  padding: govuk-spacing(4);
-
-  .govuk-select {
-    background: govuk-colour("white");
-  }
 }
 
 .app-courses-locations-list__help-text {

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -111,8 +111,8 @@ describe CourseDecorator do
     context "A non running course" do
       let(:course) { build(:course, ucas_status: "not_running") }
 
-      it "Returns phase tag withdrawn" do
-        expect(status_tag).to include("phase-tag--withdrawn")
+      it "Returns red tag" do
+        expect(status_tag).to include("govuk-tag--red")
       end
 
       it "Returns text withdrawn" do
@@ -123,8 +123,8 @@ describe CourseDecorator do
     context "An empty course" do
       let(:course) { build(:course, content_status: "empty") }
 
-      it "Returns phase tag published" do
-        expect(status_tag).to include("phase-tag--no-content")
+      it "Returns grey tag" do
+        expect(status_tag).to include("govuk-tag--grey")
       end
 
       it "Returns text empty" do
@@ -135,8 +135,8 @@ describe CourseDecorator do
     context "A draft course" do
       let(:course) { build(:course, content_status: "draft") }
 
-      it "Returns phase tag published" do
-        expect(status_tag).to include("phase-tag--draft")
+      it "Returns yellow tag" do
+        expect(status_tag).to include("govuk-tag--yellow")
       end
 
       it "Returns text draft" do
@@ -147,8 +147,8 @@ describe CourseDecorator do
     context "A published with unpublished changes course" do
       let(:course) { build(:course, content_status: "published_with_unpublished_changes") }
 
-      it "Returns phase tag published" do
-        expect(status_tag).to include("phase-tag--published")
+      it "Returns green tag" do
+        expect(status_tag).to include("govuk-tag--green")
       end
 
       it "Returns text published*" do
@@ -163,8 +163,8 @@ describe CourseDecorator do
     context "A rolled over course" do
       let(:course) { build(:course, content_status: "rolled_over") }
 
-      it "Returns phase tag no content" do
-        expect(status_tag).to include("phase-tag--no-content")
+      it "Returns grey tag" do
+        expect(status_tag).to include("govuk-tag--grey")
       end
 
       it "Returns text rolled over" do
@@ -175,8 +175,8 @@ describe CourseDecorator do
     context "A withdrawn course" do
       let(:course) { build(:course, content_status: "withdrawn") }
 
-      it "Returns phase tag withdrawn" do
-        expect(status_tag).to include("phase-tag--withdrawn")
+      it "Returns red tag" do
+        expect(status_tag).to include("govuk-tag--red")
       end
 
       it "Returns text withdrawn" do


### PR DESCRIPTION
### Context

Uses `GovukComponent::Tag` to render panel component (via `govuk-components` `govuk_tag` helper method).

### Changes proposed in this pull request

* Use `govuk_tag` for status tags
* Refactor `ApplicationDecorator` to use `govuk_tag` and supply `text` and `colour` values
* Update tests to check for `govuk--` colour modifiers instead of `phase-tag--` modifiers
* Refactor `app-related` CSS by consolidating SCSS files
* Fix some HTML markup surrounding tags, using the right elements and classes

### Guidance to review

There should be no visual changes.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
