### PR TITLE
Changed allocation view to consume allocation cycle not recruitment cycle

### DIFF
--- a/app/controllers/providers/allocations_controller.rb
+++ b/app/controllers/providers/allocations_controller.rb
@@ -18,7 +18,7 @@ module Providers
       }.sort_by(&:provider_name)
 
       @allocations_view = AllocationsView.new(
-        allocations: allocations[@recruitment_cycle.year.to_s] || [], training_providers: @training_providers,
+        allocations: allocations[Settings.allocation_cycle_year.to_s] || [], training_providers: @training_providers,
       )
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,7 +57,7 @@ environment:
   label: "Beta"
   selector_name: "beta"
 current_cycle: 2022
-next_cycle_open_date: 2021-10-5
+next_cycle_open_date: 2022-10-5
 allocation_cycle_year: 2021
 allocations_close_date: 2021-07-02
 # `financial_support_placeholder_cycle` the cycle year value should be

--- a/spec/features/providers/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/providers/allocations/edit_initial_allocation_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "PE allocations" do
 
   before do
     allow(Settings.features.allocations).to receive(:state).and_return("open")
+    allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
   end
 
   context "updating an initial allocation" do

--- a/spec/features/providers/allocations/repeat_allocations_spec.rb
+++ b/spec/features/providers/allocations/repeat_allocations_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "PE allocations" do
 
   before do
     allow(Settings.features.allocations).to receive(:state).and_return("open")
+    allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
   end
 
   context "Repeat allocations" do


### PR DESCRIPTION
### Context

- Providers were no longer able to view their allocations

### Changes proposed in this pull request

- Changed allocation view to consume the allocation cycle rather than recruitment cycle

### Guidance to review

- Go to an accredited body with allocations (on review app, durham SCITT) and view their allocations

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
