### PR TITLE
Add bespoke address logic for 28T X104

### DIFF
--- a/app/views/courses/preview/_contact_details.html.erb
+++ b/app/views/courses/preview/_contact_details.html.erb
@@ -24,7 +24,17 @@
         </dd>
       <% end %>
 
-      <% if @provider.full_address.present? %>
+      <% if course.provider.provider_code == '28T' && course.course_code == 'X104' %>
+        <dt class="app-description-list__label">Address</dt>
+        <dd data-qa="provider__address">
+          LSJS
+          <br>
+          44A Albert Road
+          <br>
+          London
+          <br>
+          NW4 2SJ
+      <% elsif @provider.full_address.present? %>
         <dt class="app-description-list__label">Address</dt>
         <dd data-qa="provider__address">
           <%= @provider.full_address %>

--- a/spec/features/courses/preview_spec.rb
+++ b/spec/features/courses/preview_spec.rb
@@ -268,6 +268,30 @@ feature "Preview course", type: :feature do
     end
   end
 
+  context "contact details for London School of Jewish Studies and the course code is X104" do
+    let(:provider) do
+      build(
+        :provider,
+        provider_code: "28T",
+      )
+    end
+
+    let(:course) do
+      build(:course,
+            course_code: "X104",
+            provider: provider)
+    end
+
+    it "renders the custom address requested via zendesk" do
+      visit preview_provider_recruitment_cycle_course_path(provider.provider_code, current_recruitment_cycle.year, course.course_code)
+
+      expect(preview_course_page).to have_content "LSJS"
+      expect(preview_course_page).to have_content "44A Albert Road"
+      expect(preview_course_page).to have_content "London"
+      expect(preview_course_page).to have_content "NW4 2SJ"
+    end
+  end
+
   def jsonapi_site_status(name, study_mode, status)
     build(:site_status, study_mode, site: build(:site, location_name: name), status: status)
   end


### PR DESCRIPTION
### Context

We've been asked to add a custom address for one course provided by London School of Jewish Studies.

This has been ✅'d by Rachael 

### Changes proposed in this pull request

Show the address found here https://www.publish-teacher-training-courses.service.gov.uk/organisations/28T/2022/courses/X104/locations for 28T X104 

### Guidance to review

I'll add the changes to the preview page on Publish in a PR now.

### Trello card

https://trello.com/c/Dvyc6Ozy/723-address-incorrect-for-1-course-for-provider-28t?filter=a%20leve&menu=filter

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
