### PR TITLE
[1918] Fixed to show previous allocations

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -13,7 +13,10 @@ module Providers
                       .all
                       .group_by { |a| a.provider.recruitment_cycle_year }
 
-      @training_providers = (allocations[previous_recruitment_cycle_year] || []).map(&:provider).sort_by(&:provider_name)
+      @training_providers = (allocations[previous_recruitment_cycle_year] || []).filter_map { |a|
+        a.provider if a.request_type != AllocationsView::RequestType::DECLINED
+      }.sort_by(&:provider_name)
+
       @allocations_view = AllocationsView.new(
         allocations: allocations[@recruitment_cycle.year.to_s] || [], training_providers: @training_providers,
       )

--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -5,23 +5,17 @@ module Providers
     before_action :build_training_provider, except: %i[index initial_request]
     before_action :require_provider_to_be_accredited_body!
 
-    PE_SUBJECT_CODE = "C6".freeze
-
     def index
-      @training_providers = TrainingProvider.where(
-        recruitment_cycle_year: @recruitment_cycle.year,
-        provider_code: @provider.provider_code,
-        subjects: PE_SUBJECT_CODE,
-        funding_type: "fee",
-      )
-
       allocations = Allocation
                       .includes(:provider, :accredited_body)
                       .where(provider_code: params[:provider_code])
+                      .where(recruitment_cycle: { year: [previous_recruitment_cycle_year, @recruitment_cycle.year] })
                       .all
+                      .group_by { |a| a.provider.recruitment_cycle_year }
 
+      @training_providers = (allocations[previous_recruitment_cycle_year] || []).map(&:provider).sort_by(&:provider_name)
       @allocations_view = AllocationsView.new(
-        allocations: allocations, training_providers: @training_providers,
+        allocations: allocations[@recruitment_cycle.year.to_s] || [], training_providers: @training_providers,
       )
     end
 
@@ -76,6 +70,10 @@ module Providers
     end
 
   private
+
+    def previous_recruitment_cycle_year
+      @previous_recruitment_cycle_year ||= (@recruitment_cycle.year.to_i - 1).to_s
+    end
 
     def build_training_provider
       return @training_provider if @training_provider

--- a/app/view_objects/allocations_view.rb
+++ b/app/view_objects/allocations_view.rb
@@ -77,8 +77,8 @@ private
     # we need to first filter out those training providers
     # who will be allocated places for the first time (i.e. where the accredited provider)
     # has made initial allocation requests on their behalf)
-    training_provider_ids = initial_allocations.map { |allocation| allocation.provider.id }
-    @training_providers.reject { |tp| training_provider_ids.include?(tp.id) }
+    training_provider_provider_codes = initial_allocations.map { |allocation| allocation.provider.provider_code }
+    @training_providers.reject { |tp| training_provider_provider_codes.include?(tp.provider_code) }
   end
 
   def repeat_allocations
@@ -102,7 +102,7 @@ private
   end
 
   def find_matching_allocation(training_provider, allocations)
-    allocations.find { |allocation| allocation.provider.id == training_provider.id }
+    allocations.find { |allocation| allocation.provider.provider_code == training_provider.provider_code }
   end
 
   def build_repeat_allocations(matching_allocation, training_provider)

