### PR TITLE
Update visa sponsorship wording and guidance

### DIFF
--- a/app/form_objects/provider_visa_form.rb
+++ b/app/form_objects/provider_visa_form.rb
@@ -5,8 +5,8 @@ class ProviderVisaForm
   attribute :can_sponsor_skilled_worker_visa, :boolean
   attribute :can_sponsor_student_visa, :boolean
 
-  validates :can_sponsor_student_visa, inclusion: { in: [true, false], message: "Select if you can sponsor Student visas" }
-  validates :can_sponsor_skilled_worker_visa, inclusion: { in: [true, false], message: "Select if you can sponsor Skilled Worker visas" }
+  validates :can_sponsor_student_visa, inclusion: { in: [true, false], message: "Select if candidates can get a Skilled Worker visa" }
+  validates :can_sponsor_skilled_worker_visa, inclusion: { in: [true, false], message: "Select if candidates can get a sponsored Skilled Worker visa" }
 
   def save(provider)
     if valid?

--- a/app/form_objects/provider_visa_form.rb
+++ b/app/form_objects/provider_visa_form.rb
@@ -5,7 +5,7 @@ class ProviderVisaForm
   attribute :can_sponsor_skilled_worker_visa, :boolean
   attribute :can_sponsor_student_visa, :boolean
 
-  validates :can_sponsor_student_visa, inclusion: { in: [true, false], message: "Select if candidates can get a Skilled Worker visa" }
+  validates :can_sponsor_student_visa, inclusion: { in: [true, false], message: "Select if candidates can get a sponsored Student visa" }
   validates :can_sponsor_skilled_worker_visa, inclusion: { in: [true, false], message: "Select if candidates can get a sponsored Skilled Worker visa" }
 
   def save(provider)

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -29,7 +29,7 @@ module ProviderHelper
     elsif provider.can_only_sponsor_skilled_worker_visa?
       "Skilled Worker visas"
     else
-      "Visas"  # TODO: drop this? Don't think we'd ever reach this condition.
+      "Visas" # TODO: drop this? Don't think we'd ever reach this condition.
     end
   end
 

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -28,8 +28,6 @@ module ProviderHelper
       "Student visas"
     elsif provider.can_only_sponsor_skilled_worker_visa?
       "Skilled Worker visas"
-    else
-      "Visas" # TODO: drop this? Don't think we'd ever reach this condition.
     end
   end
 

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -13,9 +13,9 @@ module ProviderHelper
     if !provider.declared_visa_sponsorship?
       visa_sponsorship_call_to_action(provider)
     elsif provider.can_sponsor_student_visa || provider.can_sponsor_skilled_worker_visa
-      "You can #{visa_sponsorship_short_status(provider)}"
+      "#{visa_sponsorship_short_status(provider)} can be sponsored"
     else
-      "You cannot sponsor visas"
+      "Visas cannot be sponsored"
     end
   end
 
@@ -23,13 +23,13 @@ module ProviderHelper
     if !provider.declared_visa_sponsorship?
       visa_sponsorship_call_to_action(provider)
     elsif provider.can_sponsor_all_visas?
-      "sponsor Student and Skilled Worker visas"
+      "Student and Skilled Worker visas"
     elsif provider.can_only_sponsor_student_visa?
-      "sponsor Student visas"
+      "Student visas"
     elsif provider.can_only_sponsor_skilled_worker_visa?
-      "sponsor Skilled Worker visas"
+      "Skilled Worker visas"
     else
-      "sponsor visas"
+      "Visas"  # TODO: drop this? Don't think we'd ever reach this condition.
     end
   end
 
