### PR TITLE
[367] Enable deletion of access requests from UI

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -36,6 +36,12 @@ class AccessRequestsController < ApplicationController
     end
   end
 
+  def destroy
+    AccessRequest.new(id: params[:id]).destroy
+    flash[:success] = "Successfully deleted the Access Request"
+    redirect_to access_requests_path
+  end
+
 private
 
   def access_request_params

--- a/app/views/access_requests/_access_request.html.erb
+++ b/app/views/access_requests/_access_request.html.erb
@@ -8,7 +8,7 @@
     &lt;<%= access_request.email_address %>&gt;
   </td>
   <td class="govuk-table__cell">
-    <%= govuk_button_link_to "View Request", confirm_access_request_path(access_request.id), class: "govuk-!-margin-bottom-1", data: { qa: "access-request__confirm" } %>
+    <%= govuk_button_link_to "View Request", confirm_access_request_path(access_request.id), class: "govuk-!-margin-bottom-1", data: { qa: "access-request__view_request" } %>
   </td>
   <td class="govuk-table__cell" data-qa="access-request__organisation"><%= access_request.organisation %></td>
 </tr>

--- a/app/views/access_requests/_access_request.html.erb
+++ b/app/views/access_requests/_access_request.html.erb
@@ -8,7 +8,7 @@
     &lt;<%= access_request.email_address %>&gt;
   </td>
   <td class="govuk-table__cell">
-    <%= govuk_button_link_to "Approve", confirm_access_request_path(access_request.id), class: "govuk-!-margin-bottom-0", data: { qa: "access-request__approve" } %>
+    <%= govuk_button_link_to "View Request", confirm_access_request_path(access_request.id), class: "govuk-!-margin-bottom-1", data: { qa: "access-request__confirm" } %>
   </td>
   <td class="govuk-table__cell" data-qa="access-request__organisation"><%= access_request.organisation %></td>
 </tr>

--- a/app/views/access_requests/confirm.html.erb
+++ b/app/views/access_requests/confirm.html.erb
@@ -19,4 +19,11 @@
   </div>
 </div>
 
-<%= govuk_button_to "Approve", approve_access_request_path(@access_request.id), data: { qa: "access-request__approve" } %>
+<div class="govuk-button-group">
+  <%= govuk_button_to("Approve", approve_access_request_path(@access_request.id), data: { qa: "access-request__approve" }) %>
+  <%= govuk_button_to("Delete",
+    access_request_path(@access_request.id),
+    method: :delete,
+    class: "govuk-button govuk-button--warning",
+    data: { qa: "access-request__delete" })%>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
   resources :access_requests, path: "/access-requests", controller: "access_requests", only: %i[new index create] do
     member do
       post :approve
+      delete :destroy
       get :confirm
       get "/inform-publisher", to: "access_requests#inform_publisher"
     end

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -12,12 +12,14 @@ feature "Access Requests", type: :feature do
   let(:user) { build(:user, organisations: [organisation]) }
 
   let(:submitted_access_request) { stub_api_v2_request("/access_requests/#{access_request.id}/approve", nil, :post) }
+  let(:deleted_access_request) { stub_api_v2_request("/access_requests/#{access_request.id}", nil, :delete) }
   before do
     signed_in_user
 
     stub_api_v2_resource(access_request, include: "requester,requester.organisations")
     stub_api_v2_resource_collection([access_request], include: "requester")
     submitted_access_request
+    deleted_access_request
   end
 
   describe "page header" do
@@ -134,10 +136,18 @@ feature "Access Requests", type: :feature do
 
     it "can approve a request" do
       visit access_requests_path
-      list_access_requests_page.access_requests.first.approve.click
+      list_access_requests_page.access_requests.first.view_request.click
       expect(confirm_access_requests_page).to be_displayed
       confirm_access_requests_page.approve.click
       expect(submitted_access_request).to have_been_requested
+    end
+
+    it "can decline a request" do
+      visit access_requests_path
+      list_access_requests_page.access_requests.first.view_request.click
+      expect(confirm_access_requests_page).to be_displayed
+      confirm_access_requests_page.delete.click
+      expect(deleted_access_request).to have_been_requested
     end
   end
 
@@ -156,14 +166,14 @@ feature "Access Requests", type: :feature do
 
     it "displays the inform publisher page when a request is approved" do
       visit access_requests_path
-      list_access_requests_page.access_requests.first.approve.click
+      list_access_requests_page.access_requests.first.view_request.click
       confirm_access_requests_page.approve.click
       expect(inform_publisher_page).to be_displayed
     end
 
     it "links to the correct pages" do
       visit access_requests_path
-      list_access_requests_page.access_requests.first.approve.click
+      list_access_requests_page.access_requests.first.view_request.click
       confirm_access_requests_page.approve.click
       expect(inform_publisher_page.dfe_signin_search_link[:href]).to eq("#{Settings.dfe_signin.user_search_url}?criteria=aswartz@mymail.co")
       expect(inform_publisher_page.notify_service_link[:href]).to eq("https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534")

--- a/spec/site_prism/page_objects/page/organisations/confirm_access_requests_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/confirm_access_requests_page.rb
@@ -5,6 +5,7 @@ module PageObjects
         set_url "/access-requests/{id}/confirm"
 
         element :approve, "[data-qa=\"access-request__approve\"]"
+        element :delete, "[data-qa=\"access-request__delete\"]"
       end
     end
   end

--- a/spec/site_prism/page_objects/page/organisations/list_access_requests_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/list_access_requests_page.rb
@@ -10,7 +10,7 @@ module PageObjects
           element :request_date, "[data-qa=\"access-request__request_date\"]"
           element :requester, "[data-qa=\"access-request__requester\"]"
           element :recipient, "[data-qa=\"access-request__recipient\"]"
-          element :approve, "[data-qa=\"access-request__approve\"]"
+          element :view_request, "[data-qa=\"access-request__confirm\"]"
           element :organisation, "[data-qa=\"access-request__organisation\"]"
         end
       end

--- a/spec/site_prism/page_objects/page/organisations/list_access_requests_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/list_access_requests_page.rb
@@ -10,7 +10,7 @@ module PageObjects
           element :request_date, "[data-qa=\"access-request__request_date\"]"
           element :requester, "[data-qa=\"access-request__requester\"]"
           element :recipient, "[data-qa=\"access-request__recipient\"]"
-          element :view_request, "[data-qa=\"access-request__confirm\"]"
+          element :view_request, "[data-qa=\"access-request__view_request\"]"
           element :organisation, "[data-qa=\"access-request__organisation\"]"
         end
       end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/Ham3owQ3/367-allow-access-requests-to-be-deleted-in-the-ui)

### Changes proposed in this pull request

- Enable deletion of Access Requests from the UI

### Guidance to review

- Log in as Colin
- Make an Access Request
- Go to the Access Request
- Click on view 
- Click on Delete
- See the Success Message

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
