### PR TITLE
[xxxx] Removed noisy code

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-  include DfE::Analytics::Entities
 end


### PR DESCRIPTION
### Context
Remove noisy code

### Changes proposed in this pull request
Removed noisy code
### Guidance to review

Removes all this noise
```
2022-10-04 17:13:56.765022 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (AccessRequest), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765181 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Allocation), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765234 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Contact), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765281 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Course), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765325 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (SiteStatus), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765402 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (CourseSubject), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765441 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (CourseEnrichment), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765475 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (FinancialIncentive), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765509 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (InterruptPageAcknowledgement), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765549 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Provider), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765581 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (RecruitmentCycle), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765620 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Site), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765654 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Statistic), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765687 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Subject), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765718 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (SubjectArea), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765754 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (User), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765784 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (UserNotification), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.
2022-10-04 17:13:56.765817 I [78742:6740] Rails -- DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (UserPermission), but it's included automatically since v1.4. You're running v1.5.1. To silence this warning, remove the include from model definitions in app/models.


```
