### PR TITLE
Add edit provider user journey

### DIFF
--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -26,6 +26,23 @@ module Support
         @user_form.clear_stash
       end
 
+      def edit
+        provider
+        provider_user
+        @user_form = UserForm.new(current_user, provider_user)
+      end
+
+      def update
+        provider
+        @user_form = UserForm.new(current_user, provider_user, params: user_params)
+        if @user_form.save!
+          redirect_to support_provider_user_path(provider)
+          flash[:success] = "User updated"
+        else
+          render(:edit)
+        end
+      end
+
       def create
         provider
         @user_form = UserForm.new(current_user, user, params: user_params)

--- a/app/views/support/providers/users/edit.html.erb
+++ b/app/views/support/providers/users/edit.html.erb
@@ -1,0 +1,31 @@
+<%= render PageTitle::View.new(title: t("support.providers.users.edit")) %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t("back"),
+    href: support_provider_user_path(@provider, @provider_user),
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with(model: @user_form, url: support_provider_user_path, method: :put, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <span class="govuk-caption-l"><%= "#{@provider.provider_name} (#{@provider.provider_code})" %></span>
+          <h1 class="govuk-fieldset__heading"><%= @provider_user.full_name %></h1>
+        </legend>
+
+        <%= f.govuk_text_field :first_name, label: { text: t("support.providers.users.first_name"), size: "s" }, width: 20 %>
+        <%= f.govuk_text_field :last_name, label: { text: t("support.providers.users.last_name"), size: "s" }, width: 20 %>
+        <%= f.govuk_text_field :email, label: { text: t("support.providers.users.email"), size: "s" } %>
+
+        <%= f.govuk_submit(t("support.providers.users.edit")) %>
+      </fieldset>
+    <% end %>
+
+    <%= govuk_link_to(t("cancel"), support_provider_user_path(@provider)) %>
+  </div>
+</div>

--- a/app/views/support/providers/users/show.html.erb
+++ b/app/views/support/providers/users/show.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+      <span class="govuk-caption-l"><%= "#{@provider.provider_name} (#{@provider.provider_code})" %></span>
       <%= @provider_user.full_name %>
     </h1>
 
@@ -18,19 +18,19 @@
           component.row do |row|
             row.key { "First name" }
             row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
-            row.action
+            row.action(text: t("change"), href: edit_support_provider_user_path(@provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
           end
 
           component.row do |row|
             row.key { "Last name" }
             row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
-            row.action
+            row.action(text: t("change"), href: edit_support_provider_user_path(@provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
           end
 
           component.row do |row|
             row.key { "Email address" }
             row.value(text: @provider_user.email, html_attributes: { id: "email" })
-            row.action
+            row.action(text: t("change"), href: edit_support_provider_user_path(@provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
           end
 
           component.row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,7 @@ en:
         last_name: "Last name"
         email: "Email address"
         new: "Add user"
+        edit: "Update user"
         check: "Check your answers"
     flash:
       created: "%{resource} successfully created"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,7 +237,7 @@ Rails.application.routes.draw do
 
     resources :providers, except: %i[destroy] do
       resource :check_user, only: %i[show update], controller: "providers/users_check", path: "users/check"
-      resources :users, only: %i[index show create new], controller: "providers/users" do
+      resources :users, controller: "providers/users" do
         member do
           get :delete
           delete :delete, to: "providers/users#destroy"

--- a/spec/features/support/providers/editing_a_user_from_a_provider_spec.rb
+++ b/spec/features/support/providers/editing_a_user_from_a_provider_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Editing a user under a provider as an admin" do
+  before do
+    given_i_am_authenticated(user: create(:user, :admin))
+    and_a_user_provider_relationship_exists_to_edit
+    and_i_visit_the_support_provider_user_show_page
+  end
+
+  scenario "Editing a user from a provider" do
+    when_i_click_the_change_firstname_link
+    and_i_am_taken_to_the_support_provider_user_edit_page
+    and_i_fill_the_form
+    and_i_click_update
+    then_should_see_the_updated_details_displayed
+
+    when_i_click_the_change_lastname_link
+    and_i_fill_the_form
+    and_i_click_update
+    then_should_see_the_updated_details_displayed
+
+    when_i_click_the_change_email_link
+    and_i_fill_the_form
+    and_i_click_update
+    then_should_see_the_updated_details_displayed
+  end
+
+private
+
+  def and_a_user_provider_relationship_exists_to_edit
+    @provider = create(:provider)
+    @user = create(:user, providers: [@provider])
+  end
+
+  def and_i_visit_the_support_provider_user_show_page
+    support_provider_user_show_page.load(id: @user.id, provider_id: @provider.id)
+  end
+
+  def when_i_click_the_change_firstname_link
+    support_provider_user_show_page.change_first_name.click
+  end
+
+  def and_i_fill_the_form
+    support_provider_user_edit_page.first_name.set("Aba")
+    support_provider_user_edit_page.last_name.set("Bernharb")
+    support_provider_user_edit_page.email.set("viela_fisher@boyle.io")
+  end
+
+  def and_i_click_update
+    support_provider_user_edit_page.update_user.click
+  end
+
+  def then_should_see_the_updated_details_displayed
+    expect(support_users_check_page).to have_text("Aba")
+    expect(support_users_check_page).to have_text("Bernharb")
+    expect(support_users_check_page).to have_text("viela_fisher@boyle.io")
+  end
+
+  def when_i_click_the_change_lastname_link
+    support_provider_user_show_page.change_last_name.click
+  end
+
+  def when_i_click_the_change_email_link
+    support_provider_user_show_page.change_email.click
+  end
+
+  def and_i_am_taken_to_the_support_provider_user_edit_page
+    expect(support_provider_user_edit_page).to be_displayed
+  end
+
+  def then_i_am_redirected_to_support_provider_users_index_page
+    expect(support_provider_user_edit_page).to be_displayed
+  end
+end

--- a/spec/support/page_objects/support/provider_user_edit.rb
+++ b/spec/support/page_objects/support/provider_user_edit.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class ProviderUserEdit < PageObjects::Base
+      set_url "/support/providers/{provider_id}/users/{id}/edit"
+
+      element :first_name, "#support-user-form-first-name-field"
+      element :last_name, "#support-user-form-last-name-field"
+      element :email, "#support-user-form-email-field"
+
+      element :update_user, 'button.govuk-button[type="submit"]'
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider_user_show.rb
+++ b/spec/support/page_objects/support/provider_user_show.rb
@@ -12,6 +12,10 @@ module PageObjects
       element :date_last_signed_in, "#date_last_signed_in"
 
       element :remove_user_link, ".govuk-link", text: "Remove user"
+
+      element :change_first_name, "a.govuk-link.first_name", text: "Change"
+      element :change_last_name, "a.govuk-link.last_name", text: "Change"
+      element :change_email, "a.govuk-link.email", text: "Change"
     end
   end
 end


### PR DESCRIPTION
### Context

 Adding the edit provider user journey in line with #2839, #2838 and #2844.

### Changes proposed in this pull request

Create a view, controller action and feature test

### Guidance to review

Compare and contrast with the prototype.

![edit_provider_user](https://user-images.githubusercontent.com/50492247/180469216-eae2a0a3-91ae-46de-a562-67412081f07e.gif)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
