### PR TITLE
Add support recruitment cycle page title

### DIFF
--- a/app/views/support/recruitment_cycle/index.html.erb
+++ b/app/views/support/recruitment_cycle/index.html.erb
@@ -1,3 +1,7 @@
+<%= render PageTitle::View.new(title: "support.rollover.index") %>
+
+<h1 class="govuk-heading-l"><%= t("components.page_titles.support.rollover.index") %></h1>
+
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <%= govuk_link_to(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,8 @@ en:
         new: "User not found"
         personas: Teacher Training API Personas
       support:
+        rollover:
+          index: "Recruitment Cycles"
         providers:
           index: "Providers"
           new: "Add a provider"


### PR DESCRIPTION
### Context

Adding a title to the recruitment cycle support page in line with the prototype

### Before

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/50492247/182360515-d53b83b0-4c17-4c4c-92c0-331ac87b40a7.png">


#### After

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/50492247/182360440-5d6aaac6-719e-4b32-bb45-1a751d5b7542.png">
