### PR TITLE
Scope routes based on recruitment cycle allocations

### DIFF
--- a/app/components/allocation_record_card/view.html.erb
+++ b/app/components/allocation_record_card/view.html.erb
@@ -1,7 +1,7 @@
 <div class="allocation-record-card qa-provider_row <%= "filter-row" if @iteration.first? %>">
   <div class="allocation-record-card__row-allocation-title">
     <h<%= heading_level %> class="govuk-heading-m allocation-record-card__allocation-title-header">
-      <%= govuk_link_to provider_name, support_allocation_path(allocation.id) %>
+      <%= govuk_link_to provider_name, support_recruitment_cycle_allocation_path(params[:recruitment_cycle_year], allocation.id) %>
     </h<%= heading_level %>>
   </div>
   <div class="allocation-record-card__col-allocation-details">

--- a/app/components/allocation_record_card/view.html.erb
+++ b/app/components/allocation_record_card/view.html.erb
@@ -1,7 +1,7 @@
 <div class="allocation-record-card qa-provider_row <%= "filter-row" if @iteration.first? %>">
   <div class="allocation-record-card__row-allocation-title">
     <h<%= heading_level %> class="govuk-heading-m allocation-record-card__allocation-title-header">
-      <%= govuk_link_to provider_name, support_recruitment_cycle_allocation_path(params[:recruitment_cycle_year], allocation.id) %>
+      <%= govuk_link_to provider_name, support_recruitment_cycle_allocation_path(recruitment_cycle_year, allocation.id) %>
     </h<%= heading_level %>>
   </div>
   <div class="allocation-record-card__col-allocation-details">

--- a/app/components/allocation_record_card/view.rb
+++ b/app/components/allocation_record_card/view.rb
@@ -6,13 +6,14 @@ module AllocationRecordCard
     delegate :provider, :accredited_body, to: :allocation
     delegate :provider_name, to: :provider
 
-    attr_reader :allocation, :heading_level
+    attr_reader :allocation, :heading_level, :recruitment_cycle_year
 
-    def initialize(heading_level = 3, allocation:, allocation_iteration:)
+    def initialize(heading_level = 3, allocation:, allocation_iteration:, recruitment_cycle_year:)
       super
       @allocation = allocation
       @heading_level = heading_level
       @iteration = allocation_iteration
+      @recruitment_cycle_year = recruitment_cycle_year
     end
 
     def provider_code

--- a/app/components/filters/view.rb
+++ b/app/components/filters/view.rb
@@ -36,13 +36,7 @@ module Filters
     end
 
     def reload_path
