### PR TITLE
[0780] Amended so that courses are order ascending

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -169,11 +169,11 @@ class Course < ApplicationRecord
   }
 
   scope :ascending_canonical_order, lambda {
-    joins(:provider).merge(Provider.by_name_ascending).order("name asc, course_code asc")
+    joins(:provider).merge(Provider.by_name_ascending).order(name: :asc, course_code: :asc)
   }
 
   scope :descending_canonical_order, lambda {
-    joins(:provider).merge(Provider.by_name_descending).order("name desc, course_code desc")
+    joins(:provider).merge(Provider.by_name_descending).order(name: :asc, course_code: :asc)
   }
 
   scope :accredited_body_order, lambda { |provider_name|

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -168,7 +168,7 @@ private
   end
 
   def sort_by_provider_descending?
-    sort == Set["-name", "-provider.provider_name"]
+    sort == Set["name", "-provider.provider_name"]
   end
 
   def sort_by_distance?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -288,14 +288,14 @@ describe Course do
         subject { described_class.descending_canonical_order }
 
         it "sorts in descending order of provider name" do
-          expect(subject).to eq([course_d, course_c, course_b, course_a])
+          expect(subject).to eq([course_c, course_d, course_a, another_course_a, course_b])
         end
 
         context "when there are multiple courses with the same name" do
           before { another_course_a }
 
           it "sorts by course_code" do
-            expect(subject).to eq([course_d, course_c, course_b, another_course_a, course_a])
+            expect(subject).to eq([course_c, course_d, course_a, another_course_a, course_b])
           end
         end
       end

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -214,7 +214,7 @@ describe "GET v3/courses" do
     end
 
     context "in descending order" do
-      let(:request_path) { "/api/v3/courses?include=provider&sort=-name,-provider.provider_name" }
+      let(:request_path) { "/api/v3/courses?include=provider&sort=name,-provider.provider_name" }
 
       it "returns an ordered list" do
         get request_path

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CourseSearchService do
       end
 
       context "descending provider name and course name" do
-        let(:sort) { "-provider.provider_name,-name" }
+        let(:sort) { "-provider.provider_name,name" }
 
         it "orders in descending order" do
           expect(scope).to receive(:select).and_return(inner_query_scope)


### PR DESCRIPTION
### Context

Ordering of courses

### Changes proposed in this pull request

Courses are ordered ascending
### Guidance to review


When sorting by training provider ascending
Then sort by provider ascending (a to z)
and sort by course name ascending (a to z)

When sorting by training provider descending
Then sort by provider descending (z to a)
and sort by course name ascending (a to z)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
