### PR TITLE
Scope support routes based on recruitment cycle

### DIFF
--- a/app/components/filters/view.rb
+++ b/app/components/filters/view.rb
@@ -38,12 +38,10 @@ module Filters
     def reload_path
       # This will be removed once all the scope recruitment cycle to support params PR's have been merged
       case filter_model.to_s.downcase.pluralize
-      when "allocations"
-        send("support_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
-      when "users"
-        send("support_recruitment_cycle_provider_#{filter_model.to_s.downcase.pluralize}_path".to_sym, { provider_id: 1, recruitment_cycle_year: 2022 })
-      else
+      when "providers"
         send("support_recruitment_cycle_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
+      else
+        send("support_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
       end
     end
   end

--- a/app/components/filters/view.rb
+++ b/app/components/filters/view.rb
@@ -36,7 +36,15 @@ module Filters
     end
 
     def reload_path
-      send("support_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
+      # This will be removed once all the scope recruitment cycle to support params PR's have been merged
+      case filter_model.to_s.downcase.pluralize
+      when "allocations"
+        send("support_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
+      when "users"
+        send("support_recruitment_cycle_provider_#{filter_model.to_s.downcase.pluralize}_path".to_sym, { provider_id: 1, recruitment_cycle_year: 2022 })
+      else
+        send("support_recruitment_cycle_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
+      end
     end
   end
 end

--- a/app/components/providers/provider_list/view.html.erb
+++ b/app/components/providers/provider_list/view.html.erb
@@ -2,7 +2,7 @@
       component.row do |row|
         row.key { "Name" }
         row.value { @provider.provider_name }
-        row.action(text: "Change", href: edit_support_provider_url(@provider), visually_hidden_text: "provider name")
+        row.action(text: "Change", href: edit_support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider), visually_hidden_text: "provider name")
       end
 
       component.row do |row|
@@ -20,7 +20,7 @@
       component.row do |row|
         row.key { "Provider type" }
         row.value { formatted_provider_type }
-        row.action(text: "Change", href: edit_support_provider_url(@provider), visually_hidden_text: "provider type")
+        row.action(text: "Change", href: edit_support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider), visually_hidden_text: "provider type")
       end
 
       component.row do |row|

--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -17,7 +17,7 @@ module Support
       @edit_course_form.assign_attributes(update_course_params)
 
       if @edit_course_form.save
-        redirect_to support_provider_courses_path(provider), flash: { success: t("support.flash.updated", resource: "Course") }
+        redirect_to support_recruitment_cycle_provider_courses_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.updated", resource: "Course") }
       else
         render :edit
       end

--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -5,7 +5,7 @@ module Support
       render layout: "provider_record"
     rescue ActiveRecord::RecordNotFound
       flash[:warning] = "Provider not found"
-      redirect_to support_providers_path
+      redirect_to support_recruitment_cycle_providers_path
     end
 
     def edit

--- a/app/controllers/support/locations_controller.rb
+++ b/app/controllers/support/locations_controller.rb
@@ -16,7 +16,7 @@ module Support
       @site = provider.sites.build(site_params)
 
       if @site.save
-        redirect_to support_provider_locations_path(provider), flash: { success: t("support.flash.created", resource: flash_resource) }
+        redirect_to support_recruitment_cycle_provider_locations_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.created", resource: flash_resource) }
       else
         render :new
       end
@@ -29,7 +29,7 @@ module Support
 
     def update
       if site.update(site_params)
-        redirect_to support_provider_locations_path(provider), flash: { success: t("support.flash.updated", resource: flash_resource) }
+        redirect_to support_recruitment_cycle_provider_locations_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.updated", resource: flash_resource) }
       else
         render :edit
       end
@@ -38,7 +38,7 @@ module Support
     def destroy
       site.destroy!
 
-      redirect_to support_provider_locations_path(provider), flash: { success: t("support.flash.deleted", resource: flash_resource) }
+      redirect_to support_recruitment_cycle_provider_locations_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.deleted", resource: flash_resource) }
     end
 
   private

--- a/app/controllers/support/providers/users_check_controller.rb
+++ b/app/controllers/support/providers/users_check_controller.rb
@@ -10,7 +10,7 @@ module Support
         @user_form = UserForm.new(current_user, user)
         if @user_form.save!
           UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
-          redirect_to support_provider_users_path
+          redirect_to support_recruitment_cycle_provider_users_path
           flash[:success] = "User added"
         end
       end

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -17,7 +17,7 @@ module Support
       def destroy
         UserAssociationsService::Delete.call(user: provider_user, providers: provider)
         flash[:success] = I18n.t("success.user_removed")
-        redirect_to support_provider_users_path(provider)
+        redirect_to support_recruitment_cycle_provider_users_path(provider.recruitment_cycle_year, provider)
       end
 
       def new
@@ -36,7 +36,7 @@ module Support
         provider
         @user_form = UserForm.new(current_user, provider_user, params: user_params)
         if @user_form.save!
-          redirect_to support_provider_user_path(provider)
+          redirect_to support_recruitment_cycle_provider_user_path(provider.recruitment_cycle_year, provider)
           flash[:success] = "User updated"
         else
           render(:edit)
@@ -47,7 +47,7 @@ module Support
         provider
         @user_form = UserForm.new(current_user, user, params: user_params)
         if @user_form.stash
-          redirect_to support_provider_check_user_path
+          redirect_to support_recruitment_cycle_provider_check_user_path
         else
           render(:new)
         end

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -43,20 +43,24 @@ module Support
 
   private
 
+    def recruitment_cycle
+      @recruitment_cycle ||= RecruitmentCycle.find_by(year: params.fetch(:recruitment_cycle_year))
+    end
+
     def filtered_providers
       @filtered_providers ||= Support::Filter.call(model_data_scope: find_providers, filter_params:)
     end
 
     def find_providers
-      RecruitmentCycle.current.providers.order(:provider_name).includes(:courses, :users)
+      recruitment_cycle.providers.order(:provider_name).includes(:courses, :users)
     end
 
     def filter_params
-      @filter_params ||= params.except(:commit).permit(:provider_search, :course_search, :page)
+      @filter_params ||= params.except(:commit, :recruitment_cycle_year).permit(:provider_search, :course_search, :page)
     end
 
     def provider
-      @provider ||= Provider.find(params[:id])
+      @provider ||= recruitment_cycle.providers.find(params[:id])
     end
 
     def update_provider_params
@@ -79,7 +83,7 @@ module Support
                                          address3
                                          address4
                                          postcode],
-        organisations_attributes: %i[name]).merge(recruitment_cycle: RecruitmentCycle.current_recruitment_cycle)
+        organisations_attributes: %i[name]).merge(recruitment_cycle:)
     end
   end
 end

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -13,7 +13,7 @@ module Support
     def create
       @provider = Provider.new(create_provider_params)
       if @provider.save
-        redirect_to support_provider_path(provider), flash: { success: "Provider was successfully created" }
+        redirect_to support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider), flash: { success: "Provider was successfully created" }
       else
         render :new
       end
