### PR TITLE
Scope routes based on recruitment cycle users list

### DIFF
--- a/app/components/filters/view.rb
+++ b/app/components/filters/view.rb
@@ -38,7 +38,7 @@ module Filters
     def reload_path
       # This will be removed once all the scope recruitment cycle to support params PR's have been merged
       case filter_model.to_s.downcase.pluralize
-      when "providers"
+      when "providers", "users"
         send("support_recruitment_cycle_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
       else
         send("support_#{filter_model.to_s.downcase.pluralize}_path".to_sym)

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -16,7 +16,7 @@ module Support
     def create
       @user = User.new(user_params)
       if @user.save
-        redirect_to support_users_path
+        redirect_to support_recruitment_cycle_users_path(params[:recruitment_cycle_year])
       else
         render :new
       end
@@ -28,7 +28,7 @@ module Support
 
     def update
       if user.update(update_user_params)
-        redirect_to support_user_path(user), flash: { success: t("support.flash.updated", resource: "User") }
+        redirect_to support_recruitment_cycle_user_path(params[:recruitment_cycle_year], user), flash: { success: t("support.flash.updated", resource: "User") }
       else
         render :edit
       end
@@ -36,9 +36,9 @@ module Support
 
     def destroy
       if user.discard
-        redirect_to support_users_path, flash: { success: "User successfully deleted" }
+        redirect_to support_recruitment_cycle_users_path(params[:recruitment_cycle_year]), flash: { success: "User successfully deleted" }
       else
-        redirect_to support_users_path, flash: { success: "This user has already been deleted" }
+        redirect_to support_recruitment_cycle_users_path(params[:recruitment_cycle_year]), flash: { success: "This user has already been deleted" }
       end
     end
 

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -61,7 +61,7 @@ module Support
     end
 
     def filter_params
-      @filter_params ||= params.except(:commit).permit(:text_search, :page, :commit, user_type: [])
+      @filter_params ||= params.except(:commit, :recruitment_cycle_year).permit(:text_search, :page, :commit, user_type: [])
     end
   end
 end

--- a/app/views/layouts/user_record.html.erb
+++ b/app/views/layouts/user_record.html.erb
@@ -4,15 +4,15 @@
   <%= content_for(:breadcrumbs) do %>
     <%= render GovukComponent::BackLinkComponent.new(
       text: "All user records",
-      href: support_users_path,
+      href: support_recruitment_cycle_users_path(params[:recruitment_cycle_year]),
     ) %>
   <% end %>
 
   <h1 class="govuk-heading-l"><%= @user.full_name %></h1>
 
   <%= render TabNavigation::View.new(items: [
-    { name: "Details", url: support_user_path(@user) },
-    { name: "Providers", url: support_user_providers_path(@user) },
+    { name: "Details", url: support_recruitment_cycle_user_path(params[:recruitment_cycle_year], @user) },
+    { name: "Providers", url: support_recruitment_cycle_user_providers_path(params[:recruitment_cycle_year], @user) },
   ]) %>
 
   <%= yield %>

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,6 @@
 <%= render TabNavigation::View.new(items: [
-  { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
+  { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year].to_i) },
   { name: "Users", url: support_users_path },
   { name: "PE Allocations", url: support_allocations_path },
 ]) %>
+

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= render TabNavigation::View.new(items: [
   { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
-  { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
+  { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year]) },
   { name: "PE Allocations", url: support_allocations_path },
 ]) %>

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,6 +1,5 @@
 <%= render TabNavigation::View.new(items: [
-  { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year].to_i) },
-  { name: "Users", url: support_users_path },
+  { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
+  { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
   { name: "PE Allocations", url: support_allocations_path },
 ]) %>
-

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= render TabNavigation::View.new(items: [
   { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
-  { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year]) },
+  { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
   { name: "PE Allocations", url: support_allocations_path },
 ]) %>

--- a/app/views/support/users/_users.html.erb
+++ b/app/views/support/users/_users.html.erb
@@ -12,7 +12,7 @@
       <tr class="govuk-table__row user-row">
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= govuk_link_to user.full_name, support_user_path(user) %>
+            <%= govuk_link_to user.full_name, support_recruitment_cycle_user_path(params[:recruitment_cycle_year], user) %>
           </span>
         </td>
         <td class="govuk-table__cell">

--- a/app/views/support/users/edit.html.erb
+++ b/app/views/support/users/edit.html.erb
@@ -3,14 +3,14 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: "User record",
-    href: support_user_path(@user),
+    href: support_recruitment_cycle_user_path(params[:recruitment_cycle_year], @user),
   ) %>
 <% end %>
 
 <h1 class="govuk-heading-l">Edit user details</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= form_with model: [:support, @user], local: true do |f| %>
