### PR TITLE
[1939] Fix typeface on org index autocomplete

### DIFF
--- a/app/views/providers/_search.html.erb
+++ b/app/views/providers/_search.html.erb
@@ -22,7 +22,7 @@
                               value: params[:query],
                               class: "govuk-input govuk-!-width-two-thirds",
                               data: { qa: "provider-search" } %>
-          <div id="provider-autocomplete" class="govuk-!-width-two-thirds"></div>
+          <div id="provider-autocomplete" class="govuk-body govuk-!-width-two-thirds"></div>
         </div>
         <%= form.submit "Search", name: nil, class: "govuk-button govuk-!-margin-bottom-0", data: { qa: "find-providers" } %>
       <% end %>


### PR DESCRIPTION
### Context
We lost the `govuk-body` class in this PR - https://github.com/DFE-Digital/publish-teacher-training/pull/1715/

### Changes proposed in this pull request
Re-add `govuk-body` to the autocomplete wrapper

### Guidance to review
- Login in as an admin user
- Search for a provider

### Checklist
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review


### Before
<img width="1552" alt="Screenshot 2021-06-09 at 14 48 07" src="https://user-images.githubusercontent.com/3071606/121369616-ebb5b000-c933-11eb-9018-e819f1689dda.png">
