### PR TITLE
[439] Refactor visa filters to query courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -263,17 +263,15 @@ class Course < ApplicationRecord
     where(degree_grade: degree_grades)
   }
 
-  scope :provider_can_sponsor_visa, lambda {
-    joins(:provider)
-    .where(
+  scope :can_sponsor_visa, lambda {
+    where(
       program_type: %w[school_direct_training_programme higher_education_programme scitt_programme],
-      provider: { can_sponsor_student_visa: true },
+      can_sponsor_student_visa: true,
     )
     .or(
-      joins(:provider)
-      .where(
+      where(
         program_type: %w[school_direct_salaried_training_programme pg_teaching_apprenticeship],
-        provider: { can_sponsor_skilled_worker_visa: true },
+        can_sponsor_skilled_worker_visa: true,
       ),
     )
   }

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -29,7 +29,7 @@ class CourseSearchService
     scope = scope.with_funding_types(funding_types) if funding_types.any?
     scope = scope.with_degree_grades(degree_grades) if degree_grades.any?
     scope = scope.changed_since(filter[:updated_since]) if updated_since_filter?
-    scope = scope.provider_can_sponsor_visa if can_sponsor_visa_filter?
+    scope = scope.can_sponsor_visa if can_sponsor_visa_filter?
 
     # The 'where' scope will remove duplicates
     # An outer query is required in the event the provider name is present.

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -25,7 +25,7 @@ describe "API" do
           subjects: "00,01",
           updated_since: "2020-11-13T11:21:55Z",
           degree_grade: "two_two",
-          provider_can_sponsor_visa: true,
+          can_sponsor_visa: true,
         }
       parameter name: :sort,
         in: :query,

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -31,7 +31,7 @@ describe "API" do
           subjects: "00,01",
           updated_since: "2020-11-13T11:21:55Z",
           degree_grade: "two_two",
-          provider_can_sponsor_visa: true,
+          can_sponsor_visa: true,
         }
       parameter name: :sort,
         in: :query,

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -216,5 +216,13 @@ FactoryBot.define do
     trait :published do
       enrichments { [build(:course_enrichment, :published)] }
     end
+
+    trait :can_sponsor_skilled_worker_visa do
+      can_sponsor_skilled_worker_visa { true }
+    end
+
+    trait :can_sponsor_student_visa do
+      can_sponsor_student_visa { true }
+    end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1138,20 +1138,19 @@ describe Course, type: :model do
       end
     end
 
-    describe ".provider_can_sponsor_visa" do
-      subject { described_class.provider_can_sponsor_visa }
+    describe ".can_sponsor_visa" do
+      subject { described_class.can_sponsor_visa }
 
-      let(:course) { create(:course, provider:) }
+      let(:provider) { create(:provider) }
+      let(:course) { create(:course, provider: create(:provider)) }
 
       before do
         course
       end
 
       context "when the provider can sponsor skilled worker visas" do
-        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: true, can_sponsor_student_visa: false) }
-
         context "and is a salaried course" do
-          let(:course) { create(:course, :salary_type_based, provider:) }
+          let(:course) { create(:course, :salary_type_based, :can_sponsor_skilled_worker_visa, provider:) }
 
           it "returns the course" do
             expect(subject).to eq [course]
@@ -1159,7 +1158,7 @@ describe Course, type: :model do
         end
 
         context "and is non-salaried course" do
-          let(:course) { create(:course, :fee_type_based, provider:) }
+          let(:course) { create(:course, :fee_type_based, :can_sponsor_skilled_worker_visa, provider:) }
 
           it "does not return the course" do
             expect(subject).to eq []
@@ -1168,10 +1167,8 @@ describe Course, type: :model do
       end
 
       context "when the provider can sponsor student visas" do
-        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: true) }
-
         context "and is non-salaried course" do
-          let(:course) { create(:course, :fee_type_based, provider:) }
+          let(:course) { create(:course, :fee_type_based, :can_sponsor_student_visa, provider:) }
 
           it "returns the course" do
             expect(subject).to eq [course]