--- a/spec/controllers/providers/allocations_controller_spec.rb
+++ b/spec/controllers/providers/allocations_controller_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe Providers::AllocationsController, type: :controller do
+  let(:current_recruitment_cycle) { build(:recruitment_cycle) }
+  let(:accredited_body) { build(:provider, accredited_body?: is_accredited_body, recruitment_cycle: current_recruitment_cycle) }
+  let(:is_accredited_body) { true }
+  let(:user) { build(:user) }
+  let(:allocations_state) { "open" }
+  let(:current_user) do
+    {
+      user_id: 1,
+      uid: SecureRandom.uuid,
+      info: {
+        email: "dave@example.com",
+      },
+      admin: user.admin,
+      attributes: user.attributes,
+    }.with_indifferent_access
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(accredited_body)
+    allow(Settings.features.allocations).to receive(:state).and_return(allocations_state)
+    stub_api_v2_request(
+      "/providers/#{accredited_body.provider_code}/allocations?filter[recruitment_cycle][year][0]=#{previous_recruitment_cycle.year}&filter[recruitment_cycle][year][1]=#{current_recruitment_cycle.year}&include=provider,accredited_body",
+      resource_list_to_jsonapi([*previous_allocations, *current_allocations].compact, include: "provider,accredited_body"),
+    )
+  end
+  render_views
+
+  describe "get #index" do
+    before do
+      get :index, params: {
+        on: :member,
+        provider_code: accredited_body.provider_code,
+        recruitment_cycle_year: accredited_body.recruitment_cycle.year,
+      }
+    end
+
+    shared_examples "allocation journey mode" do |journey_mode|
+      let(:previous_recruitment_cycle) { build(:recruitment_cycle, :previous_cycle) }
+      let(:previous_provider) { build(:provider, provider_code: provider.provider_code, accredited_body?: is_accredited_body, recruitment_cycle: previous_recruitment_cycle) }
+
+      let(:training_provider_and_allocations_request_types_matrix) do
+        [
+          [build(:provider, provider_code: "PI1", recruitment_cycle: previous_recruitment_cycle), :initial],
+          [build(:provider, provider_code: "PR1", recruitment_cycle: previous_recruitment_cycle), :repeat],
+          [build(:provider, provider_code: "PD1", recruitment_cycle: previous_recruitment_cycle), :declined],
+          [build(:provider, provider_code: "BI1", recruitment_cycle: previous_recruitment_cycle), :initial],
+          [build(:provider, provider_code: "BR1", recruitment_cycle: previous_recruitment_cycle), :repeat],
+          [build(:provider, provider_code: "BD1", recruitment_cycle: previous_recruitment_cycle), :declined],
+          [build(:provider, provider_code: "CI1", recruitment_cycle: current_recruitment_cycle), :initial],
+          [build(:provider, provider_code: "CR1", recruitment_cycle: current_recruitment_cycle), :repeat],
+          [build(:provider, provider_code: "CD1", recruitment_cycle: current_recruitment_cycle), :declined],
+          [build(:provider, provider_code: "BI1", recruitment_cycle: current_recruitment_cycle), :initial],
+          [build(:provider, provider_code: "BR1", recruitment_cycle: current_recruitment_cycle), :repeat],
+          [build(:provider, provider_code: "BD1", recruitment_cycle: current_recruitment_cycle), :declined],
+        ]
+      end
+      let(:previous_training_providers) do
+        training_provider_and_allocations_request_types_matrix.filter_map do |provider, _request_type|
+          provider if provider.recruitment_cycle == previous_recruitment_cycle
+        end
+      end
+
+      let(:current_training_providers) do
+        training_provider_and_allocations_request_types_matrix.filter_map do |provider, _request_type|
+          provider if provider.recruitment_cycle == current_recruitment_cycle
+        end
+      end
+
+      let(:previous_allocations) do
+        training_provider_and_allocations_request_types_matrix.filter_map do |provider, request_type|
+          build(:allocation, request_type, accredited_body: accredited_body, provider: provider) if provider.recruitment_cycle == previous_recruitment_cycle
+        end
+      end
+
+      let(:current_allocations) do
+        training_provider_and_allocations_request_types_matrix.filter_map do |provider, request_type|
+          build(:allocation, request_type, accredited_body: accredited_body, provider: provider) if provider.recruitment_cycle == current_recruitment_cycle
+        end
+      end
+
+      let(:expected_training_providers) do
+        previous_training_providers.filter_map { |provider|
+          provider if %w[PI1
+                         PR1
+                         BI1
+                         BR1].include?(provider.provider_code)
+        }.sort_by(&:provider_name)
+      end
+
+      context "when allocation state is #{journey_mode}" do
+        let(:allocations_state) { journey_mode }
+
+        it "response is successfully" do
+          expect(response).to be_successful
+        end
+
+        it "rendered the correct partials" do
+          expect(response).to render_template(partial: "providers/allocations/_allocation_request_#{journey_mode}_state")
+        end
+
+        it "has expected_training_provider" do
+          expect(controller.view_assigns["training_providers"].map(&:provider_name)).to contain_exactly(*expected_training_providers.map(&:provider_name))
+        end
+      end
+    end
+
+    include_examples "allocation journey mode", "closed"
+    include_examples "allocation journey mode", "open"
+    include_examples "allocation journey mode", "confirmed"
+
+    context "non accredited body" do
+      let(:is_accredited_body) { false }
+      it "is not found" do
+        expect(response).to be_not_found
+        expect(response.body).to render_template("errors/not_found")
+      end
+    end
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     latitude { nil }
     urn { Faker::Number.number(digits: [5, 6].sample) }
     longitude { nil }
-    recruitment_cycle_year { "2019" }
+    recruitment_cycle_year { recruitment_cycle.year.to_s }
     last_published_at { Time.zone.local(2019).utc.iso8601 }
     content_status { "Published" }
     gt12_contact { "gt12_contact@acme-scitt.org" }
@@ -59,7 +59,7 @@ FactoryBot.define do
       end
 
       provider.recruitment_cycle = evaluator.recruitment_cycle
-      provider.recruitment_cycle_year = evaluator.recruitment_cycle.year
+      provider.recruitment_cycle_year = evaluator.recruitment_cycle.year.to_s
     end
 
     trait :accredited_body do

--- a/spec/features/providers/allocations/initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/initial_allocation_spec.rb
@@ -11,10 +11,9 @@ RSpec.feature "PE allocations" do
   end
 
   scenario "Accredited body requests new PE allocations" do
-    given_accredited_body_exists
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -47,10 +46,9 @@ RSpec.feature "PE allocations" do
   end
 
   scenario "Accredited body requests new PE allocations for new training provider" do
-    given_accredited_body_exists
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -74,10 +72,9 @@ RSpec.feature "PE allocations" do
   end
 
   scenario "Accredited body requests new PE allocations for training provider they can't find on first page" do
-    given_accredited_body_exists
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -93,10 +90,9 @@ RSpec.feature "PE allocations" do
   end
 
   scenario "Accredited body requests new PE allocations for training provider they can't find on pick a provider page" do
-    given_accredited_body_exists
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -116,10 +112,9 @@ RSpec.feature "PE allocations" do
   end
 
   scenario "Accredited body requests new PE allocations for training provider with empty search" do
-    given_accredited_body_exists
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -135,10 +130,9 @@ RSpec.feature "PE allocations" do
   end
 
   scenario "Accredited body searches for provider with string containing only one character" do
-    given_accredited_body_exists
+    given_i_am_signed_in_as_a_user_from_the_accredited_body
     given_the_accredited_body_has_an_allocation
     given_there_is_a_training_provider_with_previous_allocations
