### PR TITLE
Remove the debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,9 +154,6 @@ group :development, :test do
   # Help eliminate N+1 queries
   gem "bullet"
 
-  # This is the new way to debug!
-  gem "debug"
-
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,9 +184,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    debug (1.6.3)
-      irb (>= 1.3.6)
-      reline (>= 0.3.1)
     debug_inspector (1.1.0)
     declarative (0.0.20)
     deep_merge (1.2.2)
@@ -354,9 +351,6 @@ GEM
     httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    io-console (0.5.11)
-    irb (1.4.2)
-      reline (>= 0.3.0)
     jsbundling-rails (1.0.3)
       railties (>= 6.0.0)
     json (2.6.2)
@@ -564,8 +558,6 @@ GEM
     redcarpet (3.5.1)
     redis (4.8.0)
     regexp_parser (2.6.0)
-    reline (0.3.1)
-      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -737,6 +729,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-20
   arm64-darwin-21
   x86_64-darwin-19
   x86_64-darwin-20
@@ -763,7 +756,6 @@ DEPENDENCIES
   custom_error_message!
   data_migrate
   database_cleaner
-  debug
   dfe-analytics!
   discard
   draper


### PR DESCRIPTION
### Context

Does anyone use this gem, if not can we remove it?

### Changes proposed in this pull request

Remove the debug gem.

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
