### PR TITLE
[761] Migrate the Feedback component

### DIFF
--- a/app/components/find_interface/feedback_component.html.erb
+++ b/app/components/find_interface/feedback_component.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-width-container">
+  <div class="app-feedback">
+    <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-4">
+      <%= govuk_link_to(
+        "How can we improve this page? (Opens in a new tab)",
+        "#{Settings.apply_base_url}/candidate/find-feedback?path=#{@path}&find_controller=#{@controller}",
+        class: "govuk-!-margin-top-4",
+        data: { qa: "feedback-link" },
+        target: "_blank",
+        rel: "noopener",
+      ) %>
+    </p>
+  </div>
+</div>

--- a/app/components/find_interface/feedback_component.rb
+++ b/app/components/find_interface/feedback_component.rb
@@ -1,0 +1,13 @@
+module FindInterface
+  class FeedbackComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :path, :controller
+
+    def initialize(path:, controller:)
+      super
+      @path = path
+      @controller = controller
+    end
+  end
+end

--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -3,6 +3,10 @@ module Find
     layout "find_layout"
     default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+    def render_feedback_component
+      @render_feedback_component = true
+    end
+
   private
 
     def provider

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -1,7 +1,6 @@
 module Find
   class ResultsController < ApplicationController
-    # FIND:TODO add this
-    # before_action :render_feedback_component
+    before_action :render_feedback_component
 
     def index
       @results_view = ResultsView.new(query_parameters: request.query_parameters)

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,42 +1,36 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<html>
   <head>
-    <title><%= yield :page_title %> - <%= t("service_name.find") %> - GOV.UK</title>
+    <title>Component Preview</title>
+
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
     <%= favicon_link_tag "govuk-frontend/govuk/assets/images/favicon.ico" %>
     <%= favicon_link_tag "govuk-frontend/govuk/assets/images/govuk-mask-icon.svg", rel: "mask-icon", type: "image/svg", color: "#0b0c0c" %>
     <%= favicon_link_tag "govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png", rel: "apple-touch-icon", type: "image/png" %>
     <%= favicon_link_tag "govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png", rel: "apple-touch-icon", type: "image/png", size: "152x152" %>
     <%= favicon_link_tag "govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png", rel: "apple-touch-icon", type: "image/png", size: "167x167" %>
     <%= favicon_link_tag "govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png", rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
+    <%= stylesheet_link_tag "accessible-autocomplete/dist/accessible-autocomplete.min" %>
     <%= stylesheet_link_tag "find_application" %>
+    <%= stylesheet_link_tag "publish_application" %>
     <%= javascript_include_tag "find/application", "data-turbo-track": "reload", defer: true %>
+    <%= javascript_include_tag "publish/application", "data-turbo-track": "reload", defer: true %>
   </head>
 
   <body class="govuk-template__body">
     <%= render "layouts/add_js_enabled_class_to_body" %>
 
     <%= render FindInterface::Header::View.new(
-      service_name: t("service_name.find"),
+      service_name: "Find & Publish Components",
     ) %>
 
     <div class="govuk-width-container">
-      <%= render FindInterface::PhaseBanner::View.new %>
-
-      <%= yield :before_content %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= yield %>
       </main>
     </div>
-
-    <% if @render_feedback_component %>
-      <%= render(
-        FindInterface::FeedbackComponent.new(
-          path: request.env["PATH_INFO"],
-          controller: params[:controller],
-        ),
-      ) %>
-    <% end %>
-
-    <%= render "layouts/find_footer" %>
   </body>
 </html>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -24,7 +24,7 @@
     <%= render "layouts/add_js_enabled_class_to_body" %>
 
     <%= render FindInterface::Header::View.new(
-      service_name: "Find & Publish Components",
+      service_name: "Find and Publish Components",
     ) %>
 
     <div class="govuk-width-container">

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Component Preview</title>
+    <title>Component Preview - Find and Publish Components - GOV.UK</title>
 
     <meta name="viewport" content="width=device-width,initial-scale=1">
 

