### PR TITLE
Structured gcse tidy up

### DIFF
--- a/app/components/gcse_preview_component.html.erb
+++ b/app/components/gcse_preview_component.html.erb
@@ -12,9 +12,7 @@
   </p>
 
   <% if course.additional_gcse_equivalencies %>
-    <p class="govuk-body">
-      <%= course.additional_gcse_equivalencies %>
-    </p>
+      <%= simple_format(course.additional_gcse_equivalencies, class: "govuk-body") %>
   <% end %>
 <% else %>
   <%= govuk_inset_text(classes: "app-inset-text app-inset-text--important") do %>

--- a/app/components/gcse_row_content_component.html.erb
+++ b/app/components/gcse_row_content_component.html.erb
@@ -12,9 +12,7 @@
   </p>
 
   <% if course.additional_gcse_equivalencies %>
-    <p class="govuk-body">
-      <%= course.additional_gcse_equivalencies %>
-    </p>
+    <%= simple_format(course.additional_gcse_equivalencies, class: "govuk-body") %>
   <% end %>
 <% else %>
   <%= govuk_inset_text(classes: "app-inset-text app-inset-text--important") do %>

--- a/app/controllers/courses/gcse_requirements_controller.rb
+++ b/app/controllers/courses/gcse_requirements_controller.rb
@@ -48,7 +48,7 @@ module Courses
     end
 
     def additional_gcse_equivalencies_required_params
-      params.dig(:courses_gcse_requirements_form, :additional_gcse_equivalencies)
+      raw(params.dig(:courses_gcse_requirements_form, :additional_gcse_equivalencies))
     end
 
     def translate_params(key)

--- a/app/controllers/courses/gcse_requirements_controller.rb
+++ b/app/controllers/courses/gcse_requirements_controller.rb
@@ -11,7 +11,8 @@ module Courses
       @gcse_requirements_form = GcseRequirementsForm.new(
         accept_pending_gcse: accept_pending_gcse_required_params, accept_gcse_equivalency: accept_gcse_equivalency_required_params,
         accept_english_gcse_equivalency: accept_english_gcse_equivalency_required_params, accept_maths_gcse_equivalency: accept_maths_gcse_equivalency_required_params,
-        accept_science_gcse_equivalency: accept_science_gcse_equivalency_required_params, additional_gcse_equivalencies: additional_gcse_equivalencies_required_params
+        accept_science_gcse_equivalency: accept_science_gcse_equivalency_required_params, additional_gcse_equivalencies: additional_gcse_equivalencies_required_params,
+        level: @course.level
       )
 
       if @gcse_requirements_form.save(@course)

--- a/app/form_objects/courses/gcse_requirements_form.rb
+++ b/app/form_objects/courses/gcse_requirements_form.rb
@@ -10,6 +10,7 @@ module Courses
     validates :accept_gcse_equivalency, inclusion: { in: [true, false], message: "Select if you consider candidates with pending equivalency tests" }
     validate :primary_or_secondary_equivalency_details_not_given, if: -> { equivalencies_not_selected? }
     validates :additional_gcse_equivalencies, presence: { message: "Enter details about equivalency tests" }, if: -> { equivalencies_not_selected? }
+    validates :additional_gcse_equivalencies, word_count: { maximum: 200 }
 
     def save(course)
       return false unless valid?

--- a/app/form_objects/courses/gcse_requirements_form.rb
+++ b/app/form_objects/courses/gcse_requirements_form.rb
@@ -4,11 +4,12 @@ module Courses
     include ActiveModel::Validations::Callbacks
 
     attr_accessor :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency,
-                  :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies
+                  :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :level
 
     validates :accept_pending_gcse, inclusion: { in: [true, false], message: "Select if you consider candidates with pending GCSEs" }
     validates :accept_gcse_equivalency, inclusion: { in: [true, false], message: "Select if you consider candidates with pending equivalency tests" }
-    validates :additional_gcse_equivalencies, presence: { message: "Enter details about equivalency tests" }, if: -> { equivalency_details_not_given }
+    validate :primary_or_secondary_equivalency_details_not_given, if: -> { equivalencies_not_selected? }
+    validates :additional_gcse_equivalencies, presence: { message: "Enter details about equivalency tests" }, if: -> { equivalencies_not_selected? }
 
     def save(course)
       return false unless valid?
