### PR TITLE
Migrate to GitHub container registry

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: dfedigital/publish-teacher-training
+      DOCKER_IMAGE: ghcr.io/dfe-digital/publish-teacher-training
     outputs:
       docker_image_tag: ${{ env.DOCKER_IMAGE_TAG }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: dfedigital/publish-teacher-training
+      DOCKER_IMAGE: ghcr.io/dfe-digital/publish-teacher-training
     outputs:
       docker_image_tag: ${{ env.DOCKER_IMAGE_TAG }}
 
@@ -39,11 +39,13 @@ jobs:
         # This is the latest commit on the actual PR branch
         echo "DOCKER_IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
+    - name: Login to GitHub Container Registry
+      if: github.actor != 'dependabot[bot]'
+      uses: docker/login-action@v1.12.0
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -56,9 +58,9 @@ jobs:
           ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
         push: true
         cache-from: |
-          ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
-          ${{ env.DOCKER_IMAGE}}:${{ env.DOCKER_IMAGE_TAG }}
-          ${{ env.DOCKER_IMAGE}}:master
+          type=registry,ref=${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+          type=registry,ref=${{ env.DOCKER_IMAGE}}:${{ env.DOCKER_IMAGE_TAG }}
+          type=registry,ref=${{ env.DOCKER_IMAGE}}:master
         build-args: |
           BUILDKIT_INLINE_CACHE=1
           COMMIT_SHA=${{ env.DOCKER_IMAGE_TAG }}
@@ -75,7 +77,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: [build]
-    container: dfedigital/publish-teacher-training:${{ needs.build.outputs.docker_image_tag }}
+    container: ghcr.io/dfe-digital/publish-teacher-training:${{ needs.build.outputs.docker_image_tag }}
     env:
       DOCKER_IMAGE_TAG: ${{ needs.build.outputs.docker_image_tag }}
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ deploy-init:
 	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=master))
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_paas_sso_passcode=$(PASSCODE))
-	$(eval export TF_VAR_paas_docker_image=dfedigital/publish-teacher-training:$(IMAGE_TAG))
+	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/publish-teacher-training:$(IMAGE_TAG))
 	$(eval export TF_VAR_paas_app_config_file=./workspace_variables/app_config.yml)
 	$(eval export TF_VAR_paas_app_secrets_file=./workspace_variables/app_secrets.yml)
 	az account set -s ${AZ_SUBSCRIPTION} && az account show

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -4,7 +4,6 @@ resource cloudfoundry_app web_app {
   health_check_type          = "http"
   health_check_http_endpoint = "/ping"
   docker_image               = var.docker_image
-  docker_credentials         = var.dockerhub_credentials
   timeout                    = 300
   strategy                   = "blue-green-v2"
   environment                = var.app_environment_variables
@@ -30,7 +29,6 @@ resource cloudfoundry_app worker_app {
   space              = data.cloudfoundry_space.space.id
   health_check_type  = "process"
   docker_image       = var.docker_image
-  docker_credentials = var.dockerhub_credentials
   timeout            = 300
   strategy           = "blue-green-v2"
   command            = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -14,8 +14,6 @@ variable redis_service_plan {}
 
 variable docker_image {}
 
-variable dockerhub_credentials {}
-
 variable logstash_url {}
 
 variable app_environment {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -48,7 +48,6 @@ module paas {
   cf_space                  = var.cf_space
   app_environment           = var.paas_app_environment
   docker_image              = var.paas_docker_image
-  dockerhub_credentials     = local.dockerhub_credentials
   web_app_host_name         = var.paas_web_app_host_name
   web_app_memory            = var.paas_web_app_memory
   web_app_instances         = var.paas_web_app_instances

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -48,9 +48,4 @@ locals {
   infra_secrets                  = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
   paas_app_environment_variables = merge(local.app_secrets, local.paas_app_config)
   azure_credentials              = try(jsondecode(var.azure_credentials), null)
-
-  dockerhub_credentials = {
-    username = local.infra_secrets.DOCKERHUB_USERNAME
-    password = local.infra_secrets.DOCKERHUB_PASSWORD
-  }
 }


### PR DESCRIPTION
### Context
Containers for this repo are currently published to Dockerhub. Publishing images to GitHub container registry is simpler and more secure.

### Changes proposed in this pull request
This commit migrates workflows from Dockerhub to the GitHub Container Packages registry.

### Guidance to review
- Confirm that image is being published as a GitHub Container Package
- Confirm that deployment is using the correct GitHub Container Package
### Trello card
https://trello.com/c/wVT0QcJ4

### Checklist

- [x] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product Review