@@ -39,7 +39,7 @@ private
     govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do
       raw("<p class=\"govuk-heading-s app-inset-text__title\">Can you sponsor visas?</p>") +
         govuk_link_to(
-          "Select if you can sponsor visas",
+          "Select if visas can be sponsored",
           provider_recruitment_cycle_visas_path(
             provider.provider_code,
             provider.recruitment_cycle_year,

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -143,9 +143,9 @@ private
 
   def base_errors_hash(provider_code, course)
     {
-      "You must say whether you can sponsor visas" =>
+      "You must say whether candidates can get a visa sponsored" =>
         provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
-      "Select if you can sponsor visas" =>
+      "Select if visas can be sponsored" =>
         provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
       "You must provide a Unique Reference Number (URN) for all course locations" =>
         provider_recruitment_cycle_sites_path(provider_code, course.recruitment_cycle_year),

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -143,8 +143,6 @@ private
 
   def base_errors_hash(provider_code, course)
     {
-      "You must say whether candidates can get a visa sponsored" =>
-        provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
       "Select if visas can be sponsored" =>
         provider_recruitment_cycle_visas_path(provider_code, course.recruitment_cycle_year),
       "You must provide a Unique Reference Number (URN) for all course locations" =>

--- a/app/views/courses/preview/_international_students.html.erb
+++ b/app/views/courses/preview/_international_students.html.erb
@@ -9,7 +9,7 @@
          "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
        ) %>.
       <% else %>
-        We can
+        We can sponsor
       <%= govuk_link_to(
         visa_sponsorship_short_status(@provider),
         "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -37,7 +37,7 @@
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-4">
       <li>degree requirements</li>
       <li>GCSE requirements</li>
-      <li>whether you can sponsor visas</li>
+      <li>whether visas can be sponsored</li>
       <li>locations of school placements</li>
       <li>the <abbr class="app-!-text-decoration-underline-dotted" title="Unique Reference Number">URN</abbr> for each school course location</li>
       <li>the <abbr class="app-!-text-decoration-underline-dotted" title="UK Provider Reference Number">UKPRN</abbr> for your organisation</li>

--- a/app/views/pages/rollover.html.erb
+++ b/app/views/pages/rollover.html.erb
@@ -37,7 +37,7 @@
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-4">
       <li>degree requirements</li>
       <li>GCSE requirements</li>
-      <li>whether visas can be sponsored</li>
+      <li>if candidates can get visa sponsorship</li>
       <li>locations of school placements</li>
       <li>the <abbr class="app-!-text-decoration-underline-dotted" title="Unique Reference Number">URN</abbr> for each school course location</li>
       <li>the <abbr class="app-!-text-decoration-underline-dotted" title="UK Provider Reference Number">UKPRN</abbr> for your organisation</li>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -70,7 +70,7 @@
           %w[can_sponsor_student_visa can_sponsor_skilled_worker_visa],
           truncate_value: false,
           change_link: provider.declared_visa_sponsorship? ? provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year) : nil,
-          change_link_visually_hidden: "if you can sponsor visas",
+          change_link_visually_hidden: "if candidates can get a sponsored visa",
         )) %>
       <% end %>
     <% end %>

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -70,7 +70,7 @@
           %w[can_sponsor_student_visa can_sponsor_skilled_worker_visa],
           truncate_value: false,
           change_link: provider.declared_visa_sponsorship? ? provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year) : nil,
-          change_link_visually_hidden: "if candidates can get a sponsored visa",
+          change_link_visually_hidden: "if candidates can get visa sponsorship",
         )) %>
       <% end %>
     <% end %>

--- a/app/views/providers/visas/edit.html.erb
+++ b/app/views/providers/visas/edit.html.erb
@@ -22,16 +22,19 @@
         <%= page_title %>
       </h1>
 
+      <p class="govuk-body">If you’re unsure if your courses can sponsor visas, check the <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-students" class="govuk-link">Register of Student sponsors</a> and <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers" class="govuk-link">Register of Worker and Temporary Worker licensed sponsors</a>.</p>
+
+      <p class="govuk-body">Find out how to <a href="https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers#recruit-by-becoming-a-visa-sponsor" class="govuk-link">become a visa sponsor</a>.</p>
+
+
       <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa,
