### PR TITLE
[694] Fix findable courses which shouldn't be

### DIFF
--- a/db/data/20221011111721_fix_incorrect_withdrawn_findable_courses.rb
+++ b/db/data/20221011111721_fix_incorrect_withdrawn_findable_courses.rb
@@ -5,7 +5,7 @@ class FixIncorrectWithdrawnFindableCourses < ActiveRecord::Migration[7.0]
     Course.joins(:site_statuses, :enrichments, provider: :recruitment_cycle).where(provider: { recruitment_cycle: { year: "2023" } }, enrichments: { status: %w[withdrawn] }, site_statuses: { status: "running" }).find_each do |course|
       next if course.is_published?
 
-      course.site_statuses.update_all(publish: :unpublished, status: :suspended)
+      course.site_statuses.update_all(vac_status: :no_vacancies, publish: :unpublished, status: :suspended)
     end
   end
 

--- a/db/data/20221011111721_fix_incorrect_withdrawn_findable_courses.rb
+++ b/db/data/20221011111721_fix_incorrect_withdrawn_findable_courses.rb
@@ -2,7 +2,9 @@
 
 class FixIncorrectWithdrawnFindableCourses < ActiveRecord::Migration[7.0]
   def up
-    Course.joins(:site_statuses, :enrichments).where(enrichments: { status: %w[withdrawn] }, site_statuses: { status: "running" }).find_each do |course|
+    Course.joins(:site_statuses, :enrichments, provider: :recruitment_cycle).where(provider: { recruitment_cycle: { year: "2023" } }, enrichments: { status: %w[withdrawn] }, site_statuses: { status: "running" }).find_each do |course|
+      next if course.is_published?
+
       course.site_statuses.update_all(publish: :unpublished, status: :suspended)
     end
   end

--- a/db/data/20221011111721_fix_incorrect_withdrawn_findable_courses.rb
+++ b/db/data/20221011111721_fix_incorrect_withdrawn_findable_courses.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FixIncorrectWithdrawnFindableCourses < ActiveRecord::Migration[7.0]
+  def up
+    Course.joins(:site_statuses, :enrichments).where(enrichments: { status: %w[withdrawn] }, site_statuses: { status: "running" }).find_each do |course|
+      course.site_statuses.update_all(publish: :unpublished, status: :suspended)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20221011111730_fix_incorrect_draft_findable_courses.rb
+++ b/db/data/20221011111730_fix_incorrect_draft_findable_courses.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class FixIncorrectDraftFindableCourses < ActiveRecord::Migration[7.0]
+  VAC_MAPPING = {
+    full_time_or_part_time: :both_full_time_and_part_time_vacancies,
+    part_time: :part_time_vacancies,
+    full_time: :full_time_vacancies,
+  }.freeze
+
   def up
     Course.joins(:site_statuses, :enrichments, provider: :recruitment_cycle).where(provider: { recruitment_cycle: { year: "2023" } }, enrichments: { status: %w[draft rolled_over] }, site_statuses: { status: "running" }).find_each do |course|
       next if course.is_published?
 
-      course.site_statuses.update_all(publish: :unpublished, status: :new_status)
+      course.site_statuses.update_all(publish: :unpublished, status: :new_status, vac_status: VAC_MAPPING[course.study_mode.to_sym] || :no_vacancies)
     end
   end
 

--- a/db/data/20221011111730_fix_incorrect_draft_findable_courses.rb
+++ b/db/data/20221011111730_fix_incorrect_draft_findable_courses.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FixIncorrectDraftFindableCourses < ActiveRecord::Migration[7.0]
+  def up
+    Course.joins(:site_statuses, :enrichments).where(enrichments: { status: %w[draft] }, site_statuses: { status: "running" }).find_each do |course|
+      course.site_statuses.update_all(publish: :unpublished, status: :new_status)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20221011111730_fix_incorrect_draft_findable_courses.rb
+++ b/db/data/20221011111730_fix_incorrect_draft_findable_courses.rb
@@ -2,7 +2,9 @@
 
 class FixIncorrectDraftFindableCourses < ActiveRecord::Migration[7.0]
   def up
-    Course.joins(:site_statuses, :enrichments).where(enrichments: { status: %w[draft] }, site_statuses: { status: "running" }).find_each do |course|
+    Course.joins(:site_statuses, :enrichments, provider: :recruitment_cycle).where(provider: { recruitment_cycle: { year: "2023" } }, enrichments: { status: %w[draft rolled_over] }, site_statuses: { status: "running" }).find_each do |course|
+      next if course.is_published?
+
       course.site_statuses.update_all(publish: :unpublished, status: :new_status)
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/vPsLFM54/694-fix-courses-appearing-on-find-when-in-withdrawn-draft-via-migrations

### Changes proposed in this pull request

We have had support tickets about withdrawn/draft courses appearing in Find. The issue is that the `site_statuses` for these courses have been marked to be findable. This PR introduces a couple of data migrations to make them unfindable.

### Guidance to review

- Get the latest snapshot.
- Check this provider who has a draft course which is findable `publish/organisations/179/2023/courses` `3C2J`
- Check it appears on Find locally
- Run data migrations `bundle exec rails data:migrate`
- Check course shouldn't appear on Find

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
