### PR TITLE
Revert "Remove salary_details validations"

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -26,12 +26,20 @@ class CourseEnrichment < ApplicationRecord
     status.in? %w[draft rolled_over]
   end
 
+  # About this course
+  # TODO POST MIGRATION: Move out of this as it's handled in the form object
+  validates :about_course, presence: true, on: :publish
+  validates :about_course, words_count: { maximum: 400 }
+
   validates :interview_process, words_count: { maximum: 250 }
 
   validates :how_school_placements_work, presence: true, on: :publish
   validates :how_school_placements_work, words_count: { maximum: 350 }
 
-  # Fees
+  # Course length and fees
+
+  # TODO: POST MIGRATION: Move out of this as it's handled in the form object
+  validates :course_length, presence: true, on: :publish
 
   validates :fee_uk_eu, presence: true, on: :publish, if: :is_fee_based?
   validates :fee_uk_eu,
@@ -53,6 +61,11 @@ class CourseEnrichment < ApplicationRecord
   validates :financial_support,
             words_count: { maximum: 250 },
             if: :is_fee_based?
+
+  # Course length and salary
+  # TODO: POST MIGRATION: Move out of this as it's handled in the form object
+  validates :salary_details, presence: true, on: :publish, unless: :is_fee_based?
+  validates :salary_details, words_count: { maximum: 250 }, unless: :is_fee_based?
 
   # Requirements and qualifications
 

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -66,6 +66,44 @@ describe CourseEnrichment, type: :model do
     end
   end
 
