### PR TITLE
Moved saved and publish messages to translation string + added TTL inset

### DIFF
--- a/app/controllers/concerns/course_basic_detail_concern.rb
+++ b/app/controllers/concerns/course_basic_detail_concern.rb
@@ -21,7 +21,7 @@ module CourseBasicDetailConcern
     return render :edit if @errors.present?
 
     if @course.update(course_params)
-      flash[:success] = "Your changes have been saved"
+      flash[:success] = I18n.t("success.saved")
       redirect_to(
         details_provider_recruitment_cycle_course_path(
           @course.provider_code,

--- a/app/controllers/courses/accredited_body_controller.rb
+++ b/app/controllers/courses/accredited_body_controller.rb
@@ -95,7 +95,7 @@ module Courses
     end
 
     def redirect_to_update_successful
-      flash[:success] = "Your changes have been saved"
+      flash[:success] = I18n.t("success.saved")
       redirect_to(
         details_provider_recruitment_cycle_course_path(
           @course.provider_code,

--- a/app/controllers/courses/age_range_controller.rb
+++ b/app/controllers/courses/age_range_controller.rb
@@ -14,7 +14,7 @@ module Courses
 
     def update
       if form_object.valid?
-        flash[:success] = "Your changes have been saved"
+        flash[:success] = I18n.t("success.saved")
 
         update_age_range_param
 

--- a/app/controllers/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/courses/degrees/subject_requirements_controller.rb
@@ -16,7 +16,7 @@ module Courses
         @subject_requirements_form = SubjectRequirementsForm.new(subject_requirements_params)
 
         if @subject_requirements_form.save(@course)
-          flash[:success] = "Your changes have been saved"
+          flash[:success] = I18n.t("success.saved")
 
           redirect_to provider_recruitment_cycle_course_path
         else

--- a/app/controllers/courses/gcse_requirements_controller.rb
+++ b/app/controllers/courses/gcse_requirements_controller.rb
@@ -24,7 +24,7 @@ module Courses
       )
 
       if @gcse_requirements_form.save(@course)
-        flash[:success] = "Your changes have been saved"
+        flash[:success] = I18n.t("success.saved")
 
         redirect_to provider_recruitment_cycle_course_path
       else

--- a/app/controllers/courses/modern_languages_controller.rb
+++ b/app/controllers/courses/modern_languages_controller.rb
@@ -32,7 +32,7 @@ module Courses
       updated_subject_list += selected_non_language_subjects
 
       if @course.update(subjects: updated_subject_list)
-        flash[:success] = "Your changes have been saved"
+        flash[:success] = I18n.t("success.saved")
         redirect_to(
           details_provider_recruitment_cycle_course_path(
             @course.provider_code,

--- a/app/controllers/courses/subjects_controller.rb
+++ b/app/controllers/courses/subjects_controller.rb
@@ -22,7 +22,7 @@ module Courses
           ),
         )
       elsif @course.update(subjects: selected_subjects)
-        flash[:success] = "Your changes have been saved"
+        flash[:success] = I18n.t("success.saved")
         redirect_to(
           details_provider_recruitment_cycle_course_path(
             @course.provider_code,

--- a/app/controllers/courses/title_controller.rb
+++ b/app/controllers/courses/title_controller.rb
@@ -8,7 +8,7 @@ module Courses
 
     def update
       if course.update(course_params)
-        flash[:success] = "Your changes have been saved"
+        flash[:success] = I18n.t("success.saved")
 
         redirect_to(
           details_provider_recruitment_cycle_course_path(

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -72,7 +72,7 @@ class CoursesController < ApplicationController
     massage_update_course_params
 
     if @course.update(course_params)
-      flash[:success] = "Your changes have been saved"
+      flash[:success] = I18n.t("success.saved")
       redirect_to(
         provider_recruitment_cycle_course_path(
           @course.provider_code,

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -40,7 +40,7 @@ class ProvidersController < ApplicationController
 
   def update
     if @provider.update(provider_params)
-      flash[:success] = "Your changes have been published"
+      flash[:success] = I18n.t("success.published")
       redirect_to(
         details_provider_recruitment_cycle_path(
           @provider.provider_code,
@@ -56,7 +56,7 @@ class ProvidersController < ApplicationController
 
   def publish
     if @provider.publish
-      flash[:success] = "Your changes have been published."
+      flash[:success] = I18n.t("success.published")
     else
       flash[:error_summary] = @provider.errors.messages
     end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -32,7 +32,7 @@ class SitesController < ApplicationController
     @site.provider_code = @provider.provider_code
 
     if @site.update(site_params)
-      redirect_to provider_recruitment_cycle_sites_path(@site.provider_code, @site.recruitment_cycle_year), flash: { success: "Your changes have been published" }
+      redirect_to provider_recruitment_cycle_sites_path(@site.provider_code, @site.recruitment_cycle_year), flash: { success: I18n.t("success.published") }
     else
       @errors = @site.errors.messages
 

--- a/app/controllers/ucas_contacts_controller.rb
+++ b/app/controllers/ucas_contacts_controller.rb
@@ -36,7 +36,7 @@ class UcasContactsController < ApplicationController
         application_alert_contact: email,
       )
       redirect_to provider_ucas_contacts_path(@provider.provider_code),
-                  flash: { success: "Your changes have been saved" }
+                  flash: { success: I18n.t("success.saved") }
     end
   end
 

--- a/app/views/courses/age_range/edit.html.erb
+++ b/app/views/courses/age_range/edit.html.erb
@@ -36,6 +36,7 @@
         <% end %>
       <% end %>
 
+      <%= render GovukComponent::InsetTextComponent.new(text: I18n.t("success.changes_ttl")) if course.is_running? %>
       <%= f.govuk_submit course.is_running? ? "Save and publish changes" : "Save", data: { qa: "course__save" } %>
     <% end %>
   </div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -20,6 +20,7 @@
   <% else %>
     <%= govuk_notification_banner(title_text: t("notification_banner.success"), success: true, html_attributes: { role: "alert" }) do |notification_banner| %>
       <% notification_banner.heading(text: value) %>
+      <p class="govuk-body"><%= t("success.changes_ttl") %></p>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -20,7 +20,6 @@
   <% else %>
     <%= govuk_notification_banner(title_text: t("notification_banner.success"), success: true, html_attributes: { role: "alert" }) do |notification_banner| %>
       <% notification_banner.heading(text: value) %>
-      <p class="govuk-body"><%= t("success.changes_ttl") %></p>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/providers/about.html.erb
+++ b/app/views/providers/about.html.erb
@@ -84,6 +84,7 @@
         max_words: 250,
         rows: 15) %>
 
+      <%= render GovukComponent::InsetTextComponent.new(text: I18n.t("success.changes_ttl")) %>
       <%= f.govuk_submit "Save and publish changes" %>
     <% end %>
   </div>

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -95,7 +95,7 @@
           data: { qa: "postcode" }) %>
       <% end %>
 
-      <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 2 hours.</p>
+      <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 15 minutes.</p>
 
       <%= f.govuk_submit "Save and publish changes" %>
     <% end %>

--- a/app/views/providers/contact.html.erb
+++ b/app/views/providers/contact.html.erb
@@ -95,8 +95,7 @@
           data: { qa: "postcode" }) %>
       <% end %>
 
-      <p class="govuk-body">Changes will appear on Find postgraduate teacher training within 15 minutes.</p>
-
+      <%= render GovukComponent::InsetTextComponent.new(text: I18n.t("success.changes_ttl")) %>
       <%= f.govuk_submit "Save and publish changes" %>
     <% end %>
   </div>

--- a/app/views/providers/visas/edit.html.erb
+++ b/app/views/providers/visas/edit.html.erb
@@ -39,6 +39,7 @@
         <%= f.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: "No, or not applicable" } %>
       <% end %>
 
+      <%= render GovukComponent::InsetTextComponent.new(text: I18n.t("success.changes_ttl")) %>
       <%= f.govuk_submit "Save and publish changes" %>
     <% end %>
   </div>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -18,6 +18,7 @@
 
       <p class="govuk-body">You can assign locations to a course from the ‘Basic details’ tab on the course page.</p>
       <%= render "form", f: f %>
+      <%= render GovukComponent::InsetTextComponent.new(text: I18n.t("success.changes_ttl")) %>
       <%= f.govuk_submit "Save and publish changes", data: { qa: "location__publish-changes" } %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,3 +165,8 @@ en:
   errors:
     messages:
       too_many_words: Must be %{count} words or fewer
+  success:
+    published: "Your changes have been published."
+    saved: "Your changes have been saved."
+    changes_ttl: "Changes will appear on Find postgraduate teacher training within 15 minutes."
+

--- a/spec/features/courses/about_spec.rb
+++ b/spec/features/courses/about_spec.rb
@@ -78,7 +78,7 @@ feature "About course", type: :feature do
       click_on "Save"
 
       expect(about_course_page.flash).to have_content(
-        "Your changes have been saved",
+        I18n.t("success.saved"),
       )
       expect(current_path).to eq provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
     end

--- a/spec/features/courses/accredited_body/edit_spec.rb
+++ b/spec/features/courses/accredited_body/edit_spec.rb
@@ -153,7 +153,7 @@ feature "Edit accredited body", type: :feature do
       click_on "Save and publish changes"
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
 

--- a/spec/features/courses/age_range_in_years/edit_spec.rb
+++ b/spec/features/courses/age_range_in_years/edit_spec.rb
@@ -85,7 +85,7 @@ feature "Edit course age range in years", type: :feature do
       age_range_in_years_page.save_button.click
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
 
@@ -105,7 +105,7 @@ feature "Edit course age range in years", type: :feature do
       age_range_in_years_page.save_button.click
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
 

--- a/spec/features/courses/applications_open/edit_spec.rb
+++ b/spec/features/courses/applications_open/edit_spec.rb
@@ -113,7 +113,7 @@ feature "Edit course applications open", type: :feature do
 
       click_on "Save"
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
 

--- a/spec/features/courses/entry_requirements/edit_spec.rb
+++ b/spec/features/courses/entry_requirements/edit_spec.rb
@@ -103,7 +103,7 @@ feature "Edit course entry requirements", type: :feature do
       click_on "Save"
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
   end
@@ -151,7 +151,7 @@ feature "Edit course entry requirements", type: :feature do
       click_on "Save"
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
   end
@@ -198,7 +198,7 @@ feature "Edit course entry requirements", type: :feature do
       click_on "Save"
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
   end

--- a/spec/features/courses/fees_spec.rb
+++ b/spec/features/courses/fees_spec.rb
@@ -74,7 +74,7 @@ feature "Course fees", type: :feature do
     click_on "Save"
 
     expect(course_fees_page.flash).to have_content(
-      "Your changes have been saved",
+      I18n.t("success.saved"),
     )
     expect(current_path).to eq provider_recruitment_cycle_course_path("A0", course_1.recruitment_cycle_year, course_1.course_code)
   end
@@ -87,7 +87,7 @@ feature "Course fees", type: :feature do
       expect(request_attributes["course_length"]).to eq("4 years")
     end
     click_on "Save"
-    expect(course_fees_page.flash).to have_content("Your changes have been saved")
+    expect(course_fees_page.flash).to have_content(I18n.t("success.saved"))
     expect(current_path).to eq provider_recruitment_cycle_course_path("A0", course_1.recruitment_cycle_year, course_1.course_code)
   end
 

--- a/spec/features/courses/outcome/edit_spec.rb
+++ b/spec/features/courses/outcome/edit_spec.rb
@@ -61,7 +61,7 @@ feature "Edit course outcome", type: :feature do
       click_on "Save"
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
   end

--- a/spec/features/courses/requirements_spec.rb
+++ b/spec/features/courses/requirements_spec.rb
@@ -82,7 +82,7 @@ feature "Course requirements", type: :feature do
     click_on "Save"
 
     expect(course_requirements_page.flash).to have_content(
-      "Your changes have been saved",
+      I18n.t("success.saved"),
     )
 
     expect(current_path).to eq provider_recruitment_cycle_course_path("A0", course.recruitment_cycle.year, course.course_code)
@@ -128,7 +128,7 @@ feature "Course requirements", type: :feature do
     click_on "Save"
 
     expect(course_requirements_page.flash).to have_content(
-      "Your changes have been saved",
+      I18n.t("success.saved"),
     )
 
     expect(current_path).to eq provider_recruitment_cycle_course_path("A0", course.recruitment_cycle.year, course.course_code)

--- a/spec/features/courses/salary_spec.rb
+++ b/spec/features/courses/salary_spec.rb
@@ -62,7 +62,7 @@ feature "Course salary", type: :feature do
     click_on "Save"
 
     expect(course_salary_page.flash).to have_content(
-      "Your changes have been saved",
+      I18n.t("success.saved"),
     )
 
     expect(current_path).to eq provider_recruitment_cycle_course_path("A0", course.recruitment_cycle_year, course.course_code)

--- a/spec/features/courses/start_date/edit_spec.rb
+++ b/spec/features/courses/start_date/edit_spec.rb
@@ -106,7 +106,7 @@ feature "Edit course start date", type: :feature do
       click_on "Save"
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
   end

--- a/spec/features/courses/study_mode/edit_spec.rb
+++ b/spec/features/courses/study_mode/edit_spec.rb
@@ -63,7 +63,7 @@ feature "Edit course study mode", type: :feature do
       click_on "Save"
 
       expect(course_details_page).to be_displayed
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
       expect(update_course_stub).to have_been_requested
     end
 
@@ -95,7 +95,7 @@ feature "Edit course study mode", type: :feature do
       click_on "Save"
 
       expect(update_course_stub).to have_been_requested
-      expect(course_details_page.flash).to have_content("Your changes have been saved")
+      expect(course_details_page.flash).to have_content(I18n.t("success.saved"))
     end
 
     scenario "It displays the correct title" do

--- a/spec/features/providers/about_spec.rb
+++ b/spec/features/providers/about_spec.rb
@@ -79,7 +79,7 @@ feature "View provider about", type: :feature do
     click_on "Save"
 
     expect(org_details_page.flash).to have_content(
-      "Your changes have been published",
+      I18n.t("success.published"),
     )
     expect(current_path).to eq details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
   end

--- a/spec/features/providers/ucas_alerts_spec.rb
+++ b/spec/features/providers/ucas_alerts_spec.rb
@@ -31,7 +31,7 @@ feature "Edit UCAS email alerts", type: :feature do
     page.alerts_enabled_fields.all.click
     click_on "Save"
     expect(org_ucas_contacts_page).to be_displayed
-    expect(org_ucas_contacts_page.flash).to have_content("Your changes have been saved")
+    expect(org_ucas_contacts_page.flash).to have_content(I18n.t("success.saved"))
   end
 
   context "email alerts: none" do
@@ -86,7 +86,7 @@ feature "Edit UCAS email alerts", type: :feature do
       end
       click_on "Save"
       expect(org_ucas_contacts_page).to be_displayed
-      expect(org_ucas_contacts_page.flash).to have_content("Your changes have been saved")
+      expect(org_ucas_contacts_page.flash).to have_content(I18n.t("success.saved"))
     end
 
     scenario "not ticking permissions box for sharing with ucas" do

--- a/spec/features/sites/edit_spec.rb
+++ b/spec/features/sites/edit_spec.rb
@@ -67,7 +67,7 @@ feature "Edit locations", type: :feature do
       location_page.publish_changes.click
 
       expect(locations_page).to be_displayed
-      expect(locations_page.success_summary).to have_content("Your changes have been published")
+      expect(locations_page.success_summary).to have_content(I18n.t("success.published"))
     end
   end
 

--- a/spec/requests/courses/about_spec.rb
+++ b/spec/requests/courses/about_spec.rb
@@ -151,7 +151,7 @@ describe "Courses", type: :request do
       end
 
       it "redirects to the course description page" do
-        expect(flash[:success]).to include("Your changes have been saved")
+        expect(flash[:success]).to include(I18n.t("success.saved"))
         expect(response).to redirect_to(provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle.year, course.course_code))
       end
     end


### PR DESCRIPTION
### Context

- N/A

### Changes proposed in this pull request

- Moved saved and published messages to i18 for easier maintenence
- Added a ttl translation message and included it above save buttons that have publishable ability (not just regular save buttons)

### Guidance to review

- Successfully publish or change details to see the changes in the flash message

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
