### PR TITLE
[1905] Show last year allocations for re-requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD Gemfile $APP_HOME/Gemfile
 ADD Gemfile.lock $APP_HOME/Gemfile.lock
 
 RUN apk add --update --no-cache --virtual build-dependances \
- build-base  && \
+ git build-base && \
  bundle install --jobs=4 && \
  apk del build-dependances
 

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "omniauth-rails_csrf_protection"
 gem "pkg-config", "~> 1.4.6"
 
 # Parsing JSON from an API
-gem "json_api_client"
+gem "json_api_client", git: "https://github.com/DFE-Digital/json_api_client.git"
 
 # For encoding/decoding web token used for authentication
 gem "jwt"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/DFE-Digital/json_api_client.git
+  revision: 5ec65c56cd3922e9928f3068c9cdb4c1ff88d9ec
+  specs:
+    json_api_client (1.18.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      addressable (~> 2.2)
+      faraday (>= 0.15.2, < 1.2.0)
+      faraday_middleware (>= 0.9.0, < 1.2.0)
+      rack (>= 0.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -222,13 +234,6 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
-    json_api_client (1.18.0)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      addressable (~> 2.2)
-      faraday (>= 0.15.2, < 1.2.0)
-      faraday_middleware (>= 0.9.0, < 1.2.0)
-      rack (>= 0.2)
     jsonapi-deserializable (0.2.0)
     jsonapi-renderer (0.2.2)
     jsonapi-serializable (0.3.1)
@@ -548,7 +553,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   httparty
-  json_api_client
+  json_api_client!
   jsonapi-deserializable
   jsonapi-renderer
   jsonapi-serializable

--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -15,13 +15,21 @@ module Providers
         funding_type: "fee",
       )
 
+      previous_allocations = Allocation
+                      .includes(:provider, :accredited_body)
+                      .where(provider_code: params[:provider_code])
+                      .where(recruitment_cycle_year: Settings.allocation_cycle_year - 1)
+                      .all
+
       allocations = Allocation
                       .includes(:provider, :accredited_body)
                       .where(provider_code: params[:provider_code])
                       .all
 
       @allocations_view = AllocationsView.new(
-        allocations: allocations, training_providers: @training_providers,
+        previous_allocations: previous_allocations,
+        allocations: allocations,
+        training_providers: @training_providers,
       )
     end
 

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -13,6 +13,7 @@ class Allocation < Base
     }.fetch(Settings.features.allocations.state, "open")
   end
 
+  belongs_to :recruitment_cycle, param: :recruitment_cycle_year, shallow_path: true
   belongs_to :provider, param: :provider_code, shallow_path: true # accredited_body
 
   property :number_of_places

--- a/app/view_objects/allocations_view.rb
+++ b/app/view_objects/allocations_view.rb
@@ -25,13 +25,14 @@ class AllocationsView
     DECLINED = "declined".freeze
   end
 
-  def initialize(training_providers:, allocations:)
+  def initialize(training_providers:, allocations:, previous_allocations:)
     @training_providers = training_providers
     @allocations = allocations
+    @previous_allocations = previous_allocations
   end
 
   def repeat_allocation_statuses
-    filtered_training_providers.map do |training_provider|
+    previous_allocated_providers.map do |training_provider|
       matching_allocation = find_matching_allocation(training_provider, repeat_allocations)
       build_repeat_allocations(matching_allocation, training_provider)
     end
@@ -79,6 +80,12 @@ private
     # has made initial allocation requests on their behalf)
     training_provider_ids = initial_allocations.map { |allocation| allocation.provider.id }
     @training_providers.reject { |tp| training_provider_ids.include?(tp.id) }
+  end
+
+  def previous_allocated_providers
+    @training_providers.reject do |tp|
+      @previous_allocations.map { |a| a.provider.provider_code }.exclude?(tp.provider_code)
+    end
   end
 
   def repeat_allocations

--- a/app/views/providers/allocations/_allocation_request_open_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_open_state.html.erb
@@ -43,6 +43,7 @@
     <% end %>
   </div>
 
+
   <% if @training_providers.present? %>
     <div class="govuk-grid-column-full">
       <%= render partial: "providers/allocations/request_status", locals: {

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -7,7 +7,7 @@ environment:
   selector_name: "review"
 authentication:
   mode: persona
-allocation_cycle_year: 2020
+allocation_cycle_year: 2021
 allocations_close_date: 2021-07-02
 features:
   allocations:

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -179,6 +179,11 @@ RSpec.feature "PE allocations" do
     )
 
     stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year - 1}/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
+      resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
+    )
+
+    stub_api_v2_request(
       "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
       "#{@training_provider_with_allocation.provider_code}/show_any" \
       "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -297,6 +297,11 @@ RSpec.feature "PE allocations" do
     )
 
     stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year - 1}/providers/" \
+      "#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
+      resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
+    )
+    stub_api_v2_request(
       "/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
       resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
     )
@@ -340,10 +345,23 @@ RSpec.feature "PE allocations" do
 
   def and_i_choose_a_training_provider
     stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations?filter[recruitment_cycle_year]=#{@accredited_body.recruitment_cycle.year}&filter[training_provider_code]=#{@training_provider.provider_code}&page[page]=1&page[per_page]=1",
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "#{@accredited_body.provider_code}/allocations?" \
+      "filter[training_provider_code]=#{@training_provider.provider_code}&page[page]=1&page[per_page]=1",
       resource_list_to_jsonapi([]),
     )
