### PR TITLE
#536 add campaign_name enum

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -48,6 +48,11 @@ class Course < ApplicationRecord
     not_required: 9,
   }
 
+  enum :campaign_name,
+    {
+      engineers_teach_physics: 0, # should this be a string?
+    }
+
   ENTRY_REQUIREMENT_OPTIONS = {
     must_have_qualification_at_application_time: 1,
     expect_to_achieve_before_training_begins: 2,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -48,10 +48,7 @@ class Course < ApplicationRecord
     not_required: 9,
   }
 
-  enum :campaign_name,
-    {
-      engineers_teach_physics: 0, # should this be a string?
-    }
+  enum :campaign_name, COURSE_CAMPAIGNS
 
   ENTRY_REQUIREMENT_OPTIONS = {
     must_have_qualification_at_application_time: 1,

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -85,3 +85,5 @@
   - version
   :data_migrations:
   - version
+  :course:
+  - campaign_name

--- a/config/initializers/course_enums.rb
+++ b/config/initializers/course_enums.rb
@@ -1,0 +1,7 @@
+COURSE_CAMPAIGN_ENUMS = {
+  engineers_teach_physics: "engineers_teach_physics",
+}.freeze
+
+COURSE_CAMPAIGNS = {
+  COURSE_CAMPAIGN_ENUMS[:engineers_teach_physics] => 0,
+}

--- a/config/initializers/course_enums.rb
+++ b/config/initializers/course_enums.rb
@@ -4,4 +4,4 @@ COURSE_CAMPAIGN_ENUMS = {
 
 COURSE_CAMPAIGNS = {
   COURSE_CAMPAIGN_ENUMS[:engineers_teach_physics] => 0,
-}
+}.freeze

--- a/db/migrate/20220928150349_add_campaign_name_to_course.rb
+++ b/db/migrate/20220928150349_add_campaign_name_to_course.rb
@@ -1,0 +1,5 @@
+class AddCampaignNameToCourse < ActiveRecord::Migration[7.0]
+  def change
+    add_column :course, :campaign_name, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_28_150349) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -30,11 +30,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.text "last_name"
     t.text "organisation"
     t.text "reason"
-    t.datetime "request_date_utc", null: false
+    t.datetime "request_date_utc", precision: nil, null: false
     t.integer "requester_id"
     t.integer "status", null: false
     t.text "requester_email"
-    t.datetime "discarded_at"
+    t.datetime "discarded_at", precision: nil
     t.index ["discarded_at"], name: "index_access_request_on_discarded_at"
     t.index ["requester_id"], name: "IX_access_request_requester_id"
   end
@@ -43,8 +43,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.bigint "provider_id"
     t.bigint "accredited_body_id"
     t.integer "number_of_places"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "request_type", default: 0
     t.text "accredited_body_code"
     t.text "provider_code"
@@ -60,8 +60,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
   create_table "allocation_uplift", force: :cascade do |t|
     t.bigint "allocation_id", null: false
     t.integer "uplifts"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["allocation_id"], name: "index_allocation_uplift_on_allocation_id"
   end
 
@@ -79,7 +79,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.string "comment"
     t.string "remote_address"
     t.string "request_uuid"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.index ["associated_type", "associated_id"], name: "associated_index"
     t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
     t.index ["created_at"], name: "index_audit_on_created_at"
@@ -93,8 +93,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.text "name"
     t.text "email"
     t.text "telephone"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "permission_given", default: false
     t.index ["provider_id", "type"], name: "index_contact_on_provider_id_and_type", unique: true
     t.index ["provider_id"], name: "index_contact_on_provider_id"
@@ -106,18 +106,18 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.text "profpost_flag"
     t.text "program_type"
     t.integer "qualification", null: false
-    t.datetime "start_date"
+    t.datetime "start_date", precision: nil
     t.text "study_mode"
     t.integer "provider_id", default: 0, null: false
     t.text "modular"
     t.integer "english"
     t.integer "maths"
     t.integer "science"
-    t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "created_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "updated_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "changed_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "accredited_body_code"
-    t.datetime "discarded_at"
+    t.datetime "discarded_at", precision: nil
     t.string "age_range_in_years"
     t.date "applications_open_from"
     t.boolean "is_send", default: false
