### PR TITLE
342 add cycle switcher to support console

### DIFF
--- a/app/components/support_title_bar/view.html.erb
+++ b/app/components/support_title_bar/view.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <div class="title-bar" aria-label="Organisation switcher">
+      <% if rollover_active? && !support_index_page %>
+        <div class="title-bar__title">
+          <%= title %>
+        </div>
+
+        <div class="title-bar__actions">
+            <ul class="title-bar__actions-list">
+              <% change_items.each do |item| item %>
+                <li class="title-bar__actions-list-item">
+                  <%= item %>
+              <% end %>
+              </li>
+            </ul>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/support_title_bar/view.rb
+++ b/app/components/support_title_bar/view.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SupportTitleBar
+  class View < ViewComponent::Base
+  private
+
+    def title
+      if current_recruitment_cycle?
+        "Recruitment cycle #{current_recruitment_cycle_year} to #{next_recruitment_cycle_year} - current"
+      else
+        "Recruitment cycle #{current_recruitment_cycle_year + 1} to #{next_recruitment_cycle_year + 1}"
+      end
+    end
+
+    def change_cycle_link
+      govuk_link_to t("page_titles.rollover.change_cycle"), support_path, class: "title-bar__link govuk-link--no-visited-state"
+    end
+
+    def change_items
+      [change_cycle_link]
+    end
+
+    def rollover_active?
+      Settings.features.rollover.can_edit_current_and_next_cycles == true
+    end
+
+    def recruitment_cycle_year
+      params[:recruitment_cycle_year].to_i
+    end
+
+    def current_recruitment_cycle?
+      recruitment_cycle_year == Settings.current_recruitment_cycle_year
+    end
+
+    def next_recruitment_cycle?
+      recruitment_cycle_year == Settings.current_recruitment_cycle_year + 1
+    end
+
+    def current_recruitment_cycle_year
+      Settings.current_recruitment_cycle_year - 1
+    end
+
+    def next_recruitment_cycle_year
+      Settings.current_recruitment_cycle_year
+    end
+
+    def support_index_page
+      request.path == "/support"
+    end
+
+  end
+end

--- a/app/components/support_title_bar/view.rb
+++ b/app/components/support_title_bar/view.rb
@@ -47,6 +47,5 @@ module SupportTitleBar
     def support_index_page
       request.path == "/support"
     end
-
   end
 end

--- a/app/controllers/support/recruitment_cycle_controller.rb
+++ b/app/controllers/support/recruitment_cycle_controller.rb
@@ -1,0 +1,9 @@
+module Support
+  class RecruitmentCycleController < SupportController
+    def index
+      unless FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
+        redirect_to support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year)
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,6 +59,9 @@
           <%= render PhaseBanner::View.new %>
         <% end %>
         <%= yield :navigation_bar %>
+        <% if params[:controller].start_with?("support") %>
+          <%= render SupportTitleBar::View.new %>
+        <% end %>
         <%= yield :breadcrumbs %>
       </div>
 
@@ -67,10 +70,6 @@
           <% if render_title_bar?(current_user: current_user, provider: @provider) && !request.path.end_with?(@provider.provider_code.to_s) %>
            <%= render TitleBar::View.new(title: @provider.provider_name, provider: @provider.provider_code, current_user:) %>
           <% end %>
-        <% end %>
-
-        <% if params[:controller].start_with?("support") %>
-          <%= render SupportTitleBar::View.new %>
         <% end %>
       </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,6 +68,10 @@
            <%= render TitleBar::View.new(title: @provider.provider_name, provider: @provider.provider_code, current_user:) %>
           <% end %>
         <% end %>
+
+        <% if params[:controller].start_with?("support") %>
+          <%= render SupportTitleBar::View.new %>
+        <% end %>
       </div>
 
     <%= render partial: "publish/shared/navigation_bar" %>

--- a/app/views/support/recruitment_cycle/index.html.erb
+++ b/app/views/support/recruitment_cycle/index.html.erb
@@ -1,0 +1,17 @@
+<ul class="govuk-list govuk-list--spaced">
+  <li>
+    <%= govuk_link_to(
+          "#{current_recruitment_cycle_period_text} - current",
+          support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year),
+          data: { qa: "provider__courses__current_cycle" },
+        ) %>
+  </li>
+
+    <li>
+      <%= govuk_link_to(
+            next_recruitment_cycle_period_text.to_s,
+            support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year + 1),
+            data: { qa: "provider__courses__next_cycle" },
+          ) %>
+    </li>
+    </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,7 +233,7 @@ Rails.application.routes.draw do
   end
 
   namespace :support do
