### PR TITLE
Tidy up course degree forms

### DIFF
--- a/app/views/courses/degrees/grade/edit.html.erb
+++ b/app/views/courses/degrees/grade/edit.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}What is the minimum degree classification you require?" %>
+<% page_title = "What is the minimum degree classification you require?" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @grade_form.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to degrees_start_provider_recruitment_cycle_course_path %>
@@ -6,23 +7,25 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @grade_form, url: degrees_grade_provider_recruitment_cycle_course_path(
-                    @course.provider.provider_code,
-                    @course.provider.recruitment_cycle_year,
-                    @course.course_code,
-                  ),
-                  method: :put,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: @grade_form, url: degrees_grade_provider_recruitment_cycle_course_path(
+        @course.provider.provider_code,
+        @course.provider.recruitment_cycle_year,
+        @course.course_code,
+      ),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-      <%= form.govuk_radio_buttons_fieldset :grade, caption: { text: course.name_and_code, size: "l" }, legend: { text: "What is the minimum degree classification you require?", tag: "h1", size: "l" } do %>
-        <%= form.govuk_radio_button :grade, "two_one", label: { text: "2:1 or above (or equivalent)" }, data: { qa: "degree_grade__two_one" }, link_errors: true %>
-        <%= form.govuk_radio_button :grade, "two_two", label: { text: "2:2 or above (or equivalent)" }, data: { qa: "degree_grade__two_two" } %>
-        <%= form.govuk_radio_button :grade, "third", label: { text: "Third or above (or equivalent)" }, data: { qa: "degree_grade__third_class" } %>
+      <%= f.govuk_radio_buttons_fieldset :grade, caption: { text: course.name_and_code, size: "l" }, legend: { text: page_title, size: "l", tag: "h1" } do %>
+        <%= f.govuk_radio_button :grade, "two_one", label: { text: "2:1 or above (or equivalent)" }, data: { qa: "degree_grade__two_one" }, link_errors: true %>
+        <%= f.govuk_radio_button :grade, "two_two", label: { text: "2:2 or above (or equivalent)" }, data: { qa: "degree_grade__two_two" } %>
+        <%= f.govuk_radio_button :grade, "third", label: { text: "Third or above (or equivalent)" }, data: { qa: "degree_grade__third_class" } %>
       <% end %>
 
-      <%= form.govuk_submit "Save", data: { qa: "degree_grade__save" } %>
+      <%= f.govuk_submit "Save", data: { qa: "degree_grade__save" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/degrees/start/edit.html.erb
+++ b/app/views/courses/degrees/start/edit.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}Do you require a minimum degree classification?" %>
+<% page_title = "Do you require a minimum degree classification?" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @start_form.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to provider_recruitment_cycle_course_path %>
@@ -6,27 +7,24 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @start_form, url: degrees_start_provider_recruitment_cycle_course_path(
-                    @course.provider.provider_code,
-                    @course.provider.recruitment_cycle_year,
-                    @course.course_code,
-                  ),
-                  method: :put,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: @start_form, url: degrees_start_provider_recruitment_cycle_course_path(
+        @course.provider.provider_code,
+        @course.provider.recruitment_cycle_year,
+        @course.course_code,
+      ),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-        <span class="govuk-caption-l"><%= course.name_and_code %></span>
-        Do you require a minimum degree classification?
-      </h1>
-
-      <%= form.govuk_radio_buttons_fieldset :degree_grade_required, legend: { text: "If you specify a minimum (for example, 2:1), candidates will be discouraged but not blocked from applying if they do not meet this level.", size: "m", class: "govuk-hint" } do %>
-        <%= form.govuk_radio_button :degree_grade_required, true, label: { text: "Yes" }, data: { qa: "start__yes_radio" }, link_errors: true %>
-        <%= form.govuk_radio_button :degree_grade_required, false, label: { text: "No" }, data: { qa: "start__no_radio" } %>
+      <%= f.govuk_radio_buttons_fieldset :degree_grade_required, legend: { text: page_title, size: "l", tag: "h1" }, hint: { text: "If you specify a minimum (for example, 2:1), candidates will be discouraged but not blocked from applying if they do not meet this level." } do %>
+        <%= f.govuk_radio_button :degree_grade_required, true, label: { text: "Yes" }, data: { qa: "start__yes_radio" }, link_errors: true %>
+        <%= f.govuk_radio_button :degree_grade_required, false, label: { text: "No" }, data: { qa: "start__no_radio" } %>
       <% end %>
 
-      <%= form.govuk_submit "Save", data: { qa: "start__save" } %>
+      <%= f.govuk_submit "Save", data: { qa: "start__save" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/degrees/subject_requirements/edit.html.erb
+++ b/app/views/courses/degrees/subject_requirements/edit.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "#{@errors && @errors.any? ? 'Error: ' : ''}Degree subject" %>
+<% page_title = "Degree subject" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @subject_requirements_form.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to @backlink %>
@@ -6,31 +7,33 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @subject_requirements_form, url: degrees_subject_requirements_provider_recruitment_cycle_course_path(
-                    @course.provider.provider_code,
-                    @course.provider.recruitment_cycle_year,
-                    @course.course_code,
-                  ),
-                  method: :put,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: @subject_requirements_form, url: degrees_subject_requirements_provider_recruitment_cycle_course_path(
+        @course.provider.provider_code,
+        @course.provider.recruitment_cycle_year,
+        @course.course_code,
+      ),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= course.name_and_code %></span>
-        Degree subject
+        <%= page_title %>
       </h1>
 
       <p class="govuk-body">Candidates will be advised that their degree subject should match or be closely related to <%= course.name %>.</p>
 
-      <%= form.govuk_radio_buttons_fieldset :additional_degree_subject_requirements, legend: { text: "Do you have any additional degree subject requirements?" } do %>
-        <%= form.govuk_radio_button :additional_degree_subject_requirements, false, label: { text: "No" }, data: { qa: "degree_subject_requirements__no_radio" }, link_errors: true %>
-        <%= form.govuk_radio_button :additional_degree_subject_requirements, true, label: { text: "Yes" }, data: { qa: "degree_subject_requirements__yes_radio" } do %>
-          <%= form.govuk_text_area :degree_subject_requirements, label: { text: "Degree subject requirements" }, data: { qa: "degree_subject_requirements__requirements" } %>
+      <%= f.govuk_radio_buttons_fieldset :additional_degree_subject_requirements, legend: { text: "Do you have any additional degree subject requirements?" } do %>
+        <%= f.govuk_radio_button :additional_degree_subject_requirements, false, label: { text: "No" }, data: { qa: "degree_subject_requirements__no_radio" }, link_errors: true %>
+        <%= f.govuk_radio_button :additional_degree_subject_requirements, true, label: { text: "Yes" }, data: { qa: "degree_subject_requirements__yes_radio" } do %>
+          <%= f.govuk_text_area :degree_subject_requirements, label: { text: "Degree subject requirements" }, data: { qa: "degree_subject_requirements__requirements" } %>
         <% end %>
       <% end %>
 
-      <%= form.govuk_submit "Save", data: { qa: "degree_subject_requirements__save" } %>
+      <%= f.govuk_submit "Save", data: { qa: "degree_subject_requirements__save" } %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context

Updates course degree forms to align with some recent changes.

### Changes proposed in this pull request

* Make `page_title` a variable
* Use `title_with_error_prefix` helper for page title
* Use `hint` option for `degree_grade_required` fieldset
* Use `f` for forms that use the form builder

### Guidance to review

* Are the right errors being tested for in `title_with_error_prefix`

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