-      # This will be removed once all the scope recruitment cycle to support params PR's have been merged
-      case filter_model.to_s.downcase.pluralize
-      when "providers", "users"
-        send("support_recruitment_cycle_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
-      else
-        send("support_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
-      end
+      send("support_recruitment_cycle_#{filter_model.to_s.downcase.pluralize}_path".to_sym)
     end
   end
 end

--- a/app/controllers/support/allocation_uplifts_controller.rb
+++ b/app/controllers/support/allocation_uplifts_controller.rb
@@ -12,7 +12,7 @@ module Support
       @allocation_uplift = AllocationUplift.new(create_allocation_uplift_params)
       @allocation_uplift.allocation = allocation
       if @allocation_uplift.save
-        redirect_to support_allocation_path(@allocation_uplift.allocation), flash: { success: "Allocation Uplift was successfully created" }
+        redirect_to support_recruitment_cycle_allocation_path(params[:recruitment_cycle_year], @allocation_uplift.allocation), flash: { success: "Allocation Uplift was successfully created" }
       else
         render :new
       end
@@ -20,7 +20,7 @@ module Support
 
     def update
       if allocation_uplift.update(update_allocation_uplift_params)
-        redirect_to support_allocation_path(allocation_uplift.allocation), flash: { success: "Allocation Uplift was successfully updated" }
+        redirect_to support_recruitment_cycle_allocation_path(params[:recruitment_cycle_year], allocation_uplift.allocation), flash: { success: "Allocation Uplift was successfully updated" }
       else
         render :edit
       end

--- a/app/controllers/support/allocations_controller.rb
+++ b/app/controllers/support/allocations_controller.rb
@@ -19,7 +19,7 @@ module Support
     end
 
     def filter_params
-      @filter_params ||= params.except(:commit).permit(:text_search, :page)
+      @filter_params ||= params.except(:commit, :recruitment_cycle_year).permit(:text_search, :page)
     end
   end
 end

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= render TabNavigation::View.new(items: [
   { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
   { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
-  { name: "PE Allocations", url: support_allocations_path },
+  { name: "PE Allocations", url: support_recruitment_cycle_allocations_path },
 ]) %>

--- a/app/views/support/allocation_uplifts/edit.html.erb
+++ b/app/views/support/allocation_uplifts/edit.html.erb
@@ -5,13 +5,13 @@
 <%= content_for(:breadcrumbs) do %>
     <%= render GovukComponent::BackLinkComponent.new(
       text: "Allocation record for #{@allocation_uplift.provider.provider_name}",
-      href: support_allocation_path(@allocation_uplift.allocation.id),
+      href: support_recruitment_cycle_allocation_path(params[:recruitment_cycle_year], @allocation_uplift.allocation.id),
     ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: [@allocation, @allocation_uplift], url: support_allocation_uplift_path, local: true, method: :patch do |f| %>
+    <%= form_with model: [@allocation, @allocation_uplift], url: support_recruitment_cycle_allocation_uplift_path(params[:recruitment_cycle_year]), local: true, method: :patch do |f| %>
 
     <%= f.govuk_error_summary %>
 
@@ -19,6 +19,6 @@
     <%= f.govuk_submit %>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), support_allocation_path(@allocation_uplift)) %>
+    <%= govuk_link_to(t("cancel"), support_recruitment_cycle_allocation_path(params[:recruitment_cycle_year], @allocation_uplift)) %>
   </div>
 </div>

--- a/app/views/support/allocation_uplifts/new.html.erb
+++ b/app/views/support/allocation_uplifts/new.html.erb
@@ -5,13 +5,13 @@
 <%= content_for(:breadcrumbs) do %>
     <%= render GovukComponent::BackLinkComponent.new(
       text: "Allocation record for #{@allocation_uplift.provider.provider_name}",
-      href: support_allocation_path(@allocation_uplift.allocation.id),
+      href: support_recruitment_cycle_allocation_path(params[:recruitment_cycle_year], @allocation_uplift.allocation.id),
     ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: [:support, @allocation_uplift], local: true do |f| %>
+    <%= form_with model: [:support_recruitment_cycle, @allocation_uplift], local: true do |f| %>
 
       <%= f.govuk_error_summary %>
 
@@ -20,7 +20,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), support_allocation_path(@allocation)) %>
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_allocation_path(params[:recruitment_cycle_year], @allocation)) %>
     </p>
   </div>
 </div>

--- a/app/views/support/allocations/index.html.erb
+++ b/app/views/support/allocations/index.html.erb
@@ -5,5 +5,5 @@
 <%= render "support/menu" %>
 
 <%= render PaginatedFilter::View.new(filter_params: @filter_params, collection: @allocations) do %>
-  <%= render AllocationRecordCard::View.with_collection(@allocations) %>
+  <%= render AllocationRecordCard::View.with_collection(@allocations, recruitment_cycle_year: params[:recruitment_cycle_year]) %>
 <% end %>

--- a/app/views/support/allocations/show.html.erb
+++ b/app/views/support/allocations/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
     <%= render GovukComponent::BackLinkComponent.new(
       text: "All Allocation records",
-      href: support_allocations_path,
+      href: support_recruitment_cycle_allocations_path(params[:recruitment_cycle_year]),
     ) %>
 <% end %>
 
@@ -44,9 +44,9 @@
         row.key { "Allocation Uplifts" }
         row.value { @allocation.allocation_uplift&.uplifts.to_i.to_s }
         if @allocation.allocation_uplift.nil?
-          row.action(text: "Change", href: new_support_allocation_uplift_path(allocation_id: @allocation.id))
+          row.action(text: "Change", href: new_support_recruitment_cycle_allocation_uplift_path(params[:recruitment_cycle_year], allocation_id: @allocation.id))
         else
-          row.action(text: "Change", href: edit_support_allocation_uplift_path(allocation_id: @allocation.id, id: @allocation.allocation_uplift&.id))
+          row.action(text: "Change", href: edit_support_recruitment_cycle_allocation_uplift_path(params[:recruitment_cycle_year], allocation_id: @allocation.id, id: @allocation.allocation_uplift&.id))
         end
       end
     end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,13 +252,13 @@ Rails.application.routes.draw do
           resource :providers, on: :member, only: %i[show]
         end
       end
+
+      resources :allocations, only: %i[index show] do
+        resources :uplifts, only: %i[edit update create new], controller: :allocation_uplifts
+      end
     end
 
     resources :user_permissions, only: %i[destroy]
-
-    resources :allocations, only: %i[index show] do
-      resources :uplifts, only: %i[edit update create new], controller: :allocation_uplifts
-    end
 
     resources :data_exports, path: "data-exports", only: [:index] do
       member do

--- a/spec/components/allocation_record_card/view_preview.rb
+++ b/spec/components/allocation_record_card/view_preview.rb
@@ -3,7 +3,7 @@
 module AllocationRecordCard
   class ViewPreview < ViewComponent::Preview
     def multiple_cards
-      render(AllocationRecordCard::View.with_collection(multiple_allocations))
+      render(AllocationRecordCard::View.with_collection(multiple_allocations, recruitment_cycle_year: Settings.current_recruitment_cycle_year))
     end
 
   private

--- a/spec/components/allocation_record_card/view_spec.rb
+++ b/spec/components/allocation_record_card/view_spec.rb
@@ -11,7 +11,7 @@ module AllocationRecordCard
     let(:accredited_body) { allocation.accredited_body }
 
     before do
-      render_inline(described_class.with_collection([allocation]))
+      render_inline(described_class.with_collection([allocation], recruitment_cycle_year: Settings.current_recruitment_cycle_year))
     end
 
     it "renders all the correct details" do

--- a/spec/features/support/allocations/allocation_uplift_edit_spec.rb
+++ b/spec/features/support/allocations/allocation_uplift_edit_spec.rb
@@ -25,7 +25,7 @@ private
   end
 
   def when_i_visit_the_support_allocation_uplift_edit_page
-    support_allocation_uplift_edit_page.load(uplift_id: @allocation.allocation_uplift.id, allocation_id: @allocation.id)
+    support_allocation_uplift_edit_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, uplift_id: @allocation.allocation_uplift.id, allocation_id: @allocation.id)
   end
 
   def then_i_can_edit_their_allocation_uplift_amount
