### PR TITLE
229 add user to org via support

### DIFF
--- a/app/controllers/support/providers/users_check_controller.rb
+++ b/app/controllers/support/providers/users_check_controller.rb
@@ -2,6 +2,7 @@ module Support
   module Providers
     class UsersCheckController < SupportController
       def show
+        provider
         @user_form = UserForm.new(current_user, user)
       end
 
@@ -17,7 +18,6 @@ module Support
     private
 
       def user
-        provider
         User.find_or_initialize_by(email: params.dig(:support_user_form, :email))
       end
 

--- a/app/controllers/support/providers/users_check_controller.rb
+++ b/app/controllers/support/providers/users_check_controller.rb
@@ -1,0 +1,20 @@
+module Support
+  module Providers
+    class UsersCheckController < SupportController
+      def show
+        @user_form = UserForm.new(current_user, user)
+      end
+
+    private
+
+      def user
+        provider
+        User.find_or_initialize_by(email: params.dig(:support_user_form, :email))
+      end
+
+      def provider
+        @provider ||= Provider.find(params[:provider_id])
+      end
+    end
+  end
+end

--- a/app/controllers/support/providers/users_check_controller.rb
+++ b/app/controllers/support/providers/users_check_controller.rb
@@ -5,6 +5,15 @@ module Support
         @user_form = UserForm.new(current_user, user)
       end
 
+      def update
+        @user_form = UserForm.new(current_user, user)
+        if @user_form.save!
+          UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
+          redirect_to support_provider_users_path
+          flash[:success] = "User added"
+        end
+      end
+
     private
 
       def user

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -21,11 +21,13 @@ module Support
       end
 
       def new
+        provider
         @user_form = UserForm.new(current_user, user)
         @user_form.clear_stash
       end
 
       def create
+        provider
         @user_form = UserForm.new(current_user, user, params: user_params)
         if @user_form.stash
           redirect_to support_provider_check_user_path
@@ -37,7 +39,6 @@ module Support
     private
 
       def user
-        provider
         User.find_or_initialize_by(email: params.dig(:support_user_form, :email))
       end
 

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -22,6 +22,7 @@ module Support
 
       def new
         @user_form = UserForm.new(current_user, user)
+        @user_form.clear_stash
       end
 
       def create

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -7,15 +7,15 @@ module Support
       end
 
       def show
-        user
+        provider_user
       end
 
       def delete
-        user
+        provider_user
       end
 
       def destroy
-        UserAssociationsService::Delete.call(user:, providers: provider)
+        UserAssociationsService::Delete.call(user: provider_user, providers: provider)
         flash[:success] = I18n.t("success.user_removed")
         redirect_to support_provider_users_path(provider)
       end
@@ -34,15 +34,6 @@ module Support
         end
       end
 
-      def update
-        @user_form = UserForm.new(current_user, user)
-        if @user_form.save!
-          UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
-          redirect_to support_provider_users_path
-          flash[:success] = "User added"
-        end
-      end
-
     private
 
       def user
@@ -58,8 +49,8 @@ module Support
         @provider ||= Provider.find(params[:provider_id])
       end
 
-      def user
-        @user ||= provider.users.find(params[:id])
+      def provider_user
+        @provider_user ||= provider.users.find(params[:id])
       end
     end
   end

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -28,15 +28,15 @@ module Support
       def create
         @user_form = UserForm.new(current_user, user, params: user_params)
         if @user_form.stash
-          redirect_to check_support_provider_users_path
+          redirect_to support_provider_check_user_path
         else
           render(:new)
         end
       end
 
-      def check
+      def update
         @user_form = UserForm.new(current_user, user)
-        if request.method == "POST" && @user_form.save!
+        if @user_form.save!
           UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
           redirect_to support_provider_users_path
           flash[:success] = "User added"

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -35,16 +35,15 @@ module Support
 
       def check
         @user_form = UserForm.new(current_user, user)
-        if request.method == "POST"
-          if @user_form.save!
-            UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
-            redirect_to support_provider_users_path
-            flash[:success] = "User added"
-          end
+        if request.method == "POST" && @user_form.save!
+          UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
+          redirect_to support_provider_users_path
+          flash[:success] = "User added"
         end
       end
 
     private
+
       def user
         provider
         User.find_or_initialize_by(email: params.dig(:support_user_form, :email))

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -20,6 +20,11 @@ module Support
         redirect_to support_provider_users_path(provider)
       end
 
+      def new
+        provider
+        @user = User.new
+      end
+
     private
 
       def provider

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -21,11 +21,32 @@ module Support
       end
 
       def new
-        provider
-        @user = User.new
+        user = provider.users.new
+        @user_form = UserForm.new(current_user, user)
+      end
+
+      def create
+        user = provider.users.new
+        @user_form = UserForm.new(current_user, user, params: user_params)
+
+        if @user_form.stash
+          redirect_to check_support_provider_users_path
+        else
+          render(:new)
+        end
+      end
+
+      def check
+        user = provider.users.new
+        @user_form = UserForm.new(current_user, user)
       end
 
     private
+
+      def user_params
+        params.require(:support_user_form).permit(:first_name, :last_name, :email)
+      end
+
 
       def provider
         @provider ||= Provider.find(params[:provider_id])

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class Form
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :user, :model, :params, :fields
+
+  def initialize(user, model, params: {})
+    @user = user
+    @model = model
+    @params = params
+    @fields = compute_fields
+    assign_attributes(fields)
+  end
+
+  def save!
+    if valid?
+      assign_attributes_to_model
+      model.save!
+      clear_stash
+    else
+      false
+    end
+  end
+
+  def missing_fields
+    return [] if valid?
+
+    [
+      errors.attribute_names.filter_map do |attribute_name|
+        attribute_name if public_send(attribute_name).blank?
+      end,
+    ]
+  end
+
+  def clear_stash
+    store.clear_stash(form_store_key)
+  end
+
+  def stash
+    store.stash(form_store_key, fields.except(*fields_to_ignore_before_stash)) if valid?
+  end
+
+  def store
+    @store ||= UserStore.new(user)
+  end
+
+private
+
+  def assign_attributes_to_model
+    model.assign_attributes(fields.except(*fields_to_ignore_before_save))
+  end
+
+  def compute_fields
+    raise(NotImplementedError)
+  end
+
+  def fields_to_ignore_before_stash
+    []
+  end
+
+  def fields_to_ignore_before_save
+    []
+  end
+
+  def new_attributes
+    fields_from_store.merge(params).symbolize_keys
+  end
+
+  def validation_error_details
+    errors.messages.map do |field, messages|
+      [field, { messages:, value: public_send(field) }]
+    end
+  end
+
+  def fields_from_store
+    store.get(form_store_key).presence || {}
+  end
+
+  def form_store_key
+    self.class.name.underscore.chomp("_form").split("/").last.to_sym
+  end
+end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -25,16 +25,6 @@ class Form
     end
   end
 
