### PR TITLE
Use form builder for site forms

### DIFF
--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -59,7 +59,8 @@
       <% if @provider.provider_type == "lead_school" %>
         <%= f.govuk_text_field(:urn,
           label: { size: "m" },
-          width: 10, data: { qa: "urn" }) %>
+          width: 10,
+          data: { qa: "urn" }) %>
       <% end %>
 
       <%= f.govuk_fieldset legend: { text: "Contact address", size: "m" } do %>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,46 +1,34 @@
-<%= render "shared/form_field",
-  form: f, field: :location_name, label: capture { %>
-    <span class="<%= cns("govuk-label--m govuk-!-margin-bottom-2", "govuk-!-margin-bottom-0": @errors.present? && @errors.key?(:location_name)) %>">Name</span>
-  <% } do |field, options| %>
-  <%= f.text_field field, options %>
-<% end %>
+<%= f.govuk_text_field(:location_name,
+  label: { size: "m" },
+  data: { qa: "location_name" }) %>
 
-<%= render "shared/form_field",
-  form: f, field: :urn, label: capture { %>
-    <span class="<%= cns("govuk-label--m govuk-!-margin-bottom-2", "govuk-!-margin-bottom-0": @errors.present? && @errors.key?(:urn)) %>">Unique Reference Number (URN)</span>
-    <span class="govuk-hint">You can find URNs on the <%= govuk_link_to "Get information about schools (opens in new tab)", "https://www.get-information-schools.service.gov.uk", target: "_blank" %> service</span>
-  <% } do |field, options| %>
-  <%= f.text_field field, options.merge(class: "govuk-input govuk-input--width-10") %>
-<% end %>
+<%= f.govuk_text_field(:urn,
+  label: { size: "m" },
+  width: 10) %>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-8">Address</h2>
+<%= f.govuk_fieldset legend: { text: "Address", size: "m" } do %>
+  <%= f.govuk_text_field(:address1,
+    label: -> { safe_join([t("helpers.label.site.address1"), " ", tag.span("line 1 of 2", class: "govuk-visually-hidden")]) },
+    autocomplete: "address-line1",
+    data: { qa: "address1" }) %>
 
-<%= render "shared/form_field",
-  form: f, field: :address1, label: capture { %>
-    Building and street
-    <span class="govuk-visually-hidden">line 1 of 2</span>
-  <% } do |field, options| %>
-  <%= f.text_field field, options %>
-<% end %>
+  <%= f.govuk_text_field(:address2,
+    label: { hidden: true },
+    autocomplete: "address-line2",
+    data: { qa: "address2" }) %>
 
-<%= render "shared/form_field",
-  form: f, field: :address2, label: capture { %>
-    <span class="govuk-visually-hidden">line 2 of 2</span>
-  <% } do |field, options| %>
-  <%= f.text_field field, options %>
-<% end %>
+  <%= f.govuk_text_field(:address3,
+    width: "two-thirds",
+    autocomplete: "address-level2",
+    data: { qa: "address3" }) %>
 
-<%= render "shared/form_field",
-  form: f, field: :address3, label: "Town or city" do |field, options| %>
-  <%= f.text_field field, options.merge(class: "govuk-input govuk-!-width-two-thirds") %>
-<% end %>
+  <%= f.govuk_text_field(:address4,
+    width: "two-thirds",
+    autocomplete: "address-level1",
+    data: { qa: "address4" }) %>
 
-<%= render "shared/form_field",
-  form: f, field: :address4, label: "County" do |field, options| %>
-  <%= f.text_field field, options.merge(class: "govuk-input govuk-!-width-two-thirds") %>
-<% end %>
-
-<%= render "shared/form_field",
-  form: f, field: :postcode do |field, options| %>
-  <%= f.text_field field, options.merge(class: "govuk-input govuk-input--width-10") %>
+  <%= f.govuk_text_field(:postcode,
+    width: 10,
+    autocomplete: "postal-code",
+    data: { qa: "postcode" }) %>
 <% end %>

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -1,7 +1,7 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell" data-qa="provider__location-name">
-    <%= govuk_link_to site.location_name, edit_provider_recruitment_cycle_site_path(@provider.provider_code, site.recruitment_cycle_year, site.id), class: "govuk-!-font-weight-bold" %>
-  </td>
+  <th class="govuk-table__header" scope="row" data-qa="provider__location-name">
+    <%= govuk_link_to site.location_name, edit_provider_recruitment_cycle_site_path(@provider.provider_code, site.recruitment_cycle_year, site.id) %>
+  </th>
   <td class="govuk-table__cell">
     <%= site.code %> <%= site.code == "-" ? "(dash)" : "" %>
   </td>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,18 +1,24 @@
 <%= content_for :page_title, title_with_error_prefix(@site_name_before_update, @site.errors.any?) %>
 <%= content_for :before_content, render_breadcrumbs(:edit_site) %>
 
