### PR TITLE
Base Image Vulnerability fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.7.5-alpine3.15
-# Remove apk add for libretls when the base image is updated
+
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
@@ -7,9 +7,6 @@ RUN apk add --update --no-cache tzdata && \
 RUN apk add --update --no-cache --virtual runtime-dependances \
  yarn \
  openssl-dev
-
-# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest libretls
-RUN apk add --no-cache libretls=3.3.4-r3
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
### Context

Remove the hardcoded libretls update from the Dockerfile
as it is now in the base image

### Changes proposed in this pull request

updates to Dockerfile

### Guidance to review

check Dockerfile
check build completed ok
Tested branch snyk scan with build-no-cache workflow

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
