### PR TITLE
Reduce heading sizes

### DIFF
--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
         Create access request
       </h1>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -15,14 +15,14 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl" data-qa="ucas_contacts__alerts__main_heading">
+      <h1 class="govuk-heading-l" data-qa="ucas_contacts__alerts__main_heading">
         <%= t("ucas_contacts.#{@contact.type}.heading") %>
       </h1>
 
       <p class="govuk-body"><%= t("ucas_contacts.#{@contact.type}.purpose") %></p>
 
       <% if @contact.admin? %>
-        <h2 class="govuk-heading-l">Request a change to your UCAS administrator</h2>
+        <h2 class="govuk-heading-m">Request a change to your UCAS administrator</h2>
         <p class="govuk-body" id="admin_subtext">Changes can take up to 7 days to process.</p>
       <% end %>
 

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -263,7 +263,7 @@
   <% if course.is_running? || course.new_and_not_running? %>
     <aside class="govuk-grid-column-one-third">
       <div class="app-status-box">
-        <h2 class="govuk-heading-m">Changing your basic details</h2>
+        <h3 class="govuk-heading-m">Changing your basic details</h3>
         <p class="govuk-body">At the moment you can change:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li><abbr class="app-!-text-decoration-underline-dotted" title="Special educational needs and disability">SEND</abbr> specialism</li>

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_radio_buttons_fieldset(:course_length,
   legend: {
     text: "Course length",
-    size: "l",
+    size: "m",
   },
   form_group: {
     id: @errors.key?(:course_length) ? "course_length-error" : "",

--- a/app/views/courses/_related_sidebar.html.erb
+++ b/app/views/courses/_related_sidebar.html.erb
@@ -26,15 +26,15 @@
     <p class="govuk-body">When you&#8217;ve added content to this page, you can copy it to other courses</p>
   <% end %>
 
-  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 
-  <h4 class="govuk-heading-m">Formatting</h4>
-  <h5 class="govuk-heading-s">Links</h5>
+  <h3 class="govuk-heading-m">Formatting</h3>
+  <h4 class="govuk-heading-s">Links</h4>
   <p class="govuk-body">Use square brackets [] around the link text and round brackets () around the link URL. Make sure there are no spaces between the brackets.</p>
 
   <p class="govuk-body">For example:<br>[GOV.UK](https://gov.uk/)</p>
 
-  <h5 class="govuk-heading-s">Lists</h5>
+  <h4 class="govuk-heading-s">Lists</h4>
   <p class="govuk-body">To create a bulleted list:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>use asterisks (*) to create a bullet point (hyphens also work)</li>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -16,8 +16,8 @@
   <%= f.govuk_error_summary "You’ll need to correct some information." %>
 <% end %>
 
-  <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= course.name_and_code %></span>
     About this course
   </h1>
 
@@ -63,9 +63,9 @@
 
         <%= f.govuk_text_area :about_course, label: { text: "About this course", size: "s" }, max_words: 400, rows: 20 %>
 
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-        <h3 class="govuk-heading-l remove-top-margin">Interview process</h3>
+        <h3 class="govuk-heading-m">Interview process</h3>
 
         <p class="govuk-body">Tell applicants:</p>
         <ul class="govuk-list govuk-list--bullet">
@@ -77,9 +77,9 @@
 
         <%= f.govuk_text_area :interview_process, label: { text: "Interview process (optional)", size: "s" }, max_words: 250, rows: 15 %>
 
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-        <h3 class="govuk-heading-l remove-top-margin"><%= course.placements_heading %></h3>
+        <h3 class="govuk-heading-m"><%= course.placements_heading %></h3>
 
         <p class="govuk-body">
           Give applicants more information about the schools they’ll be teaching in. Tell them:

--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -7,8 +7,8 @@
 <%= render "shared/errors" %>
 
 <fieldset class="govuk-fieldset">
-  <legend class="govuk-fieldset__legend">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
       Who is the accredited body?
     </h1>
   </legend>

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -7,8 +7,8 @@
 <%= render "shared/errors" %>
 
 <fieldset class="govuk-fieldset">
-  <legend class="govuk-fieldset__legend">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
       Who is the accredited body?
     </h1>
   </legend>

--- a/app/views/courses/accredited_body/search.html.erb
+++ b/app/views/courses/accredited_body/search.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Pick an accredited body
     </h1>
 

--- a/app/views/courses/accredited_body/search_new.html.erb
+++ b/app/views/courses/accredited_body/search_new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Pick an accredited body
     </h1>
 

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -14,7 +14,7 @@
 
       <%= form.govuk_error_summary "You’ll need to correct some information." %>
 
-      <%= form.govuk_radio_buttons_fieldset(:age_range_in_years, legend: { size: "xl", text: "Specify an age range" }, caption: { text: course.name_and_code, size: "xl" }) do %>
+      <%= form.govuk_radio_buttons_fieldset(:age_range_in_years, legend: { size: "l", text: "Specify an age range" }, caption: { text: course.name_and_code, size: "l" }) do %>
         <% @course.meta["edit_options"]["age_range_in_years"].each do |value| %>
           <%= form.govuk_radio_button :age_range_in_years,
             value,

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -17,7 +17,7 @@
       <%= render "courses/new_fields_holder", form: form, except_keys: [:age_range_in_years] do |fields| %>
         <%= render "shared/error_wrapper", error_keys: [:age_range_in_years], data_qa: "course__age_range_in_years" do %>
           <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h1 class="govuk-fieldset__heading">
                 Specify an age range
               </h1>

--- a/app/views/courses/applications_open/_form_fields.html.erb
+++ b/app/views/courses/applications_open/_form_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-form-group">
   <div class="govuk-radios govuk-!-margin-top-2 govuk-radios--conditional" data-module="govuk-radios">
     <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading" id="applications_open_from-error">
           When will applications open?
         </h1>

--- a/app/views/courses/apprenticeship/_form_fields.html.erb
+++ b/app/views/courses/apprenticeship/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/error_wrapper", error_keys: %i[funding_type program_type], data_qa: "course__funding_type" do %>
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
         Is this a teaching apprenticeship?
       </h1>

--- a/app/views/courses/apprenticeship/edit.html.erb
+++ b/app/views/courses/apprenticeship/edit.html.erb
@@ -6,8 +6,6 @@
 
 <%= render "shared/errors" %>
 
-<h1 class="govuk-heading-xl">
-</h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with model: course,

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Check your answers before confirming
     </h1>
 
@@ -269,7 +269,7 @@
       <% end %>
 
       <div class="govuk-!-margin-top-8" data-qa="course__preview">
-        <h2 class="govuk-heading-l">Preview</h2>
+        <h2 class="govuk-heading-m">Preview</h2>
         <p class="govuk-body">See how this course will appear when it’s published on Find postgraduate teacher training:</p>
         <%= govuk_inset_text do %>
           <h3 class="govuk-heading-m" data-qa="course__name">

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= course.name_and_code %></span>
       Are you sure you want to delete this course?
     </h1>
 
@@ -36,7 +36,7 @@
         <% end %>
         <%= f.text_field "confirm_course_code", class: "govuk-input govuk-input--width-5" %>
       </div>
-      <hr class="govuk-section-break govuk-section-break--m">
+
       <%= f.submit "Yes I’m sure – delete this course", class: "govuk-button govuk-button--warning" %>
     <% end %>
 

--- a/app/views/courses/details.html.erb
+++ b/app/views/courses/details.html.erb
@@ -1,8 +1,8 @@
 <%= content_for :page_title, "#{course.name_and_code} - Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:course) %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= course.description %></span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= course.description %></span>
   <%= course.name %> (<%= course.course_code %>)
 </h1>
 

--- a/app/views/courses/entry_requirements/_page_intro.html.erb
+++ b/app/views/courses/entry_requirements/_page_intro.html.erb
@@ -1,5 +1,5 @@
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">UCAS Apply</span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">UCAS Apply</span>
   GCSE requirements for&nbsp;applicants
 </h1>
 

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -16,7 +16,8 @@
 
       <%= render "form_fields", form: form, gcse_subjects_required: course.gcse_subjects_required %>
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
       <p class="govuk-body">Changes will appear on UCAS Apply within 2 hours.</p>
 
       <%= form.submit "Save changes", class: "govuk-button", data: { qa: "course__save" } %>

--- a/app/views/courses/fee_or_salary/_form_fields.html.erb
+++ b/app/views/courses/fee_or_salary/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/error_wrapper", error_keys: [:funding_type], data_qa: "course__funding_type" do %>
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
         Is it fee paying or salaried?
       </h1>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -15,8 +15,8 @@
 
   <%= render "shared/errors" %>
 
-  <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= course.name_and_code %></span>
     Course length and fees
   </h1>
 
@@ -26,9 +26,9 @@
 
       <%= render partial: "courses/course_length", locals: { f: f } %>
 
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-      <h3 class="govuk-heading-l remove-top-margin">Course fees</h3>
+      <h3 class="govuk-heading-m">Course fees</h3>
 
       <%= f.govuk_text_field(:fee_uk_eu,
         value: number_with_precision(course.fee_uk_eu, precision: 2, strip_insignificant_zeros: true),
@@ -47,7 +47,7 @@
         width: 5,
         data: { qa: "course_fee_international" }) %>
 
-      <h4 class="govuk-heading-m">Fee details</h4>
+      <h3 class="govuk-heading-m">Fee details</h3>
       <p class="govuk-body">If applicable, give further details about the fees for this course.</p>
       <p class="govuk-body">This could include:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -61,9 +61,9 @@
         max_words: 250,
         data: { qa: "course_fee_details" }) %>
 
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-      <h2 class="govuk-heading-l">Financial support you offer</h2>
+      <h3 class="govuk-heading-m">Financial support you offer</h3>
       <p class="govuk-body">If applicable, say more about the financial support you offer for this course. For example, any bursaries available.</p>
       <p class="govuk-body">You don’t need to add details of any DfE bursaries and subject scholarships here. These will be published automatically to your course page</p>
 
@@ -83,6 +83,7 @@
         ) %>
       </p>
     </div>
+
     <aside class="govuk-grid-column-one-third">
       <%= render(
         partial: "courses/related_sidebar",

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,8 +1,8 @@
 <%= content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= @recruitment_cycle.title %></span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
   Courses
 </h1>
 <p class="govuk-body">Use this section to:</p>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -6,7 +6,7 @@
 
 <%= render "shared/errors" %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-l">
   What type of course?
 </h1>
 <div class="govuk-grid-row">
@@ -28,7 +28,7 @@
           </fieldset>
         <% end %>
 
-        <h2 class="govuk-heading-m remove-top-margin">
+        <h2 class="govuk-heading-m">
           Special educational needs and disability (SEND)
         </h2>
 

--- a/app/views/courses/modern_languages/_form_fields.html.erb
+++ b/app/views/courses/modern_languages/_form_fields.html.erb
@@ -1,9 +1,9 @@
 <%= render "shared/error_wrapper", error_keys: [:modern_languages_subjects], data_qa: "course__modern_languages_subjects" do %>
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading" data-qa="page-heading">
         <% if course.course_code %>
-          <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+          <span class="govuk-caption-l"><%= course.name_and_code %></span>
         <% end %>
         Pick all the languages for this&nbsp;course
       </h1>

--- a/app/views/courses/outcome/_form_fields.html.erb
+++ b/app/views/courses/outcome/_form_fields.html.erb
@@ -1,5 +1,5 @@
 <% legend = capture do %>
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading">
             <%= course_name_and_code %>
             Pick a course outcome

--- a/app/views/courses/outcome/edit.html.erb
+++ b/app/views/courses/outcome/edit.html.erb
@@ -13,7 +13,7 @@
                   method: :put do |form| %>
 
       <% course_name_and_code = capture do %>
-        <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+        <span class="govuk-caption-l"><%= course.name_and_code %></span>
       <% end %>
 
       <%= render "form_fields", form: form, course_name_and_code: course_name_and_code %>

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -8,7 +8,7 @@
   <%= notification_banner.add_heading(text: "This is a preview of the ‘#{course.name_and_code}’ course.") %>
 <% end %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-l">
   <span class="govuk-!-font-size-36" data-qa="course__provider_name"><%= course.provider.provider_name %></span><br>
   <%= course.name_and_code %>
 </h1>

--- a/app/views/courses/request_change.html.erb
+++ b/app/views/courses/request_change.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Request a change to this course" %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-l">
   Request a change to this course
 </h1>
 <div class="govuk-grid-row">

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -14,8 +14,8 @@
   <%= f.govuk_error_summary "You’ll need to correct some information." %>
 <% end %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= course.name_and_code %></span>
   Requirements and eligibility
 </h1>
 
@@ -28,7 +28,7 @@
 
       <%= f.hidden_field :page, value: :requirements %>
 
-      <h3 class="govuk-heading-l remove-top-margin">Qualifications needed</h3>
+      <h2 class="govuk-heading-m">Qualifications needed</h2>
 
       <p class="govuk-body">
         State the minimum academic qualifications needed for this course.
@@ -58,9 +58,9 @@
 
       <%= f.govuk_text_area :required_qualifications, label: { text: "Qualifications needed", size: "s" }, max_words: 100, rows: 10 %>
 
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-      <h3 class="govuk-heading-l remove-top-margin">Personal qualities</h3>
+      <h2 class="govuk-heading-m">Personal qualities</h2>
 
       <p class="govuk-body">
         Tell applicants about the skills, motivation and experience you’re looking for
@@ -69,9 +69,9 @@
 
       <%= f.govuk_text_area :personal_qualities, label: { text: "Personal qualities (optional)", size: "s" }, max_words: 100, rows: 10 %>
 
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-      <h3 class="govuk-heading-l remove-top-margin">Other requirements</h3>
+      <h2 class="govuk-heading-m">Other requirements</h2>
 
       <p class="govuk-body">
         If applicants need any non-academic qualifications or documents, list them here

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -15,8 +15,8 @@
 
   <%= render "shared/errors" %>
 
-  <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= course.name_and_code %></span>
     Course length and salary
   </h1>
 
@@ -26,9 +26,9 @@
 
       <%= render partial: "courses/course_length", locals: { f: f } %>
 
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-      <h3 class="govuk-heading-l remove-top-margin">Salary</h3>
+      <h3 class="govuk-heading-m">Salary</h3>
 
       <p class="govuk-body">Give details about the salary for this course.</p>
       <p class="govuk-body">You should:</p>

--- a/app/views/courses/send/edit.html.erb
+++ b/app/views/courses/send/edit.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
       Special educational needs and disability (SEND)
     </h1>
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -35,8 +35,8 @@
   <% end %>
 <% end %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= course.description %></span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= course.description %></span>
   <%= course.name_and_code %>
 </h1>
 

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -19,8 +19,8 @@
   </div>
 <% end %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= course.name_and_code %></span>
   Pick the locations for this course
 </h1>
 

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -12,7 +12,7 @@
   <%= render "courses/new_fields_holder", form: form, except_keys: [:sites_ids] do |fields| %>
     <%= render "shared/error_wrapper", error_keys: [:sites], data_qa: "course__sites" do %>
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading" data-qa="page-heading">
             Pick the locations for this course
           </h1>

--- a/app/views/courses/start_date/edit.html.erb
+++ b/app/views/courses/start_date/edit.html.erb
@@ -6,7 +6,7 @@
 
 <%= render "shared/errors" %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+<h1 class="govuk-heading-l">
   When does the course start?
 </h1>
 

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -6,7 +6,7 @@
 
 <%= render "shared/errors" %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+<h1 class="govuk-heading-l">
   When does the course start?
 </h1>
 

--- a/app/views/courses/study_mode/_form_fields.html.erb
+++ b/app/views/courses/study_mode/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/error_wrapper", error_keys: [:study_mode], data_qa: "course__study_mode" do %>
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
         Full time or part time?
       </h1>

--- a/app/views/courses/subjects/_form_fields.html.erb
+++ b/app/views/courses/subjects/_form_fields.html.erb
@@ -1,9 +1,9 @@
 <%= render "shared/error_wrapper", error_keys: [:subjects], data_qa: "course__subjects" do %>
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading" data-qa="page-heading">
         <% if course.course_code %>
-          <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+          <span class="govuk-caption-l"><%= course.name_and_code %></span>
         <% end %>
 
         <%= course.subject_page_title %>

--- a/app/views/courses/title/edit.html.erb
+++ b/app/views/courses/title/edit.html.erb
@@ -13,7 +13,7 @@
         <%= govuk_tag(text: "Admin feature", colour: "purple") %>
       </p>
 
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         Change course title
       </h1>
 

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -10,9 +10,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @course, url: vacancies_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code), method: :put do |form| %>
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-7">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-7">
           <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= @course.name %>
+            <span class="govuk-caption-l"><%= @course.name %>
               (<%= @course.course_code %>)</span>
             Edit vacancies
           </h1>

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl"><%= course.name_and_code %></span>
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= course.name_and_code %></span>
       Are you sure you want to withdraw this course?
     </h1>
 
@@ -33,7 +33,7 @@
         <% end %>
         <%= f.text_field "confirm_course_code", class: "govuk-input govuk-input--width-5" %>
       </div>
-      <hr class="govuk-section-break govuk-section-break--m">
+
       <%= f.submit "Yes I’m sure – withdraw this course", class: "govuk-button govuk-button--warning" %>
     <% end %>
 

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row" data-qa="errors__forbidden">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You are not permitted to see this page</h1>
+    <h1 class="govuk-heading-l">You are not permitted to see this page</h1>
     <p class="govuk-body">This page is restricted to certain users only.</p>
     <p class="govuk-body">
       Contact us by email to request access: <%= bat_contact_mail_to subject: "Publish teacher training courses access request" %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
     <p class="govuk-body">Try again later.</p>
     <p class="govuk-body">
       If you continue to see this error contact the Becoming a Teacher team: <%= bat_contact_mail_to subject: "Problem with the service" %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Page not found</h1>
+    <h1 class="govuk-heading-l">Page not found</h1>
     <p class="govuk-body">
       If you typed the web address, check it is correct.
     </p>

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row" data-qa="errors__unauthorized">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Page not available</h1>
+    <h1 class="govuk-heading-l">Page not available</h1>
     <!-- users should never see this page, if they do it's because sign-in failed for some reason -->
     <p class="govuk-body">If you are seeing this, something went wrong and we can't identify you.
       Please try to log in again.</p>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -2,8 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl" data-qa="page-heading">
-      <span class="govuk-caption-xl">Notifications for accredited bodies</span>
+    <h1 class="govuk-heading-l" data-qa="page-heading">
+      <span class="govuk-caption-l">Notifications for accredited bodies</span>
       Changes to courses
     </h1>
 

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Active users by organisation" %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-l">
   Active users by organisation
 </h1>
 

--- a/app/views/pages/accept_terms.html.erb
+++ b/app/views/pages/accept_terms.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Before you begin</h1>
+    <h1 class="govuk-heading-l">Before you begin</h1>
     <p class="govuk-body">We need you to read and agree to our terms and conditions.</p>
     <p class="govuk-body">These set out your responsibilities when publishing content to Publish teacher training courses. This includes making sure your content:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -26,11 +26,11 @@
 
     <p class="govuk-body">The service was designed using the <%= govuk_link_to "GOV.UK design system", "https://design-system.service.gov.uk/accessibility/" %>, which conforms to the WCAG 2.1 AA standard. To ensure the service fully meets the WCAG 2.1 AA standard, we are currently arranging an accessibility audit. We will update this page following the audit, and publish details of any accessibility issues identified.</p>
 
-    <h3 class="govuk-heading-m">Reporting accessibility problems with Publish teacher training courses</h3>
+    <h2 class="govuk-heading-l">Reporting accessibility problems with Publish teacher training courses</h2>
 
     <p class="govuk-body">If you think we’re not meeting accessibility requirements, or you’d like to access any information in a different format (such as accessible PDF, large print, easy read, audio recording or braille), contact <%= bat_contact_mail_to %>. Include ‘Accessibility issues’ in the subject line of your email.</p>
 
-    <h3 class="govuk-heading-m">Enforcement procedure</h3>
+    <h2 class="govuk-heading-l">Enforcement procedure</h2>
 
     <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <%= govuk_link_to "contact the Equality Advisory and Support Service (EASS)", "https://www.equalityadvisoryservice.com/" %>.</p>
 

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -29,7 +29,7 @@
     <%= govuk_details(summary: "Read a transcript of the video here") do %>
       <p class="govuk-body">In this video we’ll show you how to change the vacancy status of a course in Publish teacher training courses. First we’ll show you how to switch vacancies off for a course. And then we’ll show you how to switch vacancies on.</p>
 
-      <h2 class="govuk-heading-m">To switch vacancies off</h2>
+      <h4 class="govuk-heading-s">To switch vacancies off</h4>
       <p class="govuk-body">First, scroll down to the Courses section on your Organisation Overview page.</p>
       <p class="govuk-body">The Courses section now contains an option allowing you to manage vacancies. Click through.</p>
       <p class="govuk-body">Here – on the Courses page – you’ll see the courses table.</p>
@@ -42,7 +42,7 @@
       <p class="govuk-body">Click ‘Publish changes’. You’ll see that the vacancy status of the course has now been updated – a message will tell you that the changes you’ve just made have been published.</p>
       <p class="govuk-body">If you now go back to the main Courses page, you’ll see that the Vacancies column has been updated too. This course is no longer accepting applications.</p>
 
-      <h2 class="govuk-heading-m">To switch vacancies on</h2>
+      <h4 class="govuk-heading-s">To switch vacancies on</h4>
       <p class="govuk-body">Scroll down the Courses page to the courses table. And select the relevant course.</p>
       <p class="govuk-body">As you can see in the Vacancies column, this course currently doesn’t have any vacancies.</p>
       <p class="govuk-body">Click ‘Edit’.</p>
@@ -62,18 +62,18 @@
       <p class="govuk-body">However, it could also be a main address that represents a number of training sites.</p>
       <p class="govuk-body">In this video, first of all we’ll show you how to change the details for a location. Then, we’ll show you how to add a new location – and assign it to one of your courses.</p>
 
-      <h2 class="govuk-heading-m">1.</h2>
+      <h4 class="govuk-heading-s">1.</h4>
       <p class="govuk-body">To change location details, click on the location you’d like to edit.</p>
       <p class="govuk-body">You’ll be taken to a page showing the name and address of this location. Make your changes in the relevant fields.</p>
       <p class="govuk-body">When you’ve finished, click ‘save and publish changes’. Alternatively, click ‘cancel changes’ if you don’t wish to make any edits.</p>
       <p class="govuk-body">You’ll be taken back to the main Locations page. Any changes you make will be published immediately to Find postgraduate teacher training courses.</p>
       <p class="govuk-body">They’ll also be updated in UCAS Apply within two hours.</p>
 
-      <h2 class="govuk-heading-m">2.</h2>
+      <h4 class="govuk-heading-s">2.</h4>
       <p class="govuk-body">To add a new location, click the green ‘Add a location’ button on the Locations page. Note that you can only enter 37 locations in total. </p>
       <p class="govuk-body">Fill in the name and address of the location, including the full postcode. You should also specify a region. A UCAS code will automatically be generated for this location. Click Save.</p>
 
-      <h2 class="govuk-heading-m">3.</h2>
+      <h4 class="govuk-heading-s">3.</h4>
       <p class="govuk-body">Once you’ve added your location, you can assign it to a course. This will allow candidates to select it during the application process.</p>
       <p class="govuk-body">To assign your location to a course, go back to the main page for your organisation. Scroll down to Courses.</p>
       <p class="govuk-body">Though you can only edit your locations in the Locations section, you can only assign them to a course in Courses.</p>

--- a/app/views/pages/notifications_info.html.erb
+++ b/app/views/pages/notifications_info.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Get notifications about your courses</h1>
+    <h1 class="govuk-heading-l">Get notifications about your courses</h1>
 
     <p class="govuk-body">
       You can now sign up for email notifications about courses that you're the accredited body for.

--- a/app/views/pages/performance_dashboard/_allocations_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_allocations_tab.html.erb
@@ -1,11 +1,11 @@
-<h2 class="govuk-heading-l">Allocations</h2>
+<h2 class="govuk-heading-m">Allocations</h2>
 
-<h3 class="govuk-heading-m">
+<h3 class="govuk-heading-s">
   PE Requests for <%= next_allocation_cycle_period_text %>
 </h3>
 <%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "current" } %>
 
