### PR TITLE
[777] Migrate the find feature flags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,6 +137,9 @@ gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"
 # For running data migrations
 gem "data_migrate"
 
+# For outgoing http requests
+gem "http"
+
 group :production, :qa, :sandbox, :staging do
   gem "cloudfront-rails"
 end
@@ -230,6 +233,7 @@ end
 group :test do
   gem "database_cleaner"
   gem "jsonapi-rspec"
+  gem "mock_redis"
   gem "rspec_junit_formatter"
   gem "shoulda-matchers", "~> 5.2"
   gem "simplecov", "< 0.22", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,8 @@ GEM
     discard (1.2.1)
       activerecord (>= 4.2, < 8)
     docile (1.4.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -259,6 +261,9 @@ GEM
       faraday (~> 2.5)
       net-http-persistent (~> 4.0)
     ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     formatador (1.1.0)
     fugit (1.7.1)
       et-orbi (~> 1, >= 1.2.7)
@@ -335,6 +340,14 @@ GEM
     hashie (5.0.0)
     html-attributes-utils (0.9.2)
       activesupport (>= 6.1.4.4)
+    http (5.1.0)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -387,6 +400,9 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -402,6 +418,8 @@ GEM
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     minitest (5.16.3)
+    mock_redis (0.34.0)
+      ruby2_keywords
     msgpack (1.5.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -688,6 +706,9 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     uk_postcode (2.1.8)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.3.0)
     uniform_notifier (1.16.0)
     validate_email (0.1.6)
@@ -761,6 +782,7 @@ DEPENDENCIES
   guard
   guard-rspec
   guard-rubocop
+  http
   httparty
   jsbundling-rails (~> 1.0)
   jsonapi-rails!
@@ -771,6 +793,7 @@ DEPENDENCIES
   kaminari
   launchy
   listen (>= 3.0.5, < 3.8)
+  mock_redis
   oj
   omniauth (~> 2.1)
   omniauth-rails_csrf_protection (~> 1.0)

--- a/app/components/find_interface/feature_history_component.html.erb
+++ b/app/components/find_interface/feature_history_component.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= history %>
+</p>

--- a/app/components/find_interface/feature_history_component.rb
+++ b/app/components/find_interface/feature_history_component.rb
@@ -1,0 +1,29 @@
+module FindInterface
+  class FeatureHistoryComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(feature_name)
+      super
+      @feature_name = feature_name
+    end
+
+    def history
+      if last_updated
+        formatted_date = DateTime.parse(last_updated).to_fs(:govuk_date_and_time)
+        "Changed to #{status} at #{formatted_date}"
+      else
+        "This flag has not been updated"
+      end
+    end
+
+  private
+
+    def last_updated
+      FeatureFlag.last_updated(@feature_name)
+    end
+
+    def status
+      FeatureFlag.active?(@feature_name) ? "active" : "inactive"
+    end
+  end
+end

--- a/app/components/find_interface/feature_toggle_component.html.erb
+++ b/app/components/find_interface/feature_toggle_component.html.erb
@@ -1,0 +1,7 @@
+<%= govuk_button_to(
+  toggle_label,
+  toggle_link,
+  class: 'app-button--tertiary govuk-!-margin-bottom-0',
+  aria: {
+    label: toggle_aria_label,
+  }) %>

--- a/app/components/find_interface/feature_toggle_component.rb
+++ b/app/components/find_interface/feature_toggle_component.rb
@@ -1,0 +1,28 @@
+module FindInterface
+  class FeatureToggleComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :feature_name
+
+    def initialize(feature_name:)
+      super
+      @feature_name = feature_name
+    end
+
+    def toggle_label
+      FeatureFlag.active?(feature_name) ? "Deactivate" : "Activate"
+    end
+
+    def toggle_link
+      if FeatureFlag.active?(feature_name)
+        find_feature_flags_path(feature_name:, state: :deactivate)
+      else
+        find_feature_flags_path(feature_name:, state: :activate)
+      end
+    end
+
+    def toggle_aria_label
+      "#{toggle_label} ‘#{feature_name}’ feature"
+    end
+  end
+end

--- a/app/components/find_interface/maintenance_banner_component.html.erb
+++ b/app/components/find_interface/maintenance_banner_component.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_notification_banner(title_text: 'Important') do |notification_banner| %>
+  <% notification_banner.heading(text: 'This service will be unavailable on Monday 11 October for a short period between 8pm and 9pm, while we carry out maintenance') %>
+  <p class="govuk-body">If you have any questions, contact us at <%= govuk_mail_to bat_contact_email_address %>.</p>
+<% end %>

--- a/app/components/find_interface/maintenance_banner_component.rb
+++ b/app/components/find_interface/maintenance_banner_component.rb
@@ -1,0 +1,8 @@
+module FindInterface
+  class MaintenanceBannerComponent < ViewComponent::Base
+    include ViewHelper
+    def render?
+      FeatureFlag.active?(:maintenance_banner) && !FeatureFlag.active?(:maintenance_mode)
+    end
+  end
+end

--- a/app/components/find_interface/utility/summary_card_component.html.erb
+++ b/app/components/find_interface/utility/summary_card_component.html.erb
@@ -1,0 +1,6 @@
+<section class="app-summary-card govuk-!-margin-bottom-6 <%= border_css_class %>">
+  <%= content %>
+  <div class="app-summary-card__body">
+    <%= render FindInterface::Utility::SummaryListComponent.new(rows: rows) %>
+  </div>
+</section>

--- a/app/components/find_interface/utility/summary_card_component.rb
+++ b/app/components/find_interface/utility/summary_card_component.rb
@@ -1,0 +1,41 @@
+module FindInterface
+  module Utility
+    class SummaryCardComponent < ViewComponent::Base
+      def initialize(rows:, border: true, editable: true, ignore_editable: [])
+        super
+        rows = transform_hash(rows) if rows.is_a?(Hash)
+        @rows = rows_including_actions_if_editable(rows, editable, ignore_editable)
+        @border = border
+      end
+
+      def border_css_class
+        @border ? "" : "no-border"
+      end
+
+    private
+
+      attr_reader :rows, :ignore_editable
+
+      def rows_including_actions_if_editable(rows, editable, ignore_editable)
+        rows.map do |row|
+          row.tap do |r|
+            next if r[:key].in? ignore_editable
+
+            unless editable
+              r.delete(:action)
+            end
+          end
+        end
+      end
+
+      def transform_hash(row_hash)
+        row_hash.map do |key, value|
+          {
+            key:,
+            value:,
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/components/find_interface/utility/summary_card_header_component.html.erb
+++ b/app/components/find_interface/utility/summary_card_header_component.html.erb
@@ -1,0 +1,6 @@
+<header class="app-summary-card__header" <%= @anchor ? "id=#{@anchor}" : nil %>>
+  <h<%= @heading_level %> class="app-summary-card__title">
+    <%= @title %>
+  </h<%= @heading_level %>>
+  <%= content %>
+</header>

--- a/app/components/find_interface/utility/summary_card_header_component.rb
+++ b/app/components/find_interface/utility/summary_card_header_component.rb
@@ -1,0 +1,12 @@
+module FindInterface
+  module Utility
+    class SummaryCardHeaderComponent < ViewComponent::Base
+      def initialize(title:, heading_level: 2, anchor: nil)
+        super
+        @title = title
+        @heading_level = heading_level
+        @anchor = anchor
+      end
+    end
+  end
+end

--- a/app/components/find_interface/utility/summary_list_component.html.erb
+++ b/app/components/find_interface/utility/summary_list_component.html.erb
@@ -1,0 +1,12 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% rows.each do |row| %>
+    <% summary_list.row(html_attributes: html_attributes(row)) do |summary_list_row| %>
+      <% summary_list_row.key { row[:key] } %>
+      <% summary_list_row.value { value(row) } %>
+
+      <% Array.wrap(actions(row)).each do |action| %>
+        <% summary_list_row.action(classes: 'govuk-!-display-none-print', **action) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/find_interface/utility/summary_list_component.rb
+++ b/app/components/find_interface/utility/summary_list_component.rb
@@ -1,0 +1,68 @@
+module FindInterface
+  module Utility
+    class SummaryListComponent < ViewComponent::Base
+      include ViewHelper
+
+      def initialize(rows:)
+        super
+        rows = transform_hash(rows) if rows.is_a?(Hash)
+        @rows = rows
+      end
+
+      def value(row)
+        if row[:value].is_a?(Array)
+          if row[:bulleted_format]
+            format_list_with_bullets(row[:value])
+          elsif row[:paragraph_format]
+            format_list_as_paragraphs(row[:value])
+          else
+            row[:value].map { |s| ERB::Util.html_escape(s) }.join("<br>").html_safe
+          end
+        elsif row[:value].html_safe?
+          row[:value].to_s
+        else
+          simple_format(row[:value], class: "govuk-body")
+        end
+      end
+
+      def actions(row)
+        defined_action = row[:action] || row[:actions]
+
+        return defined_action if defined_action.present?
+
+        { href: "" } if any_rows_with_actions?
+      end
+
+      def html_attributes(row)
+        row[:html_attributes] || {}
+      end
+
+    private
+
+      attr_reader :rows
+
+      def transform_hash(row_hash)
+        row_hash.map do |key, value|
+          {
+            key:,
+            value:,
+          }
+        end
+      end
+
+      def format_list_with_bullets(list)
+        tag.ul(class: "govuk-list govuk-list--bullet") do
+          safe_join(list.map { |item| tag.li(item) })
+        end
+      end
+
+      def format_list_as_paragraphs(list)
+        safe_join(list.map { |s| tag.p(class: "govuk-body") { ERB::Util.html_escape(s) } })
+      end
+
+      def any_rows_with_actions?
+        rows.any? { |row| (row[:action] || row[:actions]).present? }
+      end
+    end
+  end
+end

--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -16,7 +16,7 @@ module Find
     end
 
     def redirect_to_maintenance_page_if_flag_is_active
-      redirect_to maintainance_path if FeatureFlag.active?(:maintenance_mode)
+      redirect_to find_maintenance_path if FeatureFlag.active?(:maintenance_mode)
     end
   end
 end

--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -3,6 +3,8 @@ module Find
     layout "find_layout"
     default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+    before_action :redirect_to_maintenance_page_if_flag_is_active
+
     def render_feedback_component
       @render_feedback_component = true
     end
@@ -11,6 +13,10 @@ module Find
 
     def provider
       @provider ||= RecruitmentCycle.current.providers.find_by(provider_code: params[:provider_code])
+    end
+
+    def redirect_to_maintenance_page_if_flag_is_active
+      redirect_to maintainance_path if FeatureFlag.active?(:maintenance_mode)
     end
   end
 end

--- a/app/controllers/find/confirm_environment_controller.rb
+++ b/app/controllers/find/confirm_environment_controller.rb
@@ -1,5 +1,7 @@
 module Find
   class ConfirmEnvironmentController < ApplicationController
+    skip_before_action :redirect_to_maintenance_page_if_flag_is_active
+
     def new
       @confirmation = ConfirmEnvironment.new(from: params[:from])
     end

--- a/app/controllers/find/confirm_environment_controller.rb
+++ b/app/controllers/find/confirm_environment_controller.rb
@@ -1,0 +1,18 @@
+module Find
+  class ConfirmEnvironmentController < ApplicationController
+    def new
+      @confirmation = ConfirmEnvironment.new(from: params[:from])
+    end
+
+    def create
+      @confirmation = ConfirmEnvironment.new(params.require(:find_confirm_environment).permit(:from, :environment))
+
+      if @confirmation.valid?
+        session[:confirmed_environment_at] = Time.zone.now
+        redirect_to @confirmation.from
+      else
+        render :new
+      end
+    end
+  end
+end

--- a/app/controllers/find/feature_flags_controller.rb
+++ b/app/controllers/find/feature_flags_controller.rb
@@ -1,0 +1,38 @@
+module Find
+  class FeatureFlagsController < ApplicationController
+    before_action :enforce_basic_auth
+    skip_before_action :redirect_to_maintenance_page_if_flag_is_active
+
+    def index; end
+
+    def update
+      FeatureFlag.send(action, feature_name)
+
+      if Rails.env.production?
+        SlackNotificationJob.perform_now(
+          ":flags: Feature ‘#{feature_name}‘ was #{action}d",
+          find_feature_flags_path,
+        )
+      end
+
+      flash[:success] = "Feature ‘#{feature_name.humanize}’ #{action}d"
+      redirect_to find_feature_flags_path
+    end
+
+  private
+
+    def enforce_basic_auth
+      authenticate_or_request_with_http_basic do |username, password|
+        BasicAuthenticable.authenticate(username, password)
+      end
+    end
+
+    def action
+      params[:state]
+    end
+
+    def feature_name
+      params[:feature_name]
+    end
+  end
+end

--- a/app/controllers/find/pages_controller.rb
+++ b/app/controllers/find/pages_controller.rb
@@ -1,9 +1,20 @@
 module Find
   class PagesController < ApplicationController
+    skip_before_action :redirect_to_maintenance_page_if_flag_is_active, only: :maintenance
+    before_action :redirect_to_homepage_unless_in_maintenance_mode, only: :maintenance
+
     def accessibility; end
 
     def privacy; end
 
     def terms; end
+
+    def maintenance; end
+
+  private
+
+    def redirect_to_homepage_unless_in_maintenance_mode
+      redirect_to find_path unless FeatureFlag.active?(:maintenance_mode)
+    end
   end
 end

--- a/app/forms/find/confirm_environment.rb
+++ b/app/forms/find/confirm_environment.rb
@@ -1,0 +1,14 @@
+module Find
+  class ConfirmEnvironment
+    include ActiveModel::Model
+    attr_accessor :from, :environment
+
+    validate :correct_environment
+
+    def correct_environment
+      if environment != Rails.env
+        errors.add(:environment, :invalid_environment, environment: Rails.env)
+      end
+    end
+  end
+end

--- a/app/helpers/find/view_helper.rb
+++ b/app/helpers/find/view_helper.rb
@@ -1,0 +1,11 @@
+module Find
+  module ViewHelper
+    def protect_against_mistakes
+      if session[:confirmed_environment_at] && session[:confirmed_environment_at] > 5.minutes.ago
+        yield
+      else
+        govuk_link_to "Confirm environment to make changes", find_confirm_environment_path(from: request.fullpath)
+      end
+    end
+  end
+end

--- a/app/jobs/find/slack_notification_job.rb
+++ b/app/jobs/find/slack_notification_job.rb
@@ -1,0 +1,39 @@
+require "http"
+
+module Find
+  class SlackNotificationJob < ApplicationJob
+    SLACK_CHANNEL = "#twd_findpub_tech".freeze
+
+    def perform(text, url = nil)
+      @webhook_url = Settings.STATE_CHANGE_SLACK_URL
+      if @webhook_url.present?
+        message = url.present? ? hyperlink(text, url) : text
+        post_to_slack message
+      end
+    end
+
+  private
+
+    def hyperlink(text, url)
+      "<#{url}|#{text}>"
+    end
+
+    def post_to_slack(text)
+      payload = {
+        username: "Find postgraduate teacher training",
+        channel: SLACK_CHANNEL,
+        text:,
+        mrkdwn: true,
+        icon_emoji: ":livecanary:",
+      }
+
+      response = HTTP.post(@webhook_url, body: payload.to_json)
+
+      unless response.status.success?
+        raise SlackMessageError, "Slack error: #{response.body}"
+      end
+    end
+
+    class SlackMessageError < StandardError; end
+  end
+end

--- a/app/lib/feature_flag.rb
+++ b/app/lib/feature_flag.rb
@@ -1,0 +1,55 @@
+class FeatureFlag
+  class << self
+    def active?(feature_name)
+      feature = RedisClient.current.get("feature_flags_#{feature_name}")
+
+      return false unless feature
+
+      JSON.parse(feature)["state"]
+    end
+
+    def activate(feature_name)
+      raise UnknownFeatureError unless feature_name.in?(features)
+
+      sync_with_redis(feature_name, true)
+    end
+
+    def deactivate(feature_name)
+      raise UnknownFeatureError unless feature_name.in?(features)
+
+      sync_with_redis(feature_name, false)
+    end
+
+    def features
+      FeatureFlags.all.to_h do |name, description, owner|
+        [name, FeatureFlag.new(name:, description:, owner:)]
+      end.with_indifferent_access
+    end
+
+    def last_updated(feature_name)
+      feature = RedisClient.current.get("feature_flags_#{feature_name}")
+
+      return unless feature
+
+      JSON.parse(feature)["updated_at"]
+    end
+
+  private
+
+    def sync_with_redis(feature_name, feature_state)
+      RedisClient.current.set(
+        "feature_flags_#{feature_name}", { state: feature_state, updated_at: Time.zone.now }.to_json
+      )
+    end
+  end
+
+  attr_accessor :name, :description, :owner, :type
+
+  def initialize(name:, description:, owner:)
+    self.name = name
+    self.description = description
+    self.owner = owner
+  end
+
+  class UnknownFeatureError < StandardError; end
+end

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -1,0 +1,11 @@
+class FeatureFlags
+  def self.all
+    [
+      [:maintenance_mode, "Puts Find into maintenance mode", "Find and Publish team"],
+      [:maintenance_banner, "Displays the maintenance mode banner", "Find and Publish team"],
+      [:cache_courses, "Caches request to the Teacher Training API for individual courses", "Find and Publish team"],
+      [:send_web_requests_to_big_query, "Send events to Google Big Query", "Find and Publish team"],
+      [:bursaries_and_scholarships_announced, "Display scholarship and bursary information", "Find and Publish team"],
+    ]
+  end
+end

--- a/app/views/find/confirm_environment/new.html.erb
+++ b/app/views/find/confirm_environment/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Confirm you want to make changes to #{Rails.env}" %>
+
+<div class="govuk-grid-row-two-thirds">
+  <h1 class="govuk-heading-xl">Confirm you want to make changes to this environment</h1>
+  <p class="govuk-body">This is the <strong><%= Rails.env %></strong> environment.</p>
+
+  <%= form_with(url: find_confirm_environment_path, model: @confirmation) do |f| %>
+    <%= f.hidden_field :from %>
+    <%= f.govuk_text_field :environment, label: { text: "Type ‘#{Rails.env}’ to confirm that you want to proceed", size: 's' }, width: 20 %>
+    <%= f.govuk_submit t('continue') %>
+  <% end %>
+</div>

--- a/app/views/find/feature_flags/index.html.erb
+++ b/app/views/find/feature_flags/index.html.erb
@@ -1,0 +1,35 @@
+<%= content_for :page_title, 'Feature flags' %>
+
+<h2 class="govuk-heading-xl">Feature flags</h2>
+
+<% FeatureFlag.features.each do |feature_name, feature_flag| %>
+  <%= render FindInterface::Utility::SummaryCardComponent.new(editable: true, border: true, rows: [
+    {
+      key: 'Description',
+      value: feature_flag.description,
+    },
+    {
+      key: 'Status',
+      value: govuk_tag(
+        text: FeatureFlag.active?(feature_name) ? 'Active' : 'Inactive',
+        colour: FeatureFlag.active?(feature_name) ? 'green' : 'grey',
+      ),
+    },
+    {
+      key: 'Owner',
+      value: feature_flag.owner,
+    },
+    {
+      key: 'History',
+      value: render(
+        FindInterface::FeatureHistoryComponent.new(feature_name),
+      )
+    },
+  ].compact) do %>
+    <%= render FindInterface::Utility::SummaryCardHeaderComponent.new(title: feature_name.to_s.humanize, heading_level: 2) do %>
+      <% protect_against_mistakes do %>
+        <%= render FindInterface::FeatureToggleComponent.new(feature_name: feature_name) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/find/pages/maintenance.html.erb
+++ b/app/views/find/pages/maintenance.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :page_title, 'Applications closed' %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">This service is currently down for maintenance</h1>
+
+      <p class="govuk-body">The service will be available soon.</p>
+      <p class="govuk-body">If you have any questions, contact us at <%= govuk_mail_to bat_contact_email_address %>.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/find_layout.html.erb
+++ b/app/views/layouts/find_layout.html.erb
@@ -35,6 +35,8 @@
           <% end %>
         <% end %>
 
+        <%= render FindInterface::MaintenanceBannerComponent.new %>
+
         <%= yield %>
       </main>
     </div>

--- a/app/views/layouts/find_layout.html.erb
+++ b/app/views/layouts/find_layout.html.erb
@@ -24,6 +24,17 @@
 
       <%= yield :before_content %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <% if flash[:success] %>
+          <%= govuk_notification_banner(
+            title_text: 'Success',
+            success: true,
+            title_id: 'success-message',
+            html_attributes: { role: 'alert' },
+          ) do |notification_banner| %>
+            <% notification_banner.heading(text: flash[:success]) %>
+          <% end %>
+        <% end %>
+
         <%= yield %>
       </main>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -513,6 +513,11 @@ en:
           attributes:
             consent:
               blank: Select yes if you want to accept Google Analytics cookies
+        find/confirm_environment:
+          attributes:
+            environment:
+              blank: Enter the environment to proceed
+              invalid_environment: "That's not %{environment}"
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -11,6 +11,11 @@ namespace :find, path: "/find" do
   get "/results", to: "results#index", as: "results"
   get "/location-suggestions", to: "location_suggestions#index"
 
+  get "/feature-flags", to: "feature_flags#index"
+  post "/feature-flags" => "feature_flags#update"
+  get "/confirm-environment" => "confirm_environment#new"
+  post "/confirm-environment" => "confirm_environment#create"
+
   resource :cookie_preferences, only: %i[show update], path: "/cookies", as: :cookies
   resource :sitemap, only: :show
 

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -15,6 +15,7 @@ namespace :find, path: "/find" do
   post "/feature-flags" => "feature_flags#update"
   get "/confirm-environment" => "confirm_environment#new"
   post "/confirm-environment" => "confirm_environment#create"
+  get "/maintenance", to: "pages#maintenance", as: "maintenance"
 
   resource :cookie_preferences, only: %i[show update], path: "/cookies", as: :cookies
   resource :sitemap, only: :show

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -124,3 +124,5 @@ cookies:
 
 find_features:
   bursaries_and_scholarships_announced: true
+
+STATE_CHANGE_SLACK_URL: replace_me

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -3,6 +3,8 @@ publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 
+STATE_CHANGE_SLACK_URL: replace_me
+
 search_ui:
   base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -12,3 +12,9 @@ bg_jobs:
 environment:
   label: "Test"
   name: "test"
+
+basic_auth:
+  username: admin
+  password: password
+
+STATE_CHANGE_SLACK_URL: https://example.com/webhook

--- a/spec/components/find_interface/feature_history_component_spec.rb
+++ b/spec/components/find_interface/feature_history_component_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+module FindInterface
+  describe FeatureHistoryComponent, type: :component do
+    let(:feature_name) { "test_feature" }
+
+    before do
+      allow(FeatureFlag).to receive(:last_updated).with(feature_name).and_return(Time.zone.local(2021, 12, 1, 12).to_s)
+    end
+
+    context "feature is active" do
+      it "renders the correctly formatted date and time" do
+        allow(FeatureFlag).to receive(:active?).and_return(true)
+
+        result = render_inline(described_class.new(feature_name))
+
+        expect(result.text).to have_content "Changed to active at 12pm on 1 December 2021"
+      end
+    end
+
+    context "feature is inactive" do
+      it "renders the correctly formatted date and time" do
+        allow(FeatureFlag).to receive(:active?).and_return(false)
+
+        result = render_inline(described_class.new(feature_name))
+
+        expect(result.text).to have_content "Changed to inactive at 12pm on 1 December 2021"
+      end
+    end
+
+    context "feature has never been updated" do
+      it "renders a message saying the feature flag has not been updated" do
+        allow(FeatureFlag).to receive(:active?).and_return(false)
+        allow(FeatureFlag).to receive(:last_updated).and_return(nil)
+
+        result = render_inline(described_class.new(feature_name))
+
+        expect(result.text).to have_content "This flag has not been updated"
+      end
+    end
+  end
+end

--- a/spec/components/find_interface/maintenance_banner_component_spec.rb
+++ b/spec/components/find_interface/maintenance_banner_component_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+module FindInterface
+  describe MaintenanceBannerComponent, type: :component do
+    context "when the `maintenance_mode` flag is active" do
+      it "renders the correct content" do
+        FeatureFlag.activate(:maintenance_banner)
+        result = render_inline(described_class.new)
+
+        expect(result.text).to have_content "This service will be unavailable on"
+      end
+    end
+
+    context "when the `maintenance_mode` flag is deactive" do
+      it "does not render" do
+        FeatureFlag.deactivate(:maintenance_banner)
+
+        result = render_inline(described_class.new)
+
+        expect(result.text).to be_blank
+      end
+    end
+  end
+end

--- a/spec/features/find/feature_flags_spec.rb
+++ b/spec/features/find/feature_flags_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+feature "Feature flags" do
+  around do |example|
+    Timecop.freeze(Time.zone.local(2021, 12, 1, 12)) do
+      example.run
+    end
+  end
+
+  before do
+    given_there_is_a_feature_flag_set_up
+  end
+
+  scenario "basic auth" do
+    when_i_visit_the_features_page
+    i_should_see_access_denied
+  end
+
+  scenario "Manage features" do
+    given_i_am_authenticated
+    when_i_visit_the_features_page
+    then_i_should_see_the_existing_feature_flags
+
+    when_i_activate_the_feature
+    then_the_feature_is_activated
+
+    when_i_deactivate_the_feature
+    then_the_feature_is_deactivated
+  end
+
+  def given_there_is_a_feature_flag_set_up
+    allow(FeatureFlags).to receive(:all).and_return([[:test_feature, "It's a test feature", "Jasmine Java"]])
+
+    FeatureFlag.deactivate("test_feature")
+  end
+
+  def when_i_visit_the_features_page
+    feature_flag_page.load
+  end
+
+  def given_i_am_authenticated
+    page.driver.browser.authorize "admin", "password"
+  end
+
+  def i_should_see_access_denied
+    expect(page).to have_content("Access denied")
+  end
+
+  def then_i_should_see_the_existing_feature_flags
+    within(feature_card) do
+      expect(page).to have_content("Test feature")
+      expect(page).to have_content(feature.owner)
+      expect(page).to have_content(feature.description)
+    end
+  end
+
+  def when_i_activate_the_feature
+    within(feature_card) { click_link "Confirm environment to make changes" }
+    fill_in "Type ‘test’ to confirm that you want to proceed", with: "test"
+    click_button "Continue"
+
+    within(feature_card) { click_button "Activate" }
+  end
+
+  def then_the_feature_is_activated
+    expect(FeatureFlag.active?("test_feature")).to be true
+    expect(feature_flag_page).to have_content("Test feature")
+    expect(feature_flag_page).to have_content("Active")
+    expect(feature_flag_page).to have_content("12pm on 1 December 2021")
+  end
+
+  def when_i_deactivate_the_feature
+    within(feature_card) { click_button "Deactivate" }
+  end
+
+  def then_the_feature_is_deactivated
+    expect(feature_flag_page).to have_content("Inactive")
+    expect(FeatureFlag.active?("test_feature")).to be false
+  end
+
+  def feature_card
+    feature_flag_page.find(".app-summary-card")
+  end
+
+  def feature
+    @feature ||= FeatureFlag.features[:test_feature]
+  end
+end

--- a/spec/features/find/maintainance_page_spec.rb
+++ b/spec/features/find/maintainance_page_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+feature "Maintenance mode" do
+  before do
+    allow_any_instance_of(FindConstraint).to receive(:matches?).and_return(true)
+  end
+
+  context "given the maintenance_mode feature flag is active and i arrive at the site" do
+    scenario "sends me to the maintenance page" do
+      FeatureFlag.activate(:maintenance_mode)
+      FeatureFlag.activate(:maintenance_banner)
+
+      visit find_path
+
+      expect(page).to have_current_path find_maintenance_path
+      expect(page).not_to have_content "This service will be unavailable on"
+    end
+  end
+
+  context "given the maintenance_mode feature flag is deactive and i visit the maintenance_path" do
+    scenario "sends me to the homepage" do
+      FeatureFlag.deactivate(:maintenance_mode)
+
+      visit find_maintenance_path
+
+      expect(page).to have_current_path find_path
+    end
+  end
+
+  context "given the maintenance_mode feature flag is active and I visit the feature flag page" do
+    scenario "sends me to the feature flags page" do
+      FeatureFlag.activate(:maintenance_mode)
+
+      visit find_feature_flags_path
+
+      expect(page).to have_current_path find_feature_flags_path
+    end
+  end
+end

--- a/spec/features/find/maintenance_banner_spec.rb
+++ b/spec/features/find/maintenance_banner_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+feature "Maintenance banner" do
+  before do
+    allow_any_instance_of(FindConstraint).to receive(:matches?).and_return(true)
+  end
+
+  context "given the maintenance_mode feature flag is active and i arrive at the site" do
+    scenario "sends me to the maintenance page" do
+      FeatureFlag.activate(:maintenance_banner)
+
+      visit find_path
+
+      expect(page).to have_content "This service will be unavailable on"
+    end
+  end
+
+  context "given the maintenance_banner feature flag is deactive and i visit the homepage" do
+    scenario "sends me to the homepage" do
+      FeatureFlag.deactivate(:maintenance_banner)
+
+      visit find_path
+
+      expect(page).not_to have_content "This service will be unavailable on"
+    end
+  end
+end

--- a/spec/jobs/find/slack_notification_job_spec.rb
+++ b/spec/jobs/find/slack_notification_job_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+module Find
+  describe SlackNotificationJob do
+    describe "#perform" do
+      it "sends a Slack notification to this webhook if the URL is set" do
+        slack_request = stub_request(:post, "https://example.com/webhook")
+          .to_return(status: 200, headers: {})
+        invoke_worker
+
+        expect(slack_request).to have_been_made
+      end
+
+      it "does not send a Slack notification if STATE_CHANGE_SLACK_URL is empty" do
+        allow(Settings).to receive(:STATE_CHANGE_SLACK_URL).and_return(nil)
+        slack_request = stub_request(:post, "https://example.com/webhook")
+          .to_return(status: 200, headers: {})
+        invoke_worker
+
+        expect(slack_request).not_to have_been_made
+      end
+
+      it "raises an error if Slack responds with one" do
+        stub_request(:post, "https://example.com/webhook")
+          .to_return(status: 400, headers: {})
+
+        expect { invoke_worker }.to raise_error(SlackNotificationJob::SlackMessageError)
+      end
+
+      it "includes a link if given" do
+        slack_request = stub_request(:post, "https://example.com/webhook")
+          .to_return(status: 200, headers: {})
+
+        invoke_worker
+
+        # Slack will begin the message with a < character (this codepoint) when presenting content as a link
+        expect(slack_request.with(body: /\\u003/)).to have_been_made
+      end
+
+      it "does not include a link if none given" do
+        slack_request = stub_request(:post, "https://example.com/webhook")
+          .to_return(status: 200, headers: {})
+
+        described_class.new.perform("example text")
+
+        expect(slack_request.with(body: /example text/)).to have_been_made
+      end
+    end
+
+    def invoke_worker
+      described_class.new.perform("example text", "https://example.com/support")
+    end
+  end
+end

--- a/spec/lib/feature_flag_spec.rb
+++ b/spec/lib/feature_flag_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe FeatureFlag do
+  describe ".active?" do
+    before do
+      allow(FeatureFlags).to receive(:all).and_return([[:test_feature, "It's a test feature", "Jasmine Java"]])
+    end
+
+    it "returns false if the feature flag has been deactivated" do
+      described_class.deactivate("test_feature")
+
+      expect(described_class.active?("test_feature")).to be(false)
+    end
+
+    it "returns true if the feature flag has been activated" do
+      described_class.activate("test_feature")
+
+      expect(described_class.active?("test_feature")).to be(true)
+    end
+
+    it "returns false if the feature does not exist" do
+      expect(described_class.active?("test_feature")).to be(false)
+    end
+  end
+
+  describe ".deactivate" do
+    before do
+      allow(FeatureFlags).to receive(:all).and_return([[:test_feature, "It's a test feature", "Jasmine Java"]])
+    end
+
+    it "deactivates the feature flag" do
+      described_class.deactivate("test_feature")
+
+      expect(described_class.active?("test_feature")).to be(false)
+    end
+  end
+
+  describe ".activate" do
+    before do
+      allow(FeatureFlags).to receive(:all).and_return([[:test_feature, "It's a test feature", "Jasmine Java"]])
+    end
+
+    it "activates the feature flag" do
+      described_class.activate("test_feature")
+
+      expect(described_class.active?("test_feature")).to be(true)
+    end
+  end
+end

--- a/spec/support/mock_redis.rb
+++ b/spec/support/mock_redis.rb
@@ -1,0 +1,10 @@
+require "mock_redis"
+
+RSpec.configure do |config|
+  config.before do
+    mock_redis = MockRedis.new
+    allow(Redis).to receive(:new).and_return(mock_redis)
+
+    RedisClient.current.flushdb
+  end
+end

--- a/spec/support/page_objects/find/feature_flag.rb
+++ b/spec/support/page_objects/find/feature_flag.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Find
+    class FeatureFlag < PageObjects::Base
+      set_url "/find/feature-flags"
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/va70CeOB/777-migrate-the-feature-flags

### Changes proposed in this pull request

- Migrates the feature flags logic from Find including related/dependent code

### Tech notes

Find uses Redis to store the feature flags. We'll need to decide whether to adopt it for all flags for both Find/Publish later. There's also a notification job to alert when flags are updated to Slack i've only set this to run in prod to avoid noise. It was only setup in prod in Find as well.

### Guidance to review

https://publish-teacher-training-pr-3108.london.cloudapps.digital/find/feature-flags

Use the normal publish credentials and toggle some features

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
