### PR TITLE
Add ETP checkbox UI

### DIFF
--- a/app/view_objects/find/result_filters/filters_view.rb
+++ b/app/view_objects/find/result_filters/filters_view.rb
@@ -43,6 +43,10 @@ module Find
         params[:funding] == "salary"
       end
 
+      def engineers_teach_physics_checked?
+        params[:engineers_teach_physics] == "true"
+      end
+
       def send_checked?
         params[:send_courses] == "true"
       end

--- a/app/view_objects/find/results_view.rb
+++ b/app/view_objects/find/results_view.rb
@@ -239,6 +239,10 @@ module Find
       query_parameters["can_sponsor_visa"].present? && query_parameters["can_sponsor_visa"].downcase == "true"
     end
 
+    def engineers_teach_physics_courses?
+      query_parameters["engineers_teach_physics"].present? && query_parameters["engineers_teach_physics"].downcase == "true"
+    end
+
     def qts?
       qualifications.include?("qts")
     end
@@ -397,6 +401,7 @@ module Find
       base_query = base_query.where(study_type:) if study_type.present?
       base_query = base_query.where(degree_grade: degree_grade_types) if degree_required?
       base_query = base_query.where(can_sponsor_visa: true) if visa_courses?
+      base_query = base_query.where(engineers_teach_physics: true) if engineers_teach_physics_courses?
       base_query = base_query.where(qualification: qualification.join(",")) unless all_qualifications?
       base_query = base_query.joins(:subjects).merge(Subject.with_subject_codes(subject_codes)) if subject_codes.any?
       base_query = base_query.where(send_courses: true) if send_courses?

--- a/app/views/find/result_filters/_all.html.erb
+++ b/app/views/find/result_filters/_all.html.erb
@@ -4,6 +4,7 @@
   </div>
 
   <div class="app-filter__content">
+    <%= render "find/result_filters/engineers_teach_physics_filter", form: %>
     <%= render "find/result_filters/send_filter", form: %>
     <%= render "find/result_filters/vacancy_filter", form: %>
     <%= render "find/result_filters/study_type_filter", form: %>

--- a/app/views/find/result_filters/_engineers_teach_physics_filter.html.erb
+++ b/app/views/find/result_filters/_engineers_teach_physics_filter.html.erb
@@ -1,0 +1,18 @@
+<% if params["subjects"]&.include?("F3") %>
+  <fieldset class="govuk-fieldset app-filter__group" data-qa="filters__engineers_teach_physics">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Engineers teach physics</legend>
+    <div class="govuk-checkboxes govuk-checkboxes--small">
+      <div class="govuk-checkboxes__item" data-qa="subject">
+        <%= form.check_box(
+              :engineers_teach_physics,
+              { checked: @filters_view.engineers_teach_physics_checked?, data: { qa: 'engineers_teach_physics__checkbox' }, class: 'govuk-checkboxes__input' },
+              'true',
+              nil,
+              ) %>
+        <%= form.label(:subjects, { for: "engineers_teach_physics",  data: { qa: "subject__name" } }, class: "govuk-label govuk-checkboxes__label") do %>
+          Only show Engineers teach physics courses
+        <% end %>
+      </div>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/find/result_filters/_engineers_teach_physics_filter.html.erb
+++ b/app/views/find/result_filters/_engineers_teach_physics_filter.html.erb
@@ -5,11 +5,11 @@
       <div class="govuk-checkboxes__item" data-qa="subject">
         <%= form.check_box(
               :engineers_teach_physics,
-              { checked: @filters_view.engineers_teach_physics_checked?, data: { qa: 'engineers_teach_physics__checkbox' }, class: 'govuk-checkboxes__input' },
-              'true',
+              { checked: @filters_view.engineers_teach_physics_checked?, data: { qa: "engineers_teach_physics__checkbox" }, class: "govuk-checkboxes__input" },
+              "true",
               nil,
-              ) %>
-        <%= form.label(:subjects, { for: "engineers_teach_physics",  data: { qa: "subject__name" } }, class: "govuk-label govuk-checkboxes__label") do %>
+            ) %>
+        <%= form.label(:subjects, { for: "engineers_teach_physics", data: { qa: "subject__name" } }, class: "govuk-label govuk-checkboxes__label") do %>
           Only show Engineers teach physics courses
         <% end %>
       </div>