+      <%= form_with model: @user, url: support_recruitment_cycle_user_path(params[:recruitment_cycle_year], @user), local: true do |f| %>
 
         <%= f.govuk_error_summary %>
 
@@ -26,7 +26,7 @@
       <% end %>
 
       <p class="govuk-body">
-        <%= govuk_link_to(t("cancel"), support_user_path) %>
+        <%= govuk_link_to(t("cancel"), support_recruitment_cycle_user_path(params[:recruitment_cycle_year])) %>
       </p>
     </div>
   </div>

--- a/app/views/support/users/index.html.erb
+++ b/app/views/support/users/index.html.erb
@@ -5,7 +5,7 @@
 <%= render "support/menu" %>
 
 <div class="govuk-button-group">
-  <%= link_to "Add a user", new_support_user_path, class: "govuk-button govuk-button--primary" %>
+  <%= link_to "Add a user", new_support_recruitment_cycle_user_path, class: "govuk-button govuk-button--primary" %>
   <%= link_to "Download users (CSV)", support_data_exports_path(anchor: "users"), class: "govuk-button govuk-button--secondary" %>
 </div>
 

--- a/app/views/support/users/new.html.erb
+++ b/app/views/support/users/new.html.erb
@@ -3,13 +3,13 @@
 <%= content_for(:breadcrumbs) do %>
     <%= render GovukComponent::BackLinkComponent.new(
       text: "All User records",
-      href: support_users_path,
+      href: support_recruitment_cycle_users_path,
     ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: [:support, @user], local: true do |f| %>
+    <%= form_with model: [:support_recruitment_cycle, @user], local: true do |f| %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">Add a new user</h1>
@@ -25,6 +25,6 @@
       </fieldset>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), support_users_path) %>
+    <%= govuk_link_to(t("cancel"), support_recruitment_cycle_users_path) %>
   </div>
 </div>

--- a/app/views/support/users/show.html.erb
+++ b/app/views/support/users/show.html.erb
@@ -2,25 +2,25 @@
       component.row do |row|
         row.key { "First name" }
         row.value(text: @user.first_name, html_attributes: { id: "first_name" })
-        row.action(text: "Change", href: edit_support_user_path(@user), visually_hidden_text: "first name")
+        row.action(text: "Change", href: edit_support_recruitment_cycle_user_path(params[:recruitment_cycle_year], @user), visually_hidden_text: "first name")
       end
 
       component.row do |row|
         row.key { "Last name" }
         row.value(text: @user.last_name, html_attributes: { id: "last_name" })
-        row.action(text: "Change", href: edit_support_user_path(@user), visually_hidden_text: "last name")
+        row.action(text: "Change", href: edit_support_recruitment_cycle_user_path(params[:recruitment_cycle_year], @user), visually_hidden_text: "last name")
       end
 
       component.row do |row|
         row.key { "Email" }
         row.value(text: @user.email, html_attributes: { id: "email" })
-        row.action(text: "Change", href: edit_support_user_path(@user), visually_hidden_text: "email")
+        row.action(text: "Change", href: edit_support_recruitment_cycle_user_path(params[:recruitment_cycle_year], @user), visually_hidden_text: "email")
       end
 
       component.row do |row|
         row.key { "Admin?" }
         row.value(text: @user.admin?.to_s.capitalize, html_attributes: { id: "admin_status" })
-        row.action(text: "Change", href: edit_support_user_path(@user), visually_hidden_text: "admin")
+        row.action(text: "Change", href: edit_support_recruitment_cycle_user_path(params[:recruitment_cycle_year], @user), visually_hidden_text: "admin")
       end
 
       component.row do |row|
@@ -31,6 +31,6 @@
     end %>
 
 <%= govuk_button_to("Delete this user",
-      support_user_path(@user),
+      support_recruitment_cycle_user_path(params[:recruitment_cycle_year], @user),
       method: :delete,
       class: "govuk-button govuk-button--warning") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,10 +247,10 @@ Rails.application.routes.draw do
         resources :courses, only: %i[index edit update]
         resources :locations
       end
-    end
-    resources :users do
-      scope module: :users do
-        resource :providers, on: :member, only: %i[show]
+      resources :users do
+        scope module: :users do
+          resource :providers, on: :member, only: %i[show]
+        end
       end
     end
 

--- a/spec/features/support/filters/user_filters_spec.rb
+++ b/spec/features/support/filters/user_filters_spec.rb
@@ -48,7 +48,7 @@ private
   end
 
   def when_i_visit_the_support_users_index_page
-    support_users_index_page.load
+    support_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_can_search_by_first_name

