### PR TITLE
[2646] Reject qualifications needed if course recruitment cycle after 2021

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -647,7 +647,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.4p191
 
 BUNDLED WITH
    2.1.4

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -106,11 +106,7 @@ class CoursesController < ApplicationController
     show_deep_linked_errors(%i[required_qualifications personal_qualities other_requirements])
 
     if params[:copy_from].present?
-      @copied_fields = [
-        ["Qualifications needed", "required_qualifications"],
-        ["Personal qualities", "personal_qualities"],
-        ["Other requirements", "other_requirements"],
-      ].reject { |_name, field| field == "required_qualifications" && @course.recruitment_cycle_year.to_i > 2021 }.keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
+      @copied_fields = get_copied_fields.keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
     end
   end
 
@@ -372,5 +368,20 @@ private
     # By stripping commas out the backend will not reject such input.
     params[:course][:fee_uk_eu].gsub!(",", "") if params[:course][:fee_uk_eu].present?
     params[:course][:fee_international].gsub!(",", "") if params[:course][:fee_international].present?
+  end
+
+  def get_copied_fields
+    if @course.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE
+      [
+        ["Personal qualities", "personal_qualities"],
+        ["Other requirements", "other_requirements"],
+      ]
+    else
+      [
+        ["Qualifications needed", "required_qualifications"],
+        ["Personal qualities", "personal_qualities"],
+        ["Other requirements", "other_requirements"],
+      ]
+    end
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -110,7 +110,7 @@ class CoursesController < ApplicationController
         ["Qualifications needed", "required_qualifications"],
         ["Personal qualities", "personal_qualities"],
         ["Other requirements", "other_requirements"],
-      ].keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
+      ].reject { |_name, field| field == "required_qualifications" && @course.recruitment_cycle_year.to_i > 2021 }.keep_if { |_name, field| copy_field_if_present_in_source_course(field) }
     end
   end
 


### PR DESCRIPTION


### Context

- [This trello ticket](https://trello.com/c/KpMNPHrn/2646-when-copying-personal-other-details-from-another-course-banner-confirms-qual-info-have-been-copied-too)

### Changes proposed in this pull request

- If the recruitment year is after 2021, we reject the `Qualifications needed` from the requirements array

### Guidance to review

- Go to 2022-23 recruitment year
- Click add course
- Fill out all details
- And on the review page, go down to the requirements and eligibility section
- Click a course to copy the details from, and see that the warning message no longer has qualifications needed in the message. 
- You can verify it hasnt been removed from the 2021 courses, if you repeat the same as above but in the previous cycle

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
