### PR TITLE
#188 undefined split bug

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -212,12 +212,14 @@ private
 
   def degree_grades
     return [] if filter[:degree_grade].blank?
+    return [] unless filter[:degree_grade].is_a?(String)
 
     filter[:degree_grade].split(",")
   end
 
   def subject_codes
     return [] if filter[:subjects].blank?
+    return [] unless filter[:subjects].is_a?(String)
 
     filter[:subjects].split(",")
   end

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -578,7 +578,7 @@ RSpec.describe CourseSearchService do
         let(:filter) { {"hello" => "there"} }
 
         it "doesn't add the scope" do
-          expect(scope).not_to receive(:with_degree_grades)
+          expect(scope).not_to receive(:with_subjects)
           expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -527,7 +527,7 @@ RSpec.describe CourseSearchService do
       end
 
       context "when not a string" do
-        let(:filter) { {"hello" => "there"} }
+        let(:filter) { { "hello" => "there" } }
 
         it "doesn't add the scope" do
           expect(scope).not_to receive(:with_degree_grades)
@@ -575,7 +575,7 @@ RSpec.describe CourseSearchService do
       end
 
       context "when not a string" do
-        let(:filter) { {"hello" => "there"} }
+        let(:filter) { { "hello" => "there" } }
 
         it "doesn't add the scope" do
           expect(scope).not_to receive(:with_subjects)

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -525,6 +525,17 @@ RSpec.describe CourseSearchService do
           expect(subject).to eq(expected_scope)
         end
       end
+
+      context "when not a string" do
+        let(:filter) { {"hello" => "there"} }
+
+        it "doesn't add the scope" do
+          expect(scope).not_to receive(:with_degree_grades)
+          expect(scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
     end
 
     describe "filter[subjects]" do
@@ -557,6 +568,17 @@ RSpec.describe CourseSearchService do
 
         it "doesn't add the scope" do
           expect(scope).not_to receive(:with_subjects)
+          expect(scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when not a string" do
+        let(:filter) { {"hello" => "there"} }
+
+        it "doesn't add the scope" do
+          expect(scope).not_to receive(:with_degree_grades)
           expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)


### PR DESCRIPTION
### Context

## What happened?
https://sentry.io/organizations/dfe-teacher-services/issues/3356685335/?project=1377944&query=url%3A%22https%3A%2F%2Fapi.publish-teacher-training-courses.service.gov.uk%2Fapi%2Fpublic%2Fv1%2Frecruitment_cycles%2F2022%2Fcourses%22

https://sentry.io/organizations/dfe-teacher-services/issues/3356643413/?project=1377944&query=url%3A%22https%3A%2F%2Fapi.publish-teacher-training-courses.service.gov.uk%2Fapi%2Fpublic%2Fv1%2Frecruitment_cycles%2F2022%2Fcourses%22

## What was supposed to happen? 
No error on split

## Technical notes
Make a guard

## Who knows about this? 
sentry or @defong 

### Changes proposed in this pull request
The error seems to result from invalid data being passed from FIND, possibly deliberate, not able to replicate locally yet.
As the split method requires a string, have placed a guard clause in both failing methods, will continue to look at FIND tomorrow
### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
