### PR TITLE
[0570] Added redirect for the details page to new publish

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include NewPublishHelper
+
   protect_from_forgery with: :exception, except: :not_found
   rescue_from JsonApiClient::Errors::NotAuthorized, with: :render_unauthorized
   rescue_from JsonApiClient::Errors::AccessDenied, with: :handle_access_denied

--- a/app/controllers/providers/visas_controller.rb
+++ b/app/controllers/providers/visas_controller.rb
@@ -1,7 +1,7 @@
 module Providers
   class VisasController < ApplicationController
     def edit
-      redirect_to_new_publish_url_provider_recruitment_cycle_visas_path if FeatureService.enabled?("new_publish.about_your_org")
+      redirect_to_new_publish_equivalent if FeatureService.enabled?("new_publish.about_your_org")
 
       @form_object = ProviderVisaForm.new(
         can_sponsor_skilled_worker_visa: provider.can_sponsor_skilled_worker_visa,
@@ -25,10 +25,6 @@ module Providers
     end
 
   private
-
-    def redirect_to_new_publish_url_provider_recruitment_cycle_visas_path
-      redirect_to new_publish_url(provider_recruitment_cycle_visas_path(provider.provider_code, provider.recruitment_cycle_year))
-    end
 
     def provider
       @provider ||= Provider

--- a/app/controllers/providers/visas_controller.rb
+++ b/app/controllers/providers/visas_controller.rb
@@ -1,6 +1,8 @@
 module Providers
   class VisasController < ApplicationController
     def edit
+      redirect_to_new_publish_url_provider_recruitment_cycle_visas_path if FeatureService.enabled?("new_publish.about_your_org")
+
       @form_object = ProviderVisaForm.new(
         can_sponsor_skilled_worker_visa: provider.can_sponsor_skilled_worker_visa,
         can_sponsor_student_visa: provider.can_sponsor_student_visa,
@@ -23,6 +25,10 @@ module Providers
     end
 
   private
+
+    def redirect_to_new_publish_url_provider_recruitment_cycle_visas_path
+      redirect_to new_publish_url(provider_recruitment_cycle_visas_path(provider.provider_code, provider.recruitment_cycle_year))
+    end
 
     def provider
       @provider ||= Provider

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -26,7 +26,7 @@ class ProvidersController < ApplicationController
   end
 
   def details
-    redirect_to_new_publish_url_details_provider_recruitment_cycle_path if FeatureService.enabled?("new_publish.about_your_org")
+    redirect_to_new_publish_equivalent if FeatureService.enabled?("new_publish.about_your_org")
 
     redirect_to_contact_page_with_ukprn_error if @provider.ukprn.blank?
 
@@ -35,13 +35,13 @@ class ProvidersController < ApplicationController
   end
 
   def contact
-    redirect_to_new_publish_url_contact_provider_recruitment_cycle_path if FeatureService.enabled?("new_publish.about_your_org")
+    redirect_to_new_publish_equivalent if FeatureService.enabled?("new_publish.about_your_org")
 
     show_deep_linked_errors(%i[email telephone website address1 address3 address4 postcode])
   end
 
   def about
-    redirect_to_new_publish_url_about_provider_recruitment_cycle_path if FeatureService.enabled?("new_publish.about_your_org")
+    redirect_to_new_publish_equivalent if FeatureService.enabled?("new_publish.about_your_org")
 
     show_deep_linked_errors(%i[train_with_us train_with_disability])
   end
@@ -181,22 +181,6 @@ private
 
   def providers
     @providers ||= Provider.where(recruitment_cycle_year: Settings.current_cycle)
-  end
-
-  def redirect_to_new_publish_url_about_provider_recruitment_cycle_path
-    redirect_to new_publish_url(about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
-  end
-
-  def redirect_to_new_publish_url_contact_provider_recruitment_cycle_path
-    redirect_to new_publish_url(contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
-  end
-
-  def redirect_to_new_publish_url_details_provider_recruitment_cycle_path
-    redirect_to new_publish_url(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
-  end
-
-  def redirect_to_new_publish_url_show_provider_recruitment_cycle_path
-    redirect_to new_publish_url(provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
   end
 
   def redirect_to_contact_page_with_ukprn_error

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -1,4 +1,6 @@
 class ProvidersController < ApplicationController
+  include NewPublishHelper
+
   decorates_assigned :provider
   decorates_assigned :training_provider
   before_action :build_recruitment_cycle
@@ -26,6 +28,8 @@ class ProvidersController < ApplicationController
   end
 
   def details
+    redirect_to_new_publish_url_details_provider_recruitment_cycle_path if FeatureService.enabled?("new_publish.about_your_org")
+
     redirect_to_contact_page_with_ukprn_error if @provider.ukprn.blank?
 
     @errors = flash[:error_summary]
@@ -175,6 +179,10 @@ private
 
   def providers
     @providers ||= Provider.where(recruitment_cycle_year: Settings.current_cycle)
+  end
+
+  def redirect_to_new_publish_url_details_provider_recruitment_cycle_path
+    redirect_to new_publish_url(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
   end
 
   def redirect_to_contact_page_with_ukprn_error

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -1,6 +1,4 @@
 class ProvidersController < ApplicationController
-  include NewPublishHelper
-
   decorates_assigned :provider
   decorates_assigned :training_provider
   before_action :build_recruitment_cycle
@@ -37,10 +35,14 @@ class ProvidersController < ApplicationController
   end
 
   def contact
+    redirect_to_new_publish_url_contact_provider_recruitment_cycle_path if FeatureService.enabled?("new_publish.about_your_org")
+
     show_deep_linked_errors(%i[email telephone website address1 address3 address4 postcode])
   end
 
   def about
+    redirect_to_new_publish_url_about_provider_recruitment_cycle_path if FeatureService.enabled?("new_publish.about_your_org")
+
     show_deep_linked_errors(%i[train_with_us train_with_disability])
   end
 
@@ -181,8 +183,20 @@ private
     @providers ||= Provider.where(recruitment_cycle_year: Settings.current_cycle)
   end
 
+  def redirect_to_new_publish_url_about_provider_recruitment_cycle_path
+    redirect_to new_publish_url(about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
+  end
+
+  def redirect_to_new_publish_url_contact_provider_recruitment_cycle_path
+    redirect_to new_publish_url(contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
+  end
+
   def redirect_to_new_publish_url_details_provider_recruitment_cycle_path
     redirect_to new_publish_url(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
+  end
+
+  def redirect_to_new_publish_url_show_provider_recruitment_cycle_path
+    redirect_to new_publish_url(provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year))
   end
 
   def redirect_to_contact_page_with_ukprn_error

--- a/app/helpers/new_publish_helper.rb
+++ b/app/helpers/new_publish_helper.rb
@@ -2,4 +2,8 @@ module NewPublishHelper
   def new_publish_url(path)
     "#{Settings.new_publish.base_url}/publish#{path}"
   end
+
+  def redirect_to_new_publish_equivalent
+    redirect_to new_publish_url(request.path)
+  end
 end

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -14,3 +14,5 @@ allocations_close_date: 2021-07-02
 features:
   allocations:
     state: confirmed
+  new_publish:
+     about_your_org: true

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -414,7 +414,7 @@ describe ApplicationController, type: :controller do
   end
 
   describe "#redirect_to_new_publish_equivalent" do
-    it "returns a correct url linking back to the old publish" do
+    it "returns a correct url linking back to the new publish" do
       allow(request).to receive(:path).and_return("/haircut")
 
       expect(controller.redirect_to_new_publish_equivalent).to redirect_to("#{Settings.new_publish.base_url}/publish/haircut")

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -413,6 +413,14 @@ describe ApplicationController, type: :controller do
     end
   end
 
+  describe "#redirect_to_new_publish_equivalent" do
+    it "returns a correct url linking back to the old publish" do
+      allow(request).to receive(:path).and_return("/haircut")
+
+      expect(controller.redirect_to_new_publish_equivalent).to redirect_to("#{Settings.new_publish.base_url}/publish/haircut")
+    end
+  end
+
   def stub_interrupt_page_acknowledgements(body)
     url = /http:\/\/localhost:3001\/api\/v2\/recruitment_cycles\/#{Settings.current_cycle}\/users\/\d+\/interrupt_page_acknowledgements/
     stub_request(:get, url)

--- a/spec/helpers/new_publish_helper_spec.rb
+++ b/spec/helpers/new_publish_helper_spec.rb
@@ -9,7 +9,7 @@ describe NewPublishHelper do
     let(:path) { "/organisations/random" }
     let(:expected_path) { "#{Settings.new_publish.base_url}/publish/organisations/random" }
 
-    it "returns a correct url linking back to the old publish" do
+    it "returns a correct url linking back to the new publish" do
       expect(new_publish_url(path)).to eq(expected_path)
     end
   end


### PR DESCRIPTION
### Context
Redirects

### Changes proposed in this pull request
Added redirect for the details, about, contact & visas pages to new publish

### Guidance to review

Use case along the lines of a bookmark:
-  navigate and try to force your way pass

> ie  
`/organisations/T92/2022/details`
`/organisations/T92/2022/about`
`/organisations/T92/2022/contact`
`/organisations/T92/2022/visas`

### Checklist

- [x] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
