### PR TITLE
fix etp new page

### DIFF
--- a/app/controllers/publish/courses/engineers_teach_physics_controller.rb
+++ b/app/controllers/publish/courses/engineers_teach_physics_controller.rb
@@ -70,8 +70,10 @@ module Publish
 
       def continue
         authorize(@provider, :can_create_course?)
-        @errors = errors
-        if @errors.any?
+        if params[:course][:campaign_name].blank?
+          @errors = {:campaign_name=>["Select an option"]}
+        end
+        if @errors.present?
           render :new
         elsif params[:skip_languages_goto_confirmation].present?
           redirect_to confirmation_publish_provider_recruitment_cycle_courses_path(path_params)

--- a/app/controllers/publish/courses/engineers_teach_physics_controller.rb
+++ b/app/controllers/publish/courses/engineers_teach_physics_controller.rb
@@ -70,9 +70,8 @@ module Publish
 
       def continue
         authorize(@provider, :can_create_course?)
-        if params[:course][:campaign_name].blank?
-          @errors = {:campaign_name=>["Select an option"]}
-        end
+        @errors = { campaign_name: ["Select an option"] } if params[:course][:campaign_name].blank?
+
         if @errors.present?
           render :new
         elsif params[:skip_languages_goto_confirmation].present?

--- a/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
@@ -10,6 +10,8 @@ feature "selecting a physics subject", { can_edit_current_and_next_cycles: false
     when_i_select_a_subject(:physics)
     and_i_click_continue
     then_i_am_met_with_the_engineers_teach_physics_page(:secondary, :physics)
+    and_i_click_continue
+    then_i_see_an_error_message
     and_i_select_an_option
     and_i_click_continue
     then_i_am_met_with_the_age_range_page(:secondary, :physics)
@@ -48,6 +50,10 @@ private
 
   def and_i_select_an_option
     new_engineers_teach_physics_page.campaign_fields.engineers_teach_physics.click
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content("Select an option")
   end
 
   def and_i_open_second_subject


### PR DESCRIPTION
### Context
We need to add validations to the ETP step on the new course flow
Success

The page shows validation errors if the user tries to submit without selection an option

### Changes proposed in this pull request
validate in continue action on new etp page
### Guidance to review
Start a new course flow, pick secondary, then physics. On ETP page leave options unchecked, click continue to see error message
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
