### PR TITLE
Implement engineers teach physics filter on Find

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -30,6 +30,7 @@ class CourseSearchService
     scope = scope.with_degree_grades(degree_grades) if degree_grades.any?
     scope = scope.changed_since(filter[:updated_since]) if updated_since_filter?
     scope = scope.can_sponsor_visa if can_sponsor_visa_filter?
+    scope = scope.engineers_teach_physics if engineers_teach_physics_filter?
 
     # The 'where' scope will remove duplicates
     # An outer query is required in the event the provider name is present.
@@ -240,5 +241,9 @@ private
 
   def can_sponsor_visa_filter?
     filter[:can_sponsor_visa].to_s.downcase == "true"
+  end
+
+  def engineers_teach_physics_filter?
+    filter[:engineers_teach_physics].to_s.downcase == "true"
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1206,6 +1206,26 @@ describe Course do
       end
     end
 
+    describe ".engineers_teach_physics" do
+      subject { described_class.engineers_teach_physics }
+
+      context "when the course has the campaign 'engineers_teach_physics'" do
+        let(:course) { create(:course, :engineers_teach_physics) }
+
+        it "returns the course" do
+          expect(subject).to eq [course]
+        end
+      end
+
+      context "when the course has no campaign" do
+        let(:course) { create(:course, provider:) }
+
+        it "does not return the course" do
+          expect(subject).to eq []
+        end
+      end
+    end
+
     describe ".can_sponsor_visa" do
       subject { described_class.can_sponsor_visa }
 


### PR DESCRIPTION
### Context

In line with the "Engineers teach physics" work, we are adding a filter on Find to search for only these courses. This filter will appear when searching for the "Physics" subject.

These are the backend changes, see https://github.com/DFE-Digital/find-teacher-training/pull/1567 for frontend. 

### Changes proposed in this pull request

- Add scope which returns courses with the campaign_name "engineers_teach_physics"

- Add the scope to the course search service

### Guidance to review

- Checkout this branch along with the respective branch on Find, [here](https://github.com/DFE-Digital/find-teacher-training/pull/1567)
- Perform a search for a Physics course on Find
- Try out the new filter

### Screenshot

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/50492247/198319714-840746e5-b6dc-4d57-8a88-59a339e3d958.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
