### PR TITLE
[825] Add visually hidden text to errors linked to no keys

### DIFF
--- a/app/views/find/result_filters/location/_form.html.erb
+++ b/app/views/find/result_filters/location/_form.html.erb
@@ -22,6 +22,7 @@
         <div class="govuk-form-group" id="search-options">
           <% if flash[:error] and location_error? === false and provider_error? === false %>
             <p class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error: </span>
               <% if flash[:error].kind_of?(Array) %>
                 <%= flash[:error].last %>
               <% else %>


### PR DESCRIPTION
### Context

https://trello.com/b/yOZLQ2IK/find-pub-sprint-board

### Changes proposed in this pull request

- Adds visually hidden text to inline error message when linked to no fields (eg submitting without an option on start page)

### Guidance to review

- Submit without entering a value on start page and check markup (do the same for other forms)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
