### PR TITLE
[735]reset campaign name when changing from ETP

### DIFF
--- a/app/controllers/publish/courses/subjects_controller.rb
+++ b/app/controllers/publish/courses/subjects_controller.rb
@@ -4,6 +4,7 @@ module Publish
       decorates_assigned :course
       before_action :build_course, only: %i[edit update]
       before_action :build_course_params, only: [:continue]
+      before_action :campaign_name_check, only: [:continue]
       include CourseBasicDetailConcern
 
       def edit
@@ -44,6 +45,7 @@ module Publish
           # TODO: move this to the form?
           course.update(master_subject_id: params[:course][:master_subject_id])
           course.update(name: course.generate_name)
+          course.update(campaign_name: nil) unless course.master_subject_id == SecondarySubject.physics
 
           redirect_to(
             details_publish_provider_recruitment_cycle_course_path(
@@ -59,6 +61,10 @@ module Publish
       end
 
     private
+
+      def campaign_name_check
+        params[:course][:campaign_name] = "" unless @course.master_subject_id == SecondarySubject.physics
+      end
 
       def course_subjects_form
         @course_subjects_form ||= CourseSubjectsForm.new(@course, params: selected_subject_ids)

--- a/app/controllers/publish/courses/subjects_controller.rb
+++ b/app/controllers/publish/courses/subjects_controller.rb
@@ -3,8 +3,7 @@ module Publish
     class SubjectsController < PublishController
       decorates_assigned :course
       before_action :build_course, only: %i[edit update]
-      before_action :build_course_params, only: [:continue]
-      before_action :campaign_name_check, only: [:continue]
+      before_action :build_course_params, :campaign_name_check, only: [:continue]
       include CourseBasicDetailConcern
 
       def edit

--- a/app/controllers/publish/courses/subjects_controller.rb
+++ b/app/controllers/publish/courses/subjects_controller.rb
@@ -44,7 +44,7 @@ module Publish
           # TODO: move this to the form?
           course.update(master_subject_id: params[:course][:master_subject_id])
           course.update(name: course.generate_name)
-          course.update(campaign_name: nil) unless course.master_subject_id == SecondarySubject.physics
+          course.update(campaign_name: nil) unless course.master_subject_id == SecondarySubject.physics.id
 
           redirect_to(
             details_publish_provider_recruitment_cycle_course_path(
@@ -62,7 +62,7 @@ module Publish
     private
 
       def campaign_name_check
-        params[:course][:campaign_name] = "" unless @course.master_subject_id == SecondarySubject.physics
+        params[:course][:campaign_name] = "" unless @course.master_subject_id == SecondarySubject.physics.id
       end
 
       def course_subjects_form

--- a/app/views/publish/courses/engineers_teach_physics/_edit_form_fields.html.erb
+++ b/app/views/publish/courses/engineers_teach_physics/_edit_form_fields.html.erb
@@ -12,7 +12,7 @@
       Engineers Teach Physics is a new campaign to help engineers become physics teachers.
     </p>
     <p class="govuk-body">
-      For more information, email <%= govuk_mail_to(Settings.campaign_email, subject: "Engineers Teach Physics") %>
+      For more information, email <%= govuk_mail_to(Settings.campaign_email, subject: "Engineers Teach Physics", class: "govuk-link") %>
     </p>
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
       <h1 class="govuk-fieldset__heading">

--- a/app/views/publish/courses/engineers_teach_physics/_form_fields.html.erb
+++ b/app/views/publish/courses/engineers_teach_physics/_form_fields.html.erb
@@ -12,7 +12,7 @@
       Engineers Teach Physics is a new campaign to help engineers become physics teachers.
     </p>
     <p class="govuk-body">
-      For more information, email <%= govuk_mail_to(Settings.campaign_email, subject: "Engineers Teach Physics") %>
+      For more information, email <%= govuk_mail_to(Settings.campaign_email, subject: "Engineers Teach Physics", class: "govuk-link") %>
     </p>
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
       <h1 class="govuk-fieldset__heading">

--- a/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
@@ -35,6 +35,27 @@ feature "updating engineers teach physics", { can_edit_current_and_next_cycles: 
     # TODO: success message?
   end
 
+  scenario "updating subject from physics to another subject resets campaign_name" do
+    and_there_is_a_secondary_course_i_want_to_edit
+    when_i_visit_the_edit_course_subject_page
+    when_i_select_a_subject(:physics)
+    and_i_click_continue
+    then_i_am_met_with_the_edit_engineers_teach_physics_page
+    and_i_select_an_option
+    and_i_click_continue
+    then_i_am_met_with_course_details_page
+    when_i_visit_the_edit_course_subject_page
+    when_i_select_a_subject(:latin)
+    and_i_click_continue
+    then_i_am_met_with_course_details_page
+    when_i_visit_the_edit_course_subject_page
+    when_i_select_a_subject(:physics)
+    and_i_click_continue
+    then_i_am_met_with_the_edit_engineers_teach_physics_page
+    and_i_click_continue
+    then_i_see_an_error_message
+  end
+
 private
 
   def then_i_see_an_error_message
@@ -109,6 +130,8 @@ private
     case subject_type
     when :physics
       find_or_create(:secondary_subject, :physics)
+    when :latin
+      find_or_create(:secondary_subject, :latin)
     when :modern_languages
       find_or_create(:secondary_subject, :modern_languages)
     end

--- a/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
@@ -99,13 +99,13 @@ private
 
   def params_with_subject(level, subject_type)
     course_subject = course_subject(subject_type)
-    "course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}"
+    "course%5Bcampaign_name%5D=&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}"
   end
 
   def modern_language_params_with_subject(level, subject_type)
     subordinate_subject = course_subject(:modern_languages)
     course_subject = course_subject(subject_type)
-    "course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{subordinate_subject.id}"
+    "course%5Bcampaign_name%5D=&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{subordinate_subject.id}"
   end
 
   def form_params_with_subject(level, subject_type)
@@ -119,3 +119,8 @@ private
     "course%5Bcampaign_name%5D=engineers_teach_physics&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{subordinate_subject.id}"
   end
 end
+
+
+#/publish/organisations/A02/2023/courses/engineers-teach-physics/new?course%5Bcampaign_name%5D=&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=secondary&course%5Bmaster_subject_id%5D=29&course%5Bsubjects_ids%5D%5B%5D=29&course%5Bsubjects_ids%5D%5B%5D=33
+
+#/publish/organisations/A02/2023/courses/engineers-teach-physics/new?course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=secondary&course%5Bmaster_subject_id%5D=29&course%5Bsubjects_ids%5D%5B%5D=29&course%5Bsubjects_ids%5D%5B%5D=33

--- a/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
@@ -119,8 +119,3 @@ private
     "course%5Bcampaign_name%5D=engineers_teach_physics&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{subordinate_subject.id}"
   end
 end
-
-
-#/publish/organisations/A02/2023/courses/engineers-teach-physics/new?course%5Bcampaign_name%5D=&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=secondary&course%5Bmaster_subject_id%5D=29&course%5Bsubjects_ids%5D%5B%5D=29&course%5Bsubjects_ids%5D%5B%5D=33
-
-#/publish/organisations/A02/2023/courses/engineers-teach-physics/new?course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=secondary&course%5Bmaster_subject_id%5D=29&course%5Bsubjects_ids%5D%5B%5D=29&course%5Bsubjects_ids%5D%5B%5D=33

--- a/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
@@ -84,6 +84,11 @@ private
     expect(page).to have_content("Pick all the languages for this course")
   end
 
+  def then_i_am_met_with_the_modern_languages_page
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
+    expect(page).to have_content("Pick all the languages for this course")
+  end
+
   def provider
     @provider ||= @user.providers.first
   end
@@ -92,6 +97,8 @@ private
     case subject_type
     when :physics
       find_or_create(:secondary_subject, :physics)
+    when :latin
+      find_or_create(:secondary_subject, :latin)
     when :modern_languages
       find_or_create(:secondary_subject, :modern_languages)
     end
@@ -99,13 +106,13 @@ private
 
   def params_with_subject(level, subject_type)
     course_subject = course_subject(subject_type)
-    "course%5Bcampaign_name%5D=&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}"
+    "course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}"
   end
 
   def modern_language_params_with_subject(level, subject_type)
     subordinate_subject = course_subject(:modern_languages)
     course_subject = course_subject(subject_type)
-    "course%5Bcampaign_name%5D=&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{subordinate_subject.id}"
+    "course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{subordinate_subject.id}"
   end
 
   def form_params_with_subject(level, subject_type)

--- a/spec/features/publish/courses/new_subject_spec.rb
+++ b/spec/features/publish/courses/new_subject_spec.rb
@@ -83,6 +83,6 @@ private
 
   def params_with_subject(level, subject_type)
     course_subject = course_subject(subject_type)
-    "course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}"
+    "course%5Bcampaign_name%5D=&course%5Bis_send%5D=%5B%220%22%5D&course%5Blevel%5D=#{level}&course%5Bmaster_subject_id%5D=#{course_subject.id}&course%5Bsubjects_ids%5D%5B%5D=#{course_subject.id}"
   end
 end

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -115,6 +115,7 @@ private
     course_subject = course_subject(level)
     course_creation_params[:subjects_ids] = [course_subject.id.to_s]
     course_creation_params[:master_subject_id] = course_subject.id.to_s
+    course_creation_params[:campaign_name] = ""
 
     new_subjects_page.subjects_fields.select(course_subject.subject_name)
     new_subjects_page.continue.click


### PR DESCRIPTION
### Context
We need to make sure we're resetting the campaign_name back to nil when a user changes from ETP to a different subject.
What needs to be done

Handle this edge case where ever the subject is changed so that the field is set back to nil on the course
### Changes proposed in this pull request
clear campaign_name params for new action and update course model in update action in subjects controller
### Guidance to review
Create new Physics course then change course from confirmation page, then change back to Physics course, ETP radio buttons should be blank. Do same with existing course from basics details page.
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
