### PR TITLE
[xxx] Enable editing of next cycle courses

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -89,7 +89,7 @@ features:
     # state: confirmed # final allocation places are displayed to users in a readonly state
   rollover:
     # During rollover providers should be able to edit current & next recruitment cycle courses
-    can_edit_current_and_next_cycles: false
+    can_edit_current_and_next_cycles: true
     # Normally a short period of time between rollover and the next cycle
     # actually starting when it would be set to false
     has_current_cycle_started?: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -12,3 +12,6 @@ environment:
   selector_name: "qa"
 authentication:
   mode: persona   # none critical systems, ie localhost
+features:
+  rollover:
+    can_edit_current_and_next_cycles: false

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -15,3 +15,6 @@ environment:
   selector_name: "sandbox"
 authentication:
   mode: dfe_signin
+features:
+  rollover:
+    can_edit_current_and_next_cycles: false


### PR DESCRIPTION
### Context

Rollover has rolled over.

### Changes proposed in this pull request

Enable next cycle in staging, production and review.

Left disabled in QA and sandbox as those environments aren't rolled over.

We can enable QA tomorrow and 'have a think ™️' about rolling over sandbox.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
