### PR TITLE
Tidy up notifications form

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Manage notifications" %>
+<%= content_for :page_title, title_with_error_prefix("Manage notifications", flash[:error]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -16,38 +16,21 @@
       <li>withdraws a course</li>
       <li>changes the vacancy status of a course</li>
     </ul>
-  </div>
-</div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_for @notifications_view.user_notification_preferences,
+
+    <%= form_for(
+      @notifications_view.user_notification_preferences,
       url: notification_path(@notifications_view.user_id),
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <%= form.hidden_field :provider_code, value: @notifications_view.provider_code %>
-      <%= form.govuk_radio_buttons_fieldset(
-        :explitly_enabled,
-        legend: {
-          size: "l",
-          text: "Would you like to receive email notifications?",
-          tag: "span",
-        },
-      ) do %>
-        <%= form.govuk_radio_button(
-          :explicitly_enabled,
-          true,
-          label: {
-            text: "Yes, send me notifications",
-          },
-        ) %>
-        <%= form.govuk_radio_button(
-          :explicitly_enabled,
-          false,
-          label: {
-            text: "No",
-          },
-        ) %>
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
+
+      <%= f.hidden_field :provider_code, value: @notifications_view.provider_code %>
+
+      <%= f.govuk_radio_buttons_fieldset(:explicitly_enabled, legend: { text: "Would you like to receive email notifications?", size: "m" }) do %>
+        <%= f.govuk_radio_button(:explicitly_enabled, true, label: { text: "Yes, send me notifications" }) %>
+        <%= f.govuk_radio_button(:explicitly_enabled, false, label: { text: "No" }) %>
       <% end %>
-      <%= form.govuk_submit "Save" %>
+
+      <%= f.govuk_submit "Save" %>
 
       <p class="govuk-body">
         <%= govuk_link_to(


### PR DESCRIPTION
### Context

* Adds ‘Error: ’ prefix when form has validation
* Correct heading size for legend (medium, not large)
* Simplified grid markup for layout

Worth nothing that this form doesn’t actually validate correctly; if no option is selected, a flash banner is shown, but the incorrect fields are not highlighted. That’s because this isn't using a form model. *C'est la vie*

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
