### PR TITLE
Add weekly cache refresh workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -1,0 +1,95 @@
+name: Build No Cache
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '30 13 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: dfedigital/publish-teacher-training
+    outputs:
+      docker_image_tag: ${{ env.DOCKER_IMAGE_TAG }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Environment variable
+        run: |
+          GIT_REF=${{ github.ref }}
+          GIT_BRANCH=${GIT_REF##*/}
+          echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=$GITHUB_SHA" >> $GITHUB_ENV
+
+          # tag build to the review env for vars and secrets
+          tf_vars_file=terraform/workspace_variables/review.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
+
+      - name: Validate Azure Key Vault secrets
+        uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
+        with:
+          KEY_VAULT: ${{ env.KEY_VAULT_NAME }}
+          SECRETS: |
+            ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+
+      - uses: DFE-Digital/keyvault-yaml-secret@v1
+        id: get-secret
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+          key: SNYK_TOKEN
+
+      - name: Login to DockerHub
+        if: github.actor != 'dependabot[bot]'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Publish Teacher Training
+        uses: docker/build-push-action@v2
+        with:
+          tags: |
+            ${{ env.DOCKER_IMAGE}}:${{ env.DOCKER_IMAGE_TAG }}
+            ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+          push: false
+          load: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            COMMIT_SHA=${{ env.DOCKER_IMAGE_TAG }}
+
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
+        with:
+          image: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
+          args: --file=Dockerfile
+
+      - name: Push ${{ env.DOCKER_IMAGE }} images
+        if: ${{ success() }}
+        run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
+
+      - name: 'Notify #twd_publish_tech on failure'
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_publish_tech
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':github-logo:'
+          SLACK_USERNAME: Publish Teacher Training
+          SLACK_TITLE: Build failure on weekly rebuild cache workflow
+          SLACK_MESSAGE: 'Build failure'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

https://trello.com/c/UdUEnOJu/511-reload-docker-image-cache

Schedule a weekly refresh of the docker image cache, so that we pick up updates to the base images
Also runs a SNYK scan against the docker image

### Changes proposed in this pull request

New workflow for weekly docker image cache refresh

### Guidance to review

Ran workflow against branch to confirm it works as expected

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
