### PR TITLE
Use subject name not course title for qualifications needed 

### DIFF
--- a/app/components/find_interface/courses/entry_requirements_component/view.rb
+++ b/app/components/find_interface/courses/entry_requirements_component/view.rb
@@ -31,7 +31,7 @@ module FindInterface
       end
 
       def secondary_advisory(course)
-        "Your degree subject should be in #{course.name} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
+        "Your degree subject should be in #{course.subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
       end
 
       def pending_gcse_content(course)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -61,6 +61,17 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
+  def subject_name_or_names
+    case object.subjects.size
+    when 1
+      object.subjects.first.subject_name
+    when 2
+      "#{object.subjects.first.subject_name} with #{object.subjects.second.subject_name}"
+    else
+      object.name
+    end
+  end
+
   def has_scholarship_and_bursary?
     object.has_bursary? && object.has_scholarship?
   end

--- a/spec/components/find_interface/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find_interface/courses/entry_requirements_component/view_preview.rb
@@ -32,12 +32,13 @@ module FindInterface::Courses::EntryRequirementsComponent
         accept_science_gcse_equivalency: true,
         additional_gcse_equivalencies: "much much more",
         personal_qualities: "Personal Qualities Text Goes Here",
-        other_requirements: "Other Requirements Text Goes Here")
+        other_requirements: "Other Requirements Text Goes Here",
+        subject_name_or_names: "Biology")
     end
 
     class FakeCourse
       include ActiveModel::Model
-      attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements)
+      attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :subject_name_or_names)
 
       def enrichment_attribute(params)
         send(params)

--- a/spec/components/find_interface/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find_interface/courses/entry_requirements_component/view_spec.rb
@@ -49,18 +49,21 @@ describe FindInterface::Courses::EntryRequirementsComponent::View, type: :compon
 
   context "when the provider requires grade 5 and the course is secondary" do
     it "renders correct message" do
-      course = build(
+      raw_course = build(
         :course,
         provider: build(:provider, provider_code: "U80"),
         level: "secondary",
       )
+
+      course = raw_course.decorate
+
       result = render_inline(described_class.new(course: course.decorate))
 
       expect(result.text).to include(
                                "Grade 5 (C) or above in English and maths, or equivalent qualification.",
                              )
       expect(result.text).to include(
-                               "Your degree subject should be in #{course.name} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way",
+                               "Your degree subject should be in #{course.subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way",
                              )
     end
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -319,6 +319,23 @@ describe CourseDecorator do
     end
   end
 
+  describe "#subject_name_or_names" do
+    context "course has more than one subject" do
+      it "returns both subjects names seperated by a 'with'" do
+        expect(decorated_course.subject_name_or_names).to eq("English with Mathematics")
+      end
+    end
+
+    context "course has one subject" do
+      let(:course_subject) { find_or_create :secondary_subject, :computing }
+      let(:course) { build_stubbed(:course, subjects: [course_subject]) }
+
+      it "return the subject name" do
+        expect(decorated_course.subject_name_or_names).to eq("Computing")
+      end
+    end
+  end
+
   #   describe "#bursary_requirements" do
   #     let(:subject) { decorated_course.bursary_requirements }
 


### PR DESCRIPTION
### Context

Use subject name not course title for qualifications needed to satisfy entry requirements. (This has been done for the current Find [here](https://github.com/DFE-Digital/find-teacher-training/pull/1555)).

The reason for this change is because if support changes the course title, the sentence may not make sense to the candidate.

Added a new method for this to handle course with two subjects.

### Changes proposed in this pull request

Added a new method for this to handle courses with two subjects.

### Guidance to review

- Find a course
- Check the name in this section: `course/{PROVIDER_CODE}/{COURSE_CODE}#section-entry`
- Change the name in support and check the correct subject names still appear. 
- Experiment with multiple subjects

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
