### PR TITLE
[1977] Add google forms for next cycle

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -241,7 +241,7 @@
         <% content_for :allocations do %>
           <% if course.has_physical_education_subject? %>
             <p class="govuk-body">Recruitment to fee-funded PE courses is limited by the number of places allocated to you by DfE.</p>
-            <p class="govuk-body">If you haven’t already, you must <%= govuk_link_to "request allocations", "https://docs.google.com/forms/d/e/1FAIpQLScxhMGaYil9KB4XWfVXG7Y_VQ-lmmr_xEkjWetcjIgLgTCIIA/viewform?usp=sf_link" %></p>
+            <p class="govuk-body">If you haven’t already, you must <%= govuk_link_to "request allocations", "https://docs.google.com/forms/d/e/1FAIpQLSfMJDoChdgXmGJM1UcEgoiyvlR9ExESF1-vv32lrXF8AK3ShA/viewform?usp=sf_link" %></p>
           <% else %>
             Recruitment is not restricted
           <% end %>

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -250,7 +250,7 @@
           <% content_for :allocations do %>
             <% if course.has_physical_education_subject? %>
               <p class="govuk-body">Recruitment to fee-funded PE courses is limited by the number of places allocated to you by DfE.</p>
-              <p class="govuk-body">If you haven’t already, you must <%= govuk_link_to "request allocations", "https://docs.google.com/forms/d/e/1FAIpQLScxhMGaYil9KB4XWfVXG7Y_VQ-lmmr_xEkjWetcjIgLgTCIIA/viewform?usp=sf_link" %></p>
+              <p class="govuk-body">If you haven’t already, you must <%= govuk_link_to "request allocations", "https://docs.google.com/forms/d/e/1FAIpQLSfMJDoChdgXmGJM1UcEgoiyvlR9ExESF1-vv32lrXF8AK3ShA/viewform?usp=sf_link" %></p>
             <% else %>
               Recruitment is not restricted
             <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,14 +41,14 @@ google_forms:
       url: https://docs.google.com/forms/d/e/1FAIpQLSdmuYIBDGuESZJBKGVTIdEFntdcjX86J5u6yXTSFNpk18oJeA/viewform?usp=pp_url
       email_entry: entry.1033530353
       provider_code_entry: entry.158771972
-  # NOTE: not in use, url is for 2021
+  # NOTE: these forms are only in use / visible during Rollover i.e. when both cycles are visible.
   next_cycle:
     new_course_for_accredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSexQtIhIDiHM6vyy23OrJmeSoLTmLlw4y_2S3TI7FDQV2VcsQ/viewform?usp=pp_url
+      url: https://docs.google.com/forms/d/e/1FAIpQLSerPrTvuQNNkpMH_yfgJ8_o5ajthtq5XhOP9x-zG8JL4o5n-Q/viewform?usp=pp_url
       email_entry: entry.957076544
       provider_code_entry: entry.1735563938
     new_course_for_unaccredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSexQtIhIDiHM6vyy23OrJmeSoLTmLlw4y_2S3TI7FDQV2VcsQ/viewform?usp=pp_url
+      url: https://docs.google.com/forms/d/e/1FAIpQLSeZK6wGdvDy40QFiFcI8_JRgG-kPWUPBjLfY_EffebCkL0goQ/viewform?usp=pp_url
       email_entry: entry.1033530353
       provider_code_entry: entry.158771972
 service_support:

--- a/docs/rollover.md
+++ b/docs/rollover.md
@@ -38,7 +38,8 @@ updates/refactoring work.
 1. Create a **Rollover PR** including the following code changes:
     - Set feature flag `can_edit_current_and_next_cycles: true`
     - Any hardcoded copy changes
-2. Create **new Google forms** for adding PE courses for the next cycle
+2. Create **new Google forms** for adding PE courses for the next cycle and
+  update the links in the settings `google_forms: next_cycle`.
 
 ## On Rollover launch date
 
@@ -54,7 +55,6 @@ updates/refactoring work.
     - Set feature flag `can_edit_current_and_next_cycles: false`
     - Replace `google_forms: current_cycle:` settings with those in
       `google_forms: next_cycle:`
-    - Add new Google forms to `google_forms: next_cycle:`
     - Any hardcoded copy changes
 
 ## On Rollover end date


### PR DESCRIPTION
### Context

https://trello.com/c/SX21cZax/1977-s-rollover-create-update-google-forms-for-the-next-cycle

### Changes proposed in this pull request

Adds the urls for the google forms for adding a PE course to the next cycle.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
