### PR TITLE
Remove StatusCake alerts

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -12,34 +12,5 @@
     "key_vault_resource_group": "s121p01-shared-rg",
     "key_vault_name": "s121p01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-PRODUCTION",
-    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION",
-    "statuscake_alerts": {
-        "ttapi": {
-          "website_name": "teacher-training-api-prod",
-          "website_url": "https://api.publish-teacher-training-courses.service.gov.uk/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        },
-        "ttapi_paas": {
-          "website_name": "publish-teacher-training-cloudapps-prod",
-          "website_url": "https://publish-teacher-training-prod.london.cloudapps.digital/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        },
-        "publish": {
-          "website_name": "publish-teacher-training-prod",
-          "website_url": "https://www.publish-teacher-training-courses.service.gov.uk/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        }
-    }
+    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION"
 }

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -12,25 +12,5 @@
     "key_vault_resource_group": "s121d01-shared-rg",
     "key_vault_name": "s121d01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-QA",
-    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
-    "statuscake_alerts": {
-        "ttapi": {
-          "website_name": "teacher-training-api-qa",
-          "website_url": "https://qa.api.publish-teacher-training-courses.service.gov.uk/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        },
-        "publish": {
-          "website_name": "publish-teacher-training-qa",
-          "website_url": "https://qa.publish-teacher-training-courses.service.gov.uk/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        }
-    }
+    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA"
 }

--- a/terraform/workspace_variables/rollover.tfvars.json
+++ b/terraform/workspace_variables/rollover.tfvars.json
@@ -11,16 +11,5 @@
     "key_vault_resource_group": "s121p01-shared-rg",
     "key_vault_name": "s121p01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-ROLLOVER",
-    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-ROLLOVER",
-    "statuscake_alerts": {
-        "ttapi": {
-          "website_name": "publish-teacher-training-rollover",
-          "website_url": "https://publish-teacher-training-rollover.london.cloudapps.digital/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        }
-    }
+    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-ROLLOVER"
 }

--- a/terraform/workspace_variables/sandbox.tfvars.json
+++ b/terraform/workspace_variables/sandbox.tfvars.json
@@ -12,25 +12,5 @@
     "key_vault_resource_group": "s121p01-shared-rg",
     "key_vault_name": "s121p01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-SANDBOX",
-    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-SANDBOX",
-    "statuscake_alerts": {
-        "ttapi-sandbox": {
-          "website_name": "teacher-training-api-sandbox",
-          "website_url": "https://sandbox.api.publish-teacher-training-courses.service.gov.uk/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        },
-        "publish": {
-          "website_name": "publish-teacher-training-sandbox",
-          "website_url": "https://sandbox.publish-teacher-training-courses.service.gov.uk/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        }
-    }
+    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-SANDBOX"
 }

--- a/terraform/workspace_variables/staging.tfvars.json
+++ b/terraform/workspace_variables/staging.tfvars.json
@@ -12,25 +12,5 @@
     "key_vault_resource_group": "s121t01-shared-rg",
     "key_vault_name": "s121t01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-STAGING",
-    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
-    "statuscake_alerts": {
-        "ttapi": {
-          "website_name": "teacher-training-api-staging",
-          "website_url": "https://staging.api.publish-teacher-training-courses.service.gov.uk/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        },
-        "publish": {
-          "website_name": "publish-teacher-training-staging",
-          "website_url": "https://staging.publish-teacher-training-courses.service.gov.uk/ping",
-          "test_type": "HTTP",
-          "check_rate": 60,
-          "contact_group": [151103],
-          "trigger_rate": 0,
-          "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-        }
-    }
+    "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING"
 }


### PR DESCRIPTION
Remove the StatusCake alerts before creating them again with the new StatusCake Terraform provider.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
