### PR TITLE
Improve log formatting in development and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,6 +133,9 @@ group :development, :test do
   # Prettyprint in console
   gem "awesome_print"
 
+  # Better colorized logs
+  gem "amazing_print"
+
   # Help eliminate N+1 queries
   gem "bullet"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
+    amazing_print (1.4.0)
     ast (2.4.2)
     attr_extras (6.2.4)
     attr_required (1.0.1)
@@ -643,6 +644,7 @@ PLATFORMS
 DEPENDENCIES
   aasm
   active_model_serializers
+  amazing_print
   audited (~> 5.0)
   awesome_print
   better_errors

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,7 +53,5 @@ Rails.application.configure do
   config.active_job.queue_adapter = :async
 
   # Logging
-  config.log_level = Settings.log_level
-
-  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.log_format = :color
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,9 +32,8 @@ Rails.application.configure do
   # config.force_ssl = true
 
   # Logging
-  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
-  config.log_level = Settings.log_level
   config.rails_semantic_logger.add_file_appender = false
+  config.log_format = :json
 
   config.active_record.logger = nil # Don't log SQL in production
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,5 +55,5 @@ Rails.application.configure do
   config.active_job.queue_adapter = :test
 
   # Logging
-  config.log_level = :error
+  config.log_format = :color
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,4 +1,7 @@
-Rails.application.config.semantic_logger.application = Settings.application_name
-Rails.application.config.rails_semantic_logger.format = :json
-SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
+Rails.application.configure do
+  config.semantic_logger.application = Settings.application_name
+  config.log_tags = [:request_id]
+  config.log_level = Settings.log_level
+end
+SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.log_format)
 Rails.application.config.logger.info("Application logging to STDOUT")


### PR DESCRIPTION


### Context
We can make logging nicer in dev/test.

### Changes proposed in this pull request
- Add amazing_print gem for colorized semantic_logger output
- Update semantic_logger config to use this in dev/test, keeping json
  format in production

### Guidance to review
Run the app locally, gaze upon the logs.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
