### PR TITLE
[233] Surface financial incentives on course page

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -1,4 +1,6 @@
 class CourseDecorator < ApplicationDecorator
+  include ActiveSupport::NumberHelper
+
   delegate_all
 
   def name_and_code
@@ -320,6 +322,21 @@ class CourseDecorator < ApplicationDecorator
 
   def financial_support
     object.enrichment_attribute(:financial_support)
+  end
+
+  def financial_incentive_details
+    financial_incentive = object.financial_incentives.first
+    bursary_amount = number_to_currency(financial_incentive&.bursary_amount)
+    scholarship = number_to_currency(financial_incentive&.scholarship)
+
+    return I18n.t("components.course.financial_incentives.not_yet_available") if course.recruitment_cycle_year.to_i > Settings.current_recruitment_cycle_year
+    return I18n.t("components.course.financial_incentives.none") if financial_incentive.nil?
+
+    if bursary_amount.present? && scholarship.present?
+      return I18n.t("components.course.financial_incentives.bursary_and_scholarship", scholarship:, bursary_amount:)
+    end
+
+    I18n.t("components.course.financial_incentives.bursary", amount: bursary_amount)
   end
 
   def salary_details

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -18,7 +18,7 @@
   <% enrichment_summary(
     summary_list,
     :course,
-    "Interview process (optional)",
+    "Interview process",
     course.interview_process,
     %w[interview_process],
     action_path: "#{about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#interview-process",
@@ -68,7 +68,7 @@
     <% enrichment_summary(
       summary_list,
       :course,
-      "Fee for international students (optional)",
+      "Fee for international students",
       number_to_currency(course.fee_international),
       %w[fee_international],
       action_path: "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-international",
@@ -78,7 +78,7 @@
     <% enrichment_summary(
       summary_list,
       :course,
-      "Fee details (optional)",
+      "Fee details",
       course.fee_details,
       %w[fee_details],
       action_path: "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-details",
@@ -151,7 +151,7 @@
   <% enrichment_summary(
     summary_list,
     :course,
-    "Personal qualities (optional)",
+    "Personal qualities",
     course.personal_qualities,
     %w[personal_qualities],
     action_path: "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities",
@@ -161,7 +161,7 @@
   <% enrichment_summary(
     summary_list,
     :course,
-    "Other requirements (optional)",
+    "Other requirements",
     course.other_requirements,
     %w[other_requirements],
     action_path: "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements",

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -88,12 +88,18 @@
     <% enrichment_summary(
       summary_list,
       :course,
-      "Financial support you offer (optional)",
+      "Financial support you offer",
       course.financial_support,
       %w[financial_support],
       action_path: "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#financial-support",
       action_visually_hidden_text: "details of financial support you offer",
     ) %>
+
+    <% summary_list.row(html_attributes: { data: { qa: "course__financial_incentives" } }) do |row| %>
+      <% row.key { "Financial support from the government" } %>
+      <% row.value { course.financial_incentive_details } %>
+      <% row.action %>
+    <% end %>
   <% else %>
     <% enrichment_summary(
       summary_list,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,12 @@ en:
         user_types:
           admin: "Admin User"
           provider: "Provider User"
+    course:
+      financial_incentives:
+        none: "None available"
+        not_yet_available: "Information not yet available"
+        bursary_and_scholarship: "Scholarships of %{scholarship} and bursaries of %{bursary_amount} are available"
+        bursary: "Bursaries of %{amount} available"
   course:
     update_email:
       name: "title"

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -814,4 +814,46 @@ describe CourseDecorator do
       end
     end
   end
+
+  describe "#financial_incentive_details" do
+    subject { course.decorate.financial_incentive_details }
+
+    context "course has no financial incentive" do
+      it "returns the correct details under 'financial_incentive_details'" do
+        expect(subject).to eq("None available")
+      end
+    end
+
+    context "course has financial incentive" do
+      before do
+        allow(course).to receive(:financial_incentives).and_return([financial_incentive])
+      end
+
+      context "course has both bursary and scholarship available" do
+        let(:financial_incentive) { build_stubbed(:financial_incentive, scholarship: "2000", bursary_amount: "3000") }
+
+        it "returns the correct details under 'financial_incentive_details'" do
+          expect(subject).to eq("Scholarships of £2,000 and bursaries of £3,000 are available")
+        end
+      end
+
+      context "course only has bursary available" do
+        let(:financial_incentive) { build_stubbed(:financial_incentive, bursary_amount: "3000") }
+
+        it "returns the correct details under 'financial_incentive_details'" do
+          expect(subject).to eq("Bursaries of £3,000 available")
+        end
+      end
+    end
+
+    context "course is in the next cycle" do
+      before do
+        allow(course).to receive(:recruitment_cycle_year).and_return(current_recruitment_cycle.year.to_i + 1)
+      end
+
+      it "returns the correct details under 'financial_incentive_details'" do
+        expect(subject).to eq("Information not yet available")
+      end
+    end
+  end
 end

--- a/spec/factories/subjects/secondary_subjects.rb
+++ b/spec/factories/subjects/secondary_subjects.rb
@@ -36,13 +36,14 @@ FactoryBot.define do
   factory :secondary_subject do
     transient do
       sample_subject { subjects.to_a.sample }
+      bursary_amount { nil }
     end
 
     subject_name { sample_subject.first }
     subject_code { sample_subject.second }
 
-    after(:build) do |subject, _level|
-      financial_incentive = find_or_create(:financial_incentive, subject:)
+    after(:build) do |subject, evaluator|
+      financial_incentive = find_or_create(:financial_incentive, subject:, bursary_amount: evaluator.bursary_amount)
       subject.update(financial_incentive:)
     end
 

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 feature "Course show", { can_edit_current_and_next_cycles: false } do
+  include ActiveSupport::NumberHelper
+
   scenario "i can view the course basic details" do
     given_i_am_authenticated_as_a_provider_user(course: build(:course))
     when_i_visit_the_course_page
@@ -12,7 +14,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
 
   describe "with a fee paying course" do
     scenario "i can view a fee course" do
-      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], funding_type: "fee"))
+      given_i_am_authenticated_as_a_provider_user(course: course_with_financial_incentive)
       when_i_visit_the_course_page
       then_i_should_see_the_description_of_the_fee_course
       and_i_should_see_the_status_sidebar
@@ -86,6 +88,10 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     @course_enrichment ||= build(:course_enrichment, :published, course_length: :TwoYears, fee_uk_eu: 9250, fee_international: 14000)
   end
 
+  def financial_incentive
+    @financial_incentive ||= build(:financial_incentive, bursary_amount: 10000)
+  end
+
   def course_enrichment_unpublished_changes
     @course_enrichment_unpublished_changes ||= build(:course_enrichment, :subsequent_draft, course_length: :TwoYears, fee_uk_eu: 9250, fee_international: 14000)
   end
@@ -151,6 +157,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     expect(provider_courses_show_page.fee_details).to have_content(
       course_enrichment.fee_details,
     )
+    expect(provider_courses_show_page.financial_incentives).to have_content(number_to_currency(10000))
     expect(provider_courses_show_page).not_to have_salary_details
 
     expect(provider_courses_show_page).to have_degree
@@ -207,5 +214,15 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
 
   def course
     provider.courses.first
+  end
+
+  def course_with_financial_incentive
+    build(
+      :course,
+      :secondary,
+      enrichments: [course_enrichment],
+      funding_type: "fee",
+      subjects: [build(:secondary_subject, bursary_amount: 10000)],
+    )
   end
 end

--- a/spec/support/page_objects/publish/provider_courses_show.rb
+++ b/spec/support/page_objects/publish/provider_courses_show.rb
@@ -19,6 +19,7 @@ module PageObjects
       section :fee_details, Sections::SummaryList, '[data-qa="enrichment__fee_details"]'
       section :course_length, Sections::SummaryList, '[data-qa="enrichment__course_length"]'
       section :financial_support, Sections::SummaryList, '[data-qa="enrichment__financial_support"]'
+      section :financial_incentives, Sections::SummaryList, '[data-qa="course__financial_incentives"]'
       section :salary_details, Sections::SummaryList, '[data-qa="enrichment__salary_details"]'
       section :degree, Sections::SummaryList, '[data-qa="enrichment__degree_grade"]'
       section :gcse, Sections::SummaryList, '[data-qa="enrichment__accept_pending_gcse"]'


### PR DESCRIPTION
### Context

https://trello.com/c/hiRC3Z1m/233-surface-financial-incentives-on-course-page

Design history - https://bat-design-history.netlify.app/publish-teacher-training-courses/showing-financial-support-from-the-government/

### Changes proposed in this pull request

- Surfaces financial incentive detail for courses on the course show page
- Shows relevant details for the following scenarios:
  - Financial incentive is not available for the course
  - Financial incentive is available (scholarship and bursary, as well as just bursary option)
  - Financial incentive isn't available yet (during rollover/transition into next cycle)

### Guidance to review

Login as Mary and view the following courses https://publish-teacher-training-pr-2828.london.cloudapps.digital/publish/organisations/1ZN/2022/courses:

No incentive available course - https://publish-teacher-training-pr-2828.london.cloudapps.digital/publish/organisations/1ZN/2022/courses/2KSK - Should have no incentive

Only bursary available course - https://publish-teacher-training-pr-2828.london.cloudapps.digital/publish/organisations/1ZN/2022/courses/2KR6

Both scholarship and bursary available course - https://publish-teacher-training-pr-2828.london.cloudapps.digital/publish/organisations/1ZN/2022/courses/2KNR

Incentives not yet available course - https://publish-teacher-training-pr-2828.london.cloudapps.digital/publish/organisations/1ZN/2023/courses/2KSK

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
