### PR TITLE
[127] Added Important banner with reminder to publish courses ahead of SoC

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,6 +1,12 @@
 <% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
 
+<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
+  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
+
+  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
+<% end %>
+
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
   Courses

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -3,6 +3,12 @@
   <%= content_for :before_content, render_breadcrumbs(:provider) %>
 <% end %>
 
+<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
+  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
+
+  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
+<% end %>
+
 <h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
 
 <div class="govuk-grid-row">

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -1,6 +1,12 @@
 <% content_for :page_title, @recruitment_cycle.title %>
 <%= content_for :before_content, render_breadcrumbs(:recruitment_cycle) %>
 
+<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
+  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
+
+  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
+<% end %>
+
 <h1 class="govuk-heading-l">
   <%= @recruitment_cycle.title %>
 </h1>

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -7,7 +7,7 @@ environment:
   selector_name: "review"
 authentication:
   mode: persona
-allocation_cycle_year: 2020
+allocation_cycle_year: 2021
 allocations_close_date: 2021-07-02
 features:
   allocations:


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/rbExOfUP/128-add-banner-on-publishing-courses)

### Changes proposed in this pull request

- Blue 'Important' banner at the top of the provider show page

### Guidance to review

- Navigate to the Provider Show Page and see the notification banner on the top of the page. 

![Screenshot 2021-09-28 at 15 47 55](https://user-images.githubusercontent.com/53180713/135110882-d20c6ac1-55f8-4e63-b7b6-f14bc9bb7b97.png)
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
