### PR TITLE
Handle visa collection in new course flow for lead schools

### DIFF
--- a/app/controllers/publish/courses/applications_open_controller.rb
+++ b/app/controllers/publish/courses/applications_open_controller.rb
@@ -39,6 +39,7 @@ module Publish
             :month,
             :year,
             :can_sponsor_student_visa,
+            :can_sponsor_skilled_worker_visa,
           )
       end
 

--- a/app/controllers/publish/courses/applications_open_controller.rb
+++ b/app/controllers/publish/courses/applications_open_controller.rb
@@ -38,6 +38,7 @@ module Publish
             :day,
             :month,
             :year,
+            :can_sponsor_student_visa,
           )
       end
 

--- a/app/controllers/publish/courses/fee_or_salary_controller.rb
+++ b/app/controllers/publish/courses/fee_or_salary_controller.rb
@@ -3,6 +3,22 @@ module Publish
     class FeeOrSalaryController < PublishController
       include CourseBasicDetailConcern
 
+      def continue
+        authorize(@provider, :can_create_course?)
+        @errors = errors
+        if @errors.any?
+          render :new
+        elsif params[:goto_visa]
+          if course.is_fee_based?
+            redirect_to new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
+          else
+            redirect_to new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
+          end
+        else
+          redirect_to next_step
+        end
+      end
+
     private
 
       def current_step

--- a/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
@@ -1,0 +1,45 @@
+module Publish
+  module Courses
+    class SkilledWorkerVisaSponsorshipController < PublishController
+      include CourseBasicDetailConcern
+
+      def edit
+        authorize(provider)
+
+        @course_skilled_worker_visa_sponsorship_form = CourseSkilledWorkerVisaSponsorshipForm.new(@course)
+      end
+
+      def update
+        authorize(provider)
+        @course_skilled_worker_visa_sponsorship_form = CourseSkilledWorkerVisaSponsorshipForm.new(@course, params: skilled_worker_visa_sponsorship_params)
+        if @course_skilled_worker_visa_sponsorship_form.save!
+          course_description_success_message("skilled worker visa")
+
+          redirect_to details_publish_provider_recruitment_cycle_course_path(
+            provider.provider_code,
+            recruitment_cycle.year,
+            course.course_code,
+          )
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def skilled_worker_visa_sponsorship_params
+        return { visa_sponsorship: nil } if params[:publish_course_skilled_worker_visa_sponsorship_form].blank?
+
+        params.require(:publish_course_skilled_worker_visa_sponsorship_form).permit(*CourseSkilledWorkerVisaSponsorshipForm::FIELDS)
+      end
+
+      def current_step
+        :can_sponsor_skilled_worker_visa
+      end
+
+      def error_keys
+        [:can_sponsor_skilled_worker_visa]
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
@@ -3,6 +3,15 @@ module Publish
     class SkilledWorkerVisaSponsorshipController < PublishController
       include CourseBasicDetailConcern
 
+      def new
+        authorize(@provider, :can_create_course?)
+        @course.can_sponsor_skilled_worker_visa = @provider.can_sponsor_skilled_worker_visa
+        @course_skilled_worker_visa_sponsorship_form = CourseSkilledWorkerVisaSponsorshipForm.new(@course)
+        return if course.school_direct_salaried_training_programme?
+
+        redirect_to next_step
+      end
+
       def edit
         authorize(provider)
 

--- a/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
@@ -5,8 +5,7 @@ module Publish
 
       def new
         authorize(@provider, :can_create_course?)
-        @course.can_sponsor_skilled_worker_visa = @provider.can_sponsor_skilled_worker_visa
-        @course_skilled_worker_visa_sponsorship_form = CourseSkilledWorkerVisaSponsorshipForm.new(@course)
+        @course.can_sponsor_skilled_worker_visa = @provider.can_sponsor_skilled_worker_visa unless @course.can_sponsor_skilled_worker_visa
         return if course.school_direct_salaried_training_programme?
 
         redirect_to next_step

--- a/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
@@ -3,6 +3,15 @@ module Publish
     class StudentVisaSponsorshipController < PublishController
       include CourseBasicDetailConcern
 
+      def new
+        authorize(@provider, :can_create_course?)
+        @course.can_sponsor_student_visa = @provider.can_sponsor_student_visa
+        @course_student_visa_sponsorship_form = CourseStudentVisaSponsorshipForm.new(@course)
+        return if course.is_fee_based?
+
+        redirect_to next_step
+      end
+
       def edit
         authorize(provider)
 

--- a/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
@@ -1,0 +1,45 @@
+module Publish
+  module Courses
+    class StudentVisaSponsorshipController < PublishController
+      include CourseBasicDetailConcern
+
+      def edit
+        authorize(provider)
+
+        @course_student_visa_sponsorship_form = CourseStudentVisaSponsorshipForm.new(@course)
+      end
+
+      def update
+        authorize(provider)
+        @course_student_visa_sponsorship_form = CourseStudentVisaSponsorshipForm.new(@course, params: student_visa_sponsorship_params)
+        if @course_student_visa_sponsorship_form.save!
+          course_description_success_message("student visa")
+
+          redirect_to details_publish_provider_recruitment_cycle_course_path(
+            provider.provider_code,
+            recruitment_cycle.year,
+            course.course_code,
+          )
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def student_visa_sponsorship_params
+        return { visa_sponsorship: nil } if params[:publish_course_student_visa_sponsorship_form].blank?
+
+        params.require(:publish_course_student_visa_sponsorship_form).permit(*CourseStudentVisaSponsorshipForm::FIELDS)
+      end
+
+      def current_step
+        :can_sponsor_student_visa
+      end
+
+      def error_keys
+        [:can_sponsor_student_visa]
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
@@ -5,8 +5,7 @@ module Publish
 
       def new
         authorize(@provider, :can_create_course?)
-        @course.can_sponsor_student_visa = @provider.can_sponsor_student_visa
-        @course_student_visa_sponsorship_form = CourseStudentVisaSponsorshipForm.new(@course)
+        @course.can_sponsor_student_visa = @provider.can_sponsor_student_visa unless @course.can_sponsor_student_visa
         return if course.is_fee_based?
 
         redirect_to next_step

