### PR TITLE
Enforce use of govuk_link_to et al

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,12 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
+require:
+- ./lib/rubocop/cop/govuk/govuk_link_to.rb
+- ./lib/rubocop/cop/govuk/govuk_button_to.rb
+# TODO: Enable following cop once all forms are using GOVUKDesignSystemFormBuilder
+# - ./lib/rubocop/cop/govuk/govuk_submit.rb
+
 AllCops:
   Exclude:
     - 'bin/rails'
@@ -37,3 +43,16 @@ Rails/ApplicationController:
 # https://github.com/alphagov/rubocop-govuk/commit/c4a4329d5e44dc98b24f1d344a3532054b1539e0
 Rails/SaveBang:
   Enabled: false
+
+Govuk:
+  Include:
+    - 'app/views/**/*'
+    - 'app/components/**/*'
+
+Govuk/GovukLinkTo:
+  Exclude:
+    # link_to in manual error summaries
+    - 'app/views/shared/_errors.html.erb'
+    - 'app/views/courses/age_range/_errors.html.erb'
+    # link_to in footers
+    - 'app/views/layouts/_footer.html.erb'

--- a/app/views/access_requests/confirm.html.erb
+++ b/app/views/access_requests/confirm.html.erb
@@ -19,4 +19,4 @@
   </div>
 </div>
 
-<%= button_to "Approve", approve_access_request_path(@access_request.id), class: "govuk-button govuk-!-margin-bottom-0", data: { qa: "access-request__approve" } %>
+<%= govuk_button_to "Approve", approve_access_request_path(@access_request.id), data: { qa: "access-request__approve" } %>

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -33,8 +33,7 @@
         <% end %>
       <% end %>
 
-      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
-        class: "govuk-button", data: { qa: "course__save" } %>
+      <%= form.govuk_submit course.is_running? ? "Save and publish changes" : "Save", data: { qa: "course__save" } %>
 
       <p class="govuk-body">
         <%= govuk_link_to(

--- a/app/views/courses/details.html.erb
+++ b/app/views/courses/details.html.erb
@@ -11,7 +11,7 @@
 
   <ul class="govuk-tabs__list" role="tablist">
     <li class="govuk-tabs__list-item" role="presentation">
-      <%= link_to(
+      <%= govuk_link_to(
         provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
         class: "govuk-tabs__tab",
         role: "tab",
@@ -24,7 +24,7 @@
     </li>
 
     <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
-      <%= link_to(
+      <%= govuk_link_to(
         "#basic_details",
         class: "govuk-tabs__tab",
         id: "basic_details_tab",

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -27,7 +27,7 @@
 <% if course.age_range_in_years.nil? && !course.is_further_education? %>
   <%= govuk_notification_banner(title: t("notification_banner.info")) do |notification_banner| %>
     <%= notification_banner.add_heading(text: "You need to provide some information before publishing this course") %>
-    <%= link_to(
+    <%= govuk_link_to(
       "Specify an age range",
       age_range_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
       class: "govuk-notification-banner__link",
@@ -45,7 +45,7 @@
 
   <ul class="govuk-tabs__list" role="tablist">
     <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
-      <%= link_to(
+      <%= govuk_link_to(
         "#description",
         class: "govuk-tabs__tab",
         role: "tab",
@@ -58,7 +58,7 @@
     </li>
 
     <li class="govuk-tabs__list-item" role="presentation">
-      <%= link_to(
+      <%= govuk_link_to(
         details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
         class: "govuk-tabs__tab",
         role: "tab",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,7 @@ en:
     open_state_link_text: "Request PE courses for %{period}"
     closed_state_link_text: "Request PE courses for %{period}"
     confirmed_state_link_text: "View PE courses for %{period}"
-    open_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses(ones without a salary) for the next recruitment cycle."
+    open_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses (ones without a salary) for the next recruitment cycle."
     closed_state_copy: "Only accredited bodies are able to see this section. Use it to request fee-funded PE courses (ones without a salary) for the next recruitment cycle."
     confirmed_state_copy: "Use it to view the outcome of requests for fee-funded PE courses (ones without a salary) for the next recruitment cycle."
   ucas_contacts:

--- a/lib/rubocop/cop/govuk/govuk_button_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_button_to.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukButtonTo < Base
+        def on_send(node)
+          return unless node.method_name == :button_to
+
+          add_offense(node, message: "Use govuk_button_to instead of button_to")
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/govuk/govuk_link_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_link_to.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukLinkTo < Base
+        def on_send(node)
+          return unless node.method_name == :link_to
+
+          add_offense(node, message: "Use govuk_link_to or govuk_back_link_to instead of link_to")
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/govuk/govuk_submit.rb
+++ b/lib/rubocop/cop/govuk/govuk_submit.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukSubmit < Base
+        def on_send(node)
+          return unless node.method_name == :submit
+
+          add_offense(node, message: "Use govuk_submit instead of submit")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Add custom cops to check for use of `govuk_link_to` and `govuk_button_to` helpers. Also added a cop to check for use of `govuk_submit`, but disabled until all forms are using the form builder.

This follows a similar PR to that on [Apply](https://github.com/DFE-Digital/apply-for-teacher-training/pull/4078).

### Changes proposed in this pull request

* Add custom cops
* Fix instances of helpers not being used
* Fix a type (missing space in allocations copy)

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
