### PR TITLE
Update guidance for international candidates

### DIFF
--- a/app/components/find_interface/courses/international_students_component/view.html.erb
+++ b/app/components/find_interface/courses/international_students_component/view.html.erb
@@ -2,7 +2,15 @@
   <h2 class="govuk-heading-l" id="section-international-students">International candidates</h2>
   <div data-qa="course__international_students">
 
-    <p class="govuk-body">You’ll need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
+    <% if apprenticeship? %>
+      <p class="govuk-body">To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course.</p>
+
+      <p class="govuk-body">EEA nationals with settled or pre-settled status under the
+        <%= govuk_link_to("EU Settlement Scheme", t("links.eu_settlement_scheme")) %> who have lived continuously in the
+        EEA, Switzerland, Gibraltar, or the UK for at least the previous 3 years will also be eligible.</p>
+    <% end %>
+
+    <p class="govuk-body"><%= apprenticeship? ? "You’ll also" : "You’ll" %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>are an Irish citizen</li>

--- a/app/components/find_interface/courses/international_students_component/view.rb
+++ b/app/components/find_interface/courses/international_students_component/view.rb
@@ -3,6 +3,8 @@ module FindInterface
     class InternationalStudentsComponent::View < ViewComponent::Base
       attr_reader :course
 
+      delegate :apprenticeship?, to: :course
+
       def initialize(course:)
         super
         @course = course

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -119,6 +119,10 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def apprenticeship?
+    object.funding_type == "apprenticeship"
+  end
+
+  def apprenticeship
     object.funding_type.to_s == "apprenticeship" ? "Yes" : "No"
   end
 

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -65,7 +65,7 @@
       <% if @provider.accredited_body? %>
         <% summary_list.row(html_attributes: { data: { qa: "course__apprenticeship" } }) do |row| %>
           <% row.key { "Apprenticeship" } %>
-          <% row.value { course.apprenticeship? } %>
+          <% row.value { course.apprenticeship } %>
           <% if course.is_published? %>
             <% row.action %>
           <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -544,6 +544,7 @@ en:
     web_content_accessibility_guidelines: "https://www.w3.org/TR/WCAG21/"
     gov_design_accessibility: "https://design-system.service.gov.uk/accessibility/"
     ico_complaint: "https://ico.org.uk/make-a-complaint/"
+    eu_settlement_scheme: "https://www.gov.uk/settled-status-eu-citizens-families"
   edit_options:
     qualifications:
       qts:

--- a/spec/components/find_interface/courses/international_students_component/view_preview.rb
+++ b/spec/components/find_interface/courses/international_students_component/view_preview.rb
@@ -14,6 +14,12 @@ module FindInterface::Courses::InternationalStudentsComponent
       render FindInterface::Courses::InternationalStudentsComponent::View.new(course:)
     end
 
+    def apprenticeship_course
+      course = Course.new(course_code: "FIND", program_type: "pg_teaching_apprenticeship",
+        provider:).decorate
+      render FindInterface::Courses::InternationalStudentsComponent::View.new(course:)
+    end
+
     def non_salaried_course_and_can_sponsor_student_visa
       course = Course.new(course_code: "FIND", program_type: "school_direct_training_programme", can_sponsor_student_visa: true,
         provider:).decorate

--- a/spec/components/find_interface/courses/international_students_component/view_spec.rb
+++ b/spec/components/find_interface/courses/international_students_component/view_spec.rb
@@ -37,6 +37,14 @@ describe FindInterface::Courses::InternationalStudentsComponent::View, type: :co
     it "tells candidates visa sponsorship may be available, but they should check" do
       expect(page).to have_text("Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.")
     end
+
+    it "does not tell candidates the 3-year residency rule" do
+      expect(page).not_to have_text("To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course")
+    end
+
+    it "does not tell candidates about settled and pre-settled status" do
+      expect(page).not_to have_text("EEA nationals with settled or pre-settled status under the")
+    end
   end
 
   context "when the course is salaried and can sponsor Skilled Worker visas" do
@@ -74,6 +82,32 @@ describe FindInterface::Courses::InternationalStudentsComponent::View, type: :co
 
     it "tells candidates visa sponsorship is not available" do
       expect(page).to have_text("Sponsorship is not available for this course")
+    end
+
+    it "does not tell candidates the 3-year residency rule" do
+      expect(page).not_to have_text("To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course")
+    end
+
+    it "does not tell candidates about settled and pre-settled status" do
+      expect(page).not_to have_text("EEA nationals with settled or pre-settled status under the")
+    end
+  end
+
+  context "when the course is an apprenticeship" do
+    before do
+      course = build(
+        :course,
+        funding_type: "apprenticeship",
+      )
+      render_inline(described_class.new(course: CourseDecorator.new(course)))
+    end
+
+    it "tells candidates the 3-year residency rule" do
+      expect(page).to have_text("To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course")
+    end
+
+    it "tells candidates about settled and pre-settled status" do
+      expect(page).to have_text("EEA nationals with settled or pre-settled status under the")
     end
   end
 end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -64,7 +64,7 @@ describe CourseDecorator do
   end
 
   it "returns if course is an apprenticeship" do
-    expect(decorated_course.apprenticeship?).to eq("No")
+    expect(decorated_course.apprenticeship?).to be(false)
   end
 
   it "returns if course is SEND?" do


### PR DESCRIPTION
### Context

State the 3-year residency rule for apprenticeship courses.

### Changes proposed in this pull request

- Change the `apprenticeship?` method to return true or false 
- Add a new `apprenticeship` method for the basic details page (previously using `apprenticeship?` which is semantically incorrect.
- Utilise this in the view component to render the 3-year text if the course is an apprenticeship
- Add the word `also` if the course is an apprenticeship (as there is content before this now).
- Add view preview

### Guidance to review

- Check `#section-international-students` for apprenticeship courses and ensure the new content is there and is correct.
- Repeat for fee paying and salaried courses and ensure the new content is not present. 
- Checkout the view preview
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
