### PR TITLE
[0803] Update qualifications needed content for ETP courses for newer find

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -223,7 +223,7 @@ group :development do
   gem "guard-rspec", require: false
   gem "guard-rubocop", require: false
 
-  # For Ruby LSP & vscode
+  # For Ruby LSP & IDE
   gem "ruby-lsp", require: false
 end
 

--- a/app/components/find_interface/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find_interface/courses/entry_requirements_component/view.html.erb
@@ -12,10 +12,19 @@
       </p>
     <% end %>
 
-    <% if course.level == "secondary" %>
-      <p class="govuk-body">
-        <%= secondary_advisory(course) %>
-      </p>
+    <% if course.secondary_course? %>
+      <% if course.engineers_teach_physics? %>
+        <p class="govuk-body">
+          Your degree subject should be in engineering, materials science or a related subject, otherwise you’ll need to prove your subject knowledge in some other way.
+        </p>
+        <p class="govuk-body">
+          If your degree is not engineering or a related subject, please apply to our physics course.
+        </p>
+      <% else %>
+        <p class="govuk-body">
+          <%= secondary_advisory(course) %>
+        </p>
+      <% end %>
     <% end %>
 
     <p class="govuk-body">

--- a/spec/components/find_interface/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find_interface/courses/entry_requirements_component/view_preview.rb
@@ -17,7 +17,7 @@ module FindInterface::Courses::EntryRequirementsComponent
       render FindInterface::Courses::EntryRequirementsComponent::View.new(course: mock_course)
     end
 
-    def fully_etp_populated
+    def fully_populated_with_etp_course
       render FindInterface::Courses::EntryRequirementsComponent::View.new(course: mock_etp_course)
     end
 

--- a/spec/components/find_interface/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find_interface/courses/entry_requirements_component/view_preview.rb
@@ -17,10 +17,22 @@ module FindInterface::Courses::EntryRequirementsComponent
       render FindInterface::Courses::EntryRequirementsComponent::View.new(course: mock_course)
     end
 
+    def fully_etp_populated
+      render FindInterface::Courses::EntryRequirementsComponent::View.new(course: mock_etp_course)
+    end
+
   private
 
-    def mock_course
-      FakeCourse.new(degree_grade: 1,
+    def mock_etp_course
+      FakeCourse.new(**mock_etp_course_attributes)
+    end
+
+    def mock_etp_course_attributes
+      mock_course_attributes.merge({ campaign_name: :engineers_teach_physics })
+    end
+
+    def mock_course_attributes
+      { degree_grade: 1,
         degree_subject_requirements: "Degree Subject Requirements Text Goes Here",
         level: "secondary",
         name: "Super Awesome Course",
@@ -33,12 +45,16 @@ module FindInterface::Courses::EntryRequirementsComponent
         additional_gcse_equivalencies: "much much more",
         personal_qualities: "Personal Qualities Text Goes Here",
         other_requirements: "Other Requirements Text Goes Here",
-        subject_name_or_names: "Biology")
+        subject_name_or_names: "Biology" }
+    end
+
+    def mock_course
+      FakeCourse.new(**mock_course_attributes)
     end
 
     class FakeCourse
       include ActiveModel::Model
-      attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :subject_name_or_names)
+      attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :subject_name_or_names, :campaign_name)
 
       def enrichment_attribute(params)
         send(params)
@@ -46,6 +62,14 @@ module FindInterface::Courses::EntryRequirementsComponent
 
       def accept_gcse_equivalency?
         accept_gcse_equivalency
+      end
+
+      def secondary_course?
+        level == "secondary"
+      end
+
+      def engineers_teach_physics?
+        campaign_name&.to_sym == :engineers_teach_physics
       end
     end
   end

--- a/spec/components/find_interface/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find_interface/courses/entry_requirements_component/view_spec.rb
@@ -67,6 +67,24 @@ describe FindInterface::Courses::EntryRequirementsComponent::View, type: :compon
                              )
     end
 
+    context "when the campaign_name is set to engineers_teach_physics" do
+      it "renders correct message" do
+        raw_course = build(
+          :course,
+          :engineers_teach_physics,
+          :secondary,
+          provider: build(:provider, provider_code: "U80"),
+        )
+
+        course = raw_course.decorate
+        result = render_inline(described_class.new(course:))
+
+        expect(result.text).to include(
+          "Your degree subject should be in engineering, materials science or a related subject, otherwise you’ll need to prove your subject knowledge in some other way.",
+        )
+      end
+    end
+
     context "when the accrediting provider requires grade 5 and the course is secondary" do
       it "renders correct message" do
         accrediting_provider = build(:provider, provider_code: "U80")


### PR DESCRIPTION
### Context
ETP courses

### Changes proposed in this pull request
Update qualifications needed content for ETP courses

### Guidance to review

#### From `find`
##### Non ETP course
https://publish-teacher-training-pr-3114.london.cloudapps.digital/find/course/2CG/M064#section-entry

##### ETP course
https://publish-teacher-training-pr-3114.london.cloudapps.digital/find/course/S66/Y193#section-entry


#### From `publish`
##### Preview
https://publish-teacher-training-pr-3114.london.cloudapps.digital/publish/organisations/S66/2023/courses/Y193/preview#section-entry

#### View components
https://publish-teacher-training-pr-3114.london.cloudapps.digital/view_components
https://publish-teacher-training-pr-3114.london.cloudapps.digital/view_components/find_interface/courses/entry_requirements_component/view/fully_populated_with_etp_course

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
