### PR TITLE
Attach users to both cycles

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -119,6 +119,8 @@ class Provider < ApplicationRecord
 
   scope :in_current_cycle, -> { where(recruitment_cycle: RecruitmentCycle.current_recruitment_cycle) }
 
+  scope :in_next_cycle, -> { where(recruitment_cycle: RecruitmentCycle.next_recruitment_cycle) }
+
   scope :with_allocations_for_current_cycle_year, -> { joins(:allocations).merge(Allocation.current_allocations).order(:provider_name) }
 
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil).or where(region_code: nil) }

--- a/app/services/user_associations_service/create.rb
+++ b/app/services/user_associations_service/create.rb
@@ -1,5 +1,7 @@
 module UserAssociationsService
   class Create
+    include RolloverHelper
+
     attr_reader :provider, :user, :all_providers
 
     class << self
@@ -33,7 +35,19 @@ module UserAssociationsService
     end
 
     def add_user_to_a_single_provider
+      add_user_to_provider_in_current_cycle
+
+      if rollover_active?
+        add_user_to_provider_in_next_cycle
+      end
+    end
+
+    def add_user_to_provider_in_current_cycle
       provider.users << user
+    end
+
+    def add_user_to_provider_in_next_cycle
+      RecruitmentCycle.next.providers.find_by(provider_code: provider.provider_code).users << user
     end
 
     def send_user_added_to_provider_email

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,6 +113,19 @@ describe User, type: :model do
       end
     end
 
+    describe "during rollover" do
+      let(:rolled_over_provider) { create(:provider, :next_recruitment_cycle) }
+
+      before do
+        subject.providers = [provider, other_provider, rolled_over_provider]
+        subject.remove_access_to(rolled_over_provider)
+      end
+
+      it "removes the right provider" do
+        expect(subject.reload.providers).to eq([provider, other_provider])
+      end
+    end
+
     describe "#associated_with_accredited_body?" do
       context "user is associated with accredited body" do
         let(:current_recruitment_cycle) { find_or_create(:recruitment_cycle) }

--- a/spec/services/user_associations_service/delete_spec.rb
+++ b/spec/services/user_associations_service/delete_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe UserAssociationsService::Delete do
+RSpec.describe UserAssociationsService::Delete, { can_edit_current_and_next_cycles: false } do
   let(:user) { create :user }
 
   let(:accredited_body1) { create(:provider, :accredited_body, users: [user]) }
@@ -89,6 +89,19 @@ RSpec.describe UserAssociationsService::Delete do
           subject
 
           expect(UserNotification.where(user_id: user.id).count).to eq(0)
+        end
+      end
+
+      context "during rollover", { can_edit_current_and_next_cycles: true } do
+        let(:next_accredited_body1) { create(:provider, :accredited_body, :next_recruitment_cycle, provider_code: "AAA") }
+
+        it "removes user_permissions association in both cycles" do
+          subject
+          accredited_body1.reload
+          expect(accredited_body1.users).not_to include(user)
+          expect(next_accredited_body1.users).not_to include(user)
+          expect(user.providers).not_to include(accredited_body1)
+          expect(user.providers).not_to include(next_accredited_body1)
         end
       end
     end


### PR DESCRIPTION
### Context

This is a bug that prevents users from getting the correct access when granting access using the UserAssociationService. This is because the UserAssociationService doesn't consider rollover, when there are two cycles. 

### Changes proposed in this pull request

- Update the UserAssociationsService to handle adding users to two cycles when rollover is active.
- Update the UserAssociationsService to handle removing users from both cycles when rollover is active.

### Guidance to review

- Add a user using the UserAssociationService
- Ensure the user is added to both cycles
- Repeat for removing a user

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
