### PR TITLE
# 157 Fix belongs to in fixture creation

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -10,7 +10,7 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 # Temporarily disable this until we clean up the reference data stuff
-Rails.configuration.active_record.belongs_to_required_by_default = true
+# Rails.configuration.active_record.belongs_to_required_by_default = false
 
 # `button_to` view helper will render `<button>` element, regardless of whether
 # or not the content is passed as the first argument or as a block.

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -10,7 +10,7 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 # Temporarily disable this until we clean up the reference data stuff
-Rails.configuration.active_record.belongs_to_required_by_default = false
+Rails.configuration.active_record.belongs_to_required_by_default = true
 
 # `button_to` view helper will render `<button>` element, regardless of whether
 # or not the content is passed as the first argument or as a block.


### PR DESCRIPTION
### Context
As part of the Rails 7 upgrade, we've had to turn off this setting:

[new_framework_defaults_7_0.rb](https://github.com/DFE-Digital/teacher-training-api/blob/main/config/initializers/new_framework_defaults_7_0.rb#L13)

As it causes some tests to fail, particularly around this service:

[creator_service.rb](https://github.com/DFE-Digital/teacher-training-api/blob/main/app/services/subjects/creator_service.rb#L2)

It needs to also handle it's belongs_to relationship (subject area) as this is now validated by default by Rails.

What needs to be done
Fix the service above to also handle setting the subject area
Maybe it can be combined with this? [subject_area_creator_service.rb](https://github.com/DFE-Digital/teacher-training-api/blob/main/app/services/subjects/subject_area_creator_service.rb)
Success
We can remove the setting above

### Changes proposed in this pull request
I am slightly confused by this, setting the config to true, or commenting it out does not cause any test failures. The actions within the creator_service seem to associate the subject_area without any issue
```
[3] pry(main)> s =  PrimarySubject.find_or_create_by!(subject_name: "test name", subject_code: "aas")
2022-06-20 17:39:02.328854 D [57213:11300 (pry):3] (0.516ms) ActiveRecord -- PrimarySubject Load -- { :sql => "SELECT \"subject\".* FROM \"subject\" WHERE \"subject\".\"type\" = $1 AND \"subject\".\"subject_name\" = $2 AND \"subject\".\"subject_code\" = $3 LIMIT $4", :binds => { :type => "PrimarySubject", :subject_name => "test name", :subject_code => "aas", :limit => 1 }, :allocations => 7, :cached => nil }
2022-06-20 17:39:02.351496 D [57213:11300 (pry):3] (0.181ms) ActiveRecord -- TRANSACTION -- { :sql => "BEGIN", :allocations => 4, :cached => nil }
2022-06-20 17:39:02.357033 D [57213:11300 (pry):3] (0.591ms) ActiveRecord -- SubjectArea Load -- { :sql => "SELECT \"subject_area\".* FROM \"subject_area\" WHERE \"subject_area\".\"typename\" = $1 LIMIT $2", :binds => { :typename => "PrimarySubject", :limit => 1 }, :allocations => 6, :cached => nil }
2022-06-20 17:39:02.377287 D [57213:11300 (pry):3] (1.646ms) ActiveRecord -- PrimarySubject Create -- { :sql => "INSERT INTO \"subject\" (\"type\", \"subject_code\", \"subject_name\") VALUES ($1, $2, $3) RETURNING \"id\"", :binds => { :type => "PrimarySubject", :subject_code => "aas", :subject_name => "test name" }, :allocations => 6, :cached => nil }
2022-06-20 17:39:02.382401 D [57213:11300 (pry):3] (0.579ms) ActiveRecord -- TRANSACTION -- { :sql => "COMMIT", :allocations => 4, :cached => nil }
=> #<PrimarySubject:0x00007f898219f498 id: 50, type: "PrimarySubject", subject_code: "aas", subject_name: "test name">
[4] pry(main)> s.subject_area
=> #<SubjectArea:0x00007f8978684ff8
 typename: "PrimarySubject",
 name: "Primary",
 created_at: Thu, 30 Jan 2020 08:39:12.879216000 UTC +00:00,
 updated_at: Thu, 30 Jan 2020 08:39:12.879216000 UTC +00:00>
```
### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
