### PR TITLE
Only add users to the cycle you are in

### DIFF
--- a/app/services/user_associations_service/create.rb
+++ b/app/services/user_associations_service/create.rb
@@ -1,6 +1,5 @@
 module UserAssociationsService
   class Create
-    include RolloverHelper
 
     attr_reader :provider, :user, :all_providers
 
@@ -36,18 +35,10 @@ module UserAssociationsService
 
     def add_user_to_a_single_provider
       add_user_to_provider_in_current_cycle
-
-      if rollover_active?
-        add_user_to_provider_in_next_cycle
-      end
     end
 
     def add_user_to_provider_in_current_cycle
       provider.users << user
-    end
-
-    def add_user_to_provider_in_next_cycle
-      RecruitmentCycle.next.providers.find_by(provider_code: provider.provider_code).users << user
     end
 
     def send_user_added_to_provider_email

--- a/app/services/user_associations_service/create.rb
+++ b/app/services/user_associations_service/create.rb
@@ -1,6 +1,5 @@
 module UserAssociationsService
   class Create
-
     attr_reader :provider, :user, :all_providers
 
     class << self

--- a/spec/services/user_associations_service/create_spec.rb
+++ b/spec/services/user_associations_service/create_spec.rb
@@ -83,17 +83,6 @@ RSpec.describe UserAssociationsService::Create, { can_edit_current_and_next_cycl
           expect(UserNotification.where(user_id: user.id).count).to eq(0)
         end
       end
-
-      context "during rollover", { can_edit_current_and_next_cycles: true } do
-        let!(:next_new_accredited_body) { create(:provider, :accredited_body, :next_recruitment_cycle, provider_code: "AAA") }
-
-        it "creates user_permissions association in both cycles" do
-          subject
-          expect(new_accredited_body.users).to eq([user])
-          expect(next_new_accredited_body.users).to eq([user])
-          expect(user.providers).to include(accredited_body, new_accredited_body, next_new_accredited_body)
-        end
-      end
     end
 
     context "when adding to all providers" do


### PR DESCRIPTION
### Context

Now that we have added the cycle switcher to support, it feels wrong to add the user to both cycles in one go

### Changes proposed in this pull request

- Remove the logic that used to handle this