### PR TITLE
[xxx] Fix broken locations error link

### DIFF
--- a/app/controllers/publish/courses/sites_controller.rb
+++ b/app/controllers/publish/courses/sites_controller.rb
@@ -21,6 +21,7 @@ module Publish
         authorize(provider)
 
         @course_location_form = CourseLocationForm.new(@course)
+        @course_location_form.valid? if show_errors_on_publish?
       end
 
       def update

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -56,6 +56,7 @@ module ViewHelper
         salary_details: "#{base}/salary?display_errors=true#salary_details-error",
         required_qualifications: "#{base}/requirements?display_errors=true#required_qualifications_wrapper",
         age_range_in_years: "#{base}/age-range?display_errors=true",
+        sites: "#{base}/locations?display_errors=true",
       }.with_indifferent_access[field]
     end
   end


### PR DESCRIPTION
### Context

We've got a support request which will involve copying courses from one provider to another. These courses will have no locations set. When providers try to publish they'll see an error (below) where the link is currently broken. This PR fixes it so it takes them to the correct section to complete.

<img width="1098" alt="Screenshot 2022-09-30 at 15 00 07" src="https://user-images.githubusercontent.com/616080/193288001-7477c308-3087-4712-8edd-6ad6aa767e0f.png">


