### PR TITLE
Remove subjects from ignored list

### DIFF
--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -20,14 +20,12 @@ module Find
 
   private
 
-    # These subjects don’t currently match any courses, and so can be dropped.
-    IGNORED_SUBJECTS = ["Philosophy", "Modern Languages", "Ancient Hebrew", "Ancient Greek"].freeze
     SecondarySubjectInput = Struct.new(:code, :name, :financial_info)
 
     def secondary_subjects
       Subject.includes(:financial_incentive)
              .where(type: %w[SecondarySubject ModernLanguagesSubject])
-             .where.not(subject_name: IGNORED_SUBJECTS)
+             .where.not(subject_name: ["Modern Languages"])
              .order(:subject_name)
     end
   end

--- a/spec/features/find/course_searches_spec.rb
+++ b/spec/features/find/course_searches_spec.rb
@@ -28,7 +28,7 @@ feature "course searches" do
     when_i_choose_secondary
     then_i_click_continue_on_the(age_groups_page)
     then_i_should_see_the_subjects_form
-    and_i_should_not_see_hidden_subjects
+    and_i_should_not_see_modern_languages
     then_the_correct_subjects_form_page_url_and_query_params_are_present
   end
 
@@ -100,9 +100,7 @@ private
     expect(secondary_subjects_page).to have_content("Which secondary subjects do you want to teach?")
   end
 
-  def and_i_should_not_see_hidden_subjects
-    expect(secondary_subjects_page).not_to have_content("Ancient Hebrew")
-    expect(secondary_subjects_page).not_to have_content("Philosophy")
+  def and_i_should_not_see_modern_languages
     expect(secondary_subjects_page).not_to have_content("Modern Languages")
   end
 


### PR DESCRIPTION
### Context

Remove Ancient greek, Hebrew and Philosophy from the ignored list. We handle empty states on the course list, not by hiding subjects.

### Changes proposed in this pull request

- Remove the `IGNORED_SUBJECTS` array and only reject modern languages.

### Guidance to review

- Perform a search on Find and ensure that you now see Ancient greek, Hebrew and Philosophy (you should see no courses with these subjects).
- Create these courses and search for them and ensure the courses created appear in the search.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
