### PR TITLE
Fix issue with the `provider_can_sponsor_visa` scope

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -259,7 +259,18 @@ class Course < ApplicationRecord
 
   scope :provider_can_sponsor_visa, -> do
     joins(:provider)
-    .where("provider.can_sponsor_student_visa = true OR provider.can_sponsor_skilled_worker_visa = true")
+    .where(
+      program_type: %w[school_direct_training_programme higher_education_programme scitt_programme],
+      provider: { can_sponsor_student_visa: true },
+    )
+    .or(
+      joins(:provider)
+      .where(
+        program_type: %w[school_direct_salaried_training_programme pg_teaching_apprenticeship],
+        provider: { can_sponsor_skilled_worker_visa: true },
+      ),
+    )
+    .distinct
   end
 
   def self.entry_requirement_options_without_nil_choice

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1138,16 +1138,40 @@ describe Course, type: :model do
       context "when the provider can sponsor skilled worker visas" do
         let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: true, can_sponsor_student_visa: false) }
 
-        it "returns the course" do
-          expect(subject).to eq [course]
+        context "and is a salaried course" do
+          let(:course) { create(:course, :salary_type_based, provider: provider) }
+
+          it "returns the course" do
+            expect(subject).to eq [course]
+          end
+        end
+
+        context "and is non-salaried course" do
+          let(:course) { create(:course, :fee_type_based, provider: provider) }
+
+          it "does not return the course" do
+            expect(subject).to eq []
+          end
         end
       end
 
       context "when the provider can sponsor student visas" do
         let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: true) }
 
-        it "returns the course" do
-          expect(subject).to eq [course]
+        context "and is non-salaried course" do
+          let(:course) { create(:course, :fee_type_based, provider: provider) }
+
+          it "returns the course" do
+            expect(subject).to eq [course]
+          end
+        end
+
+        context "and is a salaried course" do
+          let(:course) { create(:course, :salary_type_based, provider: provider) }
+
+          it "does not return the course" do
+            expect(subject).to eq []
+          end
         end
       end
 

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -777,8 +777,8 @@ describe "GET v3/courses" do
       let(:provider_that_can_sponsor_student_visa) { build(:provider, can_sponsor_student_visa: true, can_sponsor_skilled_worker_visa: false) }
       let(:provider_that_can_sponsor_skilled_worker_visa) { build(:provider, can_sponsor_student_visa: false, can_sponsor_skilled_worker_visa: true) }
       let(:provider_that_cant_sponsor_visas) { build(:provider, can_sponsor_student_visa: false, can_sponsor_skilled_worker_visa: false) }
-      let(:course1) { create(:course, provider: provider_that_can_sponsor_student_visa, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
-      let(:course2) { create(:course, provider: provider_that_can_sponsor_skilled_worker_visa, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
+      let(:course1) { create(:course, :fee_type_based, provider: provider_that_can_sponsor_student_visa, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
+      let(:course2) { create(:course, :salary_type_based, provider: provider_that_can_sponsor_skilled_worker_visa, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
       let(:course3) { create(:course, provider: provider_that_cant_sponsor_visas, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
 
       before do


### PR DESCRIPTION
### Context

At the moment the logic around displaying if a provider can provide a visa is off between the TTAPI and Find. For providers who can sponsor a skilled worker visa, courses should only be returned when they are salaried.

### Changes proposed in this pull request

- Only pass salaried courses back for providers who can sponsor skilled worker visas in the `provider_can_sponsor_visa` scope

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally