### PR TITLE
[0435] Handle visa editing in course show page for Scitts and HEIs

### DIFF
--- a/app/controllers/publish/courses/apprenticeship_controller.rb
+++ b/app/controllers/publish/courses/apprenticeship_controller.rb
@@ -1,32 +1,10 @@
 module Publish
   module Courses
-    class ApprenticeshipController < PublishController
-      include CourseBasicDetailConcern
-
-      def continue
-        authorize(@provider, :can_create_course?)
-        @errors = errors
-        if @errors.any?
-          render :new
-        elsif params[:goto_visa]
-          if course.is_fee_based?
-            redirect_to new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
-          else
-            redirect_to new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
-          end
-        else
-          redirect_to next_step
-        end
-      end
-
+    class ApprenticeshipController < FundingTypeController
     private
 
       def current_step
         :apprenticeship
-      end
-
-      def error_keys
-        %i[funding_type program_type]
       end
     end
   end

--- a/app/controllers/publish/courses/fee_or_salary_controller.rb
+++ b/app/controllers/publish/courses/fee_or_salary_controller.rb
@@ -1,88 +1,10 @@
 module Publish
   module Courses
-    class FeeOrSalaryController < PublishController
-      include CourseBasicDetailConcern
-
-      def continue
-        authorize(@provider, :can_create_course?)
-        @errors = errors
-        if @errors.any?
-          render :new
-        elsif params[:goto_visa]
-          if course.is_fee_based?
-            redirect_to new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
-          else
-            redirect_to new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
-          end
-        else
-          redirect_to next_step
-        end
-      end
-
-      def edit
-        authorize(course, :can_update_funding_type?)
-      end
-
-      def update
-        authorize(course, :can_update_funding_type?)
-
-        @errors = errors
-        return render :edit if @errors.present?
-
-        track_funding_type_changes
-
-        if @course.update(course_params)
-          if @funding_type_updated
-            redirect_to_visa_step
-          else
-            redirect_to_course_page
-          end
-        else
-          @errors = @course.errors.messages
-          render :edit
-        end
-      end
-
+    class FeeOrSalaryController < FundingTypeController
     private
 
       def current_step
         :fee_or_salary
-      end
-
-      def error_keys
-        %i[funding_type program_type]
-      end
-
-      def track_funding_type_changes
-        @funding_type_updated = params[:course][:funding_type] != @course.funding_type
-      end
-
-      def redirect_to_visa_step
-        if course.is_fee_based?
-          redirect_to student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
-            course.provider_code,
-            course.recruitment_cycle_year,
-            course.course_code,
-            funding_type_updated: @funding_type_updated,
-          )
-        else
-          redirect_to skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
-            course.provider_code,
-            course.recruitment_cycle_year,
-            course.course_code,
-            funding_type_updated: @funding_type_updated,
-          )
-        end
-      end
-
-      def redirect_to_course_page
-        redirect_to(
-          details_publish_provider_recruitment_cycle_course_path(
-            course.provider_code,
-            course.recruitment_cycle_year,
-            course.course_code,
-          ),
-        )
       end
     end
   end

--- a/app/controllers/publish/courses/funding_type_controller.rb
+++ b/app/controllers/publish/courses/funding_type_controller.rb
@@ -64,6 +64,7 @@ module Publish
             course.recruitment_cycle_year,
             course.course_code,
             funding_type_updated: @funding_type_updated,
+            origin_step: current_step,
           )
         else
           redirect_to skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
@@ -71,6 +72,7 @@ module Publish
             course.recruitment_cycle_year,
             course.course_code,
             funding_type_updated: @funding_type_updated,
+            origin_step: current_step,
           )
         end
       end

