### PR TITLE
Change heading and column content for will it be on find next recruitment cycle

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -22,7 +22,7 @@ class CourseDecorator < ApplicationDecorator
       if current_cycle_and_open?
         h.govuk_link_to("Yes - view online", h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code))
       else
-        "Yes - from #{Date::MONTHNAMES[Settings.next_cycle_open_date.to_date.month]}"
+        "No - live on #{l(Settings.next_cycle_open_date.to_date, format: :govuk_short)}"
       end
     else
       not_on_find

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -200,7 +200,7 @@ class CourseDecorator < ApplicationDecorator
     else
       year = recruitment_cycle.year.to_i
       day_month = recruitment_cycle.application_start_date.strftime("%-d %B")
-      "On #{day_month} when applications for the #{year} to #{year + 1} cycle open"
+      "On #{day_month} when applications for the #{year - 1} to #{year} cycle open"
     end
   end
 

--- a/app/views/publish/courses/_course_table.html.erb
+++ b/app/views/publish/courses/_course_table.html.erb
@@ -4,7 +4,7 @@
       <th class="govuk-table__header">Course</th>
       <th class="govuk-table__header">Status</th>
       <th class="govuk-table__header">
-        <% if @recruitment_cycle.current_and_open? %>Is it<% else %>Will it be<% end %> on <abbr class="app-!-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
+       Is it on <abbr class="app-!-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
       </th>
       <th class="govuk-table__header">Applications</th>
       <% if @recruitment_cycle.current_and_open? %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,7 +44,7 @@ cookies:
     expire_after_days: 182
 
 current_recruitment_cycle_year: 2022
-next_cycle_open_date: 2022-10-5
+next_cycle_open_date: 2022-10-4
 
 allocation_cycle_year: 2021
 allocations_close_date: 2021-07-02


### PR DESCRIPTION
### Context

We have decided to change the `Will it be on Find?` column on the courses table in the next cycle to match the one in the current cycle, which is `Is it on Find?`. 

This change was made so that users can switch between cycles and be able to see at a glance what is on Find as that is the header they would be used to seeing all year. 

### Changes proposed in this pull request

- Change the `next_cycle_open_date` in `Settings.yml` to `2022-10-4`
- Change the `Will it be on Find?` header in the courses cycle to match what is displayed in the current cycle.
- Change the value in that column so that it makes sense in the new context
- Our recruitment cycle year is displaying incorrectly in the course creation flow. I've updated that too.  

### Guidance to review

The main thing that concerns me here is changing the date in `Settings.yml`. Is this change OK to make and has it been changed to the correct date?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
