### PR TITLE
[2301] Hide CSV export if there are no training providers

### DIFF
--- a/app/views/providers/training_providers.html.erb
+++ b/app/views/providers/training_providers.html.erb
@@ -38,20 +38,22 @@
     </ul>
   </div>
 
-  <aside class="govuk-grid-column-one-third">
-    <div class="app-status-box" data-qa="download-section">
-      <h2 class="govuk-heading-m">Download</h2>
-      <p class="govuk-body">Export all the courses you’re the accredited body for.</p>
-      <p class="govuk-body">
-        <%= govuk_link_to(
-          "Download as a CSV file",
-          download_training_providers_courses_provider_recruitment_cycle_path(
-            provider.provider_code,
-            provider.recruitment_cycle_year,
-            format: :csv,
-          ),
-        ) %>
-      </p>
-    </div>
-  </aside>
+  <% unless @training_providers.empty? %>
+    <aside class="govuk-grid-column-one-third">
+      <div class="app-status-box" data-qa="download-section">
+        <h2 class="govuk-heading-m">Download</h2>
+        <p class="govuk-body">Export all the courses you’re the accredited body for.</p>
+        <p class="govuk-body">
+          <%= govuk_link_to(
+            "Download as a CSV file",
+            download_training_providers_courses_provider_recruitment_cycle_path(
+              provider.provider_code,
+              provider.recruitment_cycle_year,
+              format: :csv,
+            ),
+          ) %>
+        </p>
+      </div>
+    </aside>
+  <% end %>
 </div>

--- a/spec/features/providers/training_providers_spec.rb
+++ b/spec/features/providers/training_providers_spec.rb
@@ -78,4 +78,19 @@ feature "get training_providers", type: :feature do
       expect(organisation_training_providers_page.training_providers_list).to_not have_content(accrediting_body1.provider_name)
     end
   end
+
+  context "when the provider has no training providers" do
+    before do
+      stub_api_v2_request(
+        "/recruitment_cycles/#{accrediting_body1.recruitment_cycle.year}/providers/" \
+        "#{accrediting_body1.provider_code}/training_providers",
+        resource_list_to_jsonapi([]),
+      )
+      visit training_providers_provider_recruitment_cycle_path(accrediting_body1.provider_code, accrediting_body1.recruitment_cycle.year)
+    end
+
+    it "should not show the csv export" do
+      expect(organisation_training_providers_page).not_to have_link("Download as a CSV file")
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/LNFxpRa0/2301-remove-download-csv-link-when-no-training-providers-listed

### Changes proposed in this pull request

<img width="1139" alt="Screenshot 2021-07-22 at 15 32 43" src="https://user-images.githubusercontent.com/616080/126656999-9df12970-149d-4e84-9952-b7c89e2c9da4.png">

### Guidance to review

- Head to http://localhost:3000/organisations/13S/2022/training-providers (as Colin), assert no CSV export is offered
- Head to http://localhost:3000/organisations/D87/2022/training-providers (as Susy) and assert CSV export is shown

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