-<h3 class="govuk-heading-m">
+<h3 class="govuk-heading-s">
   PE Requests for <%= current_allocation_cycle_period_text %>
 </h3>
 <%= render partial: "pages/performance_dashboard/allocation_content", locals: { recruitment_cycle: "previous" } %>

--- a/app/views/pages/performance_dashboard/_courses_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_courses_tab.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Courses</h2>
+<h2 class="govuk-heading-m">Courses</h2>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-full">

--- a/app/views/pages/performance_dashboard/_providers_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_providers_tab.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Providers</h2>
+<h2 class="govuk-heading-m">Providers</h2>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-full">

--- a/app/views/pages/performance_dashboard/_rollover_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_rollover_tab.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Rollover</h2>
+<h2 class="govuk-heading-m">Rollover</h2>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-full">

--- a/app/views/pages/performance_dashboard/_users_tab.html.erb
+++ b/app/views/pages/performance_dashboard/_users_tab.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Users</h2>
+<h2 class="govuk-heading-m">Users</h2>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-full">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -3,10 +3,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Privacy policy</h1>
+
     <h2 class="govuk-heading-l">Who we are</h2>
     <p class="govuk-body">This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of ‘Publish teacher training courses’.</p>
 
-    <h2 class="govuk-heading-l">What personal information we will store</h2>
+    <h2 class="govuk-heading-l">What personal information we will&nbsp;store</h2>
     <p class="govuk-body">For all users, we will store:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>part of your IP address to track user journeys. We do not collect IP addresses in their entirety to avoid the personal identification of users</li>