-  def missing_fields
-    return [] if valid?
-
-    [
-      errors.attribute_names.filter_map do |attribute_name|
-        attribute_name if public_send(attribute_name).blank?
-      end,
-    ]
-  end
-
   def clear_stash
     store.clear_stash(form_store_key)
   end
@@ -43,11 +33,11 @@ class Form
     store.stash(form_store_key, fields.except(*fields_to_ignore_before_stash)) if valid?
   end
 
+private
+
   def store
     @store ||= UserStore.new(user)
   end
-
-private
 
   def assign_attributes_to_model
     model.assign_attributes(fields.except(*fields_to_ignore_before_save))

--- a/app/forms/support/user_form.rb
+++ b/app/forms/support/user_form.rb
@@ -28,7 +28,7 @@ module Support
 
     def email_is_lowercase
       if email.present? && email.downcase != email
-        errors.add(:email, "must be lowercase")
+        errors.add(:email, I18n.t("activemodel.errors.models.support/user_form.attributes.email.lowercase"))
       end
     end
   end

--- a/app/forms/support/user_form.rb
+++ b/app/forms/support/user_form.rb
@@ -6,11 +6,12 @@ module Support
       first_name
       last_name
       email
+      id
     ].freeze
 
     attr_accessor(*FIELDS)
 
-    alias :user :model
+    # alias :user :model
 
     validates :first_name, presence: true
     validates :last_name, presence: true
@@ -21,7 +22,7 @@ module Support
   private
 
     def compute_fields
-      user.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+      model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end
 
     def form_store_key
@@ -35,9 +36,11 @@ module Support
     end
 
     def email_is_unique
-      if email.present? && User.exists?(email: email)
-        errors.add(:email, "must be unique")
-      end
+      # return if user.persisted? && user.email == email
+      #
+      # if email.present? && User.exists?(email:)
+      #   errors.add(:email, "must be unique")
+      # end
     end
   end
 end

--- a/app/forms/support/user_form.rb
+++ b/app/forms/support/user_form.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Support
+  class UserForm < Form
+    FIELDS = %i[
+      first_name
+      last_name
+      email
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    alias :user :model
+
+    validates :first_name, presence: true
+    validates :last_name, presence: true
+    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "must contain @" }
+    validate :email_is_lowercase
+    validate :email_is_unique
+
+  private
+
+    def compute_fields
+      user.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+
+    def form_store_key
+      :user
+    end
+
+    def email_is_lowercase
+      if email.present? && email.downcase != email
+        errors.add(:email, "must be lowercase")
+      end
+    end
+
+    def email_is_unique
+      if email.present? && User.exists?(email: email)
+        errors.add(:email, "must be unique")
+      end
+    end
+  end
+end

--- a/app/forms/support/user_form.rb
+++ b/app/forms/support/user_form.rb
@@ -15,7 +15,7 @@ module Support
 
     validates :first_name, presence: true
     validates :last_name, presence: true
-    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "must contain @" }
+    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "Enter an email address in the correct format, like name@example.com" }
     validate :email_is_lowercase
     validate :email_is_unique
 

--- a/app/forms/support/user_form.rb
+++ b/app/forms/support/user_form.rb
@@ -11,13 +11,10 @@ module Support
 
     attr_accessor(*FIELDS)
 
-    # alias :user :model
-
     validates :first_name, presence: true
     validates :last_name, presence: true
     validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "Enter an email address in the correct format, like name@example.com" }
     validate :email_is_lowercase
-    validate :email_is_unique
 
   private
 
@@ -33,14 +30,6 @@ module Support
       if email.present? && email.downcase != email
         errors.add(:email, "must be lowercase")
       end
-    end
-
-    def email_is_unique
-      # return if user.persisted? && user.email == email
-      #
-      # if email.present? && User.exists?(email:)
-      #   errors.add(:email, "must be unique")
-      # end
     end
   end
 end

--- a/app/services/user_store.rb
+++ b/app/services/user_store.rb
@@ -9,7 +9,7 @@ class UserStore
     @user = user
   end
 
-  FORM_SECTION_KEYS = %i[
+  FORM_STORE_KEYS = %i[
     user
   ].freeze
 
@@ -21,25 +21,19 @@ class UserStore
     set(form_store_key, value)
   end
 
-  def get(key)
-    value = redis.get("#{user.id}_#{key}")
+  def get(form_store_key)
+    value = redis.get("#{user.id}_#{form_store_key}")
     JSON.parse(value) if value.present?
   end
 
 private
 
-  def set(key, values)
-    raise(InvalidKeyError) unless FORM_SECTION_KEYS.include?(key)
+  def set(form_store_key, values)
+    raise(InvalidKeyError) unless FORM_STORE_KEYS.include?(form_store_key)
 
-    redis.set("#{user.id}_#{key}", values.to_json)
+    redis.set("#{user.id}_#{form_store_key}", values.to_json)
 
     true
-  end
-
-  def clear_all
-    FORM_SECTION_KEYS.each do |key|
-      redis.set("#{user.id}_#{key}", nil)
-    end
   end
 
   def redis

--- a/app/services/user_store.rb
+++ b/app/services/user_store.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class UserStore
+  class InvalidKeyError < StandardError; end
+
+  attr_accessor :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  FORM_SECTION_KEYS = %i[
+    user
+  ].freeze
+
+  def clear_stash(form_store_key)
+    set(form_store_key, nil)
+  end
+
+  def stash(form_store_key, value)
+    set(form_store_key, value)
+  end
+
+  def get(key)
+    value = redis.get("#{user.id}_#{key}")
+    JSON.parse(value) if value.present?
+  end
+
+private
+
+  def set(key, values)
+    raise(InvalidKeyError) unless FORM_SECTION_KEYS.include?(key)
+
+    redis.set("#{user.id}_#{key}", values.to_json)
+
+    true
+  end
+
+  def clear_all
+    FORM_SECTION_KEYS.each do |key|
+      redis.set("#{user.id}_#{key}", nil)
+    end
+  end
+
+  def redis
+    @redis ||= RedisClient.current
+  end
+end

--- a/app/views/support/providers/users/check.html.erb
+++ b/app/views/support/providers/users/check.html.erb
@@ -22,7 +22,7 @@
               <%= @user_form.first_name %>
             </dd>
             <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider) %>
+              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider), class: "first_name" %>
               <span class="govuk-visually-hidden"> <%= t("support.providers.users.first_name") %></span>
             </dd>
           </div>
@@ -34,7 +34,7 @@
               <%= @user_form.last_name %>
             </dd>
             <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider) %>
