### PR TITLE
[2377] Add markdown to Publish GCSE and Degree sections

### DIFF
--- a/app/components/degree_preview_component.html.erb
+++ b/app/components/degree_preview_component.html.erb
@@ -5,7 +5,7 @@
 
   <% if course.degree_subject_requirements.present? %>
     <p class="govuk-body">
-      <%= course.degree_subject_requirements %>
+      <%= markdown(course.degree_subject_requirements) %>
     </p>
   <% end %>
 <% else %>

--- a/app/components/degree_preview_component.rb
+++ b/app/components/degree_preview_component.rb
@@ -1,4 +1,5 @@
 class DegreePreviewComponent < ViewComponent::Base
+  include ApplicationHelper
   attr_reader :course
 
   def initialize(course:)

--- a/app/components/gcse_preview_component.html.erb
+++ b/app/components/gcse_preview_component.html.erb
@@ -12,7 +12,7 @@
   </p>
 
   <% if course.additional_gcse_equivalencies %>
-    <%= simple_format(course.additional_gcse_equivalencies, class: "govuk-body") %>
+    <%= markdown(course.additional_gcse_equivalencies)%>
   <% end %>
 <% else %>
   <%= govuk_inset_text(classes: "app-inset-text--important") do %>

--- a/app/components/gcse_preview_component.rb
+++ b/app/components/gcse_preview_component.rb
@@ -1,2 +1,3 @@
 class GcsePreviewComponent < GcseRequirementsComponent
+  include ApplicationHelper
 end

--- a/app/views/courses/_markdown_formatting.html.erb
+++ b/app/views/courses/_markdown_formatting.html.erb
@@ -1,0 +1,18 @@
+<div class="app-status-box">
+  <h3 class="govuk-heading-m">Formatting</h3>
+  <h4 class="govuk-heading-s">Links</h4>
+  <p class="govuk-body">Use square brackets [] around the link text and round brackets () around the link URL. Make sure there are no spaces between the brackets.</p>
+
+  <p class="govuk-body">For example:<br>[GOV.UK](https://gov.uk/)</p>
+
+  <h4 class="govuk-heading-s">Lists</h4>
+  <p class="govuk-body">To create a bulleted list:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>use asterisks (*) to create a bullet point (hyphens also work)</li>
+    <li>make sure there is one space after the asterisk</li>
+    <li>leave 1 empty line space before the bullets start, and one after</li>
+  </ul>
+
+  <p class="govuk-body">For example:</p>
+  <p class="govuk-body">* list item 1<br>* list item 2</p>
+</div>

--- a/app/views/courses/_related_sidebar.html.erb
+++ b/app/views/courses/_related_sidebar.html.erb
@@ -28,20 +28,5 @@
 
   <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 
-  <h3 class="govuk-heading-m">Formatting</h3>
-  <h4 class="govuk-heading-s">Links</h4>
-  <p class="govuk-body">Use square brackets [] around the link text and round brackets () around the link URL. Make sure there are no spaces between the brackets.</p>
-
-  <p class="govuk-body">For example:<br>[GOV.UK](https://gov.uk/)</p>
-
-  <h4 class="govuk-heading-s">Lists</h4>
-  <p class="govuk-body">To create a bulleted list:</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>use asterisks (*) to create a bullet point (hyphens also work)</li>
-    <li>make sure there is one space after the asterisk</li>
-    <li>leave 1 empty line space before the bullets start, and one after</li>
-  </ul>
-
-  <p class="govuk-body">For example:</p>
-  <p class="govuk-body">* list item 1<br>* list item 2</p>
+  <%= render partial: "markdown_formatting" %>
 </div>

--- a/app/views/courses/degrees/subject_requirements/edit.html.erb
+++ b/app/views/courses/degrees/subject_requirements/edit.html.erb
@@ -36,4 +36,7 @@
       <%= f.govuk_submit "Save", data: { qa: "degree_subject_requirements__save" } %>
     <% end %>
   </div>
+  <aside class="govuk-grid-column-one-third">
+    <%= render partial: "courses/markdown_formatting" %>
+  </aside>
 </div>

--- a/app/views/courses/gcse_requirements/edit.html.erb
+++ b/app/views/courses/gcse_requirements/edit.html.erb
@@ -47,4 +47,7 @@
       <%= f.submit "Save", class: "govuk-button", data: { qa: "gcse_requirements__save" } %>
     <% end %>
   </div>
+  <aside class="govuk-grid-column-one-third">
+    <%= render partial: "courses/markdown_formatting" %>
+  </aside>
 </div>


### PR DESCRIPTION
### Context

The `GCSE` and `Degree` sections were recently added as new features within the `Requirements and eligibility` section. Markdown was considered out of scope. We need to add this to ensure consistency across Publish. 

### Changes proposed in this pull request

- Add markdown to `Degree` and `GCSE` sections
- Add guidance text for markdown
- Refactor guidance text into partial

### Guidance to review

- Visit an organisation on Publish and go to a course in the next cycle: https://publish-teacher-training-pr-1842.london.cloudapps.digital/organisations/1A4
- Scroll down to the `Requirements and eligibility` section
- Click on change, follow the journey through and add markdown text in the free text field and save it
- Visit preview and ensure that the markdown has been translated to markdown
- Verify that the guidance text added is consistent with the rest of Publish and makes sense in the context

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
