### PR TITLE
Increase timeout on build workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
   prepare-matrix:
     name: Prepare Environment Matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     outputs:
       environments: ${{ steps.select-environments.outputs.environments || steps.set-pr-environment.outputs.environments }}
     steps:
@@ -46,6 +45,11 @@ jobs:
 
       - uses: DFE-Digital/github-actions/turnstyle@master
         name: Wait for other inprogress deployment runs
+        with:
+          initial-wait-seconds: 12
+          poll-interval-seconds: 20
+          abort-after-seconds: 3600
+          same-branch-only: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION

### Context
Some jobs are timing out https://github.com/DFE-Digital/publish-teacher-training/runs/4250898405?check_suite_focus=true
### Changes proposed in this pull request

The wait may be longer than 15 minutes if waiting for other deployments to
finish.

- Increase to 1 hour using abort-after-seconds
- Add some other options for improved reliability

### Guidance to review
Same config as Apply, TTAPI, etc

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