+              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider), class: "last_name" %>
               <span class="govuk-visually-hidden"> <%= t("support.providers.users.last_name") %></span>
             </dd>
           </div>
@@ -46,7 +46,7 @@
               <%= @user_form.email %>
             </dd>
             <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider) %>
+              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider), class: "email" %>
               <span class="govuk-visually-hidden"><%= t("support.providers.users.email") %></span>
           </div>
         </dl>

--- a/app/views/support/providers/users/check.html.erb
+++ b/app/views/support/providers/users/check.html.erb
@@ -1,0 +1,68 @@
+<%= render PageTitle::View.new(title: t("support.providers.users.check")) %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(new_support_provider_user_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with(model: @user_form, url: new_support_provider_user_path, local: true) do |f| %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <span class="govuk-caption-l"><%= t("support.providers.users.new") %> - <%= @provider.provider_name %></span>
+          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("support.providers.users.check") %></h1>
+        </legend>
+
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= t("support.providers.users.first_name") %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= @user_form.first_name %>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <%= govuk_link_to t("change"),new_support_provider_user_path(@provider) %>
+              <span class="govuk-visually-hidden"> <%= t("support.providers.users.first_name") %></span>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= t("support.providers.users.last_name") %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= @user_form.last_name %>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <%= govuk_link_to t("change"),new_support_provider_user_path(@provider) %>
+              <span class="govuk-visually-hidden"> <%= t("support.providers.users.last_name") %></span>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              <%= t("support.providers.users.email") %>
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= @user_form.email %>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <%= govuk_link_to t("change"),new_support_provider_user_path(@provider) %>
+              <span class="govuk-visually-hidden"><%= t("support.providers.users.email") %></span>
+          </div>
+        </dl>
+
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+            The user will be sent an email to tell them you’ve added them to <%= @provider.provider_name %>.
+          </strong>
+        </div>
+
+        <%= f.govuk_submit(t("support.providers.users.new")) %>
+      </fieldset>
+    <% end %>
+
+    <%= govuk_link_to(t("cancel"), users_support_provider_path(@provider)) %>
+  </div>
+</div>

--- a/app/views/support/providers/users/check.html.erb
+++ b/app/views/support/providers/users/check.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @user_form, url: new_support_provider_user_path, local: true) do |f| %>
-
+    <%= form_with(model: @user_form, url: check_support_provider_users_path, local: true) do |f| %>
+    <%= f.hidden_field(:email, value: @user_form.email)%>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <span class="govuk-caption-l"><%= t("support.providers.users.new") %> - <%= @provider.provider_name %></span>

--- a/app/views/support/providers/users/check.html.erb
+++ b/app/views/support/providers/users/check.html.erb
@@ -6,58 +6,34 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @user_form, url: check_support_provider_users_path, local: true) do |f| %>
-    <%= f.hidden_field(:email, value: @user_form.email) %>
+      <%= f.hidden_field(:email, value: @user_form.email) %>
+
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <span class="govuk-caption-l"><%= t("support.providers.users.new") %> - <%= @provider.provider_name %></span>
-          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("support.providers.users.check") %></h1>
-        </legend>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= t("support.providers.users.new") %> - <%= @provider.provider_name %> </span>
+          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("support.providers.users.check") %> </h1> </legend>
 
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              <%= t("support.providers.users.first_name") %>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <%= @user_form.first_name %>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider), class: "first_name" %>
-              <span class="govuk-visually-hidden"> <%= t("support.providers.users.first_name") %></span>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              <%= t("support.providers.users.last_name") %>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <%= @user_form.last_name %>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider), class: "last_name" %>
-              <span class="govuk-visually-hidden"> <%= t("support.providers.users.last_name") %></span>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              <%= t("support.providers.users.email") %>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <%= @user_form.email %>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider), class: "email" %>
-              <span class="govuk-visually-hidden"><%= t("support.providers.users.email") %></span>
-          </div>
-        </dl>
+    <%= render GovukComponent::SummaryListComponent.new do |component|
+          component.row do |row|
+            row.key { t("support.providers.users.first_name") }
+            row.value(text:  @user_form.first_name)
+            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
+          end
 
-        <div class="govuk-warning-text">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
-            The user will be sent an email to tell them you’ve added them to <%= @provider.provider_name %>.
-          </strong>
-        </div>
+          component.row do |row|
+            row.key { t("support.providers.users.last_name") }
+            row.value(text: @user_form.last_name)
+            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
+          end
+
+          component.row do |row|
+            row.key { t("support.providers.users.email") }
+            row.value(text: @user_form.email)
+            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
+          end
+        end %>
+
+        <div class="govuk-warning-text"> <span class="govuk-warning-text__icon" aria-hidden="true">!</span> <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span> The user will be sent an email to tell them you’ve added them to <%= @provider.provider_name %>. </strong> </div>
 
         <%= f.govuk_submit(t("support.providers.users.new")) %>
       </fieldset>

--- a/app/views/support/providers/users/check.html.erb
+++ b/app/views/support/providers/users/check.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @user_form, url: check_support_provider_users_path, local: true) do |f| %>
-    <%= f.hidden_field(:email, value: @user_form.email)%>
+    <%= f.hidden_field(:email, value: @user_form.email) %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <span class="govuk-caption-l"><%= t("support.providers.users.new") %> - <%= @provider.provider_name %></span>
@@ -22,7 +22,7 @@
               <%= @user_form.first_name %>
             </dd>
             <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"),new_support_provider_user_path(@provider) %>
+              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider) %>
               <span class="govuk-visually-hidden"> <%= t("support.providers.users.first_name") %></span>
             </dd>
           </div>
@@ -34,7 +34,7 @@
               <%= @user_form.last_name %>
             </dd>
             <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"),new_support_provider_user_path(@provider) %>
+              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider) %>
               <span class="govuk-visually-hidden"> <%= t("support.providers.users.last_name") %></span>
             </dd>
           </div>
@@ -46,7 +46,7 @@
               <%= @user_form.email %>
             </dd>
             <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to t("change"),new_support_provider_user_path(@provider) %>
+              <%= govuk_link_to t("change"), new_support_provider_user_path(@provider) %>
               <span class="govuk-visually-hidden"><%= t("support.providers.users.email") %></span>
           </div>
         </dl>

--- a/app/views/support/providers/users/delete.html.erb
+++ b/app/views/support/providers/users/delete.html.erb
@@ -3,14 +3,14 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: "Back",
-    href: support_provider_user_path(@provider, @user),
+    href: support_provider_user_path(@provider, @provider_user),
   ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= "#{@user.full_name} - #{@provider.provider_name}" %></span>
+      <span class="govuk-caption-l"><%= "#{@provider_user.full_name} - #{@provider.provider_name}" %></span>
         <%= t("components.page_titles.support.providers.users.delete") %>
     </h1>
 
