### PR TITLE
Update requirements page and course description page

### DIFF
--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -2,38 +2,38 @@
   <%= govuk_warning(text: "This course has been withdrawn.") %>
 <% end %>
 
-<h3 class="govuk-heading-m">
-  <%= govuk_link_to "About this course", about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
-</h3>
+<h3 class="govuk-heading-m">About this course</h3>
+
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "About this course", course.about_course, %w[about_course])) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Interview process (optional)", course.interview_process, %w[interview_process])) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, course.placements_heading, course.how_school_placements_work, %w[how_school_placements_work])) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, "About this course", course.about_course, %w[about_course], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, "Interview process (optional)", course.interview_process, %w[interview_process], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, course.placements_heading, course.how_school_placements_work, %w[how_school_placements_work], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
 <% end %>
 
 <h3 class="govuk-heading-m">
   <% if course.has_fees? %>
-    <%= govuk_link_to "Course length and fees", fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
+    Course length and fees
   <% else %>
-    <%= govuk_link_to "Course length and salary", salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
+    Course length and salary
   <% end %>
 </h3>
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length])) %>
 
   <% if course.has_fees? %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for UK students", number_to_currency(course.fee_uk_eu), %w[fee_uk_eu])) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for international students (optional)", number_to_currency(course.fee_international), %w[international_fees])) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee details (optional)", course.fee_details, %w[fee_details])) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Financial support you offer (optional)", course.financial_support, %w[financial_support])) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+
+    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for UK students", number_to_currency(course.fee_uk_eu), %w[fee_uk_eu], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for international students (optional)", number_to_currency(course.fee_international), %w[international_fees], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Fee details (optional)", course.fee_details, %w[fee_details], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Financial support you offer (optional)", course.financial_support, %w[financial_support], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
   <% else %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Salary", course.salary_details, %w[salary_details])) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length], change_link: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+
+    <% summary_list.slot(:row, enrichment_summary(:course, "Salary", course.salary_details, %w[salary_details], change_link: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
   <% end %>
 <% end %>
 
-<h3 class="govuk-heading-m">
-  <%= govuk_link_to "Requirements and eligibility", requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) %>
-</h3>
+<h3 class="govuk-heading-m">Requirements and eligibility</h3>
 
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
   <% if @provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
@@ -49,13 +49,13 @@
        :course,
        "GCSEs",
        (render GcseRowContentComponent.new(course: course)),
-       %w[degree_grade degree_subject_requirements],
+       %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
        truncate_value: false,
        change_link: course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
      )) %>
   <% else %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Qualifications needed", course.required_qualifications, %w[required_qualifications])) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Qualifications needed", course.required_qualifications, %w[required_qualifications], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
   <% end %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Personal qualities (optional)", course.personal_qualities, %w[personal_qualities])) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Other requirements (optional)", course.other_requirements, %w[other_requirements])) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, "Personal qualities (optional)", course.personal_qualities, %w[personal_qualities], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, "Other requirements (optional)", course.other_requirements, %w[other_requirements], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
 <% end %>

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -5,9 +5,9 @@
 <h3 class="govuk-heading-m">About this course</h3>
 
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "About this course", course.about_course, %w[about_course], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Interview process (optional)", course.interview_process, %w[interview_process], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, course.placements_heading, course.how_school_placements_work, %w[how_school_placements_work], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, "About this course", course.about_course, %w[about_course], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "about_course")) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, "Interview process (optional)", course.interview_process, %w[interview_process], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "interview_process")) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, course.placements_heading, course.how_school_placements_work, %w[how_school_placements_work], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "how_school_placements_work")) %>
 <% end %>
 
 <h3 class="govuk-heading-m">
@@ -20,16 +20,16 @@
 <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
 
   <% if course.has_fees? %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "course_length")) %>
 
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for UK students", number_to_currency(course.fee_uk_eu), %w[fee_uk_eu], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for international students (optional)", number_to_currency(course.fee_international), %w[international_fees], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee details (optional)", course.fee_details, %w[fee_details], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Financial support you offer (optional)", course.financial_support, %w[financial_support], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for UK students", number_to_currency(course.fee_uk_eu), %w[fee_uk_eu], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "fee_uk_eu")) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for international students (optional)", number_to_currency(course.fee_international), %w[international_fees], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "international_fees")) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Fee details (optional)", course.fee_details, %w[fee_details], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "fee_details")) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Financial support you offer (optional)", course.financial_support, %w[financial_support], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "financial_support")) %>
   <% else %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length], change_link: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length], change_link: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "course_length")) %>
 
-    <% summary_list.slot(:row, enrichment_summary(:course, "Salary", course.salary_details, %w[salary_details], change_link: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Salary", course.salary_details, %w[salary_details], change_link: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "salary_details")) %>
   <% end %>
 <% end %>
 
@@ -44,6 +44,7 @@
        %w[degree_grade degree_subject_requirements],
        truncate_value: false,
        change_link: course.degree_section_complete? ? degrees_start_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+       change_link_visually_hidden: "degree",
      )) %>
      <% summary_list.slot(:row, enrichment_summary(
        :course,
@@ -52,10 +53,11 @@
        %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
        truncate_value: false,
        change_link: course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+       change_link_visually_hidden: "GCSEs",
      )) %>
   <% else %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Qualifications needed", course.required_qualifications, %w[required_qualifications], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+    <% summary_list.slot(:row, enrichment_summary(:course, "Qualifications needed", course.required_qualifications, %w[required_qualifications], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "required_qualifications")) %>
   <% end %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Personal qualities (optional)", course.personal_qualities, %w[personal_qualities], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Other requirements (optional)", course.other_requirements, %w[other_requirements], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code))) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, "Personal qualities (optional)", course.personal_qualities, %w[personal_qualities], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "personal_qualities")) %>
