### PR TITLE
[813] Clean up find feature flags

### DIFF
--- a/app/components/find_interface/courses/financial_support/bursary_component/view.html.erb
+++ b/app/components/find_interface/courses/financial_support/bursary_component/view.html.erb
@@ -1,5 +1,5 @@
 <div data-qa="course__bursary_details">
-  <% if Settings.find_features.bursaries_and_scholarships_announced == true %>
+  <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
     <p class="govuk-body">
       You could be eligible for a bursary of <%= number_to_currency(bursary_amount) %>.
     </p>

--- a/app/components/find_interface/courses/financial_support/scholarship_and_bursary_component/view.html.erb
+++ b/app/components/find_interface/courses/financial_support/scholarship_and_bursary_component/view.html.erb
@@ -1,5 +1,5 @@
 <div data-qa="course__scholarship_and_bursary_details">
-  <% if Settings.find_features.bursaries_and_scholarships_announced %>
+  <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
     <p class="govuk-body">
       You could be eligible for either:
     </p>

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -331,7 +331,7 @@ class CourseDecorator < ApplicationDecorator
     bursary_amount = number_to_currency(financial_incentive&.bursary_amount)
     scholarship = number_to_currency(financial_incentive&.scholarship)
 
-    return I18n.t("components.course.financial_incentives.not_yet_available") if (course.recruitment_cycle_year.to_i > Settings.current_recruitment_cycle_year) || (Settings.find_features.bursaries_and_scholarships_announced == false)
+    return I18n.t("components.course.financial_incentives.not_yet_available") if (course.recruitment_cycle_year.to_i > Settings.current_recruitment_cycle_year) || !FeatureFlag.active?(:bursaries_and_scholarships_announced)
     return I18n.t("components.course.financial_incentives.none") if financial_incentive.nil?
 
     if bursary_amount.present? && scholarship.present?
@@ -408,6 +408,6 @@ private
   end
 
   def bursary_and_scholarship_flag_active_or_preview?
-    (Settings.find_features.bursaries_and_scholarships_announced == true)
+    FeatureFlag.active?(:bursaries_and_scholarships_announced)
   end
 end

--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -4,7 +4,7 @@ module Find
       subjects.map do |subject|
         financial_incentive = subject.financial_incentive
         financial_info = nil
-        if Settings.find_features.bursaries_and_scholarships_announced == true && financial_incentive.present?
+        if FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
           if financial_incentive.scholarship.present? && financial_incentive.bursary_amount.present?
             financial_info = "Scholarships of £#{number_with_delimiter(financial_incentive.scholarship, delimiter: ',')} and bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} are available"
           elsif financial_incentive.scholarship.present?

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -3,8 +3,6 @@ class FeatureFlags
     [
       [:maintenance_mode, "Puts Find into maintenance mode", "Find and Publish team"],
       [:maintenance_banner, "Displays the maintenance mode banner", "Find and Publish team"],
-      [:cache_courses, "Caches request to the Teacher Training API for individual courses", "Find and Publish team"],
-      [:send_web_requests_to_big_query, "Send events to Google Big Query", "Find and Publish team"],
       [:bursaries_and_scholarships_announced, "Display scholarship and bursary information", "Find and Publish team"],
     ]
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -122,7 +122,4 @@ cookies:
     name: _consented_to_analytics_cookies
     expire_after_days: 182
 
-find_features:
-  bursaries_and_scholarships_announced: true
-
 STATE_CHANGE_SLACK_URL: replace_me

--- a/spec/components/find_interface/courses/financial_support/bursary_component/view_spec.rb
+++ b/spec/components/find_interface/courses/financial_support/bursary_component/view_spec.rb
@@ -5,7 +5,7 @@ describe FindInterface::Courses::FinancialSupport::BursaryComponent::View, type:
 
   context "bursaries_and_scholarships_announced feature flag is on" do
     before do
-      allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(true)
+      FeatureFlag.activate(:bursaries_and_scholarships_announced)
       render_inline(described_class.new(course))
     end
 
@@ -22,8 +22,6 @@ describe FindInterface::Courses::FinancialSupport::BursaryComponent::View, type:
 
   context "bursaries_and_scholarships_announced feature flag is off" do
     it "does not render bursary details" do
-      allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(false)
-
       render_inline(described_class.new(course))
 
       expect(page.has_text?("You could be eligible for a bursary of £3,000")).to be false

--- a/spec/components/find_interface/courses/financial_support/fees_and_financial_support_component/view_spec.rb
+++ b/spec/components/find_interface/courses/financial_support/fees_and_financial_support_component/view_spec.rb
@@ -32,7 +32,7 @@ describe FindInterface::Courses::FinancialSupport::FeesAndFinancialSupportCompon
 
   context "Courses with bursary" do
     it "renders the bursary section if the course has a bursary" do
