### PR TITLE
Stream anonymised DfE Sign-in user id to bigquery

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -166,6 +166,7 @@ shared:
     - updated_at
   user:
     - id
+    - sign_in_user_id
     - first_login_date_utc
     - last_login_date_utc
     - welcome_email_date_utc

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -68,7 +68,6 @@
   - email
   - first_name
   - last_name
-  - sign_in_user_id
   - magic_link_token
   :organisation_provider:
   - id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,2 +1,4 @@
 ---
-shared: {}
+:shared:
+  :user:
+  - sign_in_user_id


### PR DESCRIPTION
### Context

All provider facing services (Publish, Manage and Register) each have their own provider users in their services. There is currently no shared identifier across the services for provider users that is accessible for analytics. Therefore there isn't a method through BQ to see which provider users engage with each service.

With ITT reform changing how we onboard providers into TS, it's important for us to have a true reflection of provider users across the service.

- Register has a dfe_sign_in_uid in the users table which is not anonymised.
- Apply has a dfe_sign_in_uid in the provider_users and support_users tables which *is* anonymised 
- Publish has a sign_in_user_id in the user table which I've confirmed with @avinhurry matches the above IDs, but currently isn't streamed at all (it's in their blocklist)

**As a**... data infrastructure team
**We need to**... join up services with a way to identify which provider-users appear in each provider facing service.
**So that**... improve cross-service analysis abilities and calculate the number of provider-users crossing into each service.

### Changes proposed in this pull request
Start streaming the sign_in_user_id from Publish (anonymised)

### Guidance to review
n/a

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
