### PR TITLE
[576] Migrate the deadline banners component

### DIFF
--- a/app/components/find_interface/deadline_banner_component.html.erb
+++ b/app/components/find_interface/deadline_banner_component.html.erb
@@ -1,0 +1,25 @@
+<% if cycle_timetable.show_apply_1_deadline_banner? %>
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.heading(text: "Apply now to get on a course starting in the #{cycle_timetable.cycle_year_range} academic year") %>
+    <p class="govuk-body">Courses can fill up at any time, so you should apply as soon as you can.</p>
+    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= cycle_timetable.find_opens.to_fs(:month_and_year) %>, apply no later than <%= apply_1_deadline %>.</p>
+    <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than <%= apply_2_deadline %>.</p>
+  <% end %>
+<% elsif cycle_timetable.show_apply_2_deadline_banner? %>
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.heading(text: "If you’re applying for the first time since applications opened in #{find_opens}") %>
+    <p class="govuk-body">It’s no longer possible to apply for teacher training starting in the <%= cycle_timetable.cycle_year_range %> academic year.</p>
+    <p class="govuk-body">You can <%= govuk_link_to("start or continue your application", Settings.apply_base_url) %> to get it ready for courses starting in the <%= cycle_timetable.cycle_year_range(cycle_timetable.next_year) %> academic year.</p>
+    <p class="govuk-body">You’ll be able to find courses from <%= find_reopens %> and submit your application from <%= apply_reopens %>.</p>
+
+    <p class="govuk-notification-banner__heading">If your application did not lead to a place and you’re applying again</p>
+    <p class="govuk-body">You can continue to view and apply for courses starting in the <%= cycle_timetable.cycle_year_range %> academic year until <%= apply_2_deadline %>.</p>
+  <% end %>
+<% elsif cycle_timetable.show_cycle_closed_banner? %>
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.heading(text: "Courses are currently closed but you can get your application ready") %>
+    <p class="govuk-body">Courses starting in the <%= cycle_timetable.cycle_year_range %> academic year are closed.</p>
+    <p class="govuk-body">You can <%= govuk_link_to("start or continue your application", Settings.apply_base_url) %> to get it ready for courses starting in the <%= cycle_timetable.next_cycle_year_range %> academic year.</p>
+    <p class="govuk-body">You’ll be able to find courses from <%= cycle_timetable.find_reopens.to_fs(:govuk_date_and_time) %> and submit your application from <%= cycle_timetable.apply_reopens.to_fs(:govuk_date_and_time) %>.</p>
+  <% end %>
+<% end %>

--- a/app/components/find_interface/deadline_banner_component.rb
+++ b/app/components/find_interface/deadline_banner_component.rb
@@ -1,0 +1,39 @@
+module FindInterface
+  class DeadlineBannerComponent < ViewComponent::Base
+    attr_accessor :flash_empty
+
+    def initialize(flash_empty:, cycle_timetable: CycleTimetable)
+      super
+      @flash_empty = flash_empty
+      @cycle_timetable = cycle_timetable
+    end
+
+    def render?
+      flash_empty && !cycle_timetable.find_down?
+    end
+
+  private
+
+    attr_reader :cycle_timetable
+
+    def apply_1_deadline
+      cycle_timetable.apply_1_deadline.to_fs(:govuk_date_and_time)
+    end
+
+    def apply_2_deadline
+      cycle_timetable.apply_2_deadline.to_fs(:govuk_date_and_time)
+    end
+
+    def find_opens
+      cycle_timetable.find_opens.to_fs(:month_and_year)
+    end
+
+    def find_reopens
+      cycle_timetable.find_reopens.to_fs(:govuk_date_and_time)
+    end
+
+    def apply_reopens
+      cycle_timetable.apply_reopens.to_fs(:govuk_date_and_time)
+    end
+  end
+end