+  <% summary_list.slot(:row, enrichment_summary(:course, "Other requirements (optional)", course.other_requirements, %w[other_requirements], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "other_requirements")) %>
 <% end %>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -1,4 +1,8 @@
-<%= content_for :page_title, title_with_error_prefix("Requirements and eligibility – #{course.name_and_code}", course.errors.any?) %>
+<% if @provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
+  <%= content_for :page_title, title_with_error_prefix("Personal qualities and other requirements – #{course.name_and_code}", course.errors.any?) %>
+<% else %>
+  <%= content_for :page_title, title_with_error_prefix("Requirements and eligibility – #{course.name_and_code}", course.errors.any?) %>
+<% end %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -8,33 +12,34 @@
   <%= render partial: "courses/copy_content_warning", locals: { copied_fields: @copied_fields } %>
 <% end %>
 
-<%= form_with model: course,
-              url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-  <%= f.govuk_error_summary %>
-<% end %>
-
-<h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= course.name_and_code %></span>
-  Requirements and eligibility
-</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course,
                   url: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                   data: { qa: "enrichment-form", module: "form-check-leave" },
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= course.name_and_code %></span>
+        <% if @provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
+          Personal qualities and other requirements
+        <% else %>
+          Requirements and eligibility
+        <% end %>
+      </h1>
 
       <%= f.hidden_field :page, value: :requirements %>
 
-      <%= f.govuk_text_area :required_qualifications,
-        label: { text: "Qualifications needed", size: "m" },
-        hint: { text: "State the minimum academic qualifications needed for this course. You could also say what happens if these requirements aren’t met." },
-        max_words: 100,
-        rows: 10 %>
+      <% if @provider.recruitment_cycle_year.to_i < Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
+        <%= f.govuk_text_area :required_qualifications,
+          label: { text: "Qualifications needed", size: "m" },
+          hint: { text: "State the minimum academic qualifications needed for this course. You could also say what happens if these requirements aren’t met." },
+          max_words: 100,
+          rows: 10 %>
 
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+      <% end %>
 
       <%= f.govuk_text_area :personal_qualities,
         label: { text: "Personal qualities (optional)", size: "m" },

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -49,7 +49,9 @@ feature "About course", type: :feature do
       stub_api_v2_resource(course, method: :patch)
 
       visit provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
-      click_on "About this course"
+      within "[data-qa='enrichment__about_course']" do
+        click_on "Change"
+      end
 
       expect(current_path).to eq about_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
 
@@ -118,7 +120,9 @@ feature "About course", type: :feature do
       stub_api_v2_resource(course, method: :patch)
 
       visit provider_recruitment_cycle_course_path(provider2.provider_code, course2.recruitment_cycle_year, course2.course_code)
-      click_on "About this course"
+      within "[data-qa='enrichment__about_course']" do
+        click_on "Change"
+      end
 
       expect(page).to have_content("Universities can work with over 100 potential placement schools.")
     end

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -24,7 +24,9 @@ feature "Course fees", type: :feature do
   scenario "viewing and updating fees" do
     visit provider_recruitment_cycle_course_path(provider.provider_code, course_1.recruitment_cycle_year, course_1.course_code)
 
-    click_on "Course length and fees"
+    within "[data-qa='enrichment__course_length']" do
+      click_on "Change"
+    end
 
     expect(current_path).to eq fees_provider_recruitment_cycle_course_path("A0", course_1.recruitment_cycle_year, course_1.course_code)
 
@@ -122,7 +124,9 @@ feature "Course fees", type: :feature do
     scenario "passes the value into course_length" do
       visit provider_recruitment_cycle_course_path(provider.provider_code, course_1.recruitment_cycle_year, course_1.course_code)
 
-      click_on "Course length and fees"
+      within "[data-qa='enrichment__course_length']" do
+        click_on "Change"
+      end
 
       expect(current_path).to eq fees_provider_recruitment_cycle_course_path("A0", course_1.recruitment_cycle_year, course_1.course_code)
 

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -37,7 +37,9 @@ feature "Course salary", type: :feature do
     )
     visit provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
 
-    click_on "Course length and salary"
+    within "[data-qa='enrichment__salary_details']" do
+      click_on "Change"
+    end
 
     expect(current_path).to eq salary_provider_recruitment_cycle_course_path("A0", course.recruitment_cycle_year, course.course_code)
 

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -126,18 +126,24 @@ feature "Course show", type: :feature do
       )
       expect(course_page).to_not have_preview_link
 
-      expect(course_page).to have_link(
-        "About this course",
-        href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/about",
-      )
-      expect(course_page).to have_link(
-        "Course length and fees",
-        href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/fees",
-      )
-      expect(course_page).to have_link(
-        "Requirements and eligibility",
-        href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/requirements",
-      )
+      within "[data-qa='enrichment__about_course']" do
+        expect(course_page).to have_link(
+          "Change",
+          href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/about",
+        )
+      end
+      within "[data-qa='enrichment__course_length']" do
+        expect(course_page).to have_link(
+          "Change",
+          href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/fees",
+        )
+      end
+      within "[data-qa='enrichment__required_qualifications']" do
+        expect(course_page).to have_link(
+          "Change",
+          href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/requirements",
+        )
+      end
     end
   end
 


### PR DESCRIPTION
### Context

follow on from  #1788

https://trello.com/c/oLvRx47b/3497-add-the-structured-gcse-requirements-section-to-publish

### Changes proposed in this pull request

Remove qualifications form requirments page for new cucle courses in order to prevent providers from updating value
for next cycle courses. New design of course page uses change links instead of linked headers.

### Guidance to review

Check in review app, ~~TTAPI fix pending for validations~~ Merged.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
