### PR TITLE
[184] Remove publish courses reminder

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,12 +1,6 @@
 <% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
 
-<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
-
-  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
-<% end %>
-
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
   Courses

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -3,12 +3,6 @@
   <%= content_for :before_content, render_breadcrumbs(:provider) %>
 <% end %>
 
-<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
-
-  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
-<% end %>
-
 <h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
 
 <div class="govuk-grid-row">

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -1,12 +1,6 @@
 <% content_for :page_title, @recruitment_cycle.title %>
 <%= content_for :before_content, render_breadcrumbs(:recruitment_cycle) %>
 
-<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
-
-  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
-<% end %>
-
 <h1 class="govuk-heading-l">
   <%= @recruitment_cycle.title %>
 </h1>


### PR DESCRIPTION
### Context

We are currently displaying:

<img width="1025" alt="Screenshot 2021-10-05 at 09 39 59" src="https://user-images.githubusercontent.com/5216/135991301-0cf7f6b2-d24e-42f6-81fa-0a9453fc212f.png">

We don't need that anymore now that the cycle is open.

### Changes proposed in this pull request

Remove notification banner.

### Guidance to review

Login and confirm that the banner is no longer visible on:

* provider home page
* course list

It has also been removed from the recruitment cycles page but that is no longer visible anyway.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
