### PR TITLE
Add example proxy to New Publish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ ruby "2.7.4"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 6.1"
 
+gem "rack-proxy", "~> 0.7.0"
+
 # Use Puma as the app server
 gem "puma", "~> 5.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -620,6 +620,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.5)
+  rack-proxy (~> 0.7.0)
   rails (~> 6.1)
   rails-controller-testing
   rails_semantic_logger

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module ManageCoursesFrontend
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.hosts << "www.publish.test"
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/example_publish_proxy.rb
+++ b/config/initializers/example_publish_proxy.rb
@@ -1,0 +1,36 @@
+class ExamplePublishProxy < Rack::Proxy
+  def perform_request(env)
+    request = Rack::Request.new(env)
+
+    path_matchers = [
+      %r{^/organisations/\w+/\d{4}/details},
+      %r{^/organisations/\w+/\d{4}/about},
+      %r{^/organisations/\w+/\d{4}/contact},
+      %r{^/publish/organisations/\w+/\d{4}/details},
+      %r{^/publish/organisations/\w+/\d{4}/about},
+      %r{^/publish/organisations/\w+/\d{4}/contact},
+    ]
+    matched = path_matchers.any? { |m| request.path =~ m }
+
+    if matched
+      env["HTTP_HOST"] = request.host_with_port
+
+      env["PATH_INFO"] = if request.fullpath.include?("/publish")
+                           request.fullpath
+                         else
+                           "/publish#{request.fullpath}"
+                         end
+
+      # Prevent Keep-Alive from causing a delay of several seconds in each request
+      env["HTTP_CONNECTION"] = "close"
+
+      # Don't send your sites cookies to target service, unless it is a trusted internal service that can parse all your cookies
+      # env["HTTP_COOKIE"] = ""
+      super(env)
+    else
+      @app.call(env)
+    end
+  end
+end
+
+Rails.application.config.middleware.use ExamplePublishProxy, backend: "http://www.ttapi.test:3001", streaming: false


### PR DESCRIPTION
Includes:

- the rack-proxy gem to assist in performing the request to New Publish
- a proxying middleware that matches certain paths to decide whether or
  not to forward the request
- hosts config to test this with a non-localhost domain (needs pairing
  with an entry in /etc/hosts)

### Context
Draft PR to share results of this spike with the team. See [matching PR](https://github.com/DFE-Digital/teacher-training-api/pull/2357) on TTAPI for more detail.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
