### PR TITLE
Make DB connection pool size independent of RAILS_MAX_THREADS

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
+  pool: <%= ENV.fetch('DATABASE_CONNECTION_POOL_SIZE', ENV.fetch('RAILS_MAX_THREADS', 5)) %>
   variables:
     statement_timeout: 20000
     idle_in_transaction_session_timeout: 10000


### PR DESCRIPTION
### Context

We would like to be able to control the number of connections to the database without reducing the number of threads in the app instances. 