### PR TITLE
[2122] Add URN column to locations table

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -53,6 +53,10 @@ module ViewHelper
           provider_code,
           course.recruitment_cycle_year,
         ),
+        "You must provide a Unique Reference Number (URN) for all course locations" => provider_recruitment_cycle_sites_path(
+          provider_code,
+          course.recruitment_cycle_year,
+        ),
       }[message]
     else
       {

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,7 +3,7 @@ class Site < Base
   belongs_to :provider, param: :provider_code
   has_one :site_status
 
-  properties :code, :location_name, :address1, :address2, :address3
+  properties :code, :location_name, :address1, :address2, :address3, :urn
   properties :address4, :postcode, :latitude, :longitude, :travel_to_work_area, :london_borough
 
   REGIONS = [

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -5,4 +5,7 @@
   <td class="govuk-table__cell">
     <%= site.code %> <%= site.code == "-" ? "(dash)" : "" %>
   </td>
+  <td class="govuk-table__cell">
+    <%= site.urn.presence || "<strong class='govuk-error-message govuk-\!-display-inline'>(Missing)</strong>".html_safe %>
+  </td>
 </tr>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -30,6 +30,7 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Name</th>
           <th class="govuk-table__header" scope="col">UCAS code</th>
+          <th class="govuk-table__header" scope="col">URN</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

- Add a new column to display the URN for the locations table
- Render a `Missing` text if the URN isn't provided
- Link back to this page upon an invalid submission when attempting to publish a course

<img width="943" alt="Screenshot 2021-06-30 at 14 44 10" src="https://user-images.githubusercontent.com/616080/123978961-31f0b300-d9b8-11eb-9692-5cf0346372f6.png">

### Guidance to review

- Needs this branch on API https://github.com/DFE-Digital/teacher-training-api/pull/2016

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
