### PR TITLE
Fix autocomplete styles

### DIFF
--- a/app/views/courses/accredited_body/_provider_search_field.html.erb
+++ b/app/views/courses/accredited_body/_provider_search_field.html.erb
@@ -9,5 +9,5 @@
   <%= form.text_field :accredited_body,
     autocomplete: "off",
     class: "govuk-input govuk-!-width-two-thirds" %>
-  <div id="provider-autocomplete" class="govuk-body govuk-!-width-two-thirds"></div>
+  <div id="provider-autocomplete" class="govuk-!-width-two-thirds"></div>
 <% end %>

--- a/app/views/providers/_search.html.erb
+++ b/app/views/providers/_search.html.erb
@@ -7,22 +7,23 @@
       </p>
 
       <%= form_with url: providers_search_path, method: :get do |form| %>
-        <div class="govuk-form-group">
+        <% error = flash[:error] && flash[:error]["message"] == "Name or provider code" %>
+        <div class="govuk-form-group<% if error %> govuk-form-group--error<% end %>">
           <%= form.label :query, { class: "govuk-label", for: "provider" } do %>
             Search for an organisation
             <span class="govuk-hint">Enter the name or provider code</span>
-            <% if flash[:error] && flash[:error]["message"] == "Name or provider code" %>
+            <% if error %>
               <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
-                <%= "Please enter the name or provider code" %>
+                Please enter the name or provider code
               </span>
             <% end %>
           <% end %>
           <%= form.text_field :query,
                               id: "provider",
                               value: params[:query],
-                              class: "govuk-input govuk-!-width-two-thirds",
+                              class: "govuk-input",
                               data: { qa: "provider-search" } %>
-          <div id="provider-autocomplete" class="govuk-!-width-two-thirds"></div>
+          <div id="provider-autocomplete"></div>
         </div>
         <%= form.submit "Search", name: nil, class: "govuk-button govuk-!-margin-bottom-0", data: { qa: "find-providers" } %>
       <% end %>

--- a/app/views/providers/_search.html.erb
+++ b/app/views/providers/_search.html.erb
@@ -22,7 +22,7 @@
                               value: params[:query],
                               class: "govuk-input govuk-!-width-two-thirds",
                               data: { qa: "provider-search" } %>
-          <div id="provider-autocomplete" class="govuk-body govuk-!-width-two-thirds"></div>
+          <div id="provider-autocomplete" class="govuk-!-width-two-thirds"></div>
         </div>
         <%= form.submit "Search", name: nil, class: "govuk-button govuk-!-margin-bottom-0", data: { qa: "find-providers" } %>
       <% end %>

--- a/app/views/providers/allocations/initial_request.html.erb
+++ b/app/views/providers/allocations/initial_request.html.erb
@@ -32,13 +32,13 @@
 
           <%= form.govuk_radio_button :training_provider_code, "-1", label: { text: "Find an organisation not listed above" } do %>
             <%= form.govuk_text_field :training_provider_query, label: { text: "Organisation name" } do %>
-              <div id="provider-autocomplete" class="govuk-body"></div>
+              <div id="provider-autocomplete"></div>
             <% end %>
           <% end %>
         <% else %>
           <%= hidden_field_tag "training_provider_code", "-1" %>
           <%= form.govuk_text_field :training_provider_query, label: { text: "Find an organisation" } %>
-          <div id="provider-autocomplete" class="govuk-body"></div>
+          <div id="provider-autocomplete"></div>
         <% end %>
       <% end %>
 

--- a/app/views/providers/allocations/pick_a_provider.html.erb
+++ b/app/views/providers/allocations/pick_a_provider.html.erb
@@ -53,7 +53,7 @@
 
         <div class="govuk-form-group">
           <%= form.govuk_text_field :training_provider_query, label: { text: "Organisation name" } %>
-          <div id="provider-autocomplete" class="govuk-body"></div>
+          <div id="provider-autocomplete"></div>
         </div>
 
         <%= form.govuk_submit "Search again" %>

--- a/app/webpacker/stylesheets/_autocomplete.scss
+++ b/app/webpacker/stylesheets/_autocomplete.scss
@@ -1,0 +1,20 @@
+.autocomplete__wrapper,
+.autocomplete__input,
+.autocomplete__hint {
+  font-family: $govuk-font-family;
+}
+
+.govuk-form-group--error {
+  .autocomplete__input {
+    border-color: $govuk-error-colour;
+  }
+
+  .autocomplete__input--focused {
+    border-color: $govuk-input-border-colour;
+  }
+}
+
+.autocomplete__dropdown-arrow-down {
+  pointer-events: none;
+  z-index: 0;
+}

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -14,6 +14,7 @@ $git-brand-colour: #159964;
 @import "~govuk-frontend/govuk/all";
 
 @import "advice";
+@import "autocomplete";
 @import "card";
 @import "description-list";
 @import "header";


### PR DESCRIPTION
### Context

Adds the necessary CSS to style autocompletes, both the font used in the suggestions list, and when they are being validated.

### Changes proposed in this pull request

| Before | After |
| - | - |
| <img width="657" alt="Screenshot 2021-06-25 at 12 10 45" src="https://user-images.githubusercontent.com/813383/123416498-88bc4e00-d5ae-11eb-9fe6-883f6a18371c.png"> |  <img width="660" alt="Screenshot 2021-06-25 at 12 13 01" src="https://user-images.githubusercontent.com/813383/123416632-b903ec80-d5ae-11eb-9587-31c343a78831.png"> |
| <img width="694" alt="Screenshot 2021-06-25 at 12 10 31" src="https://user-images.githubusercontent.com/813383/123416495-8823b780-d5ae-11eb-9f2d-0dc386c008ac.png"> | <img width="695" alt="Screenshot 2021-06-25 at 12 10 05" src="https://user-images.githubusercontent.com/813383/123416491-8823b780-d5ae-11eb-8b82-82c7111e3d20.png"> |

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