@@ -30,7 +30,7 @@ module Support
 
     def update
       if provider.update(update_provider_params)
-        redirect_to support_provider_path(provider), flash: { success: t("support.flash.updated", resource: "Provider") }
+        redirect_to support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider), flash: { success: t("support.flash.updated", resource: "Provider") }
       else
         render :edit
       end

--- a/app/views/layouts/provider_record.html.erb
+++ b/app/views/layouts/provider_record.html.erb
@@ -4,17 +4,17 @@
   <%= content_for(:breadcrumbs) do %>
     <%= render GovukComponent::BackLinkComponent.new(
       text: "All provider records",
-      href: support_providers_path,
+      href: support_recruitment_cycle_providers_path,
     ) %>
   <% end %>
 
   <h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
 
   <%= render TabNavigation::View.new(items: [
-    { name: "Details", url: support_provider_path(@provider) },
-    { name: "Users", url: support_provider_users_path(@provider) },
-    { name: "Courses", url: support_provider_courses_path(@provider) },
-    { name: "Locations", url: support_provider_locations_path(@provider) },
+    { name: "Details", url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider) },
+    { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
+    { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
+    { name: "Locations", url: support_recruitment_cycle_provider_locations_path(@provider.recruitment_cycle_year, @provider) },
   ]) %>
 
   <%= yield %>

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= render TabNavigation::View.new(items: [
-  { name: "Providers", url: support_providers_path },
+  { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year].to_i) },
   { name: "Users", url: support_users_path },
   { name: "PE Allocations", url: support_allocations_path },
 ]) %>

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= render TabNavigation::View.new(items: [
-  { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year].to_i) },
+  { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
   { name: "Users", url: support_users_path },
   { name: "PE Allocations", url: support_allocations_path },
 ]) %>

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -3,7 +3,7 @@
 <h1 class="govuk-heading-l">Edit course details</h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @edit_course_form, url: support_provider_course_path, method: :patch do |f| %>
+    <%= form_with model: @edit_course_form, url: support_recruitment_cycle_provider_course_path(@provider.recruitment_cycle_year, @provider), method: :patch do |f| %>
 
       <%= f.govuk_error_summary %>
 
@@ -23,7 +23,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), support_provider_courses_path) %>
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_courses_path) %>
     </p>
   </div>
 </div>

--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -15,7 +15,7 @@
           <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.name %> (<%= course.course_code %>)</span>
         </td>
         <td class="govuk-table__cell change">
