### PR TITLE
[0189] Refactor rollover script to handle draft and individual courses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ yarn-debug.log*
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# redis related
+dump.rdb

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -5,7 +5,7 @@ module Courses
       @enrichments_copy_to_course = enrichments_copy_to_course
     end
 
-    def execute(course:, new_provider:, force: false)
+    def execute(course:, new_provider:)
       return unless course.rollable? || force
       return if course_code_already_exists_on_provider?(course: course, new_provider: new_provider)
 
@@ -26,13 +26,15 @@ module Courses
         course.sites.each do |site|
           new_site = new_provider.sites.find_by(code: site.code)
 
-          @sites_copy_to_course.execute(new_site: new_site, new_course: new_course) if new_site.present?
+          sites_copy_to_course.execute(new_site: new_site, new_course: new_course) if new_site.present?
         end
       end
       new_course
     end
 
   private
+
+    attr_reader :sites_copy_to_course, :enrichments_copy_to_course, :force
 
     def course_code_already_exists_on_provider?(course:, new_provider:)
       new_provider.courses.with_discarded.where(course_code: course.course_code).any?

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -1,8 +1,9 @@
 module Courses
   class CopyToProviderService
-    def initialize(sites_copy_to_course:, enrichments_copy_to_course:)
+    def initialize(sites_copy_to_course:, enrichments_copy_to_course:, force:)
       @sites_copy_to_course = sites_copy_to_course
       @enrichments_copy_to_course = enrichments_copy_to_course
+      @force = force
     end
 
     def execute(course:, new_provider:)
@@ -44,7 +45,7 @@ module Courses
       last_enrichment = course.enrichments.most_recent.first
       return if last_enrichment.blank?
 
-      @enrichments_copy_to_course.execute(enrichment: last_enrichment, new_course: new_course)
+      enrichments_copy_to_course.execute(enrichment: last_enrichment, new_course: new_course)
     end
 
     def adjusted_applications_open_from_date(course, year_differential)

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -40,12 +40,13 @@ module Providers
     end
 
   private
+    attr_reader :copy_course_to_provider_service, :copy_site_to_provider_service
 
     def copy_courses_to_new_provider(provider, new_provider)
       courses_count = 0
 
       provider.courses.each do |course|
-        new_course = @copy_course_to_provider_service.execute(course: course, new_provider: new_provider)
+        new_course = copy_course_to_provider_service.execute(course: course, new_provider: new_provider)
         courses_count += 1 if new_course.present?
       rescue Exception # rubocop: disable Lint/RescueException
         Rails.logger.fatal "error trying to copy course #{course.course_code}"
@@ -59,7 +60,7 @@ module Providers
       sites_count = 0
 
       provider.sites.each do |site|
-        new_site = @copy_site_to_provider_service.execute(site: site, new_provider: new_provider)
+        new_site = copy_site_to_provider_service.execute(site: site, new_provider: new_provider)
         sites_count += 1 if new_site.present?
       end
 

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -49,7 +49,7 @@ module Providers
       provider.courses.each do |course|
         new_course = copy_course_to_provider_service.execute(course: course, new_provider: new_provider)
         courses_count += 1 if new_course.present?
-      rescue Exception # rubocop: disable Lint/RescueException
+      rescue StandardError
         Rails.logger.fatal "error trying to copy course #{course.course_code}"
         raise
       end

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -1,11 +1,8 @@
 module Providers
   class CopyToRecruitmentCycleService
-    attr :logger
-
-    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, logger: nil)
+    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:)
       @copy_course_to_provider_service = copy_course_to_provider_service
       @copy_site_to_provider_service = copy_site_to_provider_service
-      @logger = logger || Logger.new("/dev/null")
     end
 
     def execute(provider:, new_recruitment_cycle:, force: false)
@@ -51,7 +48,7 @@ module Providers
         new_course = @copy_course_to_provider_service.execute(course: course, new_provider: new_provider)
         courses_count += 1 if new_course.present?
       rescue Exception # rubocop: disable Lint/RescueException