-    given_i_am_signed_in_as_a_user_from_the_accredited_body
 
     when_i_visit_my_organisations_page
     and_i_click_request_pe_courses
@@ -155,10 +149,9 @@ RSpec.feature "PE allocations" do
 
   context "Accredited body enters number of places" do
     scenario "Accredited body submits form without specifying number of places" do
-      given_accredited_body_exists
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
       given_the_accredited_body_has_an_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -177,10 +170,9 @@ RSpec.feature "PE allocations" do
     end
 
     scenario "Accredited body enters '0'" do
-      given_accredited_body_exists
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
       given_the_accredited_body_has_an_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -200,10 +192,9 @@ RSpec.feature "PE allocations" do
     end
 
     scenario "Accredited body enters a float (1.1)" do
-      given_accredited_body_exists
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
       given_the_accredited_body_has_an_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -223,10 +214,9 @@ RSpec.feature "PE allocations" do
     end
 
     scenario "Accredited body enters a non-numeric character" do
-      given_accredited_body_exists
+      given_i_am_signed_in_as_a_user_from_the_accredited_body
       given_the_accredited_body_has_an_allocation
       given_there_is_a_training_provider_with_previous_allocations
-      given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -246,68 +236,78 @@ RSpec.feature "PE allocations" do
     end
   end
 
-  def given_accredited_body_exists
-    @accredited_body = build(:provider, accredited_body?: true, users: [user])
-    stub_api_v2_resource(@accredited_body.recruitment_cycle)
+  def previous_recruitment_cycle
+    @previous_recruitment_cycle ||= build(:recruitment_cycle, :previous_cycle)
   end
 
-  def user
-    @user ||= build(:user)
+  def current_recruitment_cycle
+    @current_recruitment_cycle ||= build(:recruitment_cycle)
+  end
+
+  def accredited_body
+    @accredited_body ||= build(:provider, accredited_body?: true,
+                                          recruitment_cycle: current_recruitment_cycle)
   end
 
   def given_i_am_signed_in_as_a_user_from_the_accredited_body
-    signed_in_user(user: user)
+    signed_in_user(provider: accredited_body)
+  end
+
+  def training_provider
+    @training_provider ||= build(:provider, recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def training_provider_with_fee_funded_pe
+    @training_provider_with_fee_funded_pe ||= build(:provider, recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def training_provider_with_allocation
+    @training_provider_with_allocation ||= build(:provider, recruitment_cycle: current_recruitment_cycle)
   end
 
   def given_there_is_a_training_provider_with_previous_allocations
-    @training_provider = build(:provider)
-
     stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@training_provider.provider_code}/show_any" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider]),
+      "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/" \
+      "#{training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=#{current_recruitment_cycle.year}",
+      resource_list_to_jsonapi([training_provider]),
     )
 
-    @training_provider_with_fee_funded_pe = build(:provider)
-
     stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@accredited_body.provider_code}/training_providers" \
+      "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/" \
+      "#{accredited_body.provider_code}/training_providers" \
       "?filter[funding_type]=fee" \
       "&filter[subjects]=C6",
-      resource_list_to_jsonapi([@training_provider_with_fee_funded_pe]),
+      resource_list_to_jsonapi([training_provider_with_fee_funded_pe]),
     )
 
     stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@accredited_body.provider_code}/training_providers",
-      resource_list_to_jsonapi([@training_provider, @training_provider_with_fee_funded_pe, @training_provider_with_allocation]),
+      "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/" \
+      "#{accredited_body.provider_code}/training_providers",
+      resource_list_to_jsonapi([training_provider, training_provider_with_fee_funded_pe, training_provider_with_allocation]),
     )
   end
 
-  def given_the_accredited_body_has_an_allocation
-    @training_provider_with_allocation = build(:provider)
-
-    @allocation = build(
+  def allocation
+    @allocation ||= build(
       :allocation,
-      accredited_body: @accredited_body,
-      provider: @training_provider_with_allocation,
+      accredited_body: accredited_body,
+      provider: training_provider_with_allocation,
       number_of_places: 2,
     )
+  end
+
+  def given_the_accredited_body_has_an_allocation(current_allocation: nil)
+    # def and_accredited_body_has_previous_allocation(current_allocation: nil)
+    stub_api_v2_request(
+      "/providers/#{accredited_body.provider_code}/allocations?filter[recruitment_cycle][year][0]=#{previous_recruitment_cycle.year}&filter[recruitment_cycle][year][1]=#{current_recruitment_cycle.year}&include=provider,accredited_body",
+      resource_list_to_jsonapi([allocation, current_allocation].compact, include: "provider,accredited_body"),
+    )
 
     stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
-      resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
+      "/providers/#{accredited_body.provider_code}/allocations?include=provider,accredited_body",
+      resource_list_to_jsonapi([allocation], include: "provider,accredited_body"),
     )
-  end
-
-  def user
-    @user ||= build(:user)
-  end
-
-  def given_i_am_signed_in_as_a_user_from_the_accredited_body
-    signed_in_user(user: user)
   end
 
   def next_allocation_cycle_period_text
@@ -319,11 +319,12 @@ RSpec.feature "PE allocations" do
   end
 
   def when_i_visit_my_organisations_page
-    stub_api_v2_resource(@accredited_body)
+    stub_api_v2_resource(current_recruitment_cycle)
+    stub_api_v2_resource(accredited_body)
     stub_api_v2_resource_collection([build(:access_request)])
 
