### PR TITLE
Remove env2 routes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,20 +156,20 @@ enable-maintenance: ## make qa enable-maintenance / make prod enable-maintenance
 	cf target -s ${space}
 	cd service_unavailable_page && cf push
 	eval cf map-route publish-unavailable api.publish-teacher-training-courses.service.gov.uk ${API_HOSTNAME_ARG}
-	cf map-route publish-unavailable publish-teacher-training-courses.service.gov.uk --hostname ${PUBLISH_HOSTNAME}2
+	cf map-route publish-unavailable publish-teacher-training-courses.service.gov.uk --hostname ${PUBLISH_HOSTNAME}
 	echo Waiting 5s for route to be registered... && sleep 5
 	eval cf unmap-route publish-teacher-training-${DEPLOY_ENV} api.publish-teacher-training-courses.service.gov.uk ${API_HOSTNAME_ARG}
-	cf unmap-route publish-teacher-training-${DEPLOY_ENV} publish-teacher-training-courses.service.gov.uk --hostname ${PUBLISH_HOSTNAME}2
+	cf unmap-route publish-teacher-training-${DEPLOY_ENV} publish-teacher-training-courses.service.gov.uk --hostname ${PUBLISH_HOSTNAME}
 
 disable-maintenance: ## make qa disable-maintenance / make prod disable-maintenance CONFIRM_PRODUCTION=y
 	$(if $(PARTIAL_HOSTNAME), $(eval API_HOSTNAME_ARG=""), $(eval API_HOSTNAME_ARG="--hostname ${DEPLOY_ENV}"))
 	$(if $(PARTIAL_HOSTNAME), $(eval PUBLISH_HOSTNAME=${PARTIAL_HOSTNAME}), $(eval PUBLISH_HOSTNAME=${DEPLOY_ENV}))
 	cf target -s ${space}
 	eval cf map-route publish-teacher-training-${DEPLOY_ENV} api.publish-teacher-training-courses.service.gov.uk ${API_HOSTNAME_ARG}
-	cf map-route publish-teacher-training-${DEPLOY_ENV} publish-teacher-training-courses.service.gov.uk --hostname ${PUBLISH_HOSTNAME}2
+	cf map-route publish-teacher-training-${DEPLOY_ENV} publish-teacher-training-courses.service.gov.uk --hostname ${PUBLISH_HOSTNAME}
 	echo Waiting 5s for route to be registered... && sleep 5
 	eval cf unmap-route publish-unavailable api.publish-teacher-training-courses.service.gov.uk ${API_HOSTNAME_ARG}
-	cf unmap-route publish-unavailable publish-teacher-training-courses.service.gov.uk --hostname ${PUBLISH_HOSTNAME}2
+	cf unmap-route publish-unavailable publish-teacher-training-courses.service.gov.uk --hostname ${PUBLISH_HOSTNAME}
 	cf delete -rf publish-unavailable
 
 restore-data-from-nightly-backup: read-deployment-config read-keyvault-config # make production restore-data-from-nightly-backup CONFIRM_PRODUCTION=YES CONFIRM_RESTORE=YES BACKUP_DATE="yyyy-mm-dd"

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -8,7 +8,7 @@
     "paas_worker_app_memory": 512,
     "paas_postgres_service_plan": "large-ha-11",
     "paas_redis_service_plan": "micro-ha-5_x",
-    "publish_gov_uk_host_names": ["www2", "www"],
+    "publish_gov_uk_host_names": ["www"],
     "key_vault_resource_group": "s121p01-shared-rg",
     "key_vault_name": "s121p01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-PRODUCTION",

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -8,7 +8,7 @@
     "paas_worker_app_memory": 512,
     "paas_postgres_service_plan": "small-11",
     "paas_redis_service_plan": "tiny-5_x",
-    "publish_gov_uk_host_names": ["qa2", "qa"],
+    "publish_gov_uk_host_names": ["qa"],
     "key_vault_resource_group": "s121d01-shared-rg",
     "key_vault_name": "s121d01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-QA",

--- a/terraform/workspace_variables/sandbox.tfvars.json
+++ b/terraform/workspace_variables/sandbox.tfvars.json
@@ -8,7 +8,7 @@
     "paas_worker_app_memory": 512,
     "paas_postgres_service_plan": "small-11",
     "paas_redis_service_plan": "micro-5_x",
-    "publish_gov_uk_host_names": ["sandbox2", "sandbox"],
+    "publish_gov_uk_host_names": ["sandbox"],
     "key_vault_resource_group": "s121p01-shared-rg",
     "key_vault_name": "s121p01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-SANDBOX",

--- a/terraform/workspace_variables/staging.tfvars.json
+++ b/terraform/workspace_variables/staging.tfvars.json
@@ -8,7 +8,7 @@
     "paas_worker_app_memory": 512,
     "paas_postgres_service_plan": "small-11",
     "paas_redis_service_plan": "tiny-5_x",
-    "publish_gov_uk_host_names": ["staging2", "staging"],
+    "publish_gov_uk_host_names": ["staging"],
     "key_vault_resource_group": "s121t01-shared-rg",
     "key_vault_name": "s121t01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-STAGING",


### PR DESCRIPTION
### Context

Remove env2 routes that were used for the publish to ttapi migration,
as they are no longer required.

https://trello.com/c/DKPhYzRh/624-publish-remove-env2-routes

### Changes proposed in this pull request

Remove env2 from publish_gov_uk_host_names workspace variable for each env
Update Makefile for maintenance enable/disable 

### Guidance to review

deploy-plan each env

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
