### PR TITLE
Fix yaml syntax for QA

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -15,7 +15,7 @@ environment:
 authentication:
   mode: persona   # none critical systems, ie localhost
 features:
-   rollover:
-     can_edit_current_and_next_cycles: true
+  rollover:
+    can_edit_current_and_next_cycles: true
   new_publish:
     locations: true


### PR DESCRIPTION
### Context

There was a syntax error in the yaml which caused an issue with the parser for the QA environment.