### PR TITLE
Increase cloudfoundry apps start timeout

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -5,7 +5,7 @@ resource cloudfoundry_app web_app {
   health_check_http_endpoint = "/ping"
   docker_image               = var.docker_image
   docker_credentials         = var.dockerhub_credentials
-  timeout                    = 180
+  timeout                    = 300
   strategy                   = "blue-green-v2"
   environment                = var.app_environment_variables
   instances                  = var.web_app_instances
@@ -31,7 +31,7 @@ resource cloudfoundry_app worker_app {
   health_check_type  = "process"
   docker_image       = var.docker_image
   docker_credentials = var.dockerhub_credentials
-  timeout            = 180
+  timeout            = 300
   strategy           = "blue-green-v2"
   command            = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
   environment        = var.app_environment_variables


### PR DESCRIPTION
### Context
https://github.com/DFE-Digital/publish-teacher-training/runs/3586753730

### Changes proposed in this pull request
Apps take a long time to start (above 2 min) and they may breach the
timeout. Increased from 3 to 5 min.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
