### PR TITLE
Campaign name api fix

### DIFF
--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -11,6 +11,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
   let(:subjects) { [course_subject_mathematics] }
 
   let(:applications_open_from) { Time.now.utc }
+  let(:campaign_name) { nil }
   let(:findable_open_course) do
     create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship, :with_gcse_equivalency,
       level: "primary",
@@ -26,7 +27,8 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
       english: :must_have_qualification_at_application_time,
       science: :must_have_qualification_at_application_time,
       age_range_in_years: "3_to_7",
-      applications_open_from:)
+      applications_open_from:,
+      campaign_name:)
   end
 
   let(:courses_site_status) do
@@ -141,6 +143,19 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
               "version" => "1.0",
             },
           )
+        end
+
+        context "with a engineers_teach_physics campaign course" do
+          let(:campaign_name) { "engineers_teach_physics" }
+
+          it "has the campaign_name 'engineers_teach_physics'" do
+            findable_open_course
+
+            perform_request
+            json_response = JSON.parse response.body
+            expect(json_response["data"].first)
+            .to have_attribute("campaign_name").with_value("engineers_teach_physics")
+          end
         end
       end
     end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -554,11 +554,7 @@
             "type": "string",
             "nullable": true,
             "description": "The course’s campaign code, corresponding to campaigns to help improve recruitment.",
-            "example": "engineers_teach_physics",
-            "enum": [
-              "engineers_teach_physics",
-              "no_campaign"
-            ]
+            "example": "engineers_teach_physics"
           }
         }
       },
@@ -699,10 +695,10 @@
             "type": "boolean",
             "example": true
           },
-          "campaign_name": {
-            "description": "Return courses which are part of a campaign.",
-            "type": "string",
-            "example": "engineers_teach_physics"
+          "engineers_teach_physics": {
+            "description": "Only return courses that are part of the engineers teach physics campaign.",
+            "type": "boolean",
+            "example": true
           }
         }
       },

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -396,6 +396,3 @@ properties:
     nullable: true
     description: "The course’s campaign code, corresponding to campaigns to help improve recruitment."
     example: "engineers_teach_physics"
-    enum:
-      - engineers_teach_physics
-      - no_campaign

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -117,6 +117,6 @@ properties:
     type: boolean
     example: true
   campaign_name:
-      description: "Return courses which are part of a campaign."
-      type: string
-      example: "campaign_name"
+    description: "Return courses which are part of a campaign."
+    type: string
+    example: "campaign_name"

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -113,9 +113,9 @@ properties:
       - third_class
       - not_required
   can_sponsor_visa:
-      description: "Only return courses where a skilled worker or student visa can be sponsored."
-      type: boolean
-      example: true
+    description: "Only return courses where a skilled worker or student visa can be sponsored."
+    type: boolean
+    example: true
   campaign_name:
       description: "Return courses which are part of a campaign."
       type: string

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -116,7 +116,7 @@ properties:
     description: "Only return courses where a skilled worker or student visa can be sponsored."
     type: boolean
     example: true
-  campaign_name:
-    description: "Return courses which are part of a campaign."
-    type: string
-    example: "campaign_name"
+  engineers_teach_physics:
+    description: "Only return courses that are part of the engineers teach physics campaign."
+    type: boolean
+    example: true


### PR DESCRIPTION
### Context

Change campaign_name to engineers_teach_physics
When you set the engineers_teach_physics filter to true it returns all courses in that campaign.

When you set the engineers_teach_physics to false it returns all courses, including those in the ETP campaign.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
