### PR TITLE
Update copy for the international candidates section of the find preview page

### DIFF
--- a/app/components/gcse_preview_component.html.erb
+++ b/app/components/gcse_preview_component.html.erb
@@ -12,7 +12,7 @@
   </p>
 
   <% if course.additional_gcse_equivalencies %>
-    <%= markdown(course.additional_gcse_equivalencies)%>
+    <%= markdown(course.additional_gcse_equivalencies) %>
   <% end %>
 <% else %>
   <%= govuk_inset_text(classes: "app-inset-text--important") do %>

--- a/app/views/courses/preview/_international_students.html.erb
+++ b/app/views/courses/preview/_international_students.html.erb
@@ -2,12 +2,19 @@
   <h2 class="govuk-heading-l" id="section-international">International students</h2>
   <% if @provider.declared_visa_sponsorship? %>
     <p class="govuk-body">
-      We
-      <%= @provider.cannot_sponsor_visas? ? "cannot" : "can" %>
+      <% if @provider.cannot_sponsor_visas? %>
+       We cannot sponsor visas. You’ll need to
+       <%= govuk_link_to(
+         "get the right visa or status to study in the UK",
+         "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
+       ) %>.
+      <% else %>
+        We can
       <%= govuk_link_to(
         visa_sponsorship_short_status(@provider),
         "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
-      ) %><%= @provider.cannot_sponsor_visas? ? "." : ", but this is not guaranteed." %>
+      ) %>, but this is not guaranteed.
+      <% end %>
     </p>
   <% else %>
     <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
@@ -20,6 +27,6 @@
       </p>
     <% end %>
   <% end %>
-  <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you are an Irish citizen.</p>
+  <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you’re an Irish citizen.</p>
   <p class="govuk-body">Candidates with qualifications from non-UK institutions may need to provide evidence of comparability by applying for a <%= govuk_link_to("UK ENIC statement", "https://www.enic.org.uk") %>.</p>
 </div>

--- a/app/views/courses/preview/_international_students.html.erb
+++ b/app/views/courses/preview/_international_students.html.erb
@@ -3,7 +3,7 @@
   <% if @provider.declared_visa_sponsorship? %>
     <p class="govuk-body">
       <% if @provider.cannot_sponsor_visas? %>
-       We cannot sponsor visas. You’ll need to
+       We’re unable to sponsor visas. You’ll need to
        <%= govuk_link_to(
          "get the right visa or status to study in the UK",
          "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
@@ -13,7 +13,7 @@
       <%= govuk_link_to(
         visa_sponsorship_short_status(@provider),
         "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
-      ) %>, but this is not guaranteed.
+      ) %>.
       <% end %>
     </p>
   <% else %>

--- a/app/views/courses/preview/placement/_hei.html.erb
+++ b/app/views/courses/preview/placement/_hei.html.erb
@@ -5,5 +5,5 @@
   </h3>
   <p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within commuting distance.</p>
   <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
-  <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>  
+  <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
 </aside>

--- a/app/views/courses/preview/placement/_scitt.html.erb
+++ b/app/views/courses/preview/placement/_scitt.html.erb
@@ -3,5 +3,5 @@
     <span class="app-advice__caption">Advice from Get Into Teaching</span>
     Where you will train
   </h3>
-  <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>  
+  <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
 </aside>

--- a/spec/features/providers/visa_spec.rb
+++ b/spec/features/providers/visa_spec.rb
@@ -139,7 +139,7 @@ feature "View and edit provider visa sponsorship", type: :feature do
         stub_api_v2_resource(course, include: "subjects,sites,site_statuses.site,provider.sites,accrediting_provider")
         visit preview_provider_recruitment_cycle_course_path("A0", "2022", course.course_code)
         expect(page).to have_content("International students")
-        expect(page).to have_content("We can sponsor Student visas, but this is not guaranteed.")
+        expect(page).to have_content("We can sponsor Student visas.")
       end
     end
 
@@ -160,7 +160,7 @@ feature "View and edit provider visa sponsorship", type: :feature do
         stub_api_v2_resource(course, include: "subjects,sites,site_statuses.site,provider.sites,accrediting_provider")
         visit preview_provider_recruitment_cycle_course_path("A0", "2022", course.course_code)
         expect(page).to have_content("International students")
-        expect(page).to have_content("We cannot sponsor visas. You’ll need to")
+        expect(page).to have_content("We’re unable to sponsor visas. You’ll need to")
         expect(page).to have_link(
           "get the right visa or status to study in the UK",
           href: "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",

--- a/spec/features/providers/visa_spec.rb
+++ b/spec/features/providers/visa_spec.rb
@@ -142,5 +142,30 @@ feature "View and edit provider visa sponsorship", type: :feature do
         expect(page).to have_content("We can sponsor Student visas, but this is not guaranteed.")
       end
     end
+
+    context "when the provider cannot sponsor visas" do
+      let(:provider) do
+        build(
+          :provider,
+          provider_code: "A0",
+          recruitment_cycle: recruitment_cycle,
+          recruitment_cycle_year: recruitment_cycle.year,
+          can_sponsor_student_visa: false,
+          can_sponsor_skilled_worker_visa: false,
+        )
+      end
+
+      it "renders the correct content of on the course preview page" do
+        course = build(:course, provider: provider)
+        stub_api_v2_resource(course, include: "subjects,sites,site_statuses.site,provider.sites,accrediting_provider")
+        visit preview_provider_recruitment_cycle_course_path("A0", "2022", course.course_code)
+        expect(page).to have_content("International students")
+        expect(page).to have_content("We cannot sponsor visas. You’ll need to")
+        expect(page).to have_link(
+          "get the right visa or status to study in the UK",
+          href: "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Follow on work done in DFE-Digital/find-teacher-training#873 to bring the preview page in line with the updated content on Find. 

### Changes proposed in this pull request

- Update the content on the course preview page to be in line with the content on Find

### Guidance to review

https://trello.com/c/eHkPZRRx/3787-update-content-on-find-publish-for-structured-quals

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
