### PR TITLE
Add link to About Your Org on New Publish

### DIFF
--- a/app/helpers/new_publish_helper.rb
+++ b/app/helpers/new_publish_helper.rb
@@ -1,0 +1,5 @@
+module NewPublishHelper
+  def new_publish_url(path)
+    Settings.new_publish.base_url + path
+  end
+end

--- a/app/helpers/new_publish_helper.rb
+++ b/app/helpers/new_publish_helper.rb
@@ -1,5 +1,5 @@
 module NewPublishHelper
   def new_publish_url(path)
-    Settings.new_publish.base_url + path
+    "#{Settings.new_publish.base_url}/publish#{path}"
   end
 end

--- a/app/views/recruitment_cycles/_about_organisation.html.erb
+++ b/app/views/recruitment_cycles/_about_organisation.html.erb
@@ -1,5 +1,9 @@
 <h2 class="govuk-heading-m">
-  <%= govuk_link_to "About your organisation", details_provider_recruitment_cycle_path(provider.provider_code, year) %>
+  <% if FeatureService.enabled?('new_publish.about_your_org') %>
+    <%= govuk_link_to "About your organisation", new_publish_url(details_provider_recruitment_cycle_path(provider.provider_code, year)) %>
+  <% else %>
+    <%= govuk_link_to "About your organisation", details_provider_recruitment_cycle_path(provider.provider_code, year) %>
+  <% end %>
 </h2>
 <p class="govuk-body">Use this section to:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -101,6 +101,8 @@ features:
     title: "This service will be unavailable on Thursday 11 October from 8pm to 9pm, while we carry out maintenance."
     body: "If you have any questions, contact us at becomingateacher@digital.education.gov.uk"
   send_request_data_to_bigquery: false
+  new_publish:
+    about_your_org: false
 
 authentication:
   mode: dfe_signin # default authentication mode

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,8 @@ teacher_training_api:
   issuer: "publish-teacher-training"
   audience: "teacher-training-api"
   subject: "access"
+new_publish:
+  base_url: http://localhost:3001
 
 search_ui:
   # URL of the C# search ui app (search-and-compare-ui)

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,7 +7,7 @@ teacher_training_api:
   secret: secret
   base_url: http://localhost:3001
 new_publish:
-  base_url: http://localhost:3001/publish
+  base_url: http://localhost:3001
 search_ui:
   base_url: https://localhost:5000
 environment:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,4 +1,4 @@
-publish_url: https://localhost:3000 
+publish_url: https://localhost:3000
 
 dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
@@ -6,6 +6,8 @@ dfe_signin:
 teacher_training_api:
   secret: secret
   base_url: http://localhost:3001
+new_publish:
+  base_url: http://localhost:3001/publish
 search_ui:
   base_url: https://localhost:5000
 environment:
@@ -18,4 +20,4 @@ use_ssl: false
 authentication:
   mode: persona     # none critical systems, ie localhost
   basic_auth:       # mainly to enforce for none critical systems
-    disabled: true 
+    disabled: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -21,3 +21,6 @@ authentication:
   mode: persona     # none critical systems, ie localhost
   basic_auth:       # mainly to enforce for none critical systems
     disabled: true
+features:
+   new_publish:
+     about_your_org: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -8,6 +8,8 @@ dfe_signin:
   user_search_url: https://support.signin.education.gov.uk/users
 teacher_training_api:
   base_url: https://api.publish-teacher-training-courses.service.gov.uk
+new_publish:
+  base_url: https://www2.publish-teacher-training-courses.service.gov.uk/publish
 search_ui:
   base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -9,7 +9,7 @@ dfe_signin:
 teacher_training_api:
   base_url: https://api.publish-teacher-training-courses.service.gov.uk
 new_publish:
-  base_url: https://www2.publish-teacher-training-courses.service.gov.uk/publish
+  base_url: https://www2.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -17,3 +17,5 @@ authentication:
 features:
    rollover:
      can_edit_current_and_next_cycles: true
