### PR TITLE
Implement open closed status labels for courses

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -19,7 +19,11 @@ class ApplicationDecorator < Draper::Decorator
   end
 
   def status_tags
-    object.has_vacancies? ? status_tags_for_vacancies : status_tags_for_no_vacancies
+    if current_recruitment_cycle_year?
+      object.has_vacancies? ? status_tags_for_vacancies : status_tags_for_no_vacancies
+    else
+      status_tags_for_rolled_over_courses
+    end
   end
 
   def unpublished_status_hint
@@ -41,5 +45,13 @@ private
 
   def status_tags_for_no_vacancies
     status_tags_for_vacancies.merge(published: { text: "Closed", colour: "purple" }, published_with_unpublished_changes: { text: "Closed&nbsp;*", colour: "purple" })
+  end
+
+  def status_tags_for_rolled_over_courses
+    status_tags_for_vacancies.merge(published: { text: "Scheduled", colour: "blue" }, published_with_unpublished_changes: { text: "Scheduled&nbsp;*", colour: "blue" })
+  end
+
+  def current_recruitment_cycle_year?
+    course.recruitment_cycle_year.to_i == Settings.current_recruitment_cycle_year
   end
 end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -21,12 +21,27 @@ private
   end
 
   def status_tags
+    object.has_vacancies? ? status_tags_for_vacancies : status_tags_for_no_vacancies
+  end
+
+  def status_tags_for_vacancies
     {
-      published: { text: "Published", colour: "green" },
+      published: { text: "Open", colour: "turquoise" },
       withdrawn: { text: "Withdrawn", colour: "red" },
       empty: { text: "Empty", colour: "grey" },
       draft: { text: "Draft", colour: "grey" },
-      published_with_unpublished_changes: { text: "Published&nbsp;*", colour: "green" },
+      published_with_unpublished_changes: { text: "Open&nbsp;*", colour: "turquoise" },
+      rolled_over: { text: "Rolled over", colour: "yellow" },
+    }
+  end
+
+  def status_tags_for_no_vacancies
+    {
+      published: { text: "Closed", colour: "purple" },
+      withdrawn: { text: "Withdrawn", colour: "red" },
+      empty: { text: "Empty", colour: "grey" },
+      draft: { text: "Draft", colour: "grey" },
+      published_with_unpublished_changes: { text: "Closed&nbsp;*", colour: "purple" },
       rolled_over: { text: "Rolled over", colour: "yellow" },
     }
   end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -52,6 +52,6 @@ private
   end
 
   def current_recruitment_cycle_year?
-    course.recruitment_cycle_year.to_i == Settings.current_recruitment_cycle_year
+    course.in_current_cycle?
   end
 end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -6,8 +6,6 @@ class ApplicationDecorator < Draper::Decorator
     tag.html_safe
   end
 
-private
-
   def status_text
     return status_tags[:withdrawn][:text] if object.ucas_status == "not_running"
 
@@ -24,6 +22,12 @@ private
     object.has_vacancies? ? status_tags_for_vacancies : status_tags_for_no_vacancies
   end
 
