### PR TITLE
[1907] Update bullet point re allocations in rollover

### DIFF
--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -12,7 +12,7 @@
   <li>manage current courses</li>
   <li>edit locations and vacancies for current courses</li>
   <% if @provider.accredited_body? %>
-    <li>see which courses you're currently the accredited body for</li>
+    <li>see which courses you’re currently the accredited body for</li>
     <li>view requests you’ve already made to recruit for fee-funded PE in the next cycle</li>
   <% end %>
 </ul>

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -34,7 +34,7 @@
   <li>prepare your courses for the next cycle</li>
   <li>manage locations for the next cycle</li>
   <% if @provider.accredited_body? %>
-    <li>see which courses in the next cycle you're the accredited body for</li>
+    <li>see which courses in the next cycle you’re the accredited body for</li>
     <li>view requests you’ve already made to recruit for fee-funded PE in the next cycle</li>
   <% end %>
 </ul>

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -13,7 +13,7 @@
   <li>edit locations and vacancies for current courses</li>
   <% if @provider.accredited_body? %>
     <li>see which courses you're currently the accredited body for</li>
-    <li>request PE courses for the next cycle (and view requests you've already made)</li>
+    <li>view requests you’ve already made to recruit for fee-funded PE in the next cycle</li>
   <% end %>
 </ul>
 
@@ -35,5 +35,6 @@
   <li>manage locations for the next cycle</li>
   <% if @provider.accredited_body? %>
     <li>see which courses in the next cycle you're the accredited body for</li>
+    <li>view requests you’ve already made to recruit for fee-funded PE in the next cycle</li>
   <% end %>
 </ul>


### PR DESCRIPTION
### Context

https://trello.com/c/LJWi1K8l/1907-s-allocations-bullet-point-should-be-in-both-cycles

### Changes proposed in this pull request

- Updates the content for the allocations bullet point seen during rollover
- Copies the bullet point into the 'Next cycle' section

### Guidance to review

This is what it now looks like 'During rollover':

<img width="677" alt="Screenshot 2021-06-21 at 10 39 30" src="https://user-images.githubusercontent.com/18436946/122741741-2c3ef300-d27d-11eb-8b78-07942fdb5c87.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
