### PR TITLE
[821] Refactor course name generation service

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -366,7 +366,7 @@ class Course < ApplicationRecord
   end
 
   def generate_name
-    services[:generate_course_name].execute(course: self)
+    Courses::GenerateCourseNameService.call(course: self)
   end
 
   def accrediting_provider_description
@@ -995,9 +995,6 @@ private
     return @services if @services.present?
 
     @services = Dry::Container.new
-    @services.register(:generate_course_name) do
-      Courses::GenerateCourseNameService.new
-    end
     @services.register(:assignable_master_subjects) do
       Courses::AssignableMasterSubjectService.new
     end

--- a/app/services/courses/generate_course_name_service.rb
+++ b/app/services/courses/generate_course_name_service.rb
@@ -1,16 +1,20 @@
 module Courses
   class GenerateCourseNameService
-    def execute(course:)
-      subjects = course.subjects
+    include ServicePattern
 
+    ENGINEERS_TEACH_PHYSICS_TITLE = I18n.t("courses.generate_course_name_service.etp_title")
+    FURTHER_EDUCATION_TITLE = I18n.t("courses.generate_course_name_service.further_education_title")
+
+    def initialize(course:)
+      @course = course
+      @subjects = course.course_subjects.sort_by(&:position).map(&:subject)
+    end
+
+    def call
       title = if course.further_education_course?
-                further_education_title
-              elsif course.is_engineers_teach_physics?
-                engineers_teach_physics_title(subjects)
-              elsif is_modern_lanuage_course?(subjects)
-                modern_language_title(subjects)
+                FURTHER_EDUCATION_TITLE
               else
-                generated_title(subjects)
+                generated_title
               end
 
       title += " (SEND)" if course.is_send?
@@ -19,74 +23,69 @@ module Courses
 
   private
 
-    def engineers_title
-      "Engineers Teach Physics"
+    attr_reader :course, :subjects
+
+    def generated_title
+      return "" if subjects.empty?
+
+      return formatted_subjects.first if formatted_subjects.length == 1
+
+      "#{formatted_subjects.first} with #{formatted_subjects.last}"
     end
 
-    def engineers_teach_physics_title(subjects)
-      subject_names = subjects.map { |s| format_subject_name(s) }
-      subject_names.delete("Physics")
+    def formatted_subjects
+      modern_language_title = [generate_modern_language_title].compact
 
-      if subject_names.blank?
-        engineers_title
-      else
-        "#{engineers_title} with #{subject_names[0]}"
-      end
+      return subjects_excluding_languages.unshift(modern_language_title).flatten if main_subject_is_modern_languages?
+
+      subjects_excluding_languages.concat(modern_language_title)
     end
 
-    def is_modern_lanuage_course?(subjects)
-      subjects.any? { |s| s == SecondarySubject.modern_languages }
-    end
+    def generate_modern_language_title
+      return unless is_modern_language_course?
 
-    def modern_language_title(subjects)
       title = SecondarySubject.modern_languages.to_s
+      official_languages = languages.reject { |language| language.subject_name.casecmp?("Modern languages (other)") }
 
-      languages = subjects.select { |s| s.type == "ModernLanguagesSubject" }
-      languages = languages.reject { |language| language.subject_name.casecmp?("Modern languages (other)") }
+      return title if official_languages.empty? || official_languages.length >= 4
 
-      return title if languages.empty? || languages.length >= 4
-
-      language_names = languages.map { |language| format_language_name(language) }
+      language_names = official_languages.map { |language| format_subject_name(language) }
 
       case language_names.length
       when 1
         title + " (#{language_names[0]})"
       when 2
+        return language_names.join(" and ") unless main_subject_is_modern_languages?
+
         title + " (#{language_names.join(' and ')})"
       when 3
         title + " (#{language_names.join(', ')})"
       end
     end
 
-    def generated_title(subjects)
-      return "" if subjects.empty?
-
-      subjects = subjects.map { |s| format_subject_name(s) }
-
-      if subjects.length == 1
-        subjects[0]
-      else
-        "#{subjects[0]} with #{subjects[1]}"
-      end
-    end
-
-    def further_education_title
-      "Further education"
+    def is_modern_language_course?
+      subjects.any? { |s| s == SecondarySubject.modern_languages }
     end
 
     def format_subject_name(subject)