-          <%= govuk_link_to "Change", edit_support_provider_course_url(@provider, course) %>
+          <%= govuk_link_to "Change", edit_support_recruitment_cycle_provider_course_url(@provider.recruitment_cycle_year, @provider, course) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/support/locations/edit.html.erb
+++ b/app/views/support/locations/edit.html.erb
@@ -4,15 +4,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= render partial: "form", locals: { site: @site, form_url: support_provider_location_path } %>
+    <%= render partial: "form", locals: { site: @site, form_url: support_recruitment_cycle_provider_location_path } %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), support_provider_locations_path) %>
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_locations_path) %>
     </p>
 
     <p class="govuk-body">
       <%= govuk_button_to t("support.actions.delete", resource: "location"),
-          support_provider_location_path(@provider, @site),
+          support_recruitment_cycle_provider_location_path(@provider.recruitment_cycle_year, @provider, @site),
           method: :delete,
           class: "govuk-button govuk-button--warning" %>
     </p>

--- a/app/views/support/locations/index.html.erb
+++ b/app/views/support/locations/index.html.erb
@@ -1,6 +1,6 @@
 <%= render PageTitle::View.new(title: "support.providers.locations.index") %>
 
-<%= govuk_link_to("Add location", new_support_provider_location_path, class: "govuk-button govuk-!-margin-bottom-3") %>
+<%= govuk_link_to("Add location", new_support_recruitment_cycle_provider_location_path, class: "govuk-button govuk-!-margin-bottom-3") %>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">
@@ -17,7 +17,7 @@
         <tr class="govuk-table__row location-row">
           <td class="govuk-table__cell name">
             <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-              <%= govuk_link_to site.location_name, edit_support_provider_location_path(@provider, site) %>
+              <%= govuk_link_to site.location_name, edit_support_recruitment_cycle_provider_location_path(@provider.recruitment_cycle_year, @provider, site) %>
             </span>
           </td>
           <td class="govuk-table__cell code">

--- a/app/views/support/locations/new.html.erb
+++ b/app/views/support/locations/new.html.erb
@@ -4,10 +4,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= render partial: "form", locals: { site: @site, form_url: support_provider_locations_path } %>
+    <%= render partial: "form", locals: { site: @site, form_url: support_recruitment_cycle_provider_locations_path } %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), support_provider_locations_path) %>
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_locations_path) %>
     </p>
 
     <% if @site.persisted? %>

--- a/app/views/support/providers/_list.html.erb
+++ b/app/views/support/providers/_list.html.erb
@@ -11,7 +11,7 @@
       <tr class="govuk-table__row qa-provider_row">
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
+            <%= govuk_link_to provider.provider_name, support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider) %>
           </span>
         </td>
 

--- a/app/views/support/providers/edit.html.erb
+++ b/app/views/support/providers/edit.html.erb
@@ -2,8 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: [:support, @provider], local: true do |f| %>
+    <%= form_with model: @provider, url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider), local: true do |f| %>
 
+      <%#= form_with url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider), local: true do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :provider_name, label: { text: "Provider name", size: "m" } %>
@@ -19,7 +20,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), support_provider_path) %>
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_path) %>
     </p>
   </div>
 </div>

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -5,7 +5,7 @@
 <%= render "support/menu" %>
 
 <%= govuk_link_to("Add provider",
-      new_support_provider_path,
+      new_support_recruitment_cycle_provider_path,
       class: "govuk-button govuk-!-margin-bottom-6") %>
 
 <%= render PaginatedFilter::View.new(filter_params: @filter_params, collection: @providers) do %>

--- a/app/views/support/providers/new.html.erb
+++ b/app/views/support/providers/new.html.erb
@@ -3,13 +3,13 @@
 <%= content_for(:breadcrumbs) do %>
     <%= render GovukComponent::BackLinkComponent.new(
       text: "All Provider records",
-      href: support_providers_path,
+      href: support_recruitment_cycle_providers_path,
     ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: [:support, @provider], local: true do |f| %>
+    <%= form_with model: [:support_recruitment_cycle, @provider], local: true do |f| %>
 
       <% if @provider.errors.size > 0 %>
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
@@ -30,7 +30,7 @@
             <% @provider_errors.each do |provider_error| %>
               <% if @provider.errors.attribute_names.any? { |s| s[/^#{Regexp.quote(provider_error.to_s)}$/] } %>
                 <li>
-                  <%= link_to @provider.errors[provider_error][0], support_providers_path(anchor: "provider-#{provider_error.to_s.gsub('_', '-')}-field-error") %>
+                  <%= link_to @provider.errors[provider_error][0], support_recruitment_cycle_providers_path(anchor: "provider-#{provider_error.to_s.gsub('_', '-')}-field-error") %>
                 </li>
               <% end %>
             <% end %>
@@ -110,6 +110,6 @@
       <%= f.govuk_submit %>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), support_providers_path) %>
+    <%= govuk_link_to(t("cancel"), support_recruitment_cycle_providers_path) %>
   </div>
 </div>

--- a/app/views/support/providers/users/_provider_user_list.html.erb
+++ b/app/views/support/providers/users/_provider_user_list.html.erb
@@ -11,7 +11,7 @@
       <tr class="govuk-table__row user-row">
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-              <%= govuk_link_to(user.full_name, support_provider_user_path(@provider, user), class: "govuk-heading-s govuk-!-margin-bottom-0") %>
+              <%= govuk_link_to(user.full_name, support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider, user), class: "govuk-heading-s govuk-!-margin-bottom-0") %>
           </span>
         </td>
 