+  def unpublished_status_hint
+    h.tag.span("*&nbsp;Unpublished&nbsp;changes".html_safe, class: "govuk-body-s govuk-!-display-block govuk-!-margin-bottom-0 govuk-!-margin-top-1")
+  end
+
+private
+
   def status_tags_for_vacancies
     {
       published: { text: "Open", colour: "turquoise" },
@@ -36,17 +40,6 @@ private
   end
 
   def status_tags_for_no_vacancies
-    {
-      published: { text: "Closed", colour: "purple" },
-      withdrawn: { text: "Withdrawn", colour: "red" },
-      empty: { text: "Empty", colour: "grey" },
-      draft: { text: "Draft", colour: "grey" },
-      published_with_unpublished_changes: { text: "Closed&nbsp;*", colour: "purple" },
-      rolled_over: { text: "Rolled over", colour: "yellow" },
-    }
-  end
-
-  def unpublished_status_hint
-    h.tag.span("*&nbsp;Unpublished&nbsp;changes".html_safe, class: "govuk-body-s govuk-!-display-block govuk-!-margin-bottom-0 govuk-!-margin-top-1")
+    status_tags_for_vacancies.merge(published: { text: "Closed", colour: "purple" }, published_with_unpublished_changes: { text: "Closed&nbsp;*", colour: "purple" })
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -402,7 +402,7 @@ class Course < ApplicationRecord
   end
 
   def open_for_applications?
-    has_vacancies? && findable?
+    applications_open_from.present? && applications_open_from <= Time.now.utc && findable? && has_vacancies?
   end
 
   def has_vacancies?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -402,7 +402,7 @@ class Course < ApplicationRecord
   end
 
   def open_for_applications?
-    applications_open_from.present? && applications_open_from <= Time.now.utc && findable?
+    has_vacancies? && findable?
   end
 
   def has_vacancies?

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -341,9 +341,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_should_see_the_course_as(status_tag)
-    expect(provider_courses_show_page.content_status).to have_content(
-                                                           status_tag,
-                                                         )
+    expect(provider_courses_show_page.content_status).to have_content(status_tag)
   end
 
   def provider

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -390,6 +390,6 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
   end
 
   def then_i_should_see_the_status_scheduled
-    expect(provider_courses_index_page).to have_scheduled
+    expect(provider_courses_index_page).to have_scheduled_tag
   end
 end

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -25,7 +25,8 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     scenario "i can view a salary course" do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], funding_type: "salary"))
       when_i_visit_the_course_page
-      then_i_should_see_the_description_of_the_salary_course("Closed")
+      then_i_should_see_the_description_of_the_salary_course
+      and_i_should_see_the_course_as("Closed")
       and_i_should_see_the_course_button_panel
     end
   end
@@ -34,7 +35,8 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     scenario "i can view the published partial" do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], funding_type: "salary", site_statuses: [build(:site_status, :findable)]))
       when_i_visit_the_course_page
-      then_i_should_see_the_description_of_the_salary_course("Open")
+      then_i_should_see_the_description_of_the_salary_course
+      and_i_should_see_the_course_as("Open")
       and_i_should_see_the_course_button_panel
       and_i_should_see_the_published_partial
       and_i_should_not_see_the_rollover_button
@@ -303,13 +305,9 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     )
   end
 
-  def then_i_should_see_the_description_of_the_salary_course(status_tag)
+  def then_i_should_see_the_description_of_the_salary_course
     expect(provider_courses_show_page.title).to have_content(
       "#{course.name} (#{course.course_code})",
-    )
-
-    expect(provider_courses_show_page.content_status).to have_content(
-      status_tag,
     )
 
     expect(provider_courses_show_page.about_course).to have_content(
@@ -340,6 +338,12 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     expect(provider_courses_show_page.other_requirements).to have_content(
       course_enrichment.other_requirements,
     )
+  end
+
+  def and_i_should_see_the_course_as(status_tag)
+    expect(provider_courses_show_page.content_status).to have_content(
+                                                           status_tag,
+                                                         )
   end
 
   def provider

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -25,7 +25,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     scenario "i can view a salary course" do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], funding_type: "salary"))
       when_i_visit_the_course_page
-      then_i_should_see_the_description_of_the_salary_course
+      then_i_should_see_the_description_of_the_salary_course("Closed")
       and_i_should_see_the_course_button_panel
     end
   end
@@ -34,7 +34,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     scenario "i can view the published partial" do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], funding_type: "salary", site_statuses: [build(:site_status, :findable)]))
       when_i_visit_the_course_page
-      then_i_should_see_the_description_of_the_salary_course
+      then_i_should_see_the_description_of_the_salary_course("Open")
       and_i_should_see_the_course_button_panel
       and_i_should_see_the_published_partial
       and_i_should_not_see_the_rollover_button
@@ -303,13 +303,13 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     )
   end
 
