### PR TITLE
Expose campaign name field in api and docs

### DIFF
--- a/app/deserializers/api/v3/deserializable_course.rb
+++ b/app/deserializers/api/v3/deserializable_course.rb
@@ -41,6 +41,7 @@ module API
         additional_gcse_equivalencies
         can_sponsor_skilled_worker_visa
         can_sponsor_student_visa
+        campaign_name
       ].freeze
 
       attributes(*COURSE_ATTRIBUTES)

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -47,7 +47,8 @@ module API
           :accept_science_gcse_equivalency,
           :additional_gcse_equivalencies,
           :can_sponsor_skilled_worker_visa,
-          :can_sponsor_student_visa
+          :can_sponsor_student_visa,
+          :campaign_name
 
         attribute :about_accredited_body do
           @object.accrediting_provider_description

--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -28,7 +28,7 @@ module API
         :accept_science_gcse_equivalency, :additional_gcse_equivalencies,
         :degree_grade, :additional_degree_subject_requirements,
         :degree_subject_requirements, :can_sponsor_skilled_worker_visa,
-        :can_sponsor_student_visa
+        :can_sponsor_student_visa, :campaign_name
 
       attribute :start_date do
         written_month_year(@object.start_date) if @object.start_date

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -7,7 +7,7 @@ weight: 2
 
 # 1 November 2022
 
-- Add `campaign_name` field to `CourseAttributes`. This is an array of strings, corresponding to campaigns created to help improve recruitment.
+- Add `campaign_name` field to `CourseAttributes`. This is a string, corresponding to campaigns created to help improve recruitment.
 
 ## 31 March 2022
 

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -5,6 +5,10 @@ weight: 2
 
 # Release Notes
 
+# 1 November 2022
+
+- Add `campaign_name` field to `CourseAttributes`. This is an array of strings, corresponding to campaigns created to help improve recruitment.
+
 ## 31 March 2022
 
 We have introduced two new fields to the `CourseAttributes` schema which provide a way to determine availability for visa sponsorships with regards to individual courses.

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -290,7 +290,8 @@ RSpec.describe API::Public::V1::CoursesController do
                 personal_qualities
                 salary_details
                 can_sponsor_skilled_worker_visa
-                can_sponsor_student_visa]
+                can_sponsor_student_visa
+                campaign_name]
           end
 
           before do

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -69,7 +69,7 @@ describe "API" do
         let(:include) { "provider" }
 
         before do
-          create(:course, course_code: "C100")
+          create(:course, :engineers_teach_physics, course_code: "C100")
         end
 
         schema({ "$ref": "#/components/schemas/CourseListResponse" })

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -74,8 +74,8 @@ describe "API" do
         let(:include) { "provider" }
 
         before do
-          create(:course, provider:, course_code: "C100")
-          create(:course, provider:, course_code: "C101")
+          create(:course, :engineers_teach_physics, provider:, course_code: "C100")
+          create(:course, :engineers_teach_physics, provider:, course_code: "C101")
         end
 
         schema({ "$ref": "#/components/schemas/CourseListResponse" })
@@ -123,7 +123,7 @@ describe "API" do
 
       response "200", "The collection of courses offered by the specified provider." do
         let(:provider) { create(:provider) }
-        let(:course) { create(:course, course_code: "A123", provider:) }
+        let(:course) { create(:course, :engineers_teach_physics, course_code: "A123", provider:) }
 
         let(:year) { provider.recruitment_cycle.year }
         let(:provider_code) { provider.provider_code }

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -124,6 +124,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                 "degree_subject_requirements" => provider.courses[0].degree_subject_requirements,
                 "can_sponsor_skilled_worker_visa" => provider.courses[0].can_sponsor_skilled_worker_visa,
                 "can_sponsor_student_visa" => provider.courses[0].can_sponsor_student_visa,
+                "campaign_name" => provider.courses[0].campaign_name,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -158,6 +158,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
             "degree_subject_requirements" => course.degree_subject_requirements,
             "can_sponsor_skilled_worker_visa" => course.can_sponsor_skilled_worker_visa,
             "can_sponsor_student_visa" => course.can_sponsor_student_visa,
+            "campaign_name" => course.campaign_name,
           },
           "relationships" => {
             "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:scholarship_amount).with_value(nil) }
   it { is_expected.to have_attribute(:can_sponsor_skilled_worker_visa) }
   it { is_expected.to have_attribute(:can_sponsor_student_visa) }
+  it { is_expected.to have_attribute(:campaign_name) }
 
   context "when bursary amount is present" do
     let(:course) { create(:course, :with_accrediting_provider, :secondary, enrichments: [enrichment], subjects: [find_or_create(:secondary_subject, :classics)]) }

--- a/spec/serializers/api/v3/serializable_course_spec.rb
+++ b/spec/serializers/api/v3/serializable_course_spec.rb
@@ -39,6 +39,7 @@ describe API::V3::SerializableCourse do
   it { is_expected.to have_attribute :program_type }
   it { is_expected.to have_attribute :can_sponsor_skilled_worker_visa }
   it { is_expected.to have_attribute :can_sponsor_student_visa }
+  it { is_expected.to have_attribute :campaign_name }
 
   context "with a provider" do
     let(:provider) { course.provider }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -549,6 +549,16 @@
             "type": "boolean",
             "description": "Does this course provide sponsorship for a student visa?",
             "example": false
+          },
+          "campaign_name": {
+            "type": "string",
+            "nullable": true,
+            "description": "The course’s campaign code, corresponding to campaigns to help improve recruitment.",
+            "example": "engineers_teach_physics",
+            "enum": [
+              "engineers_teach_physics",
+              "no_campaign"
+            ]
           }
         }
       },

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -391,3 +391,11 @@ properties:
     type: boolean
     description: "Does this course provide sponsorship for a student visa?"
     example: false
+  campaign_name:
+    type: string
+    nullable: true
+    description: "The course’s campaign code, corresponding to campaigns to help improve recruitment."
+    example: "engineers_teach_physics"
+    enum:
+      - engineers_teach_physics
+      - no_campaign


### PR DESCRIPTION
### Context

We added ETP as a new course step in the course flow on Publish. This is the PR to expose the `campaign_name` field powering this logic via the public API.

### Changes proposed in this pull request

- Expose `campaign_name` field as an attribute on the public API
- Update docs

### Guidance to review

Create a Physics course with the `campaign_name`: `engineers_teach_physics` and check that you can view the campaign name on the public api: `http://localhost:3001/api/public/v1/recruitment_cycles/2023/providers/{provider_code}/courses/{course_code}`

Repeat for a course not in that campaign and ensure it is `null`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
