### PR TITLE
[434] Handle editing funding type from course page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -703,6 +703,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
 

--- a/app/controllers/publish/courses/fee_or_salary_controller.rb
+++ b/app/controllers/publish/courses/fee_or_salary_controller.rb
@@ -19,6 +19,30 @@ module Publish
         end
       end
 
+      def edit
+        authorize(course, :can_update_funding_type?)
+      end
+
+      def update
+        authorize(course, :can_update_funding_type?)
+
+        @errors = errors
+        return render :edit if @errors.present?
+
+        track_funding_type_changes
+
+        if @course.update(course_params)
+          if @funding_type_updated
+            redirect_to_visa_step
+          else
+            redirect_to_course_page
+          end
+        else
+          @errors = @course.errors.messages
+          render :edit
+        end
+      end
+
     private
 
       def current_step
@@ -27,6 +51,38 @@ module Publish
 
       def error_keys
         %i[funding_type program_type]
+      end
+
+      def track_funding_type_changes
+        @funding_type_updated = params[:course][:funding_type] != @course.funding_type
+      end
+
+      def redirect_to_visa_step
+        if course.is_fee_based?
+          redirect_to student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+            funding_type_updated: @funding_type_updated,
+          )
+        else
+          redirect_to skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+            funding_type_updated: @funding_type_updated,
+          )
+        end
+      end
+
+      def redirect_to_course_page
+        redirect_to(
+          details_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+          ),
+        )
       end
     end
   end

--- a/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
@@ -21,7 +21,7 @@ module Publish
         authorize(provider)
         @course_skilled_worker_visa_sponsorship_form = CourseSkilledWorkerVisaSponsorshipForm.new(@course, params: skilled_worker_visa_sponsorship_params)
         if @course_skilled_worker_visa_sponsorship_form.save!
