### PR TITLE
[0830] Add additional filter options to the providers api endpoints

### DIFF
--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -26,17 +26,22 @@ module API
           @updated_since ||= params.dig(:filter, :updated_since)
         end
 
+        def provider_types
+          return [] if params.dig(:filter, :provider_types).blank?
+          return [] unless params.dig(:filter, :provider_types).is_a?(String)
+
+          params.dig(:filter, :provider_types).split(",")
+        end
         def providers
           @providers = recruitment_cycle.providers
+
+          @providers = @providers.changed_since(updated_since) if updated_since.present?
+          @providers = @providers.with_provider_types(provider_types) if provider_types.present?
           @providers = if sort_by_provider_ascending?
                          @providers.by_name_ascending
                        else
                          @providers.by_name_descending
                        end
-
-          if updated_since.present?
-            @providers = @providers.changed_since(updated_since)
-          end
 
           @providers
         end

--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -44,6 +44,10 @@ module API
           @can_sponsor_skilled_worker_visa ||= params.dig(:filter, :can_sponsor_skilled_worker_visa)&.to_s&.downcase == "true"
         end
 
+        def can_sponsor_student_visa?
+          @can_sponsor_student_visa ||= params.dig(:filter, :can_sponsor_student_visa)&.to_s&.downcase == "true"
+        end
+
         def providers
           @providers = recruitment_cycle.providers
 
@@ -51,6 +55,8 @@ module API
           @providers = @providers.with_provider_types(provider_types) if provider_types.present?
           @providers = @providers.with_region_codes(region_codes) if region_codes.present?
           @providers = @providers.with_can_sponsor_skilled_worker_visa(true) if can_sponsor_skilled_worker_visa?
+          @providers = @providers.with_can_sponsor_student_visa(true) if can_sponsor_student_visa?
+
           @providers = if sort_by_provider_ascending?
                          @providers.by_name_ascending
                        else

--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -32,11 +32,19 @@ module API
 
           params.dig(:filter, :provider_types).split(",")
         end
+
+        def region_codes
+          return [] if params.dig(:filter, :region_codes).blank?
+          return [] unless params.dig(:filter, :region_codes).is_a?(String)
+
+          params.dig(:filter, :region_codes).split(",")
+        end
         def providers
           @providers = recruitment_cycle.providers
 
           @providers = @providers.changed_since(updated_since) if updated_since.present?
           @providers = @providers.with_provider_types(provider_types) if provider_types.present?
+          @providers = @providers.with_region_codes(region_codes) if region_codes.present?
           @providers = if sort_by_provider_ascending?
                          @providers.by_name_ascending
                        else

--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -39,12 +39,18 @@ module API
 
           params.dig(:filter, :region_codes).split(",")
         end
+
+        def can_sponsor_skilled_worker_visa?
+          @can_sponsor_skilled_worker_visa ||= params.dig(:filter, :can_sponsor_skilled_worker_visa)&.to_s&.downcase == "true"
+        end
+
         def providers
           @providers = recruitment_cycle.providers
 
           @providers = @providers.changed_since(updated_since) if updated_since.present?
           @providers = @providers.with_provider_types(provider_types) if provider_types.present?
           @providers = @providers.with_region_codes(region_codes) if region_codes.present?
+          @providers = @providers.with_can_sponsor_skilled_worker_visa(true) if can_sponsor_skilled_worker_visa?
           @providers = if sort_by_provider_ascending?
                          @providers.by_name_ascending
                        else

--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -27,17 +27,17 @@ module API
         end
 
         def provider_types
-          return [] if params.dig(:filter, :provider_types).blank?
-          return [] unless params.dig(:filter, :provider_types).is_a?(String)
+          return [] if params.dig(:filter, :provider_type).blank?
+          return [] unless params.dig(:filter, :provider_type).is_a?(String)
 
-          params.dig(:filter, :provider_types).split(",")
+          params.dig(:filter, :provider_type).split(",")
         end
 
         def region_codes
