### PR TITLE
Add the structured degree flow

### DIFF
--- a/app/components/degree_preview_component.html.erb
+++ b/app/components/degree_preview_component.html.erb
@@ -1,0 +1,22 @@
+<% if course.degree_section_complete? %>
+  <p class="govuk-body">
+    <%= degree_grade_content(course) %>
+  </p>
+
+  <% if course.degree_subject_requirements %>
+    <p class="govuk-body">
+      <%= course.degree_subject_requirements %>
+    </p>
+  <% end %>
+<% else %>
+  <div class="govuk-inset-text app-inset-text app-inset-text--important">
+    <p class="govuk-body">
+      Please add details <%= govuk_link_to "about degree requirements",
+        degrees_start_provider_recruitment_cycle_course_path(
+          course.provider.provider_code,
+          course.provider.recruitment_cycle_year,
+          course.course_code,
+        ) %>.
+    </p>
+  </div>
+<% end %>

--- a/app/components/degree_preview_component.html.erb
+++ b/app/components/degree_preview_component.html.erb
@@ -3,7 +3,7 @@
     <%= degree_grade_content(course) %>
   </p>
 
-  <% if course.degree_subject_requirements %>
+  <% if course.degree_subject_requirements.present? %>
     <p class="govuk-body">
       <%= course.degree_subject_requirements %>
     </p>

--- a/app/components/degree_preview_component.rb
+++ b/app/components/degree_preview_component.rb
@@ -1,0 +1,22 @@
+class DegreePreviewComponent < ViewComponent::Base
+  attr_reader :course
+
+  def initialize(course:)
+    @course = course
+  end
+
+private
+
+  def degree_grade_content(course)
+    case course.degree_grade
+    when "two_one"
+      "An undergraduate degree at class 2:1 or above, or equivalent."
+    when "two_two"
+      "An undergraduate degree at class 2:2 or above, or equivalent."
+    when "third_class"
+      "An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent."
+    when "not_required"
+      "An undergraduate degree, or equivalent."
+    end
+  end
+end

--- a/app/components/degree_row_content_component.html.erb
+++ b/app/components/degree_row_content_component.html.erb
@@ -1,0 +1,23 @@
+<% if course.degree_section_complete? %>
+  <p class="govuk-summary-list-value govuk-!-margin-top-0">
+    <%= degree_grade_content(course) %>
+  </p>
+
+  <% if course.degree_subject_requirements %>
+    <p class="govuk-summary-list-value">
+      <%= course.degree_subject_requirements %>
+    </p>
+  <% end %>
+<% else %>
+  <%= govuk_inset_text(classes: %w[app-inset-text app-inset-text--important]) do
+        tag.p("Do you require a minimum degree classification?", class: "govuk-heading-s app-inset-text__title") +
+          govuk_link_to(
+            "Enter degree requirements",
+            degrees_start_provider_recruitment_cycle_course_path(
+              course.provider.provider_code,
+              course.recruitment_cycle_year,
+              course.course_code,
+            ),
+          )
+      end %>
+<% end %>

--- a/app/components/degree_row_content_component.html.erb
+++ b/app/components/degree_row_content_component.html.erb
@@ -3,7 +3,7 @@
     <%= degree_grade_content(course) %>
   </p>
 
-  <% if course.degree_subject_requirements %>
+  <% if course.degree_subject_requirements.present? %>
     <p class="govuk-summary-list-value">
       <%= course.degree_subject_requirements %>
     </p>

--- a/app/components/degree_row_content_component.rb
+++ b/app/components/degree_row_content_component.rb
@@ -1,0 +1,22 @@
+class DegreeRowContentComponent < ViewComponent::Base
+  attr_reader :course
+
+  def initialize(course:)
+    @course = course
+  end
+
+private
+
+  def degree_grade_content(course)
+    case course.degree_grade
+    when "two_one"
+      "2:1 or above, or equivalent"
+    when "two_two"
+      "2:2 or above, or equivalent"
+    when "third_class"
+      "Third class degree or above, or equivalent"
+    when "not_required"
+      "An undergraduate degree, or equivalent"
+    end
+  end
+end

--- a/app/controllers/courses/degrees/base_controller.rb
+++ b/app/controllers/courses/degrees/base_controller.rb
@@ -2,7 +2,7 @@ module Courses
   module Degrees
     class BaseController < ApplicationController
       decorates_assigned :course
-      before_action :build_course, :redirect_to_basic_details_page_if_provider_is_not_in_the_22_cycle_or_higher
+      before_action :build_course, :redirect_to_basic_details_page_if_provider_is_not_in_the_2022_cycle_or_higher
 
     private
 
@@ -15,8 +15,8 @@ module Courses
           .first
       end
 
-      def redirect_to_basic_details_page_if_provider_is_not_in_the_22_cycle_or_higher
-        redirect_to provider_recruitment_cycle_course_path unless @course.provider.recruitment_cycle_year.to_i >= 2022
+      def redirect_to_basic_details_page_if_provider_is_not_in_the_2022_cycle_or_higher
+        redirect_to provider_recruitment_cycle_course_path unless @course.provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE
       end
     end
   end

--- a/app/controllers/courses/degrees/base_controller.rb
+++ b/app/controllers/courses/degrees/base_controller.rb
@@ -1,0 +1,23 @@
+module Courses
+  module Degrees
+    class BaseController < ApplicationController
+      decorates_assigned :course
+      before_action :build_course, :redirect_to_basic_details_page_if_provider_is_not_in_the_22_cycle_or_higher
+
+    private
+
+      def build_course
+        @course = Course
+          .includes(:provider)
+          .where(recruitment_cycle_year: params[:recruitment_cycle_year])
+          .where(provider_code: params[:provider_code])
+          .find(params[:code])
+          .first
+      end
+
+      def redirect_to_basic_details_page_if_provider_is_not_in_the_22_cycle_or_higher
+        redirect_to provider_recruitment_cycle_course_path unless @course.provider.recruitment_cycle_year.to_i >= 2022
+      end
+    end
+  end
+end

--- a/app/controllers/courses/degrees/grade_controller.rb
+++ b/app/controllers/courses/degrees/grade_controller.rb
@@ -8,7 +8,7 @@ module Courses
       def update
         @grade_form = GradeForm.new(grade: grade_params)
 
-        if @course.level == "primary" && @grade_form.save(@course)
+        if @course.is_primary? && @grade_form.save(@course)
           redirect_to provider_recruitment_cycle_course_path
         elsif @grade_form.save(@course)
           redirect_to degrees_subject_requirements_provider_recruitment_cycle_course_path

--- a/app/controllers/courses/degrees/grade_controller.rb
+++ b/app/controllers/courses/degrees/grade_controller.rb
@@ -1,0 +1,28 @@
+module Courses
+  module Degrees
+    class GradeController < BaseController
+      def edit
+        @grade_form = GradeForm.build_from_course(@course)
+      end
+
+      def update
+        @grade_form = GradeForm.new(grade: grade_params)
+
+        if @course.level == "primary" && @grade_form.save(@course)
+          redirect_to provider_recruitment_cycle_course_path
+        elsif @grade_form.save(@course)
+          redirect_to degrees_subject_requirements_provider_recruitment_cycle_course_path
+        else
+          @errors = @grade_form.errors.messages
+          render :edit
+        end
+      end
+
+    private
+
+      def grade_params
+        params.dig(:courses_degrees_grade_form, :grade)
+      end
+    end
+  end
+end

