### PR TITLE
Remove UCAS Apply GCSE requirements from next cycle

### DIFF
--- a/app/services/course_creation_step_service.rb
+++ b/app/services/course_creation_step_service.rb
@@ -19,6 +19,26 @@ class CourseCreationStepService
   end
 
   def get_workflow_steps(course)
+    if course.provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE
+      workflows_for_2022_cycle_onwards(course)
+    else
+      workflows_for_current_cycle(course)
+    end
+  end
+
+private
+
+  def workflows_for_2022_cycle_onwards(course)
+    if course.is_further_education?
+      new_further_education_workflow_steps
+    elsif course.is_uni_or_scitt?
+      new_uni_or_scitt_workflow_steps
+    elsif course.is_school_direct?
+      new_school_direct_workflow_steps
+    end
+  end
+
+  def workflows_for_current_cycle(course)
     if course.is_further_education?
       further_education_workflow_steps
     elsif course.is_uni_or_scitt?
@@ -76,5 +96,44 @@ class CourseCreationStepService
       start_date
       confirmation
     ]
+  end
+
+  def new_school_direct_workflow_steps
+    %i[
+      courses_list
+      level
+      subjects
+      modern_languages
+      age_range
+      outcome
+      fee_or_salary
+      full_or_part_time
+      location
+      accredited_body
+      applications_open
+      start_date
+      confirmation
+    ]
+  end
+
+  def new_uni_or_scitt_workflow_steps
+    %i[
+      courses_list
+      level
+      subjects
+      modern_languages
+      age_range
+      outcome
+      apprenticeship
+      full_or_part_time
+      location
+      applications_open
+      start_date
+      confirmation
+    ]
+  end
+
+  def new_further_education_workflow_steps
+    further_education_workflow_steps
   end
 end

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -221,7 +221,7 @@
           },
         ) %>
 