-        logger&.fatal "error trying to copy course #{course.course_code}"
+        Rails.logger.fatal "error trying to copy course #{course.course_code}"
         raise
       end
 

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -48,7 +48,7 @@ module Providers
       courses = []
       if force
         if course_codes.nil?
-          Rails.logger.info "no courses will be rollover"
+          Rails.logger.info "no courses will be roll overed"
         else
           courses = courses_from_course_codes(provider, course_codes)
         end
@@ -64,8 +64,8 @@ module Providers
     def courses_from_course_codes(provider, course_codes)
       courses = provider.courses.where(course_code: course_codes.to_a.map(&:upcase))
 
-      if courses.count != course_codes.count
-        error_message = "error courses found has discrepancies (#{courses.count} vs #{course_codes.count})"
+      unless courses.count == course_codes.count
+        error_message = "Error: discrepancy between courses found and provided course codes (#{courses.count} vs #{course_codes.count})"
         Rails.logger.fatal error_message
         raise error_message
       end

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -1,8 +1,9 @@
 module Providers
   class CopyToRecruitmentCycleService
-    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:)
+    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, force:)
       @copy_course_to_provider_service = copy_course_to_provider_service
       @copy_site_to_provider_service = copy_site_to_provider_service
+      @force = force
     end
 
     def execute(provider:, new_recruitment_cycle:, force: false)
@@ -40,7 +41,7 @@ module Providers
     end
 
   private
-    attr_reader :copy_course_to_provider_service, :copy_site_to_provider_service
+    attr_reader :copy_course_to_provider_service, :copy_site_to_provider_service, :force
 
     def copy_courses_to_new_provider(provider, new_provider)
       courses_count = 0

--- a/app/services/rollover_provider_service.rb
+++ b/app/services/rollover_provider_service.rb
@@ -1,0 +1,60 @@
+class RolloverProviderService
+  include ServicePattern
+
+  def initialize(provider_code:, force:, course_codes: nil)
+    @provider_code = provider_code
+    @course_codes = course_codes
+    @force = force
+  end
+
+  def call
+    rollover
+  end
+
+private
+
+  attr_reader :provider_code, :course_codes, :force
+
+  def rollover
+    Rails.logger.info { "Copying provider #{provider.provider_code}: " }
+    counts = nil
+
+    bm = Benchmark.measure do
+      Provider.connection.transaction do
+        counts = copy_provider_to_recruitment_cycle.execute(
+          provider: provider, new_recruitment_cycle: new_recruitment_cycle, course_codes: course_codes,
+        )
+      end
+    end
+
+    Rails.logger.info "provider #{counts[:providers].zero? ? 'skipped' : 'copied'}, " \
+                      "#{counts[:sites]} sites copied, " \
+                      "#{counts[:courses]} courses copied " +
+                      format("in %.3f seconds", bm.real)
+    counts
+  end
+
+  def new_recruitment_cycle
+    @new_recruitment_cycle ||= RecruitmentCycle.next_recruitment_cycle
+  end
+
+  def provider
+    @provider ||= RecruitmentCycle.current_recruitment_cycle.providers.find_by(provider_code: provider_code)
+  end
+
+  def copy_courses_to_provider_service
+    @copy_courses_to_provider_service ||= Courses::CopyToProviderService.new(
+      sites_copy_to_course: Sites::CopyToCourseService.new,
+      enrichments_copy_to_course: Enrichments::CopyToCourseService.new,
+      force: force,
+    )
+  end
+
+  def copy_provider_to_recruitment_cycle
+    @copy_provider_to_recruitment_cycle ||= Providers::CopyToRecruitmentCycleService.new(
+      copy_course_to_provider_service: copy_courses_to_provider_service,
+      copy_site_to_provider_service: Sites::CopyToProviderService.new,
+      force: force,
+    )
+  end
+end

--- a/lib/tasks/rollover.rake
+++ b/lib/tasks/rollover.rake
@@ -1,4 +1,13 @@
 namespace :rollover do
