### PR TITLE
[515] Add helper to generate links to new publish

### DIFF
--- a/app/helpers/site_helper.rb
+++ b/app/helpers/site_helper.rb
@@ -2,4 +2,8 @@ module SiteHelper
   def urn_required?(recruitment_cycle_year)
     recruitment_cycle_year >= Site::URN_2022_REQUIREMENTS_REQUIRED_FROM
   end
+
+  def new_publish_link_for(path)
+    "#{Settings.new_publish_url}/publish#{path}"
+  end
 end

--- a/app/views/providers/details.html.erb
+++ b/app/views/providers/details.html.erb
@@ -37,7 +37,9 @@
         "Training with your organisation",
         @provider.train_with_us,
         %w[train_with_us],
-        action_path: "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-us",
+        action_path: new_publish_link_for(
+          "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-us"
+        ),
         action_visually_hidden_text: "details about training with your organisation",
       ) %>
 
@@ -49,7 +51,9 @@
             "#{provider['provider_name']} (optional)",
             provider["description"],
             ["accrediting_provider_#{provider['provider_code']}"],
-            action_path: "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{provider['provider_code']}",
+            action_path: new_publish_link_for(
+              "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{provider['provider_code']}"
+            ),
             action_visually_hidden_text: "details about #{provider['provider_name']}",
           ) %>
         <% end %>
@@ -61,7 +65,9 @@
         "Training with disabilities and other needs",
         @provider.train_with_disability,
         %w[train_with_disability],
-        action_path: "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-disability",
+        action_path: new_publish_link_for(
+          "#{about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-disability"
+        ),
         action_visually_hidden_text: "details about training with disabilities and other needs",
       ) %>
 
@@ -73,7 +79,7 @@
           visa_sponsorship_status(@provider),
           %w[can_sponsor_student_visa can_sponsor_skilled_worker_visa],
           truncate_value: false,
-          action_path: provider.declared_visa_sponsorship? ? provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year) : nil,
+          action_path: provider.declared_visa_sponsorship? ? new_publish_link_for(provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year)) : nil,
           action_visually_hidden_text: "if candidates can get visa sponsorship",
         ) %>
       <% end %>
@@ -87,7 +93,9 @@
         "Email address",
         @provider.email,
         %w[email],
-        action_path: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#email",
+        action_path: new_publish_link_for(
+          "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#email"
+        ),
         action_visually_hidden_text: "email address",
       ) %>
 
@@ -97,7 +105,9 @@
         "Telephone number",
         @provider.telephone,
         %w[telephone],
-        action_path: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#telephone",
+        action_path: new_publish_link_for(
+          "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#telephone"
+        ),
         action_visually_hidden_text: "telephone number",
       ) %>
 
@@ -107,7 +117,9 @@
         "Website",
         @provider.website,
         %w[website],
-        action_path: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#website",
+        action_path: new_publish_link_for(
+          "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#website"
+        ),
         action_visually_hidden_text: "website",
       ) %>
 
@@ -117,7 +129,9 @@
         "UKPRN",
         @provider.ukprn,
         %w[ukprn],
-        action_path: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#ukprn",
+        action_path: new_publish_link_for(
+          "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#ukprn"
+        ),
         action_visually_hidden_text: "UKPRN",
       ) %>
 
@@ -128,7 +142,9 @@
           "URN",
           @provider.urn,
           %w[urn],
-          action_path: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#urn",
+          action_path: new_publish_link_for(
+            "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#urn"
+          ),
           action_visually_hidden_text: "URN",
         ) %>
       <% end %>
@@ -139,7 +155,9 @@
         "Contact address",
         @provider.full_address,
         %w[address1 address2 address3 address4 postcode],
-        action_path: "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#address",
+        action_path: new_publish_link_for(
+          "#{contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#address"
+        ),
         action_visually_hidden_text: "contact address",
       ) %>
     <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
 publish_url: https://localhost:3000
+new_publish_url: https://localhost:3001
 
 dfe_signin:
   # Our service name

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,4 +1,4 @@
-publish_url: https://localhost:3000 
+publish_url: https://localhost:3000
 
 dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,4 +1,5 @@
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
+new_publish_url: https://www2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://oidc.signin.education.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,4 +1,5 @@
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
+new_publish_url: https://qa2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -1,4 +1,5 @@
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
+new_publish_url: https://sandbox2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://oidc.signin.education.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,4 +1,5 @@
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
+new_publish_url: https://staging2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://pp-oidc.signin.education.gov.uk

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 feature "View provider", type: :feature do
+  include SiteHelper
+
   let(:org_detail_page) { PageObjects::Page::Organisations::OrganisationDetails.new }
   let(:org_contact_page) { PageObjects::Page::Organisations::OrganisationContact.new }
 
@@ -58,7 +60,7 @@ feature "View provider", type: :feature do
 
     expect(org_detail_page).to have_link(
       "Change contact address",
-      href: "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/contact#address",
+      href: new_publish_link_for("/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/contact#address"),
     )
 
     expect(org_detail_page.email).to have_content(provider.email)
@@ -67,7 +69,7 @@ feature "View provider", type: :feature do
 
     expect(org_detail_page).to have_link(
       "details about training with your organisation",
-      href: "/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/about#train-with-us",
+      href: new_publish_link_for("/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/about#train-with-us"),
     )
     expect(org_detail_page.train_with_us).to have_content(provider.train_with_us)
     expect(org_detail_page.train_with_disability).to have_content(provider.train_with_disability)

--- a/spec/features/providers/visa_spec.rb
+++ b/spec/features/providers/visa_spec.rb
@@ -64,8 +64,7 @@ feature "View and edit provider visa sponsorship", type: :feature do
             "can_sponsor_skilled_worker_visa" => false,
           )
         end
-        visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
-        click_link "Select if visas can be sponsored"
+        visit provider_recruitment_cycle_visas_path(provider.provider_code, provider.recruitment_cycle.year)
         within_fieldset("Can candidates get a sponsored Student visa for your fee-paying courses?") do
           choose "Yes"
         end
@@ -100,11 +99,8 @@ feature "View and edit provider visa sponsorship", type: :feature do
             "can_sponsor_skilled_worker_visa" => true,
           )
         end
-        visit details_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
 
-        within find("[data-qa='enrichment__can_sponsor_student_visa']") do
-          click_link "Change"
-        end
+        visit provider_recruitment_cycle_visas_path(provider.provider_code, provider.recruitment_cycle.year)
 
         within_fieldset("Can candidates get a sponsored Student visa for your fee-paying courses?") do
           choose "No"

--- a/spec/helpers/site_helper_spec.rb
+++ b/spec/helpers/site_helper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SiteHelper do
+  include SiteHelper
+
+  describe "#new_publish_link_for" do
+    let(:path) { "/organisations/random" }
+    let(:expected_path) { "#{Settings.new_publish_url}/publish/organisations/random" }
+
+    it "returns a correct url linking back to the old publish" do
+      expect(new_publish_link_for(path)).to eq(expected_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/6Ay3bdEp/515-add-breadcrumbs-helper-for-migrated-publish-code

### Changes proposed in this pull request

Create a helper for generating links to new publish for migrated sections

### Guidance to review

Depends on this https://github.com/DFE-Digital/teacher-training-api/pull/2394 and the new publish domains set up/working

### Checklist

- [x] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