@@ -134,6 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.string "additional_gcse_equivalencies"
     t.boolean "can_sponsor_skilled_worker_visa", default: false
     t.boolean "can_sponsor_student_visa", default: false
+    t.integer "campaign_name"
     t.index ["accredited_body_code"], name: "index_course_on_accredited_body_code"
     t.index ["can_sponsor_skilled_worker_visa"], name: "index_course_on_can_sponsor_skilled_worker_visa"
     t.index ["can_sponsor_student_visa"], name: "index_course_on_can_sponsor_student_visa"
@@ -151,12 +152,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
 
   create_table "course_enrichment", id: :serial, force: :cascade do |t|
     t.integer "created_by_user_id"
-    t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "created_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
     t.jsonb "json_data"
-    t.datetime "last_published_timestamp_utc"
+    t.datetime "last_published_timestamp_utc", precision: nil
     t.integer "status", null: false
     t.integer "updated_by_user_id"
-    t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "updated_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
     t.integer "course_id", null: false
     t.index ["course_id"], name: "index_course_enrichment_on_course_id"
     t.index ["created_by_user_id"], name: "IX_course_enrichment_created_by_user_id"
@@ -179,8 +180,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
   create_table "course_subject", id: :serial, force: :cascade do |t|
     t.integer "course_id"
     t.integer "subject_id"
-    t.datetime "created_at", precision: 6
-    t.datetime "updated_at", precision: 6
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "position"
     t.index ["course_id", "subject_id"], name: "index_course_subject_on_course_id_and_subject_id", unique: true
     t.index ["course_id"], name: "index_course_subject_on_course_id"
@@ -195,13 +196,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
     t.text "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
+    t.datetime "run_at", precision: nil
+    t.datetime "locked_at", precision: nil
+    t.datetime "failed_at", precision: nil
     t.string "locked_by"
     t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
@@ -210,8 +211,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.string "bursary_amount"
     t.string "early_career_payments"
     t.string "scholarship"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "subject_knowledge_enhancement_course_available", default: false, null: false
     t.index ["subject_id"], name: "index_financial_incentive_on_subject_id"
   end
@@ -220,8 +221,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.string "page", null: false
     t.bigint "recruitment_cycle_id", null: false
     t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["page", "recruitment_cycle_id", "user_id"], name: "interrupt_page_all_column_idx", unique: true
     t.index ["recruitment_cycle_id"], name: "index_interrupt_page_acknowledgement_on_recruitment_cycle_id"
     t.index ["user_id"], name: "index_interrupt_page_acknowledgement_on_user_id"
@@ -264,12 +265,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.text "email"
     t.text "telephone"
     t.integer "region_code"
-    t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "created_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "updated_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
     t.text "accrediting_provider"
-    t.datetime "changed_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "changed_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
     t.integer "recruitment_cycle_id", null: false
-    t.datetime "discarded_at"
+    t.datetime "discarded_at", precision: nil
     t.text "train_with_us"
     t.text "train_with_disability"
     t.jsonb "accrediting_provider_enrichments"
@@ -294,8 +295,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.text "send_application_alerts"
     t.text "application_alert_email"
     t.text "gt12_response_destination"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["provider_id"], name: "index_provider_ucas_preference_on_provider_id"
   end
 
@@ -303,13 +304,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.string "year"
     t.date "application_start_date", null: false
     t.date "application_end_date", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "session", id: :serial, force: :cascade do |t|
     t.text "access_token"
-    t.datetime "created_utc", null: false
+    t.datetime "created_utc", precision: nil, null: false
     t.integer "user_id", null: false
     t.index ["access_token", "created_utc"], name: "IX_session_access_token_created_utc"
     t.index ["user_id"], name: "IX_session_user_id"
@@ -325,13 +326,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.text "address1"
     t.integer "provider_id", default: 0, null: false
     t.integer "region_code"
-    t.datetime "created_at", default: -> { "timezone('utc'::text, now())" }, null: false
-    t.datetime "updated_at", default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "created_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
+    t.datetime "updated_at", precision: nil, default: -> { "timezone('utc'::text, now())" }, null: false
     t.float "latitude"
     t.float "longitude"
     t.string "urn"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
