### PR TITLE
Update the get-image-tag recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ backup-review-database: read-deployment-config # make review backup-review-datab
 	bin/backup-review-database ${postgres_database_name} ${paas_env}
 
 get-image-tag:
-	$(eval export TAG=$(shell cf target -s ${space} 1> /dev/null && cf app publish-teacher-training-${paas_env} | grep -Po "docker image:\s+\S+:\K\w+"))
+	$(eval export TAG=$(shell cf target -s ${space} 1> /dev/null && cf app publish-teacher-training-${paas_env} | awk -F : '$$1 == "docker image" {print $$3}'))
 	@echo ${TAG}
 
 get-postgres-instance-guid: ## Gets the postgres service instance's guid make qa get-postgres-instance-guid


### PR DESCRIPTION
The -P command has been found to be incompatible on Mac OS. Updating to use awk.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
