### PR TITLE
Rename ttapi Azure resources to publish

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -57,14 +57,14 @@ jobs:
         uses: Azure/get-keyvault-secrets@v1
         with:
           keyvault: s121p01-shared-kv-01
-          secrets: TTAPI-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION
+          secrets: PUBLISH-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION
         id: GetSecretAction
 
       - name: Upload Backup to Azure Storage
         run: |
           az storage blob upload --container-name prod-db-backup \
           --file ${PROD_BACKUP}.tar.gz --name ${PROD_BACKUP}.tar.gz \
-          --connection-string '${{ env.TTAPI-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION }}'
+          --connection-string '${{ env.PUBLISH-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION }}'
 
       - name: Sanitise the Database backup
         run: |

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ review:
 	$(eval export TF_VAR_paas_web_app_host_name=$(APP_NAME))
 	$(eval space=bat-qa)
 	$(eval paas_env=pr-$(APP_NAME))
-	$(eval backup_storage_secret_name=TTAPI-STORAGE-ACCOUNT-CONNECTION-STRING-DEVELOPMENT)
+	$(eval backup_storage_secret_name=PUBLISH-STORAGE-ACCOUNT-CONNECTION-STRING-DEVELOPMENT)
 	echo https://publish-teacher-training-pr-$(APP_NAME).london.cloudapps.digital will be created in bat-qa space
 
 .PHONY: qa
@@ -51,7 +51,7 @@ qa: ## Set DEPLOY_ENV to qa
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-development)
 	$(eval space=bat-qa)
 	$(eval paas_env=qa)
-	$(eval backup_storage_secret_name=TTAPI-STORAGE-ACCOUNT-CONNECTION-STRING-DEVELOPMENT)
+	$(eval backup_storage_secret_name=PUBLISH-STORAGE-ACCOUNT-CONNECTION-STRING-DEVELOPMENT)
 
 .PHONY: staging
 staging: ## Set DEPLOY_ENV to staging
@@ -75,7 +75,7 @@ production: ## Set DEPLOY_ENV to production
 	$(eval space=bat-prod)
 	$(eval paas_env=prod)
 	$(eval PARTIAL_HOSTNAME=www)
-	$(eval backup_storage_secret_name=TTAPI-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION)
+	$(eval backup_storage_secret_name=PUBLISH-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION)
 
 .PHONY: loadtest
 loadtest: ## Set DEPLOY_ENV to loadtest

--- a/terraform/workspace_variables/loadtest.tfvars.json
+++ b/terraform/workspace_variables/loadtest.tfvars.json
@@ -10,6 +10,6 @@
     "paas_redis_service_plan": "micro-ha-5_x",
     "key_vault_resource_group": "s121d01-shared-rg",
     "key_vault_name": "s121d01-shared-kv-01",
-    "key_vault_app_secret_name": "TTAPI-APP-SECRETS-QA",
+    "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-QA",
     "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA"
 }

--- a/terraform/workspace_variables/loadtest_backend.tfvars
+++ b/terraform/workspace_variables/loadtest_backend.tfvars
@@ -1,4 +1,4 @@
-resource_group_name  = "s121d01-ttapi-rg"
-storage_account_name = "s121d01ttapiterraform"
+resource_group_name  = "s121d01-ptt-rg"
+storage_account_name = "s121d01pttterraform"
 container_name       = "loadtest-paas-tfstate"
 key                  = "terraform.tfstate"

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -11,7 +11,7 @@
     "publish_gov_uk_host_names": ["www2", "www"],
     "key_vault_resource_group": "s121p01-shared-rg",
     "key_vault_name": "s121p01-shared-kv-01",