--- a/app/controllers/courses/degrees/start_controller.rb
+++ b/app/controllers/courses/degrees/start_controller.rb
@@ -1,0 +1,31 @@
+module Courses
+  module Degrees
+    class StartController < BaseController
+      def edit
+        @start_form = StartForm.new
+        @start_form.set_attributes(@course)
+      end
+
+      def update
+        @start_form = StartForm.new(degree_grade_required: grade_required_params)
+
+        if @start_form.save(@course) && @course.level == "primary"
+          redirect_to provider_recruitment_cycle_course_path
+        elsif @start_form.save(@course)
+          redirect_to degrees_subject_requirements_provider_recruitment_cycle_course_path
+        elsif @start_form.degree_grade_required.present?
+          redirect_to degrees_grade_provider_recruitment_cycle_course_path
+        else
+          @errors = @start_form.errors.messages
+          render :edit
+        end
+      end
+
+    private
+
+      def grade_required_params
+        params.dig(:courses_degrees_start_form, :degree_grade_required)
+      end
+    end
+  end
+end

--- a/app/controllers/courses/degrees/start_controller.rb
+++ b/app/controllers/courses/degrees/start_controller.rb
@@ -9,7 +9,7 @@ module Courses
       def update
         @start_form = StartForm.new(degree_grade_required: grade_required_params)
 
-        if @start_form.save(@course) && @course.level == "primary"
+        if @course.is_primary? && @start_form.save(@course)
           redirect_to provider_recruitment_cycle_course_path
         elsif @start_form.save(@course)
           redirect_to degrees_subject_requirements_provider_recruitment_cycle_course_path

--- a/app/controllers/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/courses/degrees/subject_requirements_controller.rb
@@ -39,7 +39,7 @@ module Courses
       end
 
       def redirect_to_course_details_page_if_course_is_primary
-        redirect_to provider_recruitment_cycle_course_path if @course.level == "primary"
+        redirect_to provider_recruitment_cycle_course_path if @course.is_primary?
       end
     end
   end

--- a/app/controllers/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/courses/degrees/subject_requirements_controller.rb
@@ -1,0 +1,46 @@
+module Courses
+  module Degrees
+    class SubjectRequirementsController < BaseController
+      before_action :redirect_to_course_details_page_if_course_is_primary
+
+      def edit
+        set_backlink
+        @subject_requirements_form = SubjectRequirementsForm.build_from_course(@course)
+      end
+
+      def update
+        @subject_requirements_form = SubjectRequirementsForm.new(subject_requirements_params)
+
+        if @subject_requirements_form.save(@course)
+          flash[:success] = "Your changes have been saved"
+
+          redirect_to provider_recruitment_cycle_course_path
+        else
+          set_backlink
+          @errors = @subject_requirements_form.errors.messages
+          render :edit
+        end
+      end
+
+    private
+
+      def subject_requirements_params
+        params
+          .require(:courses_degrees_subject_requirements_form)
+          .permit(:additional_degree_subject_requirements, :degree_subject_requirements)
+      end
+
+      def set_backlink
+        @backlink = if @course.degree_grade == "not_required"
+                      degrees_start_provider_recruitment_cycle_course_path
+                    else
+                      degrees_grade_provider_recruitment_cycle_course_path
+                    end
+      end
+
+      def redirect_to_course_details_page_if_course_is_primary
+        redirect_to provider_recruitment_cycle_course_path if @course.level == "primary"
+      end
+    end
+  end
+end

--- a/app/form_objects/courses/degrees/grade_form.rb
+++ b/app/form_objects/courses/degrees/grade_form.rb
@@ -1,0 +1,21 @@
+module Courses
+  module Degrees
+    class GradeForm
+      include ActiveModel::Model
+
+      attr_accessor :grade
+
+      validates :grade, presence: { message: "Select the minimum degree classification you require" }
+
+      def save(course)
+        return false unless valid?
+
+        course.update(degree_grade: grade)
+      end
+
+      def self.build_from_course(course)
+        new(grade: course.degree_grade)
+      end
+    end
+  end
+end

--- a/app/form_objects/courses/degrees/start_form.rb
+++ b/app/form_objects/courses/degrees/start_form.rb
@@ -1,0 +1,42 @@
+module Courses
+  module Degrees
+    class StartForm
+      include ActiveModel::Model
+      include ActiveModel::Validations::Callbacks
+
+      attr_accessor :degree_grade_required
+
+      before_validation :cast_degree_grade_required
+
+      validates :degree_grade_required, inclusion: { in: [true, false], message: "Select if you require a minimum degree classification" }
+
+      def save(course)
+        return false unless valid? && degree_grade_required_is_false?
+
+        course.update(degree_grade: "not_required")
+      end
+
+      def set_attributes(course)
+        self.degree_grade_required = set_degree_grade_required(course)
+      end
+
+    private
+
+      def cast_degree_grade_required
+        self.degree_grade_required = ActiveModel::Type::Boolean.new.cast(degree_grade_required)
+      end
+
+      def degree_grade_required_is_false?
+        degree_grade_required == false
+      end
+
+      def set_degree_grade_required(course)
+        if course.degree_grade == "not_required"
+          false
+        elsif course.degree_grade.present?
+          true
+        end
+      end
+    end
+  end
+end

--- a/app/form_objects/courses/degrees/subject_requirements_form.rb
+++ b/app/form_objects/courses/degrees/subject_requirements_form.rb
@@ -8,8 +8,8 @@ module Courses
 
       before_validation :cast_additional_degree_subject_requirements
 
-      validates :additional_degree_subject_requirements, inclusion: { in: [true, false], message: "Select if you have any additional degree subject requirements" }
-      validates :degree_subject_requirements, presence: { message: "What are the degree subject requirements?" }, if: -> { additional_degree_subject_requirements }
+      validates :additional_degree_subject_requirements, inclusion: { in: [true, false], message: "Select if you have degree subject requirements" }
+      validates :degree_subject_requirements, presence: { message: "Enter details of degree subject requirements" }, if: -> { additional_degree_subject_requirements }
 
       def save(course)
         return false unless valid?

--- a/app/form_objects/courses/degrees/subject_requirements_form.rb
+++ b/app/form_objects/courses/degrees/subject_requirements_form.rb
@@ -1,0 +1,37 @@
+module Courses
+  module Degrees
+    class SubjectRequirementsForm
+      include ActiveModel::Model
+      include ActiveModel::Validations::Callbacks
+
+      attr_accessor :additional_degree_subject_requirements, :degree_subject_requirements
+
+      before_validation :cast_additional_degree_subject_requirements
+
+      validates :additional_degree_subject_requirements, inclusion: { in: [true, false], message: "Select if you have any additional degree subject requirements" }
+      validates :degree_subject_requirements, presence: { message: "What are the degree subject requirements?" }, if: -> { additional_degree_subject_requirements }
+
+      def save(course)
+        return false unless valid?
+
+        course.update(
+          additional_degree_subject_requirements: additional_degree_subject_requirements,
+          degree_subject_requirements: additional_degree_subject_requirements.present? ? degree_subject_requirements : nil,
+        )
+      end
+
+      def self.build_from_course(course)
+        new(
+          additional_degree_subject_requirements: course.additional_degree_subject_requirements,
+          degree_subject_requirements: course.degree_subject_requirements,
+        )
+      end
+
+    private
+
+      def cast_additional_degree_subject_requirements
+        self.additional_degree_subject_requirements = ActiveModel::Type::Boolean.new.cast(additional_degree_subject_requirements)
+      end
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,6 +11,9 @@ class Course < Base
   property :english, type: :string
   property :science, type: :string
   property :name, type: :string
