### PR TITLE
[140] Changed feedback mailto link to googleform link

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -34,6 +34,10 @@ module ViewHelper
     govuk_mail_to bat_contact_email_address, name || bat_contact_email_address_with_wrap, **kwargs
   end
 
+  def feedback_link_to
+    t("feedback.link")
+  end
+
   def title_with_error_prefix(title, error)
     "#{t('page_titles.error_prefix') if error}#{title}"
   end

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -7,6 +7,6 @@
   <% if sandbox_mode? %>
     This is a <%= govuk_link_to "test version of Publish", root_path %> for providers and software vendors
   <% else %>
-    This is a new service – your <%= bat_contact_mail_to "feedback", subject: "Publish teacher training courses feedback" %> will help us to improve it.
+    This is a new service – your <%= link_to "feedback", feedback_link_to %> will help us to improve it.
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,4 +169,6 @@ en:
     published: "Your changes have been published."
     saved: "Your changes have been saved."
     changes_ttl: "Changes will appear on Find postgraduate teacher training within 15 minutes."
+  feedback:
+    link: https://docs.google.com/forms/d/e/1FAIpQLSfZNWa6zx30SkF_1EAwqNPZHOgK8qYcVQ7uDyhi0P6oPm71zg/viewform
 

--- a/maintenance/maintenance.html
+++ b/maintenance/maintenance.html
@@ -635,7 +635,7 @@
           <span class="govuk-phase-banner__text">
             This is a new service – your
             <a
-              href="mailto:becomingateacher@digital.education.gov.uk?subject=Search%20beta%20feedback"
+              href="https://docs.google.com/forms/d/e/1FAIpQLSfZNWa6zx30SkF_1EAwqNPZHOgK8qYcVQ7uDyhi0P6oPm71zg/viewform"
               class="govuk-link"
               >feedback</a
             >

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -27,6 +27,12 @@ feature "View helpers", type: :helper do
     end
   end
 
+  describe "#feedback_link_to" do
+    it "returns the correct feedback link" do
+      expect(helper.feedback_link_to).to eq(I18n.t("feedback.link"))
+    end
+  end
+
   describe "#enrichment_error_url" do
     it "returns enrichment error URL" do
       course = Course.new(build(:course).attributes)


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/eaKdfhfj/140-change-feedback-hyperlink-with-survey-link)

### Changes proposed in this pull request

- Feedback changed from mailto to google form link

### Guidance to review

- Click on the feedback link on the top of the page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