--- a/app/views/support/providers/users/delete.html.erb
+++ b/app/views/support/providers/users/delete.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: "Back",
-    href: support_provider_user_path(@provider, @provider_user),
+    href: support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider, @provider_user),
   ) %>
 <% end %>
 
@@ -23,12 +23,12 @@
     </div>
 
     <%= govuk_button_to "Remove user",
-        delete_support_provider_user_path(@provider, @provider_user),
+        delete_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider, @provider_user),
         method: :delete,
         class: "govuk-button--warning" %>
 
     <p class="govuk-body">
-      <%= govuk_link_to("Cancel", support_provider_user_path(@provider, @provider_user)) %>
+      <%= govuk_link_to("Cancel", support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider, @provider_user)) %>
     </p>
   </div>
 </div>

--- a/app/views/support/providers/users/edit.html.erb
+++ b/app/views/support/providers/users/edit.html.erb
@@ -3,13 +3,13 @@
 <% content_for :before_content do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: t("back"),
-    href: support_provider_user_path(@provider, @provider_user),
+    href: support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider, @provider_user),
   ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @user_form, url: support_provider_user_path, method: :put, local: true) do |f| %>
+    <%= form_with(model: @user_form, url: support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">
@@ -26,6 +26,6 @@
       </fieldset>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), support_provider_user_path(@provider)) %>
+    <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider)) %>
   </div>
 </div>

--- a/app/views/support/providers/users/index.html.erb
+++ b/app/views/support/providers/users/index.html.erb
@@ -1,3 +1,3 @@
-<%= link_to t("components.page_titles.support.providers.users.new"), new_support_provider_user_path(@provider), class: "govuk-!-margin-top-4 govuk-button" %>
+<%= link_to t("components.page_titles.support.providers.users.new"), new_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider), class: "govuk-!-margin-top-4 govuk-button" %>
 <%= render "provider_user_list", users: @users, provider: @provider %>
 <%= render Paginator::View.new(scope: @users) %>

--- a/app/views/support/providers/users/new.html.erb
+++ b/app/views/support/providers/users/new.html.erb
@@ -3,13 +3,13 @@
 <% content_for :before_content do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: t("back"),
-    href: support_provider_users_path,
+    href: support_recruitment_cycle_provider_users_path,
   ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= form_with(model: @user_form, url: support_provider_users_path, local: true) do |f| %>
+      <%= form_with(model: @user_form, url: support_recruitment_cycle_provider_users_path, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">
@@ -26,6 +26,6 @@
       </fieldset>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), support_provider_users_path) %>
+    <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_users_path) %>
   </div>
 </div>

--- a/app/views/support/providers/users/show.html.erb
+++ b/app/views/support/providers/users/show.html.erb
@@ -35,7 +35,7 @@
 
           component.row do |row|
             row.key { "Organisations" }
-            row.value(text: sanitize(@provider_user.providers.in_current_cycle.pluck(:provider_name).join(tag.br)), html_attributes: { id: "organisations" })
+            row.value(text: sanitize(@provider_user.providers.in_current_cycle.pluck(:provider_name).sort.join(tag.br)), html_attributes: { id: "organisations" })
             row.action
           end
 

--- a/app/views/support/providers/users/show.html.erb
+++ b/app/views/support/providers/users/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: "Back",
-    href: support_provider_users_path,
+    href: support_recruitment_cycle_provider_users_path,
   ) %>
 <% end %>
 
@@ -18,19 +18,19 @@
           component.row do |row|
             row.key { "First name" }
             row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