-      if subject.subject_name.casecmp?("Communication and media studies")
-        "Media studies"
-      else
-        subject.to_s
-      end
+      {
+        "communication and media studies" => "Media studies",
+        "english as a second or other language" => "English",
+        "physics" => course.is_engineers_teach_physics? ? ENGINEERS_TEACH_PHYSICS_TITLE : subject.to_s,
+      }[subject.subject_name.downcase] || subject.to_s
     end
 
-    def format_language_name(language)
-      if language.subject_name.casecmp?("English as a second or other language")
-        "English"
-      else
-        language.to_s
+    def languages
+      @languages ||= subjects.select { |s| s.type == "ModernLanguagesSubject" }
+    end
+
+    def main_subject_is_modern_languages?
+      course.master_subject_id == SecondarySubject.modern_languages.id
+    end
+
+    def subjects_excluding_languages
+      @subjects_excluding_languages ||= (subjects - [SecondarySubject.modern_languages, languages].flatten).map do |s|
+        format_subject_name(s)
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,10 @@ en:
   back: "Back"
   continue: "Continue"
   change_organisation: "Change organisation"
+  courses:
+    generate_course_name_service:
+      further_education_title: "Further education"
+      etp_title: "Engineers Teach Physics"
   visa_sponsorships:
     student: "Student"
     skilled_worker: "Skilled Worker"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
   courses:
     generate_course_name_service:
       further_education_title: "Further education"
-      etp_title: "Engineers Teach Physics"
+      etp_title: "Engineers teach physics"
   visa_sponsorships:
     student: "Student"
     skilled_worker: "Skilled Worker"

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2542,14 +2542,8 @@ describe Course do
 
   describe "#generate_name" do
     it "Generates a name using the correct service" do
-      expect(course).to(
-        delegate_method_to_service(
-          :generate_name,
-          "Courses::GenerateCourseNameService",
-        ).with_arguments(
-          course:,
-        ),
-      )
+      expect(Courses::GenerateCourseNameService).to receive(:call).with(course:)
+      course.generate_name
     end
   end
 

--- a/spec/services/courses/generate_course_name_service_spec.rb
+++ b/spec/services/courses/generate_course_name_service_spec.rb
@@ -7,7 +7,8 @@ describe Courses::GenerateCourseNameService do
   let(:campaign_name) { "no_campaign" }
   let(:course) { Course.new(level:, subjects:, is_send:, campaign_name:) }
   let(:modern_languages) { find_or_create(:secondary_subject, :modern_languages) }
-  let(:generated_title) { described_class.call(course:) }
+
+  subject(:generated_title) { described_class.call(course:) }
 
   before do
     SecondarySubject.clear_cache
@@ -24,302 +25,300 @@ describe Courses::GenerateCourseNameService do
     end
   end
 
-  context "With no subjects" do
-    it "Returns an empty string" do
-      expect(generated_title).to eq("")
-    end
-  end
-
-  describe "Generating a title for a further education course" do
-    let(:level) { "further_education" }
-
-    it "returns 'Further education'" do
-      expect(generated_title).to eq("Further education")
+  describe ".call" do
+    context "With no subjects" do
+      it "Returns an empty string" do
+        expect(subject).to eq("")
+      end
     end
 
-    include_examples "with SEND"
-  end
+    context "Generating a title for a further education course" do
+      let(:level) { "further_education" }
 
-  describe "Generating a title for non-further education course" do
-    let(:level) { "primary" }
-
-    before do
-      set_course_subjects_and_master_id
-    end
-
-    context "With a single subject" do
-      let(:subjects) { [Subject.new(subject_name: "Physical education")] }
-
-      it "Returns the subject name" do
-        expect(generated_title).to eq("Physical education")
+      it "returns 'Further education'" do
+        expect(subject).to eq("Further education")
       end
 
       include_examples "with SEND"
     end
 
-    context "With multiple subjects" do
-      let(:subjects) { [find_or_create(:secondary_subject, :physics), find_or_create(:secondary_subject, :english)] }
+    context "Generating a title for non-further education course" do
+      let(:level) { "primary" }
 
-      it "Returns a name containing both subjects in the order they were given" do
-        expect(generated_title).to eq("Physics with English")
+      before do
+        set_course_subjects_and_master_id
       end
 
-      include_examples "with SEND"
-    end
+      context "With a single subject" do
+        let(:subjects) { [Subject.new(subject_name: "Physical education")] }
 