--- a/app/forms/publish/course_skilled_worker_visa_sponsorship_form.rb
+++ b/app/forms/publish/course_skilled_worker_visa_sponsorship_form.rb
@@ -1,0 +1,18 @@
+module Publish
+  class CourseSkilledWorkerVisaSponsorshipForm < BaseModelForm
+    alias_method :course, :model
+
+    FIELDS = %i[can_sponsor_skilled_worker_visa].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :can_sponsor_skilled_worker_visa,
+      presence: true
+
+  private
+
+    def compute_fields
+      course.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+  end
+end

--- a/app/forms/publish/course_student_visa_sponsorship_form.rb
+++ b/app/forms/publish/course_student_visa_sponsorship_form.rb
@@ -1,0 +1,18 @@
+module Publish
+  class CourseStudentVisaSponsorshipForm < BaseModelForm
+    alias_method :course, :model
+
+    FIELDS = %i[can_sponsor_student_visa].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :can_sponsor_student_visa,
+      presence: true
+
+  private
+
+    def compute_fields
+      course.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+  end
+end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,4 +1,9 @@
 module ProviderHelper
+  def course_accredited_body_name(course)
+    # TODO: Handle rollover
+    RecruitmentCycle.current.providers.find_by(provider_code: course.accredited_body_code)&.provider_name
+  end
+
   def visa_sponsorship_status(provider)
     if !provider.declared_visa_sponsorship?
       visa_sponsorship_call_to_action(provider)

--- a/app/models/concerns/courses/edit_options.rb
+++ b/app/models/concerns/courses/edit_options.rb
@@ -10,6 +10,7 @@ module Courses
     include ApplicationsOpenConcern
     include SubjectsConcern
     include CanSponsorStudentVisaConcern
+    include CanSponsorSkilledWorkerVisaConcern
 
     included do
       # When changing edit options here be sure to update the edit_options in the
@@ -24,6 +25,7 @@ module Courses
           start_dates: start_date_options,
           study_modes: study_mode_options,
           can_sponsor_student_visas: can_sponsor_student_visa_options,
+          can_sponsor_skilled_worker_visas: can_sponsor_skilled_worker_visa_options,
           show_is_send: show_is_send?,
           show_start_date: show_start_date?,
           show_applications_open: show_applications_open?,

--- a/app/models/concerns/courses/edit_options.rb
+++ b/app/models/concerns/courses/edit_options.rb
@@ -9,6 +9,7 @@ module Courses
     include IsSendConcern
     include ApplicationsOpenConcern
     include SubjectsConcern
+    include CanSponsorStudentVisaConcern
 
     included do
       # When changing edit options here be sure to update the edit_options in the
@@ -22,6 +23,7 @@ module Courses
           age_range_in_years: age_range_options,
           start_dates: start_date_options,
           study_modes: study_mode_options,
+          can_sponsor_student_visas: can_sponsor_student_visa_options,
           show_is_send: show_is_send?,
           show_start_date: show_start_date?,
           show_applications_open: show_applications_open?,

--- a/app/models/concerns/courses/edit_options/can_sponsor_skilled_worker_visa_concern.rb
+++ b/app/models/concerns/courses/edit_options/can_sponsor_skilled_worker_visa_concern.rb
@@ -1,0 +1,16 @@
+module Courses
+  module EditOptions
+    module CanSponsorSkilledWorkerVisaConcern
+      extend ActiveSupport::Concern
+      included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in publish-teacher-training:
+        #
+        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
+        def can_sponsor_skilled_worker_visa_options
+          [true, false]
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/courses/edit_options/can_sponsor_student_visa_concern.rb
+++ b/app/models/concerns/courses/edit_options/can_sponsor_student_visa_concern.rb
@@ -1,0 +1,16 @@
+module Courses
+  module EditOptions
+    module CanSponsorStudentVisaConcern
+      extend ActiveSupport::Concern
+      included do
+        # When changing anything here be sure to update the edit_options in the
+        # courses factory in publish-teacher-training:
+        #
+        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
+        def can_sponsor_student_visa_options
+          [true, false]
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -109,8 +109,10 @@ module Publish
     def continue_step
       if params[:goto_confirmation] && !%i[subjects fee_or_salary].include?(current_step)
         :confirmation
-      elsif [:fee_or_salary].include?(current_step)
+      elsif [:fee_or_salary].include?(current_step) && course.funding_type == "fee"
         :can_sponsor_student_visa
+      elsif [:fee_or_salary].include?(current_step) && course.funding_type == "salary"
+        :can_sponsor_skilled_worker_visa
       else
         CourseCreationStepService.new.execute(current_step:, course: @course)[:next]
       end
@@ -189,6 +191,8 @@ module Publish
         new_publish_provider_recruitment_cycle_courses_accredited_body_path(path_params)
       when :can_sponsor_student_visa
         new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
+      when :can_sponsor_skilled_worker_visa
+        new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
       when :start_date
         new_publish_provider_recruitment_cycle_courses_start_date_path(path_params)
       when :age_range

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -87,6 +87,7 @@ module Publish
             :course_age_range_in_years_other_from,
             :course_age_range_in_years_other_to,
             :goto_confirmation,
+            :goto_visa,
             :language_ids,
           ).permit(
             policy(Course.new).permitted_new_course_attributes,
@@ -103,16 +104,12 @@ module Publish
     end
 
     def build_meta_course_creation_params
-      @meta_course_creation_params = params.slice(:goto_confirmation)
+      @meta_course_creation_params = params.slice(:goto_confirmation, :goto_visa)
     end
 
     def continue_step
-      if params[:goto_confirmation] && !%i[subjects fee_or_salary].include?(current_step)
+      if params[:goto_confirmation] && current_step != :subjects
         :confirmation
-      elsif [:fee_or_salary].include?(current_step) && course.funding_type == "fee"
-        :can_sponsor_student_visa
-      elsif [:fee_or_salary].include?(current_step) && course.funding_type == "salary"
-        :can_sponsor_skilled_worker_visa
       else
         CourseCreationStepService.new.execute(current_step:, course: @course)[:next]
       end

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -185,6 +185,8 @@ module Publish
         new_publish_provider_recruitment_cycle_courses_applications_open_path(path_params)
       when :accredited_body
         new_publish_provider_recruitment_cycle_courses_accredited_body_path(path_params)
+      when :can_sponsor_student_visa
+        new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
       when :start_date
         new_publish_provider_recruitment_cycle_courses_start_date_path(path_params)
       when :age_range

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -107,8 +107,10 @@ module Publish
     end
 
     def continue_step
-      if params[:goto_confirmation] && current_step != :subjects
+      if params[:goto_confirmation] && !%i[subjects fee_or_salary].include?(current_step)
         :confirmation
+      elsif [:fee_or_salary].include?(current_step)
+        :can_sponsor_student_visa
       else
         CourseCreationStepService.new.execute(current_step:, course: @course)[:next]
       end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -66,6 +66,7 @@ class CoursePolicy
       qualification
       start_date
       study_mode
+      can_sponsor_student_visa
     ]
   end
 

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -67,6 +67,7 @@ class CoursePolicy
       start_date
       study_mode
       can_sponsor_student_visa
