### PR TITLE
Only run delete-review-app if labelled with deploy

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -8,12 +8,11 @@ on:
 jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
-    if: github.actor != 'dependabot[bot]'
+    if: contains(github.event.pull_request.labels.*.name, 'deploy')
     runs-on: ubuntu-latest
     steps:
       - name: Wait for Deploy App Workflow for review
         id: wait_for_deployment
-        if: contains(github.event.pull_request.labels.*.name, 'deploy')
         uses: fountainhead/action-wait-for-check@v1.0.0
         with:
          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Context

[https://trello.com/c/wPYN3Buf/466-publish-skip-delete-review-app-workflow](url)

The delete-review-app job should not run at all if there is no review app. ie there is no "deploy" label
Example: [https://github.com/DFE-Digital/publish-teacher-training/runs/4380479212](url)

Also it should run for dependabot PRs if there is a review app. 
Unlike here: [https://github.com/DFE-Digital/publish-teacher-training/actions/runs/1558507179](url)

### Changes proposed in this pull request

The build.yml workflow ONLY builds a review app if the PR is labelled with deploy.
Currently delete-review-app.yml won't run the delete step if the actor is dependabot.
So replacing this with a check for the 'deploy' label should fix both issues.

### Guidance to review

Confirm the workflow runs as above when the PR is closed.

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