-    visit provider_path(@accredited_body.provider_code)
-    expect(find("h1")).to have_content(@accredited_body.provider_name.to_s)
+    visit provider_path(accredited_body.provider_code)
+    expect(find("h1")).to have_content(accredited_body.provider_name.to_s)
   end
 
   def then_i_see_the_pe_allocations_page
@@ -340,11 +341,11 @@ RSpec.feature "PE allocations" do
 
   def and_i_choose_a_training_provider
     stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations?filter[recruitment_cycle_year]=#{@accredited_body.recruitment_cycle.year}&filter[training_provider_code]=#{@training_provider.provider_code}&page[page]=1&page[per_page]=1",
+      "/providers/#{accredited_body.provider_code}/allocations?filter[recruitment_cycle_year]=#{current_recruitment_cycle.year}&filter[training_provider_code]=#{training_provider.provider_code}&page[page]=1&page[per_page]=1",
       resource_list_to_jsonapi([]),
     )
 
-    page.choose(@training_provider.provider_name)
+    page.choose(training_provider.provider_name)
   end
 
   def when_i_search_for_a_training_provider
@@ -358,7 +359,7 @@ RSpec.feature "PE allocations" do
 
     provider_codes.each do |provider_code|
       stub_api_v2_request(
-        "/providers/#{@accredited_body.provider_code}/allocations?filter[recruitment_cycle_year]=#{@accredited_body.recruitment_cycle.year}&filter[training_provider_code]=#{provider_code}&page[page]=1&page[per_page]=1",
+        "/providers/#{accredited_body.provider_code}/allocations?filter[recruitment_cycle_year]=#{current_recruitment_cycle.year}&filter[training_provider_code]=#{provider_code}&page[page]=1&page[per_page]=1",
         resource_list_to_jsonapi([]),
       )
     end
@@ -371,9 +372,9 @@ RSpec.feature "PE allocations" do
     training_provider = build(:provider, provider_code: "A01", provider_name: "Acme SCITT")
 
     stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
+      "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/" \
       "#{training_provider.provider_code}/show_any" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
+      "?recruitment_cycle_year=#{current_recruitment_cycle.year}",
       resource_list_to_jsonapi([training_provider]),
     )
 
@@ -397,11 +398,11 @@ RSpec.feature "PE allocations" do
   end
 
   def and_i_should_not_see_training_provider_with_allocations
-    expect(page).to_not have_content(@training_provider_with_allocation.provider_name)
+    expect(page).to_not have_content(training_provider_with_allocation.provider_name)
   end
 
   def and_i_should_not_see_training_provider_with_fee_funded_pe
-    expect(page).to_not have_content(@training_provider_with_fee_funded_pe.provider_name)
+    expect(page).to_not have_content(training_provider_with_fee_funded_pe.provider_name)
   end
 
   def when_i_search_for_a_training_provider_that_does_not_exist
@@ -495,15 +496,15 @@ RSpec.feature "PE allocations" do
 
   def when_i_click_send_request
     stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations",
-      resource_list_to_jsonapi([@allocation]),
+      "/providers/#{accredited_body.provider_code}/allocations",
+      resource_list_to_jsonapi([allocation]),
       :post,
     )
     # Mimicking the setup that the API would go through
-    @allocation.request_type = "repeat"
+    allocation.request_type = "repeat"
     stub_api_v2_request(
-      "/allocations/#{@allocation.id}",
-      resource_list_to_jsonapi([@allocation]),
+      "/allocations/#{allocation.id}",
+      resource_list_to_jsonapi([allocation]),
     )
 
     check_your_info_page.send_request_button.click

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -12,10 +12,8 @@ RSpec.feature "PE allocations" do
   context "Repeat allocations" do
     context "Accredited body has previously requested a repeat allocation for a training provider" do
       scenario "Accredited body views PE allocations page" do
-        given_accredited_body_exists
-        given_training_provider_with_pe_fee_funded_course_exists
-        given_the_accredited_body_has_requested_a_repeat_allocation
         given_i_am_signed_in_as_a_user_from_the_accredited_body
+        and_accredited_body_has_previous_allocation_and_has_current_repeat_allocation
 
         when_i_visit_my_organisations_page
         and_i_click_request_pe_courses
@@ -27,10 +25,8 @@ RSpec.feature "PE allocations" do
     end
 
     scenario "Accredited body requests PE allocations" do
-      given_accredited_body_exists
-      given_training_provider_with_pe_fee_funded_course_exists
-      given_the_accredited_body_has_not_requested_an_allocation
       given_i_am_signed_in_as_a_user_from_the_accredited_body
+      and_accredited_body_has_previous_allocation_and_has_no_current_allocation
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -46,10 +42,8 @@ RSpec.feature "PE allocations" do
     end
 
     scenario "Accredited body decides not to request PE allocations" do
-      given_accredited_body_exists
-      given_training_provider_with_pe_fee_funded_course_exists
-      given_the_accredited_body_has_not_requested_an_allocation
       given_i_am_signed_in_as_a_user_from_the_accredited_body
+      and_accredited_body_has_previous_allocation_and_has_no_current_allocation
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
@@ -67,17 +61,14 @@ RSpec.feature "PE allocations" do
     end
 
     scenario "There is no PE allocations page for non accredited body" do
-      given_a_provider_exists
-      given_i_am_signed_in_as_a_user_from_the_accredited_body
+      given_i_am_signed_in_as_a_user_from_the_training_provider
 
       when_i_visit_training_providers_page
       there_is_no_request_pe_courses_link