+   new_publish:
+     about_your_org: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -5,6 +5,8 @@ dfe_signin:
   base_url: https://qa.publish-teacher-training-courses.service.gov.uk
 teacher_training_api:
   base_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
+new_publish:
+  base_url: https://qa2.publish-teacher-training-courses.service.gov.uk/publish
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -6,7 +6,7 @@ dfe_signin:
 teacher_training_api:
   base_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 new_publish:
-  base_url: https://qa2.publish-teacher-training-courses.service.gov.uk/publish
+  base_url: https://qa2.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -1,5 +1,7 @@
 teacher_training_api:
   base_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
+new_publish:
+  base_url: https://qa2.publish-teacher-training-courses.service.gov.uk/publish
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -1,7 +1,7 @@
 teacher_training_api:
   base_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 new_publish:
-  base_url: https://qa2.publish-teacher-training-courses.service.gov.uk/publish
+  base_url: https://qa2.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -9,7 +9,7 @@ dfe_signin:
 teacher_training_api:
   base_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 new_publish:
-  base_url: https://sandbox2.publish-teacher-training-courses.service.gov.uk/publish
+  base_url: https://sandbox2.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -8,6 +8,8 @@ dfe_signin:
   user_search_url: https://support.signin.education.gov.uk/users
 teacher_training_api:
   base_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
+new_publish:
+  base_url: https://sandbox2.publish-teacher-training-courses.service.gov.uk/publish
 search_ui:
   base_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -8,6 +8,8 @@ dfe_signin:
   user_search_url: https://pp-support.signin.education.gov.uk/users
 teacher_training_api:
   base_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
+new_publish:
+  base_url: https://staging2.publish-teacher-training-courses.service.gov.uk/publish
 search_ui:
   base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -9,7 +9,7 @@ dfe_signin:
 teacher_training_api:
   base_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 new_publish:
-  base_url: https://staging2.publish-teacher-training-courses.service.gov.uk/publish
+  base_url: https://staging2.publish-teacher-training-courses.service.gov.uk
 search_ui:
   base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 environment:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -4,6 +4,8 @@ dfe_signin:
   base_url: https://localhost:3000
 teacher_training_api:
   base_url: http://localhost:3001
+new_publish:
+  base_url: http://localhost:3001/publish
 search_ui:
   base_url: https://localhost:5000
 environment:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -5,7 +5,7 @@ dfe_signin:
 teacher_training_api:
   base_url: http://localhost:3001
 new_publish:
-  base_url: http://localhost:3001/publish
+  base_url: http://localhost:3001
 search_ui:
   base_url: https://localhost:5000
 environment:

--- a/spec/helpers/new_publish_helper_spec.rb
+++ b/spec/helpers/new_publish_helper_spec.rb
@@ -7,7 +7,7 @@ describe NewPublishHelper do
 
   describe "#new_publish_url" do
     let(:path) { "/organisations/random" }
-    let(:expected_path) { "#{Settings.new_publish.base_url}/organisations/random" }
+    let(:expected_path) { "#{Settings.new_publish.base_url}/publish/organisations/random" }
 
     it "returns a correct url linking back to the old publish" do
       expect(new_publish_url(path)).to eq(expected_path)

--- a/spec/helpers/new_publish_helper_spec.rb
+++ b/spec/helpers/new_publish_helper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe NewPublishHelper do
+  include NewPublishHelper
+
+  describe "#new_publish_url" do
+    let(:path) { "/organisations/random" }
+    let(:expected_path) { "#{Settings.new_publish.base_url}/organisations/random" }
+
+    it "returns a correct url linking back to the old publish" do
+      expect(new_publish_url(path)).to eq(expected_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context
This section is now present in New Publish. We can start directing users there when they click through to it.
https://trello.com/c/hqN5Z7pB
### Changes proposed in this pull request
Add a helper method and feature flag so we can conditionally link to About Your Org on New Publish.

### Guidance to review
Can be tested locally — clicking the About Your Organisation link will take you to dev TTAPI (localhost:3001 by default).

Is feature flagged, so can also be tested on QA after merge.

### Checklist

- [x] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