-          return [] if params.dig(:filter, :region_codes).blank?
-          return [] unless params.dig(:filter, :region_codes).is_a?(String)
+          return [] if params.dig(:filter, :region_code).blank?
+          return [] unless params.dig(:filter, :region_code).is_a?(String)
 
-          params.dig(:filter, :region_codes).split(",")
+          params.dig(:filter, :region_code).split(",")
         end
 
         def can_sponsor_skilled_worker_visa?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -129,6 +129,8 @@ class Provider < ApplicationRecord
 
   scope :with_provider_types, ->(provider_types) { where(provider_type: provider_types) }
 
+  scope :with_region_codes, ->(region_codes) { where(region_code: region_codes) }
+
   serialize :accrediting_provider_enrichments, AccreditingProviderEnrichment::ArraySerializer
 
   validates :train_with_us, words_count: { maximum: 250, message: "^Reduce the word count for training with you" }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -131,6 +131,7 @@ class Provider < ApplicationRecord
 
   scope :with_region_codes, ->(region_codes) { where(region_code: region_codes) }
 
+  scope :with_can_sponsor_skilled_worker_visa, ->(can_sponsor_skilled_worker_visa) { where(can_sponsor_skilled_worker_visa:) }
   serialize :accrediting_provider_enrichments, AccreditingProviderEnrichment::ArraySerializer
 
   validates :train_with_us, words_count: { maximum: 250, message: "^Reduce the word count for training with you" }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -127,6 +127,8 @@ class Provider < ApplicationRecord
 
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil).or where(region_code: nil) }
 
+  scope :with_provider_types, ->(provider_types) { where(provider_type: provider_types) }
+
   serialize :accrediting_provider_enrichments, AccreditingProviderEnrichment::ArraySerializer
 
   validates :train_with_us, words_count: { maximum: 250, message: "^Reduce the word count for training with you" }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -132,6 +132,9 @@ class Provider < ApplicationRecord
   scope :with_region_codes, ->(region_codes) { where(region_code: region_codes) }
 
   scope :with_can_sponsor_skilled_worker_visa, ->(can_sponsor_skilled_worker_visa) { where(can_sponsor_skilled_worker_visa:) }
+
+  scope :with_can_sponsor_student_visa, ->(can_sponsor_student_visa) { where(can_sponsor_student_visa:) }
+
   serialize :accrediting_provider_enrichments, AccreditingProviderEnrichment::ArraySerializer
 
   validates :train_with_us, words_count: { maximum: 250, message: "^Reduce the word count for training with you" }

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -354,8 +354,8 @@ RSpec.describe API::Public::V1::ProvidersController do
           end
         end
 
-        context "passing in provider_types param" do
-          let(:filter) { { provider_types: "university" } }
+        context "passing in provider_type param" do
+          let(:filter) { { provider_type: "university" } }
 
           it "returns 'Second' provider only" do
             expect(provider_names_in_response).to eq([provider2.provider_name])
@@ -378,8 +378,8 @@ RSpec.describe API::Public::V1::ProvidersController do
           end
         end
 
-        context "passing in region_codes param" do
-          let(:filter) { { region_codes: "yorkshire_and_the_humber" } }
+        context "passing in region_code param" do
+          let(:filter) { { region_code: "yorkshire_and_the_humber" } }
 
           it "returns 'Second' provider only" do
             expect(provider_names_in_response).to eq([provider2.provider_name])

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -362,6 +362,13 @@ RSpec.describe API::Public::V1::ProvidersController do
           end
         end
 
+        context "passing in can_sponsor_skilled_worker_visa param" do
+          let(:filter) { { can_sponsor_skilled_worker_visa: true } }
+
+          it "returns 'Second' provider only" do
+            expect(provider_names_in_response).to eq([provider2.provider_name])
+          end
+        end
         context "passing in region_codes param" do
           let(:filter) { { region_codes: ["yorkshire_and_the_humber"] } }
 

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe API::Public::V1::ProvidersController do
         end
 
         context "passing in provider_types param" do
-          let(:filter) { { provider_types: ["university"] } }
+          let(:filter) { { provider_types: "university" } }
 
           it "returns 'Second' provider only" do
             expect(provider_names_in_response).to eq([provider2.provider_name])