-      and_i_cannot_access_pe_alloacations_page
+      and_i_cannot_access_pe_allocations_page
     end
 
     scenario "Accredited body views PE allocations request page for training provider" do
-      given_accredited_body_exists
-      given_training_provider_exists
       given_i_am_signed_in_as_a_user_from_the_accredited_body
 
       when_i_visit_pe_allocations_request_page
@@ -92,10 +83,8 @@ RSpec.feature "PE allocations" do
   context "Initial allocations" do
     context "Accredited body has previously requested an initial allocations for a training provider" do
       scenario "Accredited body views PE allocation page" do
-        given_accredited_body_exists
-        given_training_provider_with_pe_fee_funded_course_exists
-        given_the_accredited_body_has_requested_an_initial_allocation
         given_i_am_signed_in_as_a_user_from_the_accredited_body
+        and_accredited_body_has_previous_allocation_and_has_current_initial_allocation
 
         when_i_visit_my_organisations_page
         and_i_click_request_pe_courses
@@ -109,43 +98,81 @@ RSpec.feature "PE allocations" do
 
   context "Accredited body previously declined a repeat PE allocation" do
     scenario "Accredited body updates an existing PE allocation to 'yes'" do
-      given_accredited_body_exists
-      given_training_provider_with_pe_fee_funded_course_exists
-      given_the_accredited_body_has_declined_an_allocation
       given_i_am_signed_in_as_a_user_from_the_accredited_body
+      and_accredited_body_has_previous_allocation_and_has_current_declined_allocation
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
 
-      when_i_click_change
+      when_i_click_change_for_the_declined_allocation
       then_i_see_request_pe_allocations_page
 
-      when_i_click_yes_to_update
-      and_i_click_continue_to_modify
+      when_i_click_yes_to_update_declined_allocation
+      and_i_click_continue_to_modify(allocation_to_modify: declined_allocation)
       and_i_see_the_corresponding_page_title("Request sent")
     end
   end
 
   context "Accredited body has previously accepted a repeat PE allocation" do
     scenario "Accredited body updates an existing PE allocation to 'no'" do
-      given_accredited_body_exists
-      given_training_provider_with_pe_fee_funded_course_exists
-      given_the_accredited_body_has_requested_a_repeat_allocation
       given_i_am_signed_in_as_a_user_from_the_accredited_body
+      and_accredited_body_has_previous_allocation_and_has_current_repeat_allocation
 
       when_i_visit_my_organisations_page
       and_i_click_request_pe_courses
 
-      when_i_click_change
+      when_i_click_change_for_the_repeat_allocation
       then_i_see_request_pe_allocations_page
 
-      when_i_click_no_to_update
-      and_i_click_continue_to_modify
-      and_i_see_the_corresponding_page_title("#{@training_provider.provider_name} Thank you")
+      when_i_click_no_to_update_repeat_allocation
+      and_i_click_continue_to_modify(allocation_to_modify: repeat_allocation)
+      and_i_see_the_corresponding_page_title("#{training_provider.provider_name} Thank you")
     end
   end
 
 private
+
+  def current_recruitment_cycle
+    @current_recruitment_cycle ||= build(:recruitment_cycle)
+  end
+
+  def accredited_body
+    @accredited_body ||= build(:provider, accredited_body?: true,
+                                          recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def training_provider_code
+    @training_provider_code ||= "TP1"
+  end
+
+  def training_provider
+    @training_provider ||= build(:provider, provider_code: training_provider_code, recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def previous_recruitment_cycle
+    @previous_recruitment_cycle ||= build(:recruitment_cycle, :previous_cycle)
+  end
+
+  def previous_training_provider
+    @previous_training_provider ||= build(:provider, provider_code: training_provider_code, recruitment_cycle: previous_recruitment_cycle)
+  end
+
+  def previous_allocation
+    @previous_allocation ||= build(:allocation, provider: previous_training_provider, accredited_body: accredited_body)
+  end
+
+  def declined_allocation
+    @declined_allocation ||= build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0)
+  end
+
+  def repeat_allocation
+    @repeat_allocation ||= build(:allocation, :repeat, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+  end
+
+  def initial_allocation
+    @initial_allocation ||= build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider,
+                                                         number_of_places: 1)
+  end
 
   def and_i_see_request_form
     expect(allocations_new_page.yes).to_not be_checked
@@ -153,7 +180,7 @@ private
   end
 
   def and_i_see_training_provider_name
-    expect(find("span.govuk-caption-xl")).to have_content(@training_provider.provider_name)
+    expect(find("span.govuk-caption-xl")).to have_content(training_provider.provider_name)
   end
 
   def then_i_see_the_pe_allocations_request_page
@@ -162,133 +189,76 @@ private
   end
 
   def when_i_visit_pe_allocations_request_page
-    stub_api_v2_resource(@accredited_body)
-    stub_api_v2_resource(@accredited_body.recruitment_cycle)
+    stub_api_v2_resource(accredited_body)
+    stub_api_v2_resource(current_recruitment_cycle)
 
     stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@training_provider.provider_code}/show_any" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider]),
+      "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/" \
+      "#{training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=#{current_recruitment_cycle.year}",
+      resource_list_to_jsonapi([training_provider]),
     )
 
     footer_stub_for_access_request_count
 