--- a/app/controllers/publish/courses/funding_type_controller.rb
+++ b/app/controllers/publish/courses/funding_type_controller.rb
@@ -1,0 +1,89 @@
+module Publish
+  module Courses
+    class FundingTypeController < PublishController
+      include CourseBasicDetailConcern
+
+      def continue
+        authorize(@provider, :can_create_course?)
+        @errors = errors
+        if @errors.any?
+          render :new
+        elsif params[:goto_visa]
+          if course.is_fee_based?
+            redirect_to new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
+          else
+            redirect_to new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
+          end
+        else
+          redirect_to next_step
+        end
+      end
+
+      def edit
+        authorize(course, :can_update_funding_type?)
+      end
+
+      def update
+        authorize(course, :can_update_funding_type?)
+
+        @errors = errors
+        return render :edit if @errors.present?
+
+        track_funding_type_changes
+
+        if @course.update(course_params)
+          if @funding_type_updated
+            redirect_to_visa_step
+          else
+            redirect_to_course_page
+          end
+        else
+          @errors = @course.errors.messages
+          render :edit
+        end
+      end
+
+    private
+
+      def current_step
+        raise NotImplementedError
+      end
+
+      def error_keys
+        %i[funding_type program_type]
+      end
+
+      def track_funding_type_changes
+        @funding_type_updated = params[:course][:funding_type] != @course.funding_type
+      end
+
+      def redirect_to_visa_step
+        if course.is_fee_based?
+          redirect_to student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+            funding_type_updated: @funding_type_updated,
+          )
+        else
+          redirect_to skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+            funding_type_updated: @funding_type_updated,
+          )
+        end
+      end
+
+      def redirect_to_course_page
+        redirect_to(
+          details_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code,
+          ),
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/skilled_worker_visa_sponsorship_controller.rb
@@ -38,18 +38,22 @@ module Publish
       def skilled_worker_visa_sponsorship_params
         return { visa_sponsorship: nil } if params[:publish_course_skilled_worker_visa_sponsorship_form].blank?
 
-        params.require(:publish_course_skilled_worker_visa_sponsorship_form).except(:funding_type_updated).permit(*CourseSkilledWorkerVisaSponsorshipForm::FIELDS)
+        params.require(:publish_course_skilled_worker_visa_sponsorship_form).except(:funding_type_updated, :origin_step).permit(*CourseSkilledWorkerVisaSponsorshipForm::FIELDS)
       end
 
       def funding_type_updated?
         params[:publish_course_skilled_worker_visa_sponsorship_form][:funding_type_updated] == "true"
       end
 
+      def origin_step
+        params[:publish_course_skilled_worker_visa_sponsorship_form][:origin_step]
+      end
+
       def render_visa_sponsorship_success_message
         if funding_type_updated?
-          flash[:success] = t("visa_sponsorships.funding_and_visa_updated", visa_type: t("visa_sponsorships.skilled_worker"))
+          flash[:success] = t("visa_sponsorships.updated.#{origin_step}_and_visa", visa_type: t("visa_sponsorships.skilled_worker"))
         else
-          flash[:success] = t("visa_sponsorships.visa_updated", visa_type: t("visa_sponsorships.skilled_worker"))
+          flash[:success] = t("visa_sponsorships.updated.visa", visa_type: t("visa_sponsorships.skilled_worker"))
         end
       end
 

--- a/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
@@ -38,18 +38,22 @@ module Publish
       def student_visa_sponsorship_params
         return { visa_sponsorship: nil } if params[:publish_course_student_visa_sponsorship_form].blank?
 
-        params.require(:publish_course_student_visa_sponsorship_form).except(:funding_type_updated).permit(*CourseStudentVisaSponsorshipForm::FIELDS)
+        params.require(:publish_course_student_visa_sponsorship_form).except(:funding_type_updated, :origin_step).permit(*CourseStudentVisaSponsorshipForm::FIELDS)
       end
 
       def funding_type_updated?
         params[:publish_course_student_visa_sponsorship_form][:funding_type_updated] == "true"
       end
 
+      def origin_step
+        params[:publish_course_student_visa_sponsorship_form][:origin_step]
+      end
+
       def render_visa_sponsorship_success_message
         if funding_type_updated?
-          flash[:success] = t("visa_sponsorships.funding_and_visa_updated", visa_type: t("visa_sponsorships.student"))
+          flash[:success] = t("visa_sponsorships.updated.#{origin_step}_and_visa", visa_type: t("visa_sponsorships.student"))
         else
-          flash[:success] = t("visa_sponsorships.visa_updated", visa_type: t("visa_sponsorships.student"))
+          flash[:success] = t("visa_sponsorships.updated.visa", visa_type: t("visa_sponsorships.student"))
         end
       end
 

--- a/app/helpers/publish/visa_sponsorship_helper.rb
+++ b/app/helpers/publish/visa_sponsorship_helper.rb
@@ -3,5 +3,9 @@ module Publish
     def funding_type_updated?
       params[:funding_type_updated] == "true"
     end
