### PR TITLE
[XXX] Tidy up environment variables

### DIFF
--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -2,7 +2,6 @@ default: &default
   ASSETS_PRECOMPILE: true
   RAILS_SERVE_STATIC_FILES: true
   WEBPACKER_DEV_SERVER_HOST: "webpacker"
-  SETTINGS__ROLLOVER: false
   SETTINGS__FEATURES__MAINTENANCE_MODE__ENABLED: false
   SETTINGS__FEATURES__MAINTENANCE_MODE__TITLE: "This service will be unavailable from Thursday 4 March at 17:00 to Friday 5 March at 09:00, while we carry out maintenance."
   SETTINGS__FEATURES__MAINTENANCE_MODE__BODY: "Find teacher training courses will still be available during this time. If you have any questions, contact us at becomingateacher@digital.education.gov.uk"

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -2,9 +2,6 @@ default: &default
   ASSETS_PRECOMPILE: true
   RAILS_SERVE_STATIC_FILES: true
   WEBPACKER_DEV_SERVER_HOST: "webpacker"
-  SETTINGS__FEATURES__DFE_SIGNIN: true
-  SETTINGS__FEATURES__SIGNIN_BY_EMAIL: false
-  SETTINGS__FEATURES__SIGNIN_INTERCEPT: false
   SETTINGS__ROLLOVER: false
   SETTINGS__FEATURES__MAINTENANCE_MODE__ENABLED: false
   SETTINGS__FEATURES__MAINTENANCE_MODE__TITLE: "This service will be unavailable from Thursday 4 March at 17:00 to Friday 5 March at 09:00, while we carry out maintenance."

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -2,9 +2,6 @@ default: &default
   ASSETS_PRECOMPILE: true
   RAILS_SERVE_STATIC_FILES: true
   WEBPACKER_DEV_SERVER_HOST: "webpacker"
-  SETTINGS__FEATURES__MAINTENANCE_MODE__ENABLED: false
-  SETTINGS__FEATURES__MAINTENANCE_MODE__TITLE: "This service will be unavailable from Thursday 4 March at 17:00 to Friday 5 March at 09:00, while we carry out maintenance."
-  SETTINGS__FEATURES__MAINTENANCE_MODE__BODY: "Find teacher training courses will still be available during this time. If you have any questions, contact us at becomingateacher@digital.education.gov.uk"
 
 qa:
   <<: *default


### PR DESCRIPTION
### Context

We manage our environment variables using a combination of the settings gem (config/settings.yml etc) and secrets merged in from a key store. We don't need to set them in from terraform as the precedence is confusing.

Some env vars need to present when the app boots so they need to be set by terraform.

### Changes proposed in this pull request

Tidy up the terraform file. Remove old unused variables and those that are in settings. 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
