### PR TITLE
Update docker base image to ruby:2.7.5-alpine3.15

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.7.4
+      - name: Set up Ruby 2.7.5
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.4
+          ruby-version: 2.7.5
 
       - name: install bundler and gems
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
-ruby 2.7.4
+ruby 2.7.5
 yarn 1.22.5
-nodejs 12.18.4
+nodejs 16.14.0
 bundler 2.1.4
 terraform 0.13.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.4-alpine3.12
+FROM ruby:2.7.5-alpine3.15
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.7.4"
+ruby "2.7.5"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -667,7 +667,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.7.4p191
+   ruby 2.7.5p203
 
 BUNDLED WITH
    2.1.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": "12.x"
+    "node": "16.x"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
### Context

https://trello.com/c/RjLvJulr/744-update-docker-base-image

This is to resolve security vulnerabilities in the base image
alpine, ruby and nodejs will be updated in this change

### Changes proposed in this pull request

ruby:2.7.4-alpine3.12 to ruby:2.7.5-alpine3.15
nodejs 12.18.3 to 16.14.0
ruby 2.7.4p191 to ruby 2.7.5p203

### Guidance to review

check locally
check review app

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
