### PR TITLE
Don't capitalise subjects unless the subject is a language

### DIFF
--- a/app/components/find_interface/courses/entry_requirements_component/view.rb
+++ b/app/components/find_interface/courses/entry_requirements_component/view.rb
@@ -31,7 +31,7 @@ module FindInterface
       end
 
       def secondary_advisory(course)
-        "Your degree subject should be in #{course.subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
+        "Your degree subject should be in #{course.computed_subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
       end
 
       def pending_gcse_content(course)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -61,14 +61,18 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
-  def subject_name_or_names
-    case object.subjects.size
-    when 1
-      object.subjects.first.subject_name
-    when 2
-      "#{object.subjects.first.subject_name} with #{object.subjects.second.subject_name}"
+  def computed_subject_name_or_names
+    language_subjects_codes = %w[Q3 A0 15 16 17 18 19 20 21 22].freeze
+
+    if (number_of_subjects(1) || modern_languages_other(object)) && language_subjects_codes.include?(object.subjects.first.subject_code)
+      first_subject_name(object)
+    elsif (number_of_subjects(1) || modern_languages_other(object)) && language_subjects_codes.exclude?(object.subjects.first.subject_code)
+      first_subject_name(object).downcase
+    elsif number_of_subjects(2)
+      transformed_subjects = object.subjects.map { |subject| language_subjects_codes.include?(subject.subject_code) ? subject.subject_name : subject.subject_name.downcase }
+      "#{transformed_subjects.first} with #{transformed_subjects.second}"
     else
-      object.name
+      object.name.gsub("Modern Languages", "modern languages")
     end
   end
 
@@ -409,5 +413,17 @@ private
 
   def bursary_and_scholarship_flag_active_or_preview?
     FeatureFlag.active?(:bursaries_and_scholarships_announced)
+  end
+
+  def number_of_subjects(number)
+    object.subjects.size == number
+  end
+
+  def first_subject_name(object)
+    object.subjects.first.subject_name
+  end
+
+  def modern_languages_other(object)
+    object.subjects.any? { |subject| subject.subject_code == "24" }
   end
 end

--- a/spec/components/find_interface/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find_interface/courses/entry_requirements_component/view_preview.rb
@@ -4,6 +4,7 @@ module FindInterface::Courses::EntryRequirementsComponent
   class ViewPreview < ViewComponent::Preview
     def qualifications_needed_only
       course = Course.new(course_code: "FIND",
+        name: "Super cool awesome course",
         provider: Provider.new(provider_code: "DFE"),
         additional_degree_subject_requirements: true,
         degree_subject_requirements: "Degree Subject Requirements Text",
@@ -45,7 +46,7 @@ module FindInterface::Courses::EntryRequirementsComponent
         additional_gcse_equivalencies: "much much more",
         personal_qualities: "Personal Qualities Text Goes Here",
         other_requirements: "Other Requirements Text Goes Here",
-        subject_name_or_names: "Biology" }
+        computed_subject_name_or_names: "Biology" }
     end
 
     def mock_course
@@ -54,7 +55,7 @@ module FindInterface::Courses::EntryRequirementsComponent
 
     class FakeCourse
       include ActiveModel::Model
-      attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :subject_name_or_names, :campaign_name)
+      attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :computed_subject_name_or_names, :campaign_name)
 
       def enrichment_attribute(params)
         send(params)

--- a/spec/components/find_interface/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find_interface/courses/entry_requirements_component/view_spec.rb
@@ -63,7 +63,7 @@ describe FindInterface::Courses::EntryRequirementsComponent::View, type: :compon
                                "Grade 5 (C) or above in English and maths, or equivalent qualification.",
                              )
       expect(result.text).to include(
-                               "Your degree subject should be in #{course.subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way",
+                               "Your degree subject should be in #{course.computed_subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way",
                              )
     end
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -319,10 +319,10 @@ describe CourseDecorator do
     end
   end
 
-  describe "#subject_name_or_names" do
+  describe "#computed_subject_name_or_names" do
     context "course has more than one subject" do
       it "returns both subjects names seperated by a 'with'" do
-        expect(decorated_course.subject_name_or_names).to eq("English with Mathematics")
+        expect(decorated_course.computed_subject_name_or_names).to eq("English with mathematics")
       end
     end
 
@@ -331,7 +331,34 @@ describe CourseDecorator do
       let(:course) { build_stubbed(:course, subjects: [course_subject]) }
 
       it "return the subject name" do
-        expect(decorated_course.subject_name_or_names).to eq("Computing")
+        expect(decorated_course.computed_subject_name_or_names).to eq("computing")
+      end
+    end
+
+    context "course has a language subject" do
+      let(:course_subject) { find_or_create :secondary_subject, :english }
+      let(:course) { build(:course, subjects: [course_subject]) }
+
+      it "return the capitalised subject name" do
+        expect(decorated_course.computed_subject_name_or_names).to eq("English")
+      end
+    end
+
+    context "course is modern languages" do
+      let(:course_subject) { find_or_create :secondary_subject, :modern_languages }
+      let(:course) { build(:course, subjects: [course_subject, build(:modern_languages_subject, :french)]) }
+
+      it "return lowercase modern languages and capitalised language" do
+        expect(decorated_course.computed_subject_name_or_names).to eq("modern languages with French")
+      end
+    end
+
+    context "course is modern languages (other)" do
+      let(:course_subject) { find_or_create :secondary_subject, :modern_languages }
+      let(:course) { build(:course, subjects: [course_subject, build(:modern_languages_subject, :modern_languages_other)]) }
+
+      it "returns one modern languages" do
+        expect(decorated_course.computed_subject_name_or_names).to eq("modern languages")
       end
     end
   end


### PR DESCRIPTION
### Context

In the entry requirements section, subjects which are also not a language should not be capitalised. 

### Screenshot

<img width="673" alt="image" src="https://user-images.githubusercontent.com/50492247/201092397-29b4b1db-fdc5-4970-9e4d-cc76eaa85bef.png">

### Changes proposed in this pull request

- Add the subject codes which are a language to an array.
- Use this array to downcase all other subject names in the view.
- Ensure modern languages is not capitalised (using gsub).

### Guidance to review

- View the entry requirements on courses with the following criteria, and ensure the capitalisation is correct. 

`Note: You may have to insert the course in to the instance variable in `app/controllers/find/courses_controller.rb` and the provider on the view as the full search functionality of new Find hasn't been built yet.`
- A course with a single language subject
- A course with a single non language subject
- A course with two subjects, one language and one non language
- A modern languages course
- A modern languages other course

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