-            row.action(text: t("change"), href: edit_support_provider_user_path(@provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
+            row.action(text: t("change"), href: edit_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
           end
 
           component.row do |row|
             row.key { "Last name" }
             row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
-            row.action(text: t("change"), href: edit_support_provider_user_path(@provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
+            row.action(text: t("change"), href: edit_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
           end
 
           component.row do |row|
             row.key { "Email address" }
             row.value(text: @provider_user.email, html_attributes: { id: "email" })
-            row.action(text: t("change"), href: edit_support_provider_user_path(@provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
+            row.action(text: t("change"), href: edit_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
           end
 
           component.row do |row|
@@ -47,7 +47,7 @@
         end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to("Remove user", delete_support_provider_user_path, class: "app-link--destructive") %>
+      <%= govuk_link_to("Remove user", delete_support_recruitment_cycle_provider_user_path, class: "app-link--destructive") %>
     </p>
   </div>
 </div>

--- a/app/views/support/providers/users_check/show.html.erb
+++ b/app/views/support/providers/users_check/show.html.erb
@@ -1,11 +1,11 @@
 <%= render PageTitle::View.new(title: t("support.providers.users.check")) %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_support_provider_user_path) %>
+  <%= govuk_back_link_to(new_support_recruitment_cycle_provider_user_path) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @user_form, url: support_provider_check_user_path, method: :put, local: true) do |f| %>
+    <%= form_with(model: @user_form, url: support_recruitment_cycle_provider_check_user_path(@provider.recruitment_cycle_year, @provider), method: :put, local: true) do |f| %>
 
       <%= f.hidden_field(:email, value: @user_form.email) %>
 
@@ -17,19 +17,19 @@
           component.row do |row|
             row.key { t("support.providers.users.first_name") }
             row.value(text:  @user_form.first_name)
-            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
+            row.action(text: t("change"), href: new_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider), classes: "first_name", visually_hidden_text: t("support.providers.users.first_name"))
           end
 
           component.row do |row|
             row.key { t("support.providers.users.last_name") }
             row.value(text: @user_form.last_name)
-            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
+            row.action(text: t("change"), href: new_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider), classes: "last_name", visually_hidden_text: t("support.providers.users.last_name"))
           end
 
           component.row do |row|
             row.key { t("support.providers.users.email") }
             row.value(text: @user_form.email)
-            row.action(text: t("change"), href: new_support_provider_user_path(@provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
+            row.action(text: t("change"), href: new_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider), classes: "email", visually_hidden_text: t("support.providers.users.email"))
           end
         end %>
 
@@ -40,6 +40,6 @@
       </fieldset>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), support_provider_users_path) %>
+    <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_users_path) %>
   </div>
 </div>

--- a/app/views/support/users/providers/show.html.erb
+++ b/app/views/support/users/providers/show.html.erb
@@ -12,7 +12,7 @@
       <tr class="govuk-table__row qa-provider_row">
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= govuk_link_to(provider.provider_name, support_provider_path(provider)) %>
+            <%= govuk_link_to(provider.provider_name, support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider)) %>
           </span>
         </td>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,18 +233,20 @@ Rails.application.routes.draw do
   end
 
   namespace :support do
-    get "/" => redirect("/support/providers")
+    get "/" => redirect("/support/#{Settings.current_recruitment_cycle_year}/providers")
 
-    resources :providers, except: %i[destroy] do
-      resource :check_user, only: %i[show update], controller: "providers/users_check", path: "users/check"
-      resources :users, controller: "providers/users" do
-        member do
-          get :delete
-          delete :delete, to: "providers/users#destroy"
+    resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "" do
+      resources :providers, except: %i[destroy] do
+        resource :check_user, only: %i[show update], controller: "providers/users_check", path: "users/check"
+        resources :users, controller: "providers/users" do
+          member do
+            get :delete
+            delete :delete, to: "providers/users#destroy"
+          end
         end
+        resources :courses, only: %i[index edit update]
+        resources :locations
       end
-      resources :courses, only: %i[index edit update]
-      resources :locations
     end
     resources :users do
       scope module: :users do

--- a/spec/components/providers/provider_list/view_preview.rb
+++ b/spec/components/providers/provider_list/view_preview.rb
@@ -4,15 +4,15 @@ module Providers
   module ProviderList
     class ViewPreview < ViewComponent::Preview
       def with_scitt_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "scitt", accrediting_provider: "accredited_body", updated_at: Time.zone.now)))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "scitt", accrediting_provider: "accredited_body", updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: 2022))))
       end
 
       def with_lead_school_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "lead_school", accrediting_provider: "not_an_accredited_body", updated_at: Time.zone.now)))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "lead_school", accrediting_provider: "not_an_accredited_body", updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: 2022))))
       end
 
       def with_university_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "university", accrediting_provider: "accredited_body", updated_at: Time.zone.now)))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "university", accrediting_provider: "accredited_body", updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: 2022))))
       end
     end
   end

--- a/spec/features/auth/persona_spec.rb
+++ b/spec/features/auth/persona_spec.rb
@@ -27,7 +27,7 @@ feature "Authentication with Personas" do
   end
 
   def when_i_go_to_support
-    support_provider_index_page.load
+    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_am_given_the_option_to_sign_in_with_a_persona

--- a/spec/features/auth/provider_user_signs_in_spec.rb
+++ b/spec/features/auth/provider_user_signs_in_spec.rb
@@ -35,8 +35,8 @@ feature "Authentication" do
   end
 
   def and_i_cannot_access_the_support_interface
-    visit support_providers_path
-    expect(page).to have_current_path support_providers_path
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
     expect(page.status_code).to eq(403)
     expect(page.find("h1")).to have_content("You are not permitted to see this page")
   end

