### PR TITLE
[0824] Fixed mis match page title vs h1

### DIFF
--- a/app/views/find/results/index.html.erb
+++ b/app/views/find/results/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, @number_of_courses_string %>
+<%= content_for :page_title, "#{@number_of_courses_string} found" %>
 
 <%= render FindInterface::Results::ResultsComponent.new(
   results: @results_view,

--- a/app/views/find/search/subjects/index.html.erb
+++ b/app/views/find/search/subjects/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix(t("find.subjects_page.title"), @subjects_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix(t("find.subjects_page.#{@subjects_form.age_group}_title"), @subjects_form.errors.present?) %>
 
 <%= form_with(model: @subjects_form, url: find_subjects_path, method: :get) do |form| %>
   <%= form.govuk_error_summary %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -29,7 +29,7 @@ en:
           radio: Further education
           hint_text: For example, teaching A levels or vocational courses
     subjects_page:
-      title: Select a subject -
+      primary_title: Primary courses with subject specialisms
       secondary_title: Which secondary subjects do you want to teach?
     courses:
       show:


### PR DESCRIPTION
### Context

Mis match page title vs h1

### Changes proposed in this pull request

Fixed mis match page title vs h1 

### Guidance to review
The page titles matches

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
