### PR TITLE
[180] Add Google tag manager script

### DIFF
--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -73,11 +73,6 @@
             <td class="govuk-table__cell">Distinguishes anonymous users</td>
             <td class="govuk-table__cell">24 hours</td>
           </tr>
-          <tr scope="row" class="govuk-table__row">
-            <td class="govuk-table__cell">_ga_RHM2PGFN72</td>
-            <td class="govuk-table__cell">Throttle requests</td>
-            <td class="govuk-table__cell">10 minutes</td>
-          </tr>
         </tbody>
       </table>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,12 +18,21 @@
     <%= stylesheet_link_tag "accessible-autocomplete/dist/accessible-autocomplete.min" %>
     <%= stylesheet_link_tag "application" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+
+    <% if google_analytics_allowed? %>
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','<%= Settings.google_tag_manager.tracking_id %>');</script>
+    <% end %>
   </head>
 
   <body class="govuk-template__body <%= yield :body_class %>">
-    <noscript>
-      <iframe title="Google Tag Manager" src="https://www.googletagmanager.com/ns.html?id=GTM-PD8MFNL" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
+    <% if google_analytics_allowed? %>
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Settings.google_tag_manager.tracking_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <% end %>
+
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,6 +87,9 @@ google:
     api_json_key: "{}"
     table_name: events
 
+google_tag_manager:
+  tracking_id: change_me
+
 feedback:
   link: https://docs.google.com/forms/d/e/1FAIpQLSfZNWa6zx30SkF_1EAwqNPZHOgK8qYcVQ7uDyhi0P6oPm71zg/viewform
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -26,5 +26,8 @@ environment:
   name: "beta"
 render_json_errors: true
 
+google_tag_manager:
+  tracking_id: GTM-W56GPKW
+
 features:
   send_request_data_to_bigquery: true


### PR DESCRIPTION
### Context

https://trello.com/c/j9ZY7rii/180-publish-install-ga-tracking-script

### Changes proposed in this pull request

- Enable the Google tag manager script if analytics have been accepted
- Only configure for prod as we don't have other envs in GA

### Guidance to review

We won't be able to verify data is coming in until this is turned on in prod. This is based on the spike integration which verified data being sent locally.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
