### PR TITLE
Add recruitment cycle scope to course fetch

### DIFF
--- a/app/controllers/concerns/copy_course_content.rb
+++ b/app/controllers/concerns/copy_course_content.rb
@@ -25,6 +25,7 @@ private
     @source_course = ::Courses::Fetch.by_code(
       provider_code: params[:provider_code],
       course_code: params[:copy_from],
+      recruitment_cycle_year: params[:recruitment_cycle_year],
     )
   end
 

--- a/app/services/courses/fetch.rb
+++ b/app/services/courses/fetch.rb
@@ -1,8 +1,8 @@
 module Courses
   class Fetch
     class << self
-      def by_code(provider_code:, course_code:)
-        RecruitmentCycle.current.providers
+      def by_code(provider_code:, course_code:, recruitment_cycle_year:)
+        RecruitmentCycle.find_by(year: recruitment_cycle_year).providers
           .find_by(provider_code:)
           .courses
           .find_by(course_code:)

--- a/spec/services/courses/fetch_spec.rb
+++ b/spec/services/courses/fetch_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe Courses::Fetch do
+  describe ".by_code" do
+    let(:provider_code) { course.provider.provider_code }
+    let(:course_code) { course.course_code }
+    let(:recruitment_cycle_year) { course.recruitment_cycle.year }
+    let(:course) { create(:course) }
+
+    it "fetches a course by course_code" do
+      expect(described_class.by_code(
+        provider_code:,
+        course_code:,
+        recruitment_cycle_year:,
+      )).to eq(course)
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/JKvoMiv7/316-bug-copying-course-content-only-copies-from-current-cycle

### Changes proposed in this pull request
When copying content for a course, it is now scoped to a course that runs in the same recruitment cycle as the course being copied to. 

Trying copying course content across from courses from the same provider, but changing the recruitment cycle - changes to the current recruitment cycle's course content will not be copyable to the next recruitment cycle's courses. 

We don't really seem to have any tests for this, I'm not entirely sure where to start introducing them either!