### PR TITLE
Tidy up forms that use GOV.UK Form Builder

### DIFF
--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -1,22 +1,25 @@
-<%= content_for :page_title, title_with_error_prefix(t("ucas_contacts.#{@contact.type}.heading"), @contact.errors.any?) %>
+<% page_title = t("ucas_contacts.#{@contact.type}.heading") %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @contact.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_ucas_contacts_path(@provider.provider_code)) %>
 <% end %>
 
-<%= form_with model: @contact,
-              url: provider_contact_path(@provider.provider_code, @contact.id),
-              id: "contact_edit_form",
-              scope: :contact,
-              method: :put,
-              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @contact,
+      url: provider_contact_path(@provider.provider_code, @contact.id),
+      id: "contact_edit_form",
+      scope: :contact,
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-  <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l" data-qa="ucas_contacts__alerts__main_heading">
-        <%= t("ucas_contacts.#{@contact.type}.heading") %>
+        <%= page_title %>
       </h1>
 
       <p class="govuk-body"><%= t("ucas_contacts.#{@contact.type}.purpose") %></p>
@@ -26,13 +29,13 @@
         <p class="govuk-body" id="admin_subtext">Changes can take up to 7 days to process.</p>
       <% end %>
 
-      <%= form.govuk_text_field :name, width: "three-quarters" %>
-      <%= form.govuk_email_field :email, label: { text: "Email address" }, width: "three-quarters" %>
-      <%= form.govuk_phone_field :telephone, width: "one-half" %>
+      <%= f.govuk_text_field :name, width: "three-quarters" %>
+      <%= f.govuk_email_field :email, label: { text: "Email address" }, width: "three-quarters" %>
+      <%= f.govuk_phone_field :telephone, width: "one-half" %>
       <div class="govuk-form-group">
-        <%= form.govuk_check_box :permission_given, 1, 0, multiple: false, label: { text: "I give permission to share this email address with UCAS" } %>
+        <%= f.govuk_check_box :permission_given, 1, 0, multiple: false, label: { text: "I give permission to share this email address with UCAS" } %>
       </div>
-      <%= form.govuk_submit t("ucas_contacts.#{@contact.type}.submit", default: "Save") %>
+      <%= f.govuk_submit t("ucas_contacts.#{@contact.type}.submit", default: "Save") %>
     </div>
   </div>
 <% end %>

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -1,25 +1,19 @@
 <%= f.govuk_radio_buttons_fieldset(:course_length,
-  legend: {
-    text: "Course length",
-    size: "m",
-  },
+  legend: { size: "m" },
   form_group: {
     id: @errors.key?(:course_length) ? "course_length-error" : "course-length",
   }) do %>
     <%= f.govuk_radio_button(:course_length, "OneYear",
-      label: { text: "1 year" },
       data: { qa: "course_course_length_oneyear" },
       link_errors: true) %>
     <%= f.govuk_radio_button(:course_length, "TwoYears",
-      label: { text: "Up to 2 years" },
       data: { qa: "course_course_length_twoyears" }) %>
     <%= f.govuk_radio_button(:course_length, "Other",
-      label: { text: "Other" },
       checked: course.other_course_length?,
       data: { qa: "course_course_length_other" }) do %>
       <%= f.govuk_text_field(:course_length_other_length,
         value: course.other_course_length? ? course.course_length : "",
-        label: { text: "Course length", size: "s" },
+        label: { size: "s" },
         width: 20,
         data: { qa: "course_course_length_other_length" }) %>
     <% end %>

--- a/app/views/courses/_related_sidebar.html.erb
+++ b/app/views/courses/_related_sidebar.html.erb
@@ -3,7 +3,7 @@
     <h3 class="govuk-heading-m">Copy content from another course</h3>
     <p class="govuk-body">Fill in this page with content from another course.</p>
     <p class="govuk-body">This will replace any existing content.</p>
-    <%= form_for course, url: page_path, data: { qa: "course__copy-content-form" }, method: :get do |f| %>
+    <%= form_for course, url: page_path, data: { qa: "course__copy-content-form" }, method: :get do |form| %>
       <div class="govuk-form-group">
         <label class="govuk-label govuk-label--s" for="copy-from">Copy from</label>
         <select id="copy-from" name="copy_from" class="govuk-select">
@@ -19,7 +19,7 @@
           <% end %>
         </select>
       </div>
-      <%= f.submit "Copy content", class: "govuk-button govuk-!-margin-bottom-0", name: nil, data: { qa: "course__copy" } %>
+      <%= form.submit "Copy content", class: "govuk-button govuk-!-margin-bottom-0", name: nil, data: { qa: "course__copy" } %>
     <% end %>
   <% else %>
     <h3 class="govuk-heading-m">Use this content again</h3>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -1,4 +1,6 @@
-<%= content_for :page_title, title_with_error_prefix("About this course – #{course.name_and_code}", course.errors.any?) %>
+
+<% page_title = "About this course" %>
+<%= content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -8,130 +10,134 @@
   <%= render partial: "courses/copy_content_warning", locals: { copied_fields: @copied_fields } %>
 <% end %>
 
-<%= form_with model: course,
-              url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              data: { qa: "enrichment-form", module: "form-check-leave" },
-              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<%= form_with(
+  model: course,
+  url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+  data: { qa: "enrichment-form", module: "form-check-leave" },
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+) do |f| %>
   <%= f.hidden_field :page, value: :about, id: nil %>
   <%= f.govuk_error_summary %>
 <% end %>
 
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l"><%= course.name_and_code %></span>
-    About this course
-  </h1>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= course.name_and_code %></span>
+  <%= page_title %>
+</h1>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= form_with model: course,
-                    url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                    data: { qa: "enrichment-form", module: "form-check-leave" },
-                    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: course,
+      url: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+      data: { qa: "enrichment-form", module: "form-check-leave" },
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-        <%= f.hidden_field :page, value: :about, id: nil %>
+      <%= f.hidden_field :page, value: :about, id: nil %>
 
