### PR TITLE
Use common error summary title

### DIFF
--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -11,7 +11,7 @@
               method: :put,
               builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
-  <%= form.govuk_error_summary "You’ll need to correct some information." %>
+  <%= form.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -13,7 +13,7 @@
               data: { qa: "enrichment-form", module: "form-check-leave" },
               builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
   <%= f.hidden_field :page, value: :about, id: nil %>
-  <%= f.govuk_error_summary "You’ll need to correct some information." %>
+  <%= f.govuk_error_summary %>
 <% end %>
 
   <h1 class="govuk-heading-xl">

--- a/app/views/courses/age_range/_errors.html.erb
+++ b/app/views/courses/age_range/_errors.html.erb
@@ -1,4 +1,4 @@
-<% error_summary_title ||= "You’ll need to correct some information." %>
+<% error_summary_title ||= "There is a problem" %>
 <% if @errors && @errors.any? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -12,7 +12,7 @@
                   method: :put,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 
-      <%= form.govuk_error_summary "You’ll need to correct some information." %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_radio_buttons_fieldset(:age_range_in_years, legend: { size: "xl", text: "Specify an age range" }, caption: { text: course.name_and_code, size: "xl" }) do %>
         <% @course.meta["edit_options"]["age_range_in_years"].each do |value| %>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -11,7 +11,7 @@
 <%= form_with model: course,
               url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
               builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-  <%= f.govuk_error_summary "You’ll need to correct some information." %>
+  <%= f.govuk_error_summary %>
 <% end %>
 
 <h1 class="govuk-heading-xl">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -4,7 +4,7 @@
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      You’ll need to correct some information.
+      There is a problem
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -2,7 +2,7 @@
   <% if key == "error" %>
     <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
       <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
-        You’ll need to correct some information.
+        There is a problem
       </h2>
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -10,7 +10,7 @@
               builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
   <%= f.hidden_field :page, value: :about %>
-  <%= f.govuk_error_summary "You’ll need to correct some information." %>
+  <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -4,7 +4,7 @@
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      You’ll need to correct some information.
+      There is a problem
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,4 +1,4 @@
-<% error_summary_title ||= "You’ll need to correct some information." %>
+<% error_summary_title ||= "There is a problem" %>
 <% if @errors && @errors.any? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -138,7 +138,7 @@ feature "About course", type: :feature do
     click_on "Save"
 
     expect(about_course_page.error_flash).to have_content(
-      "You’ll need to correct some information.",
+      "There is a problem",
     )
     expect(current_path).to eq about_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
   end

