### PR TITLE
Fix heading bug, ensure ERB variables don’t leak

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -647,7 +647,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.7.4p191
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -647,7 +647,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.4p191
 
 BUNDLED WITH
    2.1.4

--- a/app/views/access_requests/index.html.erb
+++ b/app/views/access_requests/index.html.erb
@@ -1,6 +1,13 @@
+<% page_title = "Access requests" %>
+<% content_for :page_title, page_title %>
+
 <% content_for :heading do %>
   Open access requests (<%= @access_requests.count %>)
 <% end %>
+
+<h1 class="govuk-heading-l">
+  <%= page_title %>
+</h1>
 
 <p class="govuk-body">
   <%= govuk_link_to "Create and approve an access request manually", new_access_request_path, data: { qa: "create-access-request" } %>

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Create access request" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @access_request.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @access_request.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(access_requests_path) %>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = t("ucas_contacts.#{@contact.type}.heading") %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @contact.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @contact.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_ucas_contacts_path(@provider.provider_code)) %>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -1,6 +1,6 @@
 
 <% page_title = "About this course" %>
-<%= content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/accredited_body/edit.html.erb
+++ b/app/views/courses/accredited_body/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Who is the accredited body? – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Who is the accredited body? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/accredited_body/new.html.erb
+++ b/app/views/courses/accredited_body/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Who is the accredited body? – #{course.name_and_code}", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Who is the accredited body? – #{course.name_and_code}", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/accredited_body/search.html.erb
+++ b/app/views/courses/accredited_body/search.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Organisation search", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Organisation search", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/accredited_body/search_new.html.erb
+++ b/app/views/courses/accredited_body/search_new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Organisation search", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Organisation search", course.errors.any?) %>
 
 <%= render "shared/errors" %>
 

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Specify an age range" %>
-<%= content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", form_object.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/age_range/new.html.erb
+++ b/app/views/courses/age_range/new.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Specify an age range" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/applications_open/edit.html.erb
+++ b/app/views/courses/applications_open/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("When will applications open? – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("When will applications open? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/applications_open/new.html.erb
+++ b/app/views/courses/applications_open/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("When will applications open?", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("When will applications open?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/apprenticeship/edit.html.erb
+++ b/app/views/courses/apprenticeship/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Edit Apprenticeship – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Edit Apprenticeship – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/apprenticeship/new.html.erb
+++ b/app/views/courses/apprenticeship/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Is this a teaching apprenticeship?", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Is this a teaching apprenticeship?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/confirmation.html.erb
+++ b/app/views/courses/confirmation.html.erb
@@ -1,5 +1,5 @@
-<%= page_title = "Check your answers before confirming" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, course.errors.any?) %>
+<% page_title = "Check your answers before confirming" %>
+<% content_for :page_title, title_with_error_prefix(page_title, course.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/courses/degrees/grade/edit.html.erb
+++ b/app/views/courses/degrees/grade/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "What is the minimum degree classification you require?" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @grade_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @grade_form.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to degrees_start_provider_recruitment_cycle_course_path %>

--- a/app/views/courses/degrees/start/edit.html.erb
+++ b/app/views/courses/degrees/start/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Do you require a minimum degree classification?" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @start_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @start_form.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to provider_recruitment_cycle_course_path %>

--- a/app/views/courses/degrees/subject_requirements/edit.html.erb
+++ b/app/views/courses/degrees/subject_requirements/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Degree subject" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @subject_requirements_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @subject_requirements_form.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to @backlink %>

--- a/app/views/courses/delete.html.erb
+++ b/app/views/courses/delete.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Are you sure you want to delete #{course.name_and_code})?", flash[:error] && flash[:error]["id"] == "delete-error") %>
+<% content_for :page_title, title_with_error_prefix("Are you sure you want to delete #{course.name_and_code})?", flash[:error] && flash[:error]["id"] == "delete-error") %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/details.html.erb
+++ b/app/views/courses/details.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{course.name_and_code} - Courses" %>
+<% content_for :page_title, "#{course.name_and_code} - Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:course) %>
 
 <h1 class="govuk-heading-l">

--- a/app/views/courses/entry_requirements/edit.html.erb
+++ b/app/views/courses/entry_requirements/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("GCSE requirements for applicants – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("GCSE requirements for applicants – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/entry_requirements/new.html.erb
+++ b/app/views/courses/entry_requirements/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("GCSE requirements for applicants", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("GCSE requirements for applicants", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/fee_or_salary/edit.html.erb
+++ b/app/views/courses/fee_or_salary/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Is it fee paying or salaried? – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Is it fee paying or salaried? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/fee_or_salary/new.html.erb
+++ b/app/views/courses/fee_or_salary/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Is it fee paying or salaried?", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Is it fee paying or salaried?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/fees.html.erb
+++ b/app/views/courses/fees.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Course length and fees" %>
-<%= content_for :page_title, title_with_error_prefix("#{page_title} - #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("#{page_title} - #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/gcse_requirements/edit.html.erb
+++ b/app/views/courses/gcse_requirements/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("GCSEs and equivalency tests", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("GCSEs and equivalency tests", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to provider_recruitment_cycle_course_path %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
+<% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
 
 <h1 class="govuk-heading-l">

--- a/app/views/courses/level/new.html.erb
+++ b/app/views/courses/level/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("What type of course?", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("What type of course?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/modern_languages/edit.erb
+++ b/app/views/courses/modern_languages/edit.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Pick all the languages for #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Pick all the languages for #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/modern_languages/new.html.erb
+++ b/app/views/courses/modern_languages/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Pick all the languages for this course", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Pick all the languages for this course", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/outcome/edit.html.erb
+++ b/app/views/courses/outcome/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Pick a course outcome – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Pick a course outcome – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/outcome/new.html.erb
+++ b/app/views/courses/outcome/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Pick a course outcome", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Pick a course outcome", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -8,8 +8,8 @@
   <%= notification_banner.add_heading(text: "This is a preview of the ‘#{course.name_and_code}’ course.") %>
 <% end %>
 
-<h1 class="govuk-heading-l">
-  <span class="govuk-!-font-size-36" data-qa="course__provider_name"><%= course.provider.provider_name %></span><br>
+<h1 class="govuk-heading-xl">
+  <span class="govuk-heading-l govuk-!-margin-bottom-0" data-qa="course__provider_name"><%= course.provider.provider_name %></span>
   <%= course.name_and_code %>
 </h1>
 

--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Preview: #{course.name_and_code} with #{@provider.provider_name}" %>
+<% content_for :page_title, "Preview: #{course.name_and_code} with #{@provider.provider_name}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path, "Back to course") %>

--- a/app/views/courses/request_change.html.erb
+++ b/app/views/courses/request_change.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Request a change to this course" %>
+<% content_for :page_title, "Request a change to this course" %>
 
 <h1 class="govuk-heading-l">
   Request a change to this course

--- a/app/views/courses/requirements.html.erb
+++ b/app/views/courses/requirements.html.erb
@@ -4,7 +4,7 @@
   <% page_title = "Requirements and eligibility" %>
 <% end %>
 
-<%= content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/salary.html.erb
+++ b/app/views/courses/salary.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Course length and salary" %>
-<%= content_for :page_title, "#{page_title} - #{course.name_and_code}" %>
+<% content_for :page_title, "#{page_title} - #{course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/send/edit.html.erb
+++ b/app/views/courses/send/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Edit SEND – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Edit SEND – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("#{course.name_and_code} - Courses", @errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("#{course.name_and_code} - Courses", @errors.present?) %>
 <%= content_for :before_content, render_breadcrumbs(:course) %>
 
 <% if @errors.present? %>

--- a/app/views/courses/sites/edit.html.erb
+++ b/app/views/courses/sites/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Pick the locations for this course – #{course.name_and_code}", @errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("Pick the locations for this course – #{course.name_and_code}", @errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/sites/new.html.erb
+++ b/app/views/courses/sites/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Pick the locations for this course", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Pick the locations for this course", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/start_date/edit.html.erb
+++ b/app/views/courses/start_date/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("When does the course start? – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("When does the course start? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/start_date/new.html.erb
+++ b/app/views/courses/start_date/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("When does the course start?", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("When does the course start?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/study_mode/edit.html.erb
+++ b/app/views/courses/study_mode/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Full time or part time? – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Full time or part time? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/study_mode/new.html.erb
+++ b/app/views/courses/study_mode/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Full time or part time?", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Full time or part time?", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/subjects/edit.erb
+++ b/app/views/courses/subjects/edit.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Change subjects – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Change subjects – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/subjects/new.erb
+++ b/app/views/courses/subjects/new.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix(course.subject_page_title, @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(course.subject_page_title, @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/courses/title/edit.html.erb
+++ b/app/views/courses/title/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Change course title – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Change course title – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/courses/vacancies/edit.html.erb
+++ b/app/views/courses/vacancies/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Edit vacancies – #{@course.name} (#{@course.course_code})", @course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Edit vacancies – #{@course.name} (#{@course.course_code})", @course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_courses_path(@course.provider_code, @course.recruitment_cycle_year)) %>

--- a/app/views/courses/withdraw.html.erb
+++ b/app/views/courses/withdraw.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Are you sure you want to withdraw #{course.name_and_code})?", flash[:error] && flash[:error]["id"] == "withdraw-error") %>
+<% content_for :page_title, title_with_error_prefix("Are you sure you want to withdraw #{course.name_and_code})?", flash[:error] && flash[:error]["id"] == "withdraw-error") %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "You are not permitted to see this page" %>
+<% content_for :page_title, "You are not permitted to see this page" %>
 
 <div class="govuk-grid-row" data-qa="errors__forbidden">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Sorry, there is a problem with the service" %>
+<% content_for :page_title, "Sorry, there is a problem with the service" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Page not found" %>
+<% content_for :page_title, "Page not found" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Page not available" %>
+<% content_for :page_title, "Page not available" %>
 
 <div class="govuk-grid-row" data-qa="errors__unauthorized">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Manage notifications", flash[:error]) %>
+<% content_for :page_title, title_with_error_prefix("Manage notifications", flash[:error]) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@notifications_view.back_link_path) %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Active users by organisation" %>
+<% content_for :page_title, "Active users by organisation" %>
 
 <h1 class="govuk-heading-l">
   Active users by organisation

--- a/app/views/pages/accept_terms.html.erb
+++ b/app/views/pages/accept_terms.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Accept Terms and Conditions", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Accept Terms and Conditions", @errors && @errors.any?) %>
 
 <%= render "shared/errors" %>
 

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Accessibility" %>
+<% content_for :page_title, "Accessibility" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Cookies" %>
+<% content_for :page_title, "Cookies" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Guidance" %>
+<% content_for :page_title, "Guidance" %>
 
 <% content_for :before_content do %>
   <% if request.referrer.present? %>

--- a/app/views/pages/notifications_info.html.erb
+++ b/app/views/pages/notifications_info.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Get notifications about your courses" %>
+<% content_for :page_title, "Get notifications about your courses" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/performance_dashboard.html.erb
+++ b/app/views/pages/performance_dashboard.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Service performance" %>
+<% content_for :page_title, "Service performance" %>
 
 <h1 class="govuk-heading-xl">
   Service performance

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Privacy policy" %>
+<% content_for :page_title, "Privacy policy" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Prepare for the next cycle" %>
+<% content_for :page_title, "Prepare for the next cycle" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/rollover_recruitment.html.erb
+++ b/app/views/pages/rollover_recruitment.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Recruiting for the #{next_recruitment_cycle_period_text} cycle" %>
+<% content_for :page_title, "Recruiting for the #{next_recruitment_cycle_period_text} cycle" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Terms and conditions" %>
+<% content_for :page_title, "Terms and conditions" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/transition_info.html.erb
+++ b/app/views/pages/transition_info.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "New features" %>
+<% content_for :page_title, "New features" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Publish test users" %>
+<% content_for :page_title, "Publish test users" %>
 
 <h1 class="govuk-heading-l">Publish test users</h1>
 

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "About your organisation" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>

--- a/app/views/providers/access_requests/new.html.erb
+++ b/app/views/providers/access_requests/new.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Request access for someone else" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @access_request.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @access_request.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(users_provider_path(params[:code])) %>

--- a/app/views/providers/allocations/_allocation_request_closed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_closed_state.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
+<% content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
 <%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">

--- a/app/views/providers/allocations/_allocation_request_confirmed_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_confirmed_state.html.erb
@@ -1,5 +1,5 @@
 
-<%= content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
+<% content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
 <%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">

--- a/app/views/providers/allocations/_allocation_request_open_state.html.erb
+++ b/app/views/providers/allocations/_allocation_request_open_state.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Request PE courses for #{next_allocation_cycle_period_text}" %>
+<% content_for :page_title, "Request PE courses for #{next_allocation_cycle_period_text}" %>
 <%= content_for :before_content, render_breadcrumbs("allocations") %>
 
 <div class="govuk-grid-row">

--- a/app/views/providers/allocations/check_your_information.html.erb
+++ b/app/views/providers/allocations/check_your_information.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Check your information before sending your request" %>
-<%= content_for :page_title, page_title %>
+<% content_for :page_title, page_title %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(

--- a/app/views/providers/allocations/edit.html.erb
+++ b/app/views/providers/allocations/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Do you want to request PE for this organisation?" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @allocation.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @allocation.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>

--- a/app/views/providers/allocations/initial_request.html.erb
+++ b/app/views/providers/allocations/initial_request.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Who are you requesting a course for?" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path(provider.provider_code, provider.recruitment_cycle_year)) %>

--- a/app/views/providers/allocations/new_repeat_request.html.erb
+++ b/app/views/providers/allocations/new_repeat_request.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Do you want to request PE for this organisation?" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @allocation.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @allocation.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>

--- a/app/views/providers/allocations/number_of_places.html.erb
+++ b/app/views/providers/allocations/number_of_places.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "How many places would you like to request?" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(initial_request_provider_recruitment_cycle_allocations_path) %>

--- a/app/views/providers/allocations/pick_a_provider.html.erb
+++ b/app/views/providers/allocations/pick_a_provider.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pick a provider" %>
+<% content_for :page_title, "Pick a provider" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(initial_request_provider_recruitment_cycle_allocations_path(@provider.provider_code, @recruitment_cycle.year)) %>

--- a/app/views/providers/allocations/requests/_not_requested.html.erb
+++ b/app/views/providers/allocations/requests/_not_requested.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Thank you" %>
+<% content_for :page_title, "Thank you" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/allocations/requests/_yes_requested.html.erb
+++ b/app/views/providers/allocations/requests/_yes_requested.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Request Sent" %>
+<% content_for :page_title, "Request Sent" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Contact details" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("About your organisation", @errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("About your organisation", @errors.present?) %>
 <%= content_for :before_content, render_breadcrumbs(:organisation_details) %>
 
 <% if @errors.present? %>

--- a/app/views/providers/edit_initial_allocations/check_answers.html.erb
+++ b/app/views/providers/edit_initial_allocations/check_answers.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Check your information before sending your request" %>
-<%= content_for :page_title, page_title %>
+<% content_for :page_title, page_title %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(

--- a/app/views/providers/edit_initial_allocations/do_you_want.html.erb
+++ b/app/views/providers/edit_initial_allocations/do_you_want.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Do you want to request PE for this organisation?" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_recruitment_cycle_allocations_path) %>

--- a/app/views/providers/edit_initial_allocations/number_of_places.html.erb
+++ b/app/views/providers/edit_initial_allocations/number_of_places.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "How many places would you like to request?" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, form_object.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(

--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Organisations" %>
+<% content_for :page_title, "Organisations" %>
 
 <h1 class="govuk-heading-l">Organisations</h1>
 

--- a/app/views/providers/no_providers.erb
+++ b/app/views/providers/no_providers.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "We don’t know which organisation you’re part of" %>
+<% content_for :page_title, "We don’t know which organisation you’re part of" %>
 
 <div class="govuk-grid-row" data-qa="errors__no_providers">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/references/edit.html.erb
+++ b/app/views/providers/references/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = @form_object.lead_school? ? "Organisation reference numbers" : t("helpers.label.provider.ukprn") %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @form_object.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @form_object.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @provider.provider_name %>
+<% content_for :page_title, @provider.provider_name %>
 <% if @has_multiple_providers %>
   <%= content_for :before_content, render_breadcrumbs(:provider) %>
 <% end %>

--- a/app/views/providers/training_provider_courses.html.erb
+++ b/app/views/providers/training_provider_courses.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, provider.provider_name %>
+<% content_for :page_title, provider.provider_name %>
 <%= content_for :before_content, render_breadcrumbs(:training_provider_courses) %>
 
 <h1 class="govuk-heading-l">

--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Courses as an accredited body" %>
+<% content_for :page_title, "Courses as an accredited body" %>
 <%= content_for :before_content, render_breadcrumbs(:training_providers) %>
 
 <h1 class="govuk-heading-l">

--- a/app/views/providers/users/index.html.erb
+++ b/app/views/providers/users/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Users" %>
+<% content_for :page_title, "Users" %>
 <%= content_for :before_content, render_breadcrumbs(:users) %>
 
 <div class="govuk-grid-row">

--- a/app/views/providers/visas/edit.html.erb
+++ b/app/views/providers/visas/edit.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Visa sponsorship" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @form_object.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @form_object.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @recruitment_cycle.title %>
+<% content_for :page_title, @recruitment_cycle.title %>
 <%= content_for :before_content, render_breadcrumbs(:recruitment_cycle) %>
 
 <h1 class="govuk-heading-l">

--- a/app/views/sign_in/dfe_sign_in_is_down.html.erb
+++ b/app/views/sign_in/dfe_sign_in_is_down.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Sign in" %>
-<%= content_for :page_title, page_title %>
+<% content_for :page_title, page_title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Sign in" %>
+<% content_for :page_title, "Sign in" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix(@site_name_before_update, @site.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(@site_name_before_update, @site.errors.any?) %>
 <%= content_for :before_content, render_breadcrumbs(:edit_site) %>
 
 <div class="govuk-grid-row">

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Locations" %>
-<%= content_for :page_title, page_title %>
+<% content_for :page_title, page_title %>
 <%= content_for :before_content, render_breadcrumbs(:sites) %>
 
 <div class="govuk-grid-row">

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -1,5 +1,5 @@
 <% page_title = "Add a location" %>
-<%= content_for :page_title, title_with_error_prefix(page_title, @site.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(page_title, @site.errors.any?) %>
 <%= content_for :before_content, render_breadcrumbs(:new_site) %>
 
 <div class="govuk-grid-row">

--- a/app/views/ucas_contacts/alerts.html.erb
+++ b/app/views/ucas_contacts/alerts.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix("Email alerts for new applications", @provider.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Email alerts for new applications", @provider.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(provider_ucas_contacts_path(@provider.provider_code)) %>

--- a/app/views/ucas_contacts/show.html.erb
+++ b/app/views/ucas_contacts/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "UCAS contacts" %>
+<% content_for :page_title, "UCAS contacts" %>
 
 <%= content_for :before_content, render_breadcrumbs("ucas_contacts") %>
 


### PR DESCRIPTION
### Context

Accidentally output the value of `:page_title` on the confirmation page:

<img width="677" alt="Screenshot 2021-07-08 at 16 10 00" src="https://user-images.githubusercontent.com/813383/124950966-ce473500-e00a-11eb-824f-c398cfa19b1b.png">

### Changes proposed in this pull request

* Fix `<%= …` to `<% …` for page title on course confirmation page 
* Use `<% …` for all `content_for` tags
* Add a page title for ‘Access requests’ page
* Fix heading size on course preview so that it matches that on Find

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