+  desc "Rollover provider, courses and locations to the next cycle, (Use the force to rollover for non rollable provider and or courses)"
+  task :provider, %i[provider_code course_codes force] => :environment do |_task, args|
+    provider_code = args[:provider_code]
+    course_codes = args[:course_codes]
+    force = args[:force] == "true"
+
+    RolloverProviderService.call(provider_code: provider_code, course_codes: course_codes&.split, force: force)
+  end
+
   desc "Rollover providers, courses and locations to the next cycle"
   task :providers, [:provider_codes] => :environment do |_task, args|
     provider_codes = args[:provider_codes]

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -28,8 +28,11 @@ RSpec.describe Courses::CopyToProviderService do
     described_class.new(
       sites_copy_to_course: mocked_sites_copy_to_course_service,
       enrichments_copy_to_course: mocked_enrichments_copy_to_course_service,
+      force: force,
     )
   end
+
+  let(:force) { false }
 
   it "makes a copy of the course in the new provider" do
     service.execute(course: course, new_provider: new_provider)
@@ -186,6 +189,7 @@ RSpec.describe Courses::CopyToProviderService do
       described_class.new(
         sites_copy_to_course: mocked_sites_copy_to_course_service,
         enrichments_copy_to_course: mocked_enrichments_copy_to_course_service,
+        force: force,
       ).execute(course: course, new_provider: new_provider)
     end
 
@@ -204,6 +208,7 @@ RSpec.describe Courses::CopyToProviderService do
   context "when the course is not rollable" do
     let(:site) { create :site, provider: provider }
     let!(:new_site) { create :site, provider: new_provider, code: site.code }
+    let(:force) { true }
 
     before do
       allow(course).to receive(:rollable?).and_return(false)
@@ -211,7 +216,8 @@ RSpec.describe Courses::CopyToProviderService do
       described_class.new(
         sites_copy_to_course: mocked_sites_copy_to_course_service,
         enrichments_copy_to_course: mocked_enrichments_copy_to_course_service,
-      ).execute(course: course, new_provider: new_provider, force: true)
+        force: force,
+      ).execute(course: course, new_provider: new_provider)
     end
 
     it "still copies the course to the provider" do

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -63,20 +63,13 @@ describe Providers::CopyToRecruitmentCycleService do
 
     context "an error occurs when copying the course" do
       it "logs a useful message to the provided logger" do
-        log_output = StringIO.new
-        logger = Logger.new(log_output)
-        service = described_class.new(
-          copy_course_to_provider_service: mocked_copy_course_service,
-          copy_site_to_provider_service: mocked_copy_site_service,
-          logger: logger,
-        )
-        allow(mocked_copy_course_service).to receive(:execute).and_raise("Nope")
+        allow(mocked_copy_course_service).to receive(:execute).and_raise(StandardError.new("Nope"))
+
+        expect(Rails.logger).to receive(:fatal).with("error trying to copy course #{course.course_code}")
 
         expect {
           service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
-        }.to raise_error("Nope")
-
-        expect(log_output.string).to include "error trying to copy course #{course.course_code}"
+        }.to raise_error(StandardError)
       end
     end
 

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -204,7 +204,7 @@ describe Providers::CopyToRecruitmentCycleService do
         end
 
         it "logs info message" do
-          expect(Rails.logger).to receive(:info).with("no courses will be rollover")
+          expect(Rails.logger).to receive(:info).with("no courses will be roll overed")
 
           subject
         end
@@ -247,7 +247,7 @@ describe Providers::CopyToRecruitmentCycleService do
           it "errors out with correct message" do
             expect {
               subject
-            }.to raise_error("error courses found has discrepancies (0 vs 1)")
+            }.to raise_error("Error: discrepancy between courses found and provided course codes (0 vs 1)")
           end
         end
       end

