### PR TITLE
Fix spacing for academic year

### DIFF
--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -141,7 +141,7 @@
         <% row.key { "Course starts" } %>
         <% row.value do %>
           <p class="govuk-body"><%= l(course.start_date&.to_date, format: :short) %></p>
-          <p class="govuk-hint">Academic year <%= course.academic_year %></p>
+          <p class="govuk-hint govuk-!-margin-top-0">Academic year <%= course.academic_year %></p>
         <% end %>
         <% if @course.edit_course_options[:show_start_date] %>
           <% row.action(**{


### PR DESCRIPTION
### Context

Fixing the spacing between the Academic year spacing on the course basic details page

The left is before and the right is after.

<img width="979" alt="image" src="https://user-images.githubusercontent.com/50492247/177628708-99d9c6b0-4428-48b2-a147-94bfb5e02a77.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
