### PR TITLE
[XXX] Provider code validation scoped to recruitment cycle added

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -120,6 +120,8 @@ class Provider < ApplicationRecord
 
   validates :provider_name, length: { maximum: 100 }, on: :update
 
+  validates :provider_code, uniqueness: { scope: :recruitment_cycle }
+
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 
   # TODO: Remove this validation once the 2021 recruitment cycle is over

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -80,8 +80,9 @@ describe Providers::CopyToRecruitmentCycleService do
     end
 
     context "the provider already exists in the new recruitment cycle" do
+      let(:old_recruitment_cycle) { create :recruitment_cycle, :previous }
       let(:new_provider) {
-        build :provider, provider_code: provider.provider_code
+        create :provider, recruitment_cycle: old_recruitment_cycle, provider_code: provider.provider_code
       }
       let(:new_recruitment_cycle) {
         create :recruitment_cycle, :next,


### PR DESCRIPTION
### Context

- We were getting 500 error pages as a result of PG errors that were not handled correctly. These PG errors were a result of duplicated indexes on the provider_code column. 
- We should be handling these errors at application level with model validations

### Changes proposed in this pull request

- Added model validations to the Provider model, for `provider_code`, scoped to the recruitment cycle

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
