### PR TITLE
Visa sponsorship course preview

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -12,14 +12,24 @@ module ProviderHelper
   def visa_sponsorship_status(provider)
     if !provider.declared_visa_sponsorship?
       visa_sponsorship_call_to_action(provider)
-    elsif provider.can_sponsor_all_visas?
-      "You can sponsor Student and Skilled Worker visas"
-    elsif provider.can_only_sponsor_student_visa?
-      "You can sponsor Student visas"
-    elsif provider.can_only_sponsor_skilled_worker_visa?
-      "You can sponsor Skilled Worker visas"
+    elsif provider.can_sponsor_student_visa || provider.can_sponsor_skilled_worker_visa
+      "can #{visa_sponsorship_short_status(provider)}"
     else
-      "You cannot sponsor visas"
+      "cannot sponsor visas"
+    end
+  end
+
+  def visa_sponsorship_short_status(provider)
+    if provider.can_sponsor_student_visa.nil? || provider.can_sponsor_skilled_worker_visa.nil?
+      visa_sponsorship_call_to_action(provider)
+    elsif provider.can_sponsor_all_visas?
+      "sponsor Student and Skilled Worker visas"
+    elsif provider.can_only_sponsor_student_visa?
+      "sponsor Student visas"
+    elsif provider.can_only_sponsor_skilled_worker_visa?
+      "sponsor Skilled Worker visas"
+    else
+      "sponsor visas"
     end
   end
 

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -20,7 +20,7 @@ module ProviderHelper
   end
 
   def visa_sponsorship_short_status(provider)
-    if provider.can_sponsor_student_visa.nil? || provider.can_sponsor_skilled_worker_visa.nil?
+    if !provider.declared_visa_sponsorship?
       visa_sponsorship_call_to_action(provider)
     elsif provider.can_sponsor_all_visas?
       "sponsor Student and Skilled Worker visas"

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -53,6 +53,10 @@ class Provider < Base
     !can_sponsor_student_visa && can_sponsor_skilled_worker_visa
   end
 
+  def cannot_sponsor_visas?
+    can_sponsor_student_visa == false && can_sponsor_skilled_worker_visa == false
+  end
+
 private
 
   def post_base_url

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -84,6 +84,9 @@
     <% if course.interview_process.present? %>
       <%= render partial: "courses/preview/interview_process" %>
     <% end %>
+    <% if Providers::VisaSponsorshipService.new(@provider).visa_sponsorship_enabled? %>
+      <%= render partial: "courses/preview/international_students" %>
+    <% end %>
     <%= render partial: "courses/preview/train_with_disabilities" %>
     <%= render partial: "courses/preview/contact_details" %>
     <%= render partial: "courses/preview/advice" %>

--- a/app/views/courses/preview/_international_students.html.erb
+++ b/app/views/courses/preview/_international_students.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-international">International students</h2>
+  <p class="govuk-body">
+    </p><div class="govuk-inset-text app-inset-text app-inset-text--important">
+      <% if @provider.declared_visa_sponsorship? %>
+        <p class="govuk-body">
+          We 
+          <%= @provider.cannot_sponsor_visas? ? "cannot" : "can" %>
+          <%= govuk_link_to(
+            visa_sponsorship_short_status(@provider),
+            "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
+          ) %><%= @provider.cannot_sponsor_visas? ? "." : ", but this is not guaranteed." %>
+        </p>
+      <% else %>
+        <p class="govuk-heading-s">
+          Please add details
+          <%= govuk_link_to(
+            "about visa sponsorship",
+            provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year),
+          ) %>
+        </p>
+      <% end %>
+    </div>
+  <p></p>
+  <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you are an Irish citizen.</p>
+  <p class="govuk-body">Candidates with qualifications from non-UK institutions may need to provide evidence of comparability by applying for a <%= govuk_link_to("UK ENIC statement", "https://www.enic.org.uk") %>.</p>
+</div>