-    context "Names which require altering" do
-      context "Communications and media studies -> Media studies" do
-        context "With single subject" do
-          let(:subjects) do
-            [find_or_create(:secondary_subject, :communication_and_media_studies)]
+        it "Returns the subject name" do
+          expect(subject).to eq("Physical education")
+        end
+
+        include_examples "with SEND"
+      end
+
+      context "With multiple subjects" do
+        let(:subjects) { [find_or_create(:secondary_subject, :physics), find_or_create(:secondary_subject, :english)] }
+
+        it "Returns a name containing both subjects in the order they were given" do
+          expect(subject).to eq("Physics with English")
+        end
+
+        include_examples "with SEND"
+      end
+
+      context "Names which require altering" do
+        context "Communications and media studies -> Media studies" do
+          context "With single subject" do
+            let(:subjects) do
+              [find_or_create(:secondary_subject, :communication_and_media_studies)]
+            end
+
+            it "Returns the title Media studies" do
+              expect(subject).to eq("Media studies")
+            end
           end
 
-          it "Returns the title Media studies" do
-            expect(generated_title).to eq("Media studies")
+          context "With multiple subjects" do
+            let(:subjects) do
+              [
+                find_or_create(:secondary_subject, :communication_and_media_studies),
+                find_or_create(:secondary_subject, :mathematics),
+              ]
+            end
+
+            it "Returns the title Media studies" do
+              expect(subject).to eq("Media studies with Mathematics")
+            end
           end
         end
 
