### PR TITLE
[731] Fix published courses with inconsistent vac status

### DIFF
--- a/db/data/20221020110844_fix_vac_status_on_published_courses.rb
+++ b/db/data/20221020110844_fix_vac_status_on_published_courses.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FixVacStatusOnPublishedCourses < ActiveRecord::Migration[7.0]
+  def up
+    Course.joins(:site_statuses, :enrichments, provider: :recruitment_cycle).where(
+      provider: { recruitment_cycle: { year: "2023" } },
+      enrichments: { status: %w[published] },
+      study_mode: :full_time_or_part_time,
+      site_statuses: { vac_status: %w[part_time_vacancies full_time_vacancies] },
+    ).find_each do |course|
+      next unless course.is_published?
+
+      course.site_statuses.update_all(vac_status: :both_full_time_and_part_time_vacancies)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/c4qmSGgA/731-bug-vacancy-status-doesnt-match-study-mode-for-some-courses

We have an issue where some published courses have an inconsistent study mode to their location (site) statuses reported by the Apply team. We fixed the underlying issue and updated all courses except for published. This PR is to do that

### Changes proposed in this pull request

- Data migration to fix published courses with a `full_time_or_part_time` study mode but a non equivalent for its location statuses.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
