### PR TITLE
Remove references to 'travel to work' data

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -129,12 +129,6 @@ class Course < Base
     level == "further_education"
   end
 
-  def travel_to_work_areas
-    travel_to_work_areas = sites.map { |site| site.london_borough || site.travel_to_work_area }.uniq
-
-    travel_to_work_areas.to_sentence(last_word_connector: " and ")
-  end
-
   def degree_section_complete?
     degree_grade.present?
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -6,7 +6,7 @@ class Site < Base
   has_one :site_status
 
   properties :code, :location_name, :address1, :address2, :address3, :urn
-  properties :address4, :postcode, :latitude, :longitude, :travel_to_work_area, :london_borough
+  properties :address4, :postcode, :latitude, :longitude
 
   REGIONS = [
     ["London", :london],

--- a/app/views/courses/preview/placement/_hei.html.erb
+++ b/app/views/courses/preview/placement/_hei.html.erb
@@ -1,3 +1,3 @@
-<p class="govuk-body">You’ll be placed in schools for most of your course. This university is based in <%= course.travel_to_work_areas %>, and your school placements will be within commuting distance.</p>
+<p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within commuting distance.</p>
 <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
 <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -15,8 +15,6 @@ FactoryBot.define do
     latitude { nil }
     longitude { nil }
     recruitment_cycle_year { Settings.current_cycle }
-    travel_to_work_area { nil }
-    london_borough { nil }
 
     after :build do |course, evaluator|
       course.recruitment_cycle = evaluator.recruitment_cycle

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -24,8 +24,8 @@ feature "About course", type: :feature do
     )
   end
 
-  let(:site1) { build(:site, london_borough: "Westminster") }
-  let(:site2) { build(:site, travel_to_work_area: "Brighton") }
+  let(:site1) { build(:site) }
+  let(:site2) { build(:site) }
 
   let(:course_response) do
     course.to_jsonapi(

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -154,47 +154,6 @@ describe Course do
     end
   end
 
-  describe "#travel_to_work_areas" do
-    context "when there is a single travel to work area" do
-      let(:site1) { build(:site, travel_to_work_area: "Brighton") }
-      let(:course) { build(:course, sites: [site1]) }
-
-      it "returns that site" do
-        expect(course.travel_to_work_areas).to eq "Brighton"
-      end
-    end
-
-    context "when there is a london borough and travel to work area" do
-      let(:site1) { build(:site, london_borough: "Westminster", travel_to_work_area: "Test") }
-      let(:course) { build(:course, sites: [site1]) }
-
-      it "returns just the london borough" do
-        expect(course.travel_to_work_areas).to eq "Westminster"
-      end
-    end
-
-    context "when there are two  different travel sites" do
-      let(:site1) { build(:site, london_borough: "Westminster") }
-      let(:site2) { build(:site, travel_to_work_area: "Brighton") }
-      let(:course) { build(:course, sites: [site1, site2]) }
-
-      it "returns both sites with the correct format" do
-        expect(course.travel_to_work_areas).to eq "Westminster and Brighton"
-      end
-    end
-
-    context "when there is a mixture of more than two travel sites" do
-      let(:site1) { build(:site, london_borough: "Westminster") }
-      let(:site2) { build(:site, london_borough: "Southwark") }
-      let(:site3) { build(:site, travel_to_work_area: "Brighton") }
-      let(:course) { build(:course, sites: [site1, site2, site3]) }
-
-      it "returns all sites in the correct format" do
-        expect(course.travel_to_work_areas).to eq "Westminster, Southwark and Brighton"
-      end
-    end
-  end
-
   describe "#provider_type" do
     it "returns the provider type" do
       expect(course.provider_type).to eq("lead_school")


### PR DESCRIPTION
### Context
We don't have immediate plans to utilise travel to work data as the design intent changed.

### Changes proposed in this pull request
Remove references to travel to work data

### Trello card
https://trello.com/c/Tmk3UH8J/3628-remove-travel-to-work-api-dependency-from-the-ttapi

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