-        <p class="govuk-body">You should give a short, factual summary of the course.</p>
+      <p class="govuk-body">You should give a short, factual summary of the course.</p>
 
-        <p class="govuk-body">Tell applicants:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>what they’ll learn (eg what units are taught)</li>
-          <li>how the course is structured</li>
-          <li>whether it has any distinctive features</li>
-        </ul>
+      <p class="govuk-body">Tell applicants:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>what they’ll learn (eg what units are taught)</li>
+        <li>how the course is structured</li>
+        <li>whether it has any distinctive features</li>
+      </ul>
 
-        <p class="govuk-body">You could include details such as:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>how candidates are assessed</li>
-          <li>the size of the workload (eg how many essays per term)</li>
-          <li>league-table rankings and student employability ratings</li>
-          <li>quotes from past students</li>
-        </ul>
+      <p class="govuk-body">You could include details such as:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>how candidates are assessed</li>
+        <li>the size of the workload (eg how many essays per term)</li>
+        <li>league-table rankings and student employability ratings</li>
+        <li>quotes from past students</li>
+      </ul>
 
-        <p class="govuk-body">Remember to:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>make your content specific to this course – don’t repeat the descriptions you’ve used for other courses</li>
-          <li>use short paragraphs (no more than five sentences each)</li>
-          <li>use bullet points where possible (to check formatting, use the ‘preview’ function after saving your content)</li>
-          <li>spell out all acronyms the first time you use them, eg ITT, NQT, EAL, ICT (applicants may not be familiar with these terms)
-          </li>
-        </ul>
+      <p class="govuk-body">Remember to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>make your content specific to this course – don’t repeat the descriptions you’ve used for other courses</li>
+        <li>use short paragraphs (no more than five sentences each)</li>
+        <li>use bullet points where possible (to check formatting, use the ‘preview’ function after saving your content)</li>
+        <li>spell out all acronyms the first time you use them, eg ITT, NQT, EAL, ICT (applicants may not be familiar with these terms)
+        </li>
+      </ul>
 
