### PR TITLE
[2091] Remove note about limiting to 37 locations

### DIFF
--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -70,7 +70,7 @@
       <p class="govuk-body">They’ll also be updated in UCAS Apply within two hours.</p>
 
       <h4 class="govuk-heading-s">2.</h4>
-      <p class="govuk-body">To add a new location, click the green ‘Add a location’ button on the Locations page. Note that you can only enter 37 locations in total. </p>
+      <p class="govuk-body">To add a new location, click the green ‘Add a location’ button on the Locations page. </p>
       <p class="govuk-body">Fill in the name and address of the location, including the full postcode. You should also specify a region. A UCAS code will automatically be generated for this location. Click Save.</p>
 
       <h4 class="govuk-heading-s">3.</h4>

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -71,7 +71,7 @@
 
       <h4 class="govuk-heading-s">2.</h4>
       <p class="govuk-body">To add a new location, click the green ‘Add a location’ button on the Locations page. </p>
-      <p class="govuk-body">Fill in the name and address of the location, including the full postcode. You should also specify a region. A UCAS code will automatically be generated for this location. Click Save.</p>
+      <p class="govuk-body">Fill in the name and address of the location, including the full postcode. You should also specify a region. A location code will automatically be generated for this location. Click Save.</p>
 
       <h4 class="govuk-heading-s">3.</h4>
       <p class="govuk-body">Once you’ve added your location, you can assign it to a course. This will allow candidates to select it during the application process.</p>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -19,12 +19,6 @@
 
     <p class="govuk-body">You can assign locations to a course from the ‘Basic details’ tab on the course page.</p>
 
-    <% content_for :warning_text do %>
-      You are limited to 37 locations by UCAS Apply.<br>
-      <span class="govuk-!-font-weight-regular">Each location has a single character code.</span>
-    <% end %>
-    <%= govuk_warning(text: content_for(:warning_text)) %>
-
     <table class="govuk-table app-table--vertical-align-middle">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -23,7 +23,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Name</th>
-          <th class="govuk-table__header" scope="col">UCAS code</th>
+          <th class="govuk-table__header" scope="col">Location code</th>
           <% if urn_required?(@recruitment_cycle.year.to_i) %>
             <th class="govuk-table__header" scope="col">URN</th> 
           <% end %>


### PR DESCRIPTION
### Context
Related to https://github.com/DFE-Digital/teacher-training-api/pull/2025,
Remove note about limiting to 37 locations, as providers will now be allowed more than 37 locations.

### Changes proposed in this pull request
**Locations page Current**
![image](https://user-images.githubusercontent.com/910019/124452500-5a90f800-dd7e-11eb-8abe-e9246ff7fed4.png)


**Locations page Proposed**
![image](https://user-images.githubusercontent.com/910019/124452615-72687c00-dd7e-11eb-903e-5b2523483942.png)



**Guidance page Current**
![image](https://user-images.githubusercontent.com/910019/124452306-2e757700-dd7e-11eb-85b5-9a0aca51063e.png)


**Guidance page Proposed**
![image](https://user-images.githubusercontent.com/910019/124452853-b22f6380-dd7e-11eb-9236-eb49c0ff6dda.png)

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
