### PR TITLE
Use form builder for provider forms

### DIFF
--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_warning(text: "This course has been withdrawn.") %>
 <% end %>
 
-<h3 class="govuk-heading-m govuk-!-font-size-27">
+<h3 class="govuk-heading-m">
   <%= govuk_link_to "About this course", about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
 </h3>
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
@@ -11,7 +11,7 @@
   <% summary_list.slot(:row, enrichment_summary(:course, course.placements_heading, course.how_school_placements_work, %w[how_school_placements_work])) %>
 <% end %>
 
-<h3 class="govuk-heading-m govuk-!-font-size-27">
+<h3 class="govuk-heading-m">
   <% if course.has_fees? %>
     <%= govuk_link_to "Course length and fees", fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
   <% else %>
@@ -31,7 +31,7 @@
   <% end %>
 <% end %>
 
-<h3 class="govuk-heading-m govuk-!-font-size-27">
+<h3 class="govuk-heading-m">
   <%= govuk_link_to "Requirements and eligibility", requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
 </h3>
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -1,99 +1,79 @@
-<%= content_for :page_title, title_with_error_prefix("About your organisation", @errors.present?) %>
+<% page_title = "About your organisation" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 <% end %>
 
-<%= form_with model: provider,
-              url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
-              method: :put,
-              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: provider,
+      url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-  <%= f.hidden_field :page, value: :about %>
-  <%= f.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">
-          <%= @provider.provider_name %>
-        </span>
-        About your organisation
+        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+        <%= page_title %>
       </h1>
-    </div>
-  </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">
-        Tell applicants why they should choose to train with you. Say:
-      </p>
+      <%= f.hidden_field :page, value: :about %>
 
+      <p class="govuk-body">Tell applicants why they should choose to train with you. Say:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>who you are</li>
         <li>who you work with</li>
       </ul>
-
-      <p class="govuk-body">
-        You could mention:
-      </p>
-
+      <p class="govuk-body">You could mention:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>your key values</li>
         <li>your specialisms</li>
         <li>your past achievements (eg student successes, Ofsted ratings)</li>
       </ul>
-
-      <p class="govuk-body">
-        Be specific with any claims you make, and support them with evidence. For example:
-      </p>
+      <p class="govuk-body">Be specific with any claims you make, and support them with evidence. For example:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>don’t say “our students are some of the happiest in the country”</li>
-        <li>
-          do say “the Times Educational Supplement ranked our students as 4th
-          happiest in the country”
-        </li>
+        <li>do say “the Times Educational Supplement ranked our students as 4th happiest in the country”</li>
       </ul>
 
-      <%= f.govuk_text_area :train_with_us, label: { text: "Training with you", size: "s" }, max_words: 250, rows: 15 %>
+      <%= f.govuk_text_area :train_with_us, label: { size: "m" }, max_words: 250, rows: 15 %>
 
       <% if provider.accredited_bodies.present? %>
+        <% accredited_body = "accredited body".pluralize(provider.accredited_bodies.count) %>
+
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-        <h2 class="govuk-heading-m">About your accredited body</h2>
+        <h2 class="govuk-heading-m">About your <%= accredited_body %></h2>
 
-        <p id="about-training-provider-hint" class="govuk-body">
-          Tell applicants about your accredited body - you could mention their academic specialities and achievements.
-          Be specific with the claims you make, and support with them evidence.
-        </p>
+        <p class="govuk-body">Tell applicants about your <%= accredited_body %> – you could mention their academic specialities and achievements.</p>
+        <p class="govuk-body">Be specific with the claims you make, and support them with evidence.</p>
 
         <%= f.fields model: :accredited_bodies do |abf| %>
           <%= abf.hidden_field :provider_name %>
           <%= abf.hidden_field :provider_code %>
-          <%= abf.govuk_text_area :description, label: { text: "#{abf.object.provider_name} (optional)", size: "s" }, max_words: 100, rows: 10 %>
+          <%= abf.govuk_text_area(:description,
+            label: { text: "#{abf.object.provider_name} (optional)", size: "s" },
+            max_words: 100,
+            rows: 10) %>
         <% end %>
       <% end %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
       <h2 class="govuk-heading-m">Training with disabilities and other needs</h2>
