### PR TITLE
[181] Cookie preference form

### DIFF
--- a/app/controllers/cookie_preferences_controller.rb
+++ b/app/controllers/cookie_preferences_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CookiePreferencesController < ApplicationController
+  skip_before_action :authenticate
+
+  def show
+    @cookie_preferences_form = Publish::CookiePreferencesForm.new(cookies)
+  end
+
+  def update
+    @cookie_preferences_form = Publish::CookiePreferencesForm.new(cookies, cookie_preferences_params)
+
+    if @cookie_preferences_form.save
+      redirect_back(fallback_location: root_path, flash: { success: "Your cookie preferences have been updated" })
+    else
+      render(:show)
+    end
+  end
+
+private
+
+  def cookie_preferences_params
+    params.require(:publish_cookie_preferences_form).permit(:consent)
+  end
+end

--- a/app/forms/publish/cookie_preferences_form.rb
+++ b/app/forms/publish/cookie_preferences_form.rb
@@ -1,0 +1,22 @@
+module Publish
+  class CookiePreferencesForm
+    include ActiveModel::Model
+
+    attr_accessor :consent, :cookies, :cookie_name, :expiry_date
+
+    validates :consent, presence: true, inclusion: { in: %w[yes no] }
+
+    def initialize(cookies, params = {})
+      @cookies = cookies
+      @cookie_name = Settings.cookies.consent.name
+      @expiry_date = Settings.cookies.consent.expire_after_days.days.from_now
+      @consent = params[:consent] || cookies[cookie_name]
+    end
+
+    def save
+      if valid?
+        cookies[cookie_name] = { value: consent, expires: expiry_date }
+      end
+    end
+  end
+end

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -1,0 +1,92 @@
+<% content_for :page_title, title_with_error_prefix("Cookies", @cookie_preferences_form.errors.present?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @cookie_preferences_form, url: cookies_path, method: :put do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Cookies</h1>
+
+      <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
+
+      <p class="govuk-body">We use cookies to make ‘<%= t("service_name") %> (Publish)’ work and collect information about how you use our service.</p>
+
+      <h2 class="govuk-heading-m">Essential cookies</h3>
+
+      <p class="govuk-body">Essential cookies keep your information secure while you use Publish.</p>
+
+      <p class="govuk-body">We do not need to ask permission to use them.</p>
+
+      <table class="govuk-table app-table--vertical-align-middle" aria-describedby="essential_cookies_desc">
+        <thead class="govuk-table__header">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Name</th>
+            <th class="govuk-table__header" scope="col">Purpose</th>
+            <th class="govuk-table__header" scope="col">Expires</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr scope="row" class="govuk-table__row">
+            <td class="govuk-table__cell "><span class="break-word">_publish_teacher_training_courses_session</span></td>
+            <td class="govuk-table__cell ">Remembers your identity when you are signed in</td>
+            <td class="govuk-table__cell ">After 6 hours or on signing out</td>
+          </tr>
+          <tr scope="row" class="govuk-table__row">
+            <td class="govuk-table__cell"><%= Settings.cookies.consent.name %></td>
+            <td class="govuk-table__cell">Saves your cookie consent settings</td>
+            <td class="govuk-table__cell">6 months</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 class="govuk-heading-m">Analytics cookies (optional)</h2>
+
+      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use Publish. This information helps us improve our service.</p>
+
+      <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
+
+      <p class="govuk-body">Google Analytics stores anonymised information about:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>how you got to Publish</li>
+        <li>the pages you visit on this site and how long you spend on them</li>
+        <li>what you click on while you’re visiting the site</li>
+      </ul>
+
+      <table class="govuk-table" aria-describedby="google_analytics_cookies_desc">
+        <thead class="govuk-table__header">
+          <tr>
+            <th scope="col" class="govuk-table__header">Name</th>
+            <th scope="col" class="govuk-table__header">Purpose</th>
+            <th scope="col" class="govuk-table__header">Expires</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr scope="row" class="govuk-table__row">
+            <td class="govuk-table__cell">_ga</td>
+            <td class="govuk-table__cell">Distinguishes anonymous users</td>
+            <td class="govuk-table__cell">2 years</td>
+          </tr>
+          <tr scope="row" class="govuk-table__row">
+            <td class="govuk-table__cell">_gid</td>
+            <td class="govuk-table__cell">Distinguishes anonymous users</td>
+            <td class="govuk-table__cell">24 hours</td>
+          </tr>
+          <tr scope="row" class="govuk-table__row">
+            <td class="govuk-table__cell">_ga_RHM2PGFN72</td>
+            <td class="govuk-table__cell">Throttle requests</td>
+            <td class="govuk-table__cell">10 minutes</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <%= f.govuk_collection_radio_buttons :consent,
+                                          [%w[yes Yes], %w[no No]],
+                                          :first,
+                                          :last,
+                                          legend: { text: "Do you want to accept Google Analytics cookies?", size: "s" } %>
+      <%= f.govuk_submit("Save cookie settings") %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,6 +437,10 @@ en:
             email:
               blank: "Enter an email adddress"
               invalid: "Enter a valid email address"
+        publish/cookie_preferences_form:
+          attributes:
+            consent:
+              blank: Select yes if you want to accept Google Analytics cookies
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,11 +22,16 @@ Rails.application.routes.draw do
   get "/sign-out", to: "sessions#sign_out"
 
   get "/accessibility", to: "pages#accessibility", as: :accessibility
-  get "/cookies", to: "pages#cookies", as: :cookies
   get "/guidance", to: "pages#guidance", as: :guidance
   get "/performance-dashboard", to: "pages#performance_dashboard", as: :performance_dashboard
   get "/privacy-policy", to: "pages#privacy", as: :privacy
   get "/terms-conditions", to: "pages#terms", as: :terms
+
+  if FeatureService.enabled?(:google_analytics)
+    resource :cookie_preferences, only: %i[show update], path: "/cookies", as: :cookies
+  else
+    get "/cookies", to: "pages#cookies", as: :cookies
+  end
 
   if AuthenticationService.magic_link?
     get "/sign-in/magic-link", to: "magic_links#new", as: :magic_links

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,11 @@ authentication:
   # mode: magic_link  # when dfe_signin is down
   # mode: persona     # none critical systems, ie localhost
 
+cookies:
+  consent:
+    name: _consented_to_analytics_cookies
+    expire_after_days: 182
+
 current_recruitment_cycle_year: 2022
 next_cycle_open_date: 2022-10-5
 
@@ -88,6 +93,7 @@ feedback:
 features:
   send_request_data_to_bigquery: false
   new_publish_navigation: true
+  google_analytics: false
   rollover:
     # Normally a short period of time between rollover and the next cycle
     # actually starting when it would be set to false

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -20,3 +20,4 @@ allocations_close_date: 2022-07-02
 features:
   allocations:
     state: confirmed
+  google_analytics: true

--- a/spec/features/publish/cookie_preferences_spec.rb
+++ b/spec/features/publish/cookie_preferences_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Updating cookie preferences" do
+  before do
+    enable_features(:google_analytics)
+    Rails.application.reload_routes!
+  end
+
+  scenario "i can update my cookie preferences" do
+    when_i_visit_the_cookie_preferences_page
+    and_i_give_consent_and_submit
+    then_i_should_see_a_confirmation_message
+  end
+
+  scenario "i cannot update without selecting a preference" do
+    when_i_visit_the_cookie_preferences_page
+    and_i_submit
+    then_i_should_see_an_error_message
+  end
+
+  def when_i_visit_the_cookie_preferences_page
+    cookie_preferences_page.load
+  end
+
+  def and_i_give_consent_and_submit
+    cookie_preferences_page.yes_option.choose
+    and_i_submit
+  end
+
+  def then_i_should_see_a_confirmation_message
+    expect(cookie_preferences_page).to have_text("Your cookie preferences have been updated")
+  end
+
+  def and_i_submit
+    cookie_preferences_page.submit.click
+  end
+
+  def then_i_should_see_an_error_message
+    expect(cookie_preferences_page.error_messages).to include(
+      "Select yes if you want to accept Google Analytics cookies",
+    )
+  end
+end

--- a/spec/requests/send_data_to_big_query_spec.rb
+++ b/spec/requests/send_data_to_big_query_spec.rb
@@ -81,7 +81,7 @@ describe EmitsRequestEvents, type: :request do
   end
 
   def stub_feature(enabled)
-    allow(FeatureService).to receive(:enabled?).with(:new_publish).and_return(false)
+    allow(FeatureService).to receive(:enabled?).with(:google_analytics).and_return(false)
     allow(FeatureService).to receive(:enabled?).with(:send_request_data_to_bigquery).and_return(enabled)
   end
 end

--- a/spec/support/page_objects/publish/cookie_preferences.rb
+++ b/spec/support/page_objects/publish/cookie_preferences.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../sections/errorlink"
+
+module PageObjects
+  module Publish
+    class CookiePreferences < PageObjects::Base
+      set_url "/cookies"
+
+      sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+      element :yes_option, "#publish-cookie-preferences-form-consent-yes-field"
+      element :no_option, "#publish-cookie-preferences-form-consent-no-field"
+
+      element :submit, 'button.govuk-button[type="submit"]'
+
+      def error_messages
+        errors.map(&:text)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/f02CRcnk/181-publish-cookie-preference-form

### Changes proposed in this pull request

- Implements cookie preference form on the cookies page
- Put behind feature flag

### Guidance to review

- Head to the cookies page and update your preferences, assert cookie is set in the browser

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