-  def then_i_should_see_the_description_of_the_salary_course
+  def then_i_should_see_the_description_of_the_salary_course(status_tag)
     expect(provider_courses_show_page.title).to have_content(
       "#{course.name} (#{course.course_code})",
     )
 
     expect(provider_courses_show_page.content_status).to have_content(
-      "Published",
+      status_tag,
     )
 
     expect(provider_courses_show_page.about_course).to have_content(

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -43,6 +43,15 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     end
   end
 
+  describe "in the next cycle" do
+    scenario "published courses have a 'Scheduled' status" do
+      given_there_is_a_next_recruitment_cycle
+      given_i_am_authenticated_as_a_provider_user(course: build(:course))
+      when_i_visit_the_next_cycle_courses_page
+      then_i_should_see_the_status_scheduled
+    end
+  end
+
   describe "with a published with unpublished changes course" do
     scenario "i can view the unpublished partial" do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_unpublished_changes], funding_type: "salary"))
@@ -360,5 +369,27 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
       funding_type: "fee",
       subjects: [build(:secondary_subject, bursary_amount: 10000)],
     )
+  end
+
+  def course_enrichments_published
+    build(:course_enrichment, :published)
+  end
+
+  def next_recruitment_cycle_year
+    Settings.current_recruitment_cycle_year + 1
+  end
+
+  def when_i_visit_the_next_cycle_courses_page
+    provider_courses_index_page.load(
+      provider_code: next_cycle_provider.provider_code, recruitment_cycle_year: next_recruitment_cycle_year,
+    )
+  end
+
+  def next_cycle_provider
+    create(:provider, :next_recruitment_cycle, courses: [build(:course, enrichments: [course_enrichments_published])])
+  end
+
+  def then_i_should_see_the_status_scheduled
+    expect(provider_courses_index_page).to have_scheduled
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1308,6 +1308,7 @@ describe Course, type: :model do
     let(:findable_with_vacancies) { build(:site_status, :findable, :with_any_vacancy, site:) }
     let(:published_suspended_with_any_vacancy) { build(:site_status, :published, :discontinued, :with_any_vacancy, site:) }
     let(:published_discontinued_with_any_vacancy) { build(:site_status, :published, :suspended, :with_any_vacancy, site:) }
+    let(:published_discontinued_with_no_vacancies) { build(:site_status, :published, :suspended, :with_no_vacancies, site:) }
     let(:site_statuses) { [] }
 
     subject { create(:course, provider:, site_statuses:) }
@@ -1445,157 +1446,29 @@ describe Course, type: :model do
       end
     end
 
-    describe "open_for_applications?" do
-      let(:site_statuses) { [] }
+    describe "#open_for_applications?" do
+      context "findable course with vacancies" do
+        let(:site_statuses) { [findable_with_vacancies] }
 
-      let(:applications_open_from) { Time.now.utc }
-
-      let(:course) do
-        create(:course,
-          site_statuses:,
-          applications_open_from:)
+        its(:open_for_applications?) { is_expected.to be true }
       end
 
-      subject { course }
+      context "non findable course with vacancies" do
+        let(:site_statuses) { [published_discontinued_with_any_vacancy] }
 
-      context "no site statuses" do
-        context "applications_open_from is in present or past" do
-          its(:open_for_applications?) { is_expected.to be false }
-        end
-
-        context "applications_open_from is in future" do
-          let(:applications_open_from) { Time.now.utc + 1.day }
-
-          its(:open_for_applications?) { is_expected.to be false }
-        end
+        its(:open_for_applications?) { is_expected.to be false }
       end
 
-      context "with site statuses" do
-        context "with only a single findable site statuses" do
-          let(:site_statuses) { [findable] }
+      context "findable course with no vacancies" do
+        let(:site_statuses) { [findable_without_vacancies] }
 