-      allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(true)
+      FeatureFlag.activate(:bursaries_and_scholarships_announced)
 
       course = build(:course, funding_type: "fee", name: "History", subjects: [build(:secondary_subject, bursary_amount: "2000"), build(:secondary_subject)]).decorate
 
@@ -44,7 +44,7 @@ describe FindInterface::Courses::FinancialSupport::FeesAndFinancialSupportCompon
 
   context "Courses with scholarship and bursary" do
     it "renders the scholarships and bursary section" do
-      allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(true)
+      FeatureFlag.activate(:bursaries_and_scholarships_announced)
 
       course = build(:course, funding_type: "fee", name: "History", subjects: [build(:secondary_subject, bursary_amount: "2000", financial_incentive: FinancialIncentive.new(scholarship: "1000")), build(:secondary_subject)]).decorate
 

--- a/spec/components/find_interface/courses/financial_support/scholarship_and_bursary_component/view_spec.rb
+++ b/spec/components/find_interface/courses/financial_support/scholarship_and_bursary_component/view_spec.rb
@@ -14,7 +14,7 @@ describe FindInterface::Courses::FinancialSupport::ScholarshipAndBursaryComponen
 
   context "bursaries_and_scholarships_announced feature flag is on" do
     before do
-      allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(true)
+      FeatureFlag.activate(:bursaries_and_scholarships_announced)
     end
 
     it "renders scholarship and bursary details" do
@@ -83,10 +83,6 @@ describe FindInterface::Courses::FinancialSupport::ScholarshipAndBursaryComponen
   end
 
   context "bursaries_and_scholarships_announced feature flag is off" do
-    before do
-      allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(false)
-    end
-
     it "does not render scholarship and bursary details" do
       result = render_inline(described_class.new(course))
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -818,7 +818,7 @@ describe CourseDecorator do
 
     context "bursaries and scholarships is announced" do
       before do
-        allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(true)
+        FeatureFlag.activate(:bursaries_and_scholarships_announced)
       end
 
       context "course has no financial incentive" do
@@ -861,10 +861,6 @@ describe CourseDecorator do
     end
 
     context "bursaries and scholarships is not announced" do
-      before do
-        allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(false)
-      end
-
       it "returns the correct details under 'financial_incentive_details'" do
         expect(subject).to eq("Information not yet available")
       end

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "Course show", { can_edit_current_and_next_cycles: false } do
   context "bursaries and scholarships is announced" do
     before do
-      allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(true)
+      FeatureFlag.activate(:bursaries_and_scholarships_announced)
     end
 
     scenario "i can view the course basic details" do
@@ -17,10 +17,6 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
   end
 
   context "bursaries and scholarships is not announced" do
-    before do
-      allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(false)
-    end
-
     scenario "i can view the course basic details" do
       given_i_am_authenticated(user: user_with_fee_based_course)
       when_i_visit_the_course_preview_page

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -15,7 +15,7 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
   describe "with a fee paying course" do
     context "bursaries and scholarships is announced" do
       before do
-        allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(true)
+        FeatureFlag.activate(:bursaries_and_scholarships_announced)
       end
 
       scenario "i can view a fee course" do
@@ -28,10 +28,6 @@ feature "Course show", { can_edit_current_and_next_cycles: false } do
     end
 
     context "bursaries and scholarships is not announced" do
-      before do
-        allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(false)
-      end
-
       scenario "i can view a fee course" do
         given_i_am_authenticated_as_a_provider_user(course: course_with_financial_incentive)
         when_i_visit_the_course_page

--- a/spec/helpers/find/subject_helper_spec.rb
+++ b/spec/helpers/find/subject_helper_spec.rb
@@ -22,7 +22,7 @@ describe Find::SubjectHelper do
 
     context "bursaries and scholarships is announced" do
       before do
-        allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(true)
+        FeatureFlag.activate(:bursaries_and_scholarships_announced)
       end
 
       context "with bursary only" do
@@ -51,7 +51,7 @@ describe Find::SubjectHelper do
 
       context "bursaries and scholarships is not announced" do
         before do
-          allow(Settings.find_features).to receive(:bursaries_and_scholarships_announced).and_return(false)
+          FeatureFlag.deactivate(:bursaries_and_scholarships_announced)
         end
 
         context "with bursary only" do


### PR DESCRIPTION
### Context

https://trello.com/c/KhLW22i6/813-move-over-missing-feature-flag-guard-clauses

### Changes proposed in this pull request

We moved over the feature logic from Find, this PR reinforces the flags and their guard clauses currently used in the codebase. Due to the migration, two are now redundant:

- `cache_courses` no need for this
- `send_web_requests_to_big_query` already in place app wide for the publish codebase

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