-        context "With multiple subjects" do
+        context "English as a second language -> English" do
+          context "With a single language" do
+            let(:subjects) do
+              [modern_languages, find_or_create(:modern_languages_subject, :english_as_a_second_language_or_other_language)]
+            end
+
+            it "Returns the title Modern Languages (English)" do
+              expect(subject).to eq("Modern Languages (English)")
+            end
+          end
+
+          context "With two languages" do
+            let(:subjects) do
+              [
+                modern_languages,
+                find_or_create(:modern_languages_subject, :english_as_a_second_language_or_other_language),
+                find_or_create(:modern_languages_subject, :spanish),
+              ]
+            end
+
+            it "Returns the title Modern Languages (English and Spanish)" do
+              expect(subject).to eq("Modern Languages (English and Spanish)")
+            end
+          end
+
+          context "With three languages" do
+            let(:subjects) do
+              [
+                modern_languages,
+                find_or_create(:modern_languages_subject, :english_as_a_second_language_or_other_language),
+                find_or_create(:modern_languages_subject, :french),
+                find_or_create(:modern_languages_subject, :spanish),
+              ]
+            end
+
+            it "Returns the title Modern Languages (English, French, Spanish)" do
+              expect(subject).to eq("Modern Languages (English, French, Spanish)")
+            end
+          end
+        end
+
+        context "Modern Languages (Other) -> Should be ignored for the title" do
+          context "With a single language" do
+            let(:subjects) do
+              [modern_languages, find_or_create(:modern_languages_subject, :modern_languages_other)]
+            end
+
+            it "Returns the title Modern Languages" do
+              expect(subject).to eq("Modern Languages")
+            end
+          end
+
+          context "With two languages" do
+            let(:subjects) do
+              [
+                modern_languages,
+                find_or_create(:modern_languages_subject, :modern_languages_other),
+                find_or_create(:modern_languages_subject, :spanish),
+              ]
+            end
+
+            it "Returns the title Modern Languages (Spanish)" do
+              expect(subject).to eq("Modern Languages (Spanish)")
+            end
+          end
+
+          context "With three languages" do
+            let(:subjects) do
+              [
+                modern_languages,
+                find_or_create(:modern_languages_subject, :modern_languages_other),
+                find_or_create(:modern_languages_subject, :french),
+                find_or_create(:modern_languages_subject, :spanish),
+              ]
+            end
+
+            it "Returns the title Modern Languages (French and Spanish)" do
+              expect(subject).to eq("Modern Languages (French and Spanish)")
+            end
+          end
+        end
+      end
+
+      context "Generating a title for an ETP course" do
+        before do
+          set_course_subjects_and_master_id
+        end
+
+        context "With no campaign" do
+          let(:subjects) { [SecondarySubject.find_by(subject_name: "Physics")] }
+          let(:course) { Course.new(level: :secondary, subjects:, is_send:, campaign_name:, master_subject_id: 29) }
+
+          it "returns Physics" do
+            expect(subject).to eq("Physics")
+          end
+
+          include_examples "with SEND"
+        end
+
+        context "With engineers_teach_physics campaign" do
+          let(:campaign_name) { "engineers_teach_physics" }
+          let(:subjects) { [SecondarySubject.find_by(subject_name: "Physics")] }
+          let(:course) { Course.new(level: :secondary, subjects:, is_send:, campaign_name:, master_subject_id: 29) }
+
+          it "returns Engineers teach physics" do
+            expect(subject).to eq("Engineers teach physics")
+          end
+
+          include_examples "with SEND"
+        end
+
+        context "With campaign and second subject" do
+          let(:campaign_name) { "engineers_teach_physics" }
+          let(:subjects) { [find_or_create(:secondary_subject, :physics), find_or_create(:secondary_subject, :english)] }
+          let(:course) { Course.new(level:, subjects:, is_send:, campaign_name:, master_subject_id: 29) }
+
+          it "returns Engineers teach physics with subject" do
+            expect(subject).to eq("Engineers teach physics with English")
+          end
+
+          include_examples "with SEND"
+        end
+      end
+
+      context "Generating a title for a Modern Languages course" do
+        before do
+          set_course_subjects_and_master_id
+        end
+
+        context "with one language" do
+          let(:subjects) { [modern_languages, find_or_create(:modern_languages_subject, :french)] }
+
+          it "Returns a name modern language with language" do
+            expect(subject).to eq("Modern Languages (French)")
+          end
+
+          include_examples "with SEND"
+        end
+
+        context "with two languages" do
           let(:subjects) do
             [
-              find_or_create(:secondary_subject, :communication_and_media_studies),
+              modern_languages,
+              find_or_create(:modern_languages_subject, :french),
+              find_or_create(:modern_languages_subject, :german),
+            ]
+          end
+
+          it "Returns a name modern language with both languages" do
+            expect(subject).to eq("Modern Languages (French and German)")
+          end
+
+          include_examples "with SEND"
+        end
+
+        context "with three languages" do
+          let(:subjects) do
+            [
+              modern_languages,
+              find_or_create(:modern_languages_subject, :french),
+              find_or_create(:modern_languages_subject, :german),
+              find_or_create(:modern_languages_subject, :japanese),
+            ]
+          end
+
+          it "Returns a name modern language with three languages" do
+            expect(subject).to eq("Modern Languages (French, German, Japanese)")
+          end
+
+          include_examples "with SEND"
+        end
+
+        context "with four or more languages" do
+          let(:subjects) do
+            [
+              modern_languages,
+              find_or_create(:modern_languages_subject, :french),
+              find_or_create(:modern_languages_subject, :german),
+              find_or_create(:modern_languages_subject, :japanese),
+              find_or_create(:modern_languages_subject, :spanish),
+            ]
+          end
+
+          it "Returns just modern languages" do
+            expect(subject).to eq("Modern Languages")
+          end
+
+          include_examples "with SEND"
+        end
+
+        context "when modern language is first subject" do
+          let(:subjects) do
+            [
+              modern_languages,
+              find_or_create(:modern_languages_subject, :french),
+              find_or_create(:modern_languages_subject, :spanish),
               find_or_create(:secondary_subject, :mathematics),
             ]
           end
 
-          it "Returns the title Media studies" do
-            expect(generated_title).to eq("Media studies with Mathematics")
-          end
-        end
-      end
-
-      context "English as a second language -> English" do
-        context "With a single language" do
-          let(:subjects) do
-            [modern_languages, find_or_create(:modern_languages_subject, :english_as_a_second_language_or_other_language)]
+          it "Returns a name modern language with both languages and the additional subject" do
+            expect(subject).to eq("Modern Languages (French and Spanish) with Mathematics")
           end
 
-          it "Returns the title Modern Languages (English)" do
-            expect(generated_title).to eq("Modern Languages (English)")
-          end
+          include_examples "with SEND"
         end
 