--- a/spec/features/auth/support_user_signs_in_spec.rb
+++ b/spec/features/auth/support_user_signs_in_spec.rb
@@ -17,7 +17,7 @@ feature "Authentication" do
   end
 
   def when_i_visit_the_support_interface
-    visit support_providers_path
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_am_expected_to_sign_in
@@ -29,6 +29,6 @@ feature "Authentication" do
   end
 
   def then_i_can_access_the_support_interface
-    expect(page).to have_current_path support_providers_path
+    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 end

--- a/spec/features/support/filters/provider_filters_spec.rb
+++ b/spec/features/support/filters/provider_filters_spec.rb
@@ -49,7 +49,7 @@ private
   end
 
   def when_i_visit_the_providers_index_page
-    support_provider_index_page.load
+    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_can_search_by_provider_name

--- a/spec/features/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/features/support/providers/courses/editing_a_course_spec.rb
@@ -81,7 +81,7 @@ private
   end
 
   def when_i_visit_the_support_courses_index_page
-    support_courses_index_page.load(provider_id: provider.id)
+    support_courses_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
   end
 
   def and_click_on_the_first_course_change_link
@@ -91,7 +91,7 @@ private
   alias_method :when_i_return_to_the_edit_page, :and_click_on_the_first_course_change_link
 
   def then_i_am_on_the_support_course_edit_page
-    support_course_edit_page.load(provider_id: provider.id, course_id: provider.courses.first.id)
+    support_course_edit_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id, course_id: provider.courses.first.id)
   end
 
   def course_code

--- a/spec/features/support/providers/courses/viewing_providers_courses_spec.rb
+++ b/spec/features/support/providers/courses/viewing_providers_courses_spec.rb
@@ -25,7 +25,7 @@ private
   end
 
   def when_i_visit_the_support_courses_index_page
-    support_courses_index_page.load(provider_id: provider.id)
+    support_courses_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
   end
 
   def then_i_am_redirected_to_the_providers_page

--- a/spec/features/support/providers/creating_a_provider_spec.rb
+++ b/spec/features/support/providers/creating_a_provider_spec.rb
@@ -28,7 +28,7 @@ feature "Creating a provider" do
 private
 
   def when_i_visit_the_new_provider_page
-    support_provider_new_page.load
+    support_provider_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def when_i_fill_in_a_valid_provider_details

--- a/spec/features/support/providers/editing_a_provider_spec.rb
+++ b/spec/features/support/providers/editing_a_provider_spec.rb
@@ -39,7 +39,7 @@ private
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(id: @provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @provider.id)
   end
 
   def then_i_can_view_provider_details
@@ -53,7 +53,7 @@ private
   end
 
   def then_i_am_on_the_support_provider_edit_page
-    support_provider_edit_page.load(id: @provider.id)
+    support_provider_edit_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @provider.id)
   end
 
   def when_i_fill_in_a_valid_provider_name

--- a/spec/features/support/providers/editing_a_user_from_a_provider_spec.rb
+++ b/spec/features/support/providers/editing_a_user_from_a_provider_spec.rb
@@ -35,7 +35,7 @@ private
   end
 
   def and_i_visit_the_support_provider_user_show_page
-    support_provider_user_show_page.load(id: @user.id, provider_id: @provider.id)
+    support_provider_user_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.id, provider_id: @provider.id)
   end
 
   def when_i_click_the_change_firstname_link

--- a/spec/features/support/providers/locations/managing_locations_spec.rb
+++ b/spec/features/support/providers/locations/managing_locations_spec.rb
@@ -43,7 +43,7 @@ feature "Managing a provider's locations" do
   end
 
   def when_i_visit_a_provider_locations_page
-    support_locations_index_page.load(provider_id: provider.id)
+    support_locations_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
   end
 
   def then_i_should_see_a_list_of_locations

--- a/spec/features/support/providers/provider_courses_list_spec.rb
+++ b/spec/features/support/providers/provider_courses_list_spec.rb
@@ -26,7 +26,7 @@ feature "View provider courses" do
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(id: provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: provider.id)
   end
 
   def and_click_on_the_courses_tab

--- a/spec/features/support/providers/provider_users_list_spec.rb
+++ b/spec/features/support/providers/provider_users_list_spec.rb
@@ -18,7 +18,7 @@ feature "View provider users" do
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(id: @provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @provider.id)
   end
 
   def and_click_on_the_users_tab

--- a/spec/features/support/providers/providers_filter_spec.rb
+++ b/spec/features/support/providers/providers_filter_spec.rb
@@ -39,7 +39,7 @@ feature "View filtered providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load
+    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_see_the_providers

--- a/spec/features/support/providers/providers_list_spec.rb
+++ b/spec/features/support/providers/providers_list_spec.rb
@@ -20,7 +20,7 @@ feature "View providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load
+    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_see_the_providers

--- a/spec/features/support/providers/removing_user_from_provider_spec.rb
+++ b/spec/features/support/providers/removing_user_from_provider_spec.rb
@@ -26,7 +26,7 @@ private
   end
 
   def and_i_visit_the_support_provider_user_show_page