+
+    def origin_step
+      params[:origin_step]
+    end
   end
 end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -123,7 +123,7 @@
       <% end %>
 
       <% if FeatureService.enabled?(:visa_sponsorship_on_course) %>
-        <% if course.is_fee_based? && @provider.lead_school? %>
+        <% if course.is_fee_based? %>
           <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
             <% row.key { "Student visas" } %>
             <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
@@ -136,9 +136,7 @@
               }) %>
             <% end %>
           <% end %>
-        <% end %>
-
-        <% if course.funding_type == "salary" && @provider.lead_school? %>
+        <% else %>
           <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row| %>
             <% row.key { "Skilled Worker visas" } %>
             <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -57,8 +57,8 @@
             <% row.action %>
           <% else %>
             <% row.action(**{
-              # href: apprenticeship_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              # visually_hidden_text: "if apprenticeship",
+              href: FeatureService.enabled?(:visa_sponsorship_on_course) && course.draft_or_rolled_over? ? apprenticeship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) : nil,
+              visually_hidden_text: "if apprenticeship",
             }) %>
           <% end %>
         <% end %>

--- a/app/views/publish/courses/apprenticeship/edit.html.erb
+++ b/app/views/publish/courses/apprenticeship/edit.html.erb
@@ -1,7 +1,7 @@
-<% content_for :page_title, title_with_error_prefix("Edit Apprenticeship – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Teaching apprenticeship  – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
 <%= render "publish/shared/errors" %>
@@ -9,12 +9,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with model: course,
-                  url: apprenticeship_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+                  url: apprenticeship_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                   method: :put do |form| %>
 
       <%= render "form_fields", form: %>
 
-      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+      <%= form.submit "Update teaching apprenticeship",
         class: "govuk-button", data: { qa: "course__save" } %>
     <% end %>
   </div>

--- a/app/views/publish/courses/skilled_worker_visa_sponsorship/edit.html.erb
+++ b/app/views/publish/courses/skilled_worker_visa_sponsorship/edit.html.erb
@@ -24,6 +24,7 @@
         ) do |f| %>
 
       <%= f.hidden_field :funding_type_updated, value: funding_type_updated? %>
+      <%= f.hidden_field :origin_step, value: origin_step %>
 
       <%= f.govuk_error_summary %>
 
@@ -33,7 +34,7 @@
       </h1>
 
       <% if funding_type_updated? %>
-        <p class="govuk-body"><%= t("visa_sponsorships.updated_funding") %></p>
+        <p class="govuk-body"><%= t("visa_sponsorships.updated.#{origin_step}") %></p>
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset(:can_sponsor_skilled_worker_visa, legend: { text: "Can your organisation sponsor Skilled Worker visas for this course?", tag: "h1", size: "m" }) do %>

--- a/app/views/publish/courses/student_visa_sponsorship/_form_fields.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/_form_fields.html.erb
@@ -5,19 +5,19 @@
 
   <fieldset class="govuk-fieldset">
     <% if @course.is_uni_or_scitt? %>
-      <% if !@provider.can_sponsor_student_visa && !@provider.scitt? %>
+      <% if !@provider.can_sponsor_student_visa && @provider.university? %>
         <p class="govuk-body">Learn more about <%= govuk_link_to "recruiting trainee teachers from overseas", "https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers" %>.</p>
       <% end %>
 
+        <% question = "Can your organisation sponsor Student visas for this course?" %>
+      <% else %>
+        <%= render "inset_text" if @course.accrediting_provider.present? %>
+        <% question = "Is Student visa sponsorship available for this course?" %>
+      <% end %>
+
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-        Can your organisation sponsor Student visas for this course?
+        <%= question %>
       </legend>
-    <% else %>
-      <%= render "inset_text" %>
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-        Is Student visa sponsorship available for this course?
-      </legend>
-    <% end %>
 
     <%= render "publish/shared/error_messages", error_keys: [:can_sponsor_student_visa] %>
 

--- a/app/views/publish/courses/student_visa_sponsorship/edit.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/edit.html.erb
@@ -23,7 +23,8 @@
           local: true,
         ) do |f| %>
 
-       <%= f.hidden_field :funding_type_updated, value: funding_type_updated? %>
+      <%= f.hidden_field :funding_type_updated, value: funding_type_updated? %>
+      <%= f.hidden_field :origin_step, value: origin_step %>
 
       <%= f.govuk_error_summary %>
 
