### PR TITLE
Refactor and add separator to title bar items

### DIFF
--- a/app/assets/stylesheets/components/_title-bar.scss
+++ b/app/assets/stylesheets/components/_title-bar.scss
@@ -1,19 +1,59 @@
-.title-bar-link {
-  float: right;
+.title-bar {
+  @include govuk-clearfix;
   margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
 }
 
-.title-bar-inline {
-  display: inline-block;
-  margin-top: govuk-spacing(2);
+.title-bar__title {
+  @include govuk-font($size: 19, $weight: "bold");
+  @include govuk-media-query($from: tablet) {
+    float: left;
+    width: 60%;
+  }
 }
 
-.title-bar-inline-item {
+.title-bar__link {
+  @include govuk-link-common;
+
+  &:link,
+  &:visited {
+    color: govuk-colour("blue");
+  }
+}
+
+.title-bar__actions {
+  margin: 0; // Reset default user agent styles
+
+  @include govuk-media-query($from: tablet) {
+    display: table-cell;
+    width: 40%;
+    padding-right: 0;
+    text-align: right;
+    float: right;
+  }
+}
+
+.title-bar__actions-list {
+  width: 100%;
+  margin: 0; // Reset default user agent styles
+  padding: 0; // Reset default user agent styles
+}
+
+.title-bar__actions-list-item {
   display: inline;
   margin-right: govuk-spacing(2);
   padding-right: govuk-spacing(2);
 }
 
-.title-bar-item-separator:not(:last-child) {
+// In older browsers such as IE8, :last-child is not available,
+// so only show the border divider where it is available.
+.title-bar__actions-list-item:not(:last-child) {
   border-right: 1px solid $govuk-border-colour;
 }
+
+.title-bar__actions-list-item:last-child {
+  margin-right: 0;
+  padding-right: 0;
+  border: 0;
+}
+

--- a/app/components/title_bar/view.html.erb
+++ b/app/components/title_bar/view.html.erb
@@ -1,22 +1,32 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
-    <% if multiple_providers_or_admin? || rollover_active? %>
-      <p class="govuk-heading-s title-bar-inline govuk-!-margin-bottom-2"><%= title %></p>
-    <% end %>
+    <div class="title-bar" aria-label="Organisation switcher">
+      <% if multiple_providers_or_admin? || rollover_active? %>
+        <div class="title-bar__title">
+          <%= title %>
 
-    <% if rollover_active? %>
-      <span class="govuk-hint title-bar-inline">
-        <%= recruitment_label %>
-      </span>
-    <% end %>
+          <% if rollover_active? %>
+            <span class="govuk-hint govuk-!-display-inline">
+              <%= recruitment_label %>
+            </span>
+          <% end %>
+        </div>
+      <% end %>
 
-    <% if rollover_active? %>
-      <%= change_cycle_link(@provider) %>
-    <% end %>
-
-    <% if multiple_providers_or_admin? %>
-      <%= change_organisation_link %>
-    <% end %>
+      <div class="title-bar__actions">
+        <% if change_items.count == 1 %>
+          <%= change_items.first %>
+        <% else %>
+          <ul class="title-bar__actions-list">
+            <% reversed_change_items.each do |item| item %>
+              <li class="title-bar__actions-list-item">
+                <%= item %>
+            <% end %>
+            </li>
+          </ul>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/components/title_bar/view.rb
+++ b/app/components/title_bar/view.rb
@@ -15,12 +15,20 @@ module TitleBar
 
   private
 
-    def change_organisation_link
-      govuk_link_to t("change_organisation"), root_path, class: "title-bar-link govuk-link--no-visited-state title-bar-inline-item title-bar-item-separator"
+    def change_items
+      [*(change_cycle_link if rollover_active?), *(change_organisation_link if multiple_providers_or_admin?)]
     end
 
-    def change_cycle_link(provider)
-      govuk_link_to t("page_titles.rollover.change_cycle"), publish_provider_path(code: provider, switcher: true), class: "title-bar-link govuk-link--no-visited-state"
+    def reversed_change_items
+      change_items.reverse
+    end
+
+    def change_organisation_link
+      govuk_link_to t("change_organisation"), root_path, class: "title-bar__link govuk-link--no-visited-state"
+    end
+
+    def change_cycle_link
+      govuk_link_to t("page_titles.rollover.change_cycle"), publish_provider_path(code: @provider, switcher: true), class: "title-bar__link govuk-link--no-visited-state"
     end
 
     def current_recruitment_cycle?


### PR DESCRIPTION
### Context

Add separator in between the title bar items, when there are multiple items and a small refactor.

#### Old

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/50492247/177631048-5d1a7add-33a1-407b-95ca-44e50b26dbc5.png">

#### New
<img width="1093" alt="image" src="https://user-images.githubusercontent.com/50492247/177638392-bb6d37b4-0ecf-4b55-af12-e9704f885c8f.png">


