### PR TITLE
Enable new link styles

### DIFF
--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -6,6 +6,10 @@
   @return url("~assets/images/" + $filename);
 }
 
+// Enable new link styles (currently opt-in).
+// TODO: remove this when this becomes the default.
+$govuk-new-link-styles: true;
+
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 


### PR DESCRIPTION
The [new link styles](https://github.com/alphagov/govuk-frontend/releases/tag/v3.12.0) are currently opt-in. The main differences are:

> Links now have underlines that are consistently thinner and a bit further away from the link text.
>
> Links also have a clearer hover state, where the underline gets thicker to make the link stand out to users.

Version 3.13.0 of govuk-frontend [disables ink skipping of underlines in hover state](https://github.com/alphagov/govuk-frontend/pull/2251) to avoid large gaps appearing in the underline on hover in Safari and Firefox.