-          course_description_success_message("skilled worker visa")
+          render_visa_sponsorship_success_message
 
           redirect_to details_publish_provider_recruitment_cycle_course_path(
             provider.provider_code,
@@ -38,7 +38,19 @@ module Publish
       def skilled_worker_visa_sponsorship_params
         return { visa_sponsorship: nil } if params[:publish_course_skilled_worker_visa_sponsorship_form].blank?
 
-        params.require(:publish_course_skilled_worker_visa_sponsorship_form).permit(*CourseSkilledWorkerVisaSponsorshipForm::FIELDS)
+        params.require(:publish_course_skilled_worker_visa_sponsorship_form).except(:funding_type_updated).permit(*CourseSkilledWorkerVisaSponsorshipForm::FIELDS)
+      end
+
+      def funding_type_updated?
+        params[:publish_course_skilled_worker_visa_sponsorship_form][:funding_type_updated] == "true"
+      end
+
+      def render_visa_sponsorship_success_message
+        if funding_type_updated?
+          flash[:success] = t("visa_sponsorships.funding_and_visa_updated", visa_type: t("visa_sponsorships.skilled_worker"))
+        else
+          flash[:success] = t("visa_sponsorships.visa_updated", visa_type: t("visa_sponsorships.skilled_worker"))
+        end
       end
 
       def current_step

--- a/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
@@ -21,7 +21,7 @@ module Publish
         authorize(provider)
         @course_student_visa_sponsorship_form = CourseStudentVisaSponsorshipForm.new(@course, params: student_visa_sponsorship_params)
         if @course_student_visa_sponsorship_form.save!
-          course_description_success_message("student visa")
+          render_visa_sponsorship_success_message
 
           redirect_to details_publish_provider_recruitment_cycle_course_path(
             provider.provider_code,
@@ -38,7 +38,19 @@ module Publish
       def student_visa_sponsorship_params
         return { visa_sponsorship: nil } if params[:publish_course_student_visa_sponsorship_form].blank?
 
-        params.require(:publish_course_student_visa_sponsorship_form).permit(*CourseStudentVisaSponsorshipForm::FIELDS)
+        params.require(:publish_course_student_visa_sponsorship_form).except(:funding_type_updated).permit(*CourseStudentVisaSponsorshipForm::FIELDS)
+      end
+
+      def funding_type_updated?
+        params[:publish_course_student_visa_sponsorship_form][:funding_type_updated] == "true"
+      end
+
+      def render_visa_sponsorship_success_message
+        if funding_type_updated?
+          flash[:success] = t("visa_sponsorships.funding_and_visa_updated", visa_type: t("visa_sponsorships.student"))
+        else
+          flash[:success] = t("visa_sponsorships.visa_updated", visa_type: t("visa_sponsorships.student"))
+        end
       end
 
       def current_step

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -47,9 +47,9 @@ class CourseDecorator < ApplicationDecorator
 
   def funding
     {
-      "salary" => "Salaried",
-      "apprenticeship" => "Teaching apprenticeship (with salary)",
-      "fee" => "Fee paying (no salary)",
+      "salary" => "Salary",
+      "apprenticeship" => "Teaching apprenticeship - with salary",
+      "fee" => "Fee paying - no salary",
     }[object.funding_type]
   end
 

--- a/app/helpers/publish/visa_sponsorship_helper.rb
+++ b/app/helpers/publish/visa_sponsorship_helper.rb
@@ -1,0 +1,7 @@
+module Publish
+  module VisaSponsorshipHelper
+    def funding_type_updated?
+      params[:funding_type_updated] == "true"
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -602,6 +602,10 @@ class Course < ApplicationRecord
       qualification_assignable(course_params)
   end
 
+  def draft_or_rolled_over?
+    content_status == :draft || content_status == :rolled_over
+  end
+
   def only_published?
     content_status == :published
   end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -2,7 +2,7 @@ class CoursePolicy
   attr_reader :user, :course
 
   class Scope
-    attr_reader :user, :scope
+    attr_reader :user, :course, :scope
 
     def initialize(user, scope)
       @user = user
@@ -35,6 +35,10 @@ class CoursePolicy
 
   def send_vacancies_updated_notification?
     user.present?
+  end
+
+  def can_update_funding_type?
+    course.draft_or_rolled_over?
   end
 
   alias_method :preview?, :show?

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -70,8 +70,8 @@
             <% row.action %>
           <% else %>
             <% row.action(**{
-              # href: fee_or_salary_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              # visually_hidden_text: "if fee or salary",
+              href: FeatureService.enabled?(:visa_sponsorship_on_course) && course.draft_or_rolled_over? ? fee_or_salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) : nil,
+              visually_hidden_text: "if fee or salary",
             }) %>
           <% end %>
         <% end %>
@@ -123,30 +123,30 @@
       <% end %>
 
       <% if FeatureService.enabled?(:visa_sponsorship_on_course) %>
-        <% if course.funding_type == "fee" && @provider.provider_type == "lead_school" %>
+        <% if course.is_fee_based? && @provider.lead_school? %>
           <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
-            <% row.key { "Student visa" } %>
+            <% row.key { "Student visas" } %>
             <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
             <% if course.is_published? %>
               <% row.action %>
             <% else %>
               <% row.action(**{
-                href: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                href: course.draft_or_rolled_over? ? student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) : nil,
                 visually_hidden_text: "can sponsor student visa",
               }) %>
             <% end %>
           <% end %>
         <% end %>
 
-        <% if course.funding_type == "salary" && @provider.provider_type == "lead_school" %>
+        <% if course.funding_type == "salary" && @provider.lead_school? %>
           <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row| %>
-            <% row.key { "Skilled worker visa" } %>
+            <% row.key { "Skilled Worker visas" } %>
             <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
             <% if course.is_published? %>
               <% row.action %>
             <% else %>
               <% row.action(**{
-                href: skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                href: course.draft_or_rolled_over? ? skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) : nil,
                 visually_hidden_text: "can sponsor skilled_worker visa",
               }) %>
             <% end %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -152,7 +152,7 @@
         <% if FeatureService.enabled?(:visa_sponsorship_on_course) %>
           <% if course.funding_type == "fee" %>
             <% summary_list.row(html_attributes: { data: { qa: "course__student_visa_sponsorship" } }) do |row| %>