@@ -29,11 +30,12 @@
       Personally identifiable contact information that is published in course listings may be passed on to a third party that will use our course listing data (UCAS) via an application programming interface (API), as described in our Terms and Conditions, in order to feed their postgraduate teacher training application system. Any personal information provided in a course listing will be subject to the third party’s (UCAS) data handling obligations. We are not responsible for how a third party handles any personal information you choose to include in a course listing.
     </p>
 
-    <h2 class="govuk-heading-l">Why our use of your personal data is lawful</h2>
+    <h2 class="govuk-heading-l">Why our use of your personal data is&nbsp;lawful</h2>
     <p class="govuk-body">
       In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For the purpose of this project, this processing is necessary to complete a task in the public interest as stated under GDPR Article 6 (1)(e).
     </p>
-    <h2 class="govuk-heading-l">Who we will make your personal data available to</h2>
+
+    <h2 class="govuk-heading-l">Who we will make your personal data available&nbsp;to</h2>
     <p class="govuk-body">
       We sometimes need to make personal data available to other organisations. These might include contracted partners (who we have employed to process your personal data on our behalf) and/or other organisations (with whom we need to share your personal data for specific purposes).
     </p>
@@ -50,7 +52,7 @@
       <li>to enable users to use the service and receive updates: our contracted suppliers collect the names and emails of those publishing course listings on ‘Publish teacher training courses’</li>
     </ul>
 
