### PR TITLE
Update the content around where you will train to be in line with find

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -20,6 +20,7 @@ class Course < Base
   property :accept_maths_gcse_equivalency, type: :boolean
   property :accept_science_gcse_equivalency, type: :boolean
   property :additional_gcse_equivalencies, type: :string
+  property :program_type, type: :string
 
   delegate :provider_type, to: :provider
 

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -113,11 +113,13 @@
       </ul>
 
       <%= govuk_details(summary: "See the guidance we show in this section") do %>
-        <h3 class="govuk-heading-m">Where you will train</h3>
-        <% if @provider.provider_type == 'university' %>
+        <% if @provider.provider_type == 'university' && @provider.provider_code != 'B31' %>
+          <h3 class="govuk-heading-m">Where you will train</h3>
+          <p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within commuting distance.</p>
           <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
           <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
-        <% else %>
+        <% elsif course.program_type == 'scitt_programme' && @provider.provider_code != 'E65' %>
+          <h3 class="govuk-heading-m">Where you will train</h3>
           <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
         <% end %>
       <% end %>

--- a/app/views/courses/about.html.erb
+++ b/app/views/courses/about.html.erb
@@ -112,13 +112,15 @@
         <li>how placement schools are selected</li>
       </ul>
 
-      <%= govuk_details(summary: "See the guidance we show in this section") do %>
-        <% if @provider.provider_type == 'university' && @provider.provider_code != 'B31' %>
+      <% if @provider.provider_type == 'university' && @provider.provider_code != 'B31' %>
+        <%= govuk_details(summary: "See the guidance we show in this section") do %>
           <h3 class="govuk-heading-m">Where you will train</h3>
           <p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within commuting distance.</p>
           <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
           <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
-        <% elsif course.program_type == 'scitt_programme' && @provider.provider_code != 'E65' %>
+        <% end %>
+      <% elsif course.program_type == 'scitt_programme' && @provider.provider_code != 'E65' %>
+        <%= govuk_details(summary: "See the guidance we show in this section") do %>
           <h3 class="govuk-heading-m">Where you will train</h3>
           <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
         <% end %>

--- a/app/views/courses/preview/_about_schools.html.erb
+++ b/app/views/courses/preview/_about_schools.html.erb
@@ -1,20 +1,14 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
   <div data-qa="course__about_schools">
+    <div class="app-advice__body">
+      <% if course.provider_type == "university" && course.provider.provider_code != 'B31' %>
+        <%= render partial: "courses/preview/placement/hei", locals: { course: course } %>
+      <% elsif course.program_type == 'scitt_programme' && course.provider.provider_code != 'E65' %>
+        <%= render partial: "courses/preview/placement/scitt", locals: { course: course } %>
+      <% end %>
+    </div>
     <% if course.how_school_placements_work.present? %>
-      <aside class="app-advice">
-        <h3 class="app-advice__title">
-          <span class="app-advice__caption">Advice from Get Into Teaching</span>
-          Where you will train
-        </h3>
-        <div class="app-advice__body">
-          <% if course.provider_type == "university" %>
-            <%= render partial: "courses/preview/placement/hei", locals: { course: course } %>
-          <% else %>
-            <%= render partial: "courses/preview/placement/scitt", locals: { course: course } %>
-          <% end %>
-        </div>
-      </aside>
       <%= markdown(course.how_school_placements_work) %>
     <% else %>
       <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>

--- a/app/views/courses/preview/placement/_hei.html.erb
+++ b/app/views/courses/preview/placement/_hei.html.erb
@@ -1,3 +1,9 @@
-<p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within commuting distance.</p>
-<p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
-<p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
+<aside class="app-advice">
+  <h3 class="app-advice__title">
+    <span class="app-advice__caption">Advice from Get Into Teaching</span>
+    Where you will train
+  </h3>
+  <p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within commuting distance.</p>
+  <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
+  <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>  
+</aside>

--- a/app/views/courses/preview/placement/_scitt.html.erb
+++ b/app/views/courses/preview/placement/_scitt.html.erb
@@ -1,1 +1,7 @@
-<p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
+<aside class="app-advice">
+  <h3 class="app-advice__title">
+    <span class="app-advice__caption">Advice from Get Into Teaching</span>
+    Where you will train
+  </h3>
+  <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>  
+</aside>


### PR DESCRIPTION
### Context

The preview page on Publish has got out of line with Find for the 'Where you will train content'

There's some fairly niche behaviour that can be seen here 

![image](https://user-images.githubusercontent.com/42515961/126359188-8ea82023-a26a-4507-a891-5b13aa34c91a.png)


### Changes proposed in this pull request

- only render content about not getting to choose where you will train for SCITT courses that aren't Educate Teacher Training
- only render uni content for providers that aren't The Bedfordshire Schools Training Partnership (B31) & are unis
- Don't render content for school directs

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