+  describe "about_course attribute" do
+    let(:about_course_text) { "this course is great" }
+
+    subject { build :course_enrichment, about_course: about_course_text }
+
+    context "with over 400 words" do
+      let(:about_course_text) { Faker::Lorem.sentence(word_count: 400 + 1) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when nil" do
+      let(:about_course_text) { nil }
+
+      it { is_expected.to be_valid }
+
+      describe "on publish" do
+        it { is_expected.not_to be_valid :publish }
+      end
+    end
+  end
+
+  describe "course_length attribute" do
+    let(:course_length_text) { "this course is great" }
+
+    subject { build :course_enrichment, course_length: course_length_text }
+
+    context "when nil" do
+      let(:course_length_text) { nil }
+
+      it { is_expected.to be_valid }
+
+      describe "on publish" do
+        it { is_expected.not_to be_valid :publish }
+      end
+    end
+  end
+
   describe "how_school_placements_work attribute" do
     let(:how_school_placements_work_text) { "this course is great" }
 
@@ -157,6 +195,30 @@ describe CourseEnrichment, type: :model do
     end
   end
 
+  describe "salary_details attribute" do
+    let(:salary_details_text) { "this course is great" }
+
+    let(:salaried_course) { build :course, :with_salary }
+
+    subject { build :course_enrichment, salary_details: salary_details_text, course: salaried_course }
+
+    context "with over 250 words" do
+      let(:salary_details_text) { Faker::Lorem.sentence(word_count: 250 + 1) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when nil" do
+      let(:salary_details_text) { nil }
+
+      it { is_expected.to be_valid }
+
+      describe "on publish" do
+        it { is_expected.not_to be_valid :publish }
+      end
+    end
+  end
+
   describe "validation for publish" do
     let(:course_enrichment) { build(:course_enrichment, :with_fee_based_course) }
 
@@ -197,6 +259,7 @@ describe CourseEnrichment, type: :model do
     context "salary based course" do
       let(:course_enrichment) { build(:course_enrichment, :with_salary_based_course) }
 
+      it { is_expected.to validate_presence_of(:salary_details).on(:publish) }
       it { is_expected.not_to validate_presence_of(:fee_uk_eu).on(:publish) }
       it { is_expected.not_to validate_numericality_of(:fee_uk_eu).on(:publish) }
       it { is_expected.not_to validate_numericality_of(:fee_international).on(:publish) }
@@ -206,6 +269,13 @@ describe CourseEnrichment, type: :model do
 
         expect(course_enrichment).not_to be_valid :publish
         expect(course_enrichment.errors[:required_qualifications]).to be_present
+      end
+
+      it "validates maximum word count for salary_details" do
+        course_enrichment.salary_details = Faker::Lorem.sentence(word_count: 250 + 1)
+
+        expect(course_enrichment).not_to be_valid :publish
+        expect(course_enrichment.errors[:salary_details]).to be_present
       end
 
       context "fee based fields" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -467,6 +467,21 @@ describe Course, type: :model do
           it { is_expected.to be_nil }
         end
       end
+
+      context "invalid_enrichment" do
+        let(:course) { create(:course, enrichments: [invalid_enrichment]) }
+        let(:invalid_enrichment) { build(:course_enrichment, about_course: "") }
+
+        before do
+          subject
+          invalid_enrichment.about_course = Faker::Lorem.sentence(word_count: 1000)
+          subject.valid?
+        end
+
+        it "adds enrichment errors" do
+          expect(subject.errors.full_messages).not_to be_empty
+        end
+      end
     end
 
     describe "publishable?" do

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -137,7 +137,10 @@ describe "Publish API v2", type: :request do
         it "has validation errors" do
           expect(json_data.map { |error| error["detail"] }).to match_array([
             "Select at least one location for this course",
+            "Enter details about this course",
             "Enter details about school placements",
+            "Enter a course length",
+            "Enter details about the salary for this course",
             "Enter GCSE requirements",
           ])
         end
@@ -158,7 +161,9 @@ describe "Publish API v2", type: :request do
 
           it "has validation error details" do
             expect(json_data.map { |error| error["detail"] }).to match_array([
+              "Enter details about this course",
               "Enter details about school placements",
+              "Enter a course length",
               "Enter details about the fee for UK and EU students",
               "Enter GCSE requirements",
             ])
@@ -166,7 +171,9 @@ describe "Publish API v2", type: :request do
 
           it "has validation error pointers" do
             expect(json_data.map { |error| error["source"]["pointer"] }).to match_array([
+              "/data/attributes/about_course",
               "/data/attributes/how_school_placements_work",
+              "/data/attributes/course_length",
               "/data/attributes/fee_uk_eu",
               nil,
             ])
@@ -189,7 +196,10 @@ describe "Publish API v2", type: :request do
 
           it "has validation errors" do
             expect(json_data.map { |error| error["detail"] }).to match_array([
+              "Enter details about this course",
               "Enter details about school placements",
+              "Enter a course length",
+              "Enter details about the salary for this course",
               "Enter GCSE requirements",
             ])
           end

--- a/spec/requests/api/v2/providers/courses/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publishable_spec.rb
@@ -57,7 +57,10 @@ describe "Publishable API v2", type: :request do
 
         it "has validation errors" do
           expect(json_data.map { |error| error["detail"] }).to match_array([
+            "Enter details about this course",
             "Enter details about school placements",
+            "Enter a course length",
+            "Enter details about the salary for this course",
             "Enter GCSE requirements",
             "Select at least one location for this course",
           ])
@@ -77,8 +80,10 @@ describe "Publishable API v2", type: :request do
           it { is_expected.to have_http_status(:unprocessable_entity) }
 
           it "has validation error details" do
-            expect(json_data.count).to eq 3
+            expect(json_data.count).to eq 5
             expect(json_data.map { |error| error["detail"] }).to match_array([
+              "Enter details about this course",
+              "Enter a course length",
               "Enter details about the fee for UK and EU students",
               "Enter GCSE requirements",
               "Enter details about school placements",
@@ -87,7 +92,9 @@ describe "Publishable API v2", type: :request do
 
           it "has validation error pointers" do
             expect(json_data.map { |error| error["source"]["pointer"] }).to match_array(%w[
+              /data/attributes/about_course
               /data/attributes/how_school_placements_work
+              /data/attributes/course_length
               /data/attributes/fee_uk_eu
             ] << nil)
           end

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -338,6 +338,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       it "returns validation errors" do
         perform_request(course)
 
+        expect("Invalid about_course".in?(subject)).to be(true)
         expect("Invalid interview_process".in?(subject)).to be(true)
         expect("Invalid how_school_placements_work".in?(subject)).to be(true)
         expect("Invalid required_qualifications".in?(subject)).to be(true)
@@ -408,6 +409,21 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
         perform_request(course)
       }.to(change { course.reload.content_status }.from(:published).to(:published_with_unpublished_changes))
     end
+
+    context "with invalid data" do
+      let(:enrichment_attributes) do
+        { about_course: Faker::Lorem.sentence(word_count: 1000) }
+      end
+
+      subject { JSON.parse(response.body)["errors"].map { |e| e["title"] } }
+
+      it "returns validation errors" do
+        perform_request(course)
+
+        expect("Invalid enrichments".in?(subject)).to be(false)
+        expect("Invalid about_course".in?(subject)).to be(true)
+      end
+    end
   end
 
   context "course has a rolled-over enrichment" do
@@ -459,6 +475,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       it "returns validation errors" do
         perform_request(course)
 
+        expect("Invalid about_course".in?(subject)).to be(true)
         expect("Invalid interview_process".in?(subject)).to be(true)
         expect("Invalid how_school_placements_work".in?(subject)).to be(true)
         expect("Invalid required_qualifications".in?(subject)).to be(true)


### PR DESCRIPTION
Reverts DFE-Digital/teacher-training-api#2663

Caused a regression when attempting publish a draft course.

Before:

<img width="1680" alt="Screenshot 2022-05-18 at 15 50 14" src="https://user-images.githubusercontent.com/616080/169070988-53e9a53d-7536-4e3b-aa3e-0f7f7c50e39f.png">

After:

<img width="1680" alt="Screenshot 2022-05-18 at 15 50 34" src="https://user-images.githubusercontent.com/616080/169071065-93104ab7-943e-4c16-adfa-313647b2cc87.png">