-    visit new_repeat_request_provider_recruitment_cycle_allocation_path(@accredited_body.provider_code, @accredited_body.recruitment_cycle.year, @training_provider.provider_code)
+    visit new_repeat_request_provider_recruitment_cycle_allocation_path(accredited_body.provider_code, current_recruitment_cycle.year, training_provider.provider_code)
   end
 
   def footer_stub_for_access_request_count
     stub_api_v2_resource_collection([build(:access_request)])
-    stub_api_v2_resource(@training_provider)
-  end
-
-  def given_accredited_body_exists
-    @accredited_body = build(:provider, accredited_body?: true)
   end
 
   def when_i_visit_my_organisations_page
-    visit provider_path(@accredited_body.provider_code)
-    expect(find("h1")).to have_content(@accredited_body.provider_name.to_s)
+    visit provider_path(accredited_body.provider_code)
+    expect(find("h1")).to have_content(accredited_body.provider_name.to_s)
   end
 
   def and_i_see_back_link
     expect(page).to have_link(
       "Back",
-      href: "/organisations/#{@accredited_body.provider_code}/#{@accredited_body.recruitment_cycle.year}/allocations",
+      href: "/organisations/#{accredited_body.provider_code}/#{current_recruitment_cycle.year}/allocations",
     )
-  end
-
-  def given_training_provider_exists
-    @training_provider = build(:provider)
-  end
-
-  def given_accredited_body_exists
-    @accredited_body = build(:provider, accredited_body?: true, users: [user])
-    stub_api_v2_resource(@accredited_body.recruitment_cycle)
-  end
-
-  def user
-    @user ||= build(:user)
   end
 
   def given_i_am_signed_in_as_a_user_from_the_accredited_body
-    signed_in_user(user: user)
+    signed_in_user(provider: accredited_body)
   end
 
-  def given_training_provider_with_pe_fee_funded_course_exists
-    @training_provider = build(:provider)
-    stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@accredited_body.provider_code}/training_providers" \
-      "?filter[funding_type]=fee" \
-      "&filter[subjects]=C6",
-      resource_list_to_jsonapi([@training_provider]),
-    )
+  def given_i_am_signed_in_as_a_user_from_the_training_provider
+    signed_in_user(provider: training_provider)
   end
 
-  def given_there_are_no_training_providers_with_pe_fee_funded_course
+  def and_accredited_body_has_previous_allocation(current_allocation: nil)
     stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@accredited_body.provider_code}/training_providers" \
-      "?filter[funding_type]=fee" \
-      "&filter[subjects]=C6",
-      resource_list_to_jsonapi([]),
+      "/providers/#{accredited_body.provider_code}/allocations?filter[recruitment_cycle][year][0]=#{previous_recruitment_cycle.year}&filter[recruitment_cycle][year][1]=#{current_recruitment_cycle.year}&include=provider,accredited_body",
+      resource_list_to_jsonapi([previous_allocation, current_allocation].compact, include: "provider,accredited_body"),
     )
   end
 
-  def given_the_accredited_body_has_not_requested_an_allocation
-    stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
-      resource_list_to_jsonapi([], include: "provider,accredited_body"),
-    )
+  alias_method :and_accredited_body_has_previous_allocation_and_has_no_current_allocation, :and_accredited_body_has_previous_allocation
+
+  def and_accredited_body_has_previous_allocation_and_has(current_allocation:)
+    and_accredited_body_has_previous_allocation(current_allocation: current_allocation)
   end
 
-  def given_the_accredited_body_has_declined_an_allocation
-    @allocation = build(:allocation, :declined, accredited_body: @accredited_body, provider: @training_provider, number_of_places: 0)
-    stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
-      resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
-    )
-    stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@training_provider.provider_code}/show_any" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider]),
-    )
-    stub_api_v2_resource(@allocation)
+  def and_accredited_body_has_previous_allocation_and_has_current_initial_allocation
+    and_accredited_body_has_previous_allocation(current_allocation: initial_allocation)
   end
 
-  def given_the_accredited_body_has_requested_a_repeat_allocation
-    @allocation = build(:allocation, :repeat, accredited_body: @accredited_body, provider: @training_provider, number_of_places: 1)
-    stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
-      resource_list_to_jsonapi([@allocation], include: "provider,accredited_body"),
-    )
-
-    stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@training_provider.provider_code}/show_any" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider]),
-    )
-
-    stub_api_v2_resource(@allocation)
+  def and_accredited_body_has_previous_allocation_and_has_current_repeat_allocation
+    and_accredited_body_has_previous_allocation(current_allocation: repeat_allocation)
   end
 
-  def given_the_accredited_body_has_requested_an_initial_allocation
-    initial_allocation = build(:allocation, :initial, accredited_body: @accredited_body, provider: @training_provider, number_of_places: 1)
-    stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations?include=provider,accredited_body",
-      resource_list_to_jsonapi([initial_allocation], include: "provider,accredited_body"),
-    )
+  def and_accredited_body_has_previous_allocation_and_has_current_declined_allocation
+    and_accredited_body_has_previous_allocation(current_allocation: declined_allocation)
   end
 
   def when_i_visit_my_organisations_page
-    stub_api_v2_resource(@accredited_body)
-    stub_api_v2_resource_collection([build(:access_request)])
+    stub_api_v2_resource(accredited_body)
+    footer_stub_for_access_request_count
 
-    visit provider_path(@accredited_body.provider_code)
-    expect(find("h1")).to have_content(@accredited_body.provider_name.to_s)
+    visit provider_path(accredited_body.provider_code)
+    expect(find("h1")).to have_content(accredited_body.provider_name.to_s)
   end
 
   def next_allocation_cycle_period_text
