### PR TITLE
Fix layout for ‘Courses as an accredited body’ page

### DIFF
--- a/app/views/providers/_provider.html.erb
+++ b/app/views/providers/_provider.html.erb
@@ -1,6 +1,6 @@
 <li>
   <h2 class="govuk-heading-m">
     <%= govuk_link_to provider.provider_name, provider_path(provider.provider_code) %>
-    <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block"><%= pluralize(provider.course_count, "course") %></span>
+    <span class="govuk-hint"><%= pluralize(provider.course_count, "course") %></span>
   </h2>
 </li>

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -2,22 +2,23 @@
 <%= content_for :before_content, render_breadcrumbs(:training_providers) %>
 
 <h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
   Courses as an accredited body
 </h1>
 
-<p class="govuk-body">Use this section to:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>see who lists you as their accredited body</li>
-  <li>see which courses you’re the accredited body for</li>
-</ul>
-
-<h2 class="govuk-heading-l govuk-!-margin-top-6">Training providers</h2>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>see who lists you as their accredited body</li>
+      <li>see which courses you’re the accredited body for</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Training providers</h2>
     <ul class="govuk-list" data-qa="provider__training_providers_list">
       <% @training_providers.each do |training_provider| %>
         <li data-qa="training_provider">
-          <h3 class="govuk-heading-m">
+          <h3 class="govuk-heading-s">
             <%= govuk_link_to(
               training_provider.provider_name,
               training_provider_courses_provider_recruitment_cycle_path(
@@ -28,7 +29,7 @@
               class: "govuk-!-font-weight-bold",
               data: { qa: "link" },
             ) %>
-            <span class="govuk-body govuk-!-font-weight-regular govuk-!-display-block" data-qa="course_count">
+            <span class="govuk-hint" data-qa="course_count">
               <%= pluralize(@course_counts[training_provider.provider_code], "course") %>
             </span>
           </h3>
@@ -38,19 +39,19 @@
   </div>
 
   <aside class="govuk-grid-column-one-third">
-      <div class="app-status-box" data-qa="download-section">
-        <h2 class="govuk-heading-m">Download</h2>
-        <p class="govuk-body">Export all the courses you’re the accredited body for.</p>
-        <p class="govuk-body">
-          <%= govuk_link_to(
-            "Download as a CSV file",
-            download_training_providers_courses_provider_recruitment_cycle_path(
-              provider.provider_code,
-              provider.recruitment_cycle_year,
-              format: :csv,
-            ),
-          ) %>
-        </p>
-      </div>
+    <div class="app-status-box" data-qa="download-section">
+      <h2 class="govuk-heading-m">Download</h2>
+      <p class="govuk-body">Export all the courses you’re the accredited body for.</p>
+      <p class="govuk-body">
+        <%= govuk_link_to(
+          "Download as a CSV file",
+          download_training_providers_courses_provider_recruitment_cycle_path(
+            provider.provider_code,
+            provider.recruitment_cycle_year,
+            format: :csv,
+          ),
+        ) %>
+      </p>
+    </div>
   </aside>
 </div>


### PR DESCRIPTION
### Changes proposed in this pull request

* Show current cycle in caption, like for other sections
* Move sidebar up to below page title, like in other parts of the service
* Adjust heading sizes

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/813383/123006197-3e20b300-d3af-11eb-85b8-a9a360a202d6.png) | ![after](https://user-images.githubusercontent.com/813383/123006186-3a8d2c00-d3af-11eb-9bc4-29768cc3efe1.png) |

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