-<%= render "shared/errors" %>
-
-<h1 class="govuk-heading-l"><%= @site_name_before_update %></h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @site,
-                  url: provider_recruitment_cycle_site_path(@provider.provider_code, @site.recruitment_cycle_year, @site.id),
-                  method: :put do |f| %>
+    <%= form_with(
+      model: @site,
+      url: provider_recruitment_cycle_site_path(@provider.provider_code, @site.recruitment_cycle_year, @site.id),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= @site_name_before_update %>
+      </h1>
+
       <p class="govuk-body">You can assign locations to a course from the ‘Basic details’ tab on the course page.</p>
       <%= render "form", f: f %>
-      <%= f.submit "Save and publish changes", class: "govuk-button", data: { qa: "location__publish-changes" } %>
+      <%= f.govuk_submit "Save and publish changes", data: { qa: "location__publish-changes" } %>
     <% end %>
 
     <p class="govuk-body">

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,13 +1,14 @@
-<%= content_for :page_title, "Locations" %>
+<% page_title = "Locations" %>
+<%= content_for :page_title, page_title %>
 <%= content_for :before_content, render_breadcrumbs(:sites) %>
-
-<h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
-  Locations
-</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+      <%= page_title %>
+    </h1>
+
     <p class="govuk-body">A location is a place that a candidate selects when making an application. They do this by choosing from a list on both the course page in Find and the UCAS application form.</p>
 
     <p class="govuk-body">Use this section to:</p>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -1,19 +1,26 @@
-<%= content_for :page_title, title_with_error_prefix("Add a location", @site.errors.any?) %>
+<% page_title = "Add a location" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @site.errors.any?) %>
 <%= content_for :before_content, render_breadcrumbs(:new_site) %>
-
-<%= render "shared/errors" %>
-
-<h1 class="govuk-heading-l">Add a location</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @site,
-                  url: provider_recruitment_cycle_sites_path(params[:provider_code]),
-                  method: :post do |f| %>
+    <%= form_with(
+      model: @site,
+      url: provider_recruitment_cycle_sites_path(params[:provider_code]),
+      method: :post,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= page_title %>
+      </h1>
+
       <p class="govuk-body">Once a location is added (and assigned to a course), candidates can choose it as their preferred place of training when completing the UCAS application form.</p>
       <p class="govuk-body">When you’ve added this location you can assign it to a course from the ‘Basic details’ tab on the course page.</p>
       <%= render "form", f: f %>
-      <%= f.submit "Save", class: "govuk-button", data: { qa: "location__publish-changes" } %>
+      <%= f.govuk_submit "Save", data: { qa: "location__publish-changes" } %>
     <% end %>
 
     <p class="govuk-body">

--- a/config/locales/helpers.yml
+++ b/config/locales/helpers.yml
@@ -22,9 +22,20 @@ en:
         postcode: Postcode
         train_with_us: Training with you
         train_with_disability: Training with disabilities and other needs
+      site:
+        location_name: Name
+        urn: Unique reference number (URN)
+        address1: Building and street
+        address2: Building and street line 2 of 2
+        address3: Town or city
+        address4: County
+        postcode: Postcode
     hint:
       provider:
         provider_name: The marketing name of the provider.
         email: Give an email address that applicants can use to contact you.
         telephone: Give a telephone number that applicants can use to call you.
         website: Add a link to the initial teacher training or course pages of your website.
+      site:
+        urn_html: |-
+          Find URNs on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk" target="_blank">Get information about schools (opens in new tab)</a>

--- a/spec/factories/errors.rb
+++ b/spec/factories/errors.rb
@@ -12,11 +12,6 @@ FactoryBot.define do
           detail: "Postcode is missing",
           source: { pointer: "/data/attributes/postcode" },
         },
-        {
-          title: "Invalid postcode",
-          detail: "Postcode is invalid",
-          source: { pointer: "/data/attributes/postcode" },
-        },
       ]
     end
 

--- a/spec/features/sites/edit_spec.rb
+++ b/spec/features/sites/edit_spec.rb
@@ -101,7 +101,6 @@ feature "Edit locations", type: :feature do
       expect(location_page).to be_displayed(provider_code: provider_code, site_id: site.id)
       expect(location_page.error_summary).to have_content("Name is missing")
       expect(location_page.error_summary).to have_content("Postcode is missing")
-      expect(location_page.error_summary).to have_content("Postcode is invalid")
     end
 
     scenario "displays the old location name when the change fails" do

--- a/spec/features/sites/new_spec.rb
+++ b/spec/features/sites/new_spec.rb
@@ -46,7 +46,7 @@ feature "Locations", type: :feature do
       click_on "Add a location"
 
       fill_in "Name", with: "New site"
-      fill_in "Building and street", with: "New building and street"
+      fill_in "Building and street line 1 of 2", with: "New building and street"
       fill_in "Town or city", with: "New town"
       fill_in "County", with: "New county"
       fill_in "Postcode", with: "SW1A 1AA"


### PR DESCRIPTION
### Context

Prior to removing the 37 limit, update the location forms to use the form builder.

### Changes proposed in this pull request

* Update the location forms to use the form builder.
* Tweak markup on other pages to be consistent/correct.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
