### PR TITLE
Remove the manual fix for expat vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN apk add --update --no-cache tzdata && \
 RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
-# Remove once base image ruby:3.1-alpine3.15 has been updated with latest expat
-RUN apk add --no-cache expat=2.5.0-r0
-
 ENV APP_HOME /app
 
 RUN mkdir $APP_HOME


### PR DESCRIPTION
### Context
The fixed version for [vulnerability](https://security.snyk.io/vuln/SNYK-ALPINE315-EXPAT-3062885) is now installed by default when the dependency expat is required. We can therefore remove the manual installation of this from the Dockerfile.

### Changes proposed in this pull request
Remove manual add of expat 2.5.0-r0

### Guidance to review
Confirm Snyk tests pass in build

### Trello Card
https://trello.com/c/NkBxwoiL/714-libexpat-vulnerability

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
