### PR TITLE
[365] Amended for SEND to be editable by admins after a course is published

### DIFF
--- a/app/views/courses/_basic_details_tab.html.erb
+++ b/app/views/courses/_basic_details_tab.html.erb
@@ -9,8 +9,20 @@
 
       <% summary_list.row(html_attributes: { data: { qa: "course__is_send" } }) do |row| %>
         <% row.key { raw("<abbr class=\"app-!-text-decoration-underline-dotted\" title=\"Special educational needs and disability\">SEND</abbr>") } %>
-        <% row.value { course.is_send? } %>
-        <% if @course.meta["edit_options"]["show_is_send"] %>
+        <% row.value do %>
+          <% if current_user["admin"] && !@course.meta["edit_options"]["show_is_send"]%>
+            <p class="govuk-body"><%= course.is_send? %></p>
+            <div class="app-status-box app-status-box--admin">
+              <p class="govuk-body">
+                <%= govuk_tag(text: "Admin feature", colour: "purple") %>
+              </p>
+              <p class="govuk-body">Only admins can make changes</p>
+            </div>
+          <% else %>
+            <%= course.is_send? %>
+          <% end %>
+        <% end %>
+        <% if @course.meta["edit_options"]["show_is_send"] || current_user["admin"]%>
           <% row.action({
             href: send_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
             visually_hidden_text: "SEND",

--- a/spec/features/courses/send/edit_spec.rb
+++ b/spec/features/courses/send/edit_spec.rb
@@ -6,8 +6,10 @@ feature "Edit course SEND", type: :feature do
   let(:course_details_page) { PageObjects::Page::Organisations::CourseDetails.new }
   let(:provider) { build(:provider) }
 
+  let(:user) { build(:user) }
+
   before do
-    signed_in_user
+    signed_in_user(user: user)
     stub_api_v2_resource(current_recruitment_cycle)
     stub_api_v2_resource(provider, include: "courses.accrediting_provider")
     stub_api_v2_resource(provider)
@@ -50,6 +52,15 @@ feature "Edit course SEND", type: :feature do
       scenario "should not show the edit link" do
         course_details_page.load_with_course(course)
         expect(course_details_page.is_send).to_not have_change_link
+      end
+
+      context "if the user signed as admin" do
+        let(:user) { build(:user, :admin) }
+
+        scenario "should show the edit link" do
+          course_details_page.load_with_course(course)
+          expect(course_details_page.is_send).to have_change_link
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
SEND to be editable by admins after a course is published

### Changes proposed in this pull request
Amended for SEND to be editable by admins after a course is published

### Guidance to review

Requires https://github.com/DFE-Digital/teacher-training-api/pull/2289 

![send-off](https://user-images.githubusercontent.com/470137/142648018-6be6d332-60d9-4226-9871-eadd7976ab1e.gif)



### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
