### PR TITLE
Display validation messages in 'red' when errors are present

### DIFF
--- a/app/components/degree_row_content_component.html.erb
+++ b/app/components/degree_row_content_component.html.erb
@@ -9,7 +9,7 @@
     </p>
   <% end %>
 <% else %>
-  <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+  <%= govuk_inset_text(classes: inset_text_css_classes) do %>
     <p class="govuk-heading-s app-inset-text__title">Do you require a minimum degree classification?</p>
     <p class="govuk-body">
       <%= govuk_link_to "Enter degree requirements",

--- a/app/components/degree_row_content_component.rb
+++ b/app/components/degree_row_content_component.rb
@@ -1,8 +1,22 @@
 class DegreeRowContentComponent < ViewComponent::Base
   attr_reader :course
+  attr_reader :errors
 
-  def initialize(course:)
+  def initialize(course:, errors: nil)
     @course = course
+    @errors = errors
+  end
+
+  def inset_text_css_classes
+    messages = if errors
+                 errors.values.flatten
+               end
+
+    if messages&.include?("Enter degree requirements")
+      "app-inset-text--narrow-border app-inset-text--error"
+    else
+      "app-inset-text--narrow-border app-inset-text--important"
+    end
   end
 
 private

--- a/app/components/gcse_requirements_component.rb
+++ b/app/components/gcse_requirements_component.rb
@@ -1,8 +1,21 @@
 class GcseRequirementsComponent < ViewComponent::Base
-  attr_reader :course
+  attr_reader :course, :errors
 
-  def initialize(course:)
+  def initialize(course:, errors: nil)
     @course = course
+    @errors = errors
+  end
+
+  def inset_text_css_classes
+    messages = if errors
+                 errors.values.flatten
+               end
+
+    if messages&.include?("Enter GCSE requirements")
+      "app-inset-text--narrow-border app-inset-text--error"
+    else
+      "app-inset-text--narrow-border app-inset-text--important"
+    end
   end
 
 private

--- a/app/components/gcse_row_content_component.html.erb
+++ b/app/components/gcse_row_content_component.html.erb
@@ -15,7 +15,7 @@
     <%= simple_format(course.additional_gcse_equivalencies, class: "govuk-body") %>
   <% end %>
 <% else %>
-  <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+  <%= govuk_inset_text(classes: inset_text_css_classes) do %>
     <p class="govuk-heading-s app-inset-text__title">GCSE and equivalency tests</p>
     <p class="govuk-body">
       <%= govuk_link_to "Enter GCSE and equivalency test requirements",

--- a/app/views/courses/_description_content.html.erb
+++ b/app/views/courses/_description_content.html.erb
@@ -114,7 +114,7 @@
     <% summary_list.slot(:row, enrichment_summary(
       :course,
       "Degree",
-      (render DegreeRowContentComponent.new(course: course)),
+      (render DegreeRowContentComponent.new(course: course, errors: @errors)),
       %w[degree_grade degree_subject_requirements],
       truncate_value: false,
       change_link: course.degree_section_complete? ? degrees_start_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
@@ -124,7 +124,7 @@
     <% summary_list.slot(:row, enrichment_summary(
       :course,
       "GCSEs",
-      (render GcseRowContentComponent.new(course: course)),
+      (render GcseRowContentComponent.new(course: course, errors: @errors)),
       %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
       truncate_value: false,
       change_link: course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,

--- a/spec/components/gcse_preview_component_spec.rb
+++ b/spec/components/gcse_preview_component_spec.rb
@@ -206,5 +206,20 @@ RSpec.describe GcsePreviewComponent, type: :component do
         expect(page).to have_content("Geography")
       end
     end
+
+    describe "#inset_text_css_classes" do
+      context "no relevant error exists" do
+        it "does not return an css class" do
+          expect(described_class.new(course: nil, errors: nil).inset_text_css_classes).to eq("app-inset-text--narrow-border app-inset-text--important")
+        end
+      end
+
+      context "a relevant error exists" do
+        it "returns an error css class" do
+          errors = double("errors", { values: ["Enter GCSE requirements"] })
+          expect(described_class.new(course: nil, errors: errors).inset_text_css_classes).to eq("app-inset-text--narrow-border app-inset-text--error")
+        end
+      end
+    end
   end
 end

--- a/spec/components/gcse_row_content_component_spec.rb
+++ b/spec/components/gcse_row_content_component_spec.rb
@@ -192,4 +192,19 @@ RSpec.describe GcseRowContentComponent, type: :component do
       end
     end
   end
+
+  describe "#inset_text_css_classes" do
+    context "no relevant error exists" do
+      it "does not return an css class" do
+        expect(described_class.new(course: nil, errors: nil).inset_text_css_classes).to eq("app-inset-text--narrow-border app-inset-text--important")
+      end
+    end
+
+    context "a relevant error exists" do
+      it "returns an error css class" do
+        errors = double("errors", { values: ["Enter GCSE requirements"] })
+        expect(described_class.new(course: nil, errors: errors).inset_text_css_classes).to eq("app-inset-text--narrow-border app-inset-text--error")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

If a course page is showing validation, the messages for new Degree and GCSE fields should be red (`app-inset-text--error`), not blue (`app-inset-text--important`).

### Changes proposed in this pull request
- Pass in the errors into the `DegreeRowContentComponent` and `GcseRequirementsComponent`.
- Declare a `#inset_text_css_classes` method on each component which returns the correct css classes depending on whether errors are present or not
 
### Guidance to review

Spin up Publish / API with a recent DB dumb. Find a provider who has courses in the next cycle (e.g. Claydon High School) and select a rolled over course. You should see that the GCSE and Degree fields are `blue` but when you try to publish, the error summary appears and those fields are now displayed in `red`.

This feels like a bit of a hack, however, currently we are reliant on the API to provide us with validation error messages. This seems to be the most pragmatic solution given that Publish and API are to be merged at some point?

|Before (when publishing the course) |After (when publishing the course)|
--- | --- |
|<img width="665" alt="before" src="https://user-images.githubusercontent.com/5256922/126993272-b3ed2299-405f-421f-a36d-5bfb7fe96508.png">|<img width="660" alt="after" src="https://user-images.githubusercontent.com/5256922/126993254-5a6c580b-fb3b-4f36-b0b2-9e3174de65b4.png">|

### Trello
https://trello.com/c/wmYHB2RN/3620-%F0%9F%93%90-new-field-messages-should-be-red-if-course-page-is-showing-validation-publish

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
