### PR TITLE
Add/update change links for summary lists on organisation and course description pages

### DIFF
--- a/app/components/degree_preview_component.html.erb
+++ b/app/components/degree_preview_component.html.erb
@@ -9,7 +9,7 @@
     </p>
   <% end %>
 <% else %>
-  <div class="govuk-inset-text app-inset-text app-inset-text--important">
+  <%= govuk_inset_text(classes: "app-inset-text--important") do %>
     <p class="govuk-body">
       Please add details <%= govuk_link_to "about degree requirements",
         degrees_start_provider_recruitment_cycle_course_path(
@@ -18,5 +18,5 @@
           course.course_code,
         ) %>.
     </p>
-  </div>
+  <% end %>
 <% end %>

--- a/app/components/degree_row_content_component.html.erb
+++ b/app/components/degree_row_content_component.html.erb
@@ -9,15 +9,15 @@
     </p>
   <% end %>
 <% else %>
-  <%= govuk_inset_text(classes: %w[app-inset-text app-inset-text--important]) do
-        tag.p("Do you require a minimum degree classification?", class: "govuk-heading-s app-inset-text__title") +
-          govuk_link_to(
-            "Enter degree requirements",
-            degrees_start_provider_recruitment_cycle_course_path(
-              course.provider.provider_code,
-              course.recruitment_cycle_year,
-              course.course_code,
-            ),
-          )
-      end %>
+  <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+    <p class="govuk-heading-s app-inset-text__title">Do you require a minimum degree classification?</p>
+    <p class="govuk-body">
+      <%= govuk_link_to "Enter degree requirements",
+        degrees_start_provider_recruitment_cycle_course_path(
+          course.provider.provider_code,
+          course.recruitment_cycle_year,
+          course.course_code,
+        ) %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/components/gcse_preview_component.html.erb
+++ b/app/components/gcse_preview_component.html.erb
@@ -12,10 +12,10 @@
   </p>
 
   <% if course.additional_gcse_equivalencies %>
-      <%= simple_format(course.additional_gcse_equivalencies, class: "govuk-body") %>
+    <%= simple_format(course.additional_gcse_equivalencies, class: "govuk-body") %>
   <% end %>
 <% else %>
-  <%= govuk_inset_text(classes: "app-inset-text app-inset-text--important") do %>
+  <%= govuk_inset_text(classes: "app-inset-text--important") do %>
     <p class="govuk-body">
       Please add details <%= govuk_link_to "about GCSE requirements",
         gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(

--- a/app/components/gcse_row_content_component.html.erb
+++ b/app/components/gcse_row_content_component.html.erb
@@ -15,7 +15,7 @@
     <%= simple_format(course.additional_gcse_equivalencies, class: "govuk-body") %>
   <% end %>
 <% else %>
-  <%= govuk_inset_text(classes: "app-inset-text app-inset-text--important") do %>
+  <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
     <p class="govuk-heading-s app-inset-text__title">GCSE and equivalency tests</p>
     <p class="govuk-body">
       <%= govuk_link_to "Enter GCSE and equivalency test requirements",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,19 +40,23 @@ module ApplicationHelper
                field: field.to_s,
              )
            end
-    govuk_link_to(error, href, class: "govuk-!-display-block")
+    govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--error") do
+      govuk_link_to(error, href)
+    end
   end
 
   def enrichment_summary(model, key, value, fields, truncate_value: true, change_link: nil, change_link_visually_hidden: nil)
-    classes = truncate_value ? "app-summary-list__row--truncate" : "app-summary-list__row"
+    action = render_change_link(change_link, change_link_visually_hidden)
 
     if fields.select { |field| @errors&.key? field.to_sym }.any?
       errors = fields.map { |field|
         @errors[field.to_sym]&.map { |error| enrichment_error_link(model, field, error) }
       }.flatten
 
-      key = [key, *errors].reduce(:+)
-      classes += " app-summary-list__row--error"
+      value = raw(*errors)
+      action = nil
+    elsif truncate_value
+      classes = "app-summary-list__row--truncate"
     end
 
     if value.blank?
@@ -68,7 +72,7 @@ module ApplicationHelper
           qa: "enrichment__#{fields.first}",
         },
       },
