### PR TITLE
[167] Removed cycle in production.yml

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -21,10 +21,3 @@ authentication:
 # # Uncomment if and only if dfe_signin is down
 # authentication:
 #   mode: magic_link
-
-current_cycle: 2021
-
-features:
-  rollover:
-    # During rollover providers should be able to edit current & next recruitment cycle courses
-    can_edit_current_and_next_cycles: true


### PR DESCRIPTION
### Context

- Update cycle to 2022 in production

### Changes proposed in this pull request

- Removed `current_cycle: 2021` and related info in `production.yml`. Will now fallback to `settings.yml`, where `current_cycle: 2022`

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
