### PR TITLE
load cloudfront-rails in envs that use CloudFront

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,7 +133,7 @@ gem "sprockets-rails", require: "sprockets/railtie"
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.2.1"
 
-group :production do
+group :production, :qa, :sandbox, :staging do
   gem "cloudfront-rails"
 end
 


### PR DESCRIPTION
This allows us to send the correct IPs to the analytics platform.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