-      action: render_change_link(change_link, change_link_visually_hidden),
+      action: action,
     }
   end
 

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -36,7 +36,7 @@ module ProviderHelper
 private
 
   def visa_sponsorship_call_to_action(provider)
-    govuk_inset_text(classes: %w[app-inset-text app-inset-text--important]) do
+    govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do
       raw("<p class=\"govuk-heading-s app-inset-text__title\">Can you sponsor visas?</p>") +
         govuk_link_to(
           "Select if you can sponsor visas",

--- a/app/views/courses/_course_length.html.erb
+++ b/app/views/courses/_course_length.html.erb
@@ -4,7 +4,7 @@
     size: "m",
   },
   form_group: {
-    id: @errors.key?(:course_length) ? "course_length-error" : "",
+    id: @errors.key?(:course_length) ? "course_length-error" : "course-length",
   }) do %>
     <%= f.govuk_radio_button(:course_length, "OneYear",
       label: { text: "1 year" },

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -4,10 +4,33 @@
 
 <h3 class="govuk-heading-m">About this course</h3>
 
-<%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "About this course", course.about_course, %w[about_course], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "about_course")) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Interview process (optional)", course.interview_process, %w[interview_process], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "interview_process")) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, course.placements_heading, course.how_school_placements_work, %w[how_school_placements_work], change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "how_school_placements_work")) %>
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.slot(:row, enrichment_summary(
+    :course,
+    "About this course",
+    course.about_course,
+    %w[about_course],
+    change_link: about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+    change_link_visually_hidden: "details about this course",
+  )) %>
+
+  <% summary_list.slot(:row, enrichment_summary(
+    :course,
+    "Interview process (optional)",
+    course.interview_process,
+    %w[interview_process],
+    change_link: "#{about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#interview-process",
+    change_link_visually_hidden: "details about the interview process",
+  )) %>
+
+  <% summary_list.slot(:row, enrichment_summary(
+    :course,
+    course.placements_heading,
+    course.how_school_placements_work,
+    %w[how_school_placements_work],
+    change_link: "#{about_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#how-school-placements-work",
+    change_link_visually_hidden: "details about how school placements work",
+  )) %>
 <% end %>
 
 <h3 class="govuk-heading-m">
@@ -17,47 +40,122 @@
     Course length and salary
   <% end %>
 </h3>
-<%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
-
+<%= govuk_summary_list do |summary_list| %>
   <% if course.has_fees? %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "course_length")) %>
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Course length",
+      course.length,
+      %w[course_length],
+      change_link: "#{fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
+      change_link_visually_hidden: "course length",
+    )) %>
 
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for UK students", number_to_currency(course.fee_uk_eu), %w[fee_uk_eu], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "fee_uk_eu")) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee for international students (optional)", number_to_currency(course.fee_international), %w[international_fees], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "international_fees")) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Fee details (optional)", course.fee_details, %w[fee_details], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "fee_details")) %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Financial support you offer (optional)", course.financial_support, %w[financial_support], change_link: fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "financial_support")) %>
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Fee for UK students",
+      number_to_currency(course.fee_uk_eu),
+      %w[fee_uk_eu],
+      change_link: "#{fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-uk",
+      change_link_visually_hidden: "fee for UK students",
+    )) %>
+
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Fee for international students (optional)",
+      number_to_currency(course.fee_international),
+      %w[international_fees],
+      change_link: "#{fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-international",
+      change_link_visually_hidden: "fee for international students",
+    )) %>
+
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Fee details (optional)",
+      course.fee_details,
+      %w[fee_details],
+      change_link: "#{fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-details",
+      change_link_visually_hidden: "fee details",
+    )) %>
+
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Financial support you offer (optional)",
+      course.financial_support,
+      %w[financial_support],
+      change_link: "#{fees_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#financial-support",
+      change_link_visually_hidden: "details of financial support you offer",
+    )) %>
   <% else %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Course length", course.length, %w[course_length], change_link: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "course_length")) %>
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Course length",
+      course.length,
+      %w[course_length],
+      change_link: "#{salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
+      change_link_visually_hidden: "course length",
+    )) %>
 