@@ -33,10 +34,10 @@
       </h1>
 
       <% if funding_type_updated? %>
-        <p class="govuk-body"><%= t("visa_sponsorships.updated_funding") %></p>
+        <p class="govuk-body"><%= t("visa_sponsorships.updated.#{origin_step}") %></p>
       <% end %>
 
-      <%= render "inset_text" %>
+      <%= render "inset_text" if @course.accrediting_provider.present? %>
 
       <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa, legend: { text: "Is Student visa sponsorship available for this course?", tag: "h1", size: "m" }) do %>
         <% course.edit_course_options["can_sponsor_student_visas"].each_with_index do |can_sponsor_student_visa, index| %>

--- a/app/views/publish/courses/student_visa_sponsorship/edit.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/edit.html.erb
@@ -37,9 +37,20 @@
         <p class="govuk-body"><%= t("visa_sponsorships.updated.#{origin_step}") %></p>
       <% end %>
 
+      <% if @course.is_uni_or_scitt? %>
+        <% if !@provider.can_sponsor_student_visa && @provider.university? %>
+          <p class="govuk-body">Learn more about <%= govuk_link_to "recruiting trainee teachers from overseas", "https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers" %>.</p>
+        <% end %>
+
+        <% question = "Can your organisation sponsor Student visas for this course?" %>
+      <% else %>
+        <%= render "inset_text" if @course.accrediting_provider.present? %>
+        <% question = "Is Student visa sponsorship available for this course?" %>
+      <% end %>
+
       <%= render "inset_text" if @course.accrediting_provider.present? %>
 