-              <% row.key { "Visa sponsorship" } %>
+              <% row.key { "Student visas" } %>
               <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
               <% row.action(**{
                 href: new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),

--- a/app/views/publish/courses/fee_or_salary/_form_fields.html.erb
+++ b/app/views/publish/courses/fee_or_salary/_form_fields.html.erb
@@ -13,7 +13,7 @@
                 "fee",
                 class: "govuk-radios__input" %>
         <%= form.label :funding_type,
-                "Fee paying (no salary)",
+                "Fee paying - no salary",
                 value: "fee",
                 class: "govuk-label govuk-radios__label",
                 data: { qa: "course__funding_type_fee" } %>
@@ -24,7 +24,7 @@
                 "salary",
                 class: "govuk-radios__input" %>
         <%= form.label :funding_type,
-                "Salaried",
+                "Salary",
                 value: "salary",
                 class: "govuk-label govuk-radios__label",
                 data: { qa: "course__funding_type_salary" } %>
@@ -35,7 +35,7 @@
                 "apprenticeship",
                 class: "govuk-radios__input" %>
         <%= form.label :funding_type,
-                "Teaching apprenticeship (with salary)",
+                "Teaching apprenticeship - with salary",
                 value: "apprenticeship",
                 class: "govuk-label govuk-radios__label",
                 data: { qa: "course__funding_type_apprenticeship" } %>

--- a/app/views/publish/courses/fee_or_salary/edit.html.erb
+++ b/app/views/publish/courses/fee_or_salary/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, title_with_error_prefix("Is it fee paying or salaried? – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
 <%= render "publish/shared/errors" %>
@@ -9,12 +9,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with model: course,
-                  url: fee_or_salary_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+                  url: fee_or_salary_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                   method: :put do |form| %>
 
       <%= render "form_fields", form: %>
 
-      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+      <%= form.submit "Update funding type",
         class: "govuk-button", data: { qa: "course__save" } %>
     <% end %>
   </div>

--- a/app/views/publish/courses/skilled_worker_visa_sponsorship/edit.html.erb
+++ b/app/views/publish/courses/skilled_worker_visa_sponsorship/edit.html.erb
@@ -23,14 +23,19 @@
           local: true,
         ) do |f| %>
 
+      <%= f.hidden_field :funding_type_updated, value: funding_type_updated? %>
+
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_skilled_worker_visa, legend: { text: "Can your organisation sponsor Skilled Worker visas for this course?", tag: "h1", size: "l" }) do %>
+      <h1 class="govuk-heading-l">
+        <%= t("page_titles.skilled_worker_visas.edit") %>
+      </h1>
 
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          Can your organisation sponsor Skilled Worker visas for this course?
-        </legend>
+      <% if funding_type_updated? %>
+        <p class="govuk-body"><%= t("visa_sponsorships.updated_funding") %></p>
+      <% end %>
 
