### PR TITLE
Remove PE Allocations tab from support in the next recruitment cycle

### DIFF
--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,7 @@
+#The PE allocations tab can be deleted after rollover 2022
+
 <%= render TabNavigation::View.new(items: [
-  { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
-  { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
-  { name: "PE Allocations", url: support_recruitment_cycle_allocations_path },
+{ name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
+{ name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
+*([name: "PE Allocations", url: support_recruitment_cycle_allocations_path] if params[:recruitment_cycle_year] == "2022"),
 ]) %>

--- a/spec/features/support/switching_between_recruitment_cycles_spec.rb
+++ b/spec/features/support/switching_between_recruitment_cycles_spec.rb
@@ -11,10 +11,12 @@ feature "Support index" do
 
     when_i_click_on_the_current_cycle
     i_should_see_the_current_cycle_page
+    and_i_should_see_the_pe_allocations_tab # This method can be deleted after rollover 2022
 
     when_click_the_switch_cycle_link
     and_click_on_the_next_cycle
     i_should_be_on_the_next_cycle_page
+    and_i_should_not_see_the_pe_allocations_tab # This method can be deleted after rollover 2022
   end
 
   scenario "viewing providers page when not in rollover" do
@@ -77,5 +79,13 @@ feature "Support index" do
 
   def i_should_be_on_the_next_cycle_page
     expect(support_provider_index_page).to have_text "Recruitment cycle #{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}"
+  end
+
+  def and_i_should_see_the_pe_allocations_tab
+    expect(support_provider_index_page).to have_link "PE Allocations"
+  end
+
+  def and_i_should_not_see_the_pe_allocations_tab
+    expect(support_provider_index_page).not_to have_link "PE Allocations"
   end
 end


### PR DESCRIPTION
### Context

Removing the PE Allocations tab from support in the next recruitment cycle as this is no longer required.

### Guidance to review

- Login to support in the current cycle, check that the PE allocations tab is present
- Repeat for the next cycle and ensure it is not present 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
