### PR TITLE
Remove GitHub action minor version pinning

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -51,7 +51,7 @@ runs:
       uses: actions/checkout@v2
 
     - name: Setup Terraform v1.2.3
-      uses: hashicorp/setup-terraform@v1.2.1
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: 1.2.3
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -55,7 +55,7 @@ jobs:
         echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2.1.0
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -210,7 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start review-${{ github.event.pull_request.number }} Deployment
-        uses: bobheadxi/deployments@v1.3.0
+        uses: bobheadxi/deployments@v1
         id:   deployment
         with:
           step: start
@@ -234,7 +234,7 @@ jobs:
 
       - name: Update review-${{ github.event.pull_request.number }} status
         if:   always()
-        uses: bobheadxi/deployments@v1.3.0
+        uses: bobheadxi/deployments@v1
         with:
           step:   finish
           token:  ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -46,7 +46,7 @@ jobs:
           key: SNYK_TOKEN
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Terraform v1.2.3
-        uses: hashicorp/setup-terraform@v2.0.2
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.3
 
@@ -75,7 +75,7 @@ jobs:
       - name: Update ${{ matrix.environment }} status
         id: deactivate-env
         if:   ${{ always() && env.TF_STATE_EXISTS == 'true' }}
-        uses: bobheadxi/deployments@v1.3.0
+        uses: bobheadxi/deployments@v1
         with:
           step:   deactivate-env
           token:  ${{ secrets.GITHUB_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Delete review-${{ env.PR_NUMBER }} environment
         if:   always() && (steps.deactivate-env.outcome == 'success')
-        uses: bobheadxi/deployments@v1.3.0
+        uses: bobheadxi/deployments@v1
         with:
           step:   delete-env
           token:  ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}


### PR DESCRIPTION
### Context
Dependabot is creating too many distracting PRs

### Changes proposed in this pull request
Pin to the major version and let the workflow use the latest minor version

### Guidance to review
Check the workflow run

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