+      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_skilled_worker_visa, legend: { text: "Can your organisation sponsor Skilled Worker visas for this course?", tag: "h1", size: "m" }) do %>
         <% course.edit_course_options["can_sponsor_skilled_worker_visas"].each_with_index do |can_sponsor_skilled_worker_visa, index| %>
           <%= f.govuk_radio_button(
                 :can_sponsor_skilled_worker_visa,
@@ -41,7 +46,7 @@
         <% end %>
       <% end %>
 
-      <%= f.govuk_submit course.is_published? ? "Save and publish" : "Save" %>
+      <%= f.govuk_submit "Update Skilled Worker visas" %>
     <% end %>
   </div>
 </div>

--- a/app/views/publish/courses/student_visa_sponsorship/_form_fields.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/_form_fields.html.erb
@@ -1,12 +1,14 @@
 <%= render "publish/shared/error_wrapper", error_keys: [:can_sponsor_student_visa], data_qa: "course__can_sponsor_student_visa" do %>
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-      <h1 class="govuk-fieldset__heading">
-        <%= t("page_titles.student_visas.new") %>
-      </h1>
-    </legend>
+  <h1 class="govuk-heading-l">
+    <%= t("page_titles.student_visas.new") %>
+  </h1>
 
-    <%= render "inset_text" %>
+  <%= render "inset_text" %>
+
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      Is Student visa sponsorship available for this course?
+    </legend>
 
     <%= render "publish/shared/error_messages", error_keys: [:can_sponsor_student_visa] %>
     <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">

--- a/app/views/publish/courses/student_visa_sponsorship/_inset_text.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/_inset_text.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-inset-text">
-  <%= course_accredited_body_name(@course) %> can sponsor Student visas for some of their courses.
+  <% if @course.accrediting_provider.can_sponsor_student_visa? %>
+    <%= @course.accrediting_provider.provider_name %> can sponsor Student visas for some of their courses.
+  <% else %>
+    <p class="govuk-body"><%= @course.accrediting_provider.provider_name %> have said they cannot sponsor Student visas so we have defaulted your answer to ‘No’.</p>
 
-  <!--      Todo: Add the logic to render the above or the below depending on the condition-->
-
-  <!--      <p class="govuk-body"><%#= course_accredited_body_name(@course) %> have said they cannot sponsor Student visas so we have defaulted your answer to ‘No’.</p>-->
-
-  <!--      <p class="govuk-body">If your organisation would like to sponsor Student visas, contact <%#= course_accredited_body_name(@course) %>.</p>-->
+    <p class="govuk-body">If your organisation would like to sponsor Student visas, contact <%= @course.accrediting_provider.provider_name %>.</p>
+  <% end %>
 </div>

--- a/app/views/publish/courses/student_visa_sponsorship/edit.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/edit.html.erb
@@ -23,12 +23,21 @@
           local: true,
         ) do |f| %>
 
+       <%= f.hidden_field :funding_type_updated, value: funding_type_updated? %>
+
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa, legend: { text: "Is Student visa sponsorship available for this course?", tag: "h1", size: "l" }) do %>
+      <h1 class="govuk-heading-l">
+        <%= t("page_titles.student_visas.edit") %>
+      </h1>
 
-        <%= render "inset_text" %>
+      <% if funding_type_updated? %>
+        <p class="govuk-body"><%= t("visa_sponsorships.updated_funding") %></p>
+      <% end %>
 
