### PR TITLE
[xxx] Add course.provider_id index

### DIFF
--- a/db/migrate/20211007140208_add_provider_id_index.rb
+++ b/db/migrate/20211007140208_add_provider_id_index.rb
@@ -1,0 +1,5 @@
+class AddProviderIdIndex < ActiveRecord::Migration[6.1]
+  def change
+    add_index :course, :provider_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_153519) do
+ActiveRecord::Schema.define(version: 2021_10_07_140208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 2021_10_05_153519) do
     t.index ["is_send"], name: "index_course_on_is_send"
     t.index ["program_type"], name: "index_course_on_program_type"
     t.index ["provider_id", "course_code"], name: "IX_course_provider_id_course_code", unique: true
+    t.index ["provider_id"], name: "index_course_on_provider_id"
     t.index ["qualification"], name: "index_course_on_qualification"
     t.index ["study_mode"], name: "index_course_on_study_mode"
     t.index ["uuid"], name: "index_courses_unique_uuid", unique: true


### PR DESCRIPTION
### Context

The courses endpoint is slow. We currently only have a compound index for provider_id and code but we almost always look up courses using only the provider_id.

### Changes proposed in this pull request

Add an index on provider_id

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
