### PR TITLE
Add labels to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,16 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  labels:
+  - DevOps
+  - dependencies
+  - github_actions
 - package-ecosystem: terraform
   directory: "/terraform"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  labels:
+  - DevOps
+  - dependencies
+  - terraform


### PR DESCRIPTION
### Context
Ensure the DevOps label is added to pull requests that relate to either Terraform provider versions or GitHub action and workflow task versions. This ensures the team are notified up new pull requests on their Slack channel.

### Changes proposed in this pull request
Add the labels section to the dependabot file so that it's clear what the PR's are for and so alerts are sent to Slack

### Guidance to review

### Link to Trello card
https://trello.com/c/qCIQi9lO

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
