### PR TITLE
[2122] Only render the urn column from the 2022 cycle onwards

### DIFF
--- a/app/helpers/site_helper.rb
+++ b/app/helpers/site_helper.rb
@@ -1,0 +1,5 @@
+module SiteHelper
+  def urn_required?(recruitment_cycle_year)
+    recruitment_cycle_year >= Site::URN_2022_REQUIREMENTS_REQUIRED_FROM
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,4 +1,6 @@
 class Site < Base
+  URN_2022_REQUIREMENTS_REQUIRED_FROM = 2022
+
   belongs_to :recruitment_cycle, through: :provider, param: :recruitment_cycle_year
   belongs_to :provider, param: :provider_code
   has_one :site_status

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -5,7 +5,9 @@
   <td class="govuk-table__cell">
     <%= site.code %> <%= site.code == "-" ? "(dash)" : "" %>
   </td>
-  <td class="govuk-table__cell">
-    <%= site.urn.presence || "<strong class='govuk-error-message govuk-\!-display-inline'>(Missing)</strong>".html_safe %>
-  </td>
+  <% if urn_required?(@recruitment_cycle.year.to_i) %>
+    <td class="govuk-table__cell">
+      <%= site.urn.presence || "<strong class='govuk-error-message govuk-\!-display-inline'>(Missing)</strong>".html_safe %>
+    </td>
+  <% end %>
 </tr>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -30,7 +30,9 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Name</th>
           <th class="govuk-table__header" scope="col">UCAS code</th>
-          <th class="govuk-table__header" scope="col">URN</th>
+          <% if urn_required?(@recruitment_cycle.year.to_i) %>
+            <th class="govuk-table__header" scope="col">URN</th> 
+          <% end %>
         </tr>
       </thead>
       <tbody class="govuk-table__body">


### PR DESCRIPTION
### Context

- https://trello.com/c/ivuE1Rxi/2122-s-render-urn-on-publish-locations-table-and-link-back-to-it-from-an-invalid-course-publish-submission-due-to-missing-urn

### Changes proposed in this pull request

Following up on the PR above, this PR only displays the new URN column from the next cycle onwards.

### Guidance to review

<img width="792" alt="Screenshot 2021-07-01 at 12 45 02" src="https://user-images.githubusercontent.com/616080/124121741-2a3f1600-da6d-11eb-95e7-eb2e17e21327.png">

<img width="754" alt="Screenshot 2021-07-01 at 12 45 18" src="https://user-images.githubusercontent.com/616080/124121745-2ca17000-da6d-11eb-8ccd-a4d7284b8a72.png">

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