@@ -23,12 +23,12 @@
     </div>
 
     <%= govuk_button_to "Remove user",
-        delete_support_provider_user_path(@provider, @user),
+        delete_support_provider_user_path(@provider, @provider_user),
         method: :delete,
         class: "govuk-button--warning" %>
 
     <p class="govuk-body">
-      <%= govuk_link_to("Cancel", support_provider_user_path(@provider, @user)) %>
+      <%= govuk_link_to("Cancel", support_provider_user_path(@provider, @provider_user)) %>
     </p>
   </div>
 </div>

--- a/app/views/support/providers/users/index.html.erb
+++ b/app/views/support/providers/users/index.html.erb
@@ -1,3 +1,3 @@
-<%= link_to t("components.page_titles.support.users.new"), new_support_provider_user_path(@provider), class: "govuk-!-margin-top-4 govuk-button" %>
+<%= link_to t("components.page_titles.support.providers.users.new"), new_support_provider_user_path(@provider), class: "govuk-!-margin-top-4 govuk-button" %>
 <%= render "provider_user_list", users: @users, provider: @provider %>
 <%= render Paginator::View.new(scope: @users) %>

--- a/app/views/support/providers/users/index.html.erb
+++ b/app/views/support/providers/users/index.html.erb
@@ -1,2 +1,3 @@
+<%= link_to t("components.page_titles.support.users.new"), new_support_provider_user_path(@provider), class: "govuk-!-margin-top-4 govuk-button" %>
 <%= render "provider_user_list", users: @users, provider: @provider %>
 <%= render Paginator::View.new(scope: @users) %>

--- a/app/views/support/providers/users/new.html.erb
+++ b/app/views/support/providers/users/new.html.erb
@@ -1,6 +1,10 @@
 <%= render PageTitle::View.new(title: t("support.providers.users.new")) %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(users_support_provider_path(params[:provider_id])) %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t("back"),
+    href: support_provider_users_path,
+    ) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -22,6 +26,6 @@
       </fieldset>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), users_support_provider_path(@provider)) %>
+    <%= govuk_link_to(t("cancel"), support_provider_users_path) %>
   </div>
 </div>

--- a/app/views/support/providers/users/new.html.erb
+++ b/app/views/support/providers/users/new.html.erb
@@ -10,10 +10,9 @@
 
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <span class="govuk-caption-l"><%= "#{@provider.provider_name} (#{@provider.provider_code})"%></span>
+          <span class="govuk-caption-l"><%= "#{@provider.provider_name} (#{@provider.provider_code})" %></span>
           <h1 class="govuk-fieldset__heading"><%= t("support.providers.users.new") %></h1>
         </legend>
-
 
         <%= f.govuk_text_field :first_name, label: { text: t("support.providers.users.first_name"), size: "s" }, width: 20 %>
         <%= f.govuk_text_field :last_name, label: { text: t("support.providers.users.last_name"), size: "s" }, width: 20 %>

--- a/app/views/support/providers/users/new.html.erb
+++ b/app/views/support/providers/users/new.html.erb
@@ -6,6 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= form_with(model: @user_form, url: support_provider_users_path, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/app/views/support/providers/users/new.html.erb
+++ b/app/views/support/providers/users/new.html.erb
@@ -1,0 +1,28 @@
+<%= render PageTitle::View.new(title: "support.users.new") %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(users_support_provider_path(params[:provider_id])) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: [:support, :provider, @user], local: true do |f| %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <span class="govuk-caption-l"><%= "#{@provider.provider_name} (#{@provider.provider_code})"%></span>
+          <h1 class="govuk-fieldset__heading"><%= t("components.page_titles.support.users.new") %></h1>
+        </legend>
+
+        <%= f.govuk_error_summary %>
+
+        <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: 20 %>
+        <%= f.govuk_text_field :last_name, label: { text: "Last name", size: "s" }, width: 20 %>
+        <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" } %>
+
+        <%= f.govuk_submit %>
+      </fieldset>
+    <% end %>
+
+    <%= govuk_link_to(t("cancel"), users_support_provider_path(@provider)) %>
+  </div>
+</div>

--- a/app/views/support/providers/users/new.html.erb
+++ b/app/views/support/providers/users/new.html.erb
@@ -4,7 +4,7 @@
   <%= render GovukComponent::BackLinkComponent.new(
     text: t("back"),
     href: support_provider_users_path,
-    ) %>
+  ) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/support/providers/users/new.html.erb
+++ b/app/views/support/providers/users/new.html.erb
@@ -1,23 +1,22 @@
-<%= render PageTitle::View.new(title: "support.users.new") %>
+<%= render PageTitle::View.new(title: t("support.providers.users.new")) %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(users_support_provider_path(params[:provider_id])) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: [:support, :provider, @user], local: true do |f| %>
+      <%= form_with(model: @user_form, url: support_provider_users_path, local: true) do |f| %>
 
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <span class="govuk-caption-l"><%= "#{@provider.provider_name} (#{@provider.provider_code})"%></span>
-          <h1 class="govuk-fieldset__heading"><%= t("components.page_titles.support.users.new") %></h1>
+          <h1 class="govuk-fieldset__heading"><%= t("support.providers.users.new") %></h1>
         </legend>
 
-        <%= f.govuk_error_summary %>
 
-        <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: 20 %>
-        <%= f.govuk_text_field :last_name, label: { text: "Last name", size: "s" }, width: 20 %>
-        <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" } %>
+        <%= f.govuk_text_field :first_name, label: { text: t("support.providers.users.first_name"), size: "s" }, width: 20 %>
+        <%= f.govuk_text_field :last_name, label: { text: t("support.providers.users.last_name"), size: "s" }, width: 20 %>
+        <%= f.govuk_text_field :email, label: { text: t("support.providers.users.email"), size: "s" } %>
 
         <%= f.govuk_submit %>
       </fieldset>

--- a/app/views/support/providers/users/show.html.erb
+++ b/app/views/support/providers/users/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "support.providers.users.show") %>
+<%= render PageTitle::View.new(title: "support.providers.users.check") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(

--- a/app/views/support/providers/users/show.html.erb
+++ b/app/views/support/providers/users/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "support.providers.users.check") %>
+<%= render PageTitle::View.new(title: "support.providers.users.show") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -11,37 +11,37 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l"><%= @provider.provider_name %></span>
-      <%= @user.full_name %>
+      <%= @provider_user.full_name %>
     </h1>
 
     <%= render GovukComponent::SummaryListComponent.new do |component|
           component.row do |row|
             row.key { "First name" }
-            row.value(text: @user.first_name, html_attributes: { id: "first_name" })
+            row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
             row.action
           end
 
           component.row do |row|
             row.key { "Last name" }
