### PR TITLE
Deploy review app only if labelled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+    types: [opened, reopened, synchronize, labeled]
 
 jobs:
   build:
@@ -51,7 +52,7 @@ jobs:
           COMMIT_SHA=paas-${{ github.sha }}
 
     - name: Trigger Review App Deployment
-      if: ${{ success() && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
       uses: benc-uk/workflow-dispatch@v1
       with:
         workflow: Deploy
@@ -71,7 +72,7 @@ jobs:
         name: Wait for other inprogress deployment runs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
       - name: Ruby Linting
         run:  rubocop app config lib spec --format clang
 
@@ -97,7 +98,7 @@ jobs:
 
       - name: Wait for review app deployment
         id: wait_for_review_app_deployment
-        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
         uses: fountainhead/action-wait-for-check@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: Wait for Deploy App Workflow for review
         id: wait_for_deployment
+        if: contains(github.event.pull_request.labels.*.name, 'deploy')
         uses: fountainhead/action-wait-for-check@v1.0.0
         with:
          token: ${{ secrets.GITHUB_TOKEN }}
@@ -21,7 +22,7 @@ jobs:
          timeoutSeconds: 1800
 
       - name: Exit whole workflow if wait was not successful
-        if: steps.wait_for_deployment.outputs.conclusion != 'success'
+        if: ${{ steps.wait_for_deployment.outputs.conclusion != '' && steps.wait_for_deployment.outputs.conclusion != 'success' }}
         run: exit 1
 
       - name: Checkout


### PR DESCRIPTION
### Context

To avoid unnecessary review app deployments and to keep costs down, it is decided to deploy the review app
on if it is required.

### Changes proposed in this pull request

Review app will be deployed only if the deploy label is added to the PR.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