@@ -379,7 +379,7 @@ RSpec.describe API::Public::V1::ProvidersController do
         end
 
         context "passing in region_codes param" do
-          let(:filter) { { region_codes: ["yorkshire_and_the_humber"] } }
+          let(:filter) { { region_codes: "yorkshire_and_the_humber" } }
 
           it "returns 'Second' provider only" do
             expect(provider_names_in_response).to eq([provider2.provider_name])

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -369,6 +369,15 @@ RSpec.describe API::Public::V1::ProvidersController do
             expect(provider_names_in_response).to eq([provider2.provider_name])
           end
         end
+
+        context "passing in can_sponsor_student_visa param" do
+          let(:filter) { { can_sponsor_student_visa: true } }
+
+          it "returns 'Second' provider only" do
+            expect(provider_names_in_response).to eq([provider2.provider_name])
+          end
+        end
+
         context "passing in region_codes param" do
           let(:filter) { { region_codes: ["yorkshire_and_the_humber"] } }
 

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe API::Public::V1::ProvidersController do
           provider_code: "1AT",
           provider_name: "First",
           organisations: [organisation],
-          contacts: [contact])
+          contacts: [contact],
+          can_sponsor_skilled_worker_visa: false,
+          can_sponsor_student_visa: false)
       end
 
       before do
@@ -318,10 +320,14 @@ RSpec.describe API::Public::V1::ProvidersController do
         let(:provider2) do
           Timecop.freeze(Time.zone.today + 1) do
             create(:provider,
+              :university,
               provider_code: "2AT",
               provider_name: "Second",
               organisations: [organisation],
-              contacts: [contact])
+              contacts: [contact],
+              can_sponsor_skilled_worker_visa: true,
+              can_sponsor_student_visa: true,
+              region_code: :yorkshire_and_the_humber)
           end
         end
 
@@ -333,17 +339,23 @@ RSpec.describe API::Public::V1::ProvidersController do
 
         before do
           provider2
+
+          get :index, params: {
+            recruitment_cycle_year: recruitment_cycle.year,
+            filter:,
+          }
         end
 
         context "passing in updated_since param" do
           let(:filter) { { updated_since: (provider2.changed_at - 1.second).iso8601 } }
 
-          before do
-            get :index, params: {
-              recruitment_cycle_year: recruitment_cycle.year,
-              filter:,
-            }
+          it "returns 'Second' provider only" do
+            expect(provider_names_in_response).to eq([provider2.provider_name])
           end
+        end
+
+        context "passing in provider_types param" do
+          let(:filter) { { provider_types: ["university"] } }
 
           it "returns 'Second' provider only" do
             expect(provider_names_in_response).to eq([provider2.provider_name])

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -361,6 +361,14 @@ RSpec.describe API::Public::V1::ProvidersController do
             expect(provider_names_in_response).to eq([provider2.provider_name])
           end
         end
+
+        context "passing in region_codes param" do
+          let(:filter) { { region_codes: ["yorkshire_and_the_humber"] } }
+
+          it "returns 'Second' provider only" do
+            expect(provider_names_in_response).to eq([provider2.provider_name])
+          end
+        end
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -669,6 +669,38 @@ describe Provider do
         end
       end
     end
+
+    describe "#with_can_sponsor_student_visa" do
+      subject { described_class.with_can_sponsor_student_visa(can_sponsor_student_visa) }
+
+      let(:can_sponsor_student_visa_provider) do
+        create(:provider, can_sponsor_student_visa: true)
+      end
+      let(:cannot_sponsor_student_visa_provider) do
+        create(:provider, can_sponsor_student_visa: false)
+      end
+
+      before do
+        can_sponsor_student_visa_provider
+        cannot_sponsor_student_visa_provider
+      end
+
+      context "when can_sponsor_student_visa is false" do
+        let(:can_sponsor_student_visa) { false }
+
+        it "returns the providers that cannot sponsor student visa" do
+          expect(subject).to contain_exactly(cannot_sponsor_student_visa_provider)
+        end
+      end
+
+      context "when can_sponsor_student_visa is true" do
+        let(:can_sponsor_student_visa) { true }
+
+        it "returns the providers that can sponsor student visa" do
+          expect(subject).to contain_exactly(can_sponsor_student_visa_provider)
+        end
+      end
+    end
   end
 
   describe "in_cycle" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -609,6 +609,19 @@ describe Provider do
         expect(subject).to contain_exactly(current_provider)
       end
     end