+  property :degree_grade, type: :string
+  property :additional_degree_subject_requirements, type: :boolean
+  property :degree_subject_requirements, type: :string
 
   delegate :provider_type, to: :provider
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -133,6 +133,10 @@ class Course < Base
     degree_grade.present?
   end
 
+  def is_primary?
+    level == "primary"
+  end
+
 private
 
   def post_base_url

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -129,6 +129,10 @@ class Course < Base
     travel_to_work_areas.to_sentence(last_word_connector: " and ")
   end
 
+  def degree_section_complete?
+    degree_grade.present?
+  end
+
 private
 
   def post_base_url

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -11,6 +11,8 @@ class Provider < Base
 
   custom_endpoint :show_any, on: :member, request_method: :get
 
+  CHANGES_INTRODUCED_IN_2022_CYCLE = 2022
+
   def publish
     post_request("/publish")
   end

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -34,7 +34,18 @@
 <h3 class="govuk-heading-m govuk-!-font-size-27">
   <%= govuk_link_to "Requirements and eligibility", requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
 </h3>
+
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
+  <% if @provider.recruitment_cycle_year.to_i >= 2022 %>
+     <% summary_list.slot(:row, enrichment_summary(
+       :course,
+       "Degree",
+       (render DegreeRowContentComponent.new(course: course)),
+       %w[degree_grade degree_subject_requirements],
+       truncate_value: false,
+       change_link: course.degree_section_complete? ? degrees_start_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+     )) %>
+  <% end %>
   <% summary_list.slot(:row, enrichment_summary(:course, "Qualifications needed", course.required_qualifications, %w[required_qualifications])) %>
   <% summary_list.slot(:row, enrichment_summary(:course, "Personal qualities (optional)", course.personal_qualities, %w[personal_qualities])) %>
   <% summary_list.slot(:row, enrichment_summary(:course, "Other requirements (optional)", course.other_requirements, %w[other_requirements])) %>

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -31,12 +31,12 @@
   <% end %>
 <% end %>
 
-<h3 class="govuk-heading-m govuk-!-font-size-27">
+<h3 class="govuk-heading-m">
   <%= govuk_link_to "Requirements and eligibility", requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
 </h3>
 
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
-  <% if @provider.recruitment_cycle_year.to_i >= 2022 %>
+  <% if @provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
      <% summary_list.slot(:row, enrichment_summary(
        :course,
        "Degree",

--- a/app/views/courses/degrees/grade/edit.html.erb
+++ b/app/views/courses/degrees/grade/edit.html.erb
@@ -1,10 +1,8 @@
-<%= content_for :page_title, "What is the minimum degree classification you require?" %>
+<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}What is the minimum degree classification you require?" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to degrees_start_provider_recruitment_cycle_course_path %>
 <% end %>
-
-<%= render "shared/errors" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -16,16 +14,15 @@
                   method: :put,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
-      <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+      <%= form.govuk_error_summary %>
 
-      <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: "What is the minimum degree classification you require?", tag: "h1", class: "govuk-heading-xl govuk-!-margin-bottom-2" } do %>
-
+      <%= form.govuk_radio_buttons_fieldset :grade, caption: { text: course.name_and_code, size: "l" }, legend: { text: "What is the minimum degree classification you require?", tag: "h1", size: "l" } do %>
         <%= form.govuk_radio_button :grade, "two_one", label: { text: "2:1 or above (or equivalent)" }, data: { qa: "degree_grade__two_one" }, link_errors: true %>
         <%= form.govuk_radio_button :grade, "two_two", label: { text: "2:2 or above (or equivalent)" }, data: { qa: "degree_grade__two_two" } %>
         <%= form.govuk_radio_button :grade, "third", label: { text: "Third or above (or equivalent)" }, data: { qa: "degree_grade__third_class" } %>
       <% end %>
 
