### PR TITLE
Update load test db to `large-11`

### DIFF
--- a/terraform/workspace_variables/loadtest.tfvars
+++ b/terraform/workspace_variables/loadtest.tfvars
@@ -6,7 +6,7 @@ paas_web_app_instances     = 8
 paas_web_app_memory        = 1536
 paas_worker_app_instances  = 1
 paas_worker_app_memory     = 1024
-paas_postgres_service_plan = "medium-11"
+paas_postgres_service_plan = "large-11"
 paas_redis_service_plan    = "micro-ha-5_x"
 
 # KeyVault


### PR DESCRIPTION
### Context

To test if we need to update the DB before next Tuesday, update the DB on the load testing environment to test initially

### Changes proposed in this pull request

Update`paas_postgres_service_plan` to `large-11`

### Guidance to review

This will be merged after we update the db manually:
`cf update-service teacher-training-postgres-loadtest -p large-11`

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