--- a/app/views/courses/preview/_international_students.html.erb
+++ b/app/views/courses/preview/_international_students.html.erb
@@ -1,27 +1,25 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-international">International students</h2>
-  <p class="govuk-body">
-    </p><div class="govuk-inset-text app-inset-text app-inset-text--important">
-      <% if @provider.declared_visa_sponsorship? %>
-        <p class="govuk-body">
-          We 
-          <%= @provider.cannot_sponsor_visas? ? "cannot" : "can" %>
-          <%= govuk_link_to(
-            visa_sponsorship_short_status(@provider),
-            "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
-          ) %><%= @provider.cannot_sponsor_visas? ? "." : ", but this is not guaranteed." %>
-        </p>
-      <% else %>
-        <p class="govuk-heading-s">
-          Please add details
-          <%= govuk_link_to(
-            "about visa sponsorship",
-            provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year),
-          ) %>
-        </p>
-      <% end %>
-    </div>
-  <p></p>
+  <% if @provider.declared_visa_sponsorship? %>
+    <p class="govuk-body">
+      We 
+      <%= @provider.cannot_sponsor_visas? ? "cannot" : "can" %>
+      <%= govuk_link_to(
+        visa_sponsorship_short_status(@provider),
+        "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
+      ) %><%= @provider.cannot_sponsor_visas? ? "." : ", but this is not guaranteed." %>
+    </p>
+  <% else %>
+    <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+      <p class="govuk-heading-s">
+        Please add details
+        <%= govuk_link_to(
+          "about visa sponsorship",
+          provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year),
+        ) %>
+      </p>
+    <% end %>
+  <% end %>
   <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you are an Irish citizen.</p>
   <p class="govuk-body">Candidates with qualifications from non-UK institutions may need to provide evidence of comparability by applying for a <%= govuk_link_to("UK ENIC statement", "https://www.enic.org.uk") %>.</p>
 </div>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -56,7 +56,7 @@
         <% summary_list.slot(:row, enrichment_summary(
           :provider,
           "Visa sponsorship",
-          visa_sponsorship_status(@provider),
+          raw("You #{visa_sponsorship_status(@provider)}"),
           %w[can_sponsor_student_visa can_sponsor_skilled_worker_visa],
           truncate_value: false,
           change_link: provider.declared_visa_sponsorship? ? provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year) : nil,

--- a/spec/features/providers/visa_spec.rb
+++ b/spec/features/providers/visa_spec.rb
@@ -34,7 +34,7 @@ feature "View and edit provider visa sponsorship", type: :feature do
         recruitment_cycle_year,
         course.course_code,
       )
-      expect(page).not_to have_content('International students')
+      expect(page).not_to have_content("International students")
     end
   end
 
@@ -64,8 +64,8 @@ feature "View and edit provider visa sponsorship", type: :feature do
         course = build(:course, provider: provider)
         stub_api_v2_resource(course, include: "subjects,sites,site_statuses.site,provider.sites,accrediting_provider")
         visit preview_provider_recruitment_cycle_course_path("A0", "2022", course.course_code)
-        expect(page).to have_content('International students')
-        expect(page).to have_content('Please add details about visa sponsorship')
+        expect(page).to have_content("International students")
+        expect(page).to have_content("Please add details about visa sponsorship")
       end
 
       it "visa sponsorship form renders validation errors if I submit without selecting whether provider sponsors visas" do
@@ -138,8 +138,8 @@ feature "View and edit provider visa sponsorship", type: :feature do
         course = build(:course, provider: provider)
         stub_api_v2_resource(course, include: "subjects,sites,site_statuses.site,provider.sites,accrediting_provider")
         visit preview_provider_recruitment_cycle_course_path("A0", "2022", course.course_code)
-        expect(page).to have_content('International students')
-        expect(page).to have_content('We can sponsor Student visas, but this is not guaranteed.')
+        expect(page).to have_content("International students")
+        expect(page).to have_content("We can sponsor Student visas, but this is not guaranteed.")
       end
     end
   end

--- a/spec/features/providers/visa_spec.rb
+++ b/spec/features/providers/visa_spec.rb
@@ -25,93 +25,122 @@ feature "View and edit provider visa sponsorship", type: :feature do
       visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
       expect(page).not_to have_content "Select if you can sponsor visas"
     end