-      <%= form.submit "Save", class: "govuk-button", data: { qa: "degree_grade__save" } %>
+      <%= form.govuk_submit "Save", data: { qa: "degree_grade__save" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/degrees/grade/edit.html.erb
+++ b/app/views/courses/degrees/grade/edit.html.erb
@@ -1,0 +1,31 @@
+<%= content_for :page_title, "What is the minimum degree classification you require?" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to degrees_start_provider_recruitment_cycle_course_path %>
+<% end %>
+
+<%= render "shared/errors" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @grade_form, url: degrees_grade_provider_recruitment_cycle_course_path(
+                    @course.provider.provider_code,
+                    @course.provider.recruitment_cycle_year,
+                    @course.course_code,
+                  ),
+                  method: :put,
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+
+      <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+
+      <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: "What is the minimum degree classification you require?", tag: "h1", class: "govuk-heading-xl govuk-!-margin-bottom-2" } do %>
+
+        <%= form.govuk_radio_button :grade, "two_one", label: { text: "2:1 or above (or equivalent)" }, data: { qa: "degree_grade__two_one" }, link_errors: true %>
+        <%= form.govuk_radio_button :grade, "two_two", label: { text: "2:2 or above (or equivalent)" }, data: { qa: "degree_grade__two_two" } %>
+        <%= form.govuk_radio_button :grade, "third", label: { text: "Third or above (or equivalent)" }, data: { qa: "degree_grade__third_class" } %>
+      <% end %>
+
+      <%= form.submit "Save", class: "govuk-button", data: { qa: "degree_grade__save" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/degrees/start/edit.html.erb
+++ b/app/views/courses/degrees/start/edit.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :page_title, "Do you require a minimum degree classification?" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to provider_recruitment_cycle_course_path %>
+<% end %>
+
+<%= render "shared/errors" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+      <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+      Do you require a minimum degree classification?
+    </h1>
+
+    <%= form_with model: @start_form, url: degrees_start_provider_recruitment_cycle_course_path(
+                    @course.provider.provider_code,
+                    @course.provider.recruitment_cycle_year,
+                    @course.course_code,
+                  ),
+                  method: :put,
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+
+      <%= form.govuk_radio_buttons_fieldset :degree_grade_required, legend: { text: "If you specify a minimum (for example, 2:1), candidates will be discouraged but not blocked from applying if they do not meet this level.", size: "m", class: "govuk-hint" } do %>
+        <%= form.govuk_radio_button :degree_grade_required, true, label: { text: "Yes" }, data: { qa: "start__yes_radio" }, link_errors: true %>
+        <%= form.govuk_radio_button :degree_grade_required, false, label: { text: "No" }, data: { qa: "start__no_radio" } %>
+      <% end %>
+
+      <%= form.submit "Save", class: "govuk-button", data: { qa: "start__save" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/degrees/start/edit.html.erb
+++ b/app/views/courses/degrees/start/edit.html.erb
@@ -1,18 +1,11 @@
-<%= content_for :page_title, "Do you require a minimum degree classification?" %>
+<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}Do you require a minimum degree classification?" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to provider_recruitment_cycle_course_path %>
 <% end %>
 
-<%= render "shared/errors" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-      <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-      Do you require a minimum degree classification?
-    </h1>
-
     <%= form_with model: @start_form, url: degrees_start_provider_recruitment_cycle_course_path(
                     @course.provider.provider_code,
                     @course.provider.recruitment_cycle_year,
@@ -21,12 +14,19 @@
                   method: :put,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
+      <%= form.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+        <span class="govuk-caption-l"><%= course.name_and_code %></span>
+        Do you require a minimum degree classification?
+      </h1>
+
       <%= form.govuk_radio_buttons_fieldset :degree_grade_required, legend: { text: "If you specify a minimum (for example, 2:1), candidates will be discouraged but not blocked from applying if they do not meet this level.", size: "m", class: "govuk-hint" } do %>
         <%= form.govuk_radio_button :degree_grade_required, true, label: { text: "Yes" }, data: { qa: "start__yes_radio" }, link_errors: true %>
         <%= form.govuk_radio_button :degree_grade_required, false, label: { text: "No" }, data: { qa: "start__no_radio" } %>
       <% end %>
 
-      <%= form.submit "Save", class: "govuk-button", data: { qa: "start__save" } %>
+      <%= form.govuk_submit "Save", data: { qa: "start__save" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/degrees/subject_requirements/edit.html.erb
+++ b/app/views/courses/degrees/subject_requirements/edit.html.erb
@@ -1,0 +1,36 @@
+<%= content_for :page_title, "Degree subject" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to @backlink %>
+<% end %>
+
+<%= render "shared/errors" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+      <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+      Degree subject
+    </h1>
+
+    <p class="govuk-body">Candidates will be advised that their degree subject should match or be closely related to Primary.</p>
+
+    <%= form_with model: @subject_requirements_form, url: degrees_subject_requirements_provider_recruitment_cycle_course_path(
+                    @course.provider.provider_code,
+                    @course.provider.recruitment_cycle_year,
+                    @course.course_code,
+                  ),
+                  method: :put,
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+
+      <%= form.govuk_radio_buttons_fieldset :additional_degree_subject_requirements, legend: { text: "Do you have any additional degree subject requirements?" } do %>
+        <%= form.govuk_radio_button :additional_degree_subject_requirements, false, label: { text: "No" }, data: { qa: "degree_subject_requirements__no_radio" }, link_errors: true %>
+        <%= form.govuk_radio_button :additional_degree_subject_requirements, true, label: { text: "Yes" }, data: { qa: "degree_subject_requirements__yes_radio" } do %>
+          <%= form.govuk_text_area :degree_subject_requirements, label: { text: "Degree subject requirements" }, data: { qa: "degree_subject_requirements__requirements" } %>
+        <% end %>
+      <% end %>
+
+      <%= form.submit "Save", class: "govuk-button", data: { qa: "degree_subject_requirements__save" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/degrees/subject_requirements/edit.html.erb
+++ b/app/views/courses/degrees/subject_requirements/edit.html.erb
@@ -1,20 +1,11 @@
-<%= content_for :page_title, "Degree subject" %>
+<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}Degree subject" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to @backlink %>
 <% end %>
 
-<%= render "shared/errors" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-      <span class="govuk-caption-xl"><%= course.name_and_code %></span>
-      Degree subject
-    </h1>
-
-    <p class="govuk-body">Candidates will be advised that their degree subject should match or be closely related to Primary.</p>
-
     <%= form_with model: @subject_requirements_form, url: degrees_subject_requirements_provider_recruitment_cycle_course_path(
                     @course.provider.provider_code,
                     @course.provider.recruitment_cycle_year,
@@ -23,6 +14,15 @@
                   method: :put,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
+      <%= form.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= course.name_and_code %></span>
+        Degree subject
+      </h1>
+
+      <p class="govuk-body">Candidates will be advised that their degree subject should match or be closely related to <%= course.name %>.</p>
+
       <%= form.govuk_radio_buttons_fieldset :additional_degree_subject_requirements, legend: { text: "Do you have any additional degree subject requirements?" } do %>
         <%= form.govuk_radio_button :additional_degree_subject_requirements, false, label: { text: "No" }, data: { qa: "degree_subject_requirements__no_radio" }, link_errors: true %>
         <%= form.govuk_radio_button :additional_degree_subject_requirements, true, label: { text: "Yes" }, data: { qa: "degree_subject_requirements__yes_radio" } do %>
@@ -30,7 +30,7 @@
         <% end %>
       <% end %>
 
-      <%= form.submit "Save", class: "govuk-button", data: { qa: "degree_subject_requirements__save" } %>
+      <%= form.govuk_submit "Save", data: { qa: "degree_subject_requirements__save" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/preview/_entry_requirements_qualifications.html.erb
+++ b/app/views/courses/preview/_entry_requirements_qualifications.html.erb
@@ -1,6 +1,5 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-entry">Requirements</h2>
-
   <% if course.required_qualifications.present? %>
     <aside class="app-advice">
       <h3 class="app-advice__title">
@@ -13,9 +12,13 @@
     </aside>
 
     <h3 class="govuk-heading-m">Qualifications needed</h3>
-    <div data-qa="course__required_qualifications">
-      <%= markdown(course.required_qualifications) %>
-    </div>
+    <% if course.provider.recruitment_cycle_year.to_i >= 2022 %>
+      <%= render DegreePreviewComponent.new(course: course) %>
+    <% else %>
+      <div data-qa="course__required_qualifications">
+        <%= markdown(course.required_qualifications) %>
+      </div>
+    <% end %>
   <% else %>
     <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
       <p class="govuk-body">Please add details for this section.</p>

--- a/app/views/courses/preview/_entry_requirements_qualifications.html.erb
+++ b/app/views/courses/preview/_entry_requirements_qualifications.html.erb
@@ -12,7 +12,7 @@
     </aside>
 
     <h3 class="govuk-heading-m">Qualifications needed</h3>
-    <% if course.provider.recruitment_cycle_year.to_i >= 2022 %>
+    <% if course.provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
       <%= render DegreePreviewComponent.new(course: course) %>
     <% else %>
       <div data-qa="course__required_qualifications">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -11,12 +11,21 @@
         <% @errors.each do |id, messages| %>
           <% messages.each do |message| %>
             <li data-error-message="<%= message %>">
-              <a href="<%= enrichment_error_url(
-                provider_code: @provider.provider_code,
-                course: @course,
-                field: id,
-                message: message,
-              ) %>"><%= message %></a>
+              <% if message == 'You must say whether you have additional degree requirements' %>
+                <a href="<%= degrees_start_provider_recruitment_cycle_course_path(
+                  provider_code: @provider.provider_code,
+                  recruitment_cycle_year: @provider.recruitment_cycle_year,
+                  course_code: @course.course_code,
+                  field: id,
+                ) %>"><%= message %></a>
+              <% else %>
+                <a href="<%= enrichment_error_url(
+                  provider_code: @provider.provider_code,
+                  course: @course,
+                  field: id,
+                  message: message,
+                ) %>"><%= message %></a>
+              <% end %>
             </li>
           <% end %>
         <% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -11,21 +11,12 @@
         <% @errors.each do |id, messages| %>
           <% messages.each do |message| %>
             <li data-error-message="<%= message %>">
-              <% if message == 'You must say whether you have additional degree requirements' %>
-                <a href="<%= degrees_start_provider_recruitment_cycle_course_path(
-                  provider_code: @provider.provider_code,
-                  recruitment_cycle_year: @provider.recruitment_cycle_year,
-                  course_code: @course.course_code,
-                  field: id,
-                ) %>"><%= message %></a>
-              <% else %>
-                <a href="<%= enrichment_error_url(
-                  provider_code: @provider.provider_code,
-                  course: @course,
-                  field: id,
-                  message: message,
-                ) %>"><%= message %></a>
-              <% end %>
+              <a href="<%= enrichment_error_url(
+                provider_code: @provider.provider_code,
+                course: @course,
+                field: id,
+                message: message,
+              ) %>"><%= message %></a>
             </li>
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,15 @@ Rails.application.routes.draw do
         put "/full-part-time", on: :member, to: "courses/study_mode#update"
 
         get "/request-change", on: :member, to: "courses#request_change"