@@ -33,14 +34,22 @@ module Courses
         accept_maths_gcse_equivalency: course.accept_maths_gcse_equivalency,
         accept_science_gcse_equivalency: course.accept_science_gcse_equivalency,
         additional_gcse_equivalencies: course.additional_gcse_equivalencies,
+        level: course.level,
       )
     end
 
   private
 
-    def equivalency_details_not_given
-      accept_gcse_equivalency.present? && accept_english_gcse_equivalency.blank? &&
-        accept_maths_gcse_equivalency.blank? && accept_science_gcse_equivalency.blank?
+    def primary_or_secondary_equivalency_details_not_given
+      if level == "primary"
+        errors.add(:equivalencies, "Select if you accept equivalency tests in English maths or science")
+      else
+        errors.add(:equivalencies, "Select if you accept equivalency tests in English or maths")
+      end
+    end
+
+    def equivalencies_not_selected?
+      accept_gcse_equivalency.present? && accept_english_gcse_equivalency.blank? && accept_maths_gcse_equivalency.blank? && accept_science_gcse_equivalency.blank?
     end
 
     def set_equivalency_values_to_false

--- a/app/form_objects/courses/gcse_requirements_form.rb
+++ b/app/form_objects/courses/gcse_requirements_form.rb
@@ -43,7 +43,7 @@ module Courses
 
     def primary_or_secondary_equivalency_details_not_given
       if level == "primary"
-        errors.add(:equivalencies, "Select if you accept equivalency tests in English maths or science")
+        errors.add(:equivalencies, "Select if you accept equivalency tests in English, maths or science")
       else
         errors.add(:equivalencies, "Select if you accept equivalency tests in English or maths")
       end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -139,7 +139,7 @@ module ViewHelper
 
   alias_method :cns, :classnames
 
-  private
+private
 
   def base_errors_hash(provider_code, course)
     {

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -48,16 +48,7 @@ module ViewHelper
     base = "/organisations/#{provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}"
 
     if field.to_sym == :base
-      {
-        "You must say whether you can sponsor visas" =>
-          provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
-        "You must provide a Unique Reference Number (URN) for all course locations" =>
-          provider_recruitment_cycle_sites_path(provider_code, course.recruitment_cycle_year),
-        "You must provide a UK provider reference number (UKPRN)" =>
-          provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
-        "You must provide a UK provider reference number (UKPRN) and URN" =>
-          provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
-      }[message]
+      base_errors_hash(provider_code, course)[message]
     else
       {
         about_course: base + "/about?display_errors=true#about_course_wrapper",
@@ -147,4 +138,23 @@ module ViewHelper
   end
 
   alias_method :cns, :classnames
+
+  private
+
+  def base_errors_hash(provider_code, course)
+    {
+      "You must say whether you can sponsor visas" =>
+        provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
+      "You must provide a Unique Reference Number (URN) for all course locations" =>
+        provider_recruitment_cycle_sites_path(provider_code, course.recruitment_cycle_year),
+      "You must provide a UK provider reference number (UKPRN)" =>
+        provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
+      "You must provide a UK provider reference number (UKPRN) and URN" =>
+        provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
+      "Enter degree requirements" =>
+        degrees_start_provider_recruitment_cycle_course_path(provider_code, course.recruitment_cycle_year, course.course_code),
+      "Enter GCSE requirements" =>
+        gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(provider_code, course.recruitment_cycle_year, course.course_code),
+    }
+  end
 end

--- a/app/validators/word_count_validator.rb
+++ b/app/validators/word_count_validator.rb
@@ -1,0 +1,11 @@
+class WordCountValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    # This RegExp should match the implementation in govuk-frontend:
+    # https://github.com/alphagov/govuk-frontend/blob/aa30ee76a5f84e230a323bb92d341285a6da3a10/src/govuk/components/character-count/character-count.js#L82
+    if value.scan(/\S+/).size > options[:maximum]
+      record.errors.add(attribute, :too_many_words, count: options[:maximum])
+    end
+  end
+end

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -224,18 +224,21 @@
             ) %>
           <% end %>
         <% end %>
-        <%= summary_list.slot(
-          :row,
-          key: "UCAS Apply: GCSE requirements for applicants",
-          value: content_for(:entry_requirements),
-          action: change_link_to("entry requirements", entry_requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)),
-          html_attributes: {
-            data: {
-              qa: "course__entry_requirements",
+        <% if @provider.recruitment_cycle_year.to_i < Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
+          <%= summary_list.slot(
+            :row,
+            key: "UCAS Apply: GCSE requirements for applicants",
+            value: content_for(:entry_requirements),
+            action: change_link_to("entry requirements", entry_requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)),
+            html_attributes: {
+              data: {
+                qa: "course__entry_requirements",
+              },
             },
-          },
-        ) %>
+          ) %>
+        <% end %>
       <% end %>
