### PR TITLE
#440 Update course copy service in Publish to handle visa fields

### DIFF
--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -43,6 +43,12 @@ module Courses
       ["Other requirements", "other_requirements"],
     ].freeze
 
+    # TODO This is to be utilised when we add these to a course form
+    VISA_FIELDS = [
+      ["Can sponsor skilled worker visa", "can_sponsor_skilled_worker_visa"],
+      ["Can sponsor student visa", "can_sponsor_student_visa"],
+    ].freeze
+
     def self.get_present_fields_in_source_course(fields, source_course, course)
       fields.filter_map do |name, field|
         source_value = source_course.enrichments.last[field]

--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -43,7 +43,7 @@ module Courses
       ["Other requirements", "other_requirements"],
     ].freeze
 
-    # TODO This is to be utilised when we add these to a course form
+    # TODO: This is to be utilised when we add these to a course form
     VISA_FIELDS = [
       ["Can sponsor skilled worker visa", "can_sponsor_skilled_worker_visa"],
       ["Can sponsor student visa", "can_sponsor_student_visa"],

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -20,6 +20,8 @@ module Courses
         new_course.applications_open_from = adjusted_applications_open_from_date(course, year_differential)
         new_course.start_date = course.start_date + year_differential.year
         new_course.subjects = course.subjects
+        new_course.can_sponsor_skilled_worker_visa = course.can_sponsor_skilled_worker_visa
+        new_course.can_sponsor_student_visa = course.can_sponsor_student_visa
         new_course.save!(validate: false)
 
         copy_latest_enrichment_to_course(course, new_course)

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Courses::CopyToProviderService do
     expect(new_course.content_status).to eq :rolled_over
     expect(new_course.ucas_status).to eq :new
     expect(new_course.open_for_applications?).to be_falsey
+    expect(new_course.can_sponsor_skilled_worker_visa).to eq course.can_sponsor_skilled_worker_visa
+    expect(new_course.can_sponsor_student_visa).to eq course.can_sponsor_student_visa
   end
 
   context "applications open from date" do


### PR DESCRIPTION
### Context
To simplify collecting visa information from providers, we're updating how and which providers provide their visa sponsorship information via their provider details page and when they create courses

### Changes proposed in this pull request
Add visa fields to CopyToProviderService

### Guidance to review
Not sure if this is exactly correct, we have visa fields on both the course and provider, are we transitioning from one to the other? 
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
