### PR TITLE
Fix Apply link on preview

### DIFF
--- a/app/components/find_interface/courses/apply_component/view.html.erb
+++ b/app/components/find_interface/courses/apply_component/view.html.erb
@@ -4,7 +4,7 @@
       <p class="govuk-body">
         <%= govuk_start_button(
               text: "Apply for this course",
-              href: find_apply_path(provider_code: provider.provider_code, course_code: course.course_code),
+              href: "#", # The href should be "#" for preview but the real link for Find as the real link caused error messages on Sentry when the user clicked on it
               html_attributes: {
                 data: { qa: "course__apply_link" },
               },


### PR DESCRIPTION
### Context

Preview does not require the real apply link. This caused an error on the channel.

- https://sentry.io/organizations/dfe-teacher-services/issues/3562352360/?project=1377944&referrer=slack

### Guidance to review

- Navigate to a course on preview
- Click the Apply link
- Ensure you do not get an error 

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
