### PR TITLE
[373] Handle nil sessions

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -14,7 +14,7 @@ if AuthenticationService.persona?
   private
 
     def clear_current_sessions
-      session[:auth_user].clear
+      session[:auth_user]&.clear
     end
   end
 end


### PR DESCRIPTION
### Context

We recently added this to clear the persona login if the user clicks the back link onto the index page. We also need to handle when the user first arrives at the index page without a session.

### Changes proposed in this pull request

* Handle session[:auth_user] being nil

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
