### PR TITLE
[xxx] Switch rollover in QA & Sandbox

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -12,6 +12,3 @@ environment:
   selector_name: "qa"
 authentication:
   mode: persona   # none critical systems, ie localhost
-features:
-  rollover:
-    can_edit_current_and_next_cycles: false

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -15,6 +15,3 @@ environment:
   selector_name: "sandbox"
 authentication:
   mode: dfe_signin
-features:
-  rollover:
-    can_edit_current_and_next_cycles: false


### PR DESCRIPTION
### Context

We've rolled over production and staging but needed to wait until QA synced overnight before enabling the next cycle on that environment. Sandbox has also been done manually since as it doesn't sync.

### Changes proposed in this pull request

Enable the next cycle in QA and sandbox.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
