### PR TITLE
Update zlib to r3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN apk add --update --no-cache tzdata && \
 RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
-# Remove once base image ruby:3.1-alpine3.15 has been updated with latest zlib
-RUN apk add --no-cache zlib=1.2.12-r2
+# Remove once the base image ruby:3.1-alpine3.15 has been updated with latest zlib
+RUN apk add --no-cache zlib=1.2.12-r3
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/publish-teacher-training/pull/2907 was raised to fix CVE-2022-37434 however the r2 package has been removed and replaced by r3. This caused errors when referencing r2 so we need to ensure the reference is updated to use r3.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
