### PR TITLE
[2064] Hide next cycle link for non rolled over providers

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -40,7 +40,11 @@ class Provider < Base
   end
 
   def from_next_recruitment_cycle
-    Provider.where(recruitment_cycle_year: recruitment_cycle_year.to_i.succ).any? { |provider| provider.provider_code == provider_code }
+    Provider.where(recruitment_cycle_year: recruitment_cycle_year.to_i.succ)
+      .find(provider_code)
+      .first
+  rescue JsonApiClient::Errors::NotFound
+    nil
   end
 
   def declared_visa_sponsorship?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -39,6 +39,10 @@ class Provider < Base
       .first
   end
 
+  def from_next_recruitment_cycle
+    Provider.where(recruitment_cycle_year: recruitment_cycle_year.to_i.succ).any? { |provider| provider.provider_code == provider_code }
+  end
+
   def declared_visa_sponsorship?
     !can_sponsor_student_visa.nil? && !can_sponsor_skilled_worker_visa.nil?
   end

--- a/app/views/providers/_show_during_rollover.html.erb
+++ b/app/views/providers/_show_during_rollover.html.erb
@@ -17,20 +17,36 @@
   <% end %>
 </ul>
 
-<h2 class="govuk-heading-m">
-  <%= govuk_link_to(
-    "Next cycle (#{next_recruitment_cycle_period_text})",
-    provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle + 1),
-    data: {
-      qa: "provider__courses__next_cycle",
-    },
-  ) %>
-</h2>
-<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
-  <li>prepare your courses for the next cycle</li>
-  <li>manage locations for the next cycle</li>
-  <% if @provider.accredited_body? %>
-    <li>see which courses in the next cycle you’re the accredited body for</li>
-    <li>view requests you’ve already made to recruit for fee-funded PE in the next cycle</li>
-  <% end %>
-</ul>
+<% if @provider.from_next_recruitment_cycle %>
+  <h2 class="govuk-heading-m">
+    <%= govuk_link_to(
+      "Next cycle (#{next_recruitment_cycle_period_text})",
+      provider_recruitment_cycle_path(@provider.provider_code, Settings.current_cycle + 1),
+      data: {
+        qa: "provider__courses__next_cycle",
+      },
+    ) %>
+  </h2>
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
+    <li>prepare your courses for the next cycle</li>
+    <li>manage locations for the next cycle</li>
+    <% if @provider.accredited_body? %>
+      <li>see which courses in the next cycle you’re the accredited body for</li>
+      <li>view requests you’ve already made to recruit for fee-funded PE in the next cycle</li>
+    <% end %>
+  </ul>
+<% else %>
+  <h2 class="govuk-heading-m">
+    <%= "Next cycle (#{next_recruitment_cycle_period_text})" %>
+  </h2>
+
+  <p class="govuk-body">
+    You did not publish any courses in the last cycle. Only providers with published
+    or withdrawn courses are rolled over.
+  </p>
+
+  <p class="govuk-body">
+    If you think this is a mistake contact us on <br>
+    <%= bat_contact_mail_to(subject: "Rollover support and guidance") %>
+  </p>
+<% end %>

--- a/spec/features/sites/index_spec.rb
+++ b/spec/features/sites/index_spec.rb
@@ -48,6 +48,8 @@ feature "View locations", type: :feature do
       provider.to_jsonapi(include: :sites),
     )
 
+    stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v2/recruitment_cycles/#{Settings.current_cycle.succ}/providers")
+
     stub_interrupt_acknowledgements
 
     root_page.load

--- a/spec/features/sites/index_spec.rb
+++ b/spec/features/sites/index_spec.rb
@@ -48,7 +48,7 @@ feature "View locations", type: :feature do
       provider.to_jsonapi(include: :sites),
     )
 
-    stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v2/recruitment_cycles/#{Settings.current_cycle.succ}/providers")
+    stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v2/recruitment_cycles/#{Settings.current_cycle.succ}/providers/#{provider_code}")
 
     stub_interrupt_acknowledgements
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -54,45 +54,34 @@ describe Provider do
   end
 
   describe "#from_next_recruitment_cycle" do
-    let(:provider) { build(:provider, provider_code: "007") }
-
     let(:provider_response) { <<~JSON }
         {
-          "data": [
+          "data":[
             {
-              "id": "2",
-              "type": "providers",
-              "attributes": {
-                "provider_code": "007",
-                "provider_name": "#{provider.provider_name}",
-                "recruitment_cycle_year": "#{provider.recruitment_cycle_year}"
-              },
-              "relationships": {
-                "courses": {
-                  "meta": {
-                    "count": 0
-                  }
+                "id":"",
+                "type":"providers",
+                "attributes":{
+                  "provider_code": "#{provider.provider_code}",
+                  "provider_name": "#{provider.provider_name}",
+                  "recruitment_cycle_year": "#{next_cycle}"
                 }
-              }
             }
           ],
-          "meta": {
-            "count": 1
+          "meta":{
+            "count":1
           },
-          "jsonapi": {
-            "version": "1.0"
+          "jsonapi":{
+            "version":"1.0"
           }
       }
     JSON
 
-    let(:cycle) { Settings.current_cycle.succ }
+    let(:next_cycle) { Settings.current_cycle.succ }
 
     let(:stub) do
-      stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v2/recruitment_cycles/#{cycle}/providers")
+      stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v2/recruitment_cycles/#{next_cycle}/providers/#{provider.provider_code}")
       .to_return(
-        status: 200,
-        body: provider_response,
-        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        status_body_headers,
       )
     end
 
@@ -101,17 +90,22 @@ describe Provider do
     end
 
     context "when a provider has been rolled over into the next recruitment cycle" do
+      let(:status_body_headers) { { status: 200, body: provider_response, headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" } } }
+
       it "detects that provider" do
-        expect(provider.from_next_recruitment_cycle).to eql(true)
+        from_next_cycle = provider.from_next_recruitment_cycle
+        expect(from_next_cycle.provider_code).to eql(provider.provider_code)
+        expect(from_next_cycle.recruitment_cycle_year).to eql(next_cycle.to_s)
         expect(stub).to have_been_requested
       end
     end
 
     context "when a provider has not been rolled over into the next recruitment cycle" do
-      let(:provider) { build(:provider, provider_code: "Not 007") }
+      let(:status_body_headers) { { status: 404, body: nil, headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" } } }
 
       it "does not detect that provider" do
-        expect(provider.from_next_recruitment_cycle).to eql(false)
+        from_next_cycle = provider.from_next_recruitment_cycle
+        expect(from_next_cycle).to be_nil
         expect(stub).to have_been_requested
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/EoqAKVNZ/2064-non-rolled-over-providers-get-an-error-when-clicking-into-the-next-cycle

### Changes proposed in this pull request
* Add `from_next_recruitment_cycle` method on provider model that makes an api request to provider show controller endpoint. It detects whether the provider has been rolled over into the next recruitment cycle searching by provider code. If the provider has been rolled over next cycle link will show, otherwise not found error will be rescued returning nil and different text will show. 

* Add placeholder text to notify providers who weren't automatically rolled over that they need to contact support if they would like them/their courses to be

* Model spec to test the `from_next_recruitment_cycle` method
### Guidance to review
Follow instructions on [this pr](https://github.com/DFE-Digital/teacher-training-api/pull/1991) to create new recruitment cycle and rollover a provider/providers

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
