### PR TITLE
Rename PaaS resources from ttapi to publish

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -31,7 +31,7 @@ runs:
       run: |
         if [ -n "${{ inputs.pr-number }}" ]; then
           echo "APP_NAME=${{ inputs.pr-number }}" >> $GITHUB_ENV
-          echo "::set-output name=deploy_url::https://teacher-training-api-pr-${{ inputs.pr-number }}.london.cloudapps.digital"
+          echo "::set-output name=deploy_url::https://publish-teacher-training-pr-${{ inputs.pr-number }}.london.cloudapps.digital"
           echo "DEPLOY_REF=${{ github.head_ref }}" >> $GITHUB_ENV
         else
           if [ ${{ inputs.environment }} == "production" ]; then

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -32,8 +32,8 @@ runs:
       run: |
         if [ ! -z "${{ inputs.pr-number }}" ]; then
           PR_NUMBER=${{ inputs.pr-number }}
-          echo "base_url: https://teacher-training-api-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
-          echo "publish_api_url: https://teacher-training-api-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
+          echo "base_url: https://publish-teacher-training-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
+          echo "publish_api_url: https://publish-teacher-training-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
         fi;
 
     - name: Smoke Tests ${{ inputs.environment }}

--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           now=$(date +"%F")
           PROD_BACKUP=prod_backup-$now.sql
-          cf conduit teacher-training-api-postgres-prod -- pg_dump --encoding utf8 --clean --no-owner --if-exists -f $PROD_BACKUP
+          cf conduit publish-teacher-training-postgres-prod -- pg_dump --encoding utf8 --clean --no-owner --if-exists -f $PROD_BACKUP
           tar -cvzf ${PROD_BACKUP}.tar.gz ${PROD_BACKUP}
           echo "PROD_BACKUP=$PROD_BACKUP" >> $GITHUB_ENV
 
@@ -124,4 +124,4 @@ jobs:
       - name: Restore backup to ${{ matrix.environment }}
         run: cf conduit ${POSTGRES_SERVICE_INSTANCE} -- psql < backup_sanitised.sql
         env:
-          POSTGRES_SERVICE_INSTANCE: teacher-training-api-postgres-${{ matrix.environment }}
+          POSTGRES_SERVICE_INSTANCE: publish-teacher-training-postgres-${{ matrix.environment }}

--- a/config/settings/loadtest.yml
+++ b/config/settings/loadtest.yml
@@ -1,10 +1,10 @@
 gcp_api_key: please_change_me
-publish_api_url: https://teacher-training-api-loadtest.london.cloudapps.digital
+publish_api_url: https://publish-teacher-training-loadtest.london.cloudapps.digital
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 
 # URL of this app for the callback after sigining in
-base_url: https://teacher-training-api-loadtest.london.cloudapps.digital
+base_url: https://publish-teacher-training-loadtest.london.cloudapps.digital
 
 bg_jobs:
   save_statistic:

--- a/config/settings/rollover.yml
+++ b/config/settings/rollover.yml
@@ -1,5 +1,5 @@
 gcp_api_key: please_change_me
-publish_api_url: https://teacher-training-api-rollover.london.cloudapps.digital
+publish_api_url: https://publish-teacher-training-rollover.london.cloudapps.digital
 publish_url: https://publish-rollover.london.cloudapps.digital
 find_url: https://find-rollover.london.cloudapps.digital
 

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -59,19 +59,19 @@ First make sure it is fully gone by running:
 
 N.B. When testing the `cf delete-service <instance name>` in the review environment the postgres service key needs deleting first. Retrieve the service key with `cf service-keys <instance name>` and then delete the service key using `cf delete-service-key <instance name> <service key name>`
 ```
-cf services | grep teacher-training-api
+cf services | grep publish-teacher-training
 # check output for lost or corrupted instance
 cf delete-service <instance-name>
 ```
 
 Then recreate the lost postgres database instance using the following make recipes `deploy-plan` and `deploy`. Replacing the `qa` in the app name below with `pr-1234` when testing in the review environment. To see the proposed changes:
 ```
-TAG=$(cf app teacher-training-api-qa | awk -F : '$1 == "docker image" {print $3}')
+TAG=$(cf app publish-teacher-training-qa | awk -F : '$1 == "docker image" {print $3}')
 make <env> deploy-plan PASSCODE=<my-passcode> IMAGE_TAG=${TAG}
 ```
 To apply proposed changes i.e. create new database instance:
 ```
-TAG=$(cf app teacher-training-api-qa | awk -F : '$1 == "docker image" {print $3}')
+TAG=$(cf app publish-teacher-training-qa | awk -F : '$1 == "docker image" {print $3}')
 make <env> deploy PASSCODE=<my-passcode> IMAGE_TAG=${TAG}
 ```
 This will create a new postgres database instance as described in the terraform configuration file.
