### PR TITLE
Use common error summary title (part 2)

### DIFF
--- a/app/views/courses/age_range/_errors.html.erb
+++ b/app/views/courses/age_range/_errors.html.erb
@@ -1,8 +1,7 @@
-<% error_summary_title ||= "There is a problem" %>
 <% if @errors && @errors.any? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      <%= error_summary_title %>
+      There is a problem
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -4,7 +4,7 @@
   <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(@course.provider_code, @course.recruitment_cycle_year)) %>
 <% end %>
 
-<%= render "shared/errors", error_summary_title: "We couldn’t edit the vacancies for this course" %>
+<%= render "shared/errors" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,8 +1,7 @@
-<% error_summary_title ||= "There is a problem" %>
 <% if @errors && @errors.any? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      <%= error_summary_title %>
+      There is a problem
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/spec/features/courses/vacancies/edit_spec.rb
+++ b/spec/features/courses/vacancies/edit_spec.rb
@@ -62,7 +62,7 @@ feature "Edit course vacancies", type: :feature do
       expect(course_vacancies_page).to be_displayed
 
       expect(course_vacancies_page.error_flash)
-        .to have_content("We couldn’t edit the vacancies for this course")
+        .to have_content("There is a problem")
 
       expect(course_vacancies_page.error_flash)
         .to have_content("Please confirm there are no vacancies to close applications")
@@ -106,7 +106,7 @@ feature "Edit course vacancies", type: :feature do
       expect(course_vacancies_page).to be_displayed
 
       expect(course_vacancies_page.error_flash)
-        .to have_content("We couldn’t edit the vacancies for this course")
+        .to have_content("There is a problem")
 
       expect(course_vacancies_page.error_flash)
         .to have_content("Please confirm there are vacancies to reopen applications")


### PR DESCRIPTION
### Context

Follows on from #1741.

### Changes proposed in this pull request

* Always use ‘There is a problem’, and don’t allow for customised error summary titles in shared partials.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
