### PR TITLE
Add permissions to build workflow for dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,12 @@ on:
       - master
     types: [opened, reopened, synchronize, labeled]
 
+permissions:
+  contents: write
+  deployments: write
+  packages: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,7 +46,6 @@ jobs:
         echo "DOCKER_IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
     - name: Login to GitHub Container Registry
-      if: github.actor != 'dependabot[bot]'
       uses: docker/login-action@v1.12.0
       with:
         registry: ghcr.io


### PR DESCRIPTION
### Context
Dependabot requires it's workflow permissions to be explicitly set.

### Changes proposed in this pull request
Add necessary permissions to the build workflow.

### Guidance to review
 - Changes have already been successfully applied to other workflows.  Unable to test fully until merged and a dependabot PR tries to build
 - NOTE: the PR build failed to authenticate with GHCR on the first attempt.  The 2nd run succeeded, both runs had `Secret source: Actions` and the same `GITHUB_TOKEN Permissions` so there's no obvious explanation for the failure.

### Checklist

- [x] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x]Tested by running locally
- [x] Product Review
