### PR TITLE
ignore cloudfront proxy IPs for request.remote_ip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,6 +133,10 @@ gem "sprockets-rails", require: "sprockets/railtie"
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.2.1"
 
+group :production do
+  gem "cloudfront-rails"
+end
+
 group :development, :test do
   # Prettyprint in console
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     case_transform (0.2)
       activesupport
     choice (0.2.0)
+    cloudfront-rails (0.4.0)
+      railties (> 4.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     config (4.0.0)
@@ -716,6 +718,7 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (>= 2.15)
+  cloudfront-rails
   config
   cssbundling-rails (~> 1.1)
   custom_error_message!


### PR DESCRIPTION
Up until now, when retrieving the IP of the client we've been getting the CloudFront proxy IPs. The `cloudfront-rails` gem retrieves and caches the list of CloudFront IPs, and configures Rails to ignore them when retrieving the client IP via `request.remote_ip`.

This is required by `dfe-analytics` to help us better understand who is using our services (using psuedo-anonymisation).

### Guidance to review

This has been tested locally by taking the gem line out of the production group, and making a request with X-Forwarded-For headers that include an IP from CloudFront. Without this gem installed, the CloudFront IP is returned by `request.remote_ip`.

```
curl -k -H "X-Forwarded-For: 123.12.34.123, 3.11.53.10, 10.1.2.3" https://localhost:3001/ip
Your IP: 3.11.53.10
```

Without it, this IP is ignored:

```
curl -k -H "X-Forwarded-For: 123.12.34.123, 3.11.53.10, 10.1.2.3" https://localhost:3001/ip
Your IP: 123.12.34.123
```

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