@@ -38,7 +38,7 @@ private
   end
 
   def and_i_get_redirected_to_allocation_show_page
-    expect(support_allocations_show_page).to be_displayed(id: @allocation.id)
+    expect(support_allocations_show_page).to be_displayed(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @allocation.id)
   end
 
   def with_a_success_message

--- a/spec/features/support/allocations/allocation_uplift_new_spec.rb
+++ b/spec/features/support/allocations/allocation_uplift_new_spec.rb
@@ -25,7 +25,7 @@ private
   end
 
   def when_i_visit_the_support_allocation_uplift_new_page
-    support_allocation_uplift_new_page.load(allocation_id: @allocation.id)
+    support_allocation_uplift_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, allocation_id: @allocation.id)
   end
 
   def then_i_can_create_an_uplift

--- a/spec/features/support/allocations/allocations_list_spec.rb
+++ b/spec/features/support/allocations/allocations_list_spec.rb
@@ -21,7 +21,7 @@ feature "View allocations" do
   end
 
   def when_i_visit_the_support_allocations_index_page
-    support_allocations_index_page.load
+    support_allocations_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_see_the_providers_and_their_allocations

--- a/spec/features/support/allocations/allocations_show_spec.rb
+++ b/spec/features/support/allocations/allocations_show_spec.rb
@@ -21,7 +21,7 @@ private
   end
 
   def when_i_visit_the_support_allocations_show_page
-    support_allocations_show_page.load(id: @allocation.id)
+    support_allocations_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @allocation.id)
   end
 
   def then_i_see_the_provider_and_their_allocations

--- a/spec/features/support/filters/allocation_filter_spec.rb
+++ b/spec/features/support/filters/allocation_filter_spec.rb
@@ -36,7 +36,7 @@ private
   end
 
   def when_i_visit_the_support_allocations_index_page
-    support_allocations_index_page.load
+    support_allocations_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
   end
 
   def then_i_can_search_by_allocation_provider_name

--- a/spec/support/page_objects/support/allocation_uplift_edit.rb
+++ b/spec/support/page_objects/support/allocation_uplift_edit.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class AllocationUpliftEdit < PageObjects::Base
-      set_url "/support/allocations/{allocation_id}/uplifts/{uplift_id}/edit"
+      set_url "/support/{recruitment_cycle_year}/allocations/{allocation_id}/uplifts/{uplift_id}/edit"
 
       element :allocation_uplift_amount, "#allocation-uplift-uplifts-field"
       element :submit, ".govuk-button", text: "Continue"

--- a/spec/support/page_objects/support/allocation_uplift_new.rb
+++ b/spec/support/page_objects/support/allocation_uplift_new.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class AllocationUpliftNew < PageObjects::Base
-      set_url "/support/allocations/{allocation_id}/uplifts/new"
+      set_url "/support/{recruitment_cycle_year}/allocations/{allocation_id}/uplifts/new"
 
       element :allocation_uplift_amount, "#allocation-uplift-uplifts-field"
       element :submit, ".govuk-button", text: "Update"

--- a/spec/support/page_objects/support/allocations_index.rb
+++ b/spec/support/page_objects/support/allocations_index.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class AllocationsIndex < PageObjects::Base
-      set_url "/support/allocations"
+      set_url "/support/{recruitment_cycle_year}/allocations"
 
       # Filter elements
       element :apply_filters, "input.govuk-button"

--- a/spec/support/page_objects/support/allocations_show.rb
+++ b/spec/support/page_objects/support/allocations_show.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class AllocationsShow < PageObjects::Base
-      set_url "/support/allocations/{id}"
+      set_url "/support/{recruitment_cycle_year}/allocations/{id}"
 
       element :change_link, ".govuk-link"
     end


### PR DESCRIPTION
### Context

Support agents require the ability to update information for both cycles, to do this we need to scope the support routes based on the recruitment cycle. 

This PR deals with `support_allocations`

(#2864 deals with `support_providers` #2867 deals with `support_users`)

### Changes proposed in this pull request

Add the `recruitment_cycle` to the url for `support_allocations`. For example:

from: `support/allocations/{allocation_id}`
to: `/support/{recruitment_cycle_year}/allocations/{allocation_id}`

### Guidance to review

Does everything still work as intended? Have a play around on the review app.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