+
 
       <% if course.next_cycle? && course.has_fees? %>
         <% content_for :allocations do %>

--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -239,7 +239,6 @@
         <% end %>
       <% end %>
 
-
       <% if course.next_cycle? && course.has_fees? %>
         <% content_for :allocations do %>
           <% if course.has_physical_education_subject? %>

--- a/app/views/courses/gcse_requirements/edit.html.erb
+++ b/app/views/courses/gcse_requirements/edit.html.erb
@@ -37,9 +37,9 @@
             <%= f.govuk_check_box :accept_maths_gcse_equivalency, "Maths", label: { text: "Maths" }, data: { qa: "gcse_requirements__maths_equivalency" } %>
             <% if @course.is_primary? %>
               <%= f.govuk_check_box :accept_science_gcse_equivalency, "Science", label: { text: "Science" }, data: { qa: "gcse_requirements__science_equivalency" } %>
-            <% end %>
-            <%= f.govuk_text_area :additional_gcse_equivalencies, label: { text: "Details about equivalency tests you offer or accept", size: "s" }, hint: { text: "For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay." }, data: { qa: "gcse_requirements__additional_requirements" } %>
+            <% end %><br/>
           <% end %>
+          <%= f.govuk_text_area :additional_gcse_equivalencies, label: { text: "Details about equivalency tests you offer or accept", size: "s" }, hint: { text: "For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay." }, data: { qa: "gcse_requirements__additional_requirements" } %>
         <% end %>
         <%= f.govuk_radio_button :accept_gcse_equivalency, false, label: { text: "No" }, data: { qa: "gcse_requirements__gcse_equivalency_no_radio" } %>
       <% end %>

--- a/app/views/courses/gcse_requirements/edit.html.erb
+++ b/app/views/courses/gcse_requirements/edit.html.erb
@@ -37,7 +37,7 @@
             <%= f.govuk_check_box :accept_maths_gcse_equivalency, "Maths", label: { text: "Maths" }, data: { qa: "gcse_requirements__maths_equivalency" } %>
             <% if @course.is_primary? %>
               <%= f.govuk_check_box :accept_science_gcse_equivalency, "Science", label: { text: "Science" }, data: { qa: "gcse_requirements__science_equivalency" } %>
-            <% end %><br/>
+            <% end %>
           <% end %>
           <%= f.govuk_text_area :additional_gcse_equivalencies, label: { text: "Details about equivalency tests you offer or accept", size: "s" }, hint: { text: "For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay." }, data: { qa: "gcse_requirements__additional_requirements" }, max_words: 200 %>
         <% end %>

--- a/app/views/courses/gcse_requirements/edit.html.erb
+++ b/app/views/courses/gcse_requirements/edit.html.erb
@@ -39,7 +39,7 @@
               <%= f.govuk_check_box :accept_science_gcse_equivalency, "Science", label: { text: "Science" }, data: { qa: "gcse_requirements__science_equivalency" } %>
             <% end %><br/>
           <% end %>
-          <%= f.govuk_text_area :additional_gcse_equivalencies, label: { text: "Details about equivalency tests you offer or accept", size: "s" }, hint: { text: "For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay." }, data: { qa: "gcse_requirements__additional_requirements" } %>
+          <%= f.govuk_text_area :additional_gcse_equivalencies, label: { text: "Details about equivalency tests you offer or accept", size: "s" }, hint: { text: "For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay." }, data: { qa: "gcse_requirements__additional_requirements" }, max_words: 200 %>
         <% end %>
         <%= f.govuk_radio_button :accept_gcse_equivalency, false, label: { text: "No" }, data: { qa: "gcse_requirements__gcse_equivalency_no_radio" } %>
       <% end %>

