### PR TITLE
[xxx] Update PE course form link

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -3,9 +3,9 @@ module ProviderHelper
     cycle_key = is_current_cycle(provider.recruitment_cycle_year) ? "current_cycle" : "next_cycle"
 
     if provider.accredited_body?
-      google_form_url_for(Settings.google_forms[cycle_key].new_course_for_accredited_bodies, email, provider)
+      google_form_url_for(Settings.google_forms[cycle_key].new_pe_course_for_accredited_bodies, email, provider)
     else
-      google_form_url_for(Settings.google_forms[cycle_key].new_course_for_unaccredited_bodies, email, provider)
+      google_form_url_for(Settings.google_forms[cycle_key].new_pe_course_for_unaccredited_bodies, email, provider)
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,21 +33,21 @@ notify:
   registered_user_template_url: https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534/templates/4da327dd-907a-4619-abe6-45f348bb2fa3
 google_forms:
   current_cycle:
-    new_course_for_accredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSexQtIhIDiHM6vyy23OrJmeSoLTmLlw4y_2S3TI7FDQV2VcsQ/viewform?usp=pp_url
+    new_pe_course_for_accredited_bodies:
+      url: https://docs.google.com/forms/d/e/1FAIpQLSerPrTvuQNNkpMH_yfgJ8_o5ajthtq5XhOP9x-zG8JL4o5n-Q/viewform?usp=pp_url
       email_entry: entry.957076544
       provider_code_entry: entry.1735563938
-    new_course_for_unaccredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSdmuYIBDGuESZJBKGVTIdEFntdcjX86J5u6yXTSFNpk18oJeA/viewform?usp=pp_url
+    new_pe_course_for_unaccredited_bodies:
+      url: https://docs.google.com/forms/d/e/1FAIpQLSeZK6wGdvDy40QFiFcI8_JRgG-kPWUPBjLfY_EffebCkL0goQ/viewform?usp=pp_url
       email_entry: entry.1033530353
       provider_code_entry: entry.158771972
   # NOTE: these forms are only in use / visible during Rollover i.e. when both cycles are visible.
   next_cycle:
-    new_course_for_accredited_bodies:
+    new_pe_course_for_accredited_bodies:
       url: https://docs.google.com/forms/d/e/1FAIpQLSerPrTvuQNNkpMH_yfgJ8_o5ajthtq5XhOP9x-zG8JL4o5n-Q/viewform?usp=pp_url
       email_entry: entry.957076544
       provider_code_entry: entry.1735563938
-    new_course_for_unaccredited_bodies:
+    new_pe_course_for_unaccredited_bodies:
       url: https://docs.google.com/forms/d/e/1FAIpQLSeZK6wGdvDy40QFiFcI8_JRgG-kPWUPBjLfY_EffebCkL0goQ/viewform?usp=pp_url
       email_entry: entry.1033530353
       provider_code_entry: entry.158771972

--- a/spec/helpers/provider_helper_spec.rb
+++ b/spec/helpers/provider_helper_spec.rb
@@ -13,7 +13,7 @@ feature "View helpers", type: :helper do
         let(:recruitment_cycle) { build(:recruitment_cycle) }
 
         it "returns correct google form for the current cycle" do
-          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.current_cycle.new_course_for_accredited_bodies.url)
+          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.current_cycle.new_pe_course_for_accredited_bodies.url)
           expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
           expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
         end
@@ -23,7 +23,7 @@ feature "View helpers", type: :helper do
         let(:recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
 
         it "returns correct google form for the next cycle" do
-          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.next_cycle.new_course_for_accredited_bodies.url)
+          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.next_cycle.new_pe_course_for_accredited_bodies.url)
           expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
           expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
         end
@@ -37,7 +37,7 @@ feature "View helpers", type: :helper do
         let(:recruitment_cycle) { build(:recruitment_cycle) }
 
         it "returns correct google form for the current cycle" do
-          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.current_cycle.new_course_for_unaccredited_bodies.url)
+          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.current_cycle.new_pe_course_for_unaccredited_bodies.url)
           expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
           expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
         end
@@ -47,7 +47,7 @@ feature "View helpers", type: :helper do
         let(:recruitment_cycle) { build(:recruitment_cycle, :next_cycle) }
 
         it "returns correct google form for the next cycle" do
-          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.next_cycle.new_course_for_unaccredited_bodies.url)
+          expect(helper.add_course_url(email, provider)).to start_with(Settings.google_forms.next_cycle.new_pe_course_for_unaccredited_bodies.url)
           expect(helper.add_course_url(email, provider)).to include(html_escaped_version_of_email)
           expect(helper.add_course_url(email, provider)).to include(provider.attributes[:provider_code])
         end

--- a/spec/site_prism/page_objects/page/organisations/courses_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses_page.rb
@@ -30,19 +30,19 @@ module PageObjects
         end
 
         element :link_to_add_a_course_for_unaccredited_bodies_current_cycle,
-                "a[href^=\"#{Settings.google_forms.current_cycle.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",
+                "a[href^=\"#{Settings.google_forms.current_cycle.new_pe_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",
                 text: "Add a new course"
 
         element :link_to_add_a_course_for_accredited_bodies_current_cycle,
-                "a[href^=\"#{Settings.google_forms.current_cycle.new_course_for_accredited_bodies.url.gsub('?', '\?')}\"]",
+                "a[href^=\"#{Settings.google_forms.current_cycle.new_pe_course_for_accredited_bodies.url.gsub('?', '\?')}\"]",
                 text: "Add a new course"
 
         element :link_to_add_a_course_for_unaccredited_bodies_next_cycle,
-                "a[href^=\"#{Settings.google_forms.next_cycle.new_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",
+                "a[href^=\"#{Settings.google_forms.next_cycle.new_pe_course_for_unaccredited_bodies.url.gsub('?', '\?')}\"]",
                 text: "Add a new course"
 
         element :link_to_add_a_course_for_accredited_bodies_next_cycle,
-                "a[href^=\"#{Settings.google_forms.next_cycle.new_course_for_accredited_bodies.url.gsub('?', '\?')}\"]",
+                "a[href^=\"#{Settings.google_forms.next_cycle.new_pe_course_for_accredited_bodies.url.gsub('?', '\?')}\"]",
                 text: "Add a new course"
       end
     end


### PR DESCRIPTION
### Context

PE forms are requested via a Google form. This is linked from the course subject page and there is a different form for each year. We add the new form when we open rollover (in the 'next_cycle' settings) and then this should be transferred to the `current_cycle` when the new cycle is opened. We hadn't done that this year so it reverted back to last years form.

### Changes proposed in this pull request

* Change the link for the current cycle to the 2022/23 form
* Change the name to make it more obvious what the link is

### Guidance to review

* Run the app
* Create a new secondary course
* Click the 'separate Google form' link on the subject page
* Marvel at the 2022/23 form that opens
* The forms are different for accredited bodies and non-accredited providers so we should check both

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
