### PR TITLE
Use `govuk_button_to` helper

### DIFF
--- a/app/views/courses/status_panel/_unpublished.html.erb
+++ b/app/views/courses/status_panel/_unpublished.html.erb
@@ -12,16 +12,16 @@
 <% if @recruitment_cycle.current_and_open? %>
   <p class="govuk-body">Publish your changes.</p>
   <p class="govuk-body">You can make changes to this course after publishing it.</p>
-  <%= form_for course, url: publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :post do |f| %>
-    <%= f.submit "Publish", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: "course__publish" } %>
-  <% end %>
+  <%= govuk_button_to("Publish", publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+    class: "govuk-!-margin-bottom-0",
+    data: { qa: "course__publish" }) %>
 <% else %>
   <% if course.is_published? %>
     <p class="govuk-body">Publish your changes and they will appear on Find when the cycle opens in <%= Settings.next_cycle_open_date.to_s(:month) %>.</p>
   <% else %>
     <p class="govuk-body">Publish this course and it will appear on Find when the cycle opens in <%= Settings.next_cycle_open_date.to_s(:month) %>.</p>
   <% end %>
-  <%= form_for course, url: publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :post do |f| %>
-    <%= f.submit "Publish in #{Settings.next_cycle_open_date.to_s(:month)}", class: "govuk-button govuk-!-margin-bottom-0", data: { qa: "course__publish" } %>
-  <% end %>
+  <%= govuk_button_to("Publish in #{Settings.next_cycle_open_date.to_s(:month)}", publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+    class: "govuk-!-margin-bottom-0",
+    data: { qa: "course__publish" }) %>
 <% end %>

--- a/app/views/pages/notifications_info.html.erb
+++ b/app/views/pages/notifications_info.html.erb
@@ -20,8 +20,6 @@
     <p class="govuk-body">
       or
     </p>
-    <%= form_for :user, url: accept_notifications_info_path, method: :patch do |f| %>
-      <%= f.submit "Continue", class: "govuk-button" %>
-    <% end %>
+    <%= govuk_button_to "Continue", accept_notifications_info_path, method: :patch %>
   </div>
 </div>

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -29,8 +29,6 @@
       You can also add, edit or delete courses and locations.
     </p>
 
-    <%= form_for :user, url: accept_rollover_path, method: :patch do |f| %>
-      <%= f.submit "Continue", class: "govuk-button" %>
-    <% end %>
+    <%= govuk_button_to "Continue", accept_rollover_path, method: :patch %>
   </div>
 </div>

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -13,8 +13,6 @@
       Accredited bodies should request fee-funded PE by <%= Settings.allocations_close_date.to_s(:govuk) %>.
     </p>
 
-    <%= form_for :user, url: accept_rollover_recruitment_path, method: :patch do |f| %>
-      <%= f.submit "Continue", class: "govuk-button" %>
-    <% end %>
+    <%= govuk_button_to "Continue", accept_rollover_recruitment_path, method: :patch %>
   </div>
 </div>

--- a/app/views/pages/transition_info.html.erb
+++ b/app/views/pages/transition_info.html.erb
@@ -18,8 +18,6 @@
 
     <p class="govuk-body">You’ll still need to use UCAS to view and manage course applications. This is because candidates will continue to apply for courses through UCAS.</p>
 
-    <%= form_for :user, url: accept_transition_info_path, method: :patch do |f| %>
-      <%= f.submit "Continue", class: "govuk-button", data: { qa: "transition__continue" } %>
-    <% end %>
+    <%= govuk_button_to "Continue", accept_transition_info_path, method: :patch, data: { qa: "transition__continue" } %>
   </div>
 </div>


### PR DESCRIPTION
### Context

There are few places where there are page submission buttons. These can use the `govuk_button_to` helper, to ensure they are styled using the design system.

### Changes proposed in this pull request

* Use `govuk_button_to` for form submission buttons on pages
* Use `govuk_button_to` for form submission Publish button in course sidebar

### Guidance to review

* Any reason why you wouldn’t do this?

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
