### PR TITLE
[71] Duplicated notification fix

### DIFF
--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -14,12 +14,12 @@
     </div>
   <% elsif key == "success_with_body" %>
     <%= govuk_notification_banner(title_text: t("notification_banner.success"), success: true, html_attributes: { role: "alert" }) do |notification_banner| %>
-      <%= notification_banner.heading(text: value["title"]) %>
+      <% notification_banner.heading(text: value["title"]) %>
       <p class="govuk-body" data-qa="flash__success__body"><%= value["body"] %></p>
     <% end %>
   <% else %>
     <%= govuk_notification_banner(title_text: t("notification_banner.success"), success: true, html_attributes: { role: "alert" }) do |notification_banner| %>
-      <%= notification_banner.heading(text: value) %>
+      <% notification_banner.heading(text: value) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/Uk7rxZMX/71-notices-warning-success-error-have-a-duplicated-title)

### Changes proposed in this pull request

- Replaced execution tags with expression tags to avoid duplication of notification message

### Guidance to review

- If you create and publish a course, the success message will only show one message

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
