### PR TITLE
[0243] Users should not see admin error

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,7 @@ class SessionsController < ApplicationController
       UserSession.end_session!(session)
       redirect_to(user_session.logout_url, allow_other_host: true)
     else
-      redirect_to support_providers_path
+      redirect_to publish_root_path
     end
   end
 

--- a/app/controllers/support/support_controller.rb
+++ b/app/controllers/support/support_controller.rb
@@ -7,8 +7,7 @@ module Support
 
     def check_user_is_admin
       if !current_user.admin?
-        flash[:warning] = "User is not an admin"
-        redirect_to sign_in_path
+        render "errors/forbidden", status: :forbidden, formats: :html
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -30,7 +30,7 @@ describe SessionsController, type: :controller do
 
       it "redirects to the root page" do
         request_destroy
-        expect(response).to redirect_to(support_providers_path)
+        expect(response).to redirect_to(publish_root_path)
       end
     end
   end

--- a/spec/features/auth/provider_user_signs_in_spec.rb
+++ b/spec/features/auth/provider_user_signs_in_spec.rb
@@ -36,7 +36,8 @@ feature "Authentication" do
 
   def and_i_cannot_access_the_support_interface
     visit support_providers_path
-    expect(page).to have_content "User is not an admin"
-    expect(page).to have_current_path sign_in_path
+    expect(page).to have_current_path support_providers_path
+    expect(page.status_code).to eq(403)
+    expect(page.find("h1")).to have_content("You are not permitted to see this page")
   end
 end


### PR DESCRIPTION
### Context
Users should not see admin error

### Changes proposed in this pull request
Present a forbidden page if user is not an admin instead of redirecting to sign in when they are signed in
Removed the flash, as it presents information without boundary
Redirect to the publish root path as that is really what the user wants to go to

### Guidance to review
You need DfE Sign in to reproduce the original isses

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