--- a/spec/features/find/result_page_filters/engineers_teach_physics_spec.rb
+++ b/spec/features/find/result_page_filters/engineers_teach_physics_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.feature "Engineers teach physics" do
+  include FiltersFeatureSpecsHelper
+
+  before do
+    given_i_visit_the_search_by_location_or_provider_page
+    given_i_choose_across_england
+    given_i_choose_secondary
+  end
+
+  scenario "Candidate searches for physics subject" do
+    given_i_choose_physics
+    then_i_see_that_the_etp_checkbox_is_unchecked
+  end
+
+  scenario "Candidate searches for any other subject" do
+    given_i_choose_music
+    then_i_dont_see_the_etp_checkbox
+  end
+
+  def given_i_visit_the_search_by_location_or_provider_page
+    courses_by_location_or_training_provider_page.load
+  end
+
+  def given_i_choose_across_england
+    courses_by_location_or_training_provider_page.across_england.choose
+    courses_by_location_or_training_provider_page.continue.click
+  end
+
+  def given_i_choose_secondary
+    age_groups_page.secondary.choose
+    age_groups_page.continue.click
+  end
+
+  def given_i_choose_physics
+    check "Physics"
+    secondary_subjects_page.continue.click
+  end
+
+  def given_i_choose_music
+    check "Chemistry"
+    secondary_subjects_page.continue.click
+  end
+
+  def then_i_see_that_the_etp_checkbox_is_unchecked
+    expect(results_page.engineers_teach_physics_filter.legend.text).to eq("Engineers teach physics")
+    expect(results_page.engineers_teach_physics_filter.checkbox.checked?).to be(false)
+    expect(results_page).to have_text("Only show Engineers teach physics courses")
+  end
+
+  def then_i_dont_see_the_etp_checkbox
+    expect(results_page).not_to have_text("Only show Engineers teach physics courses")
+  end
+end

--- a/spec/support/page_objects/find/results.rb
+++ b/spec/support/page_objects/find/results.rb
@@ -46,6 +46,11 @@ module PageObjects
         element :checkbox, 'input[name="can_sponsor_visa"]'
       end
 
+      class EngineersTeachPhysics < SitePrism::Section
+        element :legend, "legend"
+        element :checkbox, 'input[name="engineers_teach_physics"]'
+      end
+
       class Funding < SitePrism::Section
         element :checkbox, 'input[name="funding"]'
       end
@@ -57,6 +62,7 @@ module PageObjects
       section :qualifications, Qualifications, '[data-qa="filters__qualifications"]'
       section :degree_grade, DegreeGrade, '[data-qa="filters__degree_required"]'
       section :visa, Visa, '[data-qa="filters__visa"]'
+      section :engineers_teach_physics_filter, EngineersTeachPhysics, '[data-qa="filters__engineers_teach_physics"]'
       section :funding, Funding, '[data-qa="filters__funding"]'
 
       element :apply_filters_button, '[data-qa="apply-filters"]'


### PR DESCRIPTION
### Context

In line with the "Engineers teach physics" work, we are adding a filter on Find to search for only these courses. This filter will appear when searching for the "Physics" subject.

The was implemented in old Find, here: https://github.com/DFE-Digital/publish-teacher-training/pull/3086

### Changes proposed in this pull request

- Add UI for filter checkbox
- Only render the checkbox if the "Physics" subject has been chosen

### Guidance to review

- Perform a search for a Physics course on Find
- Try out the new filter


### Screenshot

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/50492247/204531092-474b4f0a-a6a9-4855-9359-c81d66ceb3f8.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
