### PR TITLE
Update variable qa_postgres_service_instance

### DIFF
--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -46,7 +46,10 @@ locals {
   redis_cache_service_name     = "teacher-training-api-cache-redis-${local.app_name_suffix}"
   logging_service_name         = "teacher-training-api-logit-${local.app_name_suffix}"
   deployment_strategy          = "blue-green-v2"
-  qa_postgres_service_instance = "eef01a89-0659-4eae-8220-8a142fa4502e"
+# This is the guid of the QA postgres database and is used in review app db creation
+# It must be updated within 35 days if the QA db is recreated,
+# as that is how long automated snapshots are kept
+  qa_postgres_service_instance = "6ee1518e-5a3c-4d08-abe4-6847ff7919b0"
 
   worker_app_start_command = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
 


### PR DESCRIPTION

### Context

This variable contains the QA Postgres instance guid, and is used in review app db creation
Updated as the qa postgres database was recreated mid May,
and the last snapshot is removed after 35 days

https://trello.com/c/bFW1TmiD/619-bugfix-update-qapostgresserviceinstance-variable

### Changes proposed in this pull request

Updated qa_postgres_service_instance guid to the current QA postgres DB instance,
which has been recreated recently

### Guidance to review

Check review app deploys

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
