### PR TITLE
[0617] Fixed study mode cascading issues on locations updates

### DIFF
--- a/app/forms/publish/base_model_form.rb
+++ b/app/forms/publish/base_model_form.rb
@@ -18,6 +18,7 @@ module Publish
     def save!
       if valid?
         assign_attributes_to_model
+        valid_before_save
         model.save!
       else
         false
@@ -25,6 +26,8 @@ module Publish
     end
 
   private
+
+    def valid_before_save; end
 
     def assign_attributes_to_model
       model.assign_attributes(fields.except(*fields_to_ignore_before_save))

--- a/app/forms/publish/course_study_mode_form.rb
+++ b/app/forms/publish/course_study_mode_form.rb
@@ -12,6 +12,10 @@ module Publish
 
   private
 
+    def valid_before_save
+      course.ensure_site_statuses_match_study_mode if course.changed?
+    end
+
     def compute_fields
       course.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end

--- a/spec/forms/publish/course_study_mode_form_spec.rb
+++ b/spec/forms/publish/course_study_mode_form_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  describe CourseStudyModeForm, type: :model do
+    let(:course) { create(:course) }
+
+    subject { described_class.new(course, params:) }
+
+    context "when params are blank" do
+      let(:params) { {} }
+
+      describe "#save!" do
+        it "does not call the course.ensure_site_statuses_match_study_mode" do
+          expect(course).to receive(:changed?)
+          expect(course).not_to receive(:ensure_site_statuses_match_study_mode)
+          subject.save!
+        end
+      end
+    end
+
+    context "when params are study mode is part_time" do
+      let(:params) { { study_mode: "part_time" } }
+
+      describe "#save!" do
+        it "does calls the course.ensure_site_statuses_match_study_mode" do
+          expect(course).to receive(:changed?)
+          expect(course).not_to receive(:ensure_site_statuses_match_study_mode)
+          subject.save!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Study modes affects the locations vac status

### Changes proposed in this pull request
This fixes the location update issues whereby the study mode is changed and the existing locations is not updated leading to when the locations are then manipulated it errors out

### Guidance to review
See trello ticket

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
