### PR TITLE
781 fix subject order in check your answers and course details page

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -143,7 +143,7 @@ class CourseDecorator < ApplicationDecorator
 
     if main_subject_is_modern_languages?
       format_name(modern_language_subjects.push(additional_subjects).flatten.uniq.unshift(main_subject))
-    elsif !main_subject_is_modern_languages? && has_any_modern_language_subject_type?
+    elsif !main_subject_is_modern_languages? && modern_languages_subjects.present?
       format_name(additional_subjects.push(modern_language_subjects).flatten.uniq.unshift(main_subject))
     else
       format_name(additional_subjects.unshift(main_subject))

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -149,7 +149,7 @@ class CourseDecorator < ApplicationDecorator
 
       # The below is to ensure modern language subjects chosen appear above the second main subject chosen
 
-      if main_subject_id == 33
+      if main_subject_id == SecondarySubject.modern_languages.id
         ordered_subjects = additional_subjects.push(main_subject).reverse
       else
         ordered_subjects = additional_subjects.unshift(main_subject)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -138,6 +138,27 @@ class CourseDecorator < ApplicationDecorator
     object.subjects.map(&:subject_name).sort.join("<br>").html_safe
   end
 
+  def chosen_subjects(params, course)
+    if params[:course][:master_subject_id].nil?
+      sorted_subjects
+    else
+      main_subject_id = params[:course][:master_subject_id]
+      main_subject = Subject.find(main_subject_id)
+      raw_additional_subjects = course.subjects.map { |subject| subject unless subject.id.to_s == main_subject_id }
+      additional_subjects = raw_additional_subjects.compact
+
+      # The below is to ensure modern language subjects chosen appear above the second main subject chosen
+
+      if main_subject_id == 33.to_s
+        ordered_subjects = additional_subjects.push(main_subject).reverse
+      else
+        ordered_subjects = additional_subjects.unshift(main_subject)
+      end
+
+      ordered_subjects.map(&:subject_name).join("<br>").html_safe
+    end
+  end
+
   def length
     case course_length.to_s
     when "OneYear"

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -142,9 +142,9 @@ class CourseDecorator < ApplicationDecorator
     return sorted_subjects if master_subject_nil?
 
     if main_subject_is_modern_languages?
-      format_name(modern_language_subjects.push(additional_subjects).flatten.uniq.unshift(main_subject))
+      format_name(modern_language_subjects.to_a.push(additional_subjects).flatten.uniq.unshift(main_subject))
     elsif !main_subject_is_modern_languages? && modern_languages_subjects.present?
-      format_name(additional_subjects.push(modern_language_subjects).flatten.uniq.unshift(main_subject))
+      format_name(additional_subjects.push(modern_language_subjects.to_a).flatten.uniq.unshift(main_subject))
     else
       format_name(additional_subjects.unshift(main_subject))
     end
@@ -453,10 +453,6 @@ private
 
   def additional_subjects
     object.subjects.reject { |subject| subject.id == main_subject.id }
-  end
-
-  def main_subject_is_modern_languages?
-    main_subject.id == SecondarySubject.modern_languages.id
   end
 
   def format_name(subjects)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -138,18 +138,18 @@ class CourseDecorator < ApplicationDecorator
     object.subjects.map(&:subject_name).sort.join("<br>").html_safe
   end
 
-  def chosen_subjects(params, course)
-    if params[:course][:master_subject_id].nil?
+  def chosen_subjects(course)
+    if course.master_subject_id.nil?
       sorted_subjects
     else
-      main_subject_id = params[:course][:master_subject_id]
+      main_subject_id = course.master_subject_id
       main_subject = Subject.find(main_subject_id)
-      raw_additional_subjects = course.subjects.map { |subject| subject unless subject.id.to_s == main_subject_id }
+      raw_additional_subjects = course.subjects.map { |subject| subject unless subject.id == main_subject_id }
       additional_subjects = raw_additional_subjects.compact
 
       # The below is to ensure modern language subjects chosen appear above the second main subject chosen
 
