### PR TITLE
Increase timeout on build workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
   prepare-matrix:
     name: Prepare Environment Matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     outputs:
       environments: ${{ steps.select-environments.outputs.environments || steps.set-pr-environment.outputs.environments }}
     steps:
@@ -46,6 +45,11 @@ jobs:
 
       - uses: DFE-Digital/github-actions/turnstyle@master
         name: Wait for other inprogress deployment runs
+        with:
+          initial-wait-seconds: 12
+          poll-interval-seconds: 20
+          abort-after-seconds: 3600
+          same-branch-only: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Context
Timeout reached for https://github.com/DFE-Digital/teacher-training-api/actions/runs/1389621469

### Changes proposed in this pull request
It happens to wait more than 15m for other deployments to finish. We
increase it to 1h using the action native abort-after-seconds.
Other options added to improve reliability.

### Guidance to review
Same set-up as Apply etc

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
