### PR TITLE
[2647] Warning links now link to input box

### DIFF
--- a/app/views/courses/_copy_content_warning.html.erb
+++ b/app/views/courses/_copy_content_warning.html.erb
@@ -13,7 +13,7 @@
     <p class="govuk-body">We’ve copied these fields from <%= @source_course.name %> (<%= @source_course.course_code %>):</p>
     <ul class="govuk-list">
       <% copied_fields.each do |name, field| %>
-        <li><%= govuk_link_to name, "##{field}_wrapper", class: "govuk-notification-banner__link" %></li>
+        <li><%= govuk_link_to name, "#course-#{field.gsub("_", "-")}-field", class: "govuk-notification-banner__link" %></li>
       <% end %>
     </ul>
     <p class="govuk-body">Please check them and make your changes before saving.</p>


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/02t0nzsy/2647-links-dont-work-when-copying-personal-other-details-from-another-course)

### Changes proposed in this pull request

- Appended `course` and prepended `field` onto the error links to ensure they link to their corresponding input boxes

### Guidance to review

- Find a course (any course)
- Go to personal qualities and other requirements section
- Edit it
- Use the copy from dropdown and select another course and click copy
- You are met with a warning message. 
- This warning message has links, which now link to the corresponding input box they are referencing

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