@@ -306,13 +276,13 @@ private
   def and_i_see_only_repeat_allocation_statuses
     expect(allocations_page).to have_repeat_allocations_table
     expect(allocations_page).to_not have_initial_allocations_table
-    expect(allocations_page.rows.first.provider_name.text).to eq(@training_provider.provider_name)
+    expect(allocations_page.rows.first.provider_name.text).to eq(training_provider.provider_name)
   end
 
   def and_i_see_only_initial_allocation_statuses
     expect(allocations_page).to have_initial_allocations_table
     expect(allocations_page).to_not have_repeat_allocations_table
-    expect(allocations_page.rows.first.provider_name.text).to eq(@training_provider.provider_name)
+    expect(allocations_page.rows.first.provider_name.text).to eq(training_provider.provider_name)
   end
 
   def and_i_do_not_see_request_pe_again_section
@@ -322,49 +292,43 @@ private
   def and_i_see_correct_breadcrumbs
     within(".govuk-breadcrumbs") do
       expect(page).to have_link(
-        @accredited_body.provider_name.to_s,
-        href: "/organisations/#{@accredited_body.provider_code}",
+        accredited_body.provider_name.to_s,
+        href: "/organisations/#{accredited_body.provider_code}",
       )
       expect(page).to have_content("Request PE courses for #{next_allocation_cycle_period_text}")
     end
   end
 
-  def given_a_provider_exists
-    @provider = build(:provider)
-    stub_api_v2_resource(@provider.recruitment_cycle)
-  end
-
   def there_is_no_request_pe_courses_link
-    expect(page).not_to have_link("Request PE courses for 2021 to 2022")
+    expect(page).not_to have_link("Request PE courses")
   end
 
   def when_i_visit_training_providers_page
-    stub_api_v2_resource(@provider)
-    stub_api_v2_resource_collection([build(:access_request)])
+    footer_stub_for_access_request_count
 
-    visit provider_path(@provider.provider_code)
-    expect(find("h1")).to have_content(@provider.provider_name.to_s)
+    visit provider_path(training_provider.provider_code)
+    expect(find("h1")).to have_content(training_provider.provider_name.to_s)
   end
 
-  def and_i_cannot_access_pe_alloacations_page
+  def and_i_cannot_access_pe_allocations_page
     allocations_page.load(
-      provider_code: @provider.provider_code,
-      recruitment_cycle_year: @provider.recruitment_cycle.year,
+      provider_code: training_provider.provider_code,
+      recruitment_cycle_year: current_recruitment_cycle.year,
     )
     expect(page).to have_content("Page not found")
   end
 
   def and_i_cannot_access_accredited_body_pe_allocations_page
-    visit provider_recruitment_cycle_allocations_path(@accredited_body.provider_code, @accredited_body.recruitment_cycle.year)
+    visit provider_recruitment_cycle_allocations_path(accredited_body.provider_code, current_recruitment_cycle.year)
     expect(page).to have_content("You are not permitted to see this page")
   end
 
   def when_i_click_confirm_choice
     stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@training_provider.provider_code}/show_any" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider]),
+      "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/" \
+      "#{training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=#{current_recruitment_cycle.year}",
+      resource_list_to_jsonapi([training_provider]),
     )
 
     click_on "Confirm choice"
@@ -378,15 +342,15 @@ private
     @allocation ||= build(
       :allocation,
       options[:request_type] || :repeat,
-      accredited_body: @accredited_body,
-      provider: @training_provider,
+      accredited_body: accredited_body,
+      provider: training_provider,
       number_of_places: options[:number_of_places] || 3,
     )
   end
 
   def when_i_click_yes
     stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations",
+      "/providers/#{accredited_body.provider_code}/allocations",
       resource_list_to_jsonapi([allocation]),
       :post,
     )
@@ -394,28 +358,20 @@ private
     allocations_new_page.yes.click
   end
 
-  def when_i_click_yes_to_update
-    @returned_allocation = build(:allocation, :repeat, id: @allocation.id, accredited_body: @accredited_body, provider: @training_provider, number_of_places: 1)
-    stub_request(:patch, "http://localhost:3001/api/v2/allocations/#{@allocation.id}")
-      .with(
-        body: {
-          data: {
-            id: @allocation.id,
-            type: "allocations",
-            attributes: { request_type: "repeat" },
-          },
-        }.to_json,
-      ).to_return(
-        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-        body: File.new("spec/fixtures/api_responses/repeat-allocation.json"),
-      )
+  def when_i_click_yes_to_update_declined_allocation
+    update_allocation(allocation_to_update: declined_allocation, request_type: "repeat")
 
     allocations_new_page.yes.click
   end
 
+  def when_i_click_no_to_update_repeat_allocation
+    update_allocation(allocation_to_update: repeat_allocation, request_type: "declined")
+    allocations_new_page.no.click
+  end
+
   def when_i_click_no
     stub_api_v2_request(
-      "/providers/#{@accredited_body.provider_code}/allocations",
+      "/providers/#{accredited_body.provider_code}/allocations",
       resource_list_to_jsonapi([allocation(request_type: :declined, number_of_places: 0)]),
       :post,
     )
@@ -423,35 +379,48 @@ private
     allocations_new_page.no.click
   end
 