--- a/app/models/find/site_setting.rb
+++ b/app/models/find/site_setting.rb
@@ -1,0 +1,11 @@
+module Find
+  class SiteSetting
+    def self.cycle_schedule
+      RedisClient.current.get("cycle_schedule")&.to_sym || :real
+    end
+
+    def self.set(name:, value:)
+      RedisClient.current.set(name, value)
+    end
+  end
+end

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -1,0 +1,162 @@
+module Find
+  class CycleTimetable
+    CYCLE_DATES = {
+      2021 => {
+        find_opens: Time.zone.local(2020, 10, 6, 9),
+        apply_opens: Time.zone.local(2020, 10, 13, 9),
+        first_deadline_banner: Time.zone.local(2021, 7, 12, 9),
+        apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
+        apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
+        find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
+      },
+      2022 => {
+        find_opens: Time.zone.local(2021, 10, 5, 9),
+        apply_opens: Time.zone.local(2021, 10, 12, 9),
+        first_deadline_banner: Time.zone.local(2022, 8, 2, 9),
+        apply_1_deadline: Time.zone.local(2022, 9, 6, 18),
+        apply_2_deadline: Time.zone.local(2022, 9, 20, 18),
+        find_closes: Time.zone.local(2022, 10, 3, 23, 59, 59),
+      },
+      2023 => {
+        find_opens: Time.zone.local(2022, 10, 4, 9),
+        apply_opens: Time.zone.local(2022, 10, 11, 9),
+
+        # NOTE: the dates from below here are not the finalised but are required
+        # for the current implementation
+        first_deadline_banner: Time.zone.local(2023, 7, 12, 9),
+        apply_1_deadline: Time.zone.local(2023, 9, 7, 18),
+        apply_2_deadline: Time.zone.local(2023, 9, 21, 18),
+        find_closes: Time.zone.local(2023, 10, 4, 23, 59, 59),
+      },
+      2024 => {
+        find_opens: Time.zone.local(2023, 10, 5, 9),
+        apply_opens: Time.zone.local(2023, 10, 12, 9),
+        first_deadline_banner: Time.zone.local(2024, 7, 12, 9),
+        apply_1_deadline: Time.zone.local(2024, 9, 7, 18),
+        apply_2_deadline: Time.zone.local(2024, 9, 21, 18),
+        find_closes: Time.zone.local(2024, 10, 4, 23, 59, 59),
+      },
+      2025 => {
+        find_opens: Time.zone.local(2024, 10, 5, 9),
+        apply_opens: Time.zone.local(2024, 10, 12, 9),
+        first_deadline_banner: Time.zone.local(2025, 7, 12, 9),
+        apply_1_deadline: Time.zone.local(2025, 9, 7, 18),
+        apply_2_deadline: Time.zone.local(2025, 9, 21, 18),
+        find_closes: Time.zone.local(2025, 10, 4, 23, 59, 59),
+      },
+    }.freeze
+
+    def self.current_year
+      now = Time.zone.now
+
+      current_year = CYCLE_DATES.keys.detect do |year|
+        return year if last_recruitment_cycle_year?(year)
+
+        now.between?(CYCLE_DATES[year][:find_opens], CYCLE_DATES[year + 1][:find_opens])
+      end
+
+      # If the cycle switcher has been set to 'find has reopened' then
+      # we want to request next year's courses from the TTAPI
+      if SiteSetting.cycle_schedule == :today_is_after_find_opens
+        current_year + 1
+      else
+        current_year
+      end
+    end
+
+    def self.next_year
+      current_year + 1
+    end
+
+    def self.find_closes
+      date(:find_closes)
+    end
+
+    def self.first_deadline_banner
+      date(:first_deadline_banner)
+    end
+
+    def self.apply_1_deadline
+      date(:apply_1_deadline)
+    end
+
+    def self.apply_2_deadline
+      date(:apply_2_deadline)
+    end
+
+    def self.find_opens
+      date(:find_opens, current_year)
+    end
+
+    def self.find_reopens
+      date(:find_opens, next_year)
+    end
+
+    def self.apply_reopens
+      date(:apply_opens, next_year)
+    end
+
+    def self.preview_mode?
+      Time.zone.now.between?(apply_2_deadline, find_closes)
+    end
+
+    def self.find_down?
+      current_cycle_schedule == :today_is_after_find_closes || Time.zone.now.between?(find_closes, find_reopens)
+    end
+
+    def self.mid_cycle?
+      current_cycle_schedule == :today_is_after_find_opens || Time.zone.now.between?(find_opens, apply_2_deadline)
+    end
+
+    def self.show_apply_1_deadline_banner?
+      current_cycle_schedule == :today_is_mid_cycle || Time.zone.now.between?(first_deadline_banner, apply_1_deadline)
+    end
+
+    def self.show_apply_2_deadline_banner?
+      current_cycle_schedule == :today_is_after_apply_1_deadline_passed || Time.zone.now.between?(apply_1_deadline, apply_2_deadline)
+    end
+
+    def self.show_cycle_closed_banner?
+      current_cycle_schedule == :today_is_after_apply_2_deadline_passed || Time.zone.now.between?(apply_2_deadline, find_closes)
+    end
+
+    def self.date(name, year = current_year)
+      real_schedule_for(year).fetch(name)
+    end
+
+    def self.last_recruitment_cycle_year?(year)
+      year == CYCLE_DATES.keys.last
+    end
+
+    def self.cycle_year_range(year = current_year)
+      "#{year} to #{year + 1}"
+    end
+
+    def self.next_cycle_year_range(year = current_year)
+      "#{year + 1} to #{year + 2}"
+    end
+
+    def self.current_cycle_schedule
+      # Make sure this setting only has effect on non-production environments
+      return :real if Rails.env.production?
+
+      SiteSetting.cycle_schedule
+    end
+
+    def self.real_schedule_for(year = current_year)
+      CYCLE_DATES[year]
+    end
+
+    def self.fake_point_in_recruitment_cycle
+      %i[
+        today_is_mid_cycle
+        today_is_after_apply_1_deadline_passed
+        today_is_after_apply_2_deadline_passed
+        today_is_after_find_closes
+        today_is_after_find_opens
+      ]
+    end
+
+    private_class_method :last_recruitment_cycle_year?
+  end
+end

