### PR TITLE
[xxx] Clear last cycle year in session if we're not in rollover

### DIFF
--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -5,6 +5,7 @@ module Publish
     layout "publish"
 
     before_action :check_interrupt_redirects
+    before_action :clear_previous_cycle_year_in_session, unless: -> { FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") }
 
     after_action :verify_authorized
 
@@ -40,6 +41,12 @@ module Publish
     def show_rollover_recruitment_page?
       FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page") &&
         current_user.current_rollover_recruitment_acceptance.blank?
+    end
+
+    def clear_previous_cycle_year_in_session
+      return if session[:cycle_year].to_i == Settings.current_recruitment_cycle_year
+
+      session[:cycle_year] = nil
     end
   end
 end


### PR DESCRIPTION
### Context

Now that Rollover has ended, some users who still have the last cycle year in their session will see an error unless they clear their cookies. This PR will do it for them as a fallback.

Fixes https://sentry.io/organizations/dfe-teacher-services/issues/3642874340/?environment=production&project=1377944&query=is%3Aignored