### PR TITLE
Activate about_your_org feature on staging

### DIFF
--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -15,3 +15,6 @@ search_ui:
 environment:
   label: "Staging"
   selector_name: "staging"
+features:
+   new_publish:
+     about_your_org: true


### PR DESCRIPTION
### Context
We can now start testing the migrated About Your Organisation section on staging.

### Changes proposed in this pull request
Activate the feature flag which changes the link on the provider show page.

### Guidance to review
na

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
