### PR TITLE
Fix GHCR login for build-no-cache workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -48,12 +48,13 @@ jobs:
           secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
           key: SNYK_TOKEN
 
-      - name: Login to DockerHub
+      - name: Login to Github Container Registry
         if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
### Context
Fix Github Container Registry login for the build-no-cache workflow.

### Changes proposed in this pull request
Alter workflow to use GHCR secrets instead of Dockerhub

### Guidance to review
Run workflow against branch

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
