### PR TITLE
[2121] Enrich missing UKPRN validation with link to UKPRN form

### DIFF
--- a/app/controllers/providers/references_controller.rb
+++ b/app/controllers/providers/references_controller.rb
@@ -1,0 +1,31 @@
+module Providers
+  class ReferencesController < ApplicationController
+    def edit
+      @form_object = ProviderReferencesForm.new(provider)
+    end
+
+    def update
+      @form_object = ProviderReferencesForm.new(provider, params: provider_params)
+
+      if @form_object.save
+        redirect_to details_provider_recruitment_cycle_path(provider.provider_code, recruitment_cycle.year)
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def provider
+      @provider ||= Provider.where(recruitment_cycle_year: recruitment_cycle.year).find(params[:provider_code]).first
+    end
+
+    def recruitment_cycle
+      @recruitment_cycle ||= RecruitmentCycle.find(params[:recruitment_cycle_year]).first
+    end
+
+    def provider_params
+      params.require(:provider_references_form).permit(*ProviderReferencesForm::FIELDS)
+    end
+  end
+end

--- a/app/form_objects/provider_references_form.rb
+++ b/app/form_objects/provider_references_form.rb
@@ -1,0 +1,24 @@
+class ProviderReferencesForm
+  include ActiveModel::Model
+
+  FIELDS = %w[ukprn urn].freeze
+
+  attr_accessor(*FIELDS)
+  attr_reader :provider
+
+  validates :ukprn, length: { is: 8, message: "UKPRN must be 8 numbers" }
+  validates :urn, length: { minimum: 5, maximum: 6, message: "URN must be 5 or 6 numbers" }, if: :lead_school?
+
+  def initialize(provider, params: {})
+    @provider = provider
+    super(provider.attributes.slice(*FIELDS).merge(params))
+  end
+
+  def save
+    provider.update(instance_values.slice(*FIELDS).compact) if valid?
+  end
+
+  def lead_school?
+    provider&.provider_type == "lead_school"
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -49,14 +49,14 @@ module ViewHelper
 
     if field.to_sym == :base
       {
-        "You must say whether you can sponsor visas" => provider_recruitment_cycle_visas_path(
-          provider_code,
-          course.recruitment_cycle_year,
-        ),
-        "You must provide a Unique Reference Number (URN) for all course locations" => provider_recruitment_cycle_sites_path(
-          provider_code,
-          course.recruitment_cycle_year,
-        ),
+        "You must say whether you can sponsor visas" =>
+          provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
+        "You must provide a Unique Reference Number (URN) for all course locations" =>
+          provider_recruitment_cycle_sites_path(provider_code, course.recruitment_cycle_year),
+        "You must provide a UK provider reference number (UKPRN)" =>
+          provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
+        "You must provide a UK provider reference number (UKPRN) and URN" =>
+          provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
       }[message]
     else
       {

--- a/app/views/providers/references/edit.html.erb
+++ b/app/views/providers/references/edit.html.erb
@@ -1,0 +1,35 @@
+<% page_title = @form_object.lead_school? ? "Organisation reference numbers" : t("helpers.label.provider.ukprn") %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @form_object.errors.present?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @form_object,
+      url: provider_recruitment_cycle_references_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      method: :post,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <% if @form_object.lead_school? %>
+        <h1 class="govuk-heading-l">
+          <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+          <%= page_title %>
+        </h1>
+
+        <%= f.govuk_text_field(:ukprn, label: { text: t("helpers.label.provider.ukprn"), size: "m" }, width: 10, data: { qa: "ukprn" }) %>
+
+        <%= f.govuk_text_field(:urn, label: { text: t("helpers.label.provider.urn"), size: "m" }, width: 10, data: { qa: "urn" }) %>
+      <% else %>
+        <%= f.govuk_text_field(:ukprn, caption: { text: @provider.provider_name, size: "l" }, label: { text: t("helpers.label.provider.ukprn"), size: "l" }, width: 10, data: { qa: "ukprn" }) %>
+      <% end %>
+
+      <%= f.govuk_submit "Save changes" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,8 @@ Rails.application.routes.draw do
       get "/training-providers-courses", on: :member, to: "training_providers_courses#index", as: "download_training_providers_courses"
       get "/visas", to: "providers/visas#edit"
       post "/visas", to: "providers/visas#update"
+      get "/references", to: "providers/references#edit"
+      post "/references", to: "providers/references#update"
 
       resource :training_providers, path: "/training-providers", on: :member, param: :code, only: [], as: "" do
         get "/:training_provider_code/courses", to: "providers#training_provider_courses", as: "training_provider_courses"

--- a/spec/form_objects/provider_references_form_spec.rb
+++ b/spec/form_objects/provider_references_form_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe ProviderReferencesForm do
+  let(:params) { {} }
+  let(:provider) { build(:provider, provider_type: provider_type, urn: nil) }
+  subject { described_class.new(provider, params: params) }
+
+  describe "validations and save()" do
+    before { subject.valid? }
+
+    context "non-lead school" do
+      let(:provider_type) { "scitt" }
+
+      context "UKPRN is less than 8 characters" do
+        let(:params) { { "ukprn" => "1234" } }
+
+        it "raises an error for the ukprn attribute" do
+          expect(subject.errors[:ukprn]).to eq(["UKPRN must be 8 numbers"])
+        end
+      end
+
+      context "valid UKPRN" do
+        let(:params) { { "ukprn" => "12345678" } }
+
+        it "produces no validation error" do
+          expect(subject).to be_valid
+        end
+
+        it "updates the ukprn attributes only" do
+          expect(provider).to receive(:update).with(params)
+          subject.save
+        end
+      end
+    end
+
+    context "lead school" do
+      let(:provider_type) { "lead_school" }
+
+      context "URN is less than 6 characters" do
+        let(:params) { { "ukprn" => "12345678", "urn" => "1234" } }
+
+        it "raises an error for the urn attribute" do
+          expect(subject.errors[:urn]).to eq(["URN must be 5 or 6 numbers"])
+        end
+      end
+
+      context "URN is valid" do
+        let(:params) { { "ukprn" => "12345678", "urn" => "12345" } }
+
+        it "produces no validation error" do
+          expect(subject).to be_valid
+        end
+
+        it "updates the ukprn and urn attributes" do
+          expect(provider).to receive(:update).with(params)
+          subject.save
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/OnSfBQvM/2121-s-display-required-notice-for-ukprn-with-form-to-set-it-on-publish

### Changes proposed in this pull request
- Enrich UKPRN validation error with a link that takes the user to a new form page to capture the UKPRN value

### Guidance to review
- Checkout this [Training API branch](https://github.com/DFE-Digital/teacher-training-api/pull/2022) locally and run it
- Load up the Publish app locally so that it connects to the API mentioned previously
- Find a course from the 2022-2023 recruitment cycle
- Try and publish it
- You should get a validation error about missing UKPRN
- Click on the validation error which should take you to the new form
- Play around with validation to make sure it works, then enter a valid value
- Trying publishing the course again - should not display any validation error relating to UKPRN

### Screenshots
# Validation error
<img width="978" alt="Screenshot 2021-07-01 at 14 14 45" src="https://user-images.githubusercontent.com/28728/124130525-c7eb1300-da76-11eb-9aa1-72c8ae6e894b.png">

# New form to capture UKPRN
<img width="963" alt="Screenshot 2021-07-01 at 14 16 27" src="https://user-images.githubusercontent.com/28728/124130662-eea94980-da76-11eb-897c-95cd23ad2d64.png">


### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