--- a/app/views/view_components/index.html.erb
+++ b/app/views/view_components/index.html.erb
@@ -1,0 +1,15 @@
+<h1 class="govuk-heading-l">Find and Publish Components</h1>
+
+<p class="govuk-body">
+  Below are view components used in Find and Publish.
+  These act as larger building blocks used to build pages specific to the Find and Publish services leveraging the <%= govuk_link_to("GOV.UK Design System", "https://design-system.service.gov.uk/") %> and the <%= govuk_link_to("GOV.UK components gem", "https://github.com/DFE-Digital/govuk-components") %>
+</p>
+
+<% @previews.each do |preview| %>
+  <h3 class="govuk-heading-m"><%= link_to preview.preview_name.titleize, preview_view_component_path(preview.preview_name) %></h3>
+  <ul class="govuk-list">
+    <% preview.examples.each do |preview_example| %>
+      <li><%= govuk_link_to preview_example, preview_view_component_path("#{preview.preview_name}/#{preview_example}") %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/view_components/index.html.erb
+++ b/app/views/view_components/index.html.erb
@@ -6,7 +6,7 @@
 </p>
 
 <% @previews.each do |preview| %>
-  <h3 class="govuk-heading-m"><%= link_to preview.preview_name.titleize, preview_view_component_path(preview.preview_name) %></h3>
+  <h2 class="govuk-heading-m"><%= link_to preview.preview_name.titleize, preview_view_component_path(preview.preview_name) %></h2>
   <ul class="govuk-list">
     <% preview.examples.each do |preview_example| %>
       <li><%= govuk_link_to preview_example, preview_view_component_path("#{preview.preview_name}/#{preview_example}") %></li>

--- a/app/views/view_components/previews.html.erb
+++ b/app/views/view_components/previews.html.erb
@@ -1,0 +1,7 @@
+<h2 class="govuk-heading-m"><%= @preview.preview_name.titleize %></h2>
+
+<ul class="govuk-list">
+  <% @preview.examples.each do |example| %>
+    <li><%= govuk_link_to example, preview_view_component_path("#{@preview.preview_name}/#{example}") %></li>
+  <% end %>
+</ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,7 @@ module ManageCoursesBackend
 
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/view_components"
+    config.view_component.default_preview_layout = "component_preview"
     config.view_component.preview_controller = "ComponentPreviewsController"
     config.view_component.show_previews = !Rails.env.production?
 

--- a/config/settings/loadtest.yml
+++ b/config/settings/loadtest.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://publish-teacher-training-loadtest.london.cloudapps.digital
 publish_url: https://publish-loadtest.london.cloudapps.digital
 find_url: https://find-loadtest.london.cloudapps.digital
+apply_base_url: https://apply-loadtest.london.cloudapps.digital
 
 # URL of this app for the callback after signing in
 base_url: https://publish-loadtest.london.cloudapps.digital

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -3,6 +3,7 @@ publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 find_temp_url: https://qa2.find-postgraduate-teacher-training.service.gov.uk
+apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -7,6 +7,7 @@ environment:
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
 environment:
   label: "Sandbox"

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:
   base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk

--- a/spec/components/find_interface/feedback_component_preview.rb
+++ b/spec/components/find_interface/feedback_component_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module FindInterface
+  class FeedbackComponentPreview < ViewComponent::Preview
+    def default
+      render(FeedbackComponent.new(path: "/path", controller: "results"))
+    end
+  end
+end

--- a/spec/components/find_interface/feedback_component_spec.rb
+++ b/spec/components/find_interface/feedback_component_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+module FindInterface
+  describe FeedbackComponent, type: :component do
+    let(:path) { "/path" }
+
+    it "renders the correct feedback link" do
+      render_inline(described_class.new(path:, controller: "results"))
+
+      expect(page).to have_link(
+        "How can we improve this page? (Opens in a new tab)",
+        href: "#{Settings.apply_base_url}/candidate/find-feedback?path=#{path}&find_controller=results",
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/LCDdyOYs/761-migrate-the-feedback-component

### Changes proposed in this pull request

- Migrate the Find FeedbackComponent
- Create a separate layout for previewing view components so we can load the Publish and Find styles in order for components to display properly
- Give the layout a bit of love to look more on brand

### Guidance to review

https://publish-teacher-training-pr-3095.london.cloudapps.digital/find/results (bottom of page)
https://publish-teacher-training-pr-3095.london.cloudapps.digital/view_components

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
