### PR TITLE
Add sad path test and fix blue support link in header

### DIFF
--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -8,7 +8,7 @@
 
   <% if current_user.present? %>
     <% if current_user.admin? %>
-      <% header.navigation_item(text: "Support console", href: support_path) %>
+      <% header.navigation_item(text: "Support console", href: support_path, active: false) %>
       <% header.navigation_item(text: "Sign out", href: sign_out_path) %>
     <% else %>
       <% if current_user.associated_with_accredited_body? %>

--- a/spec/features/support/switching_between_recruitment_cycles_spec.rb
+++ b/spec/features/support/switching_between_recruitment_cycles_spec.rb
@@ -17,8 +17,24 @@ feature "Support index" do
     i_should_be_on_the_next_cycle_page
   end
 
+  scenario "viewing providers page when not in rollover" do
+    given_we_are_not_in_rollover
+    and_there_are_two_recruitment_cycles
+    and_i_am_authenticated_as_an_admin_user
+    when_i_visit_the_support_index_page
+    then_i_should_be_on_the_support_providers_page
+  end
+
+  def then_i_should_be_on_the_support_providers_page
+    expect(support_provider_index_page).to be_displayed
+  end
+
   def given_we_are_in_rollover
     allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true)
+  end
+
+  def given_we_are_not_in_rollover
+    allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
   end
 
   def and_there_are_two_recruitment_cycles


### PR DESCRIPTION
### Context

A test for an unhappy path and a fix for a blue support link

### Changes proposed in this pull request

 - Add test sad path test for rollover inactive (which tests that we arrive at providers page and not the cycles page)
 - Stop support link being blue on the support cycles page

### Guidance to review

- I've deployed the review app - have a look and ensure the support console link in the header is no longer blue on the support cycles page.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
