### PR TITLE
Update setup-cf-cli location in db backup workflow

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -108,7 +108,7 @@ jobs:
      matrix:
        environment: [qa, staging]
    steps:
-      - uses: DFE-Digital/bat-infrastructure/actions/setup-cf-cli@main
+      - uses: DFE-Digital/github-actions/setup-cf-cli@master
         name: Setup cf cli
         with:
          CF_USERNAME: ${{ secrets[format('CF_USERNAME_{0}', matrix.environment)] }}


### PR DESCRIPTION
### Context

setup-cf-cli was moved from bat-infrastructure to github-actions
Need to update the database backup workflow as the restore step is currently failing

### Changes proposed in this pull request

Update workflow to point to correct location

### Guidance to review

Check correct syntax

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