-    t.datetime "discarded_at"
+    t.datetime "discarded_at", precision: nil
     t.index ["discarded_at"], name: "index_site_on_discarded_at"
     t.index ["latitude", "longitude"], name: "index_site_on_latitude_and_longitude"
     t.index ["uuid"], name: "index_sites_unique_uuid", unique: true
@@ -339,8 +340,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
 
   create_table "statistic", force: :cascade do |t|
     t.jsonb "json_data", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "subject", force: :cascade do |t|
@@ -355,8 +356,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
   create_table "subject_area", id: false, force: :cascade do |t|
     t.text "typename", null: false
     t.text "name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["typename"], name: "index_subject_area_on_typename", unique: true
   end
 
@@ -364,17 +365,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.text "email"
     t.text "first_name", null: false
     t.text "last_name", null: false
-    t.datetime "first_login_date_utc"
-    t.datetime "last_login_date_utc"
+    t.datetime "first_login_date_utc", precision: nil
+    t.datetime "last_login_date_utc", precision: nil
     t.text "sign_in_user_id"
-    t.datetime "welcome_email_date_utc"
-    t.datetime "invite_date_utc"
-    t.datetime "accept_terms_date_utc"
+    t.datetime "welcome_email_date_utc", precision: nil
+    t.datetime "invite_date_utc", precision: nil
+    t.datetime "accept_terms_date_utc", precision: nil
     t.string "state"
     t.boolean "admin", default: false
-    t.datetime "discarded_at"
+    t.datetime "discarded_at", precision: nil
     t.string "magic_link_token"
-    t.datetime "magic_link_token_sent_at"
+    t.datetime "magic_link_token_sent_at", precision: nil
     t.index ["discarded_at"], name: "index_user_on_discarded_at"
     t.index ["email"], name: "IX_user_email", unique: true
   end
@@ -383,8 +384,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
     t.integer "user_id", null: false
     t.string "provider_code", null: false
     t.boolean "course_update", default: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "course_publish", default: false
     t.index ["provider_code"], name: "index_user_notification_on_provider_code"
   end
@@ -392,8 +393,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_093437) do
   create_table "user_permission", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "provider_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["provider_id"], name: "index_user_permission_on_provider_id"
     t.index ["user_id", "provider_id"], name: "index_user_permission_on_user_id_and_provider_id", unique: true
     t.index ["user_id"], name: "index_user_permission_on_user_id"

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -22,7 +22,7 @@ describe Course, type: :model do
 
   describe "#campaign_name" do
     it "defaults to nil" do
-      expect(course.campaign_name).to be nil
+      expect(course.campaign_name).to be_nil
     end
 
     it "assigns the campaign" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -20,6 +20,18 @@ describe Course, type: :model do
   its(:to_s) { is_expected.to eq("Biology (#{course.provider.provider_code}/3X9F) [#{course.recruitment_cycle}]") }
   its(:modular) { is_expected.to eq("") }
 
+  describe "#campaign_name" do
+    it "defaults to nil" do
+      expect(course.campaign_name).to be nil
+    end
+
+    it "assigns the campaign" do
+      course.engineers_teach_physics!
+      expect(course.campaign_name).to eq "engineers_teach_physics"
+      expect(course.engineers_teach_physics?).to be true
+    end
+  end
+
   describe "auditing" do
     it { is_expected.to be_audited }
     it { is_expected.to have_associated_audits }


### PR DESCRIPTION
### Context
Some courses are created as part of a campaign to improve recruitment. The Engineers Teach Physics course is part of such a campaign. It is ultimately just a physics course but it will need to have a different title as part of the campaign.
We'll need to build a new step in the course flow to allow providers to create these types of courses.
What needs to be done

Add a new field on the course table campaign_name? this would be an enum field which could contain other campaigns in the future eg engineers_teach_physics
Write database migrations
Success

We should have a way of tracking these types of courses either by the field above or some other way
we should be able to do something like course.engineers_teach_physics? or course.has_campaign? etc

### Changes proposed in this pull request
Db migration for enum campaign_name
### Guidance to review
Should the enum be integer or string? 
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