--- a/spec/features/courses/age_range_in_years/edit_spec.rb
+++ b/spec/features/courses/age_range_in_years/edit_spec.rb
@@ -121,7 +121,7 @@ feature "Edit course age range in years", type: :feature do
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page).to have_content(
-          "You’ll need to correct some information.",
+          "There is a problem",
         )
         expect(age_range_in_years_page).to have_content(
           "Enter an age in From",
@@ -138,7 +138,7 @@ feature "Edit course age range in years", type: :feature do
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page).to have_content(
-          "You’ll need to correct some information.",
+          "There is a problem",
         )
         expect(age_range_in_years_page).to have_content(
           "Enter an age in To",
@@ -152,7 +152,7 @@ feature "Edit course age range in years", type: :feature do
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page).to have_content(
-          "You’ll need to correct some information.",
+          "There is a problem",
         )
         expect(age_range_in_years_page).to have_content(
           "Enter an age in From",
@@ -167,7 +167,7 @@ feature "Edit course age range in years", type: :feature do
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page).to have_content(
-          "You’ll need to correct some information.",
+          "There is a problem",
         )
         expect(age_range_in_years_page).to have_content(
           "Enter a valid age in From",
@@ -182,7 +182,7 @@ feature "Edit course age range in years", type: :feature do
 
         expect(age_range_in_years_page).to be_displayed
         expect(age_range_in_years_page).to have_content(
-          "You’ll need to correct some information.",
+          "There is a problem",
         )
         expect(age_range_in_years_page).to have_content(
           "Enter a valid age in To",

--- a/spec/features/courses/destroy_spec.rb
+++ b/spec/features/courses/destroy_spec.rb
@@ -64,7 +64,7 @@ feature "Delete course", type: :feature do
       click_on "Yes I’m sure – delete this course"
 
       expect(course_page.error_summary).to have_content(
-        "You’ll need to correct some information.",
+        "There is a problem",
       )
 
       expect(course_page.delete_error).to have_content(

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -179,7 +179,7 @@ feature "Edit course entry requirements", type: :feature do
       expect(entry_requirements_page).to be_displayed
 
       expect(entry_requirements_page.error_flash)
-        .to have_content("You’ll need to correct some information")
+        .to have_content("There is a problem")
 
       %w[maths english science].each do |s|
         expect(entry_requirements_page.error_flash).to have_content("Pick an option for #{s.titleize}")

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -105,7 +105,7 @@ feature "Course fees", type: :feature do
     click_on "Save"
 
     expect(course_fees_page.error_flash).to have_content(
-      "You’ll need to correct some information.",
+      "There is a problem",
     )
     expect(current_path).to eq fees_provider_recruitment_cycle_course_path(provider.provider_code, course_1.recruitment_cycle_year, course_1.course_code)
   end

--- a/spec/features/courses/outcome/edit_spec.rb
+++ b/spec/features/courses/outcome/edit_spec.rb
@@ -109,7 +109,7 @@ feature "Edit course outcome", type: :feature do
       expect(outcome_page).to be_displayed
 
       expect(outcome_page.error_flash)
-        .to have_content("You’ll need to correct some information")
+        .to have_content("There is a problem")
 
       expect(outcome_page.error_flash).to have_content("Pick an outcome")
       expect(outcome_page).to have_selector("#qualification-error")
@@ -130,7 +130,7 @@ feature "Edit course outcome", type: :feature do
       expect(outcome_page).to be_displayed
 
       expect(outcome_page.error_flash)
-        .to have_content("You’ll need to correct some information")
+        .to have_content("There is a problem")
 
       expect(outcome_page.error_flash).to have_content("Qualification error")
       expect(outcome_page).to have_selector("#qualification-error")

--- a/spec/features/courses/requirements_spec.rb
+++ b/spec/features/courses/requirements_spec.rb
@@ -90,7 +90,7 @@ feature "Course requirements", type: :feature do
     click_on "Save"
 
     expect(course_requirements_page.error_flash).to have_content(
-      "You’ll need to correct some information.",
+      "There is a problem",
     )
     expect(current_path).to eq requirements_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle.year, course.course_code)
   end

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -82,7 +82,7 @@ feature "Course salary", type: :feature do
     click_on "Save"
 
     expect(course_salary_page.error_flash).to have_content(
-      "You’ll need to correct some information.",
+      "There is a problem",
     )
     expect(current_path).to eq salary_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
   end

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -64,7 +64,7 @@ feature "Withdraw course", type: :feature do
       click_on "Yes I’m sure – withdraw this course"
 
       expect(course_page.error_summary).to have_content(
-        "You’ll need to correct some information.",
+        "There is a problem",
       )
 
       expect(course_page.withdraw_error).to have_content(

--- a/spec/features/providers/about_spec.rb
+++ b/spec/features/providers/about_spec.rb
@@ -99,7 +99,7 @@ feature "View provider about", type: :feature do
     click_on "Save"
 
     expect(org_about_page.error_flash).to have_content(
-      "You’ll need to correct some information.",
+      "There is a problem",
     )
     expect(current_path).to eq about_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
   end

--- a/spec/features/providers/contact_spec.rb
+++ b/spec/features/providers/contact_spec.rb
@@ -57,7 +57,7 @@ feature "View provider contact", type: :feature do
     click_on "Save"
 
     expect(org_contact_page.error_flash).to have_content(
-      "You’ll need to correct some information.",
+      "There is a problem",
     )
     expect(current_path).to eq contact_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
   end

--- a/spec/features/providers/search_spec.rb
+++ b/spec/features/providers/search_spec.rb
@@ -52,7 +52,7 @@ feature "Search providers", type: :feature do
       root_page.find_providers.click
 
       expect(root_page.error_summary).to have_content(
-        "You’ll need to correct some information.",
+        "There is a problem",
       )
 
       expect(root_page.provider_error).to have_content(


### PR DESCRIPTION
### Context

The commonly used title for error summaries (and the default used by the form builder) is ‘There is a problem’. We should use this rather than a customised version.

### Changes proposed in this pull request

Replace ‘You’ll need to correct some information.’ with ‘There is a problem’.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