+      can_sponsor_skilled_worker_visa
     ]
   end
 

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -30,7 +30,11 @@ module Publish
       elsif course.is_uni_or_scitt?
         new_uni_or_scitt_workflow_steps
       elsif course.is_school_direct?
-        new_school_direct_workflow_steps
+        if FeatureService.enabled?(:visa_sponsorship_on_course)
+          new_school_direct_workflow_steps
+        else
+          new_school_direct_workflow_steps_without_visa
+        end
       end
     end
 
@@ -88,6 +92,24 @@ module Publish
         outcome
         full_or_part_time
         location
+        applications_open
+        start_date
+        confirmation
+      ]
+    end
+
+    def new_school_direct_workflow_steps_without_visa
+      %i[
+        courses_list
+        level
+        subjects
+        modern_languages
+        age_range
+        outcome
+        fee_or_salary
+        full_or_part_time
+        location
+        accredited_body
         applications_open
         start_date
         confirmation

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -30,6 +30,14 @@ module Publish
       elsif course.is_uni_or_scitt?
         new_uni_or_scitt_workflow_steps
       elsif course.is_school_direct?
+        school_direct_steps(course)
+      end
+    end
+
+    def school_direct_steps(course)
+      if course.funding_type == "fee"
+        new_school_direct_workflow_steps.insert(10, :can_sponsor_student_visa)
+      else
         new_school_direct_workflow_steps
       end
     end
@@ -106,7 +114,6 @@ module Publish
         full_or_part_time
         location
         accredited_body
-        can_sponsor_student_visa
         applications_open
         start_date
         confirmation

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -30,16 +30,6 @@ module Publish
       elsif course.is_uni_or_scitt?
         new_uni_or_scitt_workflow_steps
       elsif course.is_school_direct?
-        school_direct_steps(course)
-      end
-    end
-
-    def school_direct_steps(course)
-      if course.funding_type == "fee"
-        new_school_direct_workflow_steps.insert(10, :can_sponsor_student_visa)
-      elsif course.funding_type == "salary"
-        new_school_direct_workflow_steps.insert(10, :can_sponsor_skilled_worker_visa)
-      else
         new_school_direct_workflow_steps
       end
     end
@@ -116,6 +106,8 @@ module Publish
         full_or_part_time
         location
         accredited_body
+        can_sponsor_student_visa
+        can_sponsor_skilled_worker_visa
         applications_open
         start_date
         confirmation

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -31,7 +31,7 @@ module Publish
         new_uni_or_scitt_workflow_steps
       elsif course.is_school_direct?
         if FeatureService.enabled?(:visa_sponsorship_on_course)
-          new_school_direct_workflow_steps
+          new_school_direct_workflow_steps(course)
         else
           new_school_direct_workflow_steps_without_visa
         end
@@ -116,8 +116,8 @@ module Publish
       ]
     end
 