-    get "/" => redirect("/support/#{Settings.current_recruitment_cycle_year}/providers")
+    get "/", to: "recruitment_cycle#index"
 
     resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "" do
       resources :providers, except: %i[destroy] do

--- a/spec/components/support_title_bar/view_preview.rb
+++ b/spec/components/support_title_bar/view_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SupportTitleBar
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(View.new)
+    end
+  end
+end

--- a/spec/components/support_title_bar/view_spec.rb
+++ b/spec/components/support_title_bar/view_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module SupportTitleBar
+  describe View do
+    alias_method :component, :page
+
+    context "not during rollover", { can_edit_current_and_next_cycles: false } do
+      before do
+        render_inline(described_class.new)
+      end
+
+      it "does not render the provided title" do
+        expect(component).not_to have_text("Recruitment cycle #{Settings.current_recruitment_cycle_year}")
+      end
+
+      it "does not render the recruitment cycle link" do
+        expect(component.has_link?("Change recruitment cycle", href: "/support")).to be false
+      end
+    end
+
+    context "during rollover" do
+      before do
+        allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
+        render_inline(described_class.new)
+      end
+
+      it "renders the provided title" do
+        expect(component).to have_text("Recruitment cycle #{Settings.current_recruitment_cycle_year}")
+      end
+
+      it "renders the recruitment cycle link" do
+        expect(component.has_link?("Change recruitment cycle", href: "/support")).to be true
+      end
+    end
+  end
+end

--- a/spec/features/support/switching_between_recruitment_cycles_spec.rb
+++ b/spec/features/support/switching_between_recruitment_cycles_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+feature "Support index" do
+  scenario "viewing support cycles page during rollover" do
+    given_we_are_in_rollover
+    and_there_are_two_recruitment_cycles
+    and_i_am_authenticated_as_an_admin_user
+    when_i_visit_the_support_index_page
+    then_i_should_be_on_the_recruitment_cycle_switcher_page
+    and_should_not_see_the_switch_cycle_link
+
+    when_i_click_on_the_current_cycle
+    i_should_see_the_current_cycle_page
+
+    when_click_the_switch_cycle_link
+    and_click_on_the_next_cycle
+    i_should_be_on_the_next_cycle_page
+  end
+
+  def given_we_are_in_rollover
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
+  end
+
+  def and_there_are_two_recruitment_cycles
+    find_or_create(:recruitment_cycle, :previous)
+    find_or_create(:recruitment_cycle, :next)
+  end
+
+  def and_i_am_authenticated_as_an_admin_user
+    given_i_am_authenticated(user: create(:user, :admin))
+  end
+
+  def when_i_visit_the_support_index_page
+    support_recruitment_cycle_index_page.load
+  end
+
+  def then_i_should_be_on_the_recruitment_cycle_switcher_page
+    expect(support_recruitment_cycle_index_page).to have_link "#{Settings.current_recruitment_cycle_year} - current"
+    expect(support_recruitment_cycle_index_page).to have_link Settings.current_recruitment_cycle_year + 1
+  end
+
+  def and_should_not_see_the_switch_cycle_link
+    expect(support_provider_index_page).not_to have_link "Change recruitment cycle"
+  end
+
+  def when_i_click_on_the_current_cycle
+    click_link "#{Settings.current_recruitment_cycle_year} - current"
+  end
+
+  def and_click_on_the_next_cycle
+    click_link Settings.current_recruitment_cycle_year + 1
+  end
+
+  def i_should_see_the_current_cycle_page
+    expect(support_provider_index_page).to have_text "Recruitment cycle #{Settings.current_recruitment_cycle_year - 1} to #{Settings.current_recruitment_cycle_year} - current"
+  end
+
+  def when_click_the_switch_cycle_link
+    click_link "Change recruitment cycle"
+  end
+
+  def i_should_be_on_the_next_cycle_page
+    expect(support_provider_index_page).to have_text "Recruitment cycle #{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}"
+  end
+end

--- a/spec/support/page_objects/support/recruitment_cycle_index.rb
+++ b/spec/support/page_objects/support/recruitment_cycle_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class RecruitmentCycleIndex < PageObjects::Base
+      set_url "/support"
+    end
+  end
+end


### PR DESCRIPTION
### Context

As we have now finished scoping the recruitment cycle year to the params in support, we need a way for support users to easily switch between cycles. 

We have a switcher in the app, we are building something similar for support users.

### Changes proposed in this pull request

- Implement the cycle switcher html page for support
- Show the html page when switching between cycles
- Add the cycle switcher in the title bar in line with the prototype

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
