### PR TITLE
[535] Return user providers based on cycle year

### DIFF
--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -7,6 +7,7 @@ module Support
       end
 
       def show
+        recruitment_cycle
         provider_user
       end
 

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -48,7 +48,7 @@ module Support
     end
 
     def find_providers
-      recruitment_cycle.providers.order(:provider_name).includes(:courses, :users)
+      recruitment_cycle.providers.order(:provider_name).includes(:recruitment_cycle, :courses, :users)
     end
 
     def filter_params

--- a/app/controllers/support/users/providers_controller.rb
+++ b/app/controllers/support/users/providers_controller.rb
@@ -14,7 +14,7 @@ module Support
       end
 
       def providers
-        RecruitmentCycle.current.providers.where(id: user.providers)
+        recruitment_cycle.providers.where(id: user.providers)
       end
     end
   end

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -1,6 +1,7 @@
 module Support
   class UsersController < SupportController
     def index
+      recruitment_cycle
       @users = filtered_users.page(params[:page] || 1)
     end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -121,6 +121,8 @@ class Provider < ApplicationRecord
 
   scope :in_next_cycle, -> { where(recruitment_cycle: RecruitmentCycle.next_recruitment_cycle) }
 
+  scope :in_cycle, ->(recruitment_cycle) { where(recruitment_cycle:) }
+
   scope :with_allocations_for_current_cycle_year, -> { joins(:allocations).merge(Allocation.current_allocations).order(:provider_name) }
 
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil).or where(region_code: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,11 +13,7 @@ class User < ApplicationRecord
   has_many :providers_via_organisations, through: :organisations, source: :providers
 
   has_many :user_permissions
-  has_many :providers, through: :user_permissions do
-    def in_current_cycle
-      where(recruitment_cycle: RecruitmentCycle.current)
-    end
-  end
+  has_many :providers, through: :user_permissions
 
   has_many :access_requests,
     foreign_key: :requester_id,

--- a/app/views/support/providers/users/show.html.erb
+++ b/app/views/support/providers/users/show.html.erb
@@ -35,7 +35,7 @@
 
           component.row do |row|
             row.key { "Organisations" }
-            row.value(text: sanitize(@provider_user.providers.in_current_cycle.pluck(:provider_name).sort.join(tag.br)), html_attributes: { id: "organisations" })
+            row.value(text: sanitize(@provider_user.providers.in_cycle(@recruitment_cycle).pluck(:provider_name).sort.join(tag.br)), html_attributes: { id: "organisations" })
             row.action
           end
 

--- a/app/views/support/users/_users.html.erb
+++ b/app/views/support/users/_users.html.erb
@@ -22,7 +22,7 @@
         </td>
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= user.providers.in_current_cycle.count %>
+            <%= user.providers.in_cycle(@recruitment_cycle).count %>
           </span>
         </td>
       </tr>

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -611,6 +611,22 @@ describe Provider, type: :model do
     end
   end
 
+  describe "in_cycle" do
+    let(:provider_in_current_cycle) { create(:provider) }
+    let(:provider_in_previous_cycle) { create(:provider, :previous_recruitment_cycle) }
+
+    before do
+      provider_in_current_cycle
+      provider_in_previous_cycle
+    end
+
+    subject { described_class.in_cycle(provider_in_current_cycle.recruitment_cycle) }
+
+    it "includes providers specified via the cycle provided" do
+      expect(subject).to contain_exactly(provider_in_current_cycle)
+    end
+  end
+
   describe "geolocation" do
     include ActiveJob::TestHelper
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,22 +32,6 @@ describe User, type: :model do
     end
   end
 
-  describe "#providers" do
-    describe "#in_current_cycle" do
-      let(:provider_in_current_cycle) { create(:provider) }
-      let(:provider_in_previous_cycle) { create(:provider, :previous_recruitment_cycle) }
-
-      before do
-        subject.providers << provider_in_current_cycle
-        subject.providers << provider_in_previous_cycle
-      end
-
-      it "returns the providers in the current cycle" do
-        expect(subject.providers.in_current_cycle).to eq([provider_in_current_cycle])
-      end
-    end
-  end
-
   describe "auditing" do
     it { is_expected.to be_audited }
   end


### PR DESCRIPTION
### Context

https://trello.com/c/VtEmHLuc/534-associate-users-with-organisation-1tf

### Changes proposed in this pull request

This PR fixes an issue where users are given access to a provider in the next cycle but the UI will still show the user has having 0 providers since it's looking in the current cycle.

- Change `user.providers.in_current_cycle` to `user.providers.for_cycle(cycle)` so it returns the user's providers based on the cycle provided

### Guidance to review

Add a user to a provider in the next cycle and assert they only have access to that provider in that cycle. Check the UI correctly returns their provider when viewing in the next cycle

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
