### PR TITLE
[436] Expose new course visa fields via the api

### DIFF
--- a/app/deserializers/api/v3/deserializable_course.rb
+++ b/app/deserializers/api/v3/deserializable_course.rb
@@ -39,6 +39,8 @@ module API
         accept_maths_gcse_equivalency
         accept_science_gcse_equivalency
         additional_gcse_equivalencies
+        can_sponsor_skilled_worker_visa
+        can_sponsor_student_visa
       ].freeze
 
       attributes(*COURSE_ATTRIBUTES)

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -45,7 +45,9 @@ module API
           :accept_english_gcse_equivalency,
           :accept_maths_gcse_equivalency,
           :accept_science_gcse_equivalency,
-          :additional_gcse_equivalencies
+          :additional_gcse_equivalencies,
+          :can_sponsor_skilled_worker_visa,
+          :can_sponsor_student_visa
 
         attribute :about_accredited_body do
           @object.accrediting_provider_description

--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -27,7 +27,8 @@ module API
         :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency,
         :accept_science_gcse_equivalency, :additional_gcse_equivalencies,
         :degree_grade, :additional_degree_subject_requirements,
-        :degree_subject_requirements
+        :degree_subject_requirements, :can_sponsor_skilled_worker_visa,
+        :can_sponsor_student_visa
 
       attribute :start_date do
         written_month_year(@object.start_date) if @object.start_date

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -5,6 +5,13 @@ weight: 2
 
 # Release Notes
 
+## 31 March 2022
+
+We have introduced two new fields to the `CourseAttributes` schema which provide a way to determine availability for visa sponsorships with regards to individual courses.
+
+- Add `can_sponsor_skilled_worker_visa` field to `CourseAttributes`. This is a boolean field which returns true if a skilled worker visa can be sponsored for a course.
+- Add `can_sponsor_student_visa` field to `CourseAttributes`. This is a boolean field which returns true if a student visa can be sponsored for a course.
+
 ## 5 March 2021
 
 - Add `subject_codes` field to `CourseAttributes`. This is an array of two-digit subject codes as strings, corresponding to subjects available on the `/subjects` endpoint.

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -288,7 +288,9 @@ RSpec.describe API::Public::V1::CoursesController do
                 interview_process
                 other_requirements
                 personal_qualities
-                salary_details]
+                salary_details
+                can_sponsor_skilled_worker_visa
+                can_sponsor_student_visa]
           end
 
           before do

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -122,6 +122,8 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                 "degree_grade" => provider.courses[0].degree_grade,
                 "additional_degree_subject_requirements" => provider.courses[0].additional_degree_subject_requirements,
                 "degree_subject_requirements" => provider.courses[0].degree_subject_requirements,
+                "can_sponsor_skilled_worker_visa" => provider.courses[0].can_sponsor_skilled_worker_visa,
+                "can_sponsor_student_visa" => provider.courses[0].can_sponsor_student_visa,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -156,6 +156,8 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
             "degree_grade" => course.degree_grade,
             "additional_degree_subject_requirements" => course.additional_degree_subject_requirements,
             "degree_subject_requirements" => course.degree_subject_requirements,
+            "can_sponsor_skilled_worker_visa" => course.can_sponsor_skilled_worker_visa,
+            "can_sponsor_student_visa" => course.can_sponsor_student_visa,
           },
           "relationships" => {
             "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:running).with_value(course.findable?) }
   it { is_expected.to have_attribute(:salary_details).with_value(course.latest_published_enrichment.salary_details) }
   it { is_expected.to have_attribute(:scholarship_amount).with_value(nil) }
+  it { is_expected.to have_attribute(:can_sponsor_skilled_worker_visa) }
+  it { is_expected.to have_attribute(:can_sponsor_student_visa) }
 
   context "when bursary amount is present" do
     let(:course) { create(:course, :with_accrediting_provider, :secondary, enrichments: [enrichment], subjects: [find_or_create(:secondary_subject, :classics)]) }

--- a/spec/serializers/api/v3/serializable_course_spec.rb
+++ b/spec/serializers/api/v3/serializable_course_spec.rb
@@ -37,6 +37,8 @@ describe API::V3::SerializableCourse do
   it { is_expected.to have_attribute :age_range_in_years }
   it { is_expected.to have_attribute(:recruitment_cycle_year).with_value(course.recruitment_cycle.year) }
   it { is_expected.to have_attribute :program_type }
+  it { is_expected.to have_attribute :can_sponsor_skilled_worker_visa }
+  it { is_expected.to have_attribute :can_sponsor_student_visa }
 
   context "with a provider" do
     let(:provider) { course.provider }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -539,6 +539,16 @@
             "nullable": true,
             "description": "Details about equivalency tests the provider offers or accepts",
             "example": "We offer our own equivalency tests."
+          },
+          "can_sponsor_skilled_worker_visa": {
+            "type": "boolean",
+            "description": "Does this course provide sponsorship for a skilled worker visa?",
+            "example": true
+          },
+          "can_sponsor_student_visa": {
+            "type": "boolean",
+            "description": "Does this course provide sponsorship for a student visa?",
+            "example": false
           }
         }
       },

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -383,3 +383,11 @@ properties:
     nullable: true
     description: "Details about equivalency tests the provider offers or accepts"
     example: "We offer our own equivalency tests."
+  can_sponsor_skilled_worker_visa:
+    type: boolean
+    description: "Does this course provide sponsorship for a skilled worker visa?"
+    example: true
+  can_sponsor_student_visa:
+    type: boolean
+    description: "Does this course provide sponsorship for a student visa?"
+    example: false


### PR DESCRIPTION
### Context

https://trello.com/c/9LZletSa/436-expose-new-course-visa-fields-via-the-api

### Changes proposed in this pull request

- Expose new fields in serializers for V3 and Public API
- Document fields in API

### Guidance to review

- Query the api, assert new fields are exposed
- Fire up the docs locally and assert they're documented

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