-
-      <p class="govuk-body">
-        Say how you support candidates with disabilities and other needs. This could include candidates with:
-      </p>
+      <p class="govuk-body">Say how you support candidates with disabilities and other needs. This could include candidates with:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>dyslexia</li>
         <li>physical, hearing and visual impairments</li>
         <li>mental health conditions</li>
       </ul>
-      <p class="govuk-body">
-        If accessibility varies between locations, give details. It’s also useful for applicants to know how
-        you’ve accommodated others with specific access needs in the past.
-      </p>
+      <p class="govuk-body">If accessibility varies between locations, give details. It’s also useful for applicants to know how you’ve accommodated others with specific access needs in the past.</p>
 
-      <%= f.govuk_text_area :train_with_disability,
-                            label: { text: "Training with disabilities and other needs", size: "s" },
-                            max_words: 250, rows: 15 %>
+      <%= f.govuk_text_area :train_with_disability, label: { size: "s" }, max_words: 250, rows: 15 %>
 
       <%= f.govuk_submit "Save and publish changes" %>
 
@@ -104,6 +84,6 @@
           class: "govuk-link--no-visited-state",
         ) %>
       </p>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -1,26 +1,25 @@
-<%= content_for :page_title, title_with_error_prefix("Contact details", @errors.present?) %>
+<% page_title = "Contact details" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 <% end %>
 
-<%= render "shared/errors" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @provider,
+      url: contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">
-        <%= @provider.provider_name %>
-      </span>
-      Contact details
-    </h1>
-  </div>
-</div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @provider,
-                  url: contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
-                  method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+        <%= page_title %>
+      </h1>
 
       <%= f.hidden_field :page, value: :contact %>
 
@@ -30,99 +29,77 @@
             <%= govuk_tag(text: "Admin feature", colour: "purple") %>
           </p>
 
-          <%= render "shared/form_field",
-            form: f,
-            field: :provider_name,
-            label: "Provider name" do |field, options| %>
-            <span class="govuk-hint">
-              The marketing name of the provider
-            </span>
-            <%= f.text_field field, options.merge(class: "govuk-input govuk-!-width-two-thirds") %>
-          <% end %>
+          <%= f.govuk_text_field(:provider_name,
+            label: { size: "m" },
+            data: { qa: "provider_name" }) %>
         </div>
       <% end %>
 
-      <%= render "shared/form_field",
-        form: f, field: :email, label: "Email address" do |field, options| %>
-        <span class="govuk-hint">
-          Give an email address that applicants can use to contact you
-        </span>
-        <%= f.text_field field, options.merge(class: "govuk-input govuk-!-width-two-thirds") %>
-      <% end %>
+      <%= f.govuk_text_field(:email,
+        label: { size: "m" },
+        autocomplete: "email",
+        spellcheck: false,
+        data: { qa: "email" }) %>
 
-      <%= render "shared/form_field",
-        form: f, field: :telephone, label: "Telephone number" do |field, options| %>
-        <span class="govuk-hint">
-          Give a telephone number that applicants can use to call you
-        </span>
-        <%= f.text_field field, options.merge(class: "govuk-input govuk-!-width-two-thirds") %>
-      <% end %>
+      <%= f.govuk_text_field(:telephone,
+        label: { size: "m" },
+        width: 20,
+        autocomplete: "tel",
+        data: { qa: "telephone" }) %>
 
-      <%= render "shared/form_field",
-        form: f, field: :website, label: "Website" do |field, options| %>
-        <span class="govuk-hint">
-          Add a link to the initial teacher training or course pages of your
-          website
-        </span>
-        <%= f.text_field field, options %>
-      <% end %>
+      <%= f.govuk_text_field(:website,
+        label: { size: "m" },
+        data: { qa: "website" }) %>
 
-      <%= render "shared/form_field",
-        form: f, field: :ukprn, label: "UKPRN" do |field, options| %>
-        <span class="govuk-hint">
-          Your organisation&rsquo;s UK Provider Reference Number
-        </span>
-        <%= f.text_field field, options.merge(class: "govuk-input govuk-input--width-10") %>
-      <% end %>
+      <%= f.govuk_text_field(:ukprn,
+        label: { size: "m" },
+        width: 10,
+        data: { qa: "ukprn" }) %>
 
       <% if @provider.provider_type == "lead_school" %>
