### PR TITLE
Create qa2.find route for find migration to publish

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -10,6 +10,10 @@ data cloudfoundry_domain publish_service_gov_uk {
   name = "publish-teacher-training-courses.service.gov.uk"
 }
 
+data cloudfoundry_domain find_service_gov_uk {
+  name = "find-postgraduate-teacher-training.service.gov.uk"
+}
+
 data cloudfoundry_org org {
   name = "dfe"
 }

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -74,6 +74,13 @@ resource cloudfoundry_route web_app_publish_gov_uk_route {
   hostname = each.value
 }
 
+resource cloudfoundry_route web_app_find_gov_uk_route {
+  for_each = toset(var.find_gov_uk_host_names)
+  domain   = data.cloudfoundry_domain.find_service_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = each.value
+}
+
 resource cloudfoundry_service_instance postgres {
   name         = local.postgres_service_name
   space        = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -31,6 +31,11 @@ variable "publish_gov_uk_host_names" {
   type = list
 }
 
+variable "find_gov_uk_host_names" {
+  default = []
+  type = list
+}
+
 variable "restore_from_db_guid" {}
 
 variable "db_backup_before_point_in_time" {}
@@ -76,6 +81,7 @@ locals {
   web_app_routes = flatten([
     values(cloudfoundry_route.web_app_cloudapps_digital_route),
     cloudfoundry_route.web_app_service_gov_uk_route,
-    values(cloudfoundry_route.web_app_publish_gov_uk_route)
+    values(cloudfoundry_route.web_app_publish_gov_uk_route),
+    values(cloudfoundry_route.web_app_find_gov_uk_route)
   ])
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -58,6 +58,7 @@ module "paas" {
   redis_service_plan             = var.paas_redis_service_plan
   app_environment_variables      = local.paas_app_environment_variables
   publish_gov_uk_host_names      = var.publish_gov_uk_host_names
+  find_gov_uk_host_names         = var.find_gov_uk_host_names
   restore_from_db_guid           = var.paas_restore_from_db_guid
   db_backup_before_point_in_time = var.paas_db_backup_before_point_in_time
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,6 +49,11 @@ variable "publish_gov_uk_host_names" {
   type = list
 }
 
+variable "find_gov_uk_host_names" {
+  default = []
+  type = list
+}
+
 variable statuscake_alerts {
   type    = map
   default = {}

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -9,6 +9,7 @@
     "paas_postgres_service_plan": "small-11",
     "paas_redis_service_plan": "tiny-5_x",
     "publish_gov_uk_host_names": ["qa"],
+    "find_gov_uk_host_names": ["qa2"],
     "key_vault_resource_group": "s121d01-shared-rg",
     "key_vault_name": "s121d01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-QA",


### PR DESCRIPTION
### Context

https://trello.com/c/bzTV1UDE/377-create-2https-wwwfind-postgraduate-teacher-trainingservicegovuk-domains

Create qa2.find-postgraduate-teacher-training.service.gov.uk route for find migration to publish

### Changes proposed in this pull request

Add terraform resources for new route
Add find_gov_uk_host_names variable to qa.tfvars.json to create new route
(DNS and CDN will be completed afterwards)

### Guidance to review

deploy-plan

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