-      if main_subject_id == 33.to_s
+      if main_subject_id == 33
         ordered_subjects = additional_subjects.push(main_subject).reverse
       else
         ordered_subjects = additional_subjects.unshift(main_subject)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -142,9 +142,9 @@ class CourseDecorator < ApplicationDecorator
     return sorted_subjects if master_subject_nil?
 
     if main_subject_is_modern_languages?
-      format_name(select_modern_language_subjects.push(additional_subjects).flatten.uniq.unshift(main_subject))
+      format_name(modern_language_subjects.push(additional_subjects).flatten.uniq.unshift(main_subject))
     elsif !main_subject_is_modern_languages? && has_any_modern_language_subject_type?
-      format_name(additional_subjects.push(select_modern_language_subjects).flatten.uniq.unshift(main_subject))
+      format_name(additional_subjects.push(modern_language_subjects).flatten.uniq.unshift(main_subject))
     else
       format_name(additional_subjects.unshift(main_subject))
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -751,6 +751,18 @@ class Course < ApplicationRecord
     end
   end
 
+  def select_modern_language_subjects
+    subjects.select { |subject| subject.type == "ModernLanguagesSubject" }
+  end
+
+  def master_subject_nil?
+    master_subject_id.nil?
+  end
+
+  def has_any_modern_language_subject_type?
+    subjects.any? { |subject| subject.type == "ModernLanguagesSubject" }
+  end
+
 private
 
   def add_site!(site:)
@@ -915,10 +927,6 @@ private
     unless findable?
       errors.add(:site_statuses, "must be findable")
     end
-  end
-
-  def has_any_modern_language_subject_type?
-    subjects.any? { |subject| subject.type == "ModernLanguagesSubject" }
   end
 
   def has_the_modern_languages_secondary_subject_type?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -752,7 +752,7 @@ class Course < ApplicationRecord
   end
 
   def modern_language_subjects
-    subjects.select { |subject| subject.type == "ModernLanguagesSubject" }
+    subjects.where(type: "ModernLanguagesSubject").to_a
   end
 
   def master_subject_nil?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -752,7 +752,7 @@ class Course < ApplicationRecord
   end
 
   def modern_language_subjects
-    subjects.where(type: "ModernLanguagesSubject").to_a
+    subjects.where(type: "ModernLanguagesSubject")
   end
 
   def master_subject_nil?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -751,7 +751,7 @@ class Course < ApplicationRecord
     end
   end
 
-  def select_modern_language_subjects
+  def modern_language_subjects
     subjects.select { |subject| subject.type == "ModernLanguagesSubject" }
   end
 

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -21,7 +21,7 @@
       <% unless course.further_education_course? %>
         <% summary_list.row(html_attributes: { data: { qa: "course__subjects" } }) do |row| %>
           <% row.key { "Subject".pluralize(course.subjects.count) } %>
