### PR TITLE
[xxx] Update publish course reminder

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -2,9 +2,9 @@
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
 
 <%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
+  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find.</strong></span><br><br>
 
-  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
+  <span class="govuk-body">Do this by selecting your course, check and edit the details, then click the “Publish” button.</span>
 <% end %>
 
 <h1 class="govuk-heading-l">

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -4,9 +4,9 @@
 <% end %>
 
 <%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
+  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find.</strong></span><br><br>
 
-  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
+  <span class="govuk-body">Do this by selecting your course, check and edit the details, then click the “Publish” button.</span>
 <% end %>
 
 <h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -2,9 +2,9 @@
 <%= content_for :before_content, render_breadcrumbs(:recruitment_cycle) %>
 
 <%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find from the 5 October.</strong></span><br><br>
+  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find.</strong></span><br><br>
 
-  <span class="govuk-body">Do this by selecting your courses for the <%= next_allocation_cycle_period_text %> cycle, check and edit the details, then select the “Publish” button.</span>
+  <span class="govuk-body">Do this by selecting your course, check and edit the details, then click the “Publish” button.</span>
 <% end %>
 
 <h1 class="govuk-heading-l">


### PR DESCRIPTION
### Context

We show a banner to prompt users to publish their courses. It had content referencing the forthcoming cycle. The cycle is now open.

### Changes proposed in this pull request

Update copy now that the cycle is open.

### Guidance to review

Check the banner on:

* providers show
* courses index

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
