### PR TITLE
Read redis credentials from VCAP services

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,19 @@
+redis_credentials = ENV["REDIS_URL"]
+if ENV.key?("VCAP_SERVICES")
+  service_config = JSON.parse(ENV["VCAP_SERVICES"])
+  redis_config = service_config["redis"].first
+  vcap_redis_credentials = redis_config["credentials"]
+  redis_credentials = vcap_redis_credentials["uri"]
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: redis_credentials,
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: redis_credentials,
+  }
+end


### PR DESCRIPTION
### Context

Redis connection string is not set for SideKiq
see: https://sentry.io/organizations/dfe-bat/issues/2434789702/?project=1407453

### Changes proposed in this pull request

Read redis credentials from VCAP services injected by PaaS.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
