### PR TITLE
[xxx] Fix make console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,4 +129,4 @@ destroy: deploy-init
 
 console:
 	cf target -s ${space}
-	cf ssh teacher-training-api-${paas_env} -t -c "cd /app && /usr/local/bin/bundle exec rails c"
+	cf ssh publish-teacher-training-${paas_env} -t -c "cd /app && /usr/local/bin/bundle exec rails c"


### PR DESCRIPTION
### Context

We have a make command for opening a rails console.

### Changes proposed in this pull request

Console was being opened on TTAPI. Fixed to open on Publish.

This will let us interact with the API from the console using Publish's
JSON client objects.

### Guidance to review

Open a console, check `ENV` is pointing at publish.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
