### PR TITLE
Add logic and content to GCSE components for UCL courses

### DIFF
--- a/app/components/gcse_requirements_component.rb
+++ b/app/components/gcse_requirements_component.rb
@@ -8,18 +8,11 @@ class GcseRequirementsComponent < ViewComponent::Base
 private
 
   def required_gcse_content(course)
-    grade_mapping = {
-      5 => "5 (C)",
-      4 => "4 (C)",
-    }
-
-    grade = grade_mapping.fetch(course.gcse_grade_required)
-
     case course.level
     when "primary"
-      "Grade #{grade} or above in English, maths and science, or equivalent qualification"
+      "Grade #{course.gcse_grade_required} (C) or above in English, maths and science, or equivalent qualification"
     when "secondary"
-      "Grade #{grade} or above in English and maths, or equivalent qualification"
+      "Grade #{course.gcse_grade_required} (C) or above in English and maths, or equivalent qualification"
     end
   end
 

--- a/app/components/gcse_requirements_component.rb
+++ b/app/components/gcse_requirements_component.rb
@@ -8,11 +8,18 @@ class GcseRequirementsComponent < ViewComponent::Base
 private
 
   def required_gcse_content(course)
+    grade_mapping = {
+      5 => "5 (C)",
+      4 => "4 (C)",
+    }
+
+    grade = grade_mapping.fetch(course.gcse_grade_required)
+
     case course.level
     when "primary"
-      "Grade 4 (C) or above in English, maths and science, or equivalent qualification"
+      "Grade #{grade} or above in English, maths and science, or equivalent qualification"
     when "secondary"
-      "Grade 4 (C) or above in English and maths, or equivalent qualification"
+      "Grade #{grade} or above in English and maths, or equivalent qualification"
     end
   end
 

--- a/spec/components/gcse_preview_component_spec.rb
+++ b/spec/components/gcse_preview_component_spec.rb
@@ -107,6 +107,23 @@ RSpec.describe GcsePreviewComponent, type: :component do
       end
     end
 
+    context "when course has a grade requirement of 5" do
+      it "renders alternative content" do
+        course = build(
+          :course,
+          provider: provider,
+          gcse_grade_required: 5,
+          accept_pending_gcse: true,
+          accept_gcse_equivalency: true,
+          level: "primary",
+        )
+
+        render_inline(described_class.new(course: course))
+
+        expect(page).to have_content("Grade 5 (C) or above in English, maths and science, or equivalent qualification")
+      end
+    end
+
     context "when no equivalencies are selected" do
       it "renders the correct content" do
         course = build(

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -115,6 +115,7 @@ FactoryBot.define do
     english { "must_have_qualification_at_application_time" }
     science { "not_required" }
     gcse_subjects_required { %w[maths english] }
+    gcse_grade_required { 4 }
     meta { nil }
     age_range_in_years { "11_to_16" }
     program_type { "pg_teaching_apprenticeship" }


### PR DESCRIPTION
### Context
In order to render different reqs for ucl courses I've added a method on
the course model to determine which courses are ucl. Added logic to the
view components to render different reqs in this case.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