--- a/spec/services/rollover_provider_service_spec.rb
+++ b/spec/services/rollover_provider_service_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe RolloverProviderService do
+  let!(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
+
+  let(:copy_course_to_provider_service) { instance_double(Courses::CopyToProviderService) }
+  let(:copy_provider_to_recruitment_cycle_service) { instance_double(Providers::CopyToRecruitmentCycleService) }
+
+  before do
+    allow(Courses::CopyToProviderService).to receive(:new).with(
+      sites_copy_to_course: instance_of(Sites::CopyToCourseService),
+      enrichments_copy_to_course: instance_of(Enrichments::CopyToCourseService),
+      force: force,
+    ).and_return(copy_course_to_provider_service)
+
+    allow(Providers::CopyToRecruitmentCycleService).to receive(:new).with(
+      copy_course_to_provider_service: copy_course_to_provider_service,
+      copy_site_to_provider_service: instance_of(Sites::CopyToProviderService),
+      force: force,
+    ).and_return(copy_provider_to_recruitment_cycle_service)
+  end
+
+  describe ".call" do
+    let(:force) { false }
+    let(:course_codes) { ["B05S"] }
+    let(:provider) { create(:provider, provider_code: "AB1") }
+
+    before do
+      provider
+
+      allow(copy_provider_to_recruitment_cycle_service).to receive(:execute).and_return(
+        {
+          providers: 0,
+          sites: 0,
+          courses: 0,
+        },
+      )
+    end
+
+    it "passes the correct arguments down to the `CopyToRecruitmentCycle` service" do
+      expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
+        provider: provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: course_codes,
+      )
+
+      described_class.call(provider_code: provider.provider_code, course_codes: course_codes, force: force)
+    end
+  end
+end

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -10,15 +10,19 @@ describe RolloverService do
     allow(Courses::CopyToProviderService).to receive(:new).with(
       sites_copy_to_course: instance_of(Sites::CopyToCourseService),
       enrichments_copy_to_course: instance_of(Enrichments::CopyToCourseService),
+      force: force,
     ).and_return(copy_course_to_provider_service)
 
     allow(Providers::CopyToRecruitmentCycleService).to receive(:new).with(
       copy_course_to_provider_service: copy_course_to_provider_service,
       copy_site_to_provider_service: instance_of(Sites::CopyToProviderService),
+      force: force,
     ).and_return(copy_provider_to_recruitment_cycle_service)
   end
 
   describe ".call" do
+    let(:force) { false }
+
     context "with provider codes" do
       let(:provider) { create(:provider, provider_code: "AB1") }
       let(:provider_to_ignore) { create(:provider, provider_code: "CD2") }
@@ -38,7 +42,7 @@ describe RolloverService do
 
       it "passes the providers in provider_codes to the `CopyToRecruitmentCycle` service" do
         expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-          provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          provider: provider, new_recruitment_cycle: next_recruitment_cycle,
         )
 
         no_output { described_class.call(provider_codes: ["AB1"]) }
@@ -46,7 +50,7 @@ describe RolloverService do
 
       it "doesn't pass other providers" do
         expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-          provider: provider_to_ignore, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          provider: provider_to_ignore, new_recruitment_cycle: next_recruitment_cycle,
         )
 
         no_output { described_class.call(provider_codes: ["AB1"]) }
@@ -59,15 +63,15 @@ describe RolloverService do
 
         it "doesn't pass other providers" do
           expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-            provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle,
           )
 
           expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle,
           )
 
           expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle,
           )
 
           no_output { described_class.call(provider_codes: ["AB1"]) }
@@ -94,10 +98,10 @@ describe RolloverService do
 
       it "passes all providers `CopyToRecruitmentCycle` service" do
         expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-          provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          provider: provider, new_recruitment_cycle: next_recruitment_cycle,
         )
         expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-          provider: other_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          provider: other_provider, new_recruitment_cycle: next_recruitment_cycle,
         )
 
         no_output { described_class.call(provider_codes: []) }
@@ -110,15 +114,15 @@ describe RolloverService do
 
         it "doesn't pass other providers" do
           expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-            provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle,
           )
 
           expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle,
           )
 
           expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle,
           )
 
           no_output { described_class.call(provider_codes: []) }
@@ -126,12 +130,14 @@ describe RolloverService do
       end
 
       context "force: true" do
+        let(:force) { true }
+
         it "passes the argument to the `CopyToRecruitmentCycle` service" do
           expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-            provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: true,
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle,
           )
 
