### PR TITLE
[2170] Support both UKPRN validation formats

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -147,9 +147,15 @@ private
         provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
       "You must provide a Unique Reference Number (URN) for all course locations" =>
         provider_recruitment_cycle_sites_path(provider_code, course.recruitment_cycle_year),
+      "Enter a Unique Reference Number (URN) for all course locations" =>
+        provider_recruitment_cycle_sites_path(provider_code, course.recruitment_cycle_year),
       "You must provide a UK provider reference number (UKPRN)" =>
         provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
       "You must provide a UK provider reference number (UKPRN) and URN" =>
+        provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
+      "Enter a UK Provider Reference Number (UKPRN)" =>
+        provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
+      "Enter a UK Provider Reference Number (UKPRN) and URN" =>
         provider_recruitment_cycle_references_path(provider_code, course.recruitment_cycle_year),
       "Enter degree requirements" =>
         degrees_start_provider_recruitment_cycle_course_path(provider_code, course.recruitment_cycle_year, course.course_code),


### PR DESCRIPTION
### Context

We need to change the validation error format which is set in TTAPI.
Unfortunately this is affects the functionality in publish.

Corresponding TTAPI PR -> https://github.com/DFE-Digital/teacher-training-api/pull/2042

### Changes proposed in this pull request

Support both formats for now so as we don't break when the API changes
are made.

I'll take the old format out when the change has been made and deployed on TTAPI.

### Guidance to review

* Run publish against the current TTAPI
* Try to publish a course on a provider without a UKPRN
* Click the error message
* The UKPRN form should open

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
