### PR TITLE
[407] Streamline course state values in API

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -2,6 +2,10 @@ module API
   module Public
     module V1
       class SerializableCourse < JSONAPI::Serializable::Resource
+        COURSE_STATE_MAPPING = {
+          published_with_unpublished_changes: :published,
+        }.freeze
+
         class << self
           def enrichment_attribute(name, enrichment_name = name)
             attribute name do
@@ -112,7 +116,7 @@ module API
         end
 
         attribute :state do
-          @object.content_status
+          COURSE_STATE_MAPPING[@object.content_status] || @object.content_status
         end
 
         attribute :summary do

--- a/app/services/courses/content_status_service.rb
+++ b/app/services/courses/content_status_service.rb
@@ -1,23 +1,12 @@
 module Courses
   class ContentStatusService
     def execute(enrichment:, recruitment_cycle:)
-      if enrichment.blank?
-        if recruitment_cycle.next?
-          :rolled_over
-        else
-          :empty
-        end
-      elsif enrichment.published?
-        :published
-      elsif enrichment.withdrawn?
-        :withdrawn
-      elsif enrichment.has_been_published_before?
-        :published_with_unpublished_changes
-      elsif enrichment.rolled_over?
-        :rolled_over
-      else
-        :draft
-      end
+      return :rolled_over if (recruitment_cycle.next? && enrichment.blank?) || enrichment&.rolled_over?
+      return :published if enrichment&.published?
+      return :withdrawn if enrichment&.withdrawn?
+      return :published_with_unpublished_changes if enrichment&.has_been_published_before?
+
+      :draft
     end
   end
 end

--- a/spec/models/course/publish_enrichments_spec.rb
+++ b/spec/models/course/publish_enrichments_spec.rb
@@ -31,7 +31,7 @@ describe Course, type: :model do
     context "for a course without any enrichments" do
       let(:enrichments) { [] }
 
-      its(:content_status) { is_expected.to eq(:empty) }
+      its(:content_status) { is_expected.to eq(:draft) }
     end
 
     context "for a course an initial draft enrichments" do

--- a/spec/services/courses/content_status_service_spec.rb
+++ b/spec/services/courses/content_status_service_spec.rb
@@ -17,8 +17,8 @@ describe Courses::ContentStatusService do
     end
 
     context "and does not belong to the next recruitment cycle" do
-      it "returns empty" do
-        expect(execute_service).to eq :empty
+      it "returns draft" do
+        expect(execute_service).to eq :draft
       end
     end
   end
@@ -26,7 +26,7 @@ describe Courses::ContentStatusService do
   context "when the enrichment has been published" do
     let(:enrichment) { build(:course_enrichment, :published) }
 
-    it "returns rolled over" do
+    it "returns published" do
       expect(execute_service).to eq :published
     end
   end
@@ -34,7 +34,7 @@ describe Courses::ContentStatusService do
   context "when the enrichment has been withdrawn" do
     let(:enrichment) { build(:course_enrichment, :withdrawn) }
 
-    it "returns rolled over" do
+    it "returns withdrawn" do
       expect(execute_service).to eq :withdrawn
     end
   end
@@ -42,7 +42,7 @@ describe Courses::ContentStatusService do
   context "when the enrichment has been been published previously" do
     let(:enrichment) { build(:course_enrichment, :subsequent_draft) }
 
-    it "returns rolled over" do
+    it "returns published_with_unpublished_changes" do
       expect(execute_service).to eq :published_with_unpublished_changes
     end
   end
@@ -58,7 +58,7 @@ describe Courses::ContentStatusService do
   context "when the enrichment is a draft enrichment" do
     let(:enrichment) { build(:course_enrichment) }
 
-    it "returns rolled over" do
+    it "returns draft" do
       expect(execute_service).to eq :draft
     end
   end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1152,9 +1152,7 @@
             "enum": [
               "scitt",
               "lead_school",
-              "university",
-              "unknown",
-              "invalid_value"
+              "university"
             ]
           },
           "region_code": {

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -457,11 +457,9 @@
             "description": "The state of the course in the Publish teacher training courses system.",
             "example": "published",
             "enum": [
-              "empty",
               "rolled_over",
               "draft",
               "published",
-              "published_with_unpublished_changes",
               "withdrawn"
             ]
           },
