### PR TITLE
Revert "Bump dfe-analytics from v1.2.1 to v1.3.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ gem "jsbundling-rails", "~> 1.0"
 gem "sprockets-rails", require: "sprockets/railtie"
 
 # for sending analytics data to the analytics platform
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.3.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.2.1"
 
 group :production do
   gem "cloudfront-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 0bee511339bd356217cad10a347fcff96ce44249
-  tag: v1.3.0
+  revision: 0a1c08a41ba0ce6bba6d075295e513cdc26f4ed3
+  tag: v1.2.1
   specs:
-    dfe-analytics (1.3.0)
+    dfe-analytics (1.2.1)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 


### PR DESCRIPTION
Reverts DFE-Digital/publish-teacher-training#2880

It caused this 
https://sentry.io/organizations/dfe-teacher-services/issues/3463629585/?referrer=slack