### PR TITLE
Capitalise reference number abbreviations

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -53,9 +53,9 @@ module ViewHelper
           provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
         "You must provide a Unique Reference Number (URN) for all course locations" =>
           provider_recruitment_cycle_sites_path(provider_code, course.recruitment_cycle_year),
-        "You must provide a UK provider reference number (UKPRN)" =>
+        "You must provide a UK Provider Reference Number (UKPRN)" =>
           provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
-        "You must provide a UK provider reference number (UKPRN) and URN" =>
+        "You must provide a UK Provider Reference Number (UKPRN) and URN" =>
           provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
       }[message]
     else

--- a/config/locales/helpers.yml
+++ b/config/locales/helpers.yml
@@ -13,8 +13,8 @@ en:
         email: Email address
         telephone: Telephone number
         website: Website
-        ukprn: UK provider reference number (UKPRN)
-        urn: Unique reference number (URN)
+        ukprn: UK Provider Reference Number (UKPRN)
+        urn: Unique Reference Number (URN)
         address1: Building and street
         address2: Building and street line 2 of 2
         address3: Town or city
@@ -24,7 +24,7 @@ en:
         train_with_disability: Training with disabilities and other needs
       site:
         location_name: Name
-        urn: Unique reference number (URN)
+        urn: Unique Reference Number (URN)
         address1: Building and street
         address2: Building and street line 2 of 2
         address3: Town or city


### PR DESCRIPTION
We should consistently capitalise the following:

* UK Provider Reference Number
* Unique Reference Number