+
+    it "course preview page does not render international students section" do
+      course = build(:course, provider: provider)
+      stub_api_v2_resource(course, include: "subjects,sites,site_statuses.site,provider.sites,accrediting_provider")
+      visit preview_provider_recruitment_cycle_course_path(
+        provider.provider_code,
+        recruitment_cycle_year,
+        course.course_code,
+      )
+      expect(page).not_to have_content('International students')
+    end
   end
 
-  context "when the provider has not answered the visa sponsorship questions" do
-    let(:recruitment_cycle_year) { 2022 }
-    let(:provider) do
-      build(
-        :provider,
-        provider_code: "A0",
-        recruitment_cycle: recruitment_cycle,
-        recruitment_cycle_year: recruitment_cycle.year,
-        can_sponsor_student_visa: nil,
-        can_sponsor_skilled_worker_visa: nil,
-      )
-    end
-
-    it "visa sponsorship form renders validation errors if I submit without selecting whether provider sponsors visas" do
-      visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-      click_link "Select if you can sponsor visas"
-      click_button "Save"
-      expect(page).to have_content("Select if you can sponsor Skilled Worker visas")
-      expect(page).to have_content("Select if you can sponsor Student visas")
-    end
-
-    it "visa sponsorship form updates the provider if I submit valid values" do
-      stub_api_v2_resource(provider, method: :patch) do |body|
-        expect(body["data"]["attributes"]).to eq(
-          "can_sponsor_student_visa" => true,
-          "can_sponsor_skilled_worker_visa" => false,
+  context "in recruitment cycle 2022" do
+    context "when the provider has not answered the visa sponsorship questions" do
+      let(:recruitment_cycle_year) { 2022 }
+      let(:provider) do
+        build(
+          :provider,
+          provider_code: "A0",
+          recruitment_cycle: recruitment_cycle,
+          recruitment_cycle_year: recruitment_cycle.year,
+          can_sponsor_student_visa: nil,
+          can_sponsor_skilled_worker_visa: nil,
         )
       end
-      visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-      click_link "Select if you can sponsor visas"
-      within_fieldset("Can you sponsor Student visas?") do
-        choose "Yes"
-      end
-      within_fieldset("Can you sponsor Skilled Worker visas?") do
-        choose "No"
-      end
-      click_button "Save"
-    end
 
-    it "shows a call to action in summary card" do
-      visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-      within find("[data-qa='enrichment__can_sponsor_student_visa']") do
+      it "shows a call to action in summary card" do
+        visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
+        within find("[data-qa='enrichment__can_sponsor_student_visa']") do
+          click_link "Select if you can sponsor visas"
+        end
+        expect(page).to have_content("#{provider.provider_name} Visa sponsorship")
+      end
+
+      it "course preview page renders the international students section with link to visa sponsorship" do
+        course = build(:course, provider: provider)
+        stub_api_v2_resource(course, include: "subjects,sites,site_statuses.site,provider.sites,accrediting_provider")
+        visit preview_provider_recruitment_cycle_course_path("A0", "2022", course.course_code)
+        expect(page).to have_content('International students')
+        expect(page).to have_content('Please add details about visa sponsorship')
+      end
+
+      it "visa sponsorship form renders validation errors if I submit without selecting whether provider sponsors visas" do
+        visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
         click_link "Select if you can sponsor visas"
+        click_button "Save"
+        expect(page).to have_content("Select if you can sponsor Skilled Worker visas")
+        expect(page).to have_content("Select if you can sponsor Student visas")
       end
-      expect(page).to have_content("#{provider.provider_name} Visa sponsorship")
-    end
-  end
 
-  context "when the provider has answered both visa sponsorship questions" do
-    let(:provider) do
-      build(
-        :provider,
-        provider_code: "A0",
-        recruitment_cycle: recruitment_cycle,
-        recruitment_cycle_year: recruitment_cycle.year,
-        can_sponsor_student_visa: true,
-        can_sponsor_skilled_worker_visa: false,
-      )
+      it "visa sponsorship form updates the provider if I submit valid values" do
+        stub_api_v2_resource(provider, method: :patch) do |body|
+          expect(body["data"]["attributes"]).to eq(
+            "can_sponsor_student_visa" => true,
+            "can_sponsor_skilled_worker_visa" => false,
+          )
+        end
+        visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
+        click_link "Select if you can sponsor visas"
+        within_fieldset("Can you sponsor Student visas?") do
+          choose "Yes"
+        end
+        within_fieldset("Can you sponsor Skilled Worker visas?") do
+          choose "No"
+        end
+        click_button "Save and publish changes"
+      end
     end
 
-    it "about organisation page displays the current visa sponsorship status" do
-      visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-      expect(page).to have_content("You can sponsor Student visas")
-    end
-
-    it "I can change my answers" do
-      stub_api_v2_resource(provider, method: :patch) do |body|
-        expect(body["data"]["attributes"]).to eq(
-          "can_sponsor_student_visa" => false,
-          "can_sponsor_skilled_worker_visa" => true,
+    context "when the provider has answered both visa sponsorship questions" do
+      let(:provider) do
+        build(
+          :provider,
+          provider_code: "A0",
+          recruitment_cycle: recruitment_cycle,
+          recruitment_cycle_year: recruitment_cycle.year,
+          can_sponsor_student_visa: true,
+          can_sponsor_skilled_worker_visa: false,
         )
       end
-      visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
 
-      within find("[data-qa='enrichment__can_sponsor_student_visa']") do
-        click_link "Change"
+      it "about organisation page displays the current visa sponsorship status" do
+        visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
+        expect(page).to have_content("You can sponsor Student visas")
       end
 
-      within_fieldset("Can you sponsor Student visas?") do
-        choose "No"
+      it "I can change my answers" do
+        stub_api_v2_resource(provider, method: :patch) do |body|
+          expect(body["data"]["attributes"]).to eq(
+            "can_sponsor_student_visa" => false,
+            "can_sponsor_skilled_worker_visa" => true,
+          )
+        end
+        visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
+
+        within find("[data-qa='enrichment__can_sponsor_student_visa']") do
+          click_link "Change"
+        end
+
+        within_fieldset("Can you sponsor Student visas?") do
+          choose "No"
+        end
+        within_fieldset("Can you sponsor Skilled Worker visas?") do
+          choose "Yes"
+        end
+        click_button "Save and publish changes"
       end
-      within_fieldset("Can you sponsor Skilled Worker visas?") do
-        choose "Yes"
+
+      it "course preview page renders the international students section with link to visa sponsorship" do
+        course = build(:course, provider: provider)
+        stub_api_v2_resource(course, include: "subjects,sites,site_statuses.site,provider.sites,accrediting_provider")
+        visit preview_provider_recruitment_cycle_course_path("A0", "2022", course.course_code)
+        expect(page).to have_content('International students')
+        expect(page).to have_content('We can sponsor Student visas, but this is not guaranteed.')
       end
-      click_button "Save"
     end
   end
 end

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -77,7 +77,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: false,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "You can sponsor Student visas",
+        "can sponsor Student visas",
       )
     end
 
@@ -88,7 +88,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: true,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "You can sponsor Skilled Worker visas",
+        "can sponsor Skilled Worker visas",
       )
     end
 
@@ -99,7 +99,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: true,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "You can sponsor Student and Skilled Worker visas",
+        "can sponsor Student and Skilled Worker visas",
       )
     end
 
@@ -110,7 +110,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: false,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "You cannot sponsor visas",
+        "cannot sponsor visas",
       )
     end
   end


### PR DESCRIPTION
### Context

This PR is a follow up to https://github.com/DFE-Digital/publish-teacher-training/pull/1725

It adds an _International students_ section to the course preview page.

See https://trello.com/c/I2K4fchq/3441-add-visa-flow-to-publish

### Changes proposed in this pull request

- [x] Add section to the course preview page that is only rendered when the `rollover.prepare_for_next_cycle` feature flag is switched on. Render one of these two variations depending on whether the provider has answer the visa sponsorship questions or not.
<img width="774" alt="image" src="https://user-images.githubusercontent.com/450843/122731600-5f7c8480-d273-11eb-8ade-bf898b6d0d25.png">

<img width="674" alt="image" src="https://user-images.githubusercontent.com/450843/123426049-cfb04080-d5ba-11eb-9c42-e984b34b02bc.png">

- [x] Rebase onto `master`

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