-    <% summary_list.slot(:row, enrichment_summary(:course, "Salary", course.salary_details, %w[salary_details], change_link: salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "salary_details")) %>
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Salary",
+      course.salary_details,
+      %w[salary_details],
+      change_link: "#{salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#salary",
+      change_link_visually_hidden: "salary",
+    )) %>
   <% end %>
 <% end %>
 
 <h3 class="govuk-heading-m">Requirements and eligibility</h3>
 
-<%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
+<%= govuk_summary_list do |summary_list| %>
   <% if @provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
-     <% summary_list.slot(:row, enrichment_summary(
-       :course,
-       "Degree",
-       (render DegreeRowContentComponent.new(course: course)),
-       %w[degree_grade degree_subject_requirements],
-       truncate_value: false,
-       change_link: course.degree_section_complete? ? degrees_start_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
-       change_link_visually_hidden: "degree",
-     )) %>
-     <% summary_list.slot(:row, enrichment_summary(
-       :course,
-       "GCSEs",
-       (render GcseRowContentComponent.new(course: course)),
-       %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
-       truncate_value: false,
-       change_link: course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
-       change_link_visually_hidden: "GCSEs",
-     )) %>
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Degree",
+      (render DegreeRowContentComponent.new(course: course)),
+      %w[degree_grade degree_subject_requirements],
+      truncate_value: false,
+      change_link: course.degree_section_complete? ? degrees_start_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+      change_link_visually_hidden: "degree",
+    )) %>
+
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "GCSEs",
+      (render GcseRowContentComponent.new(course: course)),
+      %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
+      truncate_value: false,
+      change_link: course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+      change_link_visually_hidden: "GCSEs",
+    )) %>
   <% else %>
-    <% summary_list.slot(:row, enrichment_summary(:course, "Qualifications needed", course.required_qualifications, %w[required_qualifications], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "required_qualifications")) %>
+    <% summary_list.slot(:row, enrichment_summary(
+      :course,
+      "Qualifications needed",
+      course.required_qualifications,
+      %w[required_qualifications],
+      change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+      change_link_visually_hidden: "qualifications needed",
+    )) %>
   <% end %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Personal qualities (optional)", course.personal_qualities, %w[personal_qualities], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "personal_qualities")) %>
-  <% summary_list.slot(:row, enrichment_summary(:course, "Other requirements (optional)", course.other_requirements, %w[other_requirements], change_link: requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), change_link_visually_hidden: "other_requirements")) %>
+
+  <% summary_list.slot(:row, enrichment_summary(
+    :course,
+    "Personal qualities (optional)",
+    course.personal_qualities,
+    %w[personal_qualities],
+    change_link: "#{requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities",
+    change_link_visually_hidden: "personal qualities",
+  )) %>
+
+  <% summary_list.slot(:row, enrichment_summary(
+    :course,
+    "Other requirements (optional)",
+    course.other_requirements,
+    %w[other_requirements],
+    change_link: "#{requirements_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements",
+    change_link_visually_hidden: "other requirements",
+  )) %>
 <% end %>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -61,11 +61,14 @@
           description: "If you offer more than one course in the same subject – eg two Primary courses – it’s important to say how they differ (eg differences in teaching placements or in the focus of the training). Otherwise, applicants may be unable to decide between them.",
         ) %>
 
-        <%= f.govuk_text_area :about_course, label: { text: "About this course", size: "s" }, max_words: 400, rows: 20 %>
+        <%= f.govuk_text_area(:about_course,
+          label: { text: "About this course", size: "s" },
+          max_words: 400,
+          rows: 20) %>
 
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-        <h3 class="govuk-heading-m">Interview process</h3>
+        <h3 class="govuk-heading-m" id="interview-process">Interview process</h3>
 
         <p class="govuk-body">Tell applicants:</p>
         <ul class="govuk-list govuk-list--bullet">
@@ -75,11 +78,14 @@
           <li>whether they’ll have to sit any tests - if so, how can they prepare?</li>
         </ul>
 