-        <% if course.gcse_subjects_required.any? %>
+        <% if course.gcse_subjects_required.any? && @provider.recruitment_cycle_year.to_i < Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
           <% content_for :entry_requirements do %>
             <% course.gcse_subjects_required.each do |subject| %>
               <%= render(

--- a/spec/services/course_creation_step_service_spec.rb
+++ b/spec/services/course_creation_step_service_spec.rb
@@ -1,6 +1,9 @@
+require "rails_helper"
+
 describe CourseCreationStepService do
   let(:service) { described_class.new }
   let(:course) { build(:course, level: level, provider: provider) }
+  let(:provider) { build(:provider) }
 
   shared_examples "next step" do |current_step, expected_next_step|
     it "Returns the correct next step" do
@@ -271,6 +274,250 @@ describe CourseCreationStepService do
 
       context "Current step: Confirmation" do
         include_examples "previous step", :confirmation, :start_date
+      end
+    end
+  end
+
+  context "creation of course for is next cycle" do
+    let(:recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
+    context "next steps" do
+      context "School Direct" do
+        let(:level) { "primary" }
+        let(:sites) { [build(:site), build(:site)] }
+        let(:provider) { build(:provider, accredited_body?: false, sites: sites, recruitment_cycle: recruitment_cycle) }
+
+        context "Current step: Subjects" do
+          include_examples "next step", :subjects, :modern_languages
+        end
+
+        context "Current step: Modern languages" do
+          include_examples "next step", :modern_languages, :age_range
+        end
+
+        context "Current step: Outcome" do
+          include_examples "next step", :outcome, :fee_or_salary
+        end
+
+        context "Current step: Fee or salary" do
+          include_examples "next step", :fee_or_salary, :full_or_part_time
+        end
+
+        context "Current step: Full or part time" do
+          include_examples "next step", :full_or_part_time, :location
+        end
+
+        context "Current step: Location" do
+          include_examples "next step", :location, :accredited_body
+        end
+
+        context "Current step: Accredited body" do
+          include_examples "next step", :accredited_body, :applications_open
+        end
+
+        context "Current step: Applications open" do
+          include_examples "next step", :applications_open, :start_date
+        end
+
+        context "Current step: Start date" do
+          include_examples "next step", :start_date, :confirmation
+        end
+      end
+
+      context "SCITT Provider" do
+        let(:level) { "primary" }
+        let(:sites) { [build(:site), build(:site)] }
+        let(:provider) { build(:provider, accredited_body?: true, sites: sites, recruitment_cycle: recruitment_cycle) }
+
+        context "Current step: Subjects" do
+          include_examples "next step", :subjects, :modern_languages
+        end
+
+        context "Current step: Modern languages" do
+          include_examples "next step", :modern_languages, :age_range
+        end
+
+        context "Current step: Level" do
+          include_examples "next step", :level, :subjects
+        end
+
+        context "Current step: Age range" do
+          include_examples "next step", :age_range, :outcome
+        end
+
+        context "Current step: Outcome" do
+          include_examples "next step", :outcome, :apprenticeship
+        end
+
+        context "Current step: Apprenticeship" do
+          include_examples "next step", :apprenticeship, :full_or_part_time
+        end
+
+        context "Current step: Full or part time" do
+          include_examples "next step", :full_or_part_time, :location
+        end
+
+        context "Current step: Locations" do
+          include_examples "next step", :location, :applications_open
+        end
+
+        context "Current step: Applications open" do
+          include_examples "next step", :applications_open, :start_date
+        end
+
+        context "Current step: Start date" do
+          include_examples "next step", :start_date, :confirmation
+        end
+      end
+
+      context "Further education" do
+        let(:sites) { [build(:site), build(:site)] }
+        let(:provider) { build(:provider, sites: sites, recruitment_cycle: recruitment_cycle) }
+        let(:level) { "further_education" }
+
+        context "Current step: Level" do
+          include_examples "next step", :level, :outcome
+        end
+
+        context "Current step: Outcome" do
+          include_examples "next step", :outcome, :full_or_part_time
+        end
+
+        context "Current step: Full or part time" do
+          include_examples "next step", :full_or_part_time, :location
+        end
+
+        context "Current step: Location" do
+          include_examples "next step", :location, :applications_open
+        end
+
+        context "Current step: Applications open" do
+          include_examples "next step", :applications_open, :start_date
+        end
+
+        context "Current step: Start date" do
+          include_examples "next step", :start_date, :confirmation
+        end
+      end
+    end
+
+    context "previous steps" do
+      context "School Direct" do
+        let(:level) { "primary" }
+        let(:provider) { build(:provider, accredited_body?: false, recruitment_cycle: recruitment_cycle) }
+
+        context "Current step: Level" do
+          include_examples "previous step", :level, :courses_list
+        end
+
+        context "Current step: Modern languages" do
+          include_examples "previous step", :modern_languages, :subjects
+        end
+
+        context "Current step: Age range" do
+          include_examples "previous step", :age_range, :modern_languages
+        end
+
+        context "Current step: Fee or salary" do
+          include_examples "previous step", :fee_or_salary, :outcome
+        end
+
+        context "Current step: Full or part time" do
+          include_examples "previous step", :full_or_part_time, :fee_or_salary
+        end
+
+        context "Current step: Accredited body" do
+          include_examples "previous step", :accredited_body, :location
+        end
+
+        context "Current step: Start date" do
+          include_examples "previous step", :start_date, :applications_open
+        end
+
+        context "Current step: Confirmation" do
+          include_examples "previous step", :confirmation, :start_date
+        end
+      end
+
+      context "SCITT Provider" do
+        let(:level) { "primary" }
+        let(:provider) { build(:provider, accredited_body?: true, recruitment_cycle: recruitment_cycle) }
+
+        context "Current step: Level" do
+          include_examples "previous step", :level, :courses_list
+        end
+
+        context "Current step: Subjects" do
+          include_examples "previous step", :subjects, :level
+        end
+
+        context "Current step: Modern languages" do
+          include_examples "previous step", :modern_languages, :subjects
+        end
+
+        context "Current step: Age range" do
+          include_examples "previous step", :age_range, :modern_languages
+        end
+
+        context "Current step: Outcome" do
+          include_examples "previous step", :outcome, :age_range
+        end
+
+        context "Current step: Apprenticeship" do
+          include_examples "previous step", :apprenticeship, :outcome
+        end
+
+        context "Current step: Full or part time" do
+          include_examples "previous step", :full_or_part_time, :apprenticeship
+        end
+
+        context "Current step: Location" do
+          include_examples "previous step", :location, :full_or_part_time
+        end
+
+        context "Current step: Applications open" do
+          include_examples "previous step", :applications_open, :location
+        end
+
+        context "Current step: Start date" do
+          include_examples "previous step", :start_date, :applications_open
+        end
+
+        context "Current step: confirmation" do
+          include_examples "previous step", :confirmation, :start_date
+        end
+      end
+
+      context "Further education" do
+        let(:provider) { build(:provider, recruitment_cycle: recruitment_cycle) }
+        let(:level) { "further_education" }
+
+        context "Current step: Level" do
+          include_examples "previous step", :level, :courses_list
+        end
+
+        context "Current step: Outcome" do
+          include_examples "previous step", :outcome, :level
+        end
+
+        context "Current step: Full or part time" do
+          include_examples "previous step", :full_or_part_time, :outcome
+        end
+
+        context "Current step: Location" do
+          include_examples "previous step", :location, :full_or_part_time
+        end
+
+        context "Current step: Applications open" do
+          include_examples "previous step", :applications_open, :location
+        end
+
+        context "Current step: Start date" do
+          include_examples "previous step", :start_date, :applications_open
+        end
+
+        context "Current step: Confirmation" do
+          include_examples "previous step", :confirmation, :start_date
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Hot fix to prevent this from displaying to providers. Test will follow.
https://trello.com/c/76ayE2pT/3600-%F0%9F%93%90-remove-ucas-gcse-requirements-from-new-course-creation-flow

### Changes proposed in this pull request

Update to `CourseBasicDetailConcern` to skip over step and fix back link. Conditionally render UCAS row on confirmation page.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