-    def new_school_direct_workflow_steps
-      %i[
+    def new_school_direct_workflow_steps(course)
+      includes_visa_sponsorship = %i[
         courses_list
         level
         subjects
@@ -134,6 +134,10 @@ module Publish
         start_date
         confirmation
       ]
+
+      includes_visa_sponsorship.delete(:can_sponsor_student_visa) unless course.is_fee_based?
+      includes_visa_sponsorship.delete(:can_sponsor_skilled_worker_visa) unless course.school_direct_salaried_training_programme?
+      includes_visa_sponsorship
     end
 
     def new_uni_or_scitt_workflow_steps

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -37,6 +37,8 @@ module Publish
     def school_direct_steps(course)
       if course.funding_type == "fee"
         new_school_direct_workflow_steps.insert(10, :can_sponsor_student_visa)
+      elsif course.funding_type == "salary"
+        new_school_direct_workflow_steps.insert(10, :can_sponsor_skilled_worker_visa)
       else
         new_school_direct_workflow_steps
       end

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -106,6 +106,7 @@ module Publish
         full_or_part_time
         location
         accredited_body
+        can_sponsor_student_visa
         applications_open
         start_date
         confirmation

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -137,6 +137,21 @@
         <% end %>
       <% end %>
 
+      <% if course.funding_type == "salary" %>
+        <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row| %>
+          <% row.key { "Skilled worker visa" } %>
+          <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+          <% if course.is_published? %>
+            <% row.action %>
+          <% else %>
+            <% row.action(**{
+              href: skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+              visually_hidden_text: "can sponsor skilled_worker visa",
+            }) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
       <% summary_list.row(html_attributes: { data: { qa: "course__applications_open" } }) do |row| %>
         <% row.key { "Applications open" } %>
         <% row.value { l(course.applications_open_from&.to_date) } %>

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -122,32 +122,34 @@
         <% end %>
       <% end %>
 
-      <% if course.funding_type == "fee" && @provider.provider_type == "lead_school" %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
-          <% row.key { "Student visa" } %>
-          <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-          <% if course.is_published? %>
-            <% row.action %>
-          <% else %>
-            <% row.action(**{
-              href: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              visually_hidden_text: "can sponsor student visa",
-            }) %>
+      <% if FeatureService.enabled?(:visa_sponsorship_on_course) %>
+        <% if course.funding_type == "fee" && @provider.provider_type == "lead_school" %>
+          <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
+            <% row.key { "Student visa" } %>
+            <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+            <% if course.is_published? %>
+              <% row.action %>
+            <% else %>
+              <% row.action(**{
+                href: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                visually_hidden_text: "can sponsor student visa",
+              }) %>
+            <% end %>
           <% end %>
         <% end %>
-      <% end %>
 
-      <% if course.funding_type == "salary" && @provider.provider_type == "lead_school" %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row| %>
-          <% row.key { "Skilled worker visa" } %>
-          <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-          <% if course.is_published? %>
-            <% row.action %>
-          <% else %>
-            <% row.action(**{
-              href: skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              visually_hidden_text: "can sponsor skilled_worker visa",
-            }) %>
+        <% if course.funding_type == "salary" && @provider.provider_type == "lead_school" %>
+          <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row| %>
+            <% row.key { "Skilled worker visa" } %>
+            <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+            <% if course.is_published? %>
+              <% row.action %>
+            <% else %>
+              <% row.action(**{
+                href: skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                visually_hidden_text: "can sponsor skilled_worker visa",
+              }) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -122,16 +122,18 @@
         <% end %>
       <% end %>
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
-        <% row.key { "Student visa" } %>
-        <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-        <% if course.is_published? %>
-          <% row.action %>
-        <% else %>
-          <% row.action(**{
-            href: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-            visually_hidden_text: "can sponsor student visa",
-          }) %>
+      <% if course.funding_type == "fee" %>
+        <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
+          <% row.key { "Student visa" } %>
+          <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+          <% if course.is_published? %>
+            <% row.action %>
+          <% else %>
+            <% row.action(**{
+              href: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+              visually_hidden_text: "can sponsor student visa",
+            }) %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -122,6 +122,19 @@
         <% end %>
       <% end %>
 
+      <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
+        <% row.key { "Student visa" } %>
+        <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+        <% if course.is_published? %>
+          <% row.action %>
+        <% else %>
+          <% row.action(**{
+            href: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+            visually_hidden_text: "can sponsor student visa",
+          }) %>
+        <% end %>
+      <% end %>
+
       <% summary_list.row(html_attributes: { data: { qa: "course__applications_open" } }) do |row| %>
         <% row.key { "Applications open" } %>
         <% row.value { l(course.applications_open_from&.to_date) } %>

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -122,7 +122,7 @@
         <% end %>
       <% end %>
 
-      <% if course.funding_type == "fee" %>
+      <% if course.funding_type == "fee" && @provider.provider_type == "lead_school" %>
         <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
           <% row.key { "Student visa" } %>
           <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
@@ -137,7 +137,7 @@
         <% end %>
       <% end %>
 
-      <% if course.funding_type == "salary" %>
+      <% if course.funding_type == "salary" && @provider.provider_type == "lead_school" %>
         <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row| %>
           <% row.key { "Skilled worker visa" } %>
           <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -139,6 +139,15 @@
           <% end %>
         <% end %>
 
+        <% summary_list.row(html_attributes: { data: { qa: "course__visa_sponsorship" } }) do |row| %>
+          <% row.key { "Visa sponsorship" } %>
+          <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+          <% row.action(**{
+            href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+            visually_hidden_text: "visa sponsorship",
+          }) %>
+        <% end %>
+
         <% summary_list.row(html_attributes: { data: { qa: "course__applications_open" } }) do |row| %>
           <% row.key { "Applications open" } %>
           <% row.value do %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -140,12 +140,23 @@
         <% end %>
 
         <% if course.funding_type == "fee" %>
-          <% summary_list.row(html_attributes: { data: { qa: "course__visa_sponsorship" } }) do |row| %>
+          <% summary_list.row(html_attributes: { data: { qa: "course__student_visa_sponsorship" } }) do |row| %>
             <% row.key { "Visa sponsorship" } %>
             <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
             <% row.action(**{
               href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
-              visually_hidden_text: "visa sponsorship",
+              visually_hidden_text: "student visa sponsorship",
+            }) %>
+          <% end %>
+        <% end %>
+
+        <% if course.funding_type == "salary" %>
+          <% summary_list.row(html_attributes: { data: { qa: "course__skilled_worker_visa_sponsorship" } }) do |row| %>
+            <% row.key { "Skilled Worker visa" } %>
+            <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+            <% row.action(**{
+              href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+              visually_hidden_text: "skilled worker visa sponsorship",
             }) %>
           <% end %>
         <% end %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -166,7 +166,7 @@
               <% row.key { "Skilled Worker visa" } %>
               <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
               <% row.action(**{
-                href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+                href: new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
                 visually_hidden_text: "skilled worker visa sponsorship",
               }) %>
             <% end %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -139,13 +139,15 @@
           <% end %>
         <% end %>
 
-        <% summary_list.row(html_attributes: { data: { qa: "course__visa_sponsorship" } }) do |row| %>
-          <% row.key { "Visa sponsorship" } %>
-          <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-          <% row.action(**{
-            href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
-            visually_hidden_text: "visa sponsorship",
-          }) %>
+        <% if course.funding_type == "fee" %>
+          <% summary_list.row(html_attributes: { data: { qa: "course__visa_sponsorship" } }) do |row| %>
+            <% row.key { "Visa sponsorship" } %>
+            <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+            <% row.action(**{
+              href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+              visually_hidden_text: "visa sponsorship",
+            }) %>
+          <% end %>
         <% end %>
 
         <% summary_list.row(html_attributes: { data: { qa: "course__applications_open" } }) do |row| %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -138,26 +138,27 @@
             }) %>
           <% end %>
         <% end %>
-
-        <% if course.funding_type == "fee" %>
-          <% summary_list.row(html_attributes: { data: { qa: "course__student_visa_sponsorship" } }) do |row| %>
-            <% row.key { "Visa sponsorship" } %>
-            <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-            <% row.action(**{
-              href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
-              visually_hidden_text: "student visa sponsorship",
-            }) %>
+        <% if FeatureService.enabled?(:visa_sponsorship_on_course) %>
+          <% if course.funding_type == "fee" %>
+            <% summary_list.row(html_attributes: { data: { qa: "course__student_visa_sponsorship" } }) do |row| %>
+              <% row.key { "Visa sponsorship" } %>
+              <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+              <% row.action(**{
+                href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+                visually_hidden_text: "student visa sponsorship",
+              }) %>
+            <% end %>
           <% end %>
-        <% end %>
 