@@ -1179,7 +1176,7 @@ describe Course, type: :model do
         end
 
         context "and is a salaried course" do
-          let(:course) { create(:course, :salary_type_based, provider:) }
+          let(:course) { create(:course, :salary_type_based, :can_sponsor_student_visa, provider:) }
 
           it "does not return the course" do
             expect(subject).to eq []
@@ -1188,8 +1185,6 @@ describe Course, type: :model do
       end
 
       context "when the provider cannot sponsor visas" do
-        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: false) }
-
         it "does not return the course" do
           expect(subject).to eq []
         end

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -797,12 +797,9 @@ describe "GET v3/courses" do
   describe "visa scoping" do
     context "with providers that can and cannot provide visas" do
       let(:request_path) { "/api/v3/courses?filter[can_sponsor_visa]=true" }
-      let(:provider_that_can_sponsor_student_visa) { build(:provider, can_sponsor_student_visa: true, can_sponsor_skilled_worker_visa: false) }
-      let(:provider_that_can_sponsor_skilled_worker_visa) { build(:provider, can_sponsor_student_visa: false, can_sponsor_skilled_worker_visa: true) }
-      let(:provider_that_cant_sponsor_visas) { build(:provider, can_sponsor_student_visa: false, can_sponsor_skilled_worker_visa: false) }
-      let(:course1) { create(:course, :fee_type_based, provider: provider_that_can_sponsor_student_visa, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
-      let(:course2) { create(:course, :salary_type_based, provider: provider_that_can_sponsor_skilled_worker_visa, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
-      let(:course3) { create(:course, provider: provider_that_cant_sponsor_visas, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
+      let(:course1) { create(:course, :fee_type_based, :can_sponsor_student_visa, provider: build(:provider), site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
+      let(:course2) { create(:course, :salary_type_based, :can_sponsor_skilled_worker_visa, provider: build(:provider), site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
+      let(:course3) { create(:course, provider: build(:provider), site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
 
       before do
         course1

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -641,8 +641,8 @@ RSpec.describe CourseSearchService do
         let(:filter) { { can_sponsor_visa: true } }
         let(:expected_scope) { double }
 
-        it "adds the provider_can_sponsor_visa scope" do
-          expect(scope).to receive(:provider_can_sponsor_visa).and_return(course_ids_scope)
+        it "adds the can_sponsor_visa scope" do
+          expect(scope).to receive(:can_sponsor_visa).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
@@ -652,8 +652,8 @@ RSpec.describe CourseSearchService do
       context "when false" do
         let(:filter) { { can_sponsor_visa: false } }
 
-        it "adds the provider_can_sponsor_visa scope" do
-          expect(scope).not_to receive(:provider_can_sponsor_visa)
+        it "adds the can_sponsor_visa scope" do
+          expect(scope).not_to receive(:can_sponsor_visa)
           expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
@@ -663,8 +663,8 @@ RSpec.describe CourseSearchService do
       context "when absent" do
         let(:filter) { {} }
 
-        it "doesn't add the provider_can_sponsor_visa scope" do
-          expect(scope).not_to receive(:provider_can_sponsor_visa)
+        it "doesn't add the can_sponsor_visa scope" do
+          expect(scope).not_to receive(:can_sponsor_visa)
           expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -112,7 +112,7 @@ properties:
       - two_two
       - third_class
       - not_required
-  provider_can_sponsor_visa:
-      description: "Only return courses where the provider can sponsor either a skilled worker or student visa"
+  can_sponsor_visa:
+      description: "Only return courses where a skilled worker or student visa can be sponsored."
       type: boolean
       example: true


### PR DESCRIPTION
### Context

https://trello.com/c/FqQN9KZt/439-update-visa-search-filter-on-find-api

### Changes proposed in this pull request

- Refactors the visa filters to query the course record instead of provider
- Update/Fix specs

### Guidance to review

You can fire up Find locally and query for visa courses against the review app in this PR or hit the endpoint directly with postman

Linked to https://github.com/DFE-Digital/find-teacher-training/pull/1491

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