-    <h2 class="govuk-heading-l">How long we will keep your personal data</h2>
+    <h2 class="govuk-heading-l">How long we will keep your personal&nbsp;data</h2>
     <p class="govuk-body">
       Neither DfE nor its contracted suppliers will keep your personal data longer than we need it for the purpose(s) of research, security and/or delivery of the service, and in any case not longer than 7 years. Your data will be securely deleted when DfE and its contracted suppliers no longer need it for these purposes, or when 7 years have passed, whichever comes first.
     </p>
@@ -74,18 +76,16 @@
     <p class="govuk-body">
       If you need to contact us regarding any of the above, please do so via the DfE site at: <%= govuk_link_to "https://www.gov.uk/contact-dfe", "https://www.gov.uk/contact-dfe" %>.
     </p>
-
     <p class="govuk-body">
       You can <%= govuk_link_to "find out more about your data protection rights", "https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights" %> on the Information Commissioner’s website.
     </p>
 
     <h2 class="govuk-heading-l">The right to lodge a complaint</h2>
-
     <p class="govuk-body">
       You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at <%= govuk_link_to "https://ico.org.uk/make-a-complaint/", "https://ico.org.uk/make-a-complaint/" %></a>.
     </p>
-    <h2 class="govuk-heading-l">Contact Info</h2>
 
+    <h2 class="govuk-heading-l">Contact information</h2>
     <p class="govuk-body">
       If you have any questions about how your personal information will be used, please contact us at <%= bat_contact_mail_to %> and enter data privacy as a reference. For the Data Protection Officer (DPO) please contact us via gov.uk and mark it for the attention of the ‘DPO’.
     </p>

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Prepare for the next cycle
     </h1>
 

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -2,8 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Requesting permission to recruit for the <br><%= next_recruitment_cycle_period_text %> cycle
+    <h1 class="govuk-heading-l">
+      Requesting permission to recruit for the <%= next_recruitment_cycle_period_text %> cycle
     </h1>
 
     <p class="govuk-body">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -3,8 +3,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Terms and conditions</h1>
-    <h2 class="govuk-heading-l">Users of the Service</h2>
-    <h3 class="govuk-heading-m">Using our website</h3>
+
+    <h2 class="govuk-heading-l">Using our website</h2>
     <p class="govuk-body">
       Please read these Terms of Use (“General Terms”) carefully before using this Publish teacher training courses (the “Service”).
     </p>
@@ -13,9 +13,9 @@
     </p>
     <p class="govuk-body">
       If we change these General Terms we will post the revised document here with an updated effective date. If we make significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on our home page.
-
     </p>
