### PR TITLE
[xxx] Render correct list of providers for access request confirm

### DIFF
--- a/app/views/publish/access_requests/confirm.html.erb
+++ b/app/views/publish/access_requests/confirm.html.erb
@@ -12,7 +12,7 @@
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="row">Will receive access to</th>
-          <td class="govuk-table__cell "><%= @access_request.requester.providers.map(&:provider_name).join(", ") %></td>
+          <td class="govuk-table__cell "><%= @access_request.requester.providers.in_current_cycle.pluck(:provider_name).join(", ") %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
### Context

This uses the new scope on `user.providers` to return providers in current cycle for the access request confirm page, preventing duplicates from being shown.