@@ -569,17 +567,6 @@
               "fee"
             ]
           },
-          "degree_grade": {
-            "description": "Return courses based on their degree grade. This is a comma delimited string. If multiple degree grade types are provided then any course matching any one of the options provided will be returned, i.e. the OR operator is used.",
-            "type": "string",
-            "example": "two_two,third_class",
-            "enum": [
-              "two_one",
-              "two_two",
-              "third_class",
-              "not_required"
-            ]
-          },
           "qualification": {
             "description": "Search courses based on the award given on course completion. This is a comma delimited string. If multiple qualifications are given then any course matching any one of the qualifications provided will be returned, i.e. the OR operator is used.",
             "type": "string",
@@ -676,8 +663,19 @@
             "type": "string",
             "example": "2020-11-13T11:21:55Z"
           },
-          "can_sponsor_visa": {
-            "description": "Return courses where the provider can sponsor a visa.",
+          "degree_grade": {
+            "description": "Return courses based on their degree grade. This is a comma delimited string. If multiple degree grade types are provided then any course matching any one of the options provided will be returned, i.e. the OR operator is used.",
+            "type": "string",
+            "example": "two_two,third_class",
+            "enum": [
+              "two_one",
+              "two_two",
+              "third_class",
+              "not_required"
+            ]
+          },
+          "provider_can_sponsor_visa": {
+            "description": "Only return courses where the provider can sponsor either a skilled worker or student visa",
             "type": "boolean",
             "example": true
           }
@@ -1154,7 +1152,9 @@
             "enum": [
               "scitt",
               "lead_school",
-              "university"
+              "university",
+              "unknown",
+              "invalid_value"
             ]
           },
           "region_code": {
@@ -1837,7 +1837,9 @@
             "example": {
               "has_vacancies": true,
               "subjects": "00,01",
-              "updated_since": "2020-11-13T11:21:55Z"
+              "updated_since": "2020-11-13T11:21:55Z",
+              "degree_grade": "two_two",
+              "provider_can_sponsor_visa": true
             }
           },
           {
@@ -1972,7 +1974,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle.",
-            "example": 2021,
+            "example": 2022,
             "schema": {
               "type": "string"
             }
@@ -2074,7 +2076,9 @@
             "example": {
               "has_vacancies": true,
               "subjects": "00,01",
-              "updated_since": "2020-11-13T11:21:55Z"
+              "updated_since": "2020-11-13T11:21:55Z",
+              "degree_grade": "two_two",
+              "provider_can_sponsor_visa": true
             }
           },
           {
@@ -2229,7 +2233,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle.",
-            "example": 2021,
+            "example": 2022,
             "schema": {
               "type": "string"
             }

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -316,11 +316,9 @@ properties:
       The state of the course in the Publish teacher training courses system.
     example: published
     enum:
-      - empty
       - rolled_over
       - draft
       - published
-      - published_with_unpublished_changes
       - withdrawn
   study_mode:
     type: string

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -112,7 +112,7 @@ properties:
       - two_two
       - third_class
       - not_required
-provider_can_sponsor_visa:
-    description: "Only return courses where the provider can sponsor either a skilled worker or student visa"
-    type: boolean
-    example: true
+  provider_can_sponsor_visa:
+      description: "Only return courses where the provider can sponsor either a skilled worker or student visa"
+      type: boolean
+      example: true

--- a/swagger/public_v1/component_schemas/ProviderAttributes.yml
+++ b/swagger/public_v1/component_schemas/ProviderAttributes.yml
@@ -83,8 +83,6 @@ properties:
       - scitt
       - lead_school
       - university
-      - unknown
-      - invalid_value
   region_code:
     type: string
     description: "The NUTS 1 region code for the provider's address."


### PR DESCRIPTION
### Context

https://trello.com/c/HzBaBvhu/407-update-course-status-send-via-the-api

### Changes proposed in this pull request

- Streamlines course state values sent via the API. Keeps the logic in the service the same as some of the values are still relevant in our system
- Update api docs

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
