### PR TITLE
Remove service.gov.uk routes as migrated to ttapi

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -50,6 +50,7 @@ resource cloudfoundry_route web_app_cloudapps_digital_route {
 }
 
 resource cloudfoundry_route publish_service_gov_uk_route {
+  count    = var.enable_service_route
   domain   = data.cloudfoundry_domain.publish_service_gov_uk.id
   space    = data.cloudfoundry_space.space.id
   hostname = var.web_app_host_name

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -8,6 +8,8 @@ variable web_app_host_name {}
 
 variable worker_app_instances { default = 1 }
 
+variable enable_service_route {}
+
 variable worker_app_memory {}
 
 variable redis_service_plan {}
@@ -25,6 +27,6 @@ locals {
   web_app_name         = "publish-teacher-training-${local.app_name_suffix}"
   worker_app_name      = "publish-teacher-training-worker-${local.app_name_suffix}"
   redis_service_name   = "publish-teacher-training-redis-${local.app_name_suffix}"
-  web_app_routes       = [cloudfoundry_route.publish_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route]
+  web_app_routes       = flatten([cloudfoundry_route.publish_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route])
   logging_service_name = "publish-teacher-training-logit-${local.app_name_suffix}"
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -56,6 +56,7 @@ module paas {
   redis_service_plan        = var.paas_redis_service_plan
   app_environment_variables = local.paas_app_environment_variables
   logstash_url              = local.infra_secrets.LOGSTASH_URL
+  enable_service_route      = var.enable_service_route
 }
 
 module statuscake {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,6 +14,8 @@ variable paas_web_app_memory {}
 
 variable paas_web_app_host_name {}
 
+variable enable_service_route { default = 1 }
+
 variable paas_worker_app_instances {}
 
 variable paas_worker_app_memory {}

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -2,6 +2,7 @@
     "cf_space": "bat-prod",
     "paas_app_environment": "prod",
     "paas_app_environment_config": "prod",
+    "enable_service_route": 0,
     "paas_web_app_host_name": "www",
     "paas_web_app_instances": 4,
     "paas_web_app_memory": 1024,

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -2,6 +2,7 @@
     "cf_space": "bat-qa",
     "paas_app_environment": "qa",
     "paas_app_environment_config": "qa",
+    "enable_service_route": 0,
     "paas_web_app_host_name": "qa",
     "paas_web_app_instances": 1,
     "paas_web_app_memory": 512,

--- a/terraform/workspace_variables/sandbox.tfvars.json
+++ b/terraform/workspace_variables/sandbox.tfvars.json
@@ -2,6 +2,7 @@
     "cf_space": "bat-prod",
     "paas_app_environment": "sandbox",
     "paas_app_environment_config": "sandbox",
+    "enable_service_route": 0,
     "paas_web_app_host_name": "sandbox",
     "paas_web_app_instances": 1,
     "paas_web_app_memory": 512,

--- a/terraform/workspace_variables/staging.tfvars.json
+++ b/terraform/workspace_variables/staging.tfvars.json
@@ -2,6 +2,7 @@
     "cf_space": "bat-staging",
     "paas_app_environment": "staging",
     "paas_app_environment_config": "staging",
+    "enable_service_route": 0,
     "paas_web_app_host_name": "staging",
     "paas_web_app_instances": 2,
     "paas_web_app_memory": 512,


### PR DESCRIPTION
### Context

Migrating from publish to ttapi

### Changes proposed in this pull request

This will remove the service.gov.uk routes after they have been added to ttapi

### Guidance to review

### Checklist

- [ ] Publish / TTAPI Merge - does this code change affect a part of the app that's currently being migrated to TTAPI? If so, speak with the dev doing the migration and ensure they've accounted for this change.
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
