### PR TITLE
[1980] Update the rollover interruption screen content for the next cycle

### DIFF
--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -7,27 +7,40 @@
     </h1>
 
     <p class="govuk-body">
-      Courses for the next cycle (<%= next_recruitment_cycle_period_text %>) will be published on <%= Settings.next_cycle_open_date.to_s(:govuk) %>.
-    </p>
-    <p class="govuk-body">
-      Your courses, locations and organisation details have been copied from the current cycle.
+      Your courses, locations and details have been copied.
     </p>
 
-    <h2 class="govuk-heading-m">What you need to do</h2>
+    <p class="govuk-body">
+      Courses for the next cycle will be published on <%= Settings.next_cycle_open_date.to_s(:govuk) %>.
+    </p>
 
     <p class="govuk-body">
-      Before you can publish courses for the next cycle, you'll need to confirm:
+      Before then, you can:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-4">
+      <li>add new courses</li>
+      <li>delete courses</li>
+      <li>edit the details of your courses</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">New for the <%= next_recruitment_cycle_period_text %> cycle</h2>
+
+    <p class="govuk-body">
+      All applications will be made via Apply for teaching training, not UCAS.
+    </p>
+
+    <p class="govuk-body">
+      You will need to confirm:
     </p>
 
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-4">
       <li>degree requirements</li>
       <li>GCSE requirements</li>
-      <li>if you can sponsor visas</li>
+      <li>whether you can sponsor visas</li>
+      <li>locations of school placements</li>
+      <li>a URN for course locations and a UKPRN for the organisation</li>
     </ul>
-
-    <p class="govuk-body">
-      You can also add, edit or delete courses and locations.
-    </p>
 
     <%= govuk_button_to "Continue", accept_rollover_path, method: :patch %>
   </div>

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -39,7 +39,9 @@
       <li>GCSE requirements</li>
       <li>whether you can sponsor visas</li>
       <li>locations of school placements</li>
-      <li>a URN for course locations and a UKPRN for the organisation</li>
+      <li>the <abbr class="app-!-text-decoration-underline-dotted" title="Unique Reference Number">URN</abbr> for each school course location</li>
+      <li>the <abbr class="app-!-text-decoration-underline-dotted" title="UK Provider Reference Number">UKPRN</abbr> for your organisation</li>
+      <li>the <abbr class="app-!-text-decoration-underline-dotted" title="Unique Reference Number">URN</abbr> if your organisation is a lead school</li>
     </ul>
 
     <%= govuk_button_to "Continue", accept_rollover_path, method: :patch %>


### PR DESCRIPTION
### Context

- https://trello.com/c/l4dxQqCP/1980-add-interruption-screen-for-rollover

### Changes proposed in this pull request

<img width="1136" alt="Screenshot 2021-06-29 at 16 00 02" src="https://user-images.githubusercontent.com/616080/123822229-02787280-d8f4-11eb-9287-c737bd9c27ba.png">

### Guidance to review

- You'll need to follow the rollover steps in both publish and api to enable the next recruitment cycle
- Login as one of the personas
- Assert updated content

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [] Product Review
