### PR TITLE
[2186] Degree grade requirements bug

### DIFF
--- a/app/views/courses/degrees/grade/edit.html.erb
+++ b/app/views/courses/degrees/grade/edit.html.erb
@@ -22,7 +22,7 @@
       <%= f.govuk_radio_buttons_fieldset :grade, caption: { text: course.name_and_code, size: "l" }, legend: { text: page_title, size: "l", tag: "h1" } do %>
         <%= f.govuk_radio_button :grade, "two_one", label: { text: "2:1 or above (or equivalent)" }, data: { qa: "degree_grade__two_one" }, link_errors: true %>
         <%= f.govuk_radio_button :grade, "two_two", label: { text: "2:2 or above (or equivalent)" }, data: { qa: "degree_grade__two_two" } %>
-        <%= f.govuk_radio_button :grade, "third", label: { text: "Third or above (or equivalent)" }, data: { qa: "degree_grade__third_class" } %>
+        <%= f.govuk_radio_button :grade, "third_class", label: { text: "Third or above (or equivalent)" }, data: { qa: "degree_grade__third_class" } %>
       <% end %>
 
       <%= f.govuk_submit "Save", data: { qa: "degree_grade__save" } %>

--- a/spec/features/courses/degree_spec.rb
+++ b/spec/features/courses/degree_spec.rb
@@ -11,6 +11,8 @@ feature "degree requirements", type: :feature do
   let(:course2) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: "not_required") }
   let(:course3) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: "two_one") }
   let(:course4) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, additional_degree_subject_requirements: true, degree_subject_requirements: "Maths A level") }
+  let(:course5) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: "two_two") }
+  let(:course6) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: "third_class") }
   let(:primary_course) { build(:course, provider: provider, recruitment_cycle: recruitment_cycle, degree_grade: nil, level: "primary") }
   let(:recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
 
@@ -27,6 +29,10 @@ feature "degree requirements", type: :feature do
     stub_api_v2_resource(course3, include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_resource(course4, include: "provider")
     stub_api_v2_resource(course4, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course5, include: "provider")
+    stub_api_v2_resource(course5, include: "subjects,sites,provider.sites,accrediting_provider")
+    stub_api_v2_resource(course6, include: "provider")
+    stub_api_v2_resource(course6, include: "subjects,sites,provider.sites,accrediting_provider")
     stub_api_v2_resource(primary_course, include: "provider")
     stub_api_v2_resource(primary_course, include: "provider")
     stub_api_v2_resource(primary_course, include: "subjects,sites,provider.sites,accrediting_provider")
@@ -133,11 +139,25 @@ feature "degree requirements", type: :feature do
     expect(start_page.no_radio).to be_checked
   end
 
-  scenario "a provider has completed the degree section and sees their answer pre-populated on the degree grade page" do
+  scenario "a provider has completed the degree section and sees their two_one answer pre-populated on the degree grade page" do
     course_page.load_with_course(course3)
-    visit_grade_page
+    visit_grade_page(course3)
 
     expect(grade_page.two_one).to be_checked
+  end
+
+  scenario "a provider has completed the degree section and sees their two_two answer pre-populated on the degree grade page" do
+    course_page.load_with_course(course5)
+    visit_grade_page(course5)
+
+    expect(grade_page.two_two).to be_checked
+  end
+
+  scenario "a provider has completed the degree section and sees their third_class answer pre-populated on the degree grade page" do
+    course_page.load_with_course(course6)
+    visit_grade_page(course6)
+
+    expect(grade_page.third_class).to be_checked
   end
 
   scenario "a provider has completed the degree section and sees their answer pre-populated on the degree subject requirements page" do
@@ -164,11 +184,11 @@ feature "degree requirements", type: :feature do
     )
   end
 
-  def visit_grade_page
+  def visit_grade_page(course)
     visit degrees_grade_provider_recruitment_cycle_course_path(
       provider.provider_code,
-      course3.recruitment_cycle.year,
-      course3.course_code,
+      course.recruitment_cycle.year,
+      course.course_code,
     )
   end
 


### PR DESCRIPTION
### Context
https://trello.com/c/0Zv8N4b8/2186-degree-grade-requirement-bug

### Changes proposed in this pull request
* Fixed bug by correcting value on radio button element
* Added more coverage to tests to prevent it happening again

### Guidance to review
Check that you can select the third class degree option on the form
`organisations/#{code}/2022/courses/#{code}/degrees/grade`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