-    <h3 class="govuk-heading-m">Information About Us</h3>
+
+    <h2 class="govuk-heading-l">Information About Us</h2>
     <p class="govuk-body">
       This Service is operated by the Department for Education (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
     </p>
@@ -23,7 +23,7 @@
       You can contact us using the following email address: <%= bat_contact_mail_to %>
     </p>
 
-    <h3 class="govuk-heading-m">Access to the Service</h3>
+    <h2 class="govuk-heading-l">Access to the Service</h2>
     <p class="govuk-body">
       We will not be liable if for any reason the Service is unavailable at any time or for any period. From time to time, we may restrict access to all or some parts of the Service to users who have registered with us.
     </p>
@@ -37,7 +37,7 @@
       The Department for Education withholds the right to withdraw without notice listings that breach these terms and to withdraw the access of users who breach them.
     </p>
 
-    <h3 class="govuk-heading-m">Hyperlinking to the Publish teacher training courses website</h3>
+    <h2 class="govuk-heading-l">Hyperlinking to the Publish teacher training courses website</h2>
     <p class="govuk-body">
       We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Publish teacher training courses’ pages must be displayed in the user's entire browser window.
     </p>
@@ -45,7 +45,7 @@
       You may not charge your website's users to click on a link to any page on the Service.
     </p>
 
-    <h3 class="govuk-heading-m">Third Party Content and Hyperlinking from the Service</h3>
+    <h2 class="govuk-heading-l">Third Party Content and Hyperlinking from the Service</h2>
     <p class="govuk-body">
       We are not liable or responsible for the third party content on the Service. Third party content includes, for example, material posted by other users of the Service and course listings.
     </p>
@@ -56,7 +56,7 @@
       We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.
     </p>
 
-    <h3 class="govuk-heading-m">Virus protection</h3>
+    <h2 class="govuk-heading-l">Virus protection</h2>
     <p class="govuk-body">
       We make every effort to check and test material at all stages of production. We do not guarantee our service will be secure or free from bugs or viruses. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.
     </p>
@@ -64,7 +64,7 @@
       We will report misuse, unauthorised access or other breaches of the Computer Misuse Act 1990 to the relevant law enforcement authorities and co-operate with them to determine your identity.
     </p>
 
-    <h3 class="govuk-heading-m">Disclaimer and Liability</h3>
+    <h2 class="govuk-heading-l">Disclaimer and Liability</h2>
     <p class="govuk-body">
       The content of this Service includes both content created by us (included but not limited to content that helps you use the Service) and third-party content (included but not limited to course listings). We do not:
     </p>
@@ -90,29 +90,26 @@
     <p class="govuk-body">
       These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.
     </p>
-    <h3 class="govuk-heading-m">
-      Validity of these General Terms
-    </h3>
+
+    <h2 class="govuk-heading-l">Validity of these General Terms</h2>
     <p class="govuk-body">
       If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the remaining terms and conditions will still apply.
     </p>
-    <h3 class="govuk-heading-m">
-      Applicable Law and Jurisdiction
-    </h3>
+
+    <h2 class="govuk-heading-l">Applicable Law and Jurisdiction</h2>
     <p class="govuk-body">
       These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms will be subject to the exclusive jurisdiction of the courts of England and Wales.
     </p>
-    <h3 class="govuk-heading-m">
-      Using the Service
-    </h3>
+
+    <h2 class="govuk-heading-l">Using the Service</h2>
     <p class="govuk-body">
       Access and use by you of this Service constitutes your acceptance of these Terms and Conditions. This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
-    </p><p class="govuk-body">
+    </p>
+    <p class="govuk-body">
       By using Publish teacher training courses you agree to abide by the following terms and conditions.
     </p>
-    <h3 class="govuk-heading-m">
-      Unacceptable Use
-    </h3>
+
+    <h2 class="govuk-heading-l">Unacceptable Use</h2>
     <p class="govuk-body">
       You must not publish:
     </p>
@@ -139,9 +136,8 @@
         material that encourages or teaches conduct that is a criminal offence, gives rise to civil liability, or is otherwise unlawful
       </li>
     </ul>
-    <h3 class="govuk-heading-m">
-      Listing Data
-    </h3>
+
+    <h2 class="govuk-heading-l">Listing Data</h2>
     <p class="govuk-body">
       Data ownership: training providers and schools have sole responsibility for maintaining the accuracy and appropriateness of the data contained in their listings.
     </p>

--- a/app/views/pages/transition_info.html.erb
+++ b/app/views/pages/transition_info.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Important new features</h1>
+    <h1 class="govuk-heading-l">Important new features</h1>
     <p class="govuk-body">You now have access to new features, allowing you to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -17,8 +17,6 @@
     <p class="govuk-body">You can no longer use UCAS to add or edit courses. All course management must now be done in this service.</p>
 
     <p class="govuk-body">You’ll still need to use UCAS to view and manage course applications. This is because candidates will continue to apply for courses through UCAS.</p>
-
-    <hr class="govuk-section-break govuk-section-break--m">
 
     <%= form_for :user, url: accept_transition_info_path, method: :patch do |f| %>
       <%= f.submit "Continue", class: "govuk-button", data: { qa: "transition__continue" } %>

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,14 +1,14 @@
 <%= content_for :page_title, "Publish test users" %>
 
-<h1 class="govuk-heading-xl">Publish test users</h1>
+<h1 class="govuk-heading-l">Publish test users</h1>
 
 <p class="govuk-body">
   <%= govuk_link_to "Login as an anonymised user", "/auth/developer" %>
 </p>
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-<h2 class="govuk-heading-l">Anne</h2>
+<h2 class="govuk-heading-m">Anne</h2>
 
 <p class="govuk-body">
   <%= govuk_tag(text: "School Direct", colour: "blue") %>
@@ -25,9 +25,9 @@
   <%= submit_tag "Login as Anne", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-<h2 class="govuk-heading-l">Susy</h2>
+<h2 class="govuk-heading-m">Susy</h2>
 
 <p class="govuk-body">
   <%= govuk_tag(text: "Accredited body", colour: "blue") %>
@@ -44,9 +44,9 @@
   <%= submit_tag "Login as Susy", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-<h2 class="govuk-heading-l">Mary</h2>
+<h2 class="govuk-heading-m">Mary</h2>
 
 <p class="govuk-body">
   <%= govuk_tag(text: "Multi-org", colour: "blue") %>
@@ -71,9 +71,9 @@
   <%= submit_tag "Login as Mary", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-<h2 class="govuk-heading-l">Colin</h2>
+<h2 class="govuk-heading-m">Colin</h2>
 
 <p class="govuk-body">
   <%= govuk_tag(text: "Admin", colour: "blue") %>

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">
           <%= @provider.provider_name %>
         </span>
         About your organisation
@@ -58,7 +58,9 @@
       <%= f.govuk_text_area :train_with_us, label: { text: "Training with you", size: "s" }, max_words: 250, rows: 15 %>
 
       <% if provider.accredited_bodies.present? %>
-        <h2 class="govuk-heading-l">About your accredited body</h2>
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+        <h2 class="govuk-heading-m">About your accredited body</h2>
 
         <p id="about-training-provider-hint" class="govuk-body">
           Tell applicants about your accredited body - you could mention their academic specialities and achievements.
@@ -72,7 +74,9 @@
         <% end %>
       <% end %>
 
-      <h2 class="govuk-heading-l">Training with disabilities and other needs</h2>
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+      <h2 class="govuk-heading-m">Training with disabilities and other needs</h2>
 
       <p class="govuk-body">
         Say how you support candidates with disabilities and other needs. This could include candidates with:
@@ -90,8 +94,6 @@
       <%= f.govuk_text_area :train_with_disability,
                             label: { text: "Training with disabilities and other needs", size: "s" },
                             max_words: 250, rows: 15 %>
-
-      <hr class="govuk-section-break govuk-section-break--l">
 
       <%= f.govuk_submit "Save and publish changes" %>
 

--- a/app/views/providers/access_requests/new.html.erb
+++ b/app/views/providers/access_requests/new.html.erb
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Request access for someone&nbsp;else</h1>
+    <h1 class="govuk-heading-l">Request access for someone&nbsp;else</h1>
     <p class="govuk-body">You can request a DfE Sign-in account for others who manage your courses.</p>
 
     <h2 class="govuk-heading-m">Request an account for:</h2>

--- a/app/views/providers/allocations/_allocation_request_closed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_closed_state.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">PE courses for <%= next_allocation_cycle_period_text %></h1>
+    <h1 class="govuk-heading-l">PE courses for <%= next_allocation_cycle_period_text %></h1>
 
     <% if @allocations_view.requested_allocations_statuses.any? || @allocations_view.not_requested_allocations_statuses.any? %>
       <p class="govuk-body">

--- a/app/views/providers/allocations/_allocation_request_confirmed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_confirmed_state.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"> Fee-funded PE courses for <%= next_allocation_cycle_period_text %></h1>
+    <h1 class="govuk-heading-l">Fee-funded PE courses for <%= next_allocation_cycle_period_text %></h1>
 
     <% if @allocations_view.confirmed_allocation_places.any? %>
       <p class="govuk-body">

--- a/app/views/providers/allocations/_allocation_request_open_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_open_state.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Request PE courses for <%= next_allocation_cycle_period_text %></h1>
+    <h1 class="govuk-heading-l">Request PE courses for <%= next_allocation_cycle_period_text %></h1>
 
     <p class="govuk-body">
       You must request any fee-funded PE courses for <%= next_allocation_cycle_period_text %> by

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -23,8 +23,8 @@
                   skip_enforcing_utf8: true,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= training_provider.provider_name %></span>
         Check your information before sending your request
       </h1>
 

--- a/app/views/providers/allocations/edit.html.erb
+++ b/app/views/providers/allocations/edit.html.erb
@@ -15,8 +15,8 @@
 
       <%= form.govuk_radio_buttons_fieldset(
         :old_department_id,
-        legend: { size: "xl", text: page_title, tag: "h1" },
-        caption: { text: "#{@training_provider.provider_name} ", size: "xl" },
+        legend: { size: "l", text: page_title, tag: "h1" },
+        caption: { text: "#{@training_provider.provider_name} ", size: "l" },
       ) do %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" } %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>

--- a/app/views/providers/allocations/initial_request.html.erb
+++ b/app/views/providers/allocations/initial_request.html.erb
@@ -14,7 +14,7 @@
 
       <%= form.govuk_error_summary %>
 
-      <%= form.govuk_radio_buttons_fieldset(:training_provider_code, legend: { size: "xl", text: "Who are you requesting a course for?", tag: "h1" }) do %>
+      <%= form.govuk_radio_buttons_fieldset(:training_provider_code, legend: { size: "l", text: "Who are you requesting a course for?", tag: "h1" }) do %>
         <p class="govuk-body">
           This should be the name of the organisation offering the course. For
           example, a lead school or your own organisation, if you’re offering it.

--- a/app/views/providers/allocations/new_repeat_request.html.erb
+++ b/app/views/providers/allocations/new_repeat_request.html.erb
@@ -16,8 +16,8 @@
 
       <%= form.govuk_radio_buttons_fieldset(
         :request_type,
-        legend: { size: "xl", text: page_title, tag: "h1" },
-        caption: { text: "#{@training_provider.provider_name} ", size: "xl" },
+        legend: { size: "l", text: page_title, tag: "h1" },
+        caption: { text: "#{@training_provider.provider_name} ", size: "l" },
       ) do %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" }, link_errors: true %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -17,10 +17,10 @@
       <%= form.govuk_text_field :number_of_places,
         label: {
           text: "How many places would you like to request?",
-          size: "xl",
+          size: "l",
           tag: "h1",
         },
-        caption: { text: "#{training_provider.provider_name} ", size: "xl" },
+        caption: { text: "#{training_provider.provider_name} ", size: "l" },
         pattern: "[0-9]*",
         inputmode: "numeric",
         width: 10 do %>

--- a/app/views/providers/allocations/pick_a_provider.html.erb
+++ b/app/views/providers/allocations/pick_a_provider.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Pick a provider</h1>
+    <h1 class="govuk-heading-l">Pick a provider</h1>
 
     <p class="govuk-body">You searched for ‘<%= params[:training_provider_query] %>’</p>
     <p class="govuk-body">We found these providers which matched your search:</p>
@@ -37,7 +37,7 @@
       <% end %>
     </ul>
 
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
     <%= govuk_details(summary: "Try another provider") do %>
       <%= form_with url: initial_request_provider_recruitment_cycle_allocations_path(

--- a/app/views/providers/allocations/requests/_not_requested.html.erb
+++ b/app/views/providers/allocations/requests/_not_requested.html.erb
@@ -2,8 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl" data-qa="page-heading">
-      <span class="govuk-caption-xl"><%= @training_provider.provider_name %> </span>
+    <h1 class="govuk-heading-l" data-qa="page-heading">
+      <span class="govuk-caption-l"><%= @training_provider.provider_name %></span>
       Thank you
     </h1>
     <p class="govuk-body">

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -8,8 +8,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">
         <%= @provider.provider_name %>
       </span>
       Contact details
@@ -82,8 +82,6 @@
         <% end %>
       <% end %>
 
-      <hr class="govuk-section-break govuk-section-break--l">
-
       <h3 class="govuk-heading-m">Contact address</h3>
 
       <%= render "shared/form_field",
@@ -115,8 +113,6 @@
         form: f, field: :postcode do |field, options| %>
         <%= f.text_field field, options.merge(class: "govuk-input govuk-input--width-10") %>
       <% end %>
-
-      <hr class="govuk-section-break govuk-section-break--l">
       <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 2 hours.</p>
       <%= f.submit "Save and publish changes", class: "govuk-button" %>
     <% end %>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -23,8 +23,8 @@
   </div>
 <% end %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= @recruitment_cycle.title %></span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
   About your organisation
 </h1>
 

--- a/app/views/providers/edit_initial_allocations/check_answers.html.erb
+++ b/app/views/providers/edit_initial_allocations/check_answers.html.erb
@@ -27,8 +27,8 @@
                   skip_enforcing_utf8: true,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl"><%= training_provider.provider_name %></span>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= training_provider.provider_name %></span>
         Check your information before sending your request
       </h1>
 

--- a/app/views/providers/edit_initial_allocations/do_you_want.html.erb
+++ b/app/views/providers/edit_initial_allocations/do_you_want.html.erb
@@ -19,8 +19,8 @@
       <%= form.govuk_error_summary %>
       <%= form.govuk_radio_buttons_fieldset(
         :request_type,
-        legend: { size: "xl", text: page_title, tag: "h1" },
-        caption: { text: "#{training_provider.provider_name} ", size: "xl" },
+        legend: { size: "l", text: page_title, tag: "h1" },
+        caption: { text: "#{training_provider.provider_name} ", size: "l" },
       ) do %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::INITIAL, label: { text: "Yes" }, link_errors: true %>
         <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>

--- a/app/views/providers/edit_initial_allocations/number_of_places.html.erb
+++ b/app/views/providers/edit_initial_allocations/number_of_places.html.erb
@@ -30,10 +30,10 @@
                                 value: params[:number_of_places] || allocation.number_of_places,
                                 label: {
                                   text: "How many places would you like to request?",
-                                  size: "xl",
+                                  size: "l",
                                   tag: "h1",
                                 },
-                                caption: { text: "#{training_provider.provider_name} ", size: "xl" },
+                                caption: { text: "#{training_provider.provider_name} ", size: "l" },
                                 pattern: "[0-9]*",
                                 inputmode: "numeric",
                                 width: 10 do %>

--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "Organisations" %>
 
-<h1 class="govuk-heading-xl">Organisations</h1>
+<h1 class="govuk-heading-l">Organisations</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/no_providers.erb
+++ b/app/views/providers/no_providers.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row" data-qa="errors__no_providers">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">We don’t know which organisation you’re part of</h1>
+    <h1 class="govuk-heading-l">We don’t know which organisation you’re part of</h1>
     <p class="govuk-body">You have successfully signed in with your DfE account but we don’t recognise the email address you’ve used. This might have happened if you were forwarded the original invitation email or if you’ve recently updated your email address.</p>
     <p class="govuk-body">We need more information from you before we can give you access to your organisation’s courses.</p>
     <p class="govuk-body">To gain access, please:</p>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -3,7 +3,7 @@
   <%= content_for :before_content, render_breadcrumbs(:provider) %>
 <% end %>
 
-<h1 class="govuk-heading-xl"><%= @provider.provider_name %></h1>
+<h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/training_provider_courses.html.erb
+++ b/app/views/providers/training_provider_courses.html.erb
@@ -1,8 +1,8 @@
 <%= content_for :page_title, provider.provider_name %>
 <%= content_for :before_content, render_breadcrumbs(:training_provider_courses) %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">Training provider</span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">Training provider</span>
   <%= @training_provider.provider_name %>
 </h1>
 

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, "Courses as an accredited body" %>
 <%= content_for :before_content, render_breadcrumbs(:training_providers) %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-l">
   Courses as an accredited body
 </h1>
 

--- a/app/views/providers/users/index.html.erb
+++ b/app/views/providers/users/index.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Users</h1>
+    <h1 class="govuk-heading-l">Users</h1>
     <p class="govuk-body">
       These users currently have access to this organisation. They can manage all your course and organisation details, including publishing, closing and withdrawing courses.
     </p>

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title, @recruitment_cycle.title %>
 <%= content_for :before_content, render_breadcrumbs(:recruitment_cycle) %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-l">
   <%= @recruitment_cycle.title %>
 </h1>
 
@@ -16,7 +16,6 @@
         Manage courses, locations and vacancies in the current&nbsp;cycle.
       </p>
     <% end %>
-    <hr class="govuk-section-break govuk-section-break--m">
 
     <%= render partial: "recruitment_cycles/about_organisation", locals: { provider: @provider, year: params[:year] } %>
     <%= render partial: "recruitment_cycles/courses_info", locals: { provider: @provider, year: params[:year] } %>

--- a/app/views/sessions/magic_link_sent.html.erb
+++ b/app/views/sessions/magic_link_sent.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Check your email
     </h1>
     <p class="govuk-body-l">

--- a/app/views/sign_in/dfe_sign_in_is_down.html.erb
+++ b/app/views/sign_in/dfe_sign_in_is_down.html.erb
@@ -7,9 +7,7 @@
       <p class="govuk-body">DfE Sign-in is experiencing problems. You need to sign in using your email address.</p>
     <% end %>
 
-    <h1 class="govuk-heading-xl">
-      Sign in
-    </h1>
+    <h1 class="govuk-heading-l">Sign in</h1>
 
     <p class="govuk-body-l">You must sign in to your account to publish teacher training courses.</p>
 
@@ -20,7 +18,7 @@
       <%= f.govuk_submit "Continue" %>
     <% end %>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
     <h2 class="govuk-heading-m">Ask for an account</h2>
     <p class="govuk-body">Do not have an account? You can get one by emailing <%= bat_contact_mail_to %>. Please include the full names and email addresses of anyone who needs access.</p>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     <% end %>
 
-    <h1 class="govuk-heading-xl">Sign in</h1>
+    <h1 class="govuk-heading-l">Sign in</h1>
 
     <p class="govuk-body-l">You must sign in to your account to publish teacher training courses.</p>
 
@@ -19,7 +19,7 @@
       <%= govuk_link_to "Sign in using a Persona", "/personas", button: true %>
     <% end %>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
     <h2 class="govuk-heading-m">Ask for an account</h2>
     <p class="govuk-body">Do not have an account? You can get one by emailing <%= bat_contact_mail_to %>. Please include the full names and email addresses of anyone who needs access.</p>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -3,7 +3,7 @@
 
 <%= render "shared/errors" %>
 
-<h1 class="govuk-heading-xl"><%= @site_name_before_update %></h1>
+<h1 class="govuk-heading-l"><%= @site_name_before_update %></h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -11,7 +11,6 @@
                   url: provider_recruitment_cycle_site_path(@provider.provider_code, @site.recruitment_cycle_year, @site.id),
                   method: :put do |f| %>
       <p class="govuk-body">You can assign locations to a course from the ‘Basic details’ tab on the course page.</p>
-      <hr class="govuk-section-break govuk-section-break--l">
       <%= render "form", f: f %>
       <%= f.submit "Save and publish changes", class: "govuk-button", data: { qa: "location__publish-changes" } %>
     <% end %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,8 +1,8 @@
 <%= content_for :page_title, "Locations" %>
 <%= content_for :before_content, render_breadcrumbs(:sites) %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= @recruitment_cycle.title %></span>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
   Locations
 </h1>
 

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -3,7 +3,7 @@
 
 <%= render "shared/errors" %>
 
-<h1 class="govuk-heading-xl">Add a location</h1>
+<h1 class="govuk-heading-l">Add a location</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -12,7 +12,6 @@
                   method: :post do |f| %>
       <p class="govuk-body">Once a location is added (and assigned to a course), candidates can choose it as their preferred place of training when completing the UCAS application form.</p>
       <p class="govuk-body">When you’ve added this location you can assign it to a course from the ‘Basic details’ tab on the course page.</p>
-      <hr class="govuk-section-break govuk-section-break--l">
       <%= render "form", f: f %>
       <%= f.submit "Save", class: "govuk-button", data: { qa: "location__publish-changes" } %>
     <% end %>

--- a/app/views/ucas_contacts/alerts.html.erb
+++ b/app/views/ucas_contacts/alerts.html.erb
@@ -6,7 +6,7 @@
 
 <%= render "shared/errors" %>
 
-<h1 class="govuk-heading-xl" data-qa="ucas_contacts__alerts__main_heading">
+<h1 class="govuk-heading-l" data-qa="ucas_contacts__alerts__main_heading">
   Email alerts for new applications
 </h1>
 
@@ -16,7 +16,7 @@
                   url: alerts_provider_ucas_contacts_path(@provider.provider_code),
                   data: { qa: "ucas_contacts__alerts_form" } do |form| %>
 
-      <div data-qa="ucas_contacts__alerts_enabled">
+      <div class="govuk-!-margin-bottom-8" data-qa="ucas_contacts__alerts_enabled">
         <div class="govuk-radios__item">
           <%= form.radio_button :send_application_alerts,
                                 "all",
@@ -40,9 +40,7 @@
         </div>
       </div>
 
-      <hr class="govuk-section-break govuk-section-break--l">
-
-      <h2 class="govuk-heading-l">Who are the alerts sent to?</h2>
+      <h2 class="govuk-heading-m">Who are the alerts sent to?</h2>
 
       <div class="govuk-form-group ">
         <%= form.label :application_alert_contact, class: "govuk-label" do %>
@@ -68,8 +66,6 @@
           </div>
         </div>
       <% end %>
-
-      <hr class="govuk-section-break govuk-section-break--l">
 
       <%= form.submit "Save", class: "govuk-button", data: { qa: "course__save" } %>
     <% end %>

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= content_for :before_content, render_breadcrumbs("ucas_contacts") %>
 
-<h1 class="govuk-heading-xl">UCAS contacts</h1>
+<h1 class="govuk-heading-l">UCAS contacts</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -11,7 +11,7 @@
     <p class="govuk-body">You can no longer change these contacts in NetUpdate, as NetUpdate has now been turned off.</p>
 
     <%= govuk_inset_text do %>
-      <h2 class="govuk-heading-m">What does ‘information unknown’ mean?</h2>
+      <h2 class="govuk-heading-s">What does ‘information unknown’ mean?</h2>
 
       <p class="govuk-body">Some of the contacts below are labelled ‘Information unknown’. This is because UCAS doesn’t have permission under the <%= govuk_link_to "General Data Protection Regulation", "https://www.gov.uk/government/publications/guide-to-the-general-data-protection-regulation" %> (GDPR) to share these details with us.</p>
 
@@ -26,15 +26,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Who will UCAS contact?</h2>
+    <h2 class="govuk-heading-m">Who will UCAS contact?</h2>
 
     <p class="govuk-body">UCAS will contact these people at your organisation:</p>
 
     <%= render partial: "ucas_contact_list", locals: { ucas_contact_view: @ucas_contact_view } %>
 
-    <hr class="govuk-section-break govuk-section-break--xl">
+    <hr class="govuk-section-break govuk-section-break--l">
 
-    <h2 class="govuk-heading-l">Letters for successful applicants</h2>
+    <h2 class="govuk-heading-m">Letters for successful applicants</h2>
 
     <p class="govuk-body">UCAS sends all successful applicants a letter – this is known as a ‘GT12&nbsp;letter’.</p>
 
@@ -55,9 +55,9 @@
       ) %>
     <% end %>
 
-    <hr class="govuk-section-break govuk-section-break--xl">
+    <hr class="govuk-section-break govuk-section-break--l">
 
-    <h2 class="govuk-heading-l">Email alerts for new applications</h2>
+    <h2 class="govuk-heading-m">Email alerts for new applications</h2>
 
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.slot(

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -55,7 +55,7 @@ feature "Edit accredited body", type: :feature do
 
     scenario "It displays the correct title" do
       expect(page.title).to start_with("Who is the accredited body?")
-      expect(accredited_body_page.title.text).to eq("Who is the accredited body?")
+      expect(accredited_body_page.legend.text).to eq("Who is the accredited body?")
     end
   end
 
@@ -197,7 +197,7 @@ feature "Edit accredited body", type: :feature do
 
     scenario "It displays the correct title" do
       expect(page.title).to start_with("Who is the accredited body?")
-      expect(accredited_body_page.title.text).to eq("Who is the accredited body?")
+      expect(accredited_body_page.legend.text).to eq("Who is the accredited body?")
     end
   end
 

--- a/spec/features/courses/accredited_body/new_spec.rb
+++ b/spec/features/courses/accredited_body/new_spec.rb
@@ -147,7 +147,7 @@ feature "New accredited body" do
   context "Page title" do
     scenario "It displays the correct title" do
       expect(page.title).to start_with("Who is the accredited body?")
-      expect(new_accredited_body_search_page.title.text).to eq("Who is the accredited body?")
+      expect(new_accredited_body_search_page.legend.text).to eq("Who is the accredited body?")
     end
   end
 

--- a/spec/features/courses/delete_or_withdraw_spec.rb
+++ b/spec/features/courses/delete_or_withdraw_spec.rb
@@ -27,10 +27,10 @@ feature "Getting rid of a course", type: :feature do
     scenario "withdrawing can be requested via support" do
       course_page.withdraw_link.click
 
-      expect(find(".govuk-caption-xl")).to have_content(
+      expect(find(".govuk-caption-l")).to have_content(
         "#{course.name} (#{course.course_code})",
       )
-      expect(find(".govuk-heading-xl")).to have_content(
+      expect(find(".govuk-heading-l")).to have_content(
         "Are you sure you want to withdraw this course?",
       )
     end
@@ -46,10 +46,10 @@ feature "Getting rid of a course", type: :feature do
     scenario "deletion can be requested via support" do
       course_page.delete_link.click
 
-      expect(find(".govuk-caption-xl")).to have_content(
+      expect(find(".govuk-caption-l")).to have_content(
         "#{course.name} (#{course.course_code})",
       )
-      expect(find(".govuk-heading-xl")).to have_content(
+      expect(find(".govuk-heading-l")).to have_content(
         "Are you sure you want to delete this course?",
       )
     end

--- a/spec/features/courses/destroy_spec.rb
+++ b/spec/features/courses/destroy_spec.rb
@@ -33,10 +33,10 @@ feature "Delete course", type: :feature do
   scenario "confirming course code" do
     course_page.delete_link.click
 
-    expect(find(".govuk-caption-xl")).to have_content(
+    expect(find(".govuk-caption-l")).to have_content(
       "#{course.name} (#{course.course_code})",
     )
-    expect(find(".govuk-heading-xl")).to have_content(
+    expect(find(".govuk-heading-l")).to have_content(
       "Are you sure you want to delete this course?",
     )
 
@@ -53,10 +53,10 @@ feature "Delete course", type: :feature do
     scenario "display validation errors" do
       course_page.delete_link.click
 
-      expect(find(".govuk-caption-xl")).to have_content(
+      expect(find(".govuk-caption-l")).to have_content(
         "#{course.name} (#{course.course_code})",
       )
-      expect(find(".govuk-heading-xl")).to have_content(
+      expect(find(".govuk-heading-l")).to have_content(
         "Are you sure you want to delete this course?",
       )
 

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -33,10 +33,10 @@ feature "Withdraw course", type: :feature do
   scenario "confirming course code" do
     course_page.withdraw_link.click
 
-    expect(find(".govuk-caption-xl")).to have_content(
+    expect(find(".govuk-caption-l")).to have_content(
       "#{course.name} (#{course.course_code})",
     )
-    expect(find(".govuk-heading-xl")).to have_content(
+    expect(find(".govuk-heading-l")).to have_content(
       "Are you sure you want to withdraw this course?",
     )
 
@@ -53,10 +53,10 @@ feature "Withdraw course", type: :feature do
     scenario "display validation errors" do
       course_page.withdraw_link.click
 
-      expect(find(".govuk-caption-xl")).to have_content(
+      expect(find(".govuk-caption-l")).to have_content(
         "#{course.name} (#{course.course_code})",
       )
-      expect(find(".govuk-heading-xl")).to have_content(
+      expect(find(".govuk-heading-l")).to have_content(
         "Are you sure you want to withdraw this course?",
       )
 

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -180,7 +180,7 @@ private
   end
 
   def and_i_see_training_provider_name
-    expect(find("span.govuk-caption-xl")).to have_content(training_provider.provider_name)
+    expect(find(".govuk-caption-l")).to have_content(training_provider.provider_name)
   end
 
   def then_i_see_the_pe_allocations_request_page

--- a/spec/site_prism/page_objects/page/organisations/course_base.rb
+++ b/spec/site_prism/page_objects/page/organisations/course_base.rb
@@ -6,8 +6,9 @@ module PageObjects
           self.load(provider_code: course.provider_code, recruitment_cycle_year: course.recruitment_cycle_year, course_code: course.course_code)
         end
 
-        element :title, ".govuk-heading-xl"
-        element :caption, ".govuk-caption-xl"
+        element :title, ".govuk-heading-l"
+        element :legend, ".govuk-fieldset__legend--l .govuk-fieldset__heading"
+        element :caption, ".govuk-caption-l"
         element :flash, ".govuk-notification-banner--success"
         element :error_flash, ".govuk-error-summary"
         element :warning_message, '[data-qa="copy-course-warning"]'

--- a/spec/site_prism/page_objects/page/organisations/courses_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses_page.rb
@@ -9,7 +9,7 @@ module PageObjects
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/courses"
 
         element :flash, ".govuk-notification-banner--success"
-        element :caption, ".govuk-caption-xl"
+        element :caption, ".govuk-caption-l"
 
         element :course_create, ".govuk-button", text: "Add a new course"
         element :course_create_additional, '[data-qa="course-create-additional"]'

--- a/spec/site_prism/page_objects/page/organisations/organisation_about.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_about.rb
@@ -4,8 +4,8 @@ module PageObjects
       class OrganisationAbout < PageObjects::Base
         set_url "/organisations/{provider_code}/about"
 
-        element :title, ".govuk-heading-xl"
-        element :caption, ".govuk-caption-xl"
+        element :title, ".govuk-heading-l"
+        element :caption, ".govuk-caption-l"
         element :train_with_us, "#provider-train-with-us-field"
         element :train_with_disability, "#provider-train-with-disability-field"
         element :error_flash, ".govuk-error-summary"

--- a/spec/site_prism/page_objects/page/organisations/organisation_contact.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_contact.rb
@@ -4,8 +4,8 @@ module PageObjects
       class OrganisationContact < PageObjects::Base
         set_url "/organisations/{provider_code}/contact"
 
-        element :title, ".govuk-heading-xl"
-        element :caption, ".govuk-caption-xl"
+        element :title, ".govuk-heading-l"
+        element :caption, ".govuk-caption-l"
         element :email, "[data-qa=email]"
         element :telephone, "[data-qa=telephone]"
         element :website, "[data-qa=website]"

--- a/spec/site_prism/page_objects/page/organisations/organisation_details.rb
+++ b/spec/site_prism/page_objects/page/organisations/organisation_details.rb
@@ -4,8 +4,8 @@ module PageObjects
       class OrganisationDetails < PageObjects::Base
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}/details"
 
-        element :title, ".govuk-heading-xl"
-        element :caption, ".govuk-caption-xl"
+        element :title, ".govuk-heading-l"
+        element :caption, ".govuk-caption-l"
         element :email, "[data-qa=enrichment__email]"
         element :telephone, "[data-qa=enrichment__telephone]"
         element :website, "[data-qa=enrichment__website]"

--- a/spec/site_prism/page_objects/page/organisations/recruitment_cycle.rb
+++ b/spec/site_prism/page_objects/page/organisations/recruitment_cycle.rb
@@ -4,8 +4,8 @@ module PageObjects
       class RecruitmentCycle < PageObjects::Base
         set_url "/organisations/{provider_code}/{recruitment_cycle_year}"
 
-        element :title, ".govuk-heading-xl"
-        element :caption, ".govuk-caption-xl"
+        element :title, ".govuk-heading-l"
+        element :caption, ".govuk-caption-l"
 
         element :about_organisation_link, "a", text: "About your organisation"
         element :locations_link, "a", text: "Locations"

--- a/spec/site_prism/page_objects/page/rollover.rb
+++ b/spec/site_prism/page_objects/page/rollover.rb
@@ -3,7 +3,7 @@ module PageObjects
     class Rollover < PageObjects::Base
       set_url "/rollover"
 
-      element :title, ".govuk-heading-xl"
+      element :title, ".govuk-heading-l"
       element :continue_link, ".govuk-button", text: "Continue"
       element :continue_input_button, ".govuk-button[value=Continue]"
     end

--- a/spec/site_prism/page_objects/page/rollover_recruitment.rb
+++ b/spec/site_prism/page_objects/page/rollover_recruitment.rb
@@ -3,7 +3,7 @@ module PageObjects
     class RolloverRecruitment < PageObjects::Base
       set_url "/rollover-recruitment"
 
-      element :title, ".govuk-heading-xl"
+      element :title, ".govuk-heading-l"
       element :continue, ".govuk-button[value=Continue]"
     end
   end


### PR DESCRIPTION
### Context

The design system guidance on heading has been updated since Publish was first designed. It now states:

> For a question page, or pages with long headings, start with `govuk-heading-l` for an `<h1>`, `govuk-heading-m` for an `<h2>` and so on.

but notes that…

> If your page has lots of long form content, start with `govuk-heading-xl` for an `<h1>`, `govuk-heading-l` for an `<h2>`, and so on.

### Changes proposed in this pull request

* Update heading sizes to follow the revised guidance (Manage, Register and Support for Apply follow this same guidance). Most pages now start with a large heading, but policy pages (accessibility, cookies, terms etc.) continue to start with an extra large heading.
* Remove a few unnecessary horizontal rules
* Use correct classes for legends that look like headings

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