+
+    describe "#with_provider_types" do
+      let(:provider_types) { ["lead_school"] }
+
+      let(:provider) { create(:provider) }
+
+      subject { described_class.with_provider_types(provider_types) }
+
+      it "returns the correct providers" do
+        expect(subject).to contain_exactly(provider)
+      end
+    end
+
   end
 
   describe "in_cycle" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -622,6 +622,21 @@ describe Provider do
       end
     end
 
+    describe "#with_region_codes" do
+      let(:region_codes) { ["london"] }
+
+      let(:provider) { create(:provider) }
+
+      before do
+        provider
+      end
+
+      subject { described_class.with_region_codes(region_codes) }
+
+      it "returns the providers with the region codes" do
+        expect(subject).to contain_exactly(provider)
+      end
+    end
   end
 
   describe "in_cycle" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -637,6 +637,38 @@ describe Provider do
         expect(subject).to contain_exactly(provider)
       end
     end
+
+    describe "#with_can_sponsor_skilled_worker_visa" do
+      subject { described_class.with_can_sponsor_skilled_worker_visa(can_sponsor_skilled_worker_visa) }
+
+      let(:can_sponsor_skilled_worker_visa_provider) do
+        create(:provider, can_sponsor_skilled_worker_visa: true)
+      end
+      let(:cannot_sponsor_skilled_worker_visa_provider) do
+        create(:provider, can_sponsor_skilled_worker_visa: false)
+      end
+
+      before do
+        can_sponsor_skilled_worker_visa_provider
+        cannot_sponsor_skilled_worker_visa_provider
+      end
+
+      context "when can_sponsor_skilled_worker_visa is false" do
+        let(:can_sponsor_skilled_worker_visa) { false }
+
+        it "returns the providers that cannot sponsor skilled worker visa" do
+          expect(subject).to contain_exactly(cannot_sponsor_skilled_worker_visa_provider)
+        end
+      end
+
+      context "when can_sponsor_skilled_worker_visa is true" do
+        let(:can_sponsor_skilled_worker_visa) { true }
+
+        it "returns the providers that can sponsor skilled worker visa" do
+          expect(subject).to contain_exactly(can_sponsor_skilled_worker_visa_provider)
+        end
+      end
+    end
   end
 
   describe "in_cycle" do

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1265,18 +1265,18 @@
             "type": "string",
             "example": "london,yorkshire_and_the_humber",
             "enum": [
-                "east_midlands",
-                "eastern",
-                "london",
                 "no_region",
                 "north_east",
                 "north_west",
-                "scotland",
+                "yorkshire_and_the_humber",
+                "east_midlands",
+                "west_midlands",
+                "eastern",
+                "london",
                 "south_east",
                 "south_west",
-                "wales",
-                "west_midlands",
-                "yorkshire_and_the_humber"
+                "scotland",
+                "wales"
             ]
           },
           "updated_since": {

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1255,8 +1255,8 @@
             "type": "string",
             "example": "scitt,lead_school",
             "enum": [
-                "scitt",
                 "lead_school",
+                "scitt",
                 "university"
             ]
           },
@@ -1265,18 +1265,18 @@
             "type": "string",
             "example": "london,yorkshire_and_the_humber",
             "enum": [
-                "no_region",
+                "east_midlands",
+                "eastern",
                 "london",
+                "no_region",
+                "north_east",
+                "north_west",
+                "scotland",
                 "south_east",
                 "south_west",
                 "wales",
                 "west_midlands",
-                "east_midlands",
-                "eastern",
-                "north_west",
-                "yorkshire_and_the_humber",
-                "north_east",
-                "scotland"
+                "yorkshire_and_the_humber"
             ]
           },
           "updated_since": {

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1245,6 +1245,11 @@
             "type": "boolean",
             "example": true
           },
