### PR TITLE
[2089] Fix delete review app timeout

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -17,7 +17,11 @@ jobs:
          token: ${{ secrets.GITHUB_TOKEN }}
          checkName: ${{ github.event.pull_request.number }} Deployment
          ref: ${{ github.event.pull_request.head.sha }}
-         timeoutSeconds: 120
+         timeoutSeconds: 1800
+
+      - name: Exit whole workflow if wait was not successful
+        if: steps.wait_for_deployment.outputs.conclusion != 'success'
+        run: exit 1
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,7 +50,7 @@ jobs:
           . terraform/workspace_variables/review.sh
           echo "TF_VAR_key_vault_name=$TF_VAR_key_vault_name" >> $GITHUB_ENV
           echo "TF_VAR_key_vault_app_secret_name=$TF_VAR_key_vault_app_secret_name" >> $GITHUB_ENV
-          echo "TF_VAR_key_vault_infra_secret_name=$TF_VAR_key_vault_infra_secret_name" >> $GITHUB_ENV          
+          echo "TF_VAR_key_vault_infra_secret_name=$TF_VAR_key_vault_infra_secret_name" >> $GITHUB_ENV
         env:
           DOCKER_IMAGE: ${{ format('dfedigital/teacher-training-api:paas-{0}', github.sha) }}
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_REVIEW }}


### PR DESCRIPTION
### Context
Delete review app may fail if the concurrent deploy takes too long

### Changes proposed in this pull request
Increase to 30 min and fail the workflow immediately if the timeout is reached

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