-  def when_i_click_no_to_update
-    @returned_allocation = build(:allocation, :declined, id: @allocation.id, accredited_body: @accredited_body, provider: @training_provider, number_of_places: 1)
-    stub_request(:patch, "http://localhost:3001/api/v2/allocations/#{@allocation.id}")
+  def update_allocation(allocation_to_update:, request_type:)
+    allocation_to_update.request_type = request_type
+    stub_request(:patch, "http://localhost:3001/api/v2/allocations/#{allocation_to_update.id}")
       .with(
         body: {
           data: {
-            id: @allocation.id,
+            id: allocation_to_update.id,
             type: "allocations",
-            attributes: { request_type: "declined" },
+            attributes: { request_type: request_type },
           },
         }.to_json,
       ).to_return(
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-        body: File.new("spec/fixtures/api_responses/declined-allocation.json"),
+        body: resource_list_to_jsonapi([allocation_to_update]).to_json,
       )
-
-    allocations_new_page.no.click
   end
 
-  def when_i_click_change
-    stub_api_v2_resource(@allocation, include: "provider,accredited_body")
+  def when_i_click_change_for_the_declined_allocation
+    when_i_click_change(allocation_to_change: declined_allocation)
+  end
+
+  def when_i_click_change_for_the_repeat_allocation
+    when_i_click_change(allocation_to_change: repeat_allocation)
+  end
+
+  def when_i_click_change(allocation_to_change:)
+    stub_api_v2_request(
+      "/recruitment_cycles/#{current_recruitment_cycle.year}/providers/" \
+      "#{training_provider.provider_code}/show_any" \
+      "?recruitment_cycle_year=#{current_recruitment_cycle.year}",
+      resource_list_to_jsonapi([training_provider]),
+    )
+
+    stub_api_v2_resource(allocation_to_change, include: "provider,accredited_body")
 
     click_on "Change"
   end
 
-  def and_i_click_continue_to_modify
+  def and_i_click_continue_to_modify(allocation_to_modify:)
     stub_api_v2_request(
-      "/allocations/#{@returned_allocation.id}",
-      resource_list_to_jsonapi([@returned_allocation]),
+      "/allocations/#{allocation_to_modify.id}",
+      resource_list_to_jsonapi([allocation_to_modify]),
     )
 
     allocations_new_page.continue_button.click
@@ -472,35 +441,5 @@ private
 
   def and_i_see_the_corresponding_page_title(title)
     expect(allocations_show_page.page_heading).to have_content(title)
-  end
-
-  def and_i_click_on_first_view_requested_confirmation
-    stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@training_provider.provider_code}/show_any" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider]),
-    )
-
-    stub_api_v2_request(
-      "/allocations/#{@allocation.id}",
-      resource_list_to_jsonapi([@allocation]),
-    )
-    allocations_page.view_requested_confirmation_links.first.click
-  end
-
-  def and_i_click_on_first_view_not_requested_confirmation
-    stub_api_v2_request(
-      "/recruitment_cycles/#{@accredited_body.recruitment_cycle.year}/providers/" \
-      "#{@training_provider.provider_code}/show_any" \
-      "?recruitment_cycle_year=#{@accredited_body.recruitment_cycle.year}",
-      resource_list_to_jsonapi([@training_provider]),
-    )
-
-    stub_api_v2_request(
-      "/allocations/#{@allocation.id}",
-      resource_list_to_jsonapi([@allocation]),
-    )
-    allocations_page.view_not_requested_confirmation_links.first.click
   end
 end


### PR DESCRIPTION
### Context
Allocations and accredited provider and its training providers
### Changes proposed in this pull request
Previously the list of training providers (for making `repeat` request type) has actual relationship with its training providers. Based on that they are running a PE course for next year as will as they have previously being allocated.

Now the same list will be based solely on previously being allocated.

### Guidance to review
Commits are probably best to view as 2 parts with the first 3 of making the changes and its related tests. The latter 3 as make the changes downstream.

You need to actually spin this up, and use https://github.com/DFE-Digital/teacher-training-api/pull/1972 

Allocations
-  is a closed loop system
- it has a sliding window of time
  - aka `journey mode`
  - it has it own lifecycle from `open`  -> `closed` -> `confirmed`
- it has its own request_type, `initial` (first timer), `repeat` (subsequence), `declined` (dead end)
- it spawns across two allocation cycles, 
  - the `previous` which holds the list of training providers that is encouraged to be used for this `current`
  - the list of training providers (for making `repeat` request type)
    - may not be related to the accredited body due to time preceptive so may not be an existing provider or still an training provider

#### Notes
It is a bit fragile as new allocations can be made with non existing training provider



### Open
#### Before
![image](https://user-images.githubusercontent.com/470137/122292465-eafdba80-ceed-11eb-9549-339db63343a9.png)
#### After
![image](https://user-images.githubusercontent.com/470137/122291844-35326c00-ceed-11eb-969b-854766973507.png)

### Closed
#### Before
![image](https://user-images.githubusercontent.com/470137/122292493-f2bd5f00-ceed-11eb-84ad-d6083a8fbed9.png)


#### After
![image](https://user-images.githubusercontent.com/470137/122291870-3ebbd400-ceed-11eb-8375-40e3856d1bc9.png)

### Confirmed
#### Before
![image](https://user-images.githubusercontent.com/470137/122292531-fbae3080-ceed-11eb-8991-0c834fe7bbff.png)


#### After
![image](https://user-images.githubusercontent.com/470137/122291844-35326c00-ceed-11eb-969b-854766973507.png)

![image](https://user-images.githubusercontent.com/470137/122291898-48453c00-ceed-11eb-8d9c-e74ab0cc5b77.png)



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
