### PR TITLE
Fix bug rendering visa sponsorship status

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -13,9 +13,9 @@ module ProviderHelper
     if !provider.declared_visa_sponsorship?
       visa_sponsorship_call_to_action(provider)
     elsif provider.can_sponsor_student_visa || provider.can_sponsor_skilled_worker_visa
-      "can #{visa_sponsorship_short_status(provider)}"
+      "You can #{visa_sponsorship_short_status(provider)}"
     else
-      "cannot sponsor visas"
+      "You cannot sponsor visas"
     end
   end
 

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -56,7 +56,7 @@
         <% summary_list.slot(:row, enrichment_summary(
           :provider,
           "Visa sponsorship",
-          raw("You #{visa_sponsorship_status(@provider)}"),
+          visa_sponsorship_status(@provider),
           %w[can_sponsor_student_visa can_sponsor_skilled_worker_visa],
           truncate_value: false,
           change_link: provider.declared_visa_sponsorship? ? provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year) : nil,

--- a/app/views/providers/visas/edit.html.erb
+++ b/app/views/providers/visas/edit.html.erb
@@ -37,7 +37,7 @@
         hint: { text: "Applies to salaried courses" },
       ) do %>
         <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, true, label: { text: "Yes" }, link_errors: true %>
-        <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: "No" } %>
+        <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: "No, or not applicable" } %>
       <% end %>
 
       <%= f.govuk_submit "Save and publish changes" %>

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -77,7 +77,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: false,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "can sponsor Student visas",
+        "You can sponsor Student visas",
       )
     end
 
@@ -88,7 +88,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: true,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "can sponsor Skilled Worker visas",
+        "You can sponsor Skilled Worker visas",
       )
     end
 
@@ -99,7 +99,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: true,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "can sponsor Student and Skilled Worker visas",
+        "You can sponsor Student and Skilled Worker visas",
       )
     end
 
@@ -110,7 +110,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: false,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "cannot sponsor visas",
+        "You cannot sponsor visas",
       )
     end
   end


### PR DESCRIPTION
### Context

This PR tidies up a couple of cosmetic issues with the recent addition of Provider visa sponsorship declarations.

### Changes proposed in this pull request

1. Remove the 'You' in the copy for the  call to action in the _About your organisation_ summary card:
BEFORE:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/450843/124461638-c7a98b00-dd88-11eb-8cc3-4e9c3da2118a.png">

AFTER:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/450843/124461417-85804980-dd88-11eb-8b05-efb3e746dcbe.png">

2. Update the copy for the negative radio button under the _Can you sponsor Skilled Worker visas?_ question in line with the latest design:
BEFORE:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/450843/124461706-e14ad280-dd88-11eb-9094-c6499b62907a.png">

AFTER:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/450843/124461777-f1fb4880-dd88-11eb-9c0f-84a89e9d6c94.png">

Original card: https://trello.com/c/I2K4fchq/3441-add-visa-flow-to-publish

### Guidance to review
Does this match the design?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