--- a/app/views/courses/preview/_entry_requirements_qualifications.html.erb
+++ b/app/views/courses/preview/_entry_requirements_qualifications.html.erb
@@ -1,18 +1,18 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-entry">Entry Requirements</h2>
   <h3 class="govuk-heading-m">Qualifications needed</h3>
-  <% if course.required_qualifications.present? %>
-    <% if course.provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
-      <%= render DegreePreviewComponent.new(course: course) %>
-      <%= render GcsePreviewComponent.new(course: course) %>
-    <% else %>
+  <% if course.provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
+    <%= render DegreePreviewComponent.new(course: course) %>
+    <%= render GcsePreviewComponent.new(course: course) %>
+  <% else %>
+    <% if course.required_qualifications.present? %>
       <div data-qa="course__required_qualifications">
         <%= markdown(course.required_qualifications) %>
       </div>
-    <% end %>
-  <% else %>
-    <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
-      <p class="govuk-body">Please add details for this section.</p>
+    <% else %>
+      <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+        <p class="govuk-body">Please add details for this section.</p>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -25,17 +25,6 @@
   </div>
 <% end %>
 
-<% if course.age_range_in_years.nil? && !course.is_further_education? %>
-  <%= govuk_notification_banner(title: t("notification_banner.info")) do |notification_banner| %>
-    <%= notification_banner.add_heading(text: "You need to provide some information before publishing this course") %>
-    <%= govuk_link_to(
-      "Specify an age range",
-      age_range_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      class: "govuk-notification-banner__link",
-    ) %>
-  <% end %>
-<% end %>
-
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l"><%= course.description %></span>
   <%= course.name_and_code %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,3 +157,11 @@ en:
     finance:
       heading: Finance contact
       purpose: This person will receive invoices from UCAS for payment of fees.
+  activemodel:
+    errors:
+      models:
+        courses/gcse_requirements_form:
+          too_many_words: Details about equivalency tests you offer or accept must be %{count} words or fewer
+  errors:
+    messages:
+      too_many_words: Must be %{count} words or fewer

--- a/spec/features/courses/gcse_equivalency_spec.rb
+++ b/spec/features/courses/gcse_equivalency_spec.rb
@@ -55,6 +55,7 @@ feature "GCSE equivalency requirements", type: :feature do
     choose "Yes", name: "courses_gcse_requirements_form[accept_gcse_equivalency]"
     gcse_requirements_page.save.click
     expect(page).to have_content("Enter details about equivalency tests")
+    expect(page).to have_content("Select if you accept equivalency tests in English or maths")
 
     check "English"
     check "Maths"

--- a/spec/form_objects/courses/gcse_requirements_form_spec.rb
+++ b/spec/form_objects/courses/gcse_requirements_form_spec.rb
@@ -12,6 +12,26 @@ RSpec.describe Courses::GcseRequirementsForm do
       expect(form.valid?).to be_falsey
     end
 
+    it "is invalid if accept_gcse_equivalency is true but no value is selected for equivalencies for primary course" do
+      form = described_class.new(
+        accept_gcse_equivalency: true, accept_english_gcse_equivalency: nil,
+        accept_maths_gcse_equivalency: nil, accept_science_gcse_equivalency: nil,
+        additional_gcse_equivalencies: nil, level: "primary"
+      )
+      expect(form.valid?).to be_falsey
+      expect(form.errors[:equivalencies]).to be_present
+    end
+
+    it "is invalid if accept_gcse_equivalency is true but no value is selected for equivalencies for non primary course" do
+      form = described_class.new(
+        accept_gcse_equivalency: true, accept_english_gcse_equivalency: nil,
+        accept_maths_gcse_equivalency: nil, accept_science_gcse_equivalency: nil,
+        additional_gcse_equivalencies: nil, level: "secondary"
+      )
+      expect(form.valid?).to be_falsey
+      expect(form.errors[:equivalencies]).to be_present
+    end
+
     it "is invalid if no value is selected for additional_gcse_equivalencies" do
       form = described_class.new(
         accept_gcse_equivalency: true, accept_english_gcse_equivalency: nil,
@@ -19,6 +39,7 @@ RSpec.describe Courses::GcseRequirementsForm do
         additional_gcse_equivalencies: nil
       )
       expect(form.valid?).to be_falsey
+      expect(form.errors[:additional_gcse_equivalencies]).to be_present
     end
   end
 