-      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa, legend: { text: "Is Student visa sponsorship available for this course?", tag: "h1", size: "m" }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:can_sponsor_student_visa, legend: { text: question, tag: "h1", size: "m" }) do %>
         <% course.edit_course_options["can_sponsor_student_visas"].each_with_index do |can_sponsor_student_visa, index| %>
           <%= f.govuk_radio_button(
                 :can_sponsor_student_visa,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,9 +24,12 @@ en:
   visa_sponsorships:
     student: "Student"
     skilled_worker: "Skilled Worker"
-    updated_funding: "You’re being shown this page because you changed your answer to funding type."
-    funding_and_visa_updated: "Funding type and %{visa_type} visas updated"
-    visa_updated: "%{visa_type} visas updated"
+    updated:
+      fee_or_salary: "You’re being shown this page because you changed your answer to funding type."
+      apprenticeship: "You’re being shown this page because you changed your answer to whether this is a teaching apprenticeship."
+      fee_or_salary_and_visa: "Funding type and %{visa_type} visas updated"
+      apprenticeship_and_visa: "Teaching apprenticeship and %{visa_type} visas updated"
+      visa: "%{visa_type} visas updated"
   page_titles:
     funding_type:
       edit: "Funding type"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -184,6 +184,9 @@ namespace :publish, as: :publish do
 
         get "/fee-or-salary", on: :member, to: "courses/fee_or_salary#edit"
         put "/fee-or-salary", on: :member, to: "courses/fee_or_salary#update"
+
+        get "/apprenticeship", on: :member, to: "courses/apprenticeship#edit"
+        put "/apprenticeship", on: :member, to: "courses/apprenticeship#update"
       end
 
       scope module: :providers do

--- a/spec/features/publish/courses/editing_apprenticeship_spec.rb
+++ b/spec/features/publish/courses/editing_apprenticeship_spec.rb
@@ -2,33 +2,33 @@
 
 require "rails_helper"
 
-feature "Editing funding type", { can_edit_current_and_next_cycles: false } do
+feature "Editing apprenticeship", { can_edit_current_and_next_cycles: false } do
   before do
     given_the_visa_sponsorship_on_course_feature_flag_is_active
     and_i_am_authenticated_as_a_lead_school_provider_user
   end
 
-  context "fee paying to salaried course" do
-    scenario "i am taken to the skilled worker visa step" do
-      given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
-      when_i_visit_the_funding_type_edit_page
-      when_i_select_an_fee_or_salary(:salary)
-      and_i_continue
-      then_i_should_be_on_the_skilled_worker_visa_sponsorship_edit_page
-      when_i_update_the_skilled_worker_visa_to_be_sponsored
-      then_i_should_see_a_success_message_for("Skilled Worker")
-    end
-  end
-
-  context "salaried to fee paying course" do
-    scenario "i am taken to the student visa step" do
-      given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
-      when_i_visit_the_funding_type_edit_page
-      when_i_select_an_fee_or_salary(:fee)
+  context "apprenticeship to non apprenticeship course" do
+    scenario "i am taken to the Student visa step" do
+      given_there_is_apprenticeship_course
+      when_i_visit_the_apprenticeship_edit_page
+      when_i_select(:no)
       and_i_continue
       then_i_should_be_on_the_student_visa_edit_page
       when_i_update_the_student_visa_to_be_sponsored
       then_i_should_see_a_success_message_for("Student")
+    end
+  end
+
+  context "non apprenticeship to apprenticeship course" do
+    scenario "i am taken to the skilled worker visa step" do
+      given_there_is_fee_course
+      when_i_visit_the_apprenticeship_edit_page
+      when_i_select(:yes)
+      and_i_continue
+      then_i_should_be_on_the_skilled_worker_visa_sponsorship_edit_page
+      when_i_update_the_skilled_worker_visa_to_be_sponsored
+      then_i_should_see_a_success_message_for("Skilled Worker")
     end
   end
 
@@ -40,24 +40,20 @@ feature "Editing funding type", { can_edit_current_and_next_cycles: false } do
     given_i_am_authenticated(user: create(:user, providers: [create(:provider)]))
   end
 
-  def given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
+  def given_there_is_fee_course
     given_a_course_exists(
       funding_type: "fee",
-      can_sponsor_student_visa: false,
-      accrediting_provider:,
     )
   end
 
-  def given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
+  def given_there_is_apprenticeship_course
     given_a_course_exists(
-      funding_type: "salary",
-      can_sponsor_skilled_worker_visa: false,
-      accrediting_provider:,
+      funding_type: "apprenticeship",
     )
   end
 
-  def when_i_visit_the_funding_type_edit_page
-    funding_type_edit_page.load(
+  def when_i_visit_the_apprenticeship_edit_page
+    apprenticeship_edit_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
     )
   end
@@ -69,15 +65,15 @@ feature "Editing funding type", { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_continue
-    funding_type_edit_page.update.click
+    apprenticeship_edit_page.update.click
   end
 
   def provider
     @current_user.providers.first
   end
 
-  def when_i_select_an_fee_or_salary(funding_type)
-    funding_type_edit_page.funding_type_fields.send(funding_type).click
+  def when_i_select(option)
+    apprenticeship_edit_page.funding_type_fields.send(option).click
   end
 
   def then_i_should_be_on_the_skilled_worker_visa_sponsorship_edit_page
@@ -99,7 +95,7 @@ feature "Editing funding type", { can_edit_current_and_next_cycles: false } do
   end
 
   def then_i_should_see_a_success_message_for(visa_type)
-    expect(page).to have_content(I18n.t("visa_sponsorships.updated.fee_or_salary_and_visa", visa_type:))
+    expect(page).to have_content(I18n.t("visa_sponsorships.updated.apprenticeship_and_visa", visa_type:))
   end
 
   def accrediting_provider

--- a/spec/features/publish/courses/editing_funding_type_spec.rb
+++ b/spec/features/publish/courses/editing_funding_type_spec.rb
@@ -37,7 +37,7 @@ feature "Editing funding type", { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_am_authenticated_as_a_lead_school_provider_user
-    given_i_am_authenticated(user: create(:user, providers: [create(:provider, :accredited_body)]))
+    given_i_am_authenticated(user: create(:user, providers: [create(:provider)]))
   end
 
   def given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa

--- a/spec/support/page_objects/publish/courses/apprenticeship_edit.rb
+++ b/spec/support/page_objects/publish/courses/apprenticeship_edit.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../../sections/funding_type_fields"
+
+module PageObjects
+  module Publish
+    module Courses
+      class ApprenticeshipEdit < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/apprenticeship"
+
+        section :funding_type_fields, '[data-qa="course__funding_type"]' do
+          element :yes, "#course_funding_type_apprenticeship"
+          element :no, "#course_funding_type_fee"
+        end
+
+        element :update, '[data-qa="course__save"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Editing of visa for an apprenticeship course

### Changes proposed in this pull request
When the course apprenticeship setting is changed  then the related visa question are asked.

### Guidance to review
Applicable to changing to and from an apprenticeship  draft/rollover course
there is no reset ability (separate card)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