--- a/spec/features/support/users/creating_a_new_user_spec.rb
+++ b/spec/features/support/users/creating_a_new_user_spec.rb
@@ -32,7 +32,7 @@ feature "Creating a new user" do
   end
 
   def when_i_visit_the_user_index_page
-    support_users_index_page.load
+    support_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def and_i_click_on_add_a_user
@@ -40,7 +40,7 @@ feature "Creating a new user" do
   end
 
   def then_i_am_taken_to_the_support_user_new_page
-    support_user_new_page.load
+    support_user_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def and_i_fill_in_first_name
@@ -60,7 +60,7 @@ feature "Creating a new user" do
   end
 
   def then_i_am_taken_to_the_user_index_page
-    support_users_index_page.load
+    support_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_should_see_the_error_summary

--- a/spec/features/support/users/deleting_a_user_spec.rb
+++ b/spec/features/support/users/deleting_a_user_spec.rb
@@ -23,7 +23,7 @@ private
   end
 
   def when_i_visit_the_user_show_page(user_id)
-    support_user_show_page.load(id: user_id)
+    support_user_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: user_id)
   end
 
   def when_i_click_the_delete_button

--- a/spec/features/support/users/deleting_user_from_provider_spec.rb
+++ b/spec/features/support/users/deleting_user_from_provider_spec.rb
@@ -24,7 +24,7 @@ private
   end
 
   def when_i_visit_the_user_show_providers_page
-    support_user_show_providers_page.load(id: @user.id)
+    support_user_show_providers_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.id)
   end
 
   def when_i_click_the_remove_user_from_provider_button

--- a/spec/features/support/users/editing_a_user_spec.rb
+++ b/spec/features/support/users/editing_a_user_spec.rb
@@ -33,7 +33,7 @@ private
   end
 
   def when_i_visit_the_support_user_edit_page
-    support_user_edit_page.load(id: @user.id)
+    support_user_edit_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.id)
   end
 
   def and_i_fill_in_correct_details

--- a/spec/features/support/users/users_list_spec.rb
+++ b/spec/features/support/users/users_list_spec.rb
@@ -18,7 +18,7 @@ feature "View users" do
   end
 
   def when_i_visit_the_support_users_index_page
-    support_users_index_page.load
+    support_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def and_click_on_the_users_tab

--- a/spec/support/page_objects/support/user_edit.rb
+++ b/spec/support/page_objects/support/user_edit.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class UserEdit < PageObjects::Base
-      set_url "/support/users/{id}/edit"
+      set_url "/support/{recruitment_cycle_year}/users/{id}/edit"
 
       element :first_name_field, "#user-first-name-field"
       element :last_name_field, "#user-last-name-field"

--- a/spec/support/page_objects/support/user_new.rb
+++ b/spec/support/page_objects/support/user_new.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class UserNew < PageObjects::Base
-      set_url "/support/users/new"
+      set_url "/support/{recruitment_cycle_year}/users/new"
 
       element :first_name, "#user-first-name-field"
       element :last_name, "#user-last-name-field"

--- a/spec/support/page_objects/support/user_show.rb
+++ b/spec/support/page_objects/support/user_show.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class UserShow < PageObjects::Base
-      set_url "/support/users/{id}"
+      set_url "/support/{recruitment_cycle_year}/users/{id}"
 
       element :delete_button, ".govuk-button", text: "Delete this user"
       element :first_name, "#first_name"

--- a/spec/support/page_objects/support/user_show_providers.rb
+++ b/spec/support/page_objects/support/user_show_providers.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class UserShowProviders < PageObjects::Base
-      set_url "/support/users/{id}/providers"
+      set_url "/support/{recruitment_cycle_year}/users/{id}/providers"
 
       sections :provider_rows, PageObjects::Sections::Provider, ".qa-provider_row"
 

--- a/spec/support/page_objects/support/users_index.rb
+++ b/spec/support/page_objects/support/users_index.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class UsersIndex < PageObjects::Base
-      set_url "/support/users"
+      set_url "/support/{recruitment_cycle_year}/users"
 
       element :add_a_user, "a", text: "Add a user"
 


### PR DESCRIPTION
### Context

Support agents require the ability to update information for both cycles, to do this we need to scope the support routes based on the recruitment cycle. 

This PR deals with `support_users`

(#2878 deals with `support_allocations` #2864 deals with `support_providers`)

### Changes proposed in this pull request

Add the `recruitment_cycle` to the url for `support_users`. For example:

from: `/support/users`
to: `/support/{recruitment_cycle_year}/users`

### Guidance to review

Does everything still work as intended? Have a play around on the review app.
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