-        <%= render "shared/form_field",
-          form: f, field: :urn, label: "URN (Unique Reference Number)" do |field, options| %>
-          <%= f.text_field field, options.merge(class: "govuk-input govuk-input--width-10") %>
-        <% end %>
+        <%= f.govuk_text_field(:urn,
+          label: { size: "m" },
+          width: 10, data: { qa: "urn" }) %>
       <% end %>
 
-      <h3 class="govuk-heading-m">Contact address</h3>
+      <%= f.govuk_fieldset legend: { text: "Contact address", size: "m" } do %>
+        <%= f.govuk_text_field(:address1,
+          label: -> { safe_join([t("helpers.label.provider.address1"), " ", tag.span("line 1 of 2", class: "govuk-visually-hidden")]) },
+          autocomplete: "address-line1",
+          data: { qa: "address1" }) %>
 
-      <%= render "shared/form_field",
-        form: f, field: :address1, label: capture { %>
-          Building and street
-          <span class="govuk-visually-hidden">line 1 of 2</span>
-        <% } do |field, options| %>
-        <%= f.text_field field, options %>
+        <%= f.govuk_text_field(:address2,
+          label: { hidden: true },
+          autocomplete: "address-line2",
+          data: { qa: "address2" }) %>
+
+        <%= f.govuk_text_field(:address3,
+          width: "two-thirds",
+          autocomplete: "address-level2",
+          data: { qa: "address3" }) %>
+
+        <%= f.govuk_text_field(:address4,
+          width: "two-thirds",
+          autocomplete: "address-level1",
+          data: { qa: "address4" }) %>
+
+        <%= f.govuk_text_field(:postcode,
+          width: 10,
+          autocomplete: "postal-code",
+          data: { qa: "postcode" }) %>
       <% end %>
 
-      <%= render "shared/form_field",
-        form: f, field: :address2, label: capture { %>
-          <span class="govuk-visually-hidden">line 2 of 2</span>
-        <% } do |field, options| %>
-        <%= f.text_field field, options %>
-      <% end %>
-
-      <%= render "shared/form_field",
-        form: f, field: :address3, label: "Town or city" do |field, options| %>
-        <%= f.text_field field, options.merge(class: "govuk-input govuk-!-width-two-thirds") %>
-      <% end %>
-
-      <%= render "shared/form_field",
-        form: f, field: :address4, label: "County" do |field, options| %>
-        <%= f.text_field field, options.merge(class: "govuk-input govuk-!-width-two-thirds") %>
-      <% end %>
-
-      <%= render "shared/form_field",
-        form: f, field: :postcode do |field, options| %>
-        <%= f.text_field field, options.merge(class: "govuk-input govuk-input--width-10") %>
-      <% end %>
       <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 2 hours.</p>
-      <%= f.submit "Save and publish changes", class: "govuk-button" %>
-    <% end %>
 
-    <p class="govuk-body">
-      <%= govuk_link_to(
-        "Cancel changes",
-        details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
-        class: "govuk-link--no-visited-state",
-      ) %>
-    </p>
+      <%= f.govuk_submit "Save and publish changes" %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(
+          "Cancel changes",
+          details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+          class: "govuk-link--no-visited-state",
+        ) %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -30,7 +30,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <h2 class="govuk-heading-m">
       <%= govuk_link_to "Contact details", contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
     </h2>
     <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
@@ -41,7 +41,7 @@
       <% summary_list.slot(:row, enrichment_summary(:provider, "UKPRN", @provider.ukprn, %w[ukprn])) %>
     <% end %>
 
-    <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <h2 class="govuk-heading-m">
       <%= govuk_link_to "About your organisation", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
     </h2>
     <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>

