### PR TITLE
Don't use json format logs in dev and test

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,4 +1,6 @@
 Rails.application.config.semantic_logger.application = Settings.application_name
 Rails.application.config.rails_semantic_logger.format = :json
-SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
-Rails.application.config.logger.info("Application logging to STDOUT")
+unless Rails.env.development? || Rails.env.test?
+  SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
+  Rails.application.config.logger.info("Application logging to STDOUT")
+end


### PR DESCRIPTION


### Context
Much easier to read the default Rails format.
### Changes proposed in this pull request
Put an env check around the relevant lines in the semantic logger initializer.

### Guidance to review
Any issues with the check? It looks like we used to do something similar until the log config was significantly reworked in https://github.com/DFE-Digital/teacher-training-api/commit/77f39d8d4c0b600c4da34a2c5a2064472dcac1ba#diff-ac0915cf8689f1e743444b83327d2cfc048d0565d926c884f688f0c9b7302a61L57
### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
