### PR TITLE
[856] Migrate CSV export for training provider courses

### DIFF
--- a/app/controllers/publish/training_providers/course_exports_controller.rb
+++ b/app/controllers/publish/training_providers/course_exports_controller.rb
@@ -1,0 +1,25 @@
+module Publish
+  module TrainingProviders
+    class CourseExportsController < PublishController
+      def index
+        authorize(provider, :can_list_training_providers?)
+
+        respond_to do |format|
+          format.csv do
+            send_data(data_export.data, filename: data_export.filename, disposition: :attachment)
+          end
+        end
+      end
+
+    private
+
+      def courses
+        @courses ||= provider.current_accredited_courses.includes(:enrichments, :sites, :site_statuses)
+      end
+
+      def data_export
+        @data_export ||= Exports::AccreditedCourseList.new(courses)
+      end
+    end
+  end
+end

--- a/app/controllers/publish/training_providers/courses_controller.rb
+++ b/app/controllers/publish/training_providers/courses_controller.rb
@@ -16,7 +16,7 @@ module Publish
       def fetch_courses
         training_provider
           .courses
-          .includes(:enrichments, site_statuses: [:site], provider: [:recruitment_cycle])
+          .includes(:enrichments, :site_statuses, provider: [:recruitment_cycle])
           .where(accredited_body_code: provider.provider_code)
           .order(:name)
           .map(&:decorate)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -11,9 +11,9 @@ class CourseDecorator < ApplicationDecorator
     content.html_safe
   end
 
-  # def find_url(provider = object.provider)
-  #   h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
-  # end
+  def find_url(provider = object.provider)
+    h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
+  end
 
   def on_find(provider = object.provider)
     if object.findable?

--- a/app/services/exports/accredited_course_list.rb
+++ b/app/services/exports/accredited_course_list.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Exports
+  class AccreditedCourseList
+    def initialize(courses)
+      @data_for_export = format_courses(courses)
+    end
+
+    def data
+      CSV.generate(headers: data_for_export.first.keys, write_headers: true) do |csv|
+        data_for_export.each do |course_csv_row|
+          csv << course_csv_row
+        end
+      end
+    end
+
+    def filename
+      "courses-#{Time.zone.today}.csv"
+    end
+
+  private
+
+    attr_reader :data_for_export
+
+    def format_courses(courses)
+      courses
+      .map(&:decorate)
+      .flat_map do |c|
+        base_data = {
+          "Provider code" => c.provider.provider_code,
+          "Provider" => c.provider.provider_name,
+          "Course code" => c.course_code,
+          "Course" => c.name,
+          "Study mode" => c.study_mode&.humanize,
+          "Programme type" => c.program_type&.humanize,
+          "Qualification" => c.outcome,
+          "Status" => c.content_status&.to_s&.humanize,
+          "View on Find" => c.find_url,
+          "Applications open from" => I18n.l(c.applications_open_from&.to_date),
+          "Vacancies" => c.has_vacancies? ? "Yes" : "No",
+        }
+        if c.sites
+          base_data.merge({ "Campus Codes" => c.sites.pluck(:code).join(" ") })
+        else
+          base_data
+        end
+      end
+    end
+  end
+end

--- a/app/views/publish/training_providers/index.html.erb
+++ b/app/views/publish/training_providers/index.html.erb
@@ -44,4 +44,23 @@
       <% end %>
     </ul>
   </div>
+
+  <% unless @training_providers.empty? %>
+    <aside class="govuk-grid-column-one-third">
+      <div class="app-status-box" data-qa="download-section">
+        <h2 class="govuk-heading-m">Download</h2>
+        <p class="govuk-body">Export all the courses you’re the accredited body for.</p>
+        <p class="govuk-body">
+          <%= govuk_link_to(
+            "Download as a CSV file",
+            download_training_providers_courses_publish_provider_recruitment_cycle_path(
+              @provider.provider_code,
+              @provider.recruitment_cycle_year,
+              format: :csv,
+            ),
+          ) %>
+        </p>
+      </div>
+    </aside>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
         get "/about", on: :member, to: "providers#about"
         put "/about", on: :member, to: "providers#update"
         get "/details", on: :member, to: "providers#details"
+        get "/training-providers-courses", on: :member, to: "training_providers/course_exports#index", as: "download_training_providers_courses"
 
         resources :training_providers, path: "/training-providers", only: [:index], param: :code do
           resources :courses, only: [:index], controller: "training_providers/courses"

--- a/spec/services/exports/accredited_course_list_spec.rb
+++ b/spec/services/exports/accredited_course_list_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Exports
+  describe AccreditedCourseList do
+    let(:course) do
+      CourseDecorator.new(
+        create(
+          :course,
+          site_statuses: [create(:site_status, :full_time_vacancies, :findable)],
+          enrichments: [build(:course_enrichment, :published)],
+        ),
+      )
+    end
+
+    subject { described_class.new([course]) }
+
+    describe "#data" do
+      let(:expected_output) do
+        {
+          "Provider code" => course.provider.provider_code,
+          "Provider" => course.provider.provider_name,
+          "Course code" => course.course_code,
+          "Course" => course.name,
+          "Study mode" => course.study_mode&.humanize,
+          "Programme type" => course.program_type&.humanize,
+          "Qualification" => course.outcome,
+          "Status" => course.content_status&.to_s&.humanize,
+          "View on Find" => course.find_url,
+          "Applications open from" => I18n.l(course.applications_open_from&.to_date),
+          "Vacancies" => "Yes",
+        }
+      end
+
+      it "sets the correct headers" do
+        expect(subject.data).to include(expected_output.keys.join(","))
+      end
+
+      it "sets the correct row values" do
+        expect(subject.data).to include(expected_output.values.join(","))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/oeUiFAo4/856-migrate-the-courses-as-an-accredited-body-section-export-csv

### Changes proposed in this pull request

- Migrate the CSV export logic for training provider courses list

### Guidance to review

Download the export from both old publish and new publish, assert results are the same.

Original implementation - https://qa.publish-teacher-training-courses.service.gov.uk/organisations/B25/2022/training-providers

Migrated version - 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
