### PR TITLE
Add 'site_statuses' to field params whitelist

### DIFF
--- a/app/controllers/api/v3/application_controller.rb
+++ b/app/controllers/api/v3/application_controller.rb
@@ -44,7 +44,7 @@ module API
 
       def fields_param
         params.fetch(:fields, {})
-          .permit(:subject_areas, :subjects, :courses, :providers)
+          .permit(:subject_areas, :subjects, :courses, :providers, :site_statuses)
           .to_h
           .map { |k, v| [k, v.split(",").map(&:to_sym)] }
       end


### PR DESCRIPTION
### Context

In order for Find limit the number of fields it requests, it needs to use 'sparse fields'.
We therefore need to add `site_statuses` to the field params whitelist

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