-            row.value(text: @user.last_name, html_attributes: { id: "last_name" })
+            row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
             row.action
           end
 
           component.row do |row|
             row.key { "Email address" }
-            row.value(text: @user.email, html_attributes: { id: "email" })
+            row.value(text: @provider_user.email, html_attributes: { id: "email" })
             row.action
           end
 
           component.row do |row|
             row.key { "Organisations" }
-            row.value(text: sanitize(@user.providers.in_current_cycle.pluck(:provider_name).join(tag.br)), html_attributes: { id: "organisations" })
+            row.value(text: sanitize(@provider_user.providers.in_current_cycle.pluck(:provider_name).join(tag.br)), html_attributes: { id: "organisations" })
             row.action
           end
 
           component.row do |row|
             row.key { "Date last signed in" }
-            row.value(text: @user.last_login_date_utc&.strftime("%d %B %Y at %I:%M%p"), html_attributes: { id: "date_last_signed_in" })
+            row.value(text: @provider_user.last_login_date_utc&.strftime("%d %B %Y at %I:%M%p"), html_attributes: { id: "date_last_signed_in" })
             row.action
           end
         end %>

--- a/app/views/support/providers/users_check/show.html.erb
+++ b/app/views/support/providers/users_check/show.html.erb
@@ -1,11 +1,12 @@
 <%= render PageTitle::View.new(title: t("support.providers.users.check")) %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_support_provider_user_path) %>
+  <%= govuk_back_link_to(new_support_provider_users_path) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @user_form, url: check_support_provider_users_path, local: true) do |f| %>
+    <%= form_with(model: @user_form, url: support_provider_users_path, method: :put, local: true) do |f| %>
+
       <%= f.hidden_field(:email, value: @user_form.email) %>
 
       <fieldset class="govuk-fieldset">
@@ -16,19 +17,19 @@
           component.row do |row|
             row.key { t("support.providers.users.first_name") }
             row.value(text:  @user_form.first_name)