-          <% row.value { course.chosen_subjects(course) } %>
+          <% row.value { course.chosen_subjects } %>
           <% row.action(**{
             href: subjects_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
             visually_hidden_text: "subjects",

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -21,7 +21,7 @@
       <% unless course.further_education_course? %>
         <% summary_list.row(html_attributes: { data: { qa: "course__subjects" } }) do |row| %>
           <% row.key { "Subject".pluralize(course.subjects.count) } %>
-          <% row.value { course.sorted_subjects } %>
+          <% row.value { course.chosen_subjects(course) } %>
           <% row.action(**{
             href: subjects_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
             visually_hidden_text: "subjects",

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -42,7 +42,7 @@
         <% unless course.is_further_education? %>
           <% summary_list.row(html_attributes: { data: { qa: "course__subjects" } }) do |row| %>
             <% row.key { "Subject".pluralize(course.subjects.length) } %>
-            <% row.value { course.chosen_subjects(params, course) } %>
+            <% row.value { course.chosen_subjects(course) } %>
             <% row.action(**{
               href: new_publish_provider_recruitment_cycle_courses_subjects_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
               visually_hidden_text: "subjects",

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -42,7 +42,7 @@
         <% unless course.is_further_education? %>
           <% summary_list.row(html_attributes: { data: { qa: "course__subjects" } }) do |row| %>
             <% row.key { "Subject".pluralize(course.subjects.length) } %>
-            <% row.value { course.sorted_subjects } %>
+            <% row.value { course.chosen_subjects(params, course) } %>
             <% row.action(**{
               href: new_publish_provider_recruitment_cycle_courses_subjects_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
               visually_hidden_text: "subjects",

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -42,7 +42,7 @@
         <% unless course.is_further_education? %>
           <% summary_list.row(html_attributes: { data: { qa: "course__subjects" } }) do |row| %>
             <% row.key { "Subject".pluralize(course.subjects.length) } %>
-            <% row.value { course.chosen_subjects(course) } %>
+            <% row.value { course.chosen_subjects } %>
             <% row.action(**{
               href: new_publish_provider_recruitment_cycle_courses_subjects_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
               visually_hidden_text: "subjects",

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -251,7 +251,7 @@ describe CourseDecorator do
       let(:decorated_course) { course.decorate }
 
       it "displays physics above the second subject chosen" do
-        expect(decorated_course.chosen_subjects(decorated_course)).to eq("Physics<br>Chemistry")
+        expect(decorated_course.chosen_subjects).to eq("Physics<br>Chemistry")
       end
     end
 
@@ -271,7 +271,7 @@ describe CourseDecorator do
       let(:decorated_course) { course.decorate }
 
       it "displays modern languages before the modern languages subjects" do
-        expect(decorated_course.chosen_subjects(decorated_course)).to eq("Modern Languages<br>German<br>French")
+        expect(decorated_course.chosen_subjects).to eq("Modern Languages<br>French<br>German")
       end
     end
 
@@ -292,7 +292,7 @@ describe CourseDecorator do
       let(:decorated_course) { course.decorate }
 
       it "displays physics before the modern languages subjects" do
-        expect(decorated_course.chosen_subjects(decorated_course)).to eq("Physics<br>Modern Languages<br>French<br>German")
+        expect(decorated_course.chosen_subjects).to eq("Physics<br>Modern Languages<br>French<br>German")
       end
     end
 
@@ -313,7 +313,7 @@ describe CourseDecorator do
       let(:decorated_course) { course.decorate }
 
       it "displays modern languages and the specific languages before the latin subject" do
-        expect(decorated_course.chosen_subjects(decorated_course)).to eq("Modern Languages<br>German<br>French<br>Latin")
+        expect(decorated_course.chosen_subjects).to eq("Modern Languages<br>French<br>German<br>Latin")
       end
     end
   end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -300,7 +300,7 @@ describe CourseDecorator do
       let(:french) { build_stubbed(:modern_languages_subject, :french) }
       let(:german) { build_stubbed(:modern_languages_subject, :german) }
       let(:latin) { build_stubbed(:secondary_subject, :latin) }
-      let(:subjects) { [latin, french, german] }
+      let(:subjects) { [french, german, latin] }
       let(:course) {
         build_stubbed(
           :course,

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -236,28 +236,26 @@ describe CourseDecorator do
 
   describe "#chosen_subjects" do
     context "when physics is the main subject" do
-      let(:params) { { course: { master_subject_id: 29 } } }
-
-      let(:chemistry) { build_stubbed(:secondary_subject, :chemistry) }
-      let(:subjects) { [chemistry] }
+      let(:physics) { build_stubbed(:secondary_subject, :physics, id: 29) }
+      let(:chemistry) { build_stubbed(:secondary_subject, :chemistry, id: 12) }
+      let(:subjects) { [physics, chemistry] }
       let(:course) {
         build_stubbed(
           :course,
-          name: "Chemistry",
+          name: "Physics",
           subjects:,
+          master_subject_id: 29,
         )
       }
 
       let(:decorated_course) { course.decorate }
 
       it "displays physics above the second subject chosen" do
-        expect(decorated_course.chosen_subjects(params, decorated_course)).to eq("Physics<br>Chemistry")
+        expect(decorated_course.chosen_subjects(decorated_course)).to eq("Physics<br>Chemistry")
       end
     end
 
     context "when modern languages only is chosen" do
-      let(:params) { { course: { master_subject_id: 33, subject_ids: %w[33 34 36] } } }
-
       let(:french) { build_stubbed(:modern_languages_subject, :french) }
       let(:german) { build_stubbed(:modern_languages_subject, :german) }
       let(:subjects) { [french, german] }
@@ -266,19 +264,18 @@ describe CourseDecorator do
           :course,
           name: "Modern languages",
           subjects:,
+          master_subject_id: 33,
         )
       }
 
       let(:decorated_course) { course.decorate }
 
       it "displays modern languages before the modern languages subjects" do
-        expect(decorated_course.chosen_subjects(params, decorated_course)).to eq("Modern Languages<br>French<br>German")
+        expect(decorated_course.chosen_subjects(decorated_course)).to eq("Modern Languages<br>German<br>French")
       end
     end
 
     context "when physics is chosen as the main subject and modern languages as the second" do
-      let(:params) { { course: { master_subject_id: 29 } } }
-
       let(:modern_languages) { build_stubbed(:secondary_subject, :modern_languages) }
       let(:french) { build_stubbed(:modern_languages_subject, :french) }
       let(:german) { build_stubbed(:modern_languages_subject, :german) }
@@ -286,37 +283,37 @@ describe CourseDecorator do
       let(:course) {
         build_stubbed(
           :course,
-          name: "Modern languages",
+          name: "Physics",
           subjects:,
+          master_subject_id: 29,
         )
       }
 
       let(:decorated_course) { course.decorate }
 
       it "displays physics before the modern languages subjects" do
-        expect(decorated_course.chosen_subjects(params, decorated_course)).to eq("Physics<br>Modern Languages<br>French<br>German")
+        expect(decorated_course.chosen_subjects(decorated_course)).to eq("Physics<br>Modern Languages<br>French<br>German")
       end
     end
 
     context "when modern languages is chosen as the main subject and latin as the second" do
-      let(:params) { { course: { master_subject_id: 33 } } }
-
       let(:french) { build_stubbed(:modern_languages_subject, :french) }
       let(:german) { build_stubbed(:modern_languages_subject, :german) }
       let(:latin) { build_stubbed(:secondary_subject, :latin) }
-      let(:subjects) { [french, german, latin] }
+      let(:subjects) { [latin, french, german] }
       let(:course) {
         build_stubbed(
           :course,
           name: "Modern languages",
           subjects:,
+          master_subject_id: 33,
         )
       }
 
       let(:decorated_course) { course.decorate }
 
-      it "displays modern languages before the latin subject" do
-        expect(decorated_course.chosen_subjects(params, decorated_course)).to eq("Modern Languages<br>French<br>German<br>Latin")
+      it "displays modern languages and the specific languages before the latin subject" do
+        expect(decorated_course.chosen_subjects(decorated_course)).to eq("Modern Languages<br>German<br>French<br>Latin")
       end
     end
   end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -234,6 +234,93 @@ describe CourseDecorator do
     end
   end
 
+  describe "#chosen_subjects" do
+    context "when physics is the main subject" do
+      let(:params) { { course: { master_subject_id: 29 } } }
+
+      let(:chemistry) { build_stubbed(:secondary_subject, :chemistry) }
+      let(:subjects) { [chemistry] }
+      let(:course) {
+        build_stubbed(
+          :course,
+          name: "Chemistry",
+          subjects:,
+        )
+      }
+
+      let(:decorated_course) { course.decorate }
+
+      it "displays physics above the second subject chosen" do
+        expect(decorated_course.chosen_subjects(params, decorated_course)).to eq("Physics<br>Chemistry")
+      end
+    end
+
+    context "when modern languages only is chosen" do
+      let(:params) { { course: { master_subject_id: 33, subject_ids: %w[33 34 36] } } }
+
+      let(:french) { build_stubbed(:modern_languages_subject, :french) }
+      let(:german) { build_stubbed(:modern_languages_subject, :german) }
+      let(:subjects) { [french, german] }
+      let(:course) {
+        build_stubbed(
+          :course,
+          name: "Modern languages",
+          subjects:,
+        )
+      }
+
+      let(:decorated_course) { course.decorate }
+
+      it "displays modern languages before the modern languages subjects" do
+        expect(decorated_course.chosen_subjects(params, decorated_course)).to eq("Modern Languages<br>French<br>German")
+      end
+    end
+
+    context "when physics is chosen as the main subject and modern languages as the second" do
+      let(:params) { { course: { master_subject_id: 29 } } }
+
+      let(:modern_languages) { build_stubbed(:secondary_subject, :modern_languages) }
+      let(:french) { build_stubbed(:modern_languages_subject, :french) }
+      let(:german) { build_stubbed(:modern_languages_subject, :german) }
+      let(:subjects) { [modern_languages, french, german] }
+      let(:course) {
+        build_stubbed(
+          :course,
+          name: "Modern languages",
+          subjects:,
+        )
+      }
+
+      let(:decorated_course) { course.decorate }
+
+      it "displays physics before the modern languages subjects" do
+        expect(decorated_course.chosen_subjects(params, decorated_course)).to eq("Physics<br>Modern Languages<br>French<br>German")
+      end
+    end
+
+    context "when modern languages is chosen as the main subject and latin as the second" do
+      let(:params) { { course: { master_subject_id: 33 } } }
+
+      let(:french) { build_stubbed(:modern_languages_subject, :french) }
+      let(:german) { build_stubbed(:modern_languages_subject, :german) }
+      let(:latin) { build_stubbed(:secondary_subject, :latin) }
+      let(:subjects) { [french, german, latin] }
+      let(:course) {
+        build_stubbed(
+          :course,
+          name: "Modern languages",
+          subjects:,
+        )
+      }
+
+      let(:decorated_course) { course.decorate }
+
+      it "displays modern languages before the latin subject" do
+        expect(decorated_course.chosen_subjects(params, decorated_course)).to eq("Modern Languages<br>French<br>German<br>Latin")
+      end
+    end
+  end
+
   # context "financial incentives" do
   #   describe "#salaried?" do
   #     let(:subject) { decorated_course }


### PR DESCRIPTION
### Context

The order of the subjects on the check your answers page and course details page should match the order they were entered.

```For example:

If the user chose Physics and Chemistry, the list should display:

- Physics
- Chemistry

If the user chose Modern Languages, the list should display:

- Modern Languages
- Language choice 1
- Language choice ...n

Where language choice is in alphabetical order as per the selection page.

If the user chose Physics and Modern Languages, the list should display:

- Physics
- Modern Languages
- Language choice 1
- Language choice ...n

If the user chose Modern Languages and Latin, the list should display:

- Modern Languages
- Language choice 1
- Language choice ...n
- Latin
```
### Changes proposed in this pull request

Display subjects in the order they were chosen, as per the requirements above.

### Guidance to review

- Choose the subjects in the various scenarios above when adding a new course and ensure they are displayed in the same order as above.

- Choose the subjects in the various scenarios above when editing basic details on an existing course and ensure they are displayed in the same order as above.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
