### PR TITLE
Update gmp in Dockerfile to fix vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2.7.5-alpine3.15
+# Remove apk add for gmp 6.2.1-r1 when the base image is updated
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
@@ -6,6 +7,9 @@ RUN apk add --update --no-cache tzdata && \
 RUN apk add --update --no-cache --virtual runtime-dependances \
  yarn \
  openssl-dev
+
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest gmp
+RUN apk add --no-cache gmp=6.2.1-r1
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
### Context

SNYK has highlighted vulnerability in gmp 6.2.1-r0 in the base image
This is fixed in 6.2.1-r1

### Changes proposed in this pull request

Change to Dockerfile to update gmp to the new version

### Guidance to review

Check build completes successfully

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