-        <% if course.funding_type == "salary" %>
-          <% summary_list.row(html_attributes: { data: { qa: "course__skilled_worker_visa_sponsorship" } }) do |row| %>
-            <% row.key { "Skilled Worker visa" } %>
-            <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-            <% row.action(**{
-              href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
-              visually_hidden_text: "skilled worker visa sponsorship",
-            }) %>
+          <% if course.funding_type == "salary" %>
+            <% summary_list.row(html_attributes: { data: { qa: "course__skilled_worker_visa_sponsorship" } }) do |row| %>
+              <% row.key { "Skilled Worker visa" } %>
+              <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
+              <% row.action(**{
+                href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+                visually_hidden_text: "skilled worker visa sponsorship",
+              }) %>
+            <% end %>
           <% end %>
         <% end %>
 

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -82,7 +82,7 @@
             <% row.key { "Fee or salary" } %>
             <% row.value { course.funding } %>
             <% row.action(**{
-              href: new_publish_provider_recruitment_cycle_courses_fee_or_salary_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+              href: new_publish_provider_recruitment_cycle_courses_fee_or_salary_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_visa: true, goto_confirmation: true)),
               visually_hidden_text: "if fee or salary",
             }) %>
           <% end %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -78,13 +78,24 @@
             }) %>
           <% end %>
         <% else %>
-          <% summary_list.row(html_attributes: { data: { qa: "course__fee_or_salary" } }) do |row| %>
-            <% row.key { "Fee or salary" } %>
-            <% row.value { course.funding } %>
-            <% row.action(**{
-              href: new_publish_provider_recruitment_cycle_courses_fee_or_salary_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_visa: true, goto_confirmation: true)),
-              visually_hidden_text: "if fee or salary",
-            }) %>
+          <% if FeatureService.enabled?(:visa_sponsorship_on_course) %>
+            <% summary_list.row(html_attributes: { data: { qa: "course__fee_or_salary" } }) do |row| %>
+              <% row.key { "Fee or salary" } %>
+              <% row.value { course.funding } %>
+              <% row.action(**{
+                href: new_publish_provider_recruitment_cycle_courses_fee_or_salary_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_visa: true, goto_confirmation: true)),
+                visually_hidden_text: "if fee or salary",
+              }) %>
+            <% end %>
+          <% else %>
+            <% summary_list.row(html_attributes: { data: { qa: "course__fee_or_salary" } }) do |row| %>
+              <% row.key { "Fee or salary" } %>
+              <% row.value { course.funding } %>
+              <% row.action(**{
+                href: new_publish_provider_recruitment_cycle_courses_fee_or_salary_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+                visually_hidden_text: "if fee or salary",
+              }) %>
+            <% end %>
           <% end %>
         <% end %>
 