-          context "applications_open_from is in present or past" do
-            its(:open_for_applications?) { is_expected.to be true }
-          end
-
-          context "applications_open_from is in future" do
-            let(:applications_open_from) { Time.now.utc + 1.day }
-
-            its(:open_for_applications?) { is_expected.to be false }
-          end
-        end
-
-        context "with at least a single findable site statuses" do
-          let(:site_statuses) do
-            [default, findable, new_site_status,
-             site_status_with_no_vacancies, suspended, with_any_vacancy]
-          end
-
-          context "applications_open_from is in present or past" do
-            its(:open_for_applications?) { is_expected.to be true }
-          end
-
-          context "applications_open_from is in future" do
-            let(:applications_open_from) { Time.now.utc + 1.day }
-
-            its(:open_for_applications?) { is_expected.to be false }
-          end
-        end
-
-        context "with no findable site statuses" do
-          let(:site_statuses) do
-            [default, new_site_status, site_status_with_no_vacancies,
-             suspended, with_any_vacancy]
-          end
-
-          context "applications_open_from is in present or past" do
-            its(:open_for_applications?) { is_expected.to be false }
-          end
-
-          context "applications_open_from is in future" do
-            let(:applications_open_from) { Time.now.utc + 1.day }
-
-            its(:open_for_applications?) { is_expected.to be false }
-          end
-        end
-      end
-    end
-
-    describe "open_for_applications? (when site_statuses not loaded)" do
-      let(:site_statuses) { [] }
-
-      let(:applications_open_from) { Time.now.utc }
-
-      let(:course) do
-        create(:course,
-          site_statuses:,
-          applications_open_from:)
+        its(:open_for_applications?) { is_expected.to be false }
       end
 
-      subject {
-        course.reload
-      }
+      context "non findable course with no vacancies" do
+        let(:site_statuses) { [published_discontinued_with_no_vacancies] }
 
-      context "no site statuses" do
-        context "applications_open_from is in present or past" do
-          its(:open_for_applications?) { is_expected.to be false }
-        end
-
-        context "applications_open_from is in future" do
-          let(:applications_open_from) { Time.now.utc + 1.day }
-
-          its(:open_for_applications?) { is_expected.to be false }
-        end
-      end
-
-      context "with site statuses" do
-        context "with only a single findable site statuses" do
-          let(:site_statuses) { [findable] }
-
-          context "applications_open_from is in present or past" do
-            its(:open_for_applications?) { is_expected.to be true }
-          end
-
-          context "applications_open_from is in future" do
-            let(:applications_open_from) { Time.now.utc + 1.day }
-
-            its(:open_for_applications?) { is_expected.to be false }
-          end
-        end
-
-        context "with at least a single findable site statuses" do
-          let(:site_statuses) do
-            [default, findable, new_site_status,
-             site_status_with_no_vacancies, suspended, with_any_vacancy]
-          end
-
-          context "applications_open_from is in present or past" do
-            its(:open_for_applications?) { is_expected.to be true }
-          end
-
-          context "applications_open_from is in future" do
-            let(:applications_open_from) { Time.now.utc + 1.day }
-
-            its(:open_for_applications?) { is_expected.to be false }
-          end
-        end
-
-        context "with no findable site statuses" do
-          let(:site_statuses) do
-            [default, new_site_status, site_status_with_no_vacancies,
-             suspended, with_any_vacancy]
-          end
-
-          context "applications_open_from is in present or past" do
-            its(:open_for_applications?) { is_expected.to be false }
-          end
-
-          context "applications_open_from is in future" do
-            let(:applications_open_from) { Time.now.utc + 1.day }
-
-            its(:open_for_applications?) { is_expected.to be false }
-          end
-        end
+        its(:open_for_applications?) { is_expected.to be false }
       end
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1447,28 +1447,102 @@ describe Course, type: :model do
     end
 
     describe "#open_for_applications?" do
-      context "findable course with vacancies" do
-        let(:site_statuses) { [findable_with_vacancies] }
+      let(:site_statuses) { [] }
 
-        its(:open_for_applications?) { is_expected.to be true }
+      let(:applications_open_from) { Time.now.utc }
+
+      let(:course) do
+        create(:course,
+          site_statuses:,
+          applications_open_from:)
       end
 
-      context "non findable course with vacancies" do
-        let(:site_statuses) { [published_discontinued_with_any_vacancy] }
+      subject { course }
 
-        its(:open_for_applications?) { is_expected.to be false }
+      context "no site statuses" do
+        context "applications_open_from is in present or past" do
+          its(:open_for_applications?) { is_expected.to be false }
+        end
+
+        context "applications_open_from is in future" do
+          let(:applications_open_from) { Time.now.utc + 1.day }
+
+          its(:open_for_applications?) { is_expected.to be false }
+        end
       end
 