-        context "With two languages" do
+        context "when modern language is additional subject" do
           let(:subjects) do
             [
+              find_or_create(:secondary_subject, :mathematics),
               modern_languages,
-              find_or_create(:modern_languages_subject, :english_as_a_second_language_or_other_language),
-              find_or_create(:modern_languages_subject, :spanish),
-            ]
-          end
-
-          it "Returns the title Modern Languages (English and Spanish)" do
-            expect(generated_title).to eq("Modern Languages (English and Spanish)")
-          end
-        end
-
-        context "With three languages" do
-          let(:subjects) do
-            [
-              modern_languages,
-              find_or_create(:modern_languages_subject, :english_as_a_second_language_or_other_language),
               find_or_create(:modern_languages_subject, :french),
               find_or_create(:modern_languages_subject, :spanish),
             ]
           end
 
-          it "Returns the title Modern Languages (English, French, Spanish)" do
-            expect(generated_title).to eq("Modern Languages (English, French, Spanish)")
+          it "Returns the main subject with the additional language subjects" do
+            expect(subject).to eq("Mathematics with French and Spanish")
           end
+
+          include_examples "with SEND"
         end
       end
-
-      context "Modern Languages (Other) -> Should be ignored for the title" do
-        context "With a single language" do
-          let(:subjects) do
-            [modern_languages, find_or_create(:modern_languages_subject, :modern_languages_other)]
-          end
-
-          it "Returns the title Modern Languages" do
-            expect(generated_title).to eq("Modern Languages")
-          end
-        end
-
-        context "With two languages" do
-          let(:subjects) do
-            [
-              modern_languages,
-              find_or_create(:modern_languages_subject, :modern_languages_other),
-              find_or_create(:modern_languages_subject, :spanish),
-            ]
-          end
-
-          it "Returns the title Modern Languages (Spanish)" do
-            expect(generated_title).to eq("Modern Languages (Spanish)")
-          end
-        end
-
-        context "With three languages" do
-          let(:subjects) do
-            [
-              modern_languages,
-              find_or_create(:modern_languages_subject, :modern_languages_other),
-              find_or_create(:modern_languages_subject, :french),
-              find_or_create(:modern_languages_subject, :spanish),
-            ]
-          end
-
-          it "Returns the title Modern Languages (French and Spanish)" do
-            expect(generated_title).to eq("Modern Languages (French and Spanish)")
-          end
-        end
-      end
-    end
-  end
-
-  describe "Generating a title for an ETP course" do
-    let(:level) { "primary" }
-
-    before do
-      set_course_subjects_and_master_id
-    end
-
-    context "With no campaign" do
-      let(:subjects) { [SecondarySubject.find_by(subject_name: "Physics")] }
-      let(:course) { Course.new(level: :secondary, subjects:, is_send:, campaign_name:, master_subject_id: 29) }
-
-      it "returns Physics" do
-        expect(generated_title).to eq("Physics")
-      end
-
-      include_examples "with SEND"
-    end
-
-    context "With engineers_teach_physics campaign" do
-      let(:campaign_name) { "engineers_teach_physics" }
-      let(:subjects) { [SecondarySubject.find_by(subject_name: "Physics")] }
-      let(:course) { Course.new(level: :secondary, subjects:, is_send:, campaign_name:, master_subject_id: 29) }
-
-      it "returns Engineers teach physics" do
-        expect(generated_title).to eq("Engineers teach physics")
-      end
-
-      include_examples "with SEND"
-    end
-
-    context "With campaign and second subject" do
-      let(:campaign_name) { "engineers_teach_physics" }
-      let(:subjects) { [find_or_create(:secondary_subject, :physics), find_or_create(:secondary_subject, :english)] }
-      let(:course) { Course.new(level:, subjects:, is_send:, campaign_name:, master_subject_id: 29) }
-
-      it "returns Engineers teach physics with subject" do
-        expect(generated_title).to eq("Engineers teach physics with English")
-      end
-
-      include_examples "with SEND"
-    end
-  end
-
-  describe "Generating a title for a Modern Languages course" do
-    let(:level) { "primary" }
-
-    before do
-      set_course_subjects_and_master_id
-    end
-
-    context "with one language" do
-      let(:subjects) { [modern_languages, find_or_create(:modern_languages_subject, :french)] }
-
-      it "Returns a name modern language with language" do
-        expect(generated_title).to eq("Modern Languages (French)")
-      end
-
-      include_examples "with SEND"
-    end
-
-    context "with two languages" do
-      let(:subjects) do
-        [
-          modern_languages,
-          find_or_create(:modern_languages_subject, :french),
-          find_or_create(:modern_languages_subject, :german),
-        ]
-      end
-
-      it "Returns a name modern language with both languages" do
-        expect(generated_title).to eq("Modern Languages (French and German)")
-      end
-
-      include_examples "with SEND"
-    end
-
-    context "with three languages" do
-      let(:subjects) do
-        [
-          modern_languages,
-          find_or_create(:modern_languages_subject, :french),
-          find_or_create(:modern_languages_subject, :german),
-          find_or_create(:modern_languages_subject, :japanese),
-        ]
-      end
-
-      it "Returns a name modern language with three languages" do
-        expect(generated_title).to eq("Modern Languages (French, German, Japanese)")
-      end
-
-      include_examples "with SEND"
-    end
-
-    context "with four or more languages" do
-      let(:subjects) do
-        [
-          modern_languages,
-          find_or_create(:modern_languages_subject, :french),
-          find_or_create(:modern_languages_subject, :german),
-          find_or_create(:modern_languages_subject, :japanese),
-          find_or_create(:modern_languages_subject, :spanish),
-        ]
-      end
-
-      it "Returns just modern languages" do
-        expect(generated_title).to eq("Modern Languages")
-      end
-
-      include_examples "with SEND"
-    end
-
-    context "when modern language is first subject" do
-      let(:subjects) do
-        [
-          modern_languages,
-          find_or_create(:modern_languages_subject, :french),
-          find_or_create(:modern_languages_subject, :spanish),
-          find_or_create(:secondary_subject, :mathematics),
-        ]
-      end
-
-      it "Returns a name modern language with both languages and the additional subject" do
-        expect(generated_title).to eq("Modern Languages (French and Spanish) with Mathematics")
-      end
-
-      include_examples "with SEND"
-    end
-
-    context "when modern language is additional subject" do
-      let(:subjects) do
-        [
-          find_or_create(:secondary_subject, :mathematics),
-          modern_languages,
-          find_or_create(:modern_languages_subject, :french),
-          find_or_create(:modern_languages_subject, :spanish),
-        ]
-      end
-
-      it "Returns the main subject with the additional language subjects" do
-        expect(generated_title).to eq("Mathematics with French and Spanish")
-      end
-
-      include_examples "with SEND"
     end
   end
 