-            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
+            row.action(text: t("change"), href: new_support_provider_users_path(@provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
           end
 
           component.row do |row|
             row.key { t("support.providers.users.last_name") }
             row.value(text: @user_form.last_name)
-            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
+            row.action(text: t("change"), href: new_support_provider_users_path(@provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
           end
 
           component.row do |row|
             row.key { t("support.providers.users.email") }
             row.value(text: @user_form.email)
-            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
+            row.action(text: t("change"), href: new_support_provider_users_path(@provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
           end
         end %>
 

--- a/app/views/support/providers/users_check/show.html.erb
+++ b/app/views/support/providers/users_check/show.html.erb
@@ -1,11 +1,11 @@
 <%= render PageTitle::View.new(title: t("support.providers.users.check")) %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_support_provider_users_path) %>
+  <%= govuk_back_link_to(new_support_provider_user_path) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @user_form, url: support_provider_users_path, method: :put, local: true) do |f| %>
+    <%= form_with(model: @user_form, url: support_provider_check_user_path, method: :put, local: true) do |f| %>
 
       <%= f.hidden_field(:email, value: @user_form.email) %>
 
@@ -17,19 +17,19 @@
           component.row do |row|
             row.key { t("support.providers.users.first_name") }
             row.value(text:  @user_form.first_name)
-            row.action(text: t("change"), href: new_support_provider_users_path(@provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
+            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
           end
 
           component.row do |row|
             row.key { t("support.providers.users.last_name") }
             row.value(text: @user_form.last_name)
-            row.action(text: t("change"), href: new_support_provider_users_path(@provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
+            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
           end
 
           component.row do |row|
             row.key { t("support.providers.users.email") }
             row.value(text: @user_form.email)
-            row.action(text: t("change"), href: new_support_provider_users_path(@provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
+            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
           end
         end %>
 
@@ -40,6 +40,6 @@
       </fieldset>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), users_support_provider_path(@provider)) %>
+    <%= govuk_link_to(t("cancel"), support_provider_users_path) %>
   </div>
 </div>

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -5,7 +5,7 @@ class RedisSetting
 
   def initialize(config = nil)
     @config = {
-      url: ENV["REDIS_URL"],
+      url: ENV.fetch("REDIS_URL", nil),
     }.merge(parse_config(config))
   end
 
@@ -29,6 +29,6 @@ end
 
 class RedisClient
   def self.current
-    @current ||= Redis.new(url: RedisSetting.new(ENV["VCAP_SERVICES"]).url)
+    @current ||= Redis.new(url: RedisSetting.new(ENV.fetch("VCAP_SERVICES", nil)).url)
   end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class RedisSetting
+  attr_reader :config
+
+  def initialize(config = nil)
+    @config = {
+      url: ENV["REDIS_URL"],
+    }.merge(parse_config(config))
+  end
+
+  def url
+    config[:url]
+  end
+
+private
+
+  def parse_config(config)
+    service_config = JSON.parse(config.presence || "{}")
+    redis_config = service_config["redis"]
+    redis_cache_config = redis_config&.select { |r| r["instance_name"].include?("cache") }&.first
+
+    return {} if redis_cache_config.nil?
+
+    redis_credentials = redis_cache_config["credentials"]
+    { url: redis_credentials["uri"] }
+  end
+end
+
+class RedisClient
+  def self.current
+    @current ||= Redis.new(url: RedisSetting.new(ENV["VCAP_SERVICES"]).url)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,6 +388,7 @@ en:
           attributes:
             email:
               blank: "Enter an email address"
+              lowercase: "Enter an email address that is lowercase, like name@example.com"
             first_name:
               blank: "Enter a first name"
             last_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,6 +384,14 @@ en:
               blank: "Enter their organisation"
             reason:
               blank: "Enter why they need access"
+        support/user_form:
+          attributes:
+            email:
+              blank: "Enter an email address"
+            first_name:
+              blank: "Enter a first name"
+            last_name:
+              blank: "Enter a last name"
         publish/course_information_form:
           attributes:
             about_course:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,7 @@ en:
         users:
           index: "Users"
           show: "User overview"
-          new: "Add a user"
+          new: "Add user"
           edit: "Edit a user"
         allocations:
           index: "Allocations"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
       sign_out: "Sign out"
   cancel: "Cancel"
   change: "Change"
+  back: "Back"
   change_organisation: "Change organisation"
   page_titles:
     error_prefix: "Error: "

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,7 @@ en:
         users:
           index: "Users"
           show: "User overview"
+          new: "Add a user"
           edit: "Edit a user"
         allocations:
           index: "Allocations"
@@ -188,6 +189,13 @@ en:
         users:
           name: "Only users affiliated with a provider"
           description: "The list of all users affiliated with a provider from current recruitment cycle with columns: provider_code, provider_name, provider_type, first_name, last_name, email_address"
+    providers:
+      users:
+        first_name: "First name"
+        last_name: "Last name"
+        email: "Email address"
+        new: "Add user"
+        check: "Check your answers"
     flash:
       created: "%{resource} successfully created"
       updated: "%{resource} successfully updated"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,12 +121,13 @@ en:
             new: "Add a location"
             edit: "Edit location details"
           users:
+            new: "Add user"
+            check: "Check your answers"
             show: "User overview"
             delete: "Are you sure you want to remove this user?"
         users:
           index: "Users"
           show: "User overview"
-          new: "Add user"
           edit: "Edit a user"
         allocations:
           index: "Allocations"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,12 +244,8 @@ Rails.application.routes.draw do
       end
       resources :courses, only: %i[index edit update]
       resources :locations
-      resources :users, controller: "providers/users" do
-        collection do
-          get :check, path: "check"
-          post :check, path: "check"
-        end
-      end
+      resource :check_user, controller: "providers/users_check", path: "users/check"
+      resource :users, controller: "providers/users"
     end
     resources :users do
       scope module: :users do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,6 +244,7 @@ Rails.application.routes.draw do
       end
       resources :courses, only: %i[index edit update]
       resources :locations
+      resources :users, controller: "providers/users"
     end
 
     resources :users do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,9 +244,13 @@ Rails.application.routes.draw do
       end
       resources :courses, only: %i[index edit update]
       resources :locations
-      resources :users, controller: "providers/users"
+      resources :users, controller: "providers/users" do
+        collection do
+          get :check, path: "check"
+          post :check, path: "check"
+        end
+      end
     end
-
     resources :users do
       scope module: :users do
         resource :providers, on: :member, only: %i[show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,7 +236,8 @@ Rails.application.routes.draw do
     get "/" => redirect("/support/providers")
 
     resources :providers, except: %i[destroy] do
-      resources :users, only: %i[index show], controller: "providers/users" do
+      resource :check_user, only: %i[show update], controller: "providers/users_check", path: "users/check"
+      resources :users, only: %i[index show create new], controller: "providers/users" do
         member do
           get :delete
           delete :delete, to: "providers/users#destroy"
@@ -244,8 +245,6 @@ Rails.application.routes.draw do
       end
       resources :courses, only: %i[index edit update]
       resources :locations
-      resource :check_user, controller: "providers/users_check", path: "users/check"
-      resource :users, controller: "providers/users"
     end
     resources :users do
       scope module: :users do

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Adding user to provider as an admin" do
+  let(:user) { create(:user, :admin) }
+
+  before do
+    given_i_am_authenticated(user:)
+    and_there_is_a_provider
+  end
+
+  describe "Adding user to organisation" do
+    scenario "With valid details" do
+      given_i_visit_the_support_provider_users_index_page
+      and_the_user_i_want_to_add_has_not_already_been_added
+
+      when_i_click_add_user
+      and_i_fill_in_first_name
+      and_i_fill_in_last_name
+      and_i_fill_in_email
+      and_i_continue
+      then_i_should_be_on_the_check_page
+      and_the_user_should_not_be_added_to_the_database
+
+      when_i_click_add_user
+      then_i_should_see_the_users_name_listed
+      and_i_should_see_the_users_email_listed
+      and_the_user_should_be_added_to_the_database
+    end
+
+    scenario "With invalid details" do
+      given_i_visit_the_support_provider_users_new_page
+      and_i_continue
+
+      then_i_should_see_the_error_summary
+    end
+  end
+
+  def and_there_is_a_provider
+    @provider = create(:provider, :with_users, provider_name: "School of bats")
+  end
+
+  def given_i_visit_the_support_provider_users_index_page
+    visit support_provider_users_path(provider_id: @provider.id)
+  end
+
+  def and_i_continue
+    support_users_new_page.submit.click
+  end
+
+  def given_i_visit_the_support_provider_users_new_page
+    support_users_new_page.load(provider_id: @provider.id)
+  end
+
+  def and_i_fill_in_first_name
+    support_users_new_page.first_name.set("Asa")
+
+  end
+
+  def and_i_fill_in_last_name
+    support_users_new_page.last_name.set("Bernhard")
+  end
+
+  def and_i_fill_in_email
+    support_users_new_page.email.set("viola_fisher@boyle.io")
+  end
+
+  def when_i_click_add_user
+    support_users_check_page.add_user.click
+  end
+
+  def then_i_should_be_on_the_check_page
+    expect(page).to have_current_path("/support/providers/#{@provider.id}/users/check")
+  end
+
+  def then_i_should_see_the_users_name_listed
+    expect(page).to have_text("Asa Bernhard")
+  end
+
+  def and_i_should_see_the_users_email_listed
+    expect(page).to have_text("viola_fisher@boyle.io")
+  end
+
+  def and_the_user_i_want_to_add_has_not_already_been_added
+    expect(page).not_to have_text("viola_fisher@boyle.io")
+  end
+
+  def then_i_should_see_the_error_summary
+    expect(support_user_new_page.error_summary).to be_visible
+  end
+
+  def and_it_should_display_the_correct_error_messages
+    expect(support_user_new_page.error_summary).to have_text("Enter a first name")
+    expect(support_user_new_page.error_summary).to have_text("Enter a last name")
+    expect(support_user_new_page.error_summary).to have_text("Enter an email address")
+  end
+
+  def and_the_user_should_be_added_to_the_database
+    expect(Provider.find_by(provider_name: "School of bats").users.where(email: "viola_fisher@boyle.io").blank?).to be(false)
+  end
+
+  def and_the_user_should_not_be_added_to_the_database
+    expect(Provider.find_by(provider_name: "School of bats").users.where(email: "viola_fisher@boyle.io").blank?).to be(true)
+  end
+end

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -14,8 +14,7 @@ feature "Adding user to provider as an admin" do
     scenario "With valid details" do
       given_i_visit_the_support_provider_users_index_page
       and_the_user_i_want_to_add_has_not_already_been_added
-
-      when_i_click_add_user
+      and_i_click_add_user
       and_i_fill_in_first_name
       and_i_fill_in_last_name
       and_i_fill_in_email
@@ -23,7 +22,11 @@ feature "Adding user to provider as an admin" do
       then_i_should_be_on_the_check_page
       and_the_user_should_not_be_added_to_the_database
 
-      when_i_click_add_user
+      when_i_click_change_first_name
+      and_i_enter_a_new_first_name
+      and_i_continue
+      and_i_click_add_user
+
       then_i_should_see_the_users_name_listed
       and_i_should_see_the_users_email_listed
       and_the_user_should_be_added_to_the_database
@@ -65,7 +68,7 @@ feature "Adding user to provider as an admin" do
     support_users_new_page.email.set("viola_fisher@boyle.io")
   end
 
-  def when_i_click_add_user
+  def and_i_click_add_user
     support_users_check_page.add_user.click
   end
 
@@ -74,7 +77,7 @@ feature "Adding user to provider as an admin" do
   end
 
   def then_i_should_see_the_users_name_listed
-    expect(page).to have_text("Asa Bernhard")
+    expect(page).to have_text("Aba Bernhard")
   end
 
   def and_i_should_see_the_users_email_listed
@@ -101,5 +104,13 @@ feature "Adding user to provider as an admin" do
 
   def and_the_user_should_not_be_added_to_the_database
     expect(Provider.find_by(provider_name: "School of bats").users.where(email: "viola_fisher@boyle.io").blank?).to be(true)
+  end
+
+  def when_i_click_change_first_name
+    support_users_check_page.change_first_name.click
+  end
+
+  def and_i_enter_a_new_first_name
+    support_users_new_page.first_name.set("Aba")
   end
 end

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -71,19 +71,19 @@ feature "Adding user to provider as an admin" do
   end
 
   def then_i_should_be_on_the_check_page
-    expect(page).to have_current_path("/support/providers/#{@provider.id}/users/check")
+    expect(support_users_check_page).to have_current_path("/support/providers/#{@provider.id}/users/check")
   end
 
   def then_i_should_see_the_users_name_listed
-    expect(page).to have_text("Aba Bernhard")
+    expect(support_users_check_page).to have_text("Aba Bernhard")
   end
 
   def and_i_should_see_the_users_email_listed
-    expect(page).to have_text("viola_fisher@boyle.io")
+    expect(support_users_check_page).to have_text("viola_fisher@boyle.io")
   end
 
   def and_the_user_i_want_to_add_has_not_already_been_added
-    expect(page).not_to have_text("viola_fisher@boyle.io")
+    expect(support_users_check_page).not_to have_text("viola_fisher@boyle.io")
   end
 
   def then_i_should_see_the_error_summary

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Adding user to provider as an admin" do
+feature "Adding user to provider as an admin", { can_edit_current_and_next_cycles: false } do
   before do
     given_i_am_authenticated_as_an_admin_user
     and_there_is_a_provider
@@ -71,7 +71,7 @@ feature "Adding user to provider as an admin" do
   end
 
   def then_i_should_be_on_the_check_page
-    expect(support_users_check_page).to be_displayed
+    expect(support_users_check_page).to be_displayed(provider_id: @provider.id)
   end
 
   def then_i_should_see_the_users_name_listed

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -55,7 +55,6 @@ feature "Adding user to provider as an admin" do
 
   def and_i_fill_in_first_name
     support_users_new_page.first_name.set("Asa")
-
   end
 
   def and_i_fill_in_last_name

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -34,7 +34,7 @@ feature "Adding user to provider as an admin" do
       given_i_visit_the_support_provider_users_new_page
       and_i_continue
 
-      then_i_should_see_the_error_summary
+      then_it_should_display_the_correct_error_messages
     end
   end
 
@@ -86,11 +86,7 @@ feature "Adding user to provider as an admin" do
     expect(support_users_check_page).not_to have_text("viola_fisher@boyle.io")
   end
 
-  def then_i_should_see_the_error_summary
-    expect(support_user_new_page.error_summary).to be_visible
-  end
-
-  def and_it_should_display_the_correct_error_messages
+  def then_it_should_display_the_correct_error_messages
     expect(support_user_new_page.error_summary).to have_text("Enter a first name")
     expect(support_user_new_page.error_summary).to have_text("Enter a last name")
     expect(support_user_new_page.error_summary).to have_text("Enter an email address")

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -3,10 +3,8 @@
 require "rails_helper"
 
 feature "Adding user to provider as an admin" do
-  let(:user) { create(:user, :admin) }
-
   before do
-    given_i_am_authenticated(user:)
+    given_i_am_authenticated_as_an_admin_user
     and_there_is_a_provider
   end
 
@@ -112,5 +110,9 @@ feature "Adding user to provider as an admin" do
 
   def and_i_enter_a_new_first_name
     support_users_new_page.first_name.set("Aba")
+  end
+
+  def given_i_am_authenticated_as_an_admin_user
+    given_i_am_authenticated(user: create(:user, :admin))
   end
 end

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -71,7 +71,7 @@ feature "Adding user to provider as an admin" do
   end
 
   def then_i_should_be_on_the_check_page
-    expect(support_users_check_page).to have_current_path("/support/providers/#{@provider.id}/users/check")
+    expect(support_users_check_page).to be_displayed
   end
 
   def then_i_should_see_the_users_name_listed

--- a/spec/forms/support/user_form_spec.rb
+++ b/spec/forms/support/user_form_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Support::UserForm, type: :model do
+  let(:user) { create(:user) }
+  let(:model) { create(:user) }
+  let(:user_store) { double(UserStore) }
+  let(:params) { { email: "foo@bar.com", first_name: "Foo", last_name: "Bar" } }
+
+  subject { described_class.new(user, model, params:) }
+
+  before do
+    allow(user_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    before { subject.validate }
+
+    context "blank first_name" do
+      let(:params) { { first_name: nil } }
+
+      it "is invalid" do
+        expect(subject.errors[:first_name]).to include("Enter a first name")
+        expect(subject.valid?).to be(false)
+      end
+    end
+
+    context "blank last_name" do
+      let(:params) { { last_name: nil } }
+
+      it "is invalid" do
+        expect(subject.errors[:last_name]).to include("Enter a last name")
+        expect(subject.valid?).to be(false)
+      end
+    end
+
+    context "blank email" do
+      let(:params) { { email: nil } }
+
+      it "is invalid" do
+        expect(subject.errors[:email]).to include("Enter an email address in the correct format, like name@example.com")
+        expect(subject.valid?).to be(false)
+      end
+    end
+
+    context "uppercase email" do
+      let(:params) { { email: "FOOBAR@BAT.COM" } }
+
+      it "is invalid" do
+        expect(subject.errors[:email]).to include("Enter an email address that is lowercase, like name@example.com")
+        expect(subject.valid?).to be(false)
+      end
+    end
+
+    context "valid params" do
+      it "is valid" do
+        expect(subject.valid?).to be(true)
+      end
+    end
+  end
+
+  describe "save!" do
+    context "valid form" do
+      it "updates the provider user with the new details" do
+        expect { subject.save! }
+        .to change { model.first_name }.to("Foo")
+        .and change { model.last_name }.to("Bar")
+        .and change { model.email }.to("foo@bar.com")
+      end
+    end
+
+    context "invalid email" do
+      let(:params) { { email: "invalid email", first_name: "Foo", last_name: "Bar" } }
+
+      it "does not update the provider user with invalid details" do
+        expect { subject.save! }
+        .not_to(change { model.email })
+      end
+    end
+
+    context "blank first name" do
+      let(:params) { { email: "foo@bar.com", first_name: "", last_name: "Bar" } }
+
+      it "does not update the provider user with invalid details" do
+        expect { subject.save! }
+        .not_to(change { model.first_name })
+      end
+    end
+
+    context "blank last name" do
+      let(:params) { { email: "foo@bar.com", first_name: "Foo", last_name: "" } }
+
+      it "does not update the provider user with invalid details" do
+        expect { subject.save! }
+        .not_to(change { model.last_name })
+      end
+    end
+  end
+
+  describe "#stash" do
+    context "valid details" do
+      it "returns true" do
+        expect(subject.stash).to be true
+        expect(subject.errors.messages).to be_blank
+      end
+    end
+
+    context "missing last name" do
+      let(:params) { { email: "foo@bar.com", first_name: "Foo", last_name: "" } }
+
+      it "returns nil" do
+        expect(subject.stash).to be_nil
+        expect(subject.errors.messages).to eq({ last_name: ["Enter a last name"] })
+      end
+    end
+
+    context "missing first name" do
+      let(:params) { { email: "foo@bar.com", first_name: "", last_name: "Bar" } }
+
+      it "returns nil" do
+        expect(subject.stash).to be_nil
+        expect(subject.errors.messages).to eq({ first_name: ["Enter a first name"] })
+      end
+    end
+
+    context "missing email" do
+      let(:params) { { email: "", first_name: "Foo", last_name: "Bar" } }
+
+      it "returns nil" do
+        expect(subject.stash).to be_nil
+        expect(subject.errors.messages).to eq({ email: ["Enter an email address", "Enter an email address in the correct format, like name@example.com"] })
+      end
+    end
+  end
+end

--- a/spec/services/user_store_spec.rb
+++ b/spec/services/user_store_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+
+describe UserStore do
+  let(:user) { create(:user) }
+  let(:store) { described_class.new(user) }
+  let(:form_store_key) { :user }
+  let(:redis) { double }
+
+  before do
+    allow(RedisClient).to receive(:current).and_return(redis)
+  end
+
+  describe "#clear_stash" do
+    subject do
+      store.clear_stash(form_store_key)
+    end
+
+    context "when form_store_key is nil" do
+      let(:form_store_key) { nil }
+
+      it "returns an error" do
+        expect { subject }.to raise_error(UserStore::InvalidKeyError)
+      end
+    end
+
+    context "when form_store_key is user" do
+      let(:value) { nil }
+
+      before do
+        allow(RedisClient).to receive(:current).and_return(redis)
+        allow(redis).to receive(:set)
+      end
+
+      it "does not return an error" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "returns true" do
+        expect(subject).to be(true)
+      end
+
+      it "sets the redis value to nil" do
+        subject
+        expect(RedisClient).to have_received(:current)
+        expect(redis).to have_received(:set).with("#{user.id}_#{form_store_key}", value.to_json)
+      end
+    end
+  end
+
+  describe "#stash" do
+    subject do
+      store.stash(form_store_key, value)
+    end
+
+    let(:value) { "bob" }
+
+    context "when form_store_key is nil" do
+      let(:form_store_key) { nil }
+
+      it "returns an error" do
+        expect { subject }.to raise_error(UserStore::InvalidKeyError)
+      end
+    end
+
+    context "when form_store_key is user" do
+      before do
+        allow(redis).to receive(:set)
+      end
+
+      it "does not return an error" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "returns true" do
+        expect(subject).to be(true)
+      end
+
+      it "sets the redis value to bob" do
+        subject
+        expect(RedisClient).to have_received(:current)
+        expect(redis).to have_received(:set).with("#{user.id}_#{form_store_key}", value.to_json)
+      end
+    end
+  end
+
+  describe "#get" do
+    subject do
+      store.get(form_store_key)
+    end
+
+    context "when form_store_key is user" do
+      let(:redis) { double }
+      let(:value) { "builder".to_json }
+
+      before do
+        allow(redis).to receive(:get).and_return(value)
+      end
+
+      it "returns builder" do
+        expect(subject).to eq(JSON.parse(value))
+      end
+
+      it "sets the redis value to nil" do
+        subject
+        expect(RedisClient).to have_received(:current)
+        expect(redis).to have_received(:get).with("#{user.id}_#{form_store_key}")
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider/user/users_check.rb
+++ b/spec/support/page_objects/support/provider/user/users_check.rb
@@ -8,6 +8,10 @@ module PageObjects
           set_url "/support/providers/{provider_id}/users/check"
 
           element :add_user, ".govuk-button", text: "Add user"
+
+          element :change_first_name, "a.govuk-link.first_name", text: "Change"
+          element :change_last_name, "a.govuk-link.last_name", text: "Change"
+          element :change_email, "a.govuk-link.email", text: "Change"
         end
       end
     end

--- a/spec/support/page_objects/support/provider/user/users_check.rb
+++ b/spec/support/page_objects/support/provider/user/users_check.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    module Provider
+      module User
+        class UsersCheck < PageObjects::Base
+          set_url "/support/providers/{provider_id}/users/check"
+
+          element :add_user, ".govuk-button", text: "Add user"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider/user/users_new.rb
+++ b/spec/support/page_objects/support/provider/user/users_new.rb
@@ -19,5 +19,3 @@ module PageObjects
     end
   end
 end
-
-

--- a/spec/support/page_objects/support/provider/user/users_new.rb
+++ b/spec/support/page_objects/support/provider/user/users_new.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    module Provider
+      module User
+        class UsersNew < PageObjects::Base
+          set_url "/support/providers/{provider_id}/users/new"
+
+          element :first_name, "#support-user-form-first-name-field"
+          element :last_name, "#support-user-form-last-name-field"
+          element :email, "#support-user-form-email-field"
+
+          element :error_summary, ".govuk-error-summary"
+
+          element :submit, 'button.govuk-button[type="submit"]'
+        end
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
### Context

Introducing a feature for user support admins to create Publish users and associate them with specific organisations. The users will also be sent an email, with the link and inviting them to sign up to DfE Sign in, if they haven't already. The email is being implemented in #2835. 

### Changes proposed in this pull request

- Create new views, routes, controllers and form.
- Store changes in redis when submitting the form and going to the check page.
- Update the database with the changes stored in redis on submission of the check page.
- Values in the form are persisted if you cancel or go back from the check page. If you have accidently gone to the wrong provider, when you go to the correct one the form will be prefilled.
- Utilise the `UserAssociationService`.
- If the user does not exist on Publish, create the user and associate them with the provider.
- If the user does exist on Publish, find them and associate them with the provider.

### Guidance to review

Have a play around in the review app, compare with prototype, are there any differences or bugs?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