-        <%= govuk_details(
-          summary: "Several courses in the same subject?",
-          description: "If you offer more than one course in the same subject – eg two Primary courses – it’s important to say how they differ (eg differences in teaching placements or in the focus of the training). Otherwise, applicants may be unable to decide between them.",
-        ) %>
-
-        <%= f.govuk_text_area(:about_course,
-          label: { text: "About this course", size: "s" },
-          max_words: 400,
-          rows: 20) %>
-
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
-
-        <h3 class="govuk-heading-m" id="interview-process">Interview process</h3>
-
-        <p class="govuk-body">Tell applicants:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>how many interviews they’ll have</li>
-          <li>how long each interview will be</li>
-          <li>who’ll be interviewing them - will it be one-on-one or a group interview?</li>
-          <li>whether they’ll have to sit any tests - if so, how can they prepare?</li>
-        </ul>
-
-        <%= f.govuk_text_area(:interview_process,
-          label: { text: "Interview process (optional)", size: "s" },
-          max_words: 250,
-          rows: 15) %>
-
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
-
-        <h3 class="govuk-heading-m" id="how-school-placements-work"><%= course.placements_heading %></h3>
-
-        <p class="govuk-body">
-          Give applicants more information about the schools they’ll be teaching in. Tell them:
-        </p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>how many placements a candidate will have</li>
-          <li>how much time they’ll spend in each school</li>
-          <li>if mentors are available within the schools</li>
-          <li>the average distance candidates have to travel from home to school</li>
-        </ul>
-
-        <p class="govuk-body">You could also mention:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>the age ranges taught (eg 11 to 16 or 11 to 18)</li>
-          <li>how many schools you partner with in total</li>
-          <li>whether candidates are able to change schools</li>
-          <li>how placement schools are selected</li>
-        </ul>
-
-        <%= govuk_details(summary: "See the guidance we show in this section") do %>
-          <h3 class="govuk-heading-m">Where you will train</h3>
-          <% if @provider.provider_type == 'university' %>
-            <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
-            <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
-          <% else %>
-            <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
-          <% end %>
-        <% end %>
-
-        <%= f.govuk_text_area(:how_school_placements_work,
-          label: { text: course.placements_heading, size: "s" },
-          max_words: 350,
-          rows: 15) %>
-
-        <%= f.govuk_submit "Save" %>
-      <% end %>
-    </div>
-
-    <aside class="govuk-grid-column-one-third">
-      <%= render(
-        partial: "courses/related_sidebar",
-        locals: {
-          course: course,
-          page_path: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-        },
+      <%= govuk_details(
+        summary: "Several courses in the same subject?",
+        description: "If you offer more than one course in the same subject – eg two Primary courses – it’s important to say how they differ (eg differences in teaching placements or in the focus of the training). Otherwise, applicants may be unable to decide between them.",
       ) %>
-    </aside>
+
+      <%= f.govuk_text_area(:about_course,
+        label: { size: "s" },
+        max_words: 400,
+        rows: 20) %>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+      <h3 class="govuk-heading-m" id="interview-process">Interview process</h3>
+
+      <p class="govuk-body">Tell applicants:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>how many interviews they’ll have</li>
+        <li>how long each interview will be</li>
+        <li>who’ll be interviewing them - will it be one-on-one or a group interview?</li>
+        <li>whether they’ll have to sit any tests - if so, how can they prepare?</li>
+      </ul>
+
+      <%= f.govuk_text_area(:interview_process,
+        label: { size: "s" },
+        max_words: 250,
+        rows: 15) %>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+      <h3 class="govuk-heading-m" id="how-school-placements-work"><%= course.placements_heading %></h3>
+
+      <p class="govuk-body">
+        Give applicants more information about the schools they’ll be teaching in. Tell them:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>how many placements a candidate will have</li>
+        <li>how much time they’ll spend in each school</li>
+        <li>if mentors are available within the schools</li>
+        <li>the average distance candidates have to travel from home to school</li>
+      </ul>
+
+      <p class="govuk-body">You could also mention:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the age ranges taught (eg 11 to 16 or 11 to 18)</li>
+        <li>how many schools you partner with in total</li>
+        <li>whether candidates are able to change schools</li>
+        <li>how placement schools are selected</li>
+      </ul>
+
+      <%= govuk_details(summary: "See the guidance we show in this section") do %>
+        <h3 class="govuk-heading-m">Where you will train</h3>
+        <% if @provider.provider_type == 'university' %>
+          <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
+          <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
+        <% else %>
+          <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_text_area(:how_school_placements_work,
+        label: { text: course.placements_heading, size: "s" },
+        max_words: 350,
+        rows: 15) %>
+
+      <%= f.govuk_submit "Save" %>
+    <% end %>
   </div>
+
+  <aside class="govuk-grid-column-one-third">
+    <%= render(
+      partial: "courses/related_sidebar",
+      locals: {
+        course: course,
+        page_path: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+      },
+    ) %>
+  </aside>
+</div>

--- a/app/views/courses/age_range/_form_fields.html.erb
+++ b/app/views/courses/age_range/_form_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">
+<div class="govuk-radios" data-module="govuk-radios">
   <% @course.meta["edit_options"]["age_range_in_years"].each do |value| %>
     <div class="govuk-radios__item">
       <%= form.radio_button :age_range_in_years, value, class: "govuk-radios__input", data: { qa: "course__age_range_in_years_#{value}_radio" } %>

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, title_with_error_prefix("Specify an age range – #{course.name_and_code}", form_object.errors.any?) %>
+<% page_title = "Specify an age range" %>
+<%= content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -6,34 +7,36 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: form_object,
-                  url: age_range_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
-                  scope: :course,
-                  method: :put,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: form_object,
+      url: age_range_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+      scope: :course,
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-      <%= form.govuk_radio_buttons_fieldset(:age_range_in_years, legend: { size: "l", text: "Specify an age range" }, caption: { text: course.name_and_code, size: "l" }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:age_range_in_years, legend: { text: page_title, size: "l" }, caption: { text: course.name_and_code, size: "l" }) do %>
         <% @course.meta["edit_options"]["age_range_in_years"].each do |value| %>
-          <%= form.govuk_radio_button :age_range_in_years,
+          <%= f.govuk_radio_button(:age_range_in_years,
             value,
             label: { text: I18n.t("edit_options.age_range_in_years.#{value}.label") },
-            link_errors: true %>
+            link_errors: true) %>
         <% end %>
 
-        <%= form.govuk_radio_divider %>
+        <%= f.govuk_radio_divider %>
 
-        <%= form.govuk_radio_button :age_range_in_years, "other", label: { text: "Another age range" } do %>
+        <%= f.govuk_radio_button :age_range_in_years, "other", label: { text: "Another age range" } do %>
           <p class="govuk-body">Enter an age range in years, for example: 5 to 11. The course must cover 4 or more school years.</p>
 
-          <%= form.govuk_text_field :course_age_range_in_years_other_from, label: { text: "From" }, class: "govuk-input govuk-input--width-2" %>
+          <%= f.govuk_text_field :course_age_range_in_years_other_from, label: { text: "From" }, class: "govuk-input govuk-input--width-2" %>
 
-          <%= form.govuk_text_field :course_age_range_in_years_other_to, label: { text: "To" }, class: "govuk-input govuk-input--width-2" %>
+          <%= f.govuk_text_field :course_age_range_in_years_other_to, label: { text: "To" }, class: "govuk-input govuk-input--width-2" %>
         <% end %>
       <% end %>
 
-      <%= form.govuk_submit course.is_running? ? "Save and publish changes" : "Save", data: { qa: "course__save" } %>
+      <%= f.govuk_submit course.is_running? ? "Save and publish changes" : "Save", data: { qa: "course__save" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, title_with_error_prefix("Specify an age range", @errors && @errors.any?) %>
+<% page_title = "Specify an age range" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
@@ -19,7 +20,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h1 class="govuk-fieldset__heading">
-                Specify an age range
+                <%= page_title %>
               </h1>
             </legend>
             <%= render "shared/error_messages", error_keys: [:age_range_in_years] %>

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -1,17 +1,20 @@
-<%= content_for :page_title, title_with_error_prefix("Check your answers before confirming", course.errors.any?) %>
+<%= page_title = "Check your answers before confirming" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, course.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Check your answers before confirming
-    </h1>
+    <%= form_with(
+      model: course,
+      url: provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      method: :post,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-    <%= render "shared/errors" %>
+      <%= render "shared/errors" %>
 
-    <%= form_with model: course,
-                  url: provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year),
-                  method: :post,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <h1 class="govuk-heading-l">
+        <%= page_title %>
+      </h1>
 
       <%= render "shared/course_creation_hidden_fields",
         form: f,

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -25,19 +25,19 @@
 
     <%= form_with model: @course,
                   url: provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                  method: :delete do |f| %>
+                  method: :delete do |form| %>
 
       <div class="govuk-form-group">
-        <%= f.label "confirm_course_code", "Type in the course code to confirm", class: "govuk-label" %>
+        <%= form.label "confirm_course_code", "Type in the course code to confirm", class: "govuk-label" %>
         <% if flash[:error] && flash[:error]["id"] == "delete-error" %>
           <span class="govuk-error-message" id="delete-error" data-qa="course-delete-error">
             <%= flash[:error]["message"] %>
           </span>
         <% end %>
-        <%= f.text_field "confirm_course_code", class: "govuk-input govuk-input--width-5" %>
+        <%= form.text_field "confirm_course_code", class: "govuk-input govuk-input--width-5" %>
       </div>
 
-      <%= f.submit "Yes I’m sure – delete this course", class: "govuk-button govuk-button--warning" %>
+      <%= form.submit "Yes I’m sure – delete this course", class: "govuk-button govuk-button--warning" %>
     <% end %>
 
     <p class="govuk-body govuk-!-margin-top-5">

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, title_with_error_prefix("Course length and fees - #{course.name_and_code}", course.errors.any?) %>
+<% page_title = "Course length and fees" %>
+<%= content_for :page_title, title_with_error_prefix("#{page_title} - #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -8,20 +9,22 @@
   <%= render partial: "courses/copy_content_warning", locals: { copied_fields: @copied_fields } %>
 <% end %>
 
-<%= form_with model: course,
-              url: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-              data: { qa: "enrichment-form", module: "form-check-leave" } do |f| %>
+<%= render "shared/errors" %>
 
-  <%= render "shared/errors" %>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= course.name_and_code %></span>
+  <%= page_title %>
+</h1>
 
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l"><%= course.name_and_code %></span>
-    Course length and fees
-  </h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: course,
+      url: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      data: { qa: "enrichment-form", module: "form-check-leave" },
+    ) do |f| %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <%= f.hidden_field :page, value: :fees %>
 
       <%= render partial: "courses/course_length", locals: { f: f } %>
@@ -33,7 +36,7 @@
       <%= f.govuk_text_field(:fee_uk_eu,
         form_group: { id: @errors.key?(:fee_uk_eu) ? "fee_uk_eu-error" : "fee-uk" },
         value: number_with_precision(course.fee_uk_eu, precision: 2, strip_insignificant_zeros: true),
-        label: { text: "Fee for UK students", size: "s" },
+        label: { size: "s" },
         prefix_text: "£",
         width: 5,
         data: { qa: "course_fee_uk_eu" }) %>
@@ -41,7 +44,7 @@
       <%= f.govuk_text_field(:fee_international,
         form_group: { id: "fee-international" },
         value: number_with_precision(course.fee_international, precision: 2, strip_insignificant_zeros: true),
-        label: { text: "Fee for international students (optional)", size: "s" },
+        label: { size: "s" },
         prefix_text: "£",
         width: 5,
         data: { qa: "course_fee_international" }) %>
@@ -55,7 +58,7 @@
       </ul>
 
       <%= f.govuk_text_area(:fee_details,
-        label: { text: "Fee details (optional)", size: "s" },
+        label: { size: "s" },
         rows: 15,
         max_words: 250,
         data: { qa: "course_fee_details" }) %>
@@ -67,22 +70,22 @@
       <p class="govuk-body">You don’t need to add details of any DfE bursaries and subject scholarships here. These will be published automatically to your course page</p>
 
       <%= f.govuk_text_area(:financial_support,
-        label: { text: "Financial support you offer (optional)", size: "s" },
+        label: { size: "s" },
         rows: 15,
         max_words: 250,
         data: { qa: "course_financial_support" }) %>
 
       <%= f.govuk_submit "Save", data: { qa: "course__save" } %>
-    </div>
-
-    <aside class="govuk-grid-column-one-third">
-      <%= render(
-        partial: "courses/related_sidebar",
-        locals: {
-          course: course,
-          page_path: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-        },
-      ) %>
-    </aside>
+    <% end %>
   </div>
-<% end %>
+
+  <aside class="govuk-grid-column-one-third">
+    <%= render(
+      partial: "courses/related_sidebar",
+      locals: {
+        course: course,
+        page_path: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+      },
+    ) %>
+  </aside>
+</div>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -1,8 +1,10 @@
 <% if @provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
-  <%= content_for :page_title, title_with_error_prefix("Personal qualities and other requirements – #{course.name_and_code}", course.errors.any?) %>
+  <% page_title = "Personal qualities and other requirements" %>
 <% else %>
-  <%= content_for :page_title, title_with_error_prefix("Requirements and eligibility – #{course.name_and_code}", course.errors.any?) %>
+  <% page_title = "Requirements and eligibility" %>
 <% end %>
+
+<%= content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -12,29 +14,33 @@
   <%= render partial: "courses/copy_content_warning", locals: { copied_fields: @copied_fields } %>
 <% end %>
 
+<%= form_with(
+  model: course,
+  url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+) do |f| %>
+  <%= f.govuk_error_summary %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= course.name_and_code %></span>
+  <%= page_title %>
+</h1>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                  data: { qa: "enrichment-form", module: "form-check-leave" },
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l"><%= course.name_and_code %></span>
-        <% if @provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
-          Personal qualities and other requirements
-        <% else %>
-          Requirements and eligibility
-        <% end %>
-      </h1>
+    <%= form_with(
+      model: course,
+      url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+      data: { qa: "enrichment-form", module: "form-check-leave" },
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
       <%= f.hidden_field :page, value: :requirements %>
 
       <% if @provider.recruitment_cycle_year.to_i < Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
         <%= f.govuk_text_area :required_qualifications,
-          label: { text: "Qualifications needed", size: "m" },
-          hint: { text: "State the minimum academic qualifications needed for this course. You could also say what happens if these requirements aren’t met." },
+          label: { size: "m" },
           max_words: 100,
           rows: 10 %>
 
@@ -43,8 +49,7 @@
 
       <%= f.govuk_text_area :personal_qualities,
         form_group: { id: "personal-qualities" },
-        label: { text: "Personal qualities (optional)", size: "m" },
-        hint: { text: "Tell applicants about the skills, motivation and experience you’re looking for (eg experience with children, a genuine passion for the subject, or a talent for public speaking)." },
+        label: { size: "m" },
         max_words: 100,
         rows: 10 %>
 
@@ -52,8 +57,7 @@
 
       <%= f.govuk_text_area :other_requirements,
         form_group: { id: "other-requirements" },
-        label: { text: "Other requirements (optional)", size: "m" },
-        hint: { text: "If applicants need any non-academic qualifications or documents, list them here (eg criminal record checks, or relevant work experience)." },
+        label: { size: "m" },
         max_words: 100,
         rows: 10 %>
 

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "Course length and salary - #{course.name_and_code}" %>
+<% page_title = "Course length and salary" %>
+<%= content_for :page_title, "#{page_title} - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -8,20 +9,22 @@
   <%= render partial: "courses/copy_content_warning", locals: { copied_fields: @copied_fields } %>
 <% end %>
 
-<%= form_with model: course,
-              url: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-              data: { qa: "enrichment-form", module: "form-check-leave" } do |f| %>
+<%= render "shared/errors" %>
 
-  <%= render "shared/errors" %>
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= course.name_and_code %></span>
+  <%= page_title %>
+</h1>
 
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l"><%= course.name_and_code %></span>
-    Course length and salary
-  </h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: course,
+      url: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      data: { qa: "enrichment-form", module: "form-check-leave" },
+    ) do |f| %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <%= f.hidden_field :page, value: :salary %>
 
       <%= render partial: "courses/course_length", locals: { f: f } %>
@@ -45,15 +48,16 @@
         data: { qa: "course_salary_details" }) %>
 
       <%= f.govuk_submit "Save", data: { qa: "course__save" } %>
-    </div>
-    <aside class="govuk-grid-column-one-third">
-      <%= render(
-        partial: "courses/related_sidebar",
-        locals: {
-          course: course,
-          page_path: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-        },
-      ) %>
-    </aside>
+    <% end %>
   </div>
-<% end %>
+
+  <aside class="govuk-grid-column-one-third">
+    <%= render(
+      partial: "courses/related_sidebar",
+      locals: {
+        course: course,
+        page_path: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+      },
+    ) %>
+  </aside>
+</div>

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -28,10 +28,10 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body govuk-body govuk-!-margin-bottom-6"><%= govuk_link_to "Manage all your locations", provider_recruitment_cycle_sites_path(@provider.provider_code), data: { qa: "course__manage_provider_locations_link" } %> to add to or edit this list.</p>
 
-    <%= form_for course, url: locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :put do |f| %>
+    <%= form_for course, url: locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :put do |form| %>
       <div class="govuk-form-group">
         <div class="govuk-checkboxes">
-          <%= f.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sf| %>
+          <%= form.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sf| %>
             <% site = sf.object %>
             <div class="govuk-checkboxes__item">
               <%= sf.check_box "selected", checked: course.has_site?(site), class: "govuk-checkboxes__input" %>
@@ -46,7 +46,7 @@
         </div>
       </div>
 
-      <%= f.submit course.is_running? ? "Save and publish changes" : "Save",
+      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
         class: "govuk-button", data: { qa: "course__save" } %>
     <% end %>
   </div>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -19,7 +19,7 @@
         <div data-qa="course__google_form_link" >
           <% if !current_user["admin"] && @course.level == "secondary" %>
             <h2 class="govuk-heading-m"> Adding a Physical education course?</h2>
-            <p class="govuk-body-s">You’ll need to fill in a
+            <p class="govuk-body">You’ll need to fill in a
               <%= govuk_link_to "separate Google Form", add_course_url(current_user['info']['email'], @provider), rel: "noopener noreferrer", target: "_blank" %>,
             as PE places are limited.</p>
           <% end %>

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -23,18 +23,18 @@
 
     <%= form_with model: @course,
                   url: withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                  method: :post do |f| %>
+                  method: :post do |form| %>
       <div class="govuk-form-group">
-        <%= f.label "confirm_course_code", "Type in the course code to confirm", class: "govuk-label" %>
+        <%= form.label "confirm_course_code", "Type in the course code to confirm", class: "govuk-label" %>
         <% if flash[:error] && flash[:error]["id"] == "withdraw-error" %>
           <span class="govuk-error-message" id="withdraw-error" data-qa="course-withdraw-error">
             <%= flash[:error]["message"] %>
           </span>
         <% end %>
-        <%= f.text_field "confirm_course_code", class: "govuk-input govuk-input--width-5" %>
+        <%= form.text_field "confirm_course_code", class: "govuk-input govuk-input--width-5" %>
       </div>
 
-      <%= f.submit "Yes I’m sure – withdraw this course", class: "govuk-button govuk-button--warning" %>
+      <%= form.submit "Yes I’m sure – withdraw this course", class: "govuk-button govuk-button--warning" %>
     <% end %>
 
     <p class="govuk-body govuk-!-margin-top-5">

--- a/app/views/pages/accept_terms.html.erb
+++ b/app/views/pages/accept_terms.html.erb
@@ -16,16 +16,16 @@
 
     <hr class="govuk-footer__section-break">
 
-    <%= form_for :user, url: accept_terms_path, method: :patch do |f| %>
+    <%= form_for :user, url: accept_terms_path, method: :patch do |form| %>
       <div class="govuk-form-group">
         <div class="govuk-checkboxes">
           <div class="govuk-checkboxes__item" id="user_terms_accepted-error">
-            <%= f.check_box :terms_accepted, class: "govuk-checkboxes__input" %>
-            <%= f.label :terms_accepted, "I agree to the terms and conditions", class: "govuk-label govuk-checkboxes__label" %>
+            <%= form.check_box :terms_accepted, class: "govuk-checkboxes__input" %>
+            <%= form.label :terms_accepted, "I agree to the terms and conditions", class: "govuk-label govuk-checkboxes__label" %>
           </div>
         </div>
       </div>
-      <%= f.submit "Continue", class: "govuk-button", data: { qa: "terms__continue" } %>
+      <%= form.submit "Continue", class: "govuk-button", data: { qa: "terms__continue" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "Check your information before sending your request" %>
+<% page_title = "Check your information before sending your request" %>
+<%= content_for :page_title, page_title %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(
@@ -14,18 +15,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: provider_recruitment_cycle_allocation_path(
-                    @provider.provider_code,
-                    @provider.recruitment_cycle_year,
-                    training_provider_code: params[:training_provider_code],
-                    number_of_places: params[:number_of_places],
-                  ),
-                  skip_enforcing_utf8: true,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      url: provider_recruitment_cycle_allocation_path(
+        @provider.provider_code,
+        @provider.recruitment_cycle_year,
+        training_provider_code: params[:training_provider_code],
+        number_of_places: params[:number_of_places],
+      ),
+      skip_enforcing_utf8: true,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= training_provider.provider_name %></span>
-        Check your information before sending your request
+        <%= page_title %>
       </h1>
 
       <%= govuk_summary_list do |summary_list| %>
@@ -50,7 +53,7 @@
       <%= hidden_field_tag "training_provider_code", params[:training_provider_code] %>
       <%= hidden_field_tag "number_of_places", params[:number_of_places] %>
 
-      <%= form.govuk_submit "Send request", data: { qa: "allocations__send_request" } %>
+      <%= f.govuk_submit "Send request", data: { qa: "allocations__send_request" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/edit.html.erb
+++ b/app/views/providers/allocations/edit.html.erb
@@ -7,21 +7,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @allocation,
-                  url: provider_recruitment_cycle_allocation_path(id: @allocation.id),
-                  scope: "",
-                  method: :patch,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: @allocation,
+      url: provider_recruitment_cycle_allocation_path(id: @allocation.id),
+      scope: "",
+      method: :patch,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-      <%= form.govuk_radio_buttons_fieldset(
-        :old_department_id,
-        legend: { size: "l", text: page_title, tag: "h1" },
-        caption: { text: "#{@training_provider.provider_name} ", size: "l" },
-      ) do %>
-        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" } %>
-        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
+      <%= f.govuk_radio_buttons_fieldset(:old_department_id,
+        legend: { text: page_title, size: "l", tag: "h1" },
+        caption: { text: "#{@training_provider.provider_name} ", size: "l" }) do %>
+        <%= f.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
       <% end %>
-      <%= form.govuk_submit data: { qa: "allocations__continue" } %>
+      <%= f.govuk_submit data: { qa: "allocations__continue" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/initial_request.html.erb
+++ b/app/views/providers/allocations/initial_request.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "Who are you requesting a course for?" %>
+<% page_title = "Who are you requesting a course for?" %>
+<%= content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path(provider.provider_code, provider.recruitment_cycle_year)) %>
@@ -6,15 +7,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: form_object,
-                  scope: "",
-                  url: initial_request_provider_recruitment_cycle_allocations_path(provider.provider_code, provider.recruitment_cycle_year),
-                  skip_enforcing_utf8: true,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: form_object,
+      scope: "",
+      url: initial_request_provider_recruitment_cycle_allocations_path(provider.provider_code, provider.recruitment_cycle_year),
+      skip_enforcing_utf8: true,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-      <%= form.govuk_radio_buttons_fieldset(:training_provider_code, legend: { size: "l", text: "Who are you requesting a course for?", tag: "h1" }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:training_provider_code, legend: { text: page_title, size: "l", tag: "h1" }) do %>
         <p class="govuk-body">
           This should be the name of the organisation offering the course. For
           example, a lead school or your own organisation, if you’re offering it.
@@ -22,28 +25,28 @@
 
         <% if training_providers.present? %>
           <% training_providers.each do |training_provider| %>
-            <%= form.govuk_radio_button :training_provider_code,
+            <%= f.govuk_radio_button :training_provider_code,
               training_provider.provider_code,
               label: { text: training_provider.provider_name },
               link_errors: true %>
           <% end %>
 
-          <%= form.govuk_radio_divider %>
+          <%= f.govuk_radio_divider %>
 
-          <%= form.govuk_radio_button :training_provider_code, "-1", label: { text: "Find an organisation not listed above" } do %>
-            <%= form.govuk_text_field :training_provider_query, label: { text: "Organisation name" } do %>
-              <div id="provider-autocomplete"></div>
-            <% end %>
+          <%= f.govuk_radio_button :training_provider_code, "-1", label: { text: "Find an organisation not listed above" } do %>
+            <%= f.govuk_text_field :training_provider_query, label: { text: "Organisation name" } %>
+            <div id="provider-autocomplete"></div>
           <% end %>
         <% else %>
           <%= hidden_field_tag "training_provider_code", "-1" %>
-          <%= form.govuk_text_field :training_provider_query, label: { text: "Find an organisation" } %>
+          <%= f.govuk_text_field :training_provider_query, label: { text: "Find an organisation" } %>
           <div id="provider-autocomplete"></div>
         <% end %>
       <% end %>
 
-      <%= form.govuk_submit %>
+      <%= f.govuk_submit %>
     <% end %>
+
     <p class="govuk-body">
       To add a new organisation to Publish, contact <%= bat_contact_mail_to %>.
     </p>

--- a/app/views/providers/allocations/new_repeat_request.html.erb
+++ b/app/views/providers/allocations/new_repeat_request.html.erb
@@ -7,22 +7,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @allocation,
-                  url: provider_recruitment_cycle_allocation_path(@provider.provider_code, @provider.recruitment_cycle_year, params[:training_provider_code]),
-                  scope: "",
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: @allocation,
+      url: provider_recruitment_cycle_allocation_path(@provider.provider_code, @provider.recruitment_cycle_year, params[:training_provider_code]),
+      scope: "",
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-      <%= form.govuk_radio_buttons_fieldset(
-        :request_type,
-        legend: { size: "l", text: page_title, tag: "h1" },
-        caption: { text: "#{@training_provider.provider_name} ", size: "l" },
-      ) do %>
-        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" }, link_errors: true %>
-        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
+      <%= f.govuk_radio_buttons_fieldset(:request_type,
+        legend: { text: page_title, size: "l", tag: "h1" },
+        caption: { text: @training_provider.provider_name, size: "l" }) do %>
+        <%= f.govuk_radio_button :request_type, AllocationsView::RequestType::REPEAT, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
       <% end %>
-      <%= form.govuk_submit data: { qa: "allocations__continue" } %>
+      <%= f.govuk_submit data: { qa: "allocations__continue" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -7,20 +7,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: form_object,
-                  url: initial_request_provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year),
-                  scope: "",
-                  skip_enforcing_utf8: true,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: form_object,
+      url: initial_request_provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      scope: "",
+      skip_enforcing_utf8: true,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-      <%= form.govuk_text_field :number_of_places,
-        label: {
-          text: page_title,
-          size: "l",
-          tag: "h1",
-        },
+      <%= f.govuk_text_field :number_of_places,
+        label: { text: page_title, size: "l", tag: "h1" },
         caption: { text: "#{training_provider.provider_name} ", size: "l" },
         pattern: "[0-9]*",
         inputmode: "numeric",
@@ -35,7 +33,7 @@
 
     <%= hidden_field_tag "training_provider_code", params[:training_provider_code] %>
 
-    <%= form.govuk_submit %>
+    <%= f.govuk_submit %>
   <% end %>
   </div>
 </div>

--- a/app/views/providers/allocations/pick_a_provider.html.erb
+++ b/app/views/providers/allocations/pick_a_provider.html.erb
@@ -40,23 +40,25 @@
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
     <%= govuk_details(summary: "Try another provider") do %>
-      <%= form_with url: initial_request_provider_recruitment_cycle_allocations_path(
-                      @provider.provider_code,
-                      @provider.recruitment_cycle_year,
-                      training_provider_code: params[:training_provider_code],
-                    ),
-                    skip_enforcing_utf8: true,
-                    method: :get,
-                    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <%= form_with(
+        url: initial_request_provider_recruitment_cycle_allocations_path(
+          @provider.provider_code,
+          @provider.recruitment_cycle_year,
+          training_provider_code: params[:training_provider_code],
+        ),
+        skip_enforcing_utf8: true,
+        method: :get,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      ) do |f| %>
 
-        <%= form.hidden_field :training_provider_code, value: "-1" %>
+        <%= f.hidden_field :training_provider_code, value: "-1" %>
 
         <div class="govuk-form-group">
-          <%= form.govuk_text_field :training_provider_query, label: { text: "Organisation name" } %>
+          <%= f.govuk_text_field :training_provider_query, label: { text: "Organisation name" } %>
           <div id="provider-autocomplete"></div>
         </div>
 
-        <%= form.govuk_submit "Search again" %>
+        <%= f.govuk_submit "Search again" %>
       <% end %>
     <% end %>
 

--- a/app/views/providers/edit_initial_allocations/check_answers.html.erb
+++ b/app/views/providers/edit_initial_allocations/check_answers.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "Check your information before sending your request" %>
+<% page_title = "Check your information before sending your request" %>
+<%= content_for :page_title, page_title %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(
@@ -16,20 +17,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: form_object,
-                  url: update_initial_request_provider_recruitment_cycle_allocation_path(
-                    provider.provider_code,
-                    recruitment_cycle.year,
-                    training_provider.provider_code,
-                    id: allocation.id,
-                  ),
-                  scope: "",
-                  skip_enforcing_utf8: true,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: form_object,
+      url: update_initial_request_provider_recruitment_cycle_allocation_path(
+        provider.provider_code,
+        recruitment_cycle.year,
+        training_provider.provider_code,
+        id: allocation.id,
+      ),
+      scope: "",
+      skip_enforcing_utf8: true,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= training_provider.provider_name %></span>
-        Check your information before sending your request
+        <%= page_title %>
       </h1>
 
       <%= govuk_summary_list do |summary_list| %>
@@ -56,7 +59,7 @@
       <%= hidden_field_tag "request_type", params[:request_type] %>
       <%= hidden_field_tag "finish_flow", "1" %>
 
-      <%= form.govuk_submit "Send request", data: { qa: "allocations__send_request" } %>
+      <%= f.govuk_submit "Send request", data: { qa: "allocations__send_request" } %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/edit_initial_allocations/do_you_want.html.erb
+++ b/app/views/providers/edit_initial_allocations/do_you_want.html.erb
@@ -7,27 +7,31 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: form_object,
-                  url: post_edit_initial_request_provider_recruitment_cycle_allocation_path(
-                    provider.provider_code,
-                    provider.recruitment_cycle_year,
-                    training_provider.provider_code,
-                  ),
-                  method: :post,
-                  scope: "",
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <%= form.govuk_error_summary %>
-      <%= form.govuk_radio_buttons_fieldset(
-        :request_type,
-        legend: { size: "l", text: page_title, tag: "h1" },
-        caption: { text: "#{training_provider.provider_name} ", size: "l" },
-      ) do %>
-        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::INITIAL, label: { text: "Yes" }, link_errors: true %>
-        <%= form.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
+    <%= form_with(
+      model: form_object,
+      url: post_edit_initial_request_provider_recruitment_cycle_allocation_path(
+        provider.provider_code,
+        provider.recruitment_cycle_year,
+        training_provider.provider_code,
+      ),
+      method: :post,
+      scope: "",
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:request_type,
+        legend: { text: page_title, size: "l", tag: "h1" },
+        caption: { text: "#{training_provider.provider_name} ", size: "l" }) do %>
+        <%= f.govuk_radio_button :request_type, AllocationsView::RequestType::INITIAL, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :request_type, AllocationsView::RequestType::DECLINED, label: { text: "No" } %>
       <% end %>
+
       <%= hidden_field_tag :id, allocation.id %>
       <%= hidden_field_tag "next_step", "number_of_places" %>
-      <%= form.govuk_submit %>
+
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/edit_initial_allocations/number_of_places.html.erb
+++ b/app/views/providers/edit_initial_allocations/number_of_places.html.erb
@@ -14,30 +14,29 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: form_object,
-                  url: post_edit_initial_request_provider_recruitment_cycle_allocation_path(
-                    provider.provider_code,
-                    recruitment_cycle.year,
-                    training_provider.provider_code,
-                    id: allocation.id,
-                  ),
-                  skip_enforcing_utf8: true,
-                  scope: "",
-                  method: :post,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with(
+      model: form_object,
+      url: post_edit_initial_request_provider_recruitment_cycle_allocation_path(
+        provider.provider_code,
+        recruitment_cycle.year,
+        training_provider.provider_code,
+        id: allocation.id,
+      ),
+      skip_enforcing_utf8: true,
+      scope: "",
+      method: :post,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
 
-      <%= form.govuk_error_summary %>
-      <%= form.govuk_text_field :number_of_places,
-                                value: params[:number_of_places] || allocation.number_of_places,
-                                label: {
-                                  text: page_title,
-                                  size: "l",
-                                  tag: "h1",
-                                },
-                                caption: { text: "#{training_provider.provider_name} ", size: "l" },
-                                pattern: "[0-9]*",
-                                inputmode: "numeric",
-                                width: 10 do %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :number_of_places,
+        value: params[:number_of_places] || allocation.number_of_places,
+        label: { text: page_title, size: "l", tag: "h1" },
+        caption: { text: "#{training_provider.provider_name} ", size: "l" },
+        pattern: "[0-9]*",
+        inputmode: "numeric",
+        width: 10 do %>
 
         <p class="govuk-body govuk-!-margin-bottom-4">
           Tell us how many places the organisation would like to offer for this
@@ -49,7 +48,7 @@
       <%= hidden_field_tag "next_step", "check_answers" %>
       <%= hidden_field_tag "request_type", params[:request_type] %>
 
-      <%= form.govuk_submit %>
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/visas/edit.html.erb
+++ b/app/views/providers/visas/edit.html.erb
@@ -22,20 +22,16 @@
         <%= page_title %>
       </h1>
 
-      <%= f.govuk_radio_buttons_fieldset(
-        :can_sponsor_student_visa,
+      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa,
         legend: { text: "Can you sponsor Student visas?" },
-        hint: { text: "Applies to fee-paying courses" },
-      ) do %>
+        hint: { text: "Applies to fee-paying courses" }) do %>
         <%= f.govuk_radio_button :can_sponsor_student_visa, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :can_sponsor_student_visa, false, label: { text: "No" } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(
-        :can_sponsor_skilled_worker_visa,
+      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_skilled_worker_visa,
         legend: { text: "Can you sponsor Skilled Worker visas?" },
-        hint: { text: "Applies to salaried courses" },
-      ) do %>
+        hint: { text: "Applies to salaried courses" }) do %>
         <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: "No, or not applicable" } %>
       <% end %>

--- a/app/views/sign_in/dfe_sign_in_is_down.html.erb
+++ b/app/views/sign_in/dfe_sign_in_is_down.html.erb
@@ -1,4 +1,5 @@
-<%= content_for :page_title, "Sign in" %>
+<% page_title = "Sign in" %>
+<%= content_for :page_title, page_title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -7,13 +8,17 @@
       <p class="govuk-body">DfE Sign-in is experiencing problems. You need to sign in using your email address.</p>
     <% end %>
 
-    <h1 class="govuk-heading-l">Sign in</h1>
+    <h1 class="govuk-heading-l">
+      <%= page_title %>
+    </h1>
 
     <p class="govuk-body-l">You must sign in to your account to publish teacher training courses.</p>
 
-    <%= form_with model: User.new,
-                  url: send_magic_link_path,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with(
+      model: User.new,
+      url: send_magic_link_path,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
       <%= f.govuk_text_field :email, label: { text: "Email address", size: "m" } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/config/locales/helpers.yml
+++ b/config/locales/helpers.yml
@@ -8,6 +8,21 @@ en:
         email_address: Email that should have these permissions
         organisation: Their organisation
         reason: Reason they need access
+      course:
+        about_course: About this course
+        course_length_options:
+          OneYear: 1 year
+          TwoYears: Up to 2 years
+          Other: Other
+        course_length_other_length: Course length
+        fee_details: Fee details (optional)
+        fee_international: Fee for international students (optional)
+        fee_uk_eu: Fee for UK students
+        financial_support: Financial support you offer (optional)
+        interview_process: Interview process (optional)
+        other_requirements: Other requirements (optional)
+        personal_qualities: Personal qualities (optional)
+        required_qualifications: Qualifications needed
       provider:
         provider_name: Provider name
         email: Email address
@@ -30,8 +45,15 @@ en:
         address3: Town or city
         address4: County
         postcode: Postcode
+    legend:
+      course:
+        course_length: Course length
     hint:
-      provider:
+      course:
+        required_qualifications: State the minimum academic qualifications needed for this course. You could also say what happens if these requirements aren’t met.
+        personal_qualities: Tell applicants about the skills, motivation and experience you’re looking for (eg experience with children, a genuine passion for the subject, or a talent for public speaking).
+        other_requirements: If applicants need any non-academic qualifications or documents, list them here (eg criminal record checks, or relevant work experience).
+        provider:
         provider_name: The marketing name of the provider.
         email: Give an email address that applicants can use to contact you.
         telephone: Give a telephone number that applicants can use to call you.


### PR DESCRIPTION
### Context

Where we’re using the GOV.UK Form Builder, let’s use it consistently.

### Changes proposed in this pull request

* Set `page_title` variable where this is needed twice
* Use `f` for forms that use the GOV.UK Form Builder, `form` for those that don’t, so that it’s clear which parts of the code base are using the older methods.
* Consistent code style, especially for `form_with`
* Consistent layout, with error summary always above the page heading
* Use localisation strings where possible

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