-        <%= f.govuk_text_area :interview_process, label: { text: "Interview process (optional)", size: "s" }, max_words: 250, rows: 15 %>
+        <%= f.govuk_text_area(:interview_process,
+          label: { text: "Interview process (optional)", size: "s" },
+          max_words: 250,
+          rows: 15) %>
 
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-        <h3 class="govuk-heading-m"><%= course.placements_heading %></h3>
+        <h3 class="govuk-heading-m" id="how-school-placements-work"><%= course.placements_heading %></h3>
 
         <p class="govuk-body">
           Give applicants more information about the schools they’ll be teaching in. Tell them:
@@ -110,7 +116,10 @@
           <% end %>
         <% end %>
 
-        <%= f.govuk_text_area :how_school_placements_work, label: { text: course.placements_heading, size: "s" }, max_words: 350, rows: 15 %>
+        <%= f.govuk_text_area(:how_school_placements_work,
+          label: { text: course.placements_heading, size: "s" },
+          max_words: 350,
+          rows: 15) %>
 
         <%= f.govuk_submit "Save" %>
 

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -31,23 +31,22 @@
       <h3 class="govuk-heading-m">Course fees</h3>
 
       <%= f.govuk_text_field(:fee_uk_eu,
+        form_group: { id: @errors.key?(:fee_uk_eu) ? "fee_uk_eu-error" : "fee-uk" },
         value: number_with_precision(course.fee_uk_eu, precision: 2, strip_insignificant_zeros: true),
         label: { text: "Fee for UK students", size: "s" },
         prefix_text: "£",
         width: 5,
-        form_group: {
-          id: @errors.key?(:fee_uk_eu) ? "fee_uk_eu-error" : "",
-        },
         data: { qa: "course_fee_uk_eu" }) %>
 
       <%= f.govuk_text_field(:fee_international,
+        form_group: { id: "fee-international" },
         value: number_with_precision(course.fee_international, precision: 2, strip_insignificant_zeros: true),
         label: { text: "Fee for international students (optional)", size: "s" },
         prefix_text: "£",
         width: 5,
         data: { qa: "course_fee_international" }) %>
 
-      <h3 class="govuk-heading-m">Fee details</h3>
+      <h3 class="govuk-heading-m" id="fee-details">Fee details</h3>
       <p class="govuk-body">If applicable, give further details about the fees for this course.</p>
       <p class="govuk-body">This could include:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -63,7 +62,7 @@
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-      <h3 class="govuk-heading-m">Financial support you offer</h3>
+      <h3 class="govuk-heading-m" id="financial-support">Financial support you offer</h3>
       <p class="govuk-body">If applicable, say more about the financial support you offer for this course. For example, any bursaries available.</p>
       <p class="govuk-body">You don’t need to add details of any DfE bursaries and subject scholarships here. These will be published automatically to your course page</p>
 

--- a/app/views/courses/preview/_about_course.html.erb
+++ b/app/views/courses/preview/_about_course.html.erb
@@ -4,7 +4,7 @@
     <% if course.about_course.present? %>
       <%= markdown(course.about_course) %>
     <% else %>
-      <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
         <p class="govuk-body">Please add details for this section.</p>
       <% end %>
     <% end %>

--- a/app/views/courses/preview/_about_schools.html.erb
+++ b/app/views/courses/preview/_about_schools.html.erb
@@ -17,7 +17,7 @@
       </aside>
       <%= markdown(course.how_school_placements_work) %>
     <% else %>
-      <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
         <p class="govuk-body">Please add details for this section.</p>
       <% end %>
     <% end %>

--- a/app/views/courses/preview/_about_the_provider.html.erb
+++ b/app/views/courses/preview/_about_the_provider.html.erb
@@ -4,7 +4,7 @@
     <% if @provider.train_with_us.present? %>
       <%= markdown(@provider.train_with_us) %>
     <% else %>
-      <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
         <p class="govuk-body">Please add details <%= govuk_link_to "about your organisation", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>.</p>
       <% end %>
     <% end %>

--- a/app/views/courses/preview/_entry_requirements_qualifications.html.erb
+++ b/app/views/courses/preview/_entry_requirements_qualifications.html.erb
@@ -10,7 +10,7 @@
         <%= markdown(course.required_qualifications) %>
       </div>
     <% else %>
-      <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
         <p class="govuk-body">Please add details for this section.</p>
       <% end %>
     <% end %>