+
+        get "/degrees/start", on: :member, to: "courses/degrees/start#edit"
+        put "/degrees/start", on: :member, to: "courses/degrees/start#update"
+
+        get "/degrees/grade", on: :member, to: "courses/degrees/grade#edit"
+        put "/degrees/grade", on: :member, to: "courses/degrees/grade#update"
+
+        get "/degrees/subject-requirements", on: :member, to: "courses/degrees/subject_requirements#edit"
+        put "/degrees/subject-requirements", on: :member, to: "courses/degrees/subject_requirements#update"
       end
 
       resources :sites, path: "locations", on: :member, except: %i[destroy show]

--- a/spec/components/degree_preview_component_spec.rb
+++ b/spec/components/degree_preview_component_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe DegreePreviewComponent, type: :component do
+  context "when the degree section is incomplete" do
+    it "renders a link to the degree section" do
+      recruitment_cycle = build(:recruitment_cycle)
+      provider = build(:provider, recruitment_cycle: recruitment_cycle)
+      course = build(
+        :course,
+        provider: provider,
+        degree_grade: nil,
+      )
+
+      render_inline(described_class.new(course: course))
+
+      expect(page).to have_link(
+        "about degree requirements",
+        href: Rails.application.routes.url_helpers.degrees_start_provider_recruitment_cycle_course_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year,
+          course.course_code,
+        ),
+      )
+    end
+  end
+
+  context "when the degree section is complete" do
+    context "when degree type is 'two_one'" do
+      it "renders 'An undergraduate degree at class 2:1 or above, or equivalent.'" do
+        course = build(
+          :course,
+          degree_grade: "two_one",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("An undergraduate degree at class 2:1 or above, or equivalent.")
+      end
+    end
+
+    context "when degree type is 'two_two'" do
+      it "renders 'An undergraduate degree at class 2:2 or above, or equivalent.'" do
+        course = build(
+          :course,
+          degree_grade: "two_two",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("An undergraduate degree at class 2:2 or above, or equivalent.")
+      end
+    end
+
+    context "when degree type is 'third_class'" do
+      it "renders 'An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.'" do
+        course = build(
+          :course,
+          degree_grade: "third_class",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.")
+      end
+    end
+
+    context "when degree type is 'not_required'" do
+      it "An undergraduate degree, or equivalent.'" do
+        course = build(
+          :course,
+          degree_grade: "not_required",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("An undergraduate degree, or equivalent")
+      end
+    end
+
+    context "when degree_subject_requirements and a degree grade are present" do
+      it "renders the correct content for both attributes" do
+        course = build(
+          :course,
+          degree_grade: "two_one",
+          degree_subject_requirements: "Maths A level.",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("An undergraduate degree at class 2:1 or above, or equivalent.")
+        expect(page).to have_content("Maths A level.")
+      end
+    end
+  end
+end

--- a/spec/components/degree_preview_component_spec.rb
+++ b/spec/components/degree_preview_component_spec.rb
@@ -1,19 +1,26 @@
 require "rails_helper"
 
 RSpec.describe DegreePreviewComponent, type: :component do
+  let(:recruitment_cycle) { build(:recruitment_cycle) }
+  let(:provider) { build(:provider, recruitment_cycle: recruitment_cycle) }
+  let(:course) do
+    build(
+      :course,
+      provider: provider,
+      degree_grade: degree_grade,
+      degree_subject_requirements: "Maths A level.",
+    )
+  end
+
+  before do
+    render_inline(described_class.new(course: course))
+  end
+
   context "when the degree section is incomplete" do
+    let(:degree_grade) { nil }
+
     it "renders a link to the degree section" do
-      recruitment_cycle = build(:recruitment_cycle)
-      provider = build(:provider, recruitment_cycle: recruitment_cycle)
-      course = build(
-        :course,
-        provider: provider,
-        degree_grade: nil,
-      )
-
-      render_inline(described_class.new(course: course))
-
-      expect(page).to have_link(
+      expect(rendered_component).to have_link(
         "about degree requirements",
         href: Rails.application.routes.url_helpers.degrees_start_provider_recruitment_cycle_course_path(
           provider.provider_code,
@@ -26,69 +33,43 @@ RSpec.describe DegreePreviewComponent, type: :component do
 
   context "when the degree section is complete" do
     context "when degree type is 'two_one'" do
+      let(:degree_grade) { "two_one" }
+
       it "renders 'An undergraduate degree at class 2:1 or above, or equivalent.'" do
-        course = build(
-          :course,
-          degree_grade: "two_one",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("An undergraduate degree at class 2:1 or above, or equivalent.")
+        expect(rendered_component).to have_content("An undergraduate degree at class 2:1 or above, or equivalent.")
       end
     end
 
     context "when degree type is 'two_two'" do
+      let(:degree_grade) { "two_two" }
+
       it "renders 'An undergraduate degree at class 2:2 or above, or equivalent.'" do
-        course = build(
-          :course,
-          degree_grade: "two_two",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("An undergraduate degree at class 2:2 or above, or equivalent.")
+        expect(rendered_component).to have_content("An undergraduate degree at class 2:2 or above, or equivalent.")
       end
     end
 
     context "when degree type is 'third_class'" do
+      let(:degree_grade) { "third_class" }
+
       it "renders 'An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.'" do
-        course = build(
-          :course,
-          degree_grade: "third_class",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.")
+        expect(rendered_component).to have_content("An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.")
       end
     end
 
     context "when degree type is 'not_required'" do
+      let(:degree_grade) { "not_required" }
+
       it "An undergraduate degree, or equivalent.'" do
-        course = build(
-          :course,
-          degree_grade: "not_required",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("An undergraduate degree, or equivalent")
+        expect(rendered_component).to have_content("An undergraduate degree, or equivalent")
       end
     end
 
     context "when degree_subject_requirements and a degree grade are present" do
+      let(:degree_grade) { "two_one" }
+
       it "renders the correct content for both attributes" do
-        course = build(
-          :course,
-          degree_grade: "two_one",
-          degree_subject_requirements: "Maths A level.",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("An undergraduate degree at class 2:1 or above, or equivalent.")
-        expect(page).to have_content("Maths A level.")
+        expect(rendered_component).to have_content("An undergraduate degree at class 2:1 or above, or equivalent.")
+        expect(rendered_component).to have_content("Maths A level.")
       end
     end
   end

--- a/spec/components/degree_row_content_component_spec.rb
+++ b/spec/components/degree_row_content_component_spec.rb
@@ -1,20 +1,26 @@
 require "rails_helper"
 
 RSpec.describe DegreeRowContentComponent, type: :component do
+  let(:recruitment_cycle) { build(:recruitment_cycle) }
+  let(:provider) { build(:provider, recruitment_cycle: recruitment_cycle) }
+  let(:course) do
+    build(
+      :course,
+      provider: provider,
+      degree_grade: degree_grade,
+      degree_subject_requirements: "Maths A level.",
+    )
+  end
+
+  before do
+    render_inline(described_class.new(course: course))
+  end
+
   context "when the degree section is incomplete" do
+    let(:degree_grade) { nil }
+
     it "renders a link to the degree section" do
-      recruitment_cycle = build(:recruitment_cycle)
-      provider = build(:provider, recruitment_cycle: recruitment_cycle)
-      course = build(
-        :course,
-        provider: provider,
-        degree_grade: nil,
-        degree_subject_requirement: nil,
-      )
-
-      render_inline(described_class.new(course: course))
-
-      expect(page).to have_link(
+      expect(rendered_component).to have_link(
         "Enter degree requirements",
         href: Rails.application.routes.url_helpers.degrees_start_provider_recruitment_cycle_course_path(
           provider.provider_code,
@@ -27,82 +33,43 @@ RSpec.describe DegreeRowContentComponent, type: :component do
 
   context "when the degree section is complete" do
     context "when degree type is 'two_one'" do
+      let(:degree_grade) { "two_one" }
+
       it "renders '2:1 or above, or equivalent'" do
-        course = build(
-          :course,
-          degree_grade: "two_one",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("2:1 or above, or equivalent")
+        expect(rendered_component).to have_content("2:1 or above, or equivalent")
       end
     end
 
     context "when degree type is 'two_two'" do
+      let(:degree_grade) { "two_two" }
+
       it "renders '2:2 or above, or equivalent'" do
-        course = build(
-          :course,
-          degree_grade: "two_two",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("2:2 or above, or equivalent")
-      end
-    end
-
-    context "when degree type is 'two_one'" do
-      it "renders '2:1 or above, or equivalent'" do
-        course = build(
-          :course,
-          degree_grade: "two_one",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("2:1 or above, or equivalent")
+        expect(rendered_component).to have_content("2:2 or above, or equivalent")
       end
     end
 
     context "when degree type is 'third_class'" do
+      let(:degree_grade) { "third_class" }
+
       it "renders 'Third class degree or above, or equivalent'" do
-        course = build(
-          :course,
-          degree_grade: "third_class",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("Third class degree or above, or equivalent")
+        expect(rendered_component).to have_content("Third class degree or above, or equivalent")
       end
     end
 
     context "when degree type is 'not_required'" do
+      let(:degree_grade) { "not_required" }
+
       it "renders 'Third class degree or above, or equivalent'" do
-        course = build(
-          :course,
-          degree_grade: "not_required",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("An undergraduate degree, or equivalent")
+        expect(rendered_component).to have_content("An undergraduate degree, or equivalent")
       end
     end
 
     context "when degree_subject_requirements and a degree grade are present" do
+      let(:degree_grade) { "two_one" }
+
       it "renders the correct content for both attributes" do
-        course = build(
-          :course,
-          degree_grade: "two_one",
-          degree_subject_requirements: "Maths A level.",
-        )
-
-        render_inline(described_class.new(course: course))
-
-        expect(page).to have_content("2:1 or above, or equivalent")
-        expect(page).to have_content("Maths A level.")
+        expect(rendered_component).to have_content("2:1 or above, or equivalent")
+        expect(rendered_component).to have_content("Maths A level.")
       end
     end
   end

--- a/spec/components/degree_row_content_component_spec.rb
+++ b/spec/components/degree_row_content_component_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe DegreeRowContentComponent, type: :component do
+  context "when the degree section is incomplete" do
+    it "renders a link to the degree section" do
+      recruitment_cycle = build(:recruitment_cycle)
+      provider = build(:provider, recruitment_cycle: recruitment_cycle)
+      course = build(
+        :course,
+        provider: provider,
+        degree_grade: nil,
+        degree_subject_requirement: nil,
+      )
+
+      render_inline(described_class.new(course: course))
+
+      expect(page).to have_link(
+        "Enter degree requirements",
+        href: Rails.application.routes.url_helpers.degrees_start_provider_recruitment_cycle_course_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year,
+          course.course_code,
+        ),
+      )
+    end
+  end
+
+  context "when the degree section is complete" do
+    context "when degree type is 'two_one'" do
+      it "renders '2:1 or above, or equivalent'" do
+        course = build(
+          :course,
+          degree_grade: "two_one",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("2:1 or above, or equivalent")
+      end
+    end
+
+    context "when degree type is 'two_two'" do
+      it "renders '2:2 or above, or equivalent'" do
+        course = build(
+          :course,
+          degree_grade: "two_two",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("2:2 or above, or equivalent")
+      end
+    end
+
+    context "when degree type is 'two_one'" do
+      it "renders '2:1 or above, or equivalent'" do
+        course = build(
+          :course,
+          degree_grade: "two_one",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("2:1 or above, or equivalent")
+      end
+    end
+
+    context "when degree type is 'third_class'" do
+      it "renders 'Third class degree or above, or equivalent'" do
+        course = build(
+          :course,
+          degree_grade: "third_class",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("Third class degree or above, or equivalent")
+      end
+    end
+
+    context "when degree type is 'not_required'" do
+      it "renders 'Third class degree or above, or equivalent'" do
+        course = build(
+          :course,
+          degree_grade: "not_required",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("An undergraduate degree, or equivalent")
+      end
+    end
+
+    context "when degree_subject_requirements and a degree grade are present" do
+      it "renders the correct content for both attributes" do
+        course = build(
+          :course,
+          degree_grade: "two_one",
+          degree_subject_requirements: "Maths A level.",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("2:1 or above, or equivalent")
+        expect(page).to have_content("Maths A level.")
+      end
+    end
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -118,6 +118,9 @@ FactoryBot.define do
     meta { nil }
     age_range_in_years { "11_to_16" }
     program_type { "pg_teaching_apprenticeship" }
+    degree_grade { "two_one" }
+    additional_degree_subject_requirements { true }
+    degree_subject_requirements { Faker::Lorem.sentence(word_count: 10) }
 
     after :build do |course, evaluator|
       # Necessary gubbins necessary to make JSONAPIClient's associations work.

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -118,7 +118,7 @@ FactoryBot.define do
     meta { nil }
     age_range_in_years { "11_to_16" }
     program_type { "pg_teaching_apprenticeship" }
-    degree_grade { "two_one" }
+    degree_grade { %w[two_one two_two third_class not_required].sample }
     additional_degree_subject_requirements { true }
     degree_subject_requirements { Faker::Lorem.sentence(word_count: 10) }
 

--- a/spec/features/courses/degree_spec.rb
+++ b/spec/features/courses/degree_spec.rb
@@ -1,0 +1,182 @@
+require "rails_helper"
+
+feature "degree requirements", type: :feature do
+  let(:course_page) { PageObjects::Page::Organisations::Course.new }
+  let(:start_page) { PageObjects::Page::Organisations::Courses::Degrees::StartPage.new }
+  let(:grade_page) { PageObjects::Page::Organisations::Courses::Degrees::GradePage.new }
+  let(:subject_requirements_page) { PageObjects::Page::Organisations::Courses::Degrees::SubjectRequirementsPage.new }
+
+  let(:provider) { build(:provider, recruitment_cycle: recruitment_cycle) }
+  let(:course) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: nil) }
+  let(:course2) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: "not_required") }
+  let(:course3) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: "two_one") }
+  let(:course4) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, additional_degree_subject_requirements: true, degree_subject_requirements: "Maths A level") }
+  let(:primary_course) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: nil, level: "primary") }
+  let(:recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
+
+  before do
+    signed_in_user(provider: provider)
+    stub_api_v2_resource(provider)
+    stub_api_v2_resource(recruitment_cycle)
+    stub_api_v2_resource_collection([course], include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course, include: "provider")
+    stub_api_v2_resource(course2, include: "provider")
+    stub_api_v2_resource(course2, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course3, include: "provider")
+    stub_api_v2_resource(course3, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course4, include: "provider")
+    stub_api_v2_resource(course4, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(primary_course, include: "provider")
+    stub_api_v2_resource(primary_course, include: "provider")
+    stub_api_v2_resource(primary_course, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_request(
+      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{course.course_code}",
+      course.to_jsonapi,
+      :patch,
+      200,
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{course.course_code}/degree", \
+      course2.to_jsonapi,
+      :get,
+      200,
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{primary_course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{primary_course.course_code}", \
+      primary_course.to_jsonapi,
+      :get,
+      200,
+    )
+    stub_api_v2_request(
+      "/recruitment_cycles/#{primary_course.recruitment_cycle.year}" \
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{primary_course.course_code}", \
+      primary_course.to_jsonapi,
+      :patch,
+      200,
+    )
+  end
+
+  scenario "a provider completes the degree requirements section and provides a classification" do
+    course_page.load_with_course(course)
+    visit_description_page(course)
+    click_link "Enter degree requirements"
+    choose "Yes"
+    start_page.save.click
+    choose "2:1 or above (or equivalent)"
+    grade_page.save.click
+    choose "Yes"
+    fill_in "Degree subject requirements", with: "Must have a physics A level."
+    subject_requirements_page.save.click
+    expect(page).to have_current_path provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course.recruitment_cycle.year,
+      course.course_code,
+    )
+  end
+
+  scenario "a provider completes the degree requirements section and does not provide a classification" do
+    course_page.load_with_course(course)
+    visit_description_page(course)
+    click_link "Enter degree requirements"
+    choose "No"
+    start_page.save.click
+    choose "Yes"
+    fill_in "Degree subject requirements", with: "Must have a physics A level."
+    subject_requirements_page.save.click
+    expect(page).to have_current_path provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course.recruitment_cycle.year,
+      course.course_code,
+    )
+  end
+
+  scenario "a provider chooses to have a required grade for a primary course" do
+    course_page.load_with_course(primary_course)
+    visit_description_page(primary_course)
+    click_link "Enter degree requirements"
+    choose "Yes"
+    start_page.save.click
+    choose "2:1 or above (or equivalent)"
+    grade_page.save.click
+    expect(page).to have_current_path provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      primary_course.recruitment_cycle.year,
+      primary_course.course_code,
+    )
+  end
+
+  scenario "a provider chooses not to have a required grade for a primary course" do
+    course_page.load_with_course(primary_course)
+    visit_description_page(primary_course)
+    click_link "Enter degree requirements"
+    choose "No"
+    start_page.save.click
+    expect(page).to have_current_path provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      primary_course.recruitment_cycle.year,
+      primary_course.course_code,
+    )
+  end
+
+  scenario "a provider has completed the degree section and sees their answer pre-populated on the degree page" do
+    course_page.load_with_course(course2)
+    visit_start_page
+
+    expect(start_page.no_radio).to be_checked
+  end
+
+  scenario "a provider has completed the degree section and sees their answer pre-populated on the degree grade page" do
+    course_page.load_with_course(course3)
+    visit_grade_page
+
+    expect(grade_page.two_one).to be_checked
+  end
+
+  scenario "a provider has completed the degree section and sees their answer pre-populated on the degree subject requirements page" do
+    course_page.load_with_course(course4)
+    visit_subject_requirements_page
+
+    expect(subject_requirements_page.yes_radio).to be_checked
+    expect(subject_requirements_page.requirements.text).to eq "Maths A level"
+  end
+
+  def visit_description_page(course)
+    visit provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course.recruitment_cycle.year,
+      course.course_code,
+    )
+  end
+
+  def visit_start_page
+    visit degrees_start_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course2.recruitment_cycle.year,
+      course2.course_code,
+    )
+  end
+
+  def visit_grade_page
+    visit degrees_grade_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course3.recruitment_cycle.year,
+      course3.course_code,
+    )
+  end
+
+  def visit_subject_requirements_page
+    visit degrees_subject_requirements_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course4.recruitment_cycle.year,
+      course4.course_code,
+    )
+  end
+end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -343,58 +343,6 @@ feature "Course show", type: :feature do
           expect(course_page.error_summary).to have_content("About course can't be blank")
         end
       end
-
-      describe "age range notification" do
-        context "with primary" do
-          context "with age range set" do
-            let(:course) { build(:course, level: "primary", provider: provider, age_range_in_years: "7_to_11") }
-            it "should not display a notification banner" do
-              course_page.load(provider_code: provider.provider_code,
-                               recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
-              expect(course_page).to have_no_notification_banner
-            end
-          end
-
-          context "with no age range set" do
-            let(:course) { build(:course, level: "primary", provider: provider, age_range_in_years: nil) }
-            it "should display a notification banner" do
-              course_page.load(provider_code: provider.provider_code,
-                               recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
-              expect(course_page).to have_notification_banner
-            end
-          end
-        end
-
-        context "with secondary " do
-          context "with age range set" do
-            let(:course) { build(:course, level: "secondary", provider: provider, age_range_in_years: "7_to_11") }
-            it "should not display a notification banner" do
-              course_page.load(provider_code: provider.provider_code,
-                               recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
-              expect(course_page).to have_no_notification_banner
-            end
-          end
-
-          context "with no age range set" do
-            let(:course) { build(:course, level: "secondary", provider: provider, age_range_in_years: nil) }
-            it "should display a notification banner" do
-              course_page.load(provider_code: provider.provider_code,
-                               recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
-              expect(course_page).to have_notification_banner
-            end
-          end
-        end
-
-        context "with further eduction" do
-          let(:course) { build(:course, level: "secondar", provider: provider) }
-
-          scenario "no age range notification banner" do
-            course_page.load(provider_code: provider.provider_code,
-                             recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
-            expect(course_page).to have_no_notification_banner
-          end
-        end
-      end
     end
   end
 end

--- a/spec/form_objects/courses/degrees/grade_form_spec.rb
+++ b/spec/form_objects/courses/degrees/grade_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Courses::Degrees::GradeForm do
 
   describe "#build_from_course" do
     it "builds a new DegreeGradeForm and sets degree_grade" do
-      course = build(:course, grade: "two_one")
+      course = build(:course, degree_grade: "two_one")
       form = described_class.build_from_course(course)
 
       expect(form.grade).to eq "two_one"

--- a/spec/form_objects/courses/degrees/grade_form_spec.rb
+++ b/spec/form_objects/courses/degrees/grade_form_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Courses::Degrees::GradeForm do
+  describe "validations" do
+    it "is invalid if degree grade is nil" do
+      form = described_class.new(grade: nil)
+      expect(form.valid?).to be_falsey
+    end
+  end
+
+  describe "save" do
+    let(:course) { instance_double(Course) }
+
+    it "updates the degree_grade" do
+      allow(course).to receive(:update).and_return(true)
+
+      form = described_class.new(grade: "two_two")
+
+      expect(form.save(course)).to eq true
+    end
+  end
+
+  describe "#build_from_course" do
+    it "builds a new DegreeGradeForm and sets degree_grade" do
+      course = build(:course, grade: "two_one")
+      form = described_class.build_from_course(course)
+
+      expect(form.grade).to eq "two_one"
+    end
+  end
+end

--- a/spec/form_objects/courses/degrees/start_form_spec.rb
+++ b/spec/form_objects/courses/degrees/start_form_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe Courses::Degrees::StartForm do
+  describe "validations" do
+    it "is invalid if no value is selected for degree_grade_required" do
+      form = described_class.new(degree_grade_required: nil)
+      expect(form.valid?).to be_falsey
+    end
+  end
+
+  describe "#save" do
+    let(:course) { instance_double(Course) }
+
+    it "returns false if degree_grade_required is true" do
+      form = described_class.new(degree_grade_required: true)
+      expect(form.save(course)).to eq false
+    end
+
+    it "returns false if invalid" do
+      form = described_class.new(degree_grade_required: nil)
+      expect(form.save(course)).to eq false
+    end
+
+    it "updates the degree_subject to `not_required` if false" do
+      allow(course).to receive(:update).and_return(true)
+
+      form = described_class.new(degree_grade_required: false)
+
+      expect(form.save(course)).to eq true
+    end
+  end
+
+  describe "#set_attributes" do
+    context "when the degree grade is not_required" do
+      it "sets degree_grade_required to false" do
+        course = build(:course, degree_grade: "not_required")
+        form = described_class.new
+        form.set_attributes(course)
+
+        expect(form.degree_grade_required).to eq false
+      end
+    end
+
+    context "when the degree grade is any other enum value" do
+      it "sets degree_grade_required to true" do
+        course = build(:course, degree_grade: "two_one")
+        form = described_class.new
+        form.set_attributes(course)
+
+        expect(form.degree_grade_required).to eq true
+      end
+    end
+
+    context "when the degree grade nil" do
+      it "sets degree_grade_required to nil" do
+        course = build(:course, degree_grade: nil)
+        form = described_class.new
+        form.set_attributes(course)
+
+        expect(form.degree_grade_required).to eq nil
+      end
+    end
+  end
+end

--- a/spec/form_objects/courses/degrees/subject_requirements_form_spec.rb
+++ b/spec/form_objects/courses/degrees/subject_requirements_form_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Courses::Degrees::SubjectRequirementsForm do
+  describe "validations" do
+    it "is invalid if no value is selected for `additional_degree_subject_requirements`" do
+      form = described_class.new(additional_degree_subject_requirements: nil)
+      expect(form.valid?).to be_falsey
+    end
+
+    it "is invalid if `additional_degree_subject_requirements` is true and no `degree_subject_requirements` are provided" do
+      form = described_class.new(
+        additional_degree_subject_requirements: true,
+        degree_subject_requirements: nil,
+      )
+      expect(form.valid?).to be_falsey
+    end
+  end
+
+  describe "save" do
+    let(:course) { instance_double(Course) }
+
+    it "returns false if invalid" do
+      form = described_class.new
+
+      expect(form.save(course)).to eq false
+    end
+
+    it "updates the course if valid" do
+      allow(course).to receive(:update).with({ additional_degree_subject_requirements: true, degree_subject_requirements: "Maths A level" }).and_return(true)
+
+      form = described_class.new(
+        additional_degree_subject_requirements: true,
+        degree_subject_requirements: "Maths A level",
+      )
+
+      expect(form.save(course)).to eq true
+    end
+  end
+
+  describe "#build_from_course" do
+    it "builds a new DegreeSubjectRequirementsForm and sets the attrs based on the course" do
+      course = build(
+        :course,
+        additional_degree_subject_requirements: true,
+        degree_subject_requirements: "Maths A level.",
+      )
+      form = described_class.build_from_course(course)
+
+      expect(form.additional_degree_subject_requirements).to eq true
+      expect(form.degree_subject_requirements).to eq "Maths A level."
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -200,4 +200,24 @@ describe Course do
       expect(course.provider_type).to eq("lead_school")
     end
   end
+
+  describe "degree_section_complete?" do
+    it "returns true when 'degree_grade' is set" do
+      course = build(
+        :course,
+        degree_grade: "two_one",
+      )
+
+      expect(course.degree_section_complete?).to eq true
+    end
+
+    it "return false when 'degree_grade' is nil" do
+      course = build(
+        :course,
+        degree_grade: nil,
+      )
+
+      expect(course.degree_section_complete?).to eq false
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 require "view_component/test_helpers"
+require "capybara/rspec"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 
@@ -31,6 +32,7 @@ ActiveSupport::Dependencies.autoload_paths +=
 
 RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/site_prism/page_objects/page/organisations/course.rb
+++ b/spec/site_prism/page_objects/page/organisations/course.rb
@@ -30,10 +30,6 @@ module PageObjects
         element :status_panel, "[data-qa=course__status_panel]"
         element :withdraw_link, '[data-qa="course__withdraw-link"]'
         element :delete_link, '[data-qa="course__delete-link"]'
-
-        section :notification_banner, ".govuk-notification-banner" do
-          element :age_range_link, ".govuk-notification-banner__link"
-        end
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/courses/degrees/grade_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/degrees/grade_page.rb
@@ -1,0 +1,18 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        module Degrees
+          class GradePage < NewCourseBase
+            set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/degrees/grade{?query*}"
+
+            element :save, '[data-qa="degree_grade__save"]'
+            element :two_one, '[data-qa="degree_grade__two_one"]'
+            element :two_two, '[data-qa="degree_grade__two_two"]'
+            element :third_class, '[data-qa="degree_grade__third_class"]'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/degrees/start_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/degrees/start_page.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        module Degrees
+          class StartPage < NewCourseBase
+            set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/degrees/start{?query*}"
+
+            element :save, '[data-qa="start__save"]'
+            element :yes_radio, '[data-qa="start__yes_radio"]'
+            element :no_radio, '[data-qa="start__no_radio"]'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/organisations/courses/degrees/subject_requirements_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses/degrees/subject_requirements_page.rb
@@ -1,0 +1,18 @@
+module PageObjects
+  module Page
+    module Organisations
+      module Courses
+        module Degrees
+          class SubjectRequirementsPage < NewCourseBase
+            set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses/degrees/subject-requirements{?query*}"
+
+            element :save, '[data-qa="degree_subject_requirements__save"]'
+            element :yes_radio, '[data-qa="degree_subject_requirements__yes_radio"]'
+            element :no_radio, '[data-qa="degree_subject_requirements__no_radio"]'
+            element :requirements, '[data-qa="degree_subject_requirements__requirements"]'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/waUHPqGC/3496-add-the-structured-degree-requirements-section-to-publish

https://publish-courses-prototype.herokuapp.com/

This PR adds in the new degree section for courses in the 2022 cycle. There's a good amount of detail on the requirements on the trello card, but the flow should roughly go like this:

if the course is primary they should only be asked about whether they require a minimum grade and about subject requirements.

Otherwise the provider should be asked about degree grade then the subject requirements.

Course page 

![image](https://user-images.githubusercontent.com/42515961/122550242-59946280-d02b-11eb-8c58-feb46fa911b5.png)

Start page 

![image](https://user-images.githubusercontent.com/42515961/122550348-76309a80-d02b-11eb-8331-e47e89a82a01.png)


Grade page 

![image](https://user-images.githubusercontent.com/42515961/122550427-8c3e5b00-d02b-11eb-8c8f-635f8c3700ba.png)

Subject requirements page 

![image](https://user-images.githubusercontent.com/42515961/122550502-a415df00-d02b-11eb-9948-78ed7dcd4185.png)


### Changes proposed in this pull request

- Adds in the 3 new pages shown above
- 

### Guidance to review

This branch is currently rebased off of Steve's visa work as i've reused the changes he made to the summary list component.

The `Prepare for the next cycle banner` performed poorly in the last round of testing and has been removed.

Out of scope for this PR - Backend validations for publishing a course
                                             Find preview page
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