-
+    stub_api_v2_request(
+      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year - 1}/providers" \
+      "/#{@accredited_body.provider_code}/allocations?" \
+      "filter[training_provider_code]=#{@training_provider.provider_code}&page[page]=1&page[per_page]=1",
+      resource_list_to_jsonapi([]),
+    )
+    stub_api_v2_request(
+      "/providers/#{@accredited_body.provider_code}/allocations?" \
+      "filter[recruitment_cycle_year]=#{@accredited_body.recruitment_cycle.year}&" \
+      "filter[training_provider_code]=#{@training_provider.provider_code}&page[page]=1&page[per_page]=1",
+      resource_list_to_jsonapi([]),
+    )
     page.choose(@training_provider.provider_name)
   end
 
@@ -358,7 +376,21 @@ RSpec.feature "PE allocations" do
 
     provider_codes.each do |provider_code|
       stub_api_v2_request(
-        "/providers/#{@accredited_body.provider_code}/allocations?filter[recruitment_cycle_year]=#{@accredited_body.recruitment_cycle.year}&filter[training_provider_code]=#{provider_code}&page[page]=1&page[per_page]=1",
+        "/providers/#{@accredited_body.provider_code}/allocations?" \
+        "filter[recruitment_cycle_year]=#{@accredited_body.recruitment_cycle.year}&" \
+        "filter[training_provider_code]=#{provider_code}&page[page]=1&page[per_page]=1",
+        resource_list_to_jsonapi([]),
+      )
+      stub_api_v2_request(
+        "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+        "#{@accredited_body.provider_code}/allocations?" \
+        "filter[training_provider_code]=#{provider_code}&page[page]=1&page[per_page]=1",
+        resource_list_to_jsonapi([]),
+      )
+      stub_api_v2_request(
+        "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year - 1}/providers/" \
+        "#{@accredited_body.provider_code}/allocations?" \
+        "filter[training_provider_code]=#{provider_code}&page[page]=1&page[per_page]=1",
         resource_list_to_jsonapi([]),
       )
     end

--- a/spec/view_objects/allocations_view_spec.rb
+++ b/spec/view_objects/allocations_view_spec.rb
@@ -7,16 +7,17 @@ describe AllocationsView do
   let(:training_providers) { [training_provider, another_training_provider] }
 
   describe "#allocation_renewals" do
-    subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).repeat_allocation_statuses }
+    subject { AllocationsView.new(training_providers: training_providers, allocations: allocations, previous_allocations: previous_allocations).repeat_allocation_statuses }
 
     context "Accrediting provider has re-requested an allocation for a training provider" do
       let(:repeat_allocation) do
         build(:allocation, :repeat, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
       end
-      let(:initial_allocation) do
-        build(:allocation, :initial, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 3)
+      let(:previous_allocation) do
+        build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 3)
       end
-      let(:allocations) { [repeat_allocation, initial_allocation] }
+      let(:allocations) { [repeat_allocation] }
+      let(:previous_allocations) { [previous_allocation] }
 
       it {
         is_expected.to eq([
@@ -35,11 +36,15 @@ describe AllocationsView do
     end
 
     context "Accredited body has declined an allocation for a training provider" do
-      let(:declined_allocation) { build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0) }
-      let(:initial_allocation) do
-        build(:allocation, :initial, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 3)
+      let(:declined_allocation) do
+        build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0)
       end
-      let(:allocations) { [declined_allocation, initial_allocation] }
+      let(:previous_allocation) do
+        build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 3)
+      end
+
+      let(:allocations) { [declined_allocation] }
+      let(:previous_allocations) { [previous_allocation] }
 
       it {
         is_expected.to eq([
@@ -58,7 +63,14 @@ describe AllocationsView do
     end
 
     context "Accredited body is yet to repeat or decline an allocation for a training provider" do
+      let(:previous_allocation1) do
+        build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 3)
+      end
+      let(:previous_allocation2) do
+        build(:allocation, :initial, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 3)
+      end
       let(:allocations) { [] }
+      let(:previous_allocations) { [previous_allocation1, previous_allocation2] }
 
       it {
         is_expected.to eq([
@@ -80,7 +92,7 @@ describe AllocationsView do
   end
 
   describe "#initial_allocations" do
-    subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).initial_allocation_statuses }
+    subject { AllocationsView.new(training_providers: training_providers, allocations: allocations, previous_allocations: allocations).initial_allocation_statuses }
 
     context "Accredited body has requested an initial allocation for a training provider" do
       context "more than 1 place requested" do
@@ -135,7 +147,7 @@ describe AllocationsView do
 
   context "allocations are confirmed" do
     describe "#confirmed_allocation_places" do
-      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).confirmed_allocation_places }
+      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations, previous_allocations: allocations).confirmed_allocation_places }
 
       context "returns confirmed repeat and initial allocations with number of places" do
         let(:confirmed_repeat_allocation) do
@@ -188,7 +200,7 @@ describe AllocationsView do
 
   context "allocation period is closed" do
     describe "#requested_allocations" do
-      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).requested_allocations_statuses }
+      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations, previous_allocations: allocations).requested_allocations_statuses }
 
       context "returns allocations if their status is 'REPEATED'" do
         let(:repeat_allocation) do
@@ -277,7 +289,7 @@ describe AllocationsView do
     end
 
     describe "#not_requested_allocations" do
-      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).not_requested_allocations_statuses }
+      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations, previous_allocations: allocations).not_requested_allocations_statuses }
 
       context "returns allocations where status is 'NOT REQUESTED'" do
         let(:declined_allocation) { build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0) }


### PR DESCRIPTION
### Context

https://trello.com/c/BQ6F49Q6/1905-providers-unable-to-confirm-last-years-allocations

To be deployed after: https://github.com/DFE-Digital/teacher-training-api/pull/1962

### Changes proposed in this pull request

We have been showing all training providers currently offering fee-funded PE for which an accredited body accredits courses in the re-request list for allocations.

This shows the same training providers, but filtered to those for which the accredited body requested allocations for in the previous recruitment cycle.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