@@ -186,5 +186,5 @@ Gov UK PaaS Documentation on Point-in-time database recovery can be found [here]
 Once the database has been successfully restored, the corrupted database instance should be deleted.
 
 ```
-cf delete-service teacher-training-api-postgres-<env>-old -f
+cf delete-service publish-teacher-training-postgres-<env>-old -f
 ```

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -37,14 +37,14 @@ variable "db_backup_before_point_in_time" {}
 
 locals {
   app_name_suffix              = var.app_environment != "review" ? var.app_environment : "pr-${var.web_app_host_name}"
-  web_app_name                 = "teacher-training-api-${local.app_name_suffix}"
+  web_app_name                 = "publish-teacher-training-${local.app_name_suffix}"
   publish_app_name             = "publish-${local.app_name_suffix}"
   cloudapp_names               = [local.web_app_name, local.publish_app_name]
-  worker_app_name              = "teacher-training-api-worker-${local.app_name_suffix}"
-  postgres_service_name        = "teacher-training-api-postgres-${local.app_name_suffix}"
-  redis_worker_service_name    = "teacher-training-api-worker-redis-${local.app_name_suffix}"
-  redis_cache_service_name     = "teacher-training-api-cache-redis-${local.app_name_suffix}"
-  logging_service_name         = "teacher-training-api-logit-${local.app_name_suffix}"
+  worker_app_name              = "publish-teacher-training-worker-${local.app_name_suffix}"
+  postgres_service_name        = "publish-teacher-training-postgres-${local.app_name_suffix}"
+  redis_worker_service_name    = "publish-teacher-training-worker-redis-${local.app_name_suffix}"
+  redis_cache_service_name     = "publish-teacher-training-cache-redis-${local.app_name_suffix}"
+  logging_service_name         = "publish-teacher-training-logit-${local.app_name_suffix}"
   deployment_strategy          = "blue-green-v2"
 # This is the guid of the QA postgres database and is used in review app db creation
 # It must be updated within 35 days if the QA db is recreated,

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -24,8 +24,8 @@
           "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
         },
         "ttapi_paas": {
-          "website_name": "teacher-training-api-cloudapps-prod",
-          "website_url": "https://teacher-training-api-prod.london.cloudapps.digital/ping",
+          "website_name": "publish-teacher-training-cloudapps-prod",
+          "website_url": "https://publish-teacher-training-prod.london.cloudapps.digital/ping",
           "test_type": "HTTP",
           "check_rate": 60,
           "contact_group": [151103],

--- a/terraform/workspace_variables/rollover.tfvars.json
+++ b/terraform/workspace_variables/rollover.tfvars.json
@@ -14,8 +14,8 @@
     "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-ROLLOVER",
     "statuscake_alerts": {
         "ttapi": {
-          "website_name": "teacher-training-api-rollover",
-          "website_url": "https://teacher-training-api-rollover.london.cloudapps.digital/ping",
+          "website_name": "publish-teacher-training-rollover",
+          "website_url": "https://publish-teacher-training-rollover.london.cloudapps.digital/ping",
           "test_type": "HTTP",
           "check_rate": 60,
           "contact_group": [151103],


### PR DESCRIPTION

### Context

Rename PaaS resources from teacher-training-api to publish-teacher-training

### Changes proposed in this pull request

Updates to
- terraform variables
- github workflows
- Makefile
- DR instructions
- Statuscake config if using the london.cloudapps.digital route
- config settings if using the london.cloudapps.digital route

### Guidance to review

deploy-plan against all envs
deploy to review
manual deploy to envs to be confirmed

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
