### PR TITLE
Add `title_with_error_prefix` helper, and use it for all pages with forms

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -40,6 +40,10 @@ module ViewHelper
     govuk_mail_to bat_contact_email_address, name || bat_contact_email_address_with_wrap, **kwargs
   end
 
+  def title_with_error_prefix(title, error)
+    "#{t('page_titles.error_prefix') if error}#{title}"
+  end
+
   def enrichment_error_url(provider_code:, course:, field:)
     base = "/organisations/#{provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}"
 

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}Create an access request" %>
+<%= content_for :page_title, title_with_error_prefix("Create access request", @access_request.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(access_requests_path) %>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, t("ucas_contacts.#{@contact.type}.heading") %>
+<%= content_for :page_title, title_with_error_prefix(t("ucas_contacts.#{@contact.type}.heading"), @contact.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_ucas_contacts_path(@provider.provider_code)) %>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "About this course – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("About this course – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Who is the accredited body? – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Who is the accredited body? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Who is the accredited body?" %>
+<%= content_for :page_title, title_with_error_prefix("Who is the accredited body? – #{course.name_and_code}", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/accredited_body/search.html.erb
+++ b/app/views/courses/accredited_body/search.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Organisation search" %>
+<%= content_for :page_title, title_with_error_prefix("Organisation search", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/accredited_body/search_new.html.erb
+++ b/app/views/courses/accredited_body/search_new.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "Organisation search" %>
+<%= content_for :page_title, title_with_error_prefix("Organisation search", course.errors.any?) %>
+
 <%= render "shared/errors" %>
 
 <div class="govuk-grid-row">

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Specify an age range – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Specify an age range – #{course.name_and_code}", form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Specify an age range" %>
+<%= content_for :page_title, title_with_error_prefix("Specify an age range", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/applications_open/edit.html.erb
+++ b/app/views/courses/applications_open/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "When will applications open? – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("When will applications open? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "When will applications open?" %>
+<%= content_for :page_title, title_with_error_prefix("When will applications open?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/apprenticeship/edit.html.erb
+++ b/app/views/courses/apprenticeship/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Edit Apprenticeship – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Edit Apprenticeship – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Is this a teaching apprenticeship?" %>
+<%= content_for :page_title, title_with_error_prefix("Is this a teaching apprenticeship?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Check your answers before confirming" %>
+<%= content_for :page_title, title_with_error_prefix("Check your answers before confirming", course.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Are you sure you want to delete #{course.name_and_code})?" %>
+<%= content_for :page_title, title_with_error_prefix("Are you sure you want to delete #{course.name_and_code})?", flash[:error] && flash[:error]["id"] == "delete-error") %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "GCSE requirements for applicants – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("GCSE requirements for applicants – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "GCSE requirements for applicants" %>
+<%= content_for :page_title, title_with_error_prefix("GCSE requirements for applicants", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/fee_or_salary/edit.html.erb
+++ b/app/views/courses/fee_or_salary/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Is it fee paying or salaried? – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Is it fee paying or salaried? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/fee_or_salary/new.html.erb
+++ b/app/views/courses/fee_or_salary/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Is it fee paying or salaried?" %>
+<%= content_for :page_title, title_with_error_prefix("Is it fee paying or salaried?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Course length and fees - #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Course length and fees - #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "What type of course?" %>
+<%= content_for :page_title, title_with_error_prefix("What type of course?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pick all the languages for #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Pick all the languages for #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pick all the languages for this course" %>
+<%= content_for :page_title, title_with_error_prefix("Pick all the languages for this course", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/outcome/edit.html.erb
+++ b/app/views/courses/outcome/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pick a course outcome – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Pick a course outcome – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pick a course outcome" %>
+<%= content_for :page_title, title_with_error_prefix("Pick a course outcome", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Requirements and eligibility – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Requirements and eligibility – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/send/edit.html.erb
+++ b/app/views/courses/send/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Edit SEND – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Edit SEND – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors.present? ? 'Error: ' : ''}#{course.name_and_code} - Courses" %>
+<%= content_for :page_title, title_with_error_prefix("#{course.name_and_code} - Courses", @errors.present?) %>
 <%= content_for :before_content, render_breadcrumbs(:course) %>
 
 <% if @errors.present? %>

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors.present? ? 'Error: ' : ''}Pick the locations for this course – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Pick the locations for this course – #{course.name_and_code}", @errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pick the locations for this course" %>
+<%= content_for :page_title, title_with_error_prefix("Pick the locations for this course", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/start_date/edit.html.erb
+++ b/app/views/courses/start_date/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "When does the course start?" %>
+<%= content_for :page_title, title_with_error_prefix("When does the course start? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "When does the course start?" %>
+<%= content_for :page_title, title_with_error_prefix("When does the course start?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/study_mode/edit.html.erb
+++ b/app/views/courses/study_mode/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Full time or part time? – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Full time or part time? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Full time or part time?" %>
+<%= content_for :page_title, title_with_error_prefix("Full time or part time?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/subjects/edit.erb
+++ b/app/views/courses/subjects/edit.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Change subjects – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Change subjects – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, course.subject_page_title %>
+<%= content_for :page_title, title_with_error_prefix(course.subject_page_title, @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/title/edit.html.erb
+++ b/app/views/courses/title/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Change course title – #{course.name_and_code}" %>
+<%= content_for :page_title, title_with_error_prefix("Change course title – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Edit vacancies for #{@course.name} (#{@course.course_code})" %>
+<%= content_for :page_title, title_with_error_prefix("Edit vacancies – #{@course.name} (#{@course.course_code})", @course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(@course.provider_code, @course.recruitment_cycle_year)) %>
@@ -12,8 +12,7 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-7">
           <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-l"><%= @course.name %>
-              (<%= @course.course_code %>)</span>
+            <span class="govuk-caption-l"><%= @course.name %> (<%= @course.course_code %>)</span>
             Edit vacancies
           </h1>
         </legend>

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Are you sure you want to withdraw #{course.name_and_code})?" %>
+<%= content_for :page_title, title_with_error_prefix("Are you sure you want to withdraw #{course.name_and_code})?", flash[:error] && flash[:error]["id"] == "withdraw-error") %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/pages/accept_terms.html.erb
+++ b/app/views/pages/accept_terms.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Accept Terms and Conditions" %>
+<%= content_for :page_title, title_with_error_prefix("Accept Terms and Conditions", @errors && @errors.any?) %>
 
 <%= render "shared/errors" %>
 

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors.present? ? 'Error: ' : ''}Edit 'About your organisation'" %>
+<%= content_for :page_title, title_with_error_prefix("About your organisation", @errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>

--- a/app/views/providers/access_requests/new.html.erb
+++ b/app/views/providers/access_requests/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}Request access for someone else" %>
+<%= content_for :page_title, title_with_error_prefix("Request access for someone else", @access_request.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(users_provider_path(params[:code])) %>

--- a/app/views/providers/allocations/edit.html.erb
+++ b/app/views/providers/allocations/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Do you want to request PE for this organisation?" %>
-<%= content_for :page_title, page_title %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @allocation.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>

--- a/app/views/providers/allocations/new_repeat_request.html.erb
+++ b/app/views/providers/allocations/new_repeat_request.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Do you want to request PE for this organisation?" %>
-<%= content_for :page_title, page_title %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @allocation.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "How many places would you like to request?" %>
+<% page_title = "How many places would you like to request?" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(initial_request_provider_recruitment_cycle_allocations_path) %>
@@ -16,7 +17,7 @@
 
       <%= form.govuk_text_field :number_of_places,
         label: {
-          text: "How many places would you like to request?",
+          text: page_title,
           size: "l",
           tag: "h1",
         },

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors.present? ? 'Error: ' : ''}Edit 'Contact information'" %>
+<%= content_for :page_title, title_with_error_prefix("Contact details", @errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors.present? ? 'Error: ' : ''}About your organisation" %>
+<%= content_for :page_title, title_with_error_prefix("About your organisation", @errors.present?) %>
 <%= content_for :before_content, render_breadcrumbs(:organisation_details) %>
 
 <% if @errors.present? %>

--- a/app/views/providers/edit_initial_allocations/do_you_want.html.erb
+++ b/app/views/providers/edit_initial_allocations/do_you_want.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Do you want to request PE for this organisation?" %>
-<%= content_for :page_title, page_title %>
+<%= content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>

--- a/app/views/providers/edit_initial_allocations/number_of_places.html.erb
+++ b/app/views/providers/edit_initial_allocations/number_of_places.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "How many places would you like to request?" %>
+<% page_title = "How many places would you like to request?" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(
@@ -29,7 +30,7 @@
       <%= form.govuk_text_field :number_of_places,
                                 value: params[:number_of_places] || allocation.number_of_places,
                                 label: {
-                                  text: "How many places would you like to request?",
+                                  text: page_title,
                                   size: "l",
                                   tag: "h1",
                                 },

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}#{@site_name_before_update}" %>
+<%= content_for :page_title, title_with_error_prefix(@site_name_before_update, @site.errors.any?) %>
 <%= content_for :before_content, render_breadcrumbs(:edit_site) %>
 
 <%= render "shared/errors" %>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}Add a location" %>
+<%= content_for :page_title, title_with_error_prefix("Add a location", @site.errors.any?) %>
 <%= content_for :before_content, render_breadcrumbs(:new_site) %>
 
 <%= render "shared/errors" %>

--- a/app/views/ucas_contacts/alerts.html.erb
+++ b/app/views/ucas_contacts/alerts.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Email alerts for new applications" %>
+<%= content_for :page_title, title_with_error_prefix("Email alerts for new applications", @provider.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_ucas_contacts_path(@provider.provider_code)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,8 @@ en:
     info: "Information"
     success: "Success"
     warning: "Warning"
+  page_titles:
+    error_prefix: "Error: "
   edit_options:
     entry_requirements:
       must_have_qualification_at_application_time:


### PR DESCRIPTION
### Context

When validating a page, the design system recommends that we:

> add ‘Error: ’ to the beginning of the page <title> so screen readers read it out as soon as possible

We are only doing this in a few places.

### Changes proposed in this pull request

* Add `title_with_error_prefix` used on other BAT services.
* Update page titles to use this helper
* Add this helper to pages that have form validation and display an error summary (not all pages include a summary when they probably should, but can cover the in another PR)

### Guidance to review

Am I testing for the right errors on these pages? Tests pass, and going through the app, `Error: ` is prefixed to those pages when showing validation.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