--- a/app/views/layouts/find_layout.html.erb
+++ b/app/views/layouts/find_layout.html.erb
@@ -36,6 +36,7 @@
         <% end %>
 
         <%= render FindInterface::MaintenanceBannerComponent.new %>
+        <%= render FindInterface::DeadlineBannerComponent.new(flash_empty: flash.reject { |flash| flash[0] == "start_wizard" }.empty?) unless request.url.include?("/results/filter/subject") %>
 
         <%= yield %>
       </main>

--- a/spec/components/find_interface/deadline_banner_component_spec.rb
+++ b/spec/components/find_interface/deadline_banner_component_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+module FindInterface
+  describe DeadlineBannerComponent, type: :component do
+    context "when it is mid cycle" do
+      it "does not render" do
+        Timecop.travel(CycleTimetable.first_deadline_banner - 1.hour) do
+          result = render_inline(described_class.new(flash_empty: true))
+
+          expect(result.text).to be_blank
+        end
+      end
+    end
+
+    context "when it is after the first_deadline_banner and before the apply_1_deadline" do
+      it "renders the banner with information about apply_1 and apply_2 deadlines" do
+        Timecop.travel(CycleTimetable.first_deadline_banner + 1.hour) do
+          result = render_inline(described_class.new(flash_empty: true))
+
+          expect(result.text).to include("Courses can fill up at any time, so you should apply as soon as you can.")
+          expect(result.text).not_to include("You can continue to view and apply for courses until 6pm on #{CycleTimetable.apply_2_deadline.strftime('%e %B %Y')}")
+          expect(result.text).not_to include("as there’s no guarantee that the courses currently shown on this website will be on offer next year.")
+        end
+      end
+    end
+
+    context "when it is after the apply_1_deadline and before the apply_2_deadline" do
+      it "renders the banner with information about apply_1 and apply_2 deadlines" do
+        Timecop.travel(CycleTimetable.apply_1_deadline + 1.hour) do
+          result = render_inline(described_class.new(flash_empty: true))
+
+          expect(result.text).to include("If your application did not lead to a place and you’re applying again")
+          expect(result.text).not_to include("Courses can fill up at any time, so you should apply as soon as you can.")
+          expect(result.text).not_to include("as there’s no guarantee that the courses currently shown on this website will be on offer next year.")
+        end
+      end
+    end
+
+    context "when it is after the apply_2_deadline and before the find_closes" do
+      it "renders the banner with information about apply_1 and apply_2 deadlines" do
+        Timecop.travel(CycleTimetable.apply_2_deadline + 1.hour) do
+          result = render_inline(described_class.new(flash_empty: true))
+
+          expect(result.text).to include("Courses starting in the #{CycleTimetable.cycle_year_range} academic year are closed")
+          expect(result.text).not_to include("Courses can fill up at any time, so you should apply as soon as you can.")
+          expect(result.text).not_to include("If your application did not lead to a place and you’re applying again, apply no later than 6pm on #{CycleTimetable.apply_2_deadline.strftime('%e %B %Y')}.")
+        end
+      end
+    end
+
+    context "when find is down" do
+      it "does not render" do
+        Timecop.travel(CycleTimetable.find_closes + 1.hour) do
+          result = render_inline(described_class.new(flash_empty: true))
+
+          expect(result.text).to be_blank
+        end
+      end
+    end
+  end
+end

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -1,0 +1,190 @@
+module Find
+  require "rails_helper"
+
+  RSpec.describe CycleTimetable do
+    let(:one_hour_before_find_opens) { described_class.find_opens - 1.hour }
+    let(:one_hour_after_find_opens) { described_class.find_opens + 1.hour }
+    let(:one_hour_before_first_deadline_banner) { described_class.first_deadline_banner - 1.hour }
+    let(:one_hour_before_apply_1_deadline) { described_class.apply_1_deadline - 1.hour }
+    let(:one_hour_after_apply_1_deadline) { described_class.apply_1_deadline + 1.hour  }
+    let(:one_hour_before_apply_2_deadline) { described_class.apply_2_deadline - 1.hour }
+    let(:one_hour_after_apply_2_deadline) { described_class.apply_2_deadline + 1.hour }
+    let(:one_hour_after_find_closes) { described_class.find_closes + 1.hour }
+    let(:one_hour_after_find_reopens) { described_class.find_reopens + 1.hour }
+
+    describe ".current_year" do
+      it "is 2021 if we are in the middle of the 2021 cycle" do
+        Timecop.travel(Time.zone.local(2020, 10, 6, 10, 0, 0)) do
+          expect(described_class.current_year).to eq(2021)
+        end
+      end
+
+      it "is 2022 if we are in the middle of the 2022 cycle" do
+        Timecop.travel(Time.zone.local(2021, 10, 5, 10, 0, 0)) do
+          expect(described_class.current_year).to eq(2022)
+        end
+      end
+
+      context "We are in the middle of the 2021 cycle and the cycle switcher has been set to 'find has reopened'" do
+        it "is 2022" do
+          allow(SiteSetting).to receive(:cycle_schedule).and_return(:today_is_after_find_opens)
+
+          Timecop.travel(Time.zone.local(2020, 10, 6, 10, 0, 0)) do
+            expect(described_class.current_year).to eq(2022)
+          end
+        end
+      end
+    end
+
+    describe ".next_year" do
+      it "is 2022 if we are in the middle of the 2021 cycle" do
+        Timecop.travel(Time.zone.local(2021, 1, 1, 12, 0, 0)) do
+          expect(described_class.next_year).to eq(2022)
+        end
+      end
+
+      it "is 2023 if we are in the middle of the 2022 cycle" do
+        Timecop.travel(Time.zone.local(2021, 11, 1, 12, 0, 0)) do
+          expect(described_class.next_year).to eq(2023)
+        end
+      end
+    end
+
+    describe ".preview_mode?" do
+      it "returns true when it is after the Apply 2 deadline but before Find closes" do
+        Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
+          expect(described_class.preview_mode?).to be true
+        end
+      end
+
+      it "returns false before the Apply 2 deadline" do
+        Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
+          expect(described_class.preview_mode?).to be false
+        end
+      end
+
+      it "returns false when Find has reopened" do
+        Timecop.travel(Time.zone.local(2021, 10, 5, 10, 0, 0)) do
+          expect(described_class.preview_mode?).to be false
+        end
+      end
+    end
+
+    describe ".find_down?" do
+      it "returns true when it is after Find closes and before it reopens" do
+        Timecop.travel(Time.zone.local(2021, 10, 5, 1, 0, 0)) do
+          expect(described_class.find_down?).to be true
+        end
+      end
+
+      it "returns false before Find closes" do
+        Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
+          expect(described_class.find_down?).to be false
+        end
+      end
+
+      it "returns false when Find has reopened" do
+        Timecop.travel(Time.zone.local(2021, 10, 5, 10, 0, 0)) do
+          expect(described_class.find_down?).to be false
+        end
+      end
+    end
+
+    describe ".mid_cycle??" do
+      it "returns true after Find has opened" do
+        Timecop.travel(Time.zone.local(2021, 10, 5, 10, 0, 0)) do
+          expect(described_class.mid_cycle?).to be true
+        end
+      end
+
+      it "returns false after the apply_2_deadline" do
+        Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
+          expect(described_class.mid_cycle?).to be false
+        end
+      end
+
+      context "when current_cycle_schedule returns `:today_is_after_find_opens`" do
+        it "returns true" do
+          allow(described_class).to receive(:current_cycle_schedule).and_return(:today_is_after_find_opens)
+          expect(described_class.mid_cycle?).to be true
+        end
+      end
+    end
+
+    describe ".show_apply_1_deadline_banner?" do
+      it "returns true when it is after the deadline_banner and before the apply_1_deadline" do
+        Timecop.travel(Time.zone.local(2021, 9, 7, 17, 0, 0)) do
+          expect(described_class.show_apply_1_deadline_banner?).to be true
+        end
+      end
+
+      it "returns false after the the apply_1_deadline" do
+        Timecop.travel(Time.zone.local(2021, 9, 7, 19, 0, 0)) do
+          expect(described_class.show_apply_1_deadline_banner?).to be false
+        end
+      end
+
+      it "returns false before the deadline_banner" do
+        Timecop.travel(Time.zone.local(2021, 7, 12, 8, 0, 0)) do
+          expect(described_class.show_apply_1_deadline_banner?).to be false
+        end
+      end
+    end
+
+    describe ".show_apply_2_deadline_banner?" do
+      it "returns true when it is after the apply_1_deadline and before the apply_2_deadline" do
+        Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
+          expect(described_class.show_apply_2_deadline_banner?).to be true
+        end
+      end
+
+      it "returns false before the after the apply_2_deadline" do
+        Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
+          expect(described_class.show_apply_2_deadline_banner?).to be false
+        end
+      end
+
+      it "returns false before the apply_1_deadline" do
+        Timecop.travel(Time.zone.local(2021, 9, 7, 17, 0, 0)) do
+          expect(described_class.show_apply_2_deadline_banner?).to be false
+        end
+      end
+    end
+
+    describe ".show_cycle_closed_banner?" do
+      it "returns true when it is after the apply_2_deadline and before Find closes" do
+        Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
+          expect(described_class.show_cycle_closed_banner?).to be true
+        end
+      end
+
+      it "returns false after Find closes" do
+        Timecop.travel(Time.zone.local(2021, 10, 5, 1, 0, 0)) do
+          expect(described_class.show_cycle_closed_banner?).to be false
+        end
+      end
+
+      it "returns false before the apply_2_deadline" do
+        Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
+          expect(described_class.show_cycle_closed_banner?).to be false
+        end
+      end
+    end
+
+    describe ".cycle_year_range" do
+      it "returns the correctly formatted value" do
+        Timecop.travel(Time.zone.local(2021, 9, 7, 17, 0, 0)) do
+          expect(described_class.cycle_year_range).to eq("2021 to 2022")
+        end
+      end
+    end
+
+    describe ".next_cycle_year_range" do
+      it "returns the correctly formatted value" do
+        Timecop.travel(Time.zone.local(2021, 9, 7, 17, 0, 0)) do
+          expect(described_class.next_cycle_year_range).to eq("2022 to 2023")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/8vDGqCXG/576-deadline-banners

### Changes proposed in this pull request

Migrate the deadline banner component from Find and related code.

### Guidance to review

This just migrates the banner itself and the tests. https://trello.com/c/jrhPxKuT/577-migrate-find-cycles-feature will provide the ability to preview the banner in different states in the service

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