-    support_provider_user_show_page.load(id: @user.id, provider_id: @provider.id)
+    support_provider_user_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.id, provider_id: @provider.id)
   end
 
   def and_i_click_the_remove_user_link
@@ -37,7 +37,7 @@ private
     expect(support_provider_user_delete_page).to be_displayed
     expect(support_provider_user_delete_page.heading).to have_content("#{@user.full_name} - #{@provider.provider_name}")
     expect(support_provider_user_delete_page.warning_text).to have_content("The user will be sent an email to tell them you removed them from #{@provider.provider_name}.")
-    expect(support_provider_user_delete_page.cancel_link["href"]).to eq(support_provider_user_path(@provider, @user))
+    expect(support_provider_user_delete_page.cancel_link["href"]).to eq(support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider, @user))
   end
 
   def when_i_click_remove_user_button

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -43,7 +43,7 @@ feature "Adding user to provider as an admin", { can_edit_current_and_next_cycle
   end
 
   def given_i_visit_the_support_provider_users_index_page
-    visit support_provider_users_path(provider_id: @provider.id)
+    support_provider_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
   end
 
   def and_i_continue
@@ -51,7 +51,7 @@ feature "Adding user to provider as an admin", { can_edit_current_and_next_cycle
   end
 
   def given_i_visit_the_support_provider_users_new_page
-    support_users_new_page.load(provider_id: @provider.id)
+    support_users_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
   end
 
   def and_i_fill_in_first_name

--- a/spec/features/support/providers/viewing_a_user_spec.rb
+++ b/spec/features/support/providers/viewing_a_user_spec.rb
@@ -30,7 +30,7 @@ feature "Viewing a user" do
 private
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(id: @user.providers.first.id)
+    support_provider_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.providers.first.id)
   end
 
   def and_there_is_a_user(user = nil)
@@ -62,12 +62,12 @@ private
     expect(support_provider_user_show_page.first_name.text).to eq(@user.first_name)
     expect(support_provider_user_show_page.last_name.text).to eq(@user.last_name)
     expect(support_provider_user_show_page.email.text).to eq(@user.email)
-    expect(support_provider_user_show_page.organisations.text).to eq(@user.providers.pluck(:provider_name).join)
+    expect(support_provider_user_show_page.organisations.text).to eq(@user.providers.pluck(:provider_name).sort.join)
   end
 
   def and_i_see_the_users_details_with_last_login
     and_i_see_the_users_details
     expect(support_provider_user_show_page.date_last_signed_in.text).to eq(@user.last_login_date_utc.strftime("%d %B %Y at %I:%M%p"))
-    expect(support_provider_user_show_page.remove_user_link["href"]).to eq(delete_support_provider_user_path(@user.providers.first, @user))
+    expect(support_provider_user_show_page.remove_user_link["href"]).to eq(delete_support_recruitment_cycle_provider_user_path(Settings.current_recruitment_cycle_year, @user.providers.first, @user))
   end
 end

--- a/spec/features/support/users/providers_list_spec.rb
+++ b/spec/features/support/users/providers_list_spec.rb
@@ -20,7 +20,7 @@ feature "View providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load
+    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_see_the_providers

--- a/spec/support/page_objects/support/provider/course_edit.rb
+++ b/spec/support/page_objects/support/provider/course_edit.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Support
     module Provider
       class CourseEdit < PageObjects::Base
-        set_url "/support/providers/{provider_id}/courses/{course_id}/edit"
+        set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/courses/{course_id}/edit"
 
         element :course_code, "#support-edit-course-form-course-code-field"
         element :name, "#support-edit-course-form-name-field"

--- a/spec/support/page_objects/support/provider/courses_index.rb
+++ b/spec/support/page_objects/support/provider/courses_index.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Support
     module Provider
       class CoursesIndex < PageObjects::Base
-        set_url "/support/providers/{provider_id}/courses"
+        set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/courses"
 
         sections :courses_row, Sections::Course, ".course-row"
       end

--- a/spec/support/page_objects/support/provider/location_create.rb
+++ b/spec/support/page_objects/support/provider/location_create.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Support
     module Provider
       class LocationCreate < PageObjects::Base
-        set_url "/support/providers/{provider_id}/locations/new"
+        set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/locations/new"
         element :error_summary, ".govuk-error-summary"
 
         section :location_form, Sections::LocationForm, ".location-form"

--- a/spec/support/page_objects/support/provider/location_edit.rb
+++ b/spec/support/page_objects/support/provider/location_edit.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Support
     module Provider
       class LocationEdit < PageObjects::Base
-        set_url "/support/providers/{provider_id}/locations/{location_id}/edit"
+        set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/locations/{location_id}/edit"
         element :error_summary, ".govuk-error-summary"
 
         section :location_form, Sections::LocationForm, ".location-form"

--- a/spec/support/page_objects/support/provider/locations_index.rb
+++ b/spec/support/page_objects/support/provider/locations_index.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Support
     module Provider
       class LocationsIndex < PageObjects::Base
-        set_url "/support/providers/{provider_id}/locations"
+        set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/locations"
 
         element :add_location, ".govuk-button", text: "Add location"
 

--- a/spec/support/page_objects/support/provider/user/users_check.rb
+++ b/spec/support/page_objects/support/provider/user/users_check.rb
@@ -5,7 +5,7 @@ module PageObjects
     module Provider
       module User
         class UsersCheck < PageObjects::Base
-          set_url "/support/providers/{provider_id}/users/check"
+          set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/users/check"
 
           element :add_user, ".govuk-button", text: "Add user"
 

--- a/spec/support/page_objects/support/provider/user/users_new.rb
+++ b/spec/support/page_objects/support/provider/user/users_new.rb
@@ -5,7 +5,7 @@ module PageObjects
     module Provider
       module User
         class UsersNew < PageObjects::Base
-          set_url "/support/providers/{provider_id}/users/new"
+          set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/users/new/"
 
           element :first_name, "#support-user-form-first-name-field"
           element :last_name, "#support-user-form-last-name-field"

--- a/spec/support/page_objects/support/provider_edit.rb
+++ b/spec/support/page_objects/support/provider_edit.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderEdit < PageObjects::Base
-      set_url "/support/providers/{id}/edit"
+      set_url "/support/{recruitment_cycle_year}/providers/{id}/edit"
 
       element :provider_name, "#provider-provider-name-field"
       element :provider_type, "#provider-provider-type-field"

--- a/spec/support/page_objects/support/provider_index.rb
+++ b/spec/support/page_objects/support/provider_index.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderIndex < PageObjects::Base
-      set_url "/support/providers"
+      set_url "/support/{recruitment_cycle_year}/providers"
 
       # Filter elements
       element :apply_filters, "input.govuk-button"

--- a/spec/support/page_objects/support/provider_new.rb
+++ b/spec/support/page_objects/support/provider_new.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderNew < PageObjects::Base
-      set_url "/support/providers/new"
+      set_url "/support/{recruitment_cycle_year}/providers/new"
 
       element :provider_name, "#provider-provider-name-field"
       element :provider_code, "#provider-provider-code-field"

--- a/spec/support/page_objects/support/provider_show.rb
+++ b/spec/support/page_objects/support/provider_show.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderShow < PageObjects::Base
-      set_url "/support/providers/{id}"
+      set_url "/support/{recruitment_cycle_year}/providers/{id}"
 
       element :users_tab, ".app-tab-navigation__link", text: "Users"
       element :courses_tab, ".app-tab-navigation__link", text: "Courses"

--- a/spec/support/page_objects/support/provider_user_delete.rb
+++ b/spec/support/page_objects/support/provider_user_delete.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderUserDelete < PageObjects::Base
-      set_url "/support/providers/{provider_id}/users/{id}/delete"
+      set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/users/{id}/delete"
 
       element :heading, "h1"
       element :warning_text, ".govuk-warning-text"

--- a/spec/support/page_objects/support/provider_user_edit.rb
+++ b/spec/support/page_objects/support/provider_user_edit.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderUserEdit < PageObjects::Base
-      set_url "/support/providers/{provider_id}/users/{id}/edit"
+      set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/users/{id}/edit"
 
       element :first_name, "#support-user-form-first-name-field"
       element :last_name, "#support-user-form-last-name-field"

--- a/spec/support/page_objects/support/provider_user_show.rb
+++ b/spec/support/page_objects/support/provider_user_show.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderUserShow < PageObjects::Base
-      set_url "/support/providers/{provider_id}/users/{id}"
+      set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/users/{id}"
 
       element :first_name, "#first_name"
       element :last_name, "#last_name"

--- a/spec/support/page_objects/support/provider_users_index.rb
+++ b/spec/support/page_objects/support/provider_users_index.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderUsersIndex < PageObjects::Base
-      set_url "/support/providers/{provider_id}/users"
+      set_url "/support/{recruitment_cycle_year}/providers/{provider_id}/users"
 
       sections :users, PageObjects::Sections::User, ".user-row"
       element :success_notification, ".govuk-notification-banner.govuk-notification-banner--success"


### PR DESCRIPTION
### Context

Support agents require the ability to update information for both cycles, to do this we need to scope the support routes based on the recruitment cycle. 

This PR deals with `support_providers`

(#2878  deals with `support_allocations` #2867 deals with `support_users`)

### Changes proposed in this pull request

Add the `recruitment_cycle` to the url for `support_providers`. For example:

from: `/support/providers/{provider_id}`
to: `/support/{recruitment_cycle_year}/providers/{provider_id}`

### Guidance to review

Does everything still work as intended? Have a play around on the review app.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