--- a/app/views/publish/courses/skilled_worker_visa_sponsorship/_form_fields.html.erb
+++ b/app/views/publish/courses/skilled_worker_visa_sponsorship/_form_fields.html.erb
@@ -1,0 +1,28 @@
+<%= render "publish/shared/error_wrapper", error_keys: [:can_sponsor_skilled_worker_visa], data_qa: "course__can_sponsor_skilled_worker_visa" do %>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+        <%= t("page_titles.skilled_worker_visas.new") %>
+      </h1>
+    </legend>
+
+   <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+     Can your organisation sponsor Skilled Worker visas for this course?
+   </legend>
+
+    <%= render "publish/shared/error_messages", error_keys: [:can_sponsor_skilled_worker_visa] %>
+    <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">
+      <% course.edit_course_options["can_sponsor_skilled_worker_visas"].each do |value| %>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :can_sponsor_skilled_worker_visa,
+                                value,
+                                class: "govuk-radios__input" %>
+          <%= form.label :can_sponsor_student_visa,
+                         t("edit_options.can_sponsor_skilled_worker_visas.#{value}.label"),
+                         value:,
+                         class: "govuk-label govuk-radios__label" %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/publish/courses/skilled_worker_visa_sponsorship/edit.html.erb
+++ b/app/views/publish/courses/skilled_worker_visa_sponsorship/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("#{t('page_titles.skilled_worker_visas.edit')} – #{course.name_and_code}", @course_student_visa_sponsorship_form.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("#{t('page_titles.skilled_worker_visas.edit')} – #{course.name_and_code}", @course_skilled_worker_visa_sponsorship_form.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(

--- a/app/views/publish/courses/skilled_worker_visa_sponsorship/edit.html.erb
+++ b/app/views/publish/courses/skilled_worker_visa_sponsorship/edit.html.erb
@@ -1,0 +1,47 @@
+<% content_for :page_title, title_with_error_prefix("#{t('page_titles.skilled_worker_visas.edit')} – #{course.name_and_code}", @course_student_visa_sponsorship_form.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+        details_publish_provider_recruitment_cycle_course_path(
+          course.provider_code,
+          course.recruitment_cycle_year,
+          course.course_code,
+        ),
+      ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          model: @course_skilled_worker_visa_sponsorship_form,
+          url: skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+          ),
+          method: :put,
+          local: true,
+        ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_skilled_worker_visa, legend: { text: "Can your organisation sponsor Skilled Worker visas for this course?", tag: "h1", size: "l" }) do %>
+
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          Can your organisation sponsor Skilled Worker visas for this course?
+        </legend>
+
+        <% course.edit_course_options["can_sponsor_skilled_worker_visas"].each_with_index do |can_sponsor_skilled_worker_visa, index| %>
+          <%= f.govuk_radio_button(
+                :can_sponsor_skilled_worker_visa,
+                can_sponsor_skilled_worker_visa,
+                label: { text: t("edit_options.can_sponsor_skilled_worker_visas.#{can_sponsor_skilled_worker_visa}.label") },
+                link_errors: index.zero?,
+              ) %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit course.is_published? ? "Save and publish" : "Save" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/skilled_worker_visa_sponsorship/new.html.erb
+++ b/app/views/publish/courses/skilled_worker_visa_sponsorship/new.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, title_with_error_prefix(t("page_titles.skilled_worker_visas.new"), @errors && @errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(@back_link_path) %>
+<% end %>
+
+<%= render "publish/shared/errors" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with(
+          model: @course_skilled_worker_visa_sponsorship_form,
+          url:continue_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(
+            @provider.provider_code,
+            @provider.recruitment_cycle_year,
+            ),
+          method: :get,
+          local: true,
+          )do |form| %>
+
+      <%= render "publish/courses/new_fields_holder", form:, except_keys: [:can_sponsor_skilled_worker_visa] do |fields| %>
+        <%= render "form_fields", form: fields %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/skilled_worker_visa_sponsorship/new.html.erb
+++ b/app/views/publish/courses/skilled_worker_visa_sponsorship/new.html.erb
@@ -10,7 +10,6 @@
   <div class="govuk-grid-column-two-thirds">
 
     <%= form_with(
-          model: @course_skilled_worker_visa_sponsorship_form,
           url:continue_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(
             @provider.provider_code,
             @provider.recruitment_cycle_year,

--- a/app/views/publish/courses/student_visa_sponsorship/_form_fields.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/_form_fields.html.erb
@@ -1,0 +1,26 @@
+<%= render "publish/shared/error_wrapper", error_keys: [:can_sponsor_student_visa], data_qa: "course__can_sponsor_student_visa" do %>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+        <%= t("page_titles.student_visas.new") %>
+      </h1>
+    </legend>
+
+    <%= render "inset_text" %>
+
+    <%= render "publish/shared/error_messages", error_keys: [:can_sponsor_student_visa] %>
+    <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">
+      <% course.edit_course_options["can_sponsor_student_visas"].each do |value| %>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :can_sponsor_student_visa,
+                                value,
+                                class: "govuk-radios__input" %>
+          <%= form.label :can_sponsor_student_visa,
+                         t("edit_options.can_sponsor_student_visas.#{value}.label"),
+                         value:,
+                         class: "govuk-label govuk-radios__label" %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/publish/courses/student_visa_sponsorship/_inset_text.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/_inset_text.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-inset-text">
+  <%= course_accredited_body_name(@course) %> can sponsor Student visas for some of their courses.
+
+  <!--      Todo: Add the logic to render the above or the below depending on the condition-->
+
+  <!--      <p class="govuk-body"><%#= course_accredited_body_name(@course) %> have said they cannot sponsor Student visas so we have defaulted your answer to ‘No’.</p>-->
+
+  <!--      <p class="govuk-body">If your organisation would like to sponsor Student visas, contact <%#= course_accredited_body_name(@course) %>.</p>-->
+</div>

--- a/app/views/publish/courses/student_visa_sponsorship/edit.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/edit.html.erb
@@ -1,0 +1,45 @@
+<% content_for :page_title, title_with_error_prefix("#{t('page_titles.student_visas.edit')} – #{course.name_and_code}", @course_student_visa_sponsorship_form.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+        details_publish_provider_recruitment_cycle_course_path(
+          course.provider_code,
+          course.recruitment_cycle_year,
+          course.course_code,
+        ),
+      ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          model: @course_student_visa_sponsorship_form,
+          url: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+          ),
+          method: :put,
+          local: true,
+        ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa, legend: { text: "Is Student visa sponsorship available for this course?", tag: "h1", size: "l" }) do %>
+
+        <%= render "inset_text" %>
+
+        <% course.edit_course_options["can_sponsor_student_visas"].each_with_index do |can_sponsor_student_visa, index| %>
+          <%= f.govuk_radio_button(
+                :can_sponsor_student_visa,
+                can_sponsor_student_visa,
+                label: { text: t("edit_options.can_sponsor_student_visas.#{can_sponsor_student_visa}.label") },
+                link_errors: index.zero?,
+              ) %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit course.is_published? ? "Save and publish" : "Save" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/student_visa_sponsorship/new.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/new.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, title_with_error_prefix(t("page_titles.student_visas.new"), @errors && @errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(@back_link_path) %>
+<% end %>
+
+<%= render "publish/shared/errors" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with(
+          model: @course_student_visa_sponsorship_form,
+          url:continue_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(
+            @provider.provider_code,
+            @provider.recruitment_cycle_year,
+            ),
+          method: :get,
+          local: true,
+          )do |form| %>
+
+      <%= render "publish/courses/new_fields_holder", form:, except_keys: [:can_sponsor_student_visa] do |fields| %>
+        <%= render "form_fields", form: fields %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/student_visa_sponsorship/new.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/new.html.erb
@@ -9,7 +9,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
-          model: @course_student_visa_sponsorship_form,
           url:continue_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(
             @provider.provider_code,
             @provider.recruitment_cycle_year,

--- a/app/views/publish/courses/student_visa_sponsorship/new.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/new.html.erb
@@ -8,7 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
     <%= form_with(
           model: @course_student_visa_sponsorship_form,
           url:continue_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,9 @@ en:
   continue: "Continue"
   change_organisation: "Change organisation"
   page_titles:
+    skilled_worker_visas:
+      edit: "Skilled worker visas"
+      new: "Skilled worker visas"
     student_visas:
       edit: "Student visas"
       new: "Student visas"
@@ -552,6 +555,11 @@ en:
         label: "Full time"
       full_time_or_part_time:
         label: "Full time or part time"
+    can_sponsor_skilled_worker_visas:
+      true:
+        label: "Yes"
+      false:
+        label: "No"
     can_sponsor_student_visas:
       true:
         label: "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,9 @@ en:
   continue: "Continue"
   change_organisation: "Change organisation"
   page_titles:
+    student_visas:
+      edit: "Student visas"
+      new: "Student visas"
     error_prefix: "Error: "
     rollover:
       show: "Recruitment cycles"
@@ -549,6 +552,11 @@ en:
         label: "Full time"
       full_time_or_part_time:
         label: "Full time or part time"
+    can_sponsor_student_visas:
+      true:
+        label: "Yes"
+      false:
+        label: "No"
     apprenticeship:
       pg_teaching_apprenticeship:
         label: "Yes"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -110,6 +110,9 @@ namespace :publish, as: :publish do
         resource :student_visa_sponsorship, on: :member, controller: "courses/student_visa_sponsorship", path: "student-visa-sponsorship" do
           get "continue"
         end
+        resource :skilled_worker_visa_sponsorship, on: :member, controller: "courses/skilled_worker_visa_sponsorship", path: "skilled-worker-visa-sponsorship" do
+          get "continue"
+        end
         resource :fee_or_salary, on: :member, only: %i[new], controller: "courses/fee_or_salary", path: "fee-or-salary" do
           get "continue"
         end
@@ -175,6 +178,9 @@ namespace :publish, as: :publish do
 
         get "/student-visa-sponsorship", on: :member, to: "courses/student_visa_sponsorship#edit"
         put "/student-visa-sponsorship", on: :member, to: "courses/student_visa_sponsorship#update"
+
+        get "/skilled-worker-visa-sponsorship", on: :member, to: "courses/skilled_worker_visa_sponsorship#edit"
+        put "/skilled-worker-visa-sponsorship", on: :member, to: "courses/skilled_worker_visa_sponsorship#update"
       end
 
       scope module: :providers do

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -107,6 +107,9 @@ namespace :publish, as: :publish do
           get "continue"
           get "search_new"
         end
+        resource :student_visa_sponsorship, on: :member, controller: "courses/student_visa_sponsorship", path: "student-visa-sponsorship" do
+          get "continue"
+        end
         resource :fee_or_salary, on: :member, only: %i[new], controller: "courses/fee_or_salary", path: "fee-or-salary" do
           get "continue"
         end
@@ -169,6 +172,9 @@ namespace :publish, as: :publish do
 
         get "/modern-languages", on: :member, to: "courses/modern_languages#edit"
         put "/modern-languages", on: :member, to: "courses/modern_languages#update"
+
+        get "/student-visa-sponsorship", on: :member, to: "courses/student_visa_sponsorship#edit"
+        put "/student-visa-sponsorship", on: :member, to: "courses/student_visa_sponsorship#update"
       end
 
       scope module: :providers do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -110,6 +110,7 @@ features:
     # state: open # Users can make requests for allocations
     # state: closed # Readonly - Users can see if they have or have not made request (does not show number of places)
     state: confirmed # final allocation places are displayed to users in a readonly state
+  visa_sponsorship_on_course: false
 
 cookies:
   consent:

--- a/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Editing visa sponsorship", { can_edit_current_and_next_cycles: false } do
+  before do
+    given_the_visa_sponsorship_on_course_feature_flag_is_active
+    and_i_am_authenticated_as_a_lead_school_provider_user
+  end
+
+  context "fee paying course" do
+    scenario "i can update the student visa" do
+      given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
+      when_i_visit_the_course_student_visa_sponsorship_edit_page
+      and_i_choose_yes_to_the_student_sponsorship_question
+      and_i_continue
+      and_i_click_on_basic_details
+      then_i_should_see_that_the_student_visa_can_be_sponsored
+    end
+  end
+
+  context "salaried course" do
+    scenario "i can update the skilled worker visa" do
+      given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
+      when_i_visit_the_course_skilled_worker_visa_sponsorship_edit_page
+      and_i_choose_yes_to_the_skilled_worker_sponsorship_question
+      and_i_continue
+      and_i_click_on_basic_details
+      then_i_should_see_that_the_skilled_worker_visa_can_be_sponsored
+    end
+  end
+
+  def given_the_visa_sponsorship_on_course_feature_flag_is_active
+    allow(Settings.features).to receive(:visa_sponsorship_on_course).and_return(true)
+  end
+
+  def and_i_am_authenticated_as_a_lead_school_provider_user
+    @user = create(:user, providers: [build(:provider, sites: [build(:site)])])
+    @user.providers.first.courses << create(:course, :with_accrediting_provider)
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
+    given_a_course_exists(funding_type: "fee", can_sponsor_student_visa: false)
+  end
+
+  def given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
+    given_a_course_exists(funding_type: "salary", can_sponsor_skilled_worker_visa: false)
+  end
+
+  def and_i_click_on_basic_details
+    provider_courses_show_page.basic_details_link.click
+  end
+
+  def when_i_visit_the_course_student_visa_sponsorship_edit_page
+    student_visa_sponsorship_edit_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def when_i_visit_the_course_skilled_worker_visa_sponsorship_edit_page
+    skilled_worker_visa_sponsorship_edit_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def and_i_choose_yes_to_the_student_sponsorship_question
+    student_visa_sponsorship_edit_page.yes.choose
+  end
+
+  def and_i_choose_yes_to_the_skilled_worker_sponsorship_question
+    skilled_worker_visa_sponsorship_edit_page.yes.choose
+  end
+
+  def and_i_continue
+    click_button "Save"
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def then_i_should_see_that_the_student_visa_can_be_sponsored
+    expect(page).to have_text "Student visaYes - can sponsor"
+  end
+
+  def then_i_should_see_that_the_skilled_worker_visa_can_be_sponsored
+    expect(page).to have_text "Skilled worker visaYes - can sponsor"
+  end
+end

--- a/spec/features/publish/courses/new_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_spec.rb
@@ -70,19 +70,19 @@ private
   end
 
   def then_i_should_see_the_student_visas_title
-    expect(student_visa_sponsorship_page.title).to have_text("Student visas")
+    expect(new_student_visa_sponsorship_page.title).to have_text("Student visas")
   end
 
   def then_i_should_see_the_skilled_worker_visas_title
-    expect(skilled_worker_visa_sponsorship_page.title).to have_text("Skilled worker visas")
+    expect(new_skilled_worker_visa_sponsorship_page.title).to have_text("Skilled worker visas")
   end
 
   def when_i_choose_yes_for_student_visa
-    student_visa_sponsorship_page.yes.click
+    new_student_visa_sponsorship_page.yes.click
   end
 
   def when_i_choose_yes_for_skilled_worker_visa
-    skilled_worker_visa_sponsorship_page.yes.click
+    new_skilled_worker_visa_sponsorship_page.yes.click
   end
 
   def then_i_should_be_back_on_the_course_confirmation_page

--- a/spec/features/publish/courses/new_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_spec.rb
@@ -15,7 +15,7 @@ feature "visa sponsorship for lead school (add course summary page)", { can_edit
 
     when_i_choose_yes_for_student_visa
     and_i_click_continue
-    # then_i_should_be_back_on_the_course_confirmation_page
+    then_i_should_be_back_on_the_course_confirmation_page
   end
 
   scenario "changing funding_type to salaried shows the skilled worker question" do
@@ -26,7 +26,7 @@ feature "visa sponsorship for lead school (add course summary page)", { can_edit
 
     when_i_choose_yes_for_skilled_worker_visa
     and_i_click_continue
-    # then_i_should_be_back_on_the_course_confirmation_page
+    then_i_should_be_back_on_the_course_confirmation_page
   end
 
 private
@@ -86,6 +86,6 @@ private
   end
 
   def then_i_should_be_back_on_the_course_confirmation_page
-    expect(course_confirmation_page).to be_displayed
+    expect(page).to have_text("Check your answers before confirming")
   end
 end

--- a/spec/features/publish/courses/new_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+feature "visa sponsorship for lead school (add course summary page)", { can_edit_current_and_next_cycles: false } do
+  before do
+    given_the_visa_sponsorship_on_course_feature_flag_is_active
+    given_i_am_authenticated_as_a_provider_user
+    when_i_visit_the_course_confirmation_page
+  end
+
+  scenario "changing funding_type to fee shows the student question" do
+    when_i_change_fee_or_salary
+    and_i_choose_fee
+    and_i_click_continue
+    then_i_should_see_the_student_visas_title
+
+    when_i_choose_yes_for_student_visa
+    and_i_click_continue
+    # then_i_should_be_back_on_the_course_confirmation_page
+  end
+
+  scenario "changing funding_type to salaried shows the skilled worker question" do
+    when_i_change_fee_or_salary
+    and_i_choose_salary
+    and_i_click_continue
+    then_i_should_see_the_skilled_worker_visas_title
+
+    when_i_choose_yes_for_skilled_worker_visa
+    and_i_click_continue
+    # then_i_should_be_back_on_the_course_confirmation_page
+  end
+
+private
+
+  def given_the_visa_sponsorship_on_course_feature_flag_is_active
+    allow(Settings.features).to receive(:visa_sponsorship_on_course).and_return(true)
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    @user = create(:user, providers: [build(:provider, sites: [build(:site)])])
+    @user.providers.first.courses << create(:course, :with_accrediting_provider)
+    given_i_am_authenticated(user: @user)
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def when_i_visit_the_course_confirmation_page
+    course_confirmation_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+      query: confirmation_params(provider),
+    )
+  end
+
+  def when_i_change_fee_or_salary
+    course_confirmation_page.details.fee_or_salary.change_link.click
+  end
+
+  def and_i_choose_fee
+    new_fee_or_salary_page.funding_type_fields.fee.click
+  end
+
+  def and_i_choose_salary
+    new_fee_or_salary_page.funding_type_fields.salary.click
+  end
+
+  def and_i_click_continue
+    click_button "Continue"
+  end
+
+  def then_i_should_see_the_student_visas_title
+    expect(student_visa_sponsorship_page.title).to have_text("Student visas")
+  end
+
+  def then_i_should_see_the_skilled_worker_visas_title
+    expect(skilled_worker_visa_sponsorship_page.title).to have_text("Skilled worker visas")
+  end
+
+  def when_i_choose_yes_for_student_visa
+    student_visa_sponsorship_page.yes.click
+  end
+
+  def when_i_choose_yes_for_skilled_worker_visa
+    skilled_worker_visa_sponsorship_page.yes.click
+  end
+
+  def then_i_should_be_back_on_the_course_confirmation_page
+    expect(course_confirmation_page).to be_displayed
+  end
+end

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -61,6 +61,8 @@ describe CoursePolicy do
           qualification
           start_date
           study_mode
+          can_sponsor_student_visa
+          can_sponsor_skilled_worker_visa
         ]
         expect(subject).to match_array(expected_attributes)
       end

--- a/spec/support/page_objects/publish/courses/new_skilled_worker_visa_sponsorship.rb
+++ b/spec/support/page_objects/publish/courses/new_skilled_worker_visa_sponsorship.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Publish
     module Courses
-      class SkilledWorkerVisaSponsorship < PageObjects::Base
+      class NewSkilledWorkerVisaSponsorship < PageObjects::Base
         set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/skilled-worker-visa-sponsorship/new{?query*}"
 
         element :continue, '[data-qa="course__save"]'

--- a/spec/support/page_objects/publish/courses/new_student_visa_sponsorship.rb
+++ b/spec/support/page_objects/publish/courses/new_student_visa_sponsorship.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Publish
     module Courses
-      class StudentVisaSponsorship < PageObjects::Base
+      class NewStudentVisaSponsorship < PageObjects::Base
         set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/student-visa-sponsorship/new{?query*}"
 
         element :continue, '[data-qa="course__save"]'

--- a/spec/support/page_objects/publish/courses/skilled_worker_visa_sponsorship.rb
+++ b/spec/support/page_objects/publish/courses/skilled_worker_visa_sponsorship.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    module Courses
+      class SkilledWorkerVisaSponsorship < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/skilled-worker-visa-sponsorship/new{?query*}"
+
+        element :continue, '[data-qa="course__save"]'
+
+        element :yes, "#course_can_sponsor_skilled_worker_visa_true"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/courses/skilled_worker_visa_sponsorship_edit.rb
+++ b/spec/support/page_objects/publish/courses/skilled_worker_visa_sponsorship_edit.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    module Courses
+      class SkilledWorkerVisaSponsorshipEdit < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/skilled-worker-visa-sponsorship"
+
+        element :yes, "#publish-course-skilled-worker-visa-sponsorship-form-can-sponsor-skilled-worker-visa-true-field"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/courses/student_visa_sponsorship.rb
+++ b/spec/support/page_objects/publish/courses/student_visa_sponsorship.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    module Courses
+      class StudentVisaSponsorship < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/student-visa-sponsorship/new{?query*}"
+
+        element :continue, '[data-qa="course__save"]'
+
+        element :yes, "#course_can_sponsor_student_visa_true"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/courses/student_visa_sponsorship_edit.rb
+++ b/spec/support/page_objects/publish/courses/student_visa_sponsorship_edit.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    module Courses
+      class StudentVisaSponsorshipEdit < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/student-visa-sponsorship"
+
+        element :yes, "#publish-course-student-visa-sponsorship-form-can-sponsor-student-visa-true-field"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We are collecting visa information on the course level. This PR sets out the questions in the "Add new course" flow.

### Changes proposed in this pull request

- Add student visas question to new course flow if course is fee paying
- Add skilled worker visas question to new course flow if course is salaried
- Enable editing on the confirmation page
- If `funding_type` is changed on the confirmation page, re-ask one of the visa questions depending on which funding type is chosen.
- Put behind a feature flag (visa_sponsorship_on_course)

### Guidance to review

- Activate the `visa_sponsorship_on_course` feature flag locally.
- Create a course under a `school_direct`
- Try the different funding options, i.e, `salary`, `fee`, etc
- Ensure editing is possible on the confirmation page
- Ensure the old flow continues to work correctly when the feature flag is deactivated. 


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