-        legend: { text: "Can you sponsor Student visas?" },
-        hint: { text: "Applies to fee-paying courses" }) do %>
+        legend: { text: "Can candidates get a sponsored Student visa for your fee-paying courses?" }) do %>
         <%= f.govuk_radio_button :can_sponsor_student_visa, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :can_sponsor_student_visa, false, label: { text: "No" } %>
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset(:can_sponsor_skilled_worker_visa,
-        legend: { text: "Can you sponsor Skilled Worker visas?" },
-        hint: { text: "Applies to salaried courses" }) do %>
+        legend: { text: "Can candidates get a sponsored Skilled Worker visa for your salaried courses?" }) do %>
         <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: "No, or not applicable" } %>
       <% end %>

--- a/app/views/providers/visas/edit.html.erb
+++ b/app/views/providers/visas/edit.html.erb
@@ -22,9 +22,9 @@
         <%= page_title %>
       </h1>
 
-      <p class="govuk-body">If you’re unsure if your courses can sponsor visas, check the <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-students" class="govuk-link">Register of Student sponsors</a> and <a href="https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers" class="govuk-link">Register of Worker and Temporary Worker licensed sponsors</a>.</p>
+      <p class="govuk-body">If you’re unsure if your courses can sponsor visas, check the <%= govuk_link_to("Register of Student sponsors", "https://www.gov.uk/government/publications/register-of-licensed-sponsors-students") %> and <%= govuk_link_to("Register of Worker and Temporary Worker licensed sponsors", "https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers") %>.</p>
 
-      <p class="govuk-body">Find out how to <a href="https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers#recruit-by-becoming-a-visa-sponsor" class="govuk-link">become a visa sponsor</a>.</p>
+      <p class="govuk-body">Find out how to <%= govuk_link_to("become a visa sponsor", "https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers#recruit-by-becoming-a-visa-sponsor") %>.</p>
 
 
       <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa,

--- a/spec/features/providers/visa_spec.rb
+++ b/spec/features/providers/visa_spec.rb
@@ -23,7 +23,7 @@ feature "View and edit provider visa sponsorship", type: :feature do
 
     it "does not render visa sponsorship prompt and link" do
       visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-      expect(page).not_to have_content "Select if you can sponsor visas"
+      expect(page).not_to have_content "Select if visas can be sponsored"
     end
 
     it "course preview page does not render international students section" do
@@ -55,7 +55,7 @@ feature "View and edit provider visa sponsorship", type: :feature do
       it "shows a call to action in summary card" do
         visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
         within find("[data-qa='enrichment__can_sponsor_student_visa']") do
-          click_link "Select if you can sponsor visas"
+          click_link "Select if visas can be sponsored"
         end
         expect(page).to have_content("#{provider.provider_name} Visa sponsorship")
       end
@@ -70,10 +70,10 @@ feature "View and edit provider visa sponsorship", type: :feature do
 
       it "visa sponsorship form renders validation errors if I submit without selecting whether provider sponsors visas" do
         visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-        click_link "Select if you can sponsor visas"
+        click_link "Select if visas can be sponsored"
         click_button "Save"
-        expect(page).to have_content("Select if you can sponsor Skilled Worker visas")
-        expect(page).to have_content("Select if you can sponsor Student visas")
+        expect(page).to have_content("Select if candidates can get a sponsored Skilled Worker visa")
+        expect(page).to have_content("Select if candidates can get a sponsored Student visa")
       end
 
       it "visa sponsorship form updates the provider if I submit valid values" do
@@ -84,11 +84,11 @@ feature "View and edit provider visa sponsorship", type: :feature do
           )
         end
         visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-        click_link "Select if you can sponsor visas"
-        within_fieldset("Can you sponsor Student visas?") do
+        click_link "Select if visas can be sponsored"
+        within_fieldset("Can candidates get a sponsored Student visa for your fee-paying courses?") do
           choose "Yes"
         end
-        within_fieldset("Can you sponsor Skilled Worker visas?") do
+        within_fieldset("Can candidates get a sponsored Skilled Worker visa for your salaried courses?") do
           choose "No"
         end
         click_button "Save and publish changes"
@@ -109,7 +109,7 @@ feature "View and edit provider visa sponsorship", type: :feature do
 
       it "about organisation page displays the current visa sponsorship status" do
         visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-        expect(page).to have_content("You can sponsor Student visas")
