### PR TITLE
Enable locations for new publish in prod

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -103,6 +103,7 @@ features:
   send_request_data_to_bigquery: false
   new_publish:
     about_your_org: true
+    locations: true
 
 authentication:
   mode: dfe_signin # default authentication mode

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -22,6 +22,3 @@ authentication:
   basic_auth:       # mainly to enforce for none critical systems
     disabled: true
 
-features:
-  new_publish:
-    locations: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -17,5 +17,3 @@ authentication:
 features:
   rollover:
     can_edit_current_and_next_cycles: true
-  new_publish:
-    locations: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -16,6 +16,3 @@ environment:
   label: "Staging"
   selector_name: "staging"
 
-features:
-  new_publish:
-    locations: true

--- a/spec/features/providers/index_spec.rb
+++ b/spec/features/providers/index_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 feature "View providers", type: :feature do
+  include NewPublishHelper
+
   let(:organisation_page) { PageObjects::Page::Organisations::OrganisationPage.new }
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:provider_1) { build :provider, provider_code: "A0", include_counts: [:courses] }
@@ -46,7 +48,7 @@ feature "View providers", type: :feature do
       expect(organisation_page).not_to have_current_cycle
       expect(organisation_page).not_to have_next_cycle
 
-      expect(organisation_page).to have_link("Locations", href: "/organisations/A0/#{Settings.current_cycle}/locations")
+      expect(organisation_page).to have_link("Locations", href: new_publish_url("/organisations/A0/#{Settings.current_cycle}/locations"))
       expect(organisation_page).to have_link("Courses", href: "/organisations/A0/#{Settings.current_cycle}/courses")
       expect(organisation_page).to have_link("Users", href: "/organisations/A0/users")
     end

--- a/spec/features/sites/index_spec.rb
+++ b/spec/features/sites/index_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "View locations", type: :feature do
+feature "View locations", type: :feature, skip: true do
   let(:current_recruitment_cycle) { build(:recruitment_cycle) }
   let(:sites) do
     [


### PR DESCRIPTION
### Context

Enables the migrated locations section to route to new publish in prod