-          no_output { described_class.call(provider_codes: [], force: true) }
+          no_output { described_class.call(provider_codes: [], force: force) }
         end
       end
     end

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -42,7 +42,7 @@ describe RolloverService do
 
       it "passes the providers in provider_codes to the `CopyToRecruitmentCycle` service" do
         expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-          provider: provider, new_recruitment_cycle: next_recruitment_cycle,
+          provider: provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
         )
 
         no_output { described_class.call(provider_codes: ["AB1"]) }
@@ -50,7 +50,7 @@ describe RolloverService do
 
       it "doesn't pass other providers" do
         expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-          provider: provider_to_ignore, new_recruitment_cycle: next_recruitment_cycle,
+          provider: provider_to_ignore, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
         )
 
         no_output { described_class.call(provider_codes: ["AB1"]) }
@@ -63,15 +63,15 @@ describe RolloverService do
 
         it "doesn't pass other providers" do
           expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-            provider: provider, new_recruitment_cycle: next_recruitment_cycle,
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
           )
 
           expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle,
+            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
           )
 
           expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle,
+            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
           )
 
           no_output { described_class.call(provider_codes: ["AB1"]) }
@@ -98,10 +98,10 @@ describe RolloverService do
 
       it "passes all providers `CopyToRecruitmentCycle` service" do
         expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-          provider: provider, new_recruitment_cycle: next_recruitment_cycle,
+          provider: provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
         )
         expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-          provider: other_provider, new_recruitment_cycle: next_recruitment_cycle,
+          provider: other_provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
         )
 
         no_output { described_class.call(provider_codes: []) }
@@ -114,15 +114,15 @@ describe RolloverService do
 
         it "doesn't pass other providers" do
           expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-            provider: provider, new_recruitment_cycle: next_recruitment_cycle,
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
           )
 
           expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle,
+            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
           )
 
           expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
-            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle,
+            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
           )
 
           no_output { described_class.call(provider_codes: []) }
@@ -134,7 +134,7 @@ describe RolloverService do
 
         it "passes the argument to the `CopyToRecruitmentCycle` service" do
           expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
-            provider: provider, new_recruitment_cycle: next_recruitment_cycle,
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle, course_codes: nil,
           )
 
           no_output { described_class.call(provider_codes: [], force: force) }

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -15,7 +15,6 @@ describe RolloverService do
     allow(Providers::CopyToRecruitmentCycleService).to receive(:new).with(
       copy_course_to_provider_service: copy_course_to_provider_service,
       copy_site_to_provider_service: instance_of(Sites::CopyToProviderService),
-      logger: instance_of(Logger),
     ).and_return(copy_provider_to_recruitment_cycle_service)
   end
 


### PR DESCRIPTION
### Context
Rollover script to handle draft and individual courses

### Changes proposed in this pull request
Refactor rollover script to handle draft and individual courses

### Guidance to review
```bash

# bundle exec rake 'rollover:provider[provider_code ,  course_codes, force]'
  bundle exec rake 'rollover:provider[provider_code, course_code1 course_code2 course_code3, true]'

```

#### usage
Go and create a recruitment cycle for next recruitment cycle
Find some providers with none published courses
And take a lucky dip with the below commands


```bash
bundle exec rake 'rollover:provider[provider_code, , ]'
bundle exec rake 'rollover:provider[provider_code, ,false]'
```

To rollover a `rollover-able provider` and all it `rollover-able courses`


```bash
bundle exec rake 'rollover:provider[provider_code, course_codes , ]'
bundle exec rake 'rollover:provider[provider_code, course_codes, false]'
```

To rollover a `rollover-able provider` and only the specified `rollover-able courses`


```bash
bundle exec rake 'rollover:provider[provider_code, ,true]'
```

To rollover a `rollover-able or non-rollover-able provider`


```bash
bundle exec rake 'rollover:provider[provider_code, course_codes1 course_codes2, true]'
```

To rollover a `rollover-able or non-rollover-able provider` and only the specified `rollover-able or non-rollover-able courses`


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