--- a/app/views/courses/preview/_fees.html.erb
+++ b/app/views/courses/preview/_fees.html.erb
@@ -29,7 +29,7 @@
       </div>
     <% end %>
   <% else %>
-    <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+    <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
       <p class="govuk-body">Please add details for this section.</p>
     <% end %>
   <% end %>

--- a/app/views/courses/preview/_international_students.html.erb
+++ b/app/views/courses/preview/_international_students.html.erb
@@ -10,7 +10,7 @@
       ) %><%= @provider.cannot_sponsor_visas? ? "." : ", but this is not guaranteed." %>
     </p>
   <% else %>
-    <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+    <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
       <p class="govuk-heading-s">
         Please add details
         <%= govuk_link_to(

--- a/app/views/courses/preview/_salary.html.erb
+++ b/app/views/courses/preview/_salary.html.erb
@@ -3,7 +3,7 @@
   <% if course.salary_details.present? %>
     <%= markdown(course.salary_details) %>
   <% else %>
-    <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+    <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
       <p class="govuk-body">Please add details for this section.</p>
     <% end %>
   <% end %>

--- a/app/views/courses/preview/_train_with_disabilities.html.erb
+++ b/app/views/courses/preview/_train_with_disabilities.html.erb
@@ -4,7 +4,7 @@
     <% if @provider.train_with_disability.present? %>
       <%= markdown(@provider.train_with_disability) %>
     <% else %>
-      <%= govuk_inset_text(classes: "app-inset-text app-inset-text--narrow-border app-inset-text--important") do %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
         <p class="govuk-body">Please add details about <%= govuk_link_to "training with disabilities", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>.</p>
       <% end %>
     <% end %>

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -42,6 +42,7 @@
       <% end %>
 
       <%= f.govuk_text_area :personal_qualities,
+        form_group: { id: "personal-qualities" },
         label: { text: "Personal qualities (optional)", size: "m" },
         hint: { text: "Tell applicants about the skills, motivation and experience you’re looking for (eg experience with children, a genuine passion for the subject, or a talent for public speaking)." },
         max_words: 100,
@@ -50,6 +51,7 @@
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
       <%= f.govuk_text_area :other_requirements,
+        form_group: { id: "other-requirements" },
         label: { text: "Other requirements (optional)", size: "m" },
         hint: { text: "If applicants need any non-academic qualifications or documents, list them here (eg criminal record checks, or relevant work experience)." },
         max_words: 100,

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -38,12 +38,10 @@
       </ul>
 
       <%= f.govuk_text_area(:salary_details,
+        form_group: { id: @errors.key?(:salary_details) ? "salary_details-error" : "salary" },
         label: { text: "Salary", size: "s" },
         rows: 15,
         max_words: 250,
-        form_group: {
-          id: @errors.key?(:salary_details) ? "salary_details-error" : "",
-        },
         data: { qa: "course_salary_details" }) %>
 
       <%= f.govuk_submit "Save", data: { qa: "course__save" } %>

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -40,7 +40,11 @@
         <li>do say “the Times Educational Supplement ranked our students as 4th happiest in the country”</li>
       </ul>
 
-      <%= f.govuk_text_area :train_with_us, label: { size: "m" }, max_words: 250, rows: 15 %>
+      <%= f.govuk_text_area(:train_with_us,
+        form_group: { id: "train-with-us" },
+        label: { size: "m" },
+        max_words: 250,
+        rows: 15) %>
 
       <% if provider.accredited_bodies.present? %>
         <% accredited_body = "accredited body".pluralize(provider.accredited_bodies.count) %>
@@ -56,6 +60,7 @@
           <%= abf.hidden_field :provider_name %>
           <%= abf.hidden_field :provider_code %>
           <%= abf.govuk_text_area(:description,
+            form_group: { id: "accrediting-provider-#{abf.object.provider_code}" },
             label: { text: "#{abf.object.provider_name} (optional)", size: "s" },
             max_words: 100,
             rows: 10) %>
@@ -73,7 +78,11 @@
       </ul>
       <p class="govuk-body">If accessibility varies between locations, give details. It’s also useful for applicants to know how you’ve accommodated others with specific access needs in the past.</p>
 
-      <%= f.govuk_text_area :train_with_disability, label: { size: "s" }, max_words: 250, rows: 15 %>
+      <%= f.govuk_text_area(:train_with_disability,
+        form_group: { id: "train-with-disability" },
+        label: { size: "s" },
+        max_words: 250,
+        rows: 15) %>
 
       <%= f.govuk_submit "Save and publish changes" %>
 

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -36,34 +36,39 @@
       <% end %>
 
       <%= f.govuk_text_field(:email,
+        form_group: { id: "email" },
         label: { size: "m" },
         autocomplete: "email",
         spellcheck: false,
         data: { qa: "email" }) %>
 
       <%= f.govuk_text_field(:telephone,
+        form_group: { id: "telephone" },
         label: { size: "m" },
         width: 20,
         autocomplete: "tel",
         data: { qa: "telephone" }) %>
 
       <%= f.govuk_text_field(:website,
+        form_group: { id: "website" },
         label: { size: "m" },
         data: { qa: "website" }) %>
 
       <%= f.govuk_text_field(:ukprn,
+        form_group: { id: "ukprn" },
         label: { size: "m" },
         width: 10,
         data: { qa: "ukprn" }) %>
 
       <% if @provider.provider_type == "lead_school" %>
         <%= f.govuk_text_field(:urn,
+          form_group: { id: "urn" },
           label: { size: "m" },
           width: 10,
           data: { qa: "urn" }) %>
       <% end %>
 
-      <%= f.govuk_fieldset legend: { text: "Contact address", size: "m" } do %>
+      <%= f.govuk_fieldset legend: { text: "Contact address", size: "m" }, id: "address" do %>
         <%= f.govuk_text_field(:address1,
           label: -> { safe_join([t("helpers.label.provider.address1"), " ", tag.span("line 1 of 2", class: "govuk-visually-hidden")]) },
           autocomplete: "address-line1",

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -30,28 +30,38 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">
-      <%= govuk_link_to "Contact details", contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
-    </h2>
-    <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
-      <% summary_list.slot(:row, enrichment_summary(:provider, "Email address", @provider.email, %w[email])) %>
-      <% summary_list.slot(:row, enrichment_summary(:provider, "Telephone number", @provider.telephone, %w[telephone])) %>
-      <% summary_list.slot(:row, enrichment_summary(:provider, "Website", @provider.website, %w[website])) %>
-      <% summary_list.slot(:row, enrichment_summary(:provider, "Contact address", @provider.full_address, %w[address1 address2 address3 address4 postcode])) %>
-      <% summary_list.slot(:row, enrichment_summary(:provider, "UKPRN", @provider.ukprn, %w[ukprn])) %>
-    <% end %>
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.slot(:row, enrichment_summary(
+        :provider,
+        "Training with your organisation",
+        @provider.train_with_us,
+        %w[train_with_us],
+        change_link: "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-us",
+        change_link_visually_hidden: "details about training with your organisation",
+      )) %>
 
-    <h2 class="govuk-heading-m">
-      <%= govuk_link_to "About your organisation", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>
-    </h2>
-    <%= govuk_summary_list(classes: "app-summary-list--short") do |summary_list| %>
-      <% summary_list.slot(:row, enrichment_summary(:provider, "About your organisation", @provider.train_with_us, %w[train_with_us])) %>
       <% if provider.accredited_bodies.present? %>
         <% provider.accredited_bodies.each do |provider| %>
-          <% summary_list.slot(:row, enrichment_summary(:provider, "#{provider['provider_name']} (optional)", provider["description"], ["accrediting_provider_#{provider['provider_code']}"])) %>
+          <% summary_list.slot(:row, enrichment_summary(
+            :provider,
+            "#{provider['provider_name']} (optional)",
+            provider["description"],
+            ["accrediting_provider_#{provider['provider_code']}"],
+            change_link: "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{provider['provider_code']}",
+            change_link_visually_hidden: "details about #{provider['provider_name']}",
+          )) %>
         <% end %>
       <% end %>
-      <% summary_list.slot(:row, enrichment_summary(:provider, "Training with disabilities and other needs", @provider.train_with_disability, %w[train_with_disability])) %>
+
+      <% summary_list.slot(:row, enrichment_summary(
+        :provider,
+        "Training with disabilities and other needs",
+        @provider.train_with_disability,
+        %w[train_with_disability],
+        change_link: "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-disability",
+        change_link_visually_hidden: "details about training with disabilities and other needs",
+      )) %>
+
       <% if Providers::VisaSponsorshipService.new(provider).visa_sponsorship_enabled? %>
         <% summary_list.slot(:row, enrichment_summary(
           :provider,
@@ -60,9 +70,68 @@
           %w[can_sponsor_student_visa can_sponsor_skilled_worker_visa],
           truncate_value: false,
           change_link: provider.declared_visa_sponsorship? ? provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year) : nil,
-          change_link_visually_hidden: " if you can sponsor visas",
+          change_link_visually_hidden: "if you can sponsor visas",
         )) %>
       <% end %>
+    <% end %>
+
+    <h2 class="govuk-heading-m">Contact details</h2>
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.slot(:row, enrichment_summary(
+        :provider,
+        "Email address",
+        @provider.email,
+        %w[email],
+        change_link: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#email",
+        change_link_visually_hidden: "email address",
+      )) %>
+
+      <% summary_list.slot(:row, enrichment_summary(
+        :provider,
+        "Telephone number",
+        @provider.telephone,
+        %w[telephone],
+        change_link: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#telephone",
+        change_link_visually_hidden: "telephone number",
+      )) %>
+
+      <% summary_list.slot(:row, enrichment_summary(
+        :provider,
+        "Website",
+        @provider.website,
+        %w[website],
+        change_link: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#website",
+        change_link_visually_hidden: "website",
+      )) %>
+
+      <% summary_list.slot(:row, enrichment_summary(
+        :provider,
+        "UKPRN",
+        @provider.ukprn,
+        %w[ukprn],
+        change_link: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#ukprn",
+        change_link_visually_hidden: "UKPRN",
+      )) %>
+
+      <% if @provider.provider_type == "lead_school" %>
+        <% summary_list.slot(:row, enrichment_summary(
+          :provider,
+          "URN",
+          @provider.ukprn,
+          %w[urn],
+          change_link: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#urn",
+          change_link_visually_hidden: "URN",
+        )) %>
+      <% end %>
+
+      <% summary_list.slot(:row, enrichment_summary(
+        :provider,
+        "Contact address",
+        @provider.full_address,
+        %w[address1 address2 address3 address4 postcode],
+        change_link: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#address",
+        change_link_visually_hidden: "contact address",
+      )) %>
     <% end %>
   </div>
 

--- a/app/webpacker/stylesheets/_inset-text.scss
+++ b/app/webpacker/stylesheets/_inset-text.scss
@@ -1,6 +1,5 @@
-.app-inset-text {
+.govuk-inset-text {
   .govuk-summary-list__value & {
-    border-left-width: $govuk-border-width-narrow;
     margin-top: 0;
     padding-top: 0;
     padding-bottom: 0;
@@ -10,6 +9,7 @@
 .app-inset-text--narrow-border {
   border-left-width: $govuk-border-width-narrow;
 }
+
 
 .app-inset-text--important {
   border-color: govuk-colour("blue");
@@ -24,6 +24,11 @@
   border-left-width: $govuk-border-width;
 
   .govuk-heading-s {
+    color: $govuk-error-colour;
+  }
+
+  .govuk-link {
+    @include govuk-typography-weight-bold($important: true);
     color: $govuk-error-colour;
   }
 }

--- a/app/webpacker/stylesheets/_summary-list.scss
+++ b/app/webpacker/stylesheets/_summary-list.scss
@@ -6,12 +6,3 @@
     white-space: nowrap;
   }
 }
-
-.app-summary-list__row--error {
-  .govuk-summary-list__key {
-    border-left: govuk-spacing(1) solid $govuk-error-colour;
-    color: $govuk-error-colour;
-    padding-left: govuk-spacing(2);
-    padding-top: govuk-spacing(1);
-  }
-}

--- a/app/webpacker/stylesheets/_summary-list.scss
+++ b/app/webpacker/stylesheets/_summary-list.scss
@@ -1,12 +1,3 @@
-.app-summary-list--short {
-  margin-bottom: govuk-spacing(8);
-
-  .govuk-summary-list__key,
-  .govuk-summary-list__value {
-    width: 50%;
-  }
-}
-
 .app-summary-list__row--truncate {
   .govuk-summary-list__value {
     max-width: 295px;

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -128,19 +128,19 @@ feature "Course show", type: :feature do
 
       within "[data-qa='enrichment__about_course']" do
         expect(course_page).to have_link(
-          "Change",
+          "Change details about this course",
           href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/about",
         )
       end
       within "[data-qa='enrichment__course_length']" do
         expect(course_page).to have_link(
-          "Change",
-          href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/fees",
+          "Change course length",
+          href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/fees#course-length",
         )
       end
       within "[data-qa='enrichment__required_qualifications']" do
         expect(course_page).to have_link(
-          "Change",
+          "Change qualifications needed",
           href: "/organisations/#{provider.provider_code}/#{course.recruitment_cycle_year}/courses/#{course.course_code}/requirements",
         )
       end

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -56,8 +56,8 @@ feature "View provider", type: :feature do
     expect(current_path).to eq details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
 
     expect(org_detail_page).to have_link(
-      "Contact details",
-      href: "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/contact",
+      "Change contact address",
+      href: "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/contact#address",
     )
 
     expect(org_detail_page.email).to have_content(provider.email)
@@ -65,8 +65,8 @@ feature "View provider", type: :feature do
     expect(org_detail_page.telephone).to have_content(provider.telephone)
 
     expect(org_detail_page).to have_link(
-      "About your organisation",
-      href: "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/about",
+      "details about training with your organisation",
+      href: "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/about#train-with-us",
     )
     expect(org_detail_page.train_with_us).to have_content(provider.train_with_us)
     expect(org_detail_page.train_with_disability).to have_content(provider.train_with_disability)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "View helpers", type: :helper do
 
       it "returns correct content" do
         expect(helper.enrichment_error_link(:course, "about_course", "Something about the course"))
-          .to eq("<a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a>")
+          .to eq("<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--error\"><a class=\"govuk-link\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Something about the course</a></div>")
       end
     end
   end
@@ -38,7 +38,8 @@ RSpec.feature "View helpers", type: :helper do
 
       it "returns correct content" do
         output = helper.enrichment_summary(:course, "About course", "", [:about_course])
-        expect(output[:key]).to eq("About course<a class=\"govuk-link govuk-!-display-block\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Enter something about the course</a>")
+        expect(output[:key]).to eq("About course")
+        expect(output[:value]).to eq("<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--error\"><a class=\"govuk-link\" href=\"/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#about_course_wrapper\">Enter something about the course</a></div>")
       end
     end
   end


### PR DESCRIPTION
### Context

As some questions in the organisation and course pages now take you to separate forms, we’ve normalised the summary lists so that each row has a change link.

### Changes proposed in this pull request

* Add change links to all summary rows for on the organisation page
* Add missing value for URN for lead schools in organisation summary list 
* Fix incorrect visually hidden text, and link to page fragments for change links on course description page
* Change how validation errors appear in summary lists (so more consistent with the new messages we’re showing)
* Remove `app-inset-text` class as not needed
* Refactor `app-inset-text` styles

| Before | After |
| - | - |
| ![org-before](https://user-images.githubusercontent.com/813383/124636468-7a104980-de80-11eb-848f-ab38203b18d5.png) | ![org-after](https://user-images.githubusercontent.com/813383/124636462-78df1c80-de80-11eb-81e1-715c4ad7b194.png) |
| ![course-before](https://user-images.githubusercontent.com/813383/124636459-77155900-de80-11eb-94f7-ab1545fc4b1e.png) | ![course-after](https://user-images.githubusercontent.com/813383/124636453-74b2ff00-de80-11eb-9ed8-f0860b4dcfe0.png) |
| <img width="665" alt="summary-error-before" src="https://user-images.githubusercontent.com/813383/124644684-741f6600-de8a-11eb-8f59-bf3ec448478a.png"> | <img width="665" alt="summary-error-after" src="https://user-images.githubusercontent.com/813383/124644680-72ee3900-de8a-11eb-9c49-e81957bb53a0.png"> |

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