--- a/app/views/providers/visas/edit.html.erb
+++ b/app/views/providers/visas/edit.html.erb
@@ -1,4 +1,6 @@
-<%= content_for :page_title, "#{@form_object.errors.present? ? 'Error: ' : ''}Visa sponsorship" %>
+<% page_title = "Visa sponsorship" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @form_object.errors.present?) %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 <% end %>
@@ -11,34 +13,34 @@
       method: :post,
       scope: "",
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-    ) do |form| %>
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= @provider.provider_name %></span>
-        Visa sponsorship
+        <%= page_title %>
       </h1>
 
-      <%= form.govuk_radio_buttons_fieldset(
+      <%= f.govuk_radio_buttons_fieldset(
         :can_sponsor_student_visa,
         legend: { text: "Can you sponsor Student visas?" },
         hint: { text: "Applies to fee-paying courses" },
       ) do %>
-        <%= form.govuk_radio_button :can_sponsor_student_visa, true, label: { text: "Yes" }, link_errors: true %>
-        <%= form.govuk_radio_button :can_sponsor_student_visa, false, label: { text: "No" } %>
+        <%= f.govuk_radio_button :can_sponsor_student_visa, true, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :can_sponsor_student_visa, false, label: { text: "No" } %>
       <% end %>
 
-      <%= form.govuk_radio_buttons_fieldset(
+      <%= f.govuk_radio_buttons_fieldset(
         :can_sponsor_skilled_worker_visa,
         legend: { text: "Can you sponsor Skilled Worker visas?" },
         hint: { text: "Applies to salaried courses" },
       ) do %>
-        <%= form.govuk_radio_button :can_sponsor_skilled_worker_visa, true, label: { text: "Yes" }, link_errors: true %>
-        <%= form.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: "No" } %>
+        <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, true, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: "No" } %>
       <% end %>
 
-      <%= form.govuk_submit "Save and publish changes" %>
+      <%= f.govuk_submit "Save and publish changes" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/helpers.yml
+++ b/config/locales/helpers.yml
@@ -13,6 +13,8 @@ en:
         address3: Town or city
         address4: County
         postcode: Postcode
+        train_with_us: Training with you
+        train_with_disability: Training with disabilities and other needs
     hint:
       provider:
         provider_name: The marketing name of the provider.

--- a/config/locales/helpers.yml
+++ b/config/locales/helpers.yml
@@ -1,0 +1,21 @@
+en:
+  helpers:
+    label:
+      provider:
+        provider_name: Provider name
+        email: Email address
+        telephone: Telephone number
+        website: Website
+        ukprn: UK provider reference number (UKPRN)
+        urn: Unique reference number (URN)
+        address1: Building and street
+        address2: Building and street line 2 of 2
+        address3: Town or city
+        address4: County
+        postcode: Postcode
+    hint:
+      provider:
+        provider_name: The marketing name of the provider.
+        email: Give an email address that applicants can use to contact you.
+        telephone: Give a telephone number that applicants can use to call you.
+        website: Add a link to the initial teacher training or course pages of your website.

--- a/spec/features/providers/about_spec.rb
+++ b/spec/features/providers/about_spec.rb
@@ -98,9 +98,7 @@ feature "View provider about", type: :feature do
     fill_in "provider[train_with_us]", with: "foo " * 401
     click_on "Save"
 
-    expect(org_about_page.error_flash).to have_content(
-      "There is a problem",
-    )
+    expect(org_about_page.error_flash).to have_content("There is a problem")
     expect(current_path).to eq about_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 end

--- a/spec/features/providers/contact_spec.rb
+++ b/spec/features/providers/contact_spec.rb
@@ -56,9 +56,7 @@ feature "View provider contact", type: :feature do
 
     click_on "Save"
 
-    expect(org_contact_page.error_flash).to have_content(
-      "There is a problem",
-    )
+    expect(org_contact_page.error_flash).to have_content("There is a problem")
     expect(current_path).to eq contact_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
   end
 end


### PR DESCRIPTION
### Changes proposed in this pull request

* Update provider contact details form to use the form builder
  * Adjust label sizes (use medium size)
  * Add autocomplete values
  * Use a fieldset around address fields
  * Show correct hidden label text for building and street input lines
* Tidy up corresponding about page
  * Adjust label sizes
  * Fix typo
  * Pluralise ‘accredited body’ based on number of accredited bodies provider works with
  * Update markup and syntax style to match that used on contact page

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