--- a/spec/services/courses/generate_course_name_service_spec.rb
+++ b/spec/services/courses/generate_course_name_service_spec.rb
@@ -200,8 +200,8 @@ describe Courses::GenerateCourseNameService do
       let(:subjects) { [SecondarySubject.find_by(subject_name: "Physics")] }
       let(:course) { Course.new(level: :secondary, subjects:, is_send:, campaign_name:, master_subject_id: 29) }
 
-      it "returns Engineers Teach Physics" do
-        expect(generated_title).to eq("Engineers Teach Physics")
+      it "returns Engineers teach physics" do
+        expect(generated_title).to eq("Engineers teach physics")
       end
 
       include_examples "with SEND"
@@ -212,8 +212,8 @@ describe Courses::GenerateCourseNameService do
       let(:subjects) { [find_or_create(:secondary_subject, :physics), find_or_create(:secondary_subject, :english)] }
       let(:course) { Course.new(level:, subjects:, is_send:, campaign_name:, master_subject_id: 29) }
 
-      it "returns Engineers Teach Physics with subject" do
-        expect(generated_title).to eq("Engineers Teach Physics with English")
+      it "returns Engineers teach physics with subject" do
+        expect(generated_title).to eq("Engineers teach physics with English")
       end
 
       include_examples "with SEND"


### PR DESCRIPTION
### Context

https://trello.com/c/soElYNgr/821-course-name-does-not-reflect-subjects-chosen-and-languages-are-not-in-alphabetical-order

### Changes proposed in this pull request

- Refactor `GenerateCourseNameService`, it was becoming a bit of a soup
- Implement fix to generate titles correctly for Modern language courses with an additional subject
- There is an existing bug with modern language courses not showing subjects/additional subjects correctly in the subject edit list. This was already carded up as https://trello.com/c/hsF1kHsx/818-changing-subject-does-not-maintain-first-and-second-subject-order

### Guidance to review

Review app - https://publish-teacher-training-pr-3149.london.cloudapps.digital/

- Create a course and choose modern languages with an additional subject (then the other way round) and check the title includes the additional subject

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
