### PR TITLE
[380] Add a domain constraint for the new find url

### DIFF
--- a/app/lib/find_constraint.rb
+++ b/app/lib/find_constraint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FindConstraint
+  def matches?(request)
+    Settings.find_temp_url&.include?(request.host)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,6 @@ Rails.application.routes.draw do
     get "/", to: redirect("/docs/")
   end
 
-  constraints(FindConstraint.new) do
-    get "/", to: redirect("/find/")
-  end
-
   constraints(host: /www2\./) do
     match "/(*path)" => redirect { |_, req| "#{Settings.base_url}#{req.fullpath}" }, via: %i[get post put]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     get "/", to: redirect("/docs/")
   end
 
+  constraints(FindConstraint.new) do
+    get "/", to: redirect("/find/")
+  end
+
   constraints(host: /www2\./) do
     match "/(*path)" => redirect { |_, req| "#{Settings.base_url}#{req.fullpath}" }, via: %i[get post put]
   end

--- a/config/settings/loadtest.yml
+++ b/config/settings/loadtest.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://publish-teacher-training-loadtest.london.cloudapps.digital
 publish_url: https://publish-loadtest.london.cloudapps.digital
 find_url: https://find-loadtest.london.cloudapps.digital
+find_temp_url: https://find-loadtest2.london.cloudapps.digital
 
 # URL of this app for the callback after signing in
 base_url: https://publish-loadtest.london.cloudapps.digital

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+find_temp_url: https://www2.find-postgraduate-teacher-training.service.gov.uk
 
 search_ui:
   base_url: https://www.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,6 +2,8 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+find_temp_url: https://qa2.find-postgraduate-teacher-training.service.gov.uk
+
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 

--- a/config/settings/rollover.yml
+++ b/config/settings/rollover.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://publish-teacher-training-rollover.london.cloudapps.digital
 publish_url: https://publish-rollover.london.cloudapps.digital
 find_url: https://find-rollover.london.cloudapps.digital
+find_temp_url: https://find-rollover2.london.cloudapps.digital
 
 # URL of this app for the callback after sigining in
 base_url: https://publish-rollover.london.cloudapps.digital

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -2,6 +2,8 @@ gcp_api_key: please_change_me
 publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+find_temp_url: https://sandbox2.find-postgraduate-teacher-training.service.gov.uk
+
 environment:
   label: "Sandbox"
   name: "sandbox"

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+find_temp_url: https://staging2.find-postgraduate-teacher-training.service.gov.uk
 
 search_ui:
   base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk

--- a/spec/lib/find_constraint_spec.rb
+++ b/spec/lib/find_constraint_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe FindConstraint do
+  let(:request) {
+    double(
+      :request,
+      host:,
+    )
+  }
+  let(:find_temp_url) { "find_temp_url" }
+  let(:host) { "find_temp_url" }
+
+  subject {
+    described_class.new.matches?(request)
+  }
+
+  describe "#matched?" do
+    before do
+      Settings.find_temp_url = find_temp_url
+    end
+
+    context "Settings.find_temp_url is same as host" do
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context "Settings.find_temp_url is different to host" do
+      let(:host) { "find_different_url" }
+
+      it "returns false" do
+        expect(subject).to be_falsey
+      end
+    end
+
+    context "Settings.find_temp_url is nil" do
+      let(:find_temp_url) { nil }
+
+      it "returns false" do
+        expect(subject).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
domain constraint for the new find url

### Changes proposed in this pull request
Add a domain constraint for the new find url

### Guidance to review
it redirects to `/find`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