--- a/spec/validators/word_count_validator_spec.rb
+++ b/spec/validators/word_count_validator_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe WordCountValidator do
+  maximum = 10
+
+  before do
+    stub_const("Validatable", Class.new).class_eval do
+      include ActiveModel::Validations
+      attr_accessor :some_words
+      validates :some_words, word_count: { maximum: maximum }
+    end
+  end
+
+  let(:model) do
+    Validatable.new.tap { |model| model.some_words = some_words_field }
+  end
+
+  let(:expected_errors) { ["Must be #{maximum} words or fewer"] }
+
+  subject! do
+    model.valid?
+  end
+
+  context "with max valid number of words" do
+    let(:some_words_field) { (%w[word] * maximum).join(" ") }
+
+    it { is_expected.to be true }
+  end
+
+  context "with no words" do
+    let(:some_words_field) { "" }
+
+    it { is_expected.to be true }
+  end
+
+  context "with nil words" do
+    let(:some_words_field) { nil }
+
+    it { is_expected.to be true }
+  end
+
+  context "with invalid number of words" do
+    let(:some_words_field) { "#{(%w[word] * maximum).join(' ')} popped" }
+
+    it { is_expected.to be false }
+
+    it "adds an error" do
+      expect(model.errors[:some_words]).to match_array expected_errors
+    end
+  end
+
+  context "with newlines" do
+    let(:some_words_field) { "#{(%w[word] * maximum).join("\n")} popped" }
+
+    it { is_expected.to be false }
+
+    it "adds an error" do
+      expect(model.errors[:some_words]).to match_array expected_errors
+    end
+  end
+
+  context "with non-words such as markdown" do
+    let(:some_words_field) { "#{(%w[word] * maximum).join(' ')} *" }
+
+    it { is_expected.to be false }
+
+    it "adds an error" do
+      expect(model.errors[:some_words]).to match_array expected_errors
+    end
+  end
+end

--- a/spec/views/courses/_basic_details_tab.html.erb_spec.rb
+++ b/spec/views/courses/_basic_details_tab.html.erb_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "courses/_basic_details_tab.html.erb" do
-  let(:provider) { build(:provider) }
-  let(:course) { build(:course, provider: provider).decorate }
+  let(:recruitment_cycle_year) { "2021" }
+  let(:current_recruitment_cycle) { build :recruitment_cycle, year: recruitment_cycle_year }
+  let(:provider) { build(:provider, recruitment_cycle: current_recruitment_cycle) }
+  let(:course) { build(:course, provider: provider, recruitment_cycle: current_recruitment_cycle).decorate }
   let(:details_page) { PageObjects::Page::Organisations::CourseDetails.new }
   let(:page) do
     details_page.load(rendered)
@@ -41,6 +43,27 @@ RSpec.describe "courses/_basic_details_tab.html.erb" do
 
       it "admin only help panel is displayed" do
         expect(page.name.value).to have_content("Only admins can make changes")
+      end
+    end
+
+    context "when course for 2022 cycle" do
+      let(:recruitment_cycle_year) { "2022" }
+      let(:current_user) do
+        { "admin" => true }
+      end
+
+      it "does not render the UCAS Apply: GCSE requirements for applicants row" do
+        expect(page).to_not have_content("UCAS Apply: GCSE requirements for applicants")
+      end
+    end
+
+    context "when course for 2021 cycle" do
+      let(:current_user) do
+        { "admin" => true }
+      end
+
+      it "renders the UCAS Apply: GCSE requirements for applicants row" do
+        expect(page).to have_content("UCAS Apply: GCSE requirements for applicants")
       end
     end
   end


### PR DESCRIPTION
### Context

As part of a review of the structured GCSE feature at Dev Design meeting a number of actions were required:
https://trello.com/c/oLvRx47b/3497-add-the-structured-gcse-requirements-section-to-publish

### Changes proposed in this pull request

This PR adds :

- validations to the check boxes for gcse equivalencies if none are selected. 
- length validation to the `additional_gcse_equivalencies` field along with word count, and saving formatted text.
- Removes the UCAS Apply row fro the basic details tab for next cycle course onwards.
- removes prepare for next cycle banner
- ensures that validations on course form link to correct section.

### Guidance to review

Test in the review App to check that criteria have been covered.

N.B. there is a follow up PR covering the `change` links on the course detail page and the  removal of the qualifications on the requirements page (`3497-change-links-and-requirements-view`).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
