### PR TITLE
Wait for review app deployment to finish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,21 @@ jobs:
           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN  }}
           inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "rollover": "true", "sha": "${{ github.sha }}"}'
 
+      - name: Wait for review app deployment
+        id: wait_for_review_app_deployment
+        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
+          checkName: ${{ github.event.pull_request.number }} Deployment
+          timeoutSeconds:  1800
+          intervalSeconds: 10
+
+      - name: Exit if review app deployment failed
+        if: ${{ steps.wait_for_review_app_deployment.outputs.conclusion != '' && steps.wait_for_review_app_deployment.outputs.conclusion != 'success' }}
+        run: exit 1
+
       - name: 'Notify #twd_publish_register_tech on failure'
         if: ${{ failure() && github.ref == 'refs/heads/master' }}
         uses: rtCamp/action-slack-notify@master


### PR DESCRIPTION
### Context

PR check doesn't fail if review app deployment fails.

### Changes proposed in this pull request
Wait for review app deployment in PR build workflow
and fail the PR build check, if the review app deployment fails

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