+          "can_sponsor_student_visa": {
+            "description": "Only return providers that can sponsor student visa.",
+            "type": "boolean",
+            "example": true
+          },
           "provider_types": {
             "description": "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used.",
             "type": "string",

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1240,6 +1240,11 @@
         "example": "",
         "description": "This schema is used to search within collections to return more specific results.",
         "properties": {
+          "can_sponsor_skilled_worker_visa": {
+            "description": "Only return providers that can sponsor skilled worker visa.",
+            "type": "boolean",
+            "example": true
+          },
           "provider_types": {
             "description": "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used.",
             "type": "string",

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1250,6 +1250,25 @@
                 "university"
             ]
           },
+          "region_codes": {
+            "description": "Return providers based on their region code. This is a comma delimited string. If multiple region codes are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used.",
+            "type": "string",
+            "example": "london,yorkshire_and_the_humber",
+            "enum": [
+                "no_region",
+                "london",
+                "south_east",
+                "south_west",
+                "wales",
+                "west_midlands",
+                "east_midlands",
+                "eastern",
+                "north_west",
+                "yorkshire_and_the_humber",
+                "north_east",
+                "scotland"
+            ]
+          },
           "updated_since": {
             "description": "Return providers that have been updated since the date (ISO 8601 date format)",
             "type": "string",

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1241,12 +1241,12 @@
         "description": "This schema is used to search within collections to return more specific results.",
         "properties": {
           "can_sponsor_skilled_worker_visa": {
-            "description": "Only return providers that can sponsor skilled worker visa.",
+            "description": "Only return providers that can sponsor a Skilled Worker visa.",
             "type": "boolean",
             "example": true
           },
           "can_sponsor_student_visa": {
-            "description": "Only return providers that can sponsor student visa.",
+            "description": "Only return providers that can sponsor a Student visa.",
             "type": "boolean",
             "example": true
           },

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1250,7 +1250,7 @@
             "type": "boolean",
             "example": true
           },
-          "provider_types": {
+          "provider_type": {
             "description": "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used.",
             "type": "string",
             "example": "scitt,lead_school",
@@ -1260,7 +1260,7 @@
                 "university"
             ]
           },
-          "region_codes": {
+          "region_code": {
             "description": "Return providers based on their region code. This is a comma delimited string. If multiple region codes are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used.",
             "type": "string",
             "example": "london,yorkshire_and_the_humber",

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1240,6 +1240,16 @@
         "example": "",
         "description": "This schema is used to search within collections to return more specific results.",
         "properties": {
+          "provider_types": {
+            "description": "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used.",
+            "type": "string",
+            "example": "scitt,lead_school",
+            "enum": [
+                "scitt",
+                "lead_school",
+                "university"
+            ]
+          },
           "updated_since": {
             "description": "Return providers that have been updated since the date (ISO 8601 date format)",
             "type": "string",

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -15,26 +15,26 @@ properties:
     type: string
     example: "scitt,lead_school"
     enum:
-      - scitt
       - lead_school
+      - scitt
       - university
   region_code:
     description: "Return providers based on their region code. This is a comma delimited string. If multiple region codes are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
     type: string
     example: "london,yorkshire_and_the_humber"
     enum:
-      - no_region
+      - east_midlands
+      - eastern
       - london
+      - no_region
+      - north_east
+      - north_west
+      - scotland
       - south_east
       - south_west
       - wales
       - west_midlands
-      - east_midlands
-      - eastern
-      - north_west
       - yorkshire_and_the_humber
-      - north_east
-      - scotland
   updated_since:
     description: "Return providers that have been updated since the date (ISO 8601 date format)"
     type: string

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -6,6 +6,10 @@ properties:
     description: "Only return providers that can sponsor skilled worker visa."
     type: boolean
     example: true
+  can_sponsor_student_visa:
+    description: "Only return providers that can sponsor student visa."
+    type: boolean
+    example: true
   provider_types:
     description: "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
     type: string

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -10,6 +10,23 @@ properties:
       - scitt
       - lead_school
       - university
+  region_codes:
+    description: "Return providers based on their region code. This is a comma delimited string. If multiple region codes are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
+    type: string
+    example: "london,yorkshire_and_the_humber"
+    enum:
+      - no_region
+      - london
+      - south_east
+      - south_west
+      - wales
+      - west_midlands
+      - east_midlands
+      - eastern
+      - north_west
+      - yorkshire_and_the_humber
+      - north_east
+      - scotland
   updated_since:
     description: "Return providers that have been updated since the date (ISO 8601 date format)"
     type: string

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -2,6 +2,14 @@ type: object
 example: ""
 description: "This schema is used to search within collections to return more specific results."
 properties:
+  provider_types:
+    description: "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
+    type: string
+    example: "scitt,lead_school"
+    enum:
+      - scitt
+      - lead_school
+      - university
   updated_since:
     description: "Return providers that have been updated since the date (ISO 8601 date format)"
     type: string

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -23,18 +23,18 @@ properties:
     type: string
     example: "london,yorkshire_and_the_humber"
     enum:
-      - east_midlands
-      - eastern
-      - london
       - no_region
       - north_east
       - north_west
-      - scotland
+      - yorkshire_and_the_humber
+      - east_midlands
+      - west_midlands
+      - eastern
+      - london
       - south_east
       - south_west
+      - scotland
       - wales
-      - west_midlands
-      - yorkshire_and_the_humber
   updated_since:
     description: "Return providers that have been updated since the date (ISO 8601 date format)"
     type: string

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -10,7 +10,7 @@ properties:
     description: "Only return providers that can sponsor student visa."
     type: boolean
     example: true
-  provider_types:
+  provider_type:
     description: "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
     type: string
     example: "scitt,lead_school"
@@ -18,7 +18,7 @@ properties:
       - scitt
       - lead_school
       - university
-  region_codes:
+  region_code:
     description: "Return providers based on their region code. This is a comma delimited string. If multiple region codes are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
     type: string
     example: "london,yorkshire_and_the_humber"

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -3,11 +3,11 @@ example: ""
 description: "This schema is used to search within collections to return more specific results."
 properties:
   can_sponsor_skilled_worker_visa:
-    description: "Only return providers that can sponsor skilled worker visa."
+    description: "Only return providers that can sponsor a Skilled Worker visa."
     type: boolean
     example: true
   can_sponsor_student_visa:
-    description: "Only return providers that can sponsor student visa."
+    description: "Only return providers that can sponsor a Student visa."
     type: boolean
     example: true
   provider_type:

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -2,6 +2,10 @@ type: object
 example: ""
 description: "This schema is used to search within collections to return more specific results."
 properties:
+  can_sponsor_skilled_worker_visa:
+    description: "Only return providers that can sponsor skilled worker visa."
+    type: boolean
+    example: true
   provider_types:
     description: "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
     type: string


### PR DESCRIPTION
### Context
Additional filter options for the provider end pint

### Changes proposed in this pull request

Added filter for provider_types
Added filter for region_codes
Added filter for can_sponsor_skilled_worker_visa
Added filter for can_sponsor_student_visa

### Guidance to review

#### Docs

https://publish-teacher-training-pr-3150.london.cloudapps.digital/docs/api-reference.html#recruitment_cycles-year-providers-get
https://publish-teacher-training-pr-3150.london.cloudapps.digital/docs/api-reference.html#schema-providerfilter

#### API endpoint example

> can_sponsor_student_visa AND region_codes with yorkshire_and_the_humber OR london

https://publish-teacher-training-pr-3150.london.cloudapps.digital/api/public/v1/recruitment_cycles/2023/providers?[filter][can_sponsor_student_visa]=true&[filter][region_code]=yorkshire_and_the_humber,london


> can_sponsor_skilled_worker_visa AND provider_type with scitt OR university

https://publish-teacher-training-pr-3150.london.cloudapps.digital/api/public/v1/recruitment_cycles/2023/providers?[filter][can_sponsor_skilled_worker_visa]=true&[filter][provider_type]=scitt,university

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
