### PR TITLE
[0833] Fixed incorrect URL for info on Maths scholarship

### DIFF
--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -46,7 +46,7 @@ en:
         url: https://www.bcs.org/qualifications-and-certifications/training-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/
       mathematics:
         body: Institute of Mathematics and its Applications
-        url: http://teachingmathsscholars.org/about
+        url: https://teachingmathsscholars.org/eligibilitycriteria
     international_candidates:
       skilled_worker_visa:
         not_available:


### PR DESCRIPTION
### Context
URL for info on Maths scholarship

### Changes proposed in this pull request
 Fixed incorrect URL for info on Maths scholarship


### Guidance to review
![image](https://user-images.githubusercontent.com/470137/202144926-fbbd5f95-87d2-41c9-a996-a6b57bdc6f3c.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
