### PR TITLE
[108] Skip authenticate before action on session create

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -2,11 +2,19 @@ if AuthenticationService.persona?
   class PersonasController < ActionController::Base
     layout "application"
 
-    def index; end
+    def index
+      clear_current_sessions
+    end
 
     def current_user
       session[:auth_user].presence
     end
     helper_method :current_user
+
+  private
+
+    def clear_current_sessions
+      session[:auth_user].clear
+    end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@ class SessionsController < ApplicationController
   skip_before_action :request_login
   skip_before_action :check_interrupt_redirects
   skip_before_action :verify_authenticity_token, if: proc { AuthenticationService.persona? }
-  skip_before_action :authenticate, only: :create
+  skip_before_action :authenticate, if: -> { AuthenticationService.persona? && action_name == "create" }
 
   def create
     session[:auth_user] = HashWithIndifferentAccess.new(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,7 @@ class SessionsController < ApplicationController
   skip_before_action :request_login
   skip_before_action :check_interrupt_redirects
   skip_before_action :verify_authenticity_token, if: proc { AuthenticationService.persona? }
+  skip_before_action :authenticate, only: :create
 
   def create
     session[:auth_user] = HashWithIndifferentAccess.new(


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/zRL3bsvg/108-bug-json-api-pundit-errors-if-you-use-back-button-on-personas-on-qa)

### Changes proposed in this pull request

- Added `skip_before_action :authenticate, on: :create` to ensure that pre-populated sessions that were invalid/not ended did not contaminate the authentication process. This was done where users could "log out" but their session not destroyed, by using the back button (which loads a cached sign-in page, enabling them to log in as another user while still in an active user session)

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
