### PR TITLE
Rename github ttapi repo to publish

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -2,6 +2,6 @@
 # due to a subtle bug in bundler load paths
 # https://github.com/grosser/parallel_tests/issues/649
 # https://github.com/bundler/bundler/issues/5005#issuecomment-251025953
-# See discussion on https://github.com/DFE-Digital/teacher-training-api/pull/970
+# See discussion on https://github.com/DFE-Digital/publish-teacher-training/pull/970
 ---
 BUNDLE_DISABLE_EXEC_LOAD: "true"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       image_tag: ${{ env.DOCKER_IMAGE_TAG }}
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: ghcr.io/dfe-digital/teacher-training-api
+      DOCKER_IMAGE: ghcr.io/dfe-digital/publish-teacher-training
 
     steps:
     - name: Checkout
@@ -77,7 +77,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Build Teacher-Training-Api-Middleman
+    - name: Build Publish-Teacher-Training-Middleman
       uses: docker/build-push-action@v2
       with:
         tags: ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
@@ -88,7 +88,7 @@ jobs:
           type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
         build-args: BUILDKIT_INLINE_CACHE=1
 
-    - name: Build Teacher-Training-Api
+    - name: Build Publish-Teacher-Training
       uses: docker/build-push-action@v2
       with:
         tags: |

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: ghcr.io/dfe-digital/teacher-training-api
+      DOCKER_IMAGE: ghcr.io/dfe-digital/publish-teacher-training
 
     steps:
       - name: Checkout
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Build Teacher-Training-Api-Middleman
+      - name: Build Publish-Teacher-Training-Middleman
         uses: docker/build-push-action@v2
         with:
           tags: ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
@@ -63,7 +63,7 @@ jobs:
           target: middleman
           build-args: BUILDKIT_INLINE_CACHE=1
 
-      - name: Build Teacher-Training-Api
+      - name: Build Publish-Teacher-Training
         uses: docker/build-push-action@v2
         with:
           tags: |

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ deploy-init:
 	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_cf_sso_passcode=$(PASSCODE))
-	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/teacher-training-api:$(IMAGE_TAG))
+	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/publish-teacher-training:$(IMAGE_TAG))
 	$(eval export TF_VAR_paas_app_secrets_file=./workspace_variables/app_secrets.yml)
 	az account set -s ${AZ_SUBSCRIPTION} && az account show
 	cd terraform && \
@@ -202,7 +202,7 @@ set-restore-variables:
 	$(if $(IMAGE_TAG), , $(error can only run with an IMAGE_TAG))
 	$(if $(DB_INSTANCE_GUID), , $(error can only run with DB_INSTANCE_GUID, get it by running `make ${space} get-postgres-instance-guid`))
 	$(if $(SNAPSHOT_TIME), , $(error can only run with BEFORE_TIME, eg SNAPSHOT_TIME="2021-09-14 16:00:00"))
-	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/teacher-training-api:$(IMAGE_TAG))
+	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/publish-teacher-training:$(IMAGE_TAG))
 	$(eval export TF_VAR_paas_restore_from_db_guid=$(DB_INSTANCE_GUID))
 	$(eval export TF_VAR_paas_db_backup_before_point_in_time=$(SNAPSHOT_TIME))
 	echo "Restoring teacher-training-api from $(TF_VAR_paas_restore_from_db_guid) before $(TF_VAR_paas_db_backup_before_point_in_time)"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://github.com/DFE-Digital/teacher-training-api/workflows/Build/badge.svg)
+![Build](https://github.com/DFE-Digital/publish-teacher-training/workflows/Build/badge.svg)
 [![View performance data on Skylight](https://badges.skylight.io/status/NXAwzyZjkp2m.svg?token=JaYZey50Y8gfC00RvzkcrDz5OP-SwiBSTtbhkMw1KIs)](https://www.skylight.io/app/applications/NXAwzyZjkp2m)
 
 # Publish Teacher Training Courses

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,6 @@
 Sentry.init do |config|
   # Let’s not exclude ActiveRecord::RecordNotFound from Sentry
-  # https://github.com/DFE-Digital/teacher-training-api/pull/160
+  # https://github.com/DFE-Digital/publish-teacher-training/pull/160
   config.excluded_exceptions -= ["ActiveRecord::RecordNotFound"]
 
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
     build:
       context: .
       cache_from:
-        - ghcr.io/dfe-digital/teacher-training-api:${IMAGE_TAG:-latest}
-        - ghcr.io/dfe-digital/teacher-training-api-middleman:main
-    image: ghcr.io/dfe-digital/teacher-training-api:${IMAGE_TAG:-latest}
+        - ghcr.io/dfe-digital/publish-teacher-training:${IMAGE_TAG:-latest}
+        - ghcr.io/dfe-digital/publish-teacher-training-middleman:main
+    image: ghcr.io/dfe-digital/publish-teacher-training:${IMAGE_TAG:-latest}
     command: ash -c "rm -f tmp/pids/server.pid && bundle exec rails server -p 3001 -b '0.0.0.0'"
     ports:
       - "3001:3001"
@@ -39,7 +39,7 @@ services:
       - ${PWD}/out:/app/coverage
 
   bgJobs:
-    image: ghcr.io/dfe-digital/teacher-training-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/dfe-digital/publish-teacher-training:${IMAGE_TAG:-latest}
     command: bundle exec sidekiq -c 5 -C config/sidekiq.yml
     depends_on:
       - web

--- a/docs/adr/0004-before-action-variables.md
+++ b/docs/adr/0004-before-action-variables.md
@@ -11,7 +11,7 @@ Accepted
 This code base currently has a lot of `before_action` in controllers. For
 example:
 
-- https://github.com/DFE-Digital/teacher-training-api/blob/6e18d28cafe3d4595a15eb6670cc6950ddf692b8/app/controllers/api/v2/courses_controller.rb#L6
+- https://github.com/DFE-Digital/publish-teacher-training/blob/6e18d28cafe3d4595a15eb6670cc6950ddf692b8/app/controllers/api/v2/courses_controller.rb#L6
 
 These `before_action` calls typically load data into an instance variable
 which are then used later.

--- a/docs/adr/0008-use-skylight-for-performance-monitoring.md
+++ b/docs/adr/0008-use-skylight-for-performance-monitoring.md
@@ -42,6 +42,6 @@ Sentry is an error monitoring tool, which has expanded to include performance mo
 
 ## Decision
 
-[There was an attempt](https://github.com/DFE-Digital/teacher-training-api/pull/1860) to use sentry, but we managed to fill up our quota in less than a day, and while Sentry does offer tracing a subset of requests, this would only allow us to trace less than 1% of our requests.
+[There was an attempt](https://github.com/DFE-Digital/publish-teacher-training/pull/1860) to use sentry, but we managed to fill up our quota in less than a day, and while Sentry does offer tracing a subset of requests, this would only allow us to trace less than 1% of our requests.
 
 As such, we have decided to continue using skylight for performance monitoring.

--- a/docs/config/tech-docs.yml
+++ b/docs/config/tech-docs.yml
@@ -33,6 +33,6 @@ max_toc_heading_level: 6
 prevent_indexing: false
 
 show_contribution_banner: false
-github_repo: DFE-Digital/teacher-training-api
+github_repo: DFE-Digital/publish-teacher-training
 
 open_api_path: ../swagger/public_v1/api_spec.json


### PR DESCRIPTION

### Context

Rename github ttapi repo to publish-teacher-training

### Changes proposed in this pull request

update code references for github repo and ghcr images

### Guidance to review

check build

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
