### PR TITLE
[230] Bump prod web app memory for rollover

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -3,7 +3,7 @@
     "paas_app_environment": "prod",
     "paas_web_app_host_name": null,
     "paas_web_app_instances": 10,
-    "paas_web_app_memory": 2048,
+    "paas_web_app_memory": 3072,
     "paas_worker_app_instances": 4,
     "paas_worker_app_memory": 512,
     "paas_postgres_service_plan": "large-ha-11",


### PR DESCRIPTION
### Context

- https://trello.com/c/FxZDAL9p/230-bump-memory-in-prod-instance-for-rollover

### Changes proposed in this pull request

To prevent memory issues similar to what happened last year when running the rollover script, this temporarily bumps up the size for the prod web app instance.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