+        expect(page).to have_content("Student visas can be sponsored")
       end
 
       it "I can change my answers" do
@@ -125,10 +125,10 @@ feature "View and edit provider visa sponsorship", type: :feature do
           click_link "Change"
         end
 
-        within_fieldset("Can you sponsor Student visas?") do
+        within_fieldset("Can candidates get a sponsored Student visa for your fee-paying courses?") do
           choose "No"
         end
-        within_fieldset("Can you sponsor Skilled Worker visas?") do
+        within_fieldset("Can candidates get a sponsored Skilled Worker visa for your salaried courses?") do
           choose "Yes"
         end
         click_button "Save and publish changes"

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -66,7 +66,7 @@ feature "View helpers", type: :helper do
         "Can you sponsor visas?",
       )
       expect(helper.visa_sponsorship_status(provider)).to match(
-        "Select if you can sponsor visas",
+        "Select if visas can be sponsored",
       )
     end
 
@@ -77,7 +77,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: false,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "You can sponsor Student visas",
+        "Student visas can be sponsored",
       )
     end
 
@@ -88,7 +88,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: true,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "You can sponsor Skilled Worker visas",
+        "Skilled Worker visas can be sponsored",
       )
     end
 
@@ -99,7 +99,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: true,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "You can sponsor Student and Skilled Worker visas",
+        "Student and Skilled Worker visas can be sponsored",
       )
     end
 
@@ -110,7 +110,7 @@ feature "View helpers", type: :helper do
         can_sponsor_skilled_worker_visa: false,
       )
       expect(helper.visa_sponsorship_status(provider)).to eq(
-        "You cannot sponsor visas",
+        "Visas cannot be sponsored",
       )
     end
   end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -35,7 +35,7 @@ feature "View helpers", type: :helper do
 
     it "returns enrichment error URL for base error" do
       course = Course.new(build(:course).attributes.merge(recruitment_cycle_year: "2022"))
-      expect(helper.enrichment_error_url(provider_code: "A1", course: course, field: "base", message: "You must say whether you can sponsor visas")).to eq("/organisations/A1/2022/visas")
+      expect(helper.enrichment_error_url(provider_code: "A1", course: course, field: "base", message: "You must say whether candidates can get a visa sponsored")).to eq("/organisations/A1/2022/visas")
     end
   end
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -35,7 +35,7 @@ feature "View helpers", type: :helper do
 
     it "returns enrichment error URL for base error" do
       course = Course.new(build(:course).attributes.merge(recruitment_cycle_year: "2022"))
-      expect(helper.enrichment_error_url(provider_code: "A1", course: course, field: "base", message: "You must say whether candidates can get a visa sponsored")).to eq("/organisations/A1/2022/visas")
+      expect(helper.enrichment_error_url(provider_code: "A1", course: course, field: "base", message: "Select if visas can be sponsored")).to eq("/organisations/A1/2022/visas")
     end
   end
 


### PR DESCRIPTION
This changes the visa sponsorship question from asking directly "Can you sponsor Skilled worker/Student visas?" to "Can candidates get a sponsored Skilled worker/Student visa for your fee-paying/salaried courses?"

The reason for this change is that we have now learnt that in some cases, the organisation doing the sponsoring won’t be the provider themselves, but might be the organisation accrediting the QTS status or school employing the person on the salaried course. This may or may not be the provider, depending on how the organisation is set up.

In addition we’ve also added some guidance text at the top which links to pages on GOV.UK which list organisations who have the sponsor licence (if they need to check), and to a guidance page on how to become able to sponsor visas.

See [changes in prototype](https://github.com/DFE-Digital/publish-teacher-training-prototype/pull/104).

## Screenshots

### Before

<img width="734" alt="Screenshot 2021-09-02 at 11 17 35" src="https://user-images.githubusercontent.com/30665/131826814-44c744b8-f38f-468c-9db6-2d58e88aa7bf.png">

### After

<img width="844" alt="Screenshot 2021-09-02 at 11 17 25" src="https://user-images.githubusercontent.com/30665/131826834-6df59e13-53c7-44c9-a184-9a658669773d.png">
