### PR TITLE
#325 add preview link to unpublished and withdrawn

### DIFF
--- a/app/views/publish/courses/course_button_panel/_unpublished.html.erb
+++ b/app/views/publish/courses/course_button_panel/_unpublished.html.erb
@@ -9,6 +9,6 @@
                     data: { qa: "course__rollover" },
                     method: :get) %>
 <% end %>
-<%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
+<%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
 <%= govuk_link_to "Delete course", delete_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive", data: { qa: "course__delete-link" } %>
 </div>

--- a/app/views/publish/courses/course_button_panel/_unpublished.html.erb
+++ b/app/views/publish/courses/course_button_panel/_unpublished.html.erb
@@ -9,6 +9,6 @@
                     data: { qa: "course__rollover" },
                     method: :get) %>
 <% end %>
-
+<%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
 <%= govuk_link_to "Delete course", delete_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive", data: { qa: "course__delete-link" } %>
 </div>

--- a/app/views/publish/courses/course_button_panel/_withdrawn.html.erb
+++ b/app/views/publish/courses/course_button_panel/_withdrawn.html.erb
@@ -2,5 +2,5 @@
   Withdrawn on <%= l(course.withdrawn_at.to_datetime, format: :last_event) %>
 </span>
 <p class="govuk-body">
-<%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
+<%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), data: { qa: "course__preview-link" } %>
 </p>

--- a/app/views/publish/courses/course_button_panel/_withdrawn.html.erb
+++ b/app/views/publish/courses/course_button_panel/_withdrawn.html.erb
@@ -1,3 +1,6 @@
 <span class="govuk-hint govuk-!-font-size-16" data-qa="course__withdrawn_date">
   Withdrawn on <%= l(course.withdrawn_at.to_datetime, format: :last_event) %>
 </span>
+<p class="govuk-body">
+<%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
+</p>

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -99,7 +99,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_withdrawn]))
       when_i_visit_the_course_page
       then_i_should_see_the_course_button_panel
-      and_i_should_see_the_course_withdrawn_date
+      and_i_should_see_the_course_withdrawn_date_and_preview_link
     end
   end
 
@@ -173,6 +173,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
   def and_i_should_see_the_unpublished_partial
     provider_courses_show_page.course_button_panel.within do |course_button_panel|
       expect(course_button_panel).to have_publish_button
+      expect(course_button_panel).to have_preview_link
       expect(course_button_panel).to have_delete_link
     end
   end
@@ -183,6 +184,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
       expect(course_button_panel).to have_withdraw_link
       expect(course_button_panel).to have_vacancies_link
       expect(course_button_panel).to have_last_publish_date
+      expect(course_button_panel).not_to have_delete_link
     end
   end
 
@@ -198,9 +200,10 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{course.course_code}/details")
   end
 
-  def and_i_should_see_the_course_withdrawn_date
+  def and_i_should_see_the_course_withdrawn_date_and_preview_link
     provider_courses_show_page.course_button_panel.within do |course_button_panel|
       expect(course_button_panel).to have_withdrawn_date
+      expect(course_button_panel).to have_preview_link
     end
   end
 

--- a/spec/support/page_objects/sections/course_button_panel.rb
+++ b/spec/support/page_objects/sections/course_button_panel.rb
@@ -7,6 +7,7 @@ module PageObjects
     class CourseButtonPanel < PageObjects::Sections::Base
       element :publish_button, '[data-qa="course__publish"]'
       element :rollover_button, '[data-qa="course__rollover"]'
+      element :preview_link, '[data-qa="course__preview-link"]'
       element :delete_link, '[data-qa="course__delete-link"]'
 
       element :view_on_find, '[data-qa="course__is_findable"]'


### PR DESCRIPTION
### Context
When we moved the course actions from the sidebar to below the course title, we didn't include 'Preview course'! We need to add it to empty, draft, rolled over and withdrawn courses

### Changes proposed in this pull request
Added link to unpublished and withdrawn partials
### Guidance to review
Link should appear on empty, draft, rolled over and withdrawn courses only. I note the back button on the preview pages directs to the index view
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

<img width="992" alt="draft link" src="https://user-images.githubusercontent.com/4527528/180437677-56e733ea-3f0b-45dc-9caf-363eb9cab712.png">
<img width="786" alt="withdrawn link" src="https://user-images.githubusercontent.com/4527528/180437694-7ee9a40f-e51d-4d08-b303-2d4d93c073c1.png">