+      <%= render "inset_text" %>
+
+      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa, legend: { text: "Is Student visa sponsorship available for this course?", tag: "h1", size: "m" }) do %>
         <% course.edit_course_options["can_sponsor_student_visas"].each_with_index do |can_sponsor_student_visa, index| %>
           <%= f.govuk_radio_button(
                 :can_sponsor_student_visa,
@@ -39,7 +48,7 @@
         <% end %>
       <% end %>
 
-      <%= f.govuk_submit course.is_published? ? "Save and publish" : "Save" %>
+      <%= f.govuk_submit "Update Student visas" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,10 +21,18 @@ en:
   back: "Back"
   continue: "Continue"
   change_organisation: "Change organisation"
+  visa_sponsorships:
+    student: "Student"
+    skilled_worker: "Skilled Worker"
+    updated_funding: "You’re being shown this page because you changed your answer to funding type."
+    funding_and_visa_updated: "Funding type and %{visa_type} visas updated"
+    visa_updated: "%{visa_type} visas updated"
   page_titles:
+    funding_type:
+      edit: "Funding type"
     skilled_worker_visas:
-      edit: "Skilled worker visas"
-      new: "Skilled worker visas"
+      edit: "Skilled Worker visas"
+      new: "Skilled Worker visas"
     student_visas:
       edit: "Student visas"
       new: "Student visas"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -181,6 +181,9 @@ namespace :publish, as: :publish do
 
         get "/skilled-worker-visa-sponsorship", on: :member, to: "courses/skilled_worker_visa_sponsorship#edit"
         put "/skilled-worker-visa-sponsorship", on: :member, to: "courses/skilled_worker_visa_sponsorship#update"
+
+        get "/fee-or-salary", on: :member, to: "courses/fee_or_salary#edit"
+        put "/fee-or-salary", on: :member, to: "courses/fee_or_salary#update"
       end
 
       scope module: :providers do

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,3 +8,6 @@ gcp_api_key: please_change_me
 environment:
   label: "development"
   name: "development"
+
+features:
+  visa_sponsorship_on_course: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -29,4 +29,5 @@ basic_auth:
   enabled: true
 
 features:
+  visa_sponsorship_on_course: true
   send_request_data_to_bigquery: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -20,3 +20,4 @@ allocations_close_date: 2022-07-02
 features:
   allocations:
     state: confirmed
+  visa_sponsorship_on_course: true

--- a/spec/features/publish/courses/editing_funding_type_spec.rb
+++ b/spec/features/publish/courses/editing_funding_type_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Editing funding type", { can_edit_current_and_next_cycles: false } do
+  before do
+    given_the_visa_sponsorship_on_course_feature_flag_is_active
+    and_i_am_authenticated_as_a_lead_school_provider_user
+  end
+
+  context "fee paying to salaried course" do
+    scenario "i am taken to the skilled worker visa step" do
+      given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
+      when_i_visit_the_funding_type_edit_page
+      when_i_select_an_fee_or_salary(:salary)
+      and_i_continue
+      then_i_should_be_on_the_skilled_worker_visa_sponsorship_edit_page
+      when_i_update_the_skilled_worker_visa_to_be_sponsored
+      then_i_should_see_a_success_message_for("Skilled Worker")
+    end
+  end
+
+  context "salaried to fee paying course" do
+    scenario "i am taken to the student visa step" do
+      given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
+      when_i_visit_the_funding_type_edit_page
+      when_i_select_an_fee_or_salary(:fee)
+      and_i_continue
+      then_i_should_be_on_the_student_visa_edit_page
+      when_i_update_the_student_visa_to_be_sponsored
+      then_i_should_see_a_success_message_for("Student")
+    end
+  end
+
+  def given_the_visa_sponsorship_on_course_feature_flag_is_active
+    allow(Settings.features).to receive(:visa_sponsorship_on_course).and_return(true)
+  end
+
+  def and_i_am_authenticated_as_a_lead_school_provider_user
+    given_i_am_authenticated(user: create(:user, providers: [create(:provider, :accredited_body)]))
+  end
+
+  def given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
+    given_a_course_exists(
+      funding_type: "fee",
+      can_sponsor_student_visa: false,
+      accrediting_provider:,
+    )
+  end
+
+  def given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
+    given_a_course_exists(
+      funding_type: "salary",
+      can_sponsor_skilled_worker_visa: false,
+      accrediting_provider:,
+    )
+  end
+
+  def when_i_visit_the_funding_type_edit_page
+    funding_type_edit_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def when_i_visit_the_course_skilled_worker_visa_sponsorship_edit_page
+    skilled_worker_visa_sponsorship_edit_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def and_i_continue
+    funding_type_edit_page.update.click
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def when_i_select_an_fee_or_salary(funding_type)
+    funding_type_edit_page.funding_type_fields.send(funding_type).click
+  end
+
+  def then_i_should_be_on_the_skilled_worker_visa_sponsorship_edit_page
+    expect(skilled_worker_visa_sponsorship_edit_page).to be_displayed
+  end
+
+  def then_i_should_be_on_the_student_visa_edit_page
+    expect(student_visa_sponsorship_edit_page).to be_displayed
+  end
+
+  def when_i_update_the_skilled_worker_visa_to_be_sponsored
+    skilled_worker_visa_sponsorship_edit_page.yes.choose
+    skilled_worker_visa_sponsorship_edit_page.update.click
+  end
+
+  def when_i_update_the_student_visa_to_be_sponsored
+    student_visa_sponsorship_edit_page.yes.choose
+    student_visa_sponsorship_edit_page.update.click
+  end
+
+  def then_i_should_see_a_success_message_for(visa_type)
+    expect(page).to have_content(I18n.t("visa_sponsorships.funding_and_visa_updated", visa_type:))
+  end
+
+  def accrediting_provider
+    @current_user.providers.first
+  end
+end

--- a/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
@@ -13,7 +13,7 @@ feature "Editing visa sponsorship", { can_edit_current_and_next_cycles: false } 
       given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
       when_i_visit_the_course_student_visa_sponsorship_edit_page
       and_i_choose_yes_to_the_student_sponsorship_question
-      and_i_continue
+      and_i_continue_for("Student")
       and_i_click_on_basic_details
       then_i_should_see_that_the_student_visa_can_be_sponsored
     end
@@ -24,7 +24,7 @@ feature "Editing visa sponsorship", { can_edit_current_and_next_cycles: false } 
       given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
       when_i_visit_the_course_skilled_worker_visa_sponsorship_edit_page
       and_i_choose_yes_to_the_skilled_worker_sponsorship_question
-      and_i_continue
+      and_i_continue_for("Skilled Worker")
       and_i_click_on_basic_details
       then_i_should_see_that_the_skilled_worker_visa_can_be_sponsored
     end
@@ -41,11 +41,11 @@ feature "Editing visa sponsorship", { can_edit_current_and_next_cycles: false } 
   end
 
   def given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
-    given_a_course_exists(funding_type: "fee", can_sponsor_student_visa: false)
+    given_a_course_exists(funding_type: "fee", can_sponsor_student_visa: false, accrediting_provider:)
   end
 
   def given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
-    given_a_course_exists(funding_type: "salary", can_sponsor_skilled_worker_visa: false)
+    given_a_course_exists(funding_type: "salary", can_sponsor_skilled_worker_visa: false, accrediting_provider:)
   end
 
   def and_i_click_on_basic_details
@@ -72,8 +72,8 @@ feature "Editing visa sponsorship", { can_edit_current_and_next_cycles: false } 
     skilled_worker_visa_sponsorship_edit_page.yes.choose
   end
 
-  def and_i_continue
-    click_button "Save"
+  def and_i_continue_for(visa_type)
+    click_button "Update #{visa_type} visas"
   end
 
   def provider
@@ -81,10 +81,14 @@ feature "Editing visa sponsorship", { can_edit_current_and_next_cycles: false } 
   end
 
   def then_i_should_see_that_the_student_visa_can_be_sponsored
-    expect(page).to have_text "Student visaYes - can sponsor"
+    expect(page).to have_text "Student visasYes - can sponsor"
   end
 
   def then_i_should_see_that_the_skilled_worker_visa_can_be_sponsored
-    expect(page).to have_text "Skilled worker visaYes - can sponsor"
+    expect(page).to have_text "Skilled Worker visasYes - can sponsor"
+  end
+
+  def accrediting_provider
+    @current_user.providers.first
   end
 end

--- a/spec/features/publish/courses/new_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_spec.rb
@@ -74,7 +74,7 @@ private
   end
 
   def then_i_should_see_the_skilled_worker_visas_title
-    expect(new_skilled_worker_visa_sponsorship_page.title).to have_text("Skilled worker visas")
+    expect(new_skilled_worker_visa_sponsorship_page.title).to have_text("Skilled Worker visas")
   end
 
   def when_i_choose_yes_for_student_visa

--- a/spec/features/publish/viewing_a_course_details_spec.rb
+++ b/spec/features/publish/viewing_a_course_details_spec.rb
@@ -71,7 +71,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     # expect(course_details_page).to have_no_manage_provider_locations_link
     # expect(course_details_page).to have_no_apprenticeship
     expect(provider_courses_details_page.funding).to have_content(
-      "Teaching apprenticeship (with salary)",
+      "Teaching apprenticeship - with salary",
     )
     expect(provider_courses_details_page.accredited_body).to have_content(
       course.accrediting_provider.provider_name,

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -26,6 +26,24 @@ describe CoursePolicy do
     end
   end
 
+  permissions :can_update_funding_type? do
+    let(:course) { create(:course, :published) }
+
+    it { is_expected.not_to permit(user, course) }
+
+    context "with a draft course" do
+      let(:course) { create(:course, enrichments: [build(:course_enrichment, :initial_draft)]) }
+
+      it { is_expected.to permit(user, course) }
+    end
+
+    context "with a rolled over course" do
+      let(:course) { create(:course, enrichments: [build(:course_enrichment, :rolled_over)]) }
+
+      it { is_expected.to permit(user, course) }
+    end
+  end
+
   describe "#permitted_attributes" do
     subject { described_class.new(user, build(:course)) }
 

--- a/spec/support/page_objects/publish/courses/funding_type_edit.rb
+++ b/spec/support/page_objects/publish/courses/funding_type_edit.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../../sections/funding_type_fields"
+
+module PageObjects
+  module Publish
+    module Courses
+      class FundingTypeEdit < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/fee-or-salary"
+
+        section :funding_type_fields, Sections::FundingTypeFields, '[data-qa="course__funding_type"]'
+
+        element :update, '[data-qa="course__save"]'
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/courses/new_fee_or_salary.rb
+++ b/spec/support/page_objects/publish/courses/new_fee_or_salary.rb
@@ -6,11 +6,7 @@ module PageObjects
       class NewFeeOrSalary < PageObjects::Base
         set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/fee-or-salary/new{?query*}"
 
-        section :funding_type_fields, '[data-qa="course__funding_type"]' do
-          element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
-          element :fee, '[data-qa="course__funding_type_fee"]'
-          element :salary, '[data-qa="course__funding_type_salary"]'
-        end
+        section :funding_type_fields, Sections::FundingTypeFields, '[data-qa="course__funding_type"]'
 
         element :continue, '[data-qa="course__save"]'
       end

--- a/spec/support/page_objects/publish/courses/skilled_worker_visa_sponsorship_edit.rb
+++ b/spec/support/page_objects/publish/courses/skilled_worker_visa_sponsorship_edit.rb
@@ -7,6 +7,8 @@ module PageObjects
         set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/skilled-worker-visa-sponsorship"
 
         element :yes, "#publish-course-skilled-worker-visa-sponsorship-form-can-sponsor-skilled-worker-visa-true-field"
+
+        element :update, 'button.govuk-button[type="submit"]'
       end
     end
   end

--- a/spec/support/page_objects/publish/courses/student_visa_sponsorship_edit.rb
+++ b/spec/support/page_objects/publish/courses/student_visa_sponsorship_edit.rb
@@ -7,6 +7,8 @@ module PageObjects
         set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/student-visa-sponsorship"
 
         element :yes, "#publish-course-student-visa-sponsorship-form-can-sponsor-student-visa-true-field"
+
+        element :update, 'button.govuk-button[type="submit"]'
       end
     end
   end

--- a/spec/support/page_objects/sections/funding_type_fields.rb
+++ b/spec/support/page_objects/sections/funding_type_fields.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class FundingTypeFields < PageObjects::Sections::Base
+      element :apprenticeship, '[data-qa="course__funding_type_apprenticeship"]'
+      element :fee, '[data-qa="course__funding_type_fee"]'
+      element :salary, '[data-qa="course__funding_type_salary"]'
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/6EV6dgma/434-handle-visa-editing-in-course-show-page-for-lead-schools

### Changes proposed in this pull request

- Handles ability edit the funding type when editing a course
- Handles ability to render the correct visa step when funding type is updated
- Other UI fixes to match the prototype

### Guidance to review

- Sign in as Anne and create a draft course
- Edit funding type and assert you're taken to the visa step

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