-      context "findable course with no vacancies" do
-        let(:site_statuses) { [findable_without_vacancies] }
+      context "with site statuses" do
+        context "with only a single findable site statuses" do
+          let(:site_statuses) { [findable] }
 
-        its(:open_for_applications?) { is_expected.to be false }
-      end
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { is_expected.to be true }
+          end
 
-      context "non findable course with no vacancies" do
-        let(:site_statuses) { [published_discontinued_with_no_vacancies] }
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.day }
 
-        its(:open_for_applications?) { is_expected.to be false }
+            its(:open_for_applications?) { is_expected.to be false }
+          end
+        end
+
+        context "with at least a single findable site statuses" do
+          let(:site_statuses) do
+            [default, findable, new_site_status,
+             site_status_with_no_vacancies, suspended, with_any_vacancy]
+          end
+
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { is_expected.to be true }
+          end
+
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.day }
+
+            its(:open_for_applications?) { is_expected.to be false }
+          end
+        end
+
+        context "with no findable site statuses" do
+          let(:site_statuses) do
+            [default, new_site_status, site_status_with_no_vacancies,
+             suspended, with_any_vacancy]
+          end
+
+          context "applications_open_from is in present or past" do
+            its(:open_for_applications?) { is_expected.to be false }
+          end
+
+          context "applications_open_from is in future" do
+            let(:applications_open_from) { Time.now.utc + 1.day }
+
+            its(:open_for_applications?) { is_expected.to be false }
+          end
+
+          context "findable course with vacancies" do
+            let(:site_statuses) { [findable_with_vacancies] }
+
+            its(:open_for_applications?) { is_expected.to be true }
+          end
+
+          context "non findable course with vacancies" do
+            let(:site_statuses) { [published_discontinued_with_any_vacancy] }
+
+            its(:open_for_applications?) { is_expected.to be false }
+          end
+
+          context "findable course with no vacancies" do
+            let(:site_statuses) { [findable_without_vacancies] }
+
+            its(:open_for_applications?) { is_expected.to be false }
+          end
+
+          context "non findable course with no vacancies" do
+            let(:site_statuses) { [published_discontinued_with_no_vacancies] }
+
+            its(:open_for_applications?) { is_expected.to be false }
+          end
+        end
       end
     end
 

--- a/spec/support/page_objects/publish/provider_courses_index.rb
+++ b/spec/support/page_objects/publish/provider_courses_index.rb
@@ -21,6 +21,8 @@ module PageObjects
       element :success_summary, ".govuk-notification-banner--success"
 
       element :add_course, ".govuk-button", text: "Add course"
+
+      element :scheduled, ".govuk-tag--blue", text: "Scheduled"
     end
   end
 end

--- a/spec/support/page_objects/publish/provider_courses_index.rb
+++ b/spec/support/page_objects/publish/provider_courses_index.rb
@@ -22,7 +22,7 @@ module PageObjects
 
       element :add_course, ".govuk-button", text: "Add course"
 
-      element :scheduled, ".govuk-tag--blue", text: "Scheduled"
+      element :scheduled_tag, ".govuk-tag--blue", text: "Scheduled"
     end
   end
 end


### PR DESCRIPTION
### Context

This is the beginning of a piece of work to improve course labels. This PR only makes surface level UI changes. Downstream systems can continue to rely on the internal states `published`.

### Changes proposed in this pull request

- Split the `Published` label into `Open` and `Closed`
- Only display `OPEN` if the course `has_vacancies?` other wise display `CLOSED` 
- In the next cycle display `SCHEDULED` for courses that will be published when Find opens 
- Colour changes to these statuses
- Apply the same logic to the `Applications` column on the course table, i.e `Open` if there are vacancies and `Closed` if there isn't.

### Guidance to review

- Log into the prototype, have a look at a course with vacancies, change to no vacancies, look at the new labels and watch the Applications column update. 

- Perhaps the status tags logic can be refactored in a better way?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
