### PR TITLE
[153] Removed execution tag to stop duplication of warning message

### DIFF
--- a/app/views/courses/_copy_content_warning.html.erb
+++ b/app/views/courses/_copy_content_warning.html.erb
@@ -7,7 +7,7 @@
       role: "alert",
     },
   ) do |notification_banner| %>
-    <%= notification_banner.heading(text: "Your changes are not yet saved") %>
+    <% notification_banner.heading(text: "Your changes are not yet saved") %>
     <p class="govuk-body">We’ve copied these fields from <%= @source_course.name %> (<%= @source_course.course_code %>):</p>
     <ul class="govuk-list">
       <% copied_fields.each do |name, field| %>


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/yprBbBFm/153-bug-duplicate-heading-for-your-changes-have-not-yet-been-saved)

### Changes proposed in this pull request

- Replaced execution tags with expression tags to avoid duplication of notification message

### Guidance to review

- Copy content from one course to another (such as GCSE information) and the notification only has a single title

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
