### PR TITLE
[225] Add DfE Signin UUID to export

### DIFF
--- a/app/services/support/data_exports/users_export.rb
+++ b/app/services/support/data_exports/users_export.rb
@@ -30,6 +30,7 @@ module Support
           email_address: user.email,
           first_login_at: user.first_login_date_utc,
           last_login_at: user.last_login_date_utc,
+          sign_in_user_id: user.sign_in_user_id,
         }
       end
     end

--- a/spec/services/support/data_exports/users_export_spec.rb
+++ b/spec/services/support/data_exports/users_export_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Support::DataExports::UsersExport do
           email_address: user.email,
           first_login_at: user.first_login_date_utc,
           last_login_at: user.last_login_date_utc,
+          sign_in_user_id: user.sign_in_user_id,
         },
       )
     end
@@ -53,6 +54,7 @@ RSpec.describe Support::DataExports::UsersExport do
           email_address: user1.email,
           first_login_at: user1.first_login_date_utc,
           last_login_at: user1.last_login_date_utc,
+          sign_in_user_id: user1.sign_in_user_id,
         },
         {
           user_id: user2.id,
@@ -64,6 +66,7 @@ RSpec.describe Support::DataExports::UsersExport do
           email_address: user2.email,
           first_login_at: user2.first_login_date_utc,
           last_login_at: user2.last_login_date_utc,
+          sign_in_user_id: user2.sign_in_user_id,
         },
       ])
     end


### PR DESCRIPTION
### Context

We need data that we can relate to DfE Signin for analysis.

### Changes proposed in this pull request

Add sign_in_user_id to CSV export.

### Guidance to review

This field should now be on the CSV export from the support console

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