-    "key_vault_app_secret_name": "TTAPI-APP-SECRETS-PRODUCTION",
+    "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-PRODUCTION",
     "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION",
     "statuscake_alerts": {
         "ttapi": {

--- a/terraform/workspace_variables/production_backend.tfvars
+++ b/terraform/workspace_variables/production_backend.tfvars
@@ -1,4 +1,4 @@
-resource_group_name  = "s121p01-ttapi-rg"
-storage_account_name = "s121p01ttapiterraform"
+resource_group_name  = "s121p01-ptt-rg"
+storage_account_name = "s121p01pttterraform"
 container_name       = "prod-paas-tfstate"
 key                  = "terraform.tfstate"

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -11,7 +11,7 @@
     "publish_gov_uk_host_names": ["qa2", "qa"],
     "key_vault_resource_group": "s121d01-shared-rg",
     "key_vault_name": "s121d01-shared-kv-01",
-    "key_vault_app_secret_name": "TTAPI-APP-SECRETS-QA",
+    "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-QA",
     "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
     "statuscake_alerts": {
         "ttapi": {

--- a/terraform/workspace_variables/qa_backend.tfvars
+++ b/terraform/workspace_variables/qa_backend.tfvars
@@ -1,4 +1,4 @@
-resource_group_name  = "s121d01-ttapi-rg"
-storage_account_name = "s121d01ttapiterraform"
+resource_group_name  = "s121d01-ptt-rg"
+storage_account_name = "s121d01pttterraform"
 container_name       = "qa-paas-tfstate"
 key                  = "terraform.tfstate"

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -11,6 +11,6 @@
     "paas_redis_service_plan": "micro-5_x",
     "key_vault_resource_group": "s121d01-shared-rg",
     "key_vault_name": "s121d01-shared-kv-01",
-    "key_vault_app_secret_name": "TTAPI-APP-SECRETS-QA",
+    "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-QA",
     "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA"
 }

--- a/terraform/workspace_variables/review_backend.tfvars
+++ b/terraform/workspace_variables/review_backend.tfvars
@@ -1,4 +1,4 @@
-resource_group_name  = "s121d01-ttapi-rg"
-storage_account_name = "s121d01ttapiterraform"
+resource_group_name  = "s121d01-ptt-rg"
+storage_account_name = "s121d01pttterraform"
 container_name       = "review-paas-tfstate"
 #key                 = "passed via the make command"

--- a/terraform/workspace_variables/rollover.tfvars.json
+++ b/terraform/workspace_variables/rollover.tfvars.json
@@ -10,7 +10,7 @@
     "paas_redis_service_plan": "tiny-5_x",
     "key_vault_resource_group": "s121p01-shared-rg",
     "key_vault_name": "s121p01-shared-kv-01",
-    "key_vault_app_secret_name": "TTAPI-APP-SECRETS-ROLLOVER",
+    "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-ROLLOVER",
     "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-ROLLOVER",
     "statuscake_alerts": {
         "ttapi": {

--- a/terraform/workspace_variables/rollover_backend.tfvars
+++ b/terraform/workspace_variables/rollover_backend.tfvars
@@ -1,4 +1,4 @@
-resource_group_name  = "s121p01-ttapi-rg"
-storage_account_name = "s121p01ttapiterraform"
+resource_group_name  = "s121p01-ptt-rg"
+storage_account_name = "s121p01pttterraform"
 container_name       = "rollover-paas-tfstate"
 key                  = "terraform.tfstate"

--- a/terraform/workspace_variables/sandbox.tfvars.json
+++ b/terraform/workspace_variables/sandbox.tfvars.json
@@ -11,7 +11,7 @@
     "publish_gov_uk_host_names": ["sandbox2", "sandbox"],
     "key_vault_resource_group": "s121p01-shared-rg",
     "key_vault_name": "s121p01-shared-kv-01",
-    "key_vault_app_secret_name": "TTAPI-APP-SECRETS-SANDBOX",
+    "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-SANDBOX",
     "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-SANDBOX",
     "statuscake_alerts": {
         "ttapi-sandbox": {

--- a/terraform/workspace_variables/sandbox_backend.tfvars
+++ b/terraform/workspace_variables/sandbox_backend.tfvars
@@ -1,4 +1,4 @@
-resource_group_name  = "s121p01-ttapi-rg"
-storage_account_name = "s121p01ttapiterraform"
+resource_group_name  = "s121p01-ptt-rg"
+storage_account_name = "s121p01pttterraform"
 container_name       = "sandbox-paas-tfstate"
 key                  = "terraform.tfstate"

--- a/terraform/workspace_variables/staging.tfvars.json
+++ b/terraform/workspace_variables/staging.tfvars.json
@@ -11,7 +11,7 @@
     "publish_gov_uk_host_names": ["staging2", "staging"],
     "key_vault_resource_group": "s121t01-shared-rg",
     "key_vault_name": "s121t01-shared-kv-01",
-    "key_vault_app_secret_name": "TTAPI-APP-SECRETS-STAGING",
+    "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-STAGING",
     "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
     "statuscake_alerts": {
         "ttapi": {

--- a/terraform/workspace_variables/staging_backend.tfvars
+++ b/terraform/workspace_variables/staging_backend.tfvars
@@ -1,4 +1,4 @@
-resource_group_name  = "s121t01-ttapi-rg"
-storage_account_name = "s121t01ttapiterraform"
+resource_group_name  = "s121t01-ptt-rg"
+storage_account_name = "s121t01pttterraform"
 container_name       = "staging-paas-tfstate"
 key                  = "terraform.tfstate"


### PR DESCRIPTION
### Context

Rename Azure resources from TTAPI to PUBLISH 
This affects Key Vaults and Storage Accounts used by build, deployment and database backups.

https://trello.com/c/U6UMBm0d/622-rename-ttapi-azure-resources-to-publish

### Changes proposed in this pull request

Update Makefile, workspace variables and the database restore workflow.
Key vault data has been copied from TTAPI to Publish vaults
Terraform state files have been copied from TTAPI to Publish storage accounts
DB backups have been copied from TTAPI to Publish storage accounts

Any updated terraform state files or key vaults will be copied just before merge
Github secrets that reference state files will be updated just before merge

### Guidance to review

Check config
deploy-plan all envs

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
