### PR TITLE
[0829] Add meta count to providers, provider's courses and provider's locations api endpoints

### DIFF
--- a/app/controllers/api/public/v1/providers/courses_controller.rb
+++ b/app/controllers/api/public/v1/providers/courses_controller.rb
@@ -6,6 +6,7 @@ module API
           def index
             render jsonapi: paginate(courses),
               include: include_param,
+              meta: { count: courses.count("course.id") },
               class: API::Public::V1::SerializerService.call
           end
 

--- a/app/controllers/api/public/v1/providers/locations_controller.rb
+++ b/app/controllers/api/public/v1/providers/locations_controller.rb
@@ -6,6 +6,7 @@ module API
           def index
             render jsonapi: locations,
               include: include_param,
+              meta: { count: locations.count("site.id") },
               class: API::Public::V1::SerializerService.call
           end
 

--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -4,7 +4,8 @@ module API
       class ProvidersController < API::Public::V1::ApplicationController
         def index
           render jsonapi: paginate(providers),
-            include: params[:include], class: API::Public::V1::SerializerService.call, fields:
+            include: params[:include],
+            meta: { count: providers.count("provider.id") }, class: API::Public::V1::SerializerService.call, fields:
         end
 
         def show

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
 
     context "when there are courses" do
       before do
-        create(:course, provider:)
-        create(:course, provider:)
+        create_list(:course, 3, provider:)
 
         get :index, params: {
           recruitment_cycle_year: provider.recruitment_cycle.year,
@@ -30,7 +29,16 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
       end
 
       it "returns correct number of courses" do
-        expect(JSON.parse(response.body)["data"].size).to be(2)
+        expect(JSON.parse(response.body)["data"].size).to be(3)
+      end
+
+      context "course count" do
+        it "returns the course count in a meta object" do
+          json_response = JSON.parse(response.body)
+          meta = json_response["meta"]
+
+          expect(meta["count"]).to be(3)
+        end
       end
     end
 

--- a/spec/controllers/api/public/v1/providers/locations_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/locations_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe API::Public::V1::Providers::LocationsController do
 
     context "when a provider has locations" do
       before do
-        provider.sites << build_list(:site, 2, provider:)
+        provider.sites << build_list(:site, 5, provider:)
 
         get :index, params: {
           recruitment_cycle_year: provider.recruitment_cycle.year,
@@ -28,7 +28,7 @@ RSpec.describe API::Public::V1::Providers::LocationsController do
       end
 
       it "returns the correct number of locations" do
-        expect(json_response["data"].size).to be(2)
+        expect(json_response["data"].size).to be(5)
       end
 
       context "with includes" do
@@ -52,6 +52,15 @@ RSpec.describe API::Public::V1::Providers::LocationsController do
 
           expect(recruitment_cycle_id).to eq(provider.recruitment_cycle.id)
           expect(provider_id).to eq(provider.id)
+        end
+      end
+
+      context "location count" do
+        it "returns the location count in a meta object" do
+          json_response = JSON.parse(response.body)
+          meta = json_response["meta"]
+
+          expect(meta["count"]).to be(5)
         end
       end
     end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -387,6 +387,22 @@ RSpec.describe API::Public::V1::ProvidersController do
         end
       end
     end
+
+    context "provider count" do
+      before do
+        create_list(:provider, 4)
+        get :index, params: {
+          recruitment_cycle_year: recruitment_cycle.year,
+        }
+      end
+
+      it "returns the provider count in a meta object" do
+        json_response = JSON.parse(response.body)
+        meta = json_response["meta"]
+
+        expect(meta["count"]).to be(4)
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
### Context
Meta count

### Changes proposed in this pull request

Added count for provider
Added count for provider's courses
Added count for provider's locations

### Guidance to review

https://publish-teacher-training-pr-3158.london.cloudapps.digital/api/public/v1/recruitment_cycles/2023/providers
![image](https://user-images.githubusercontent.com/470137/205031944-e67d8d95-cd76-41fa-8a6b-4c1966f7ee6e.png)

https://publish-teacher-training-pr-3158.london.cloudapps.digital/api/public/v1/recruitment_cycles/2023/providers/T92/courses
![image](https://user-images.githubusercontent.com/470137/205031979-7816a34c-3eec-413b-8788-5415a1a33441.png)
https://publish-teacher-training-pr-3158.london.cloudapps.digital/api/public/v1/recruitment_cycles/2023/providers/T92/locations
![image](https://user-images.githubusercontent.com/470137/205032003-58227da8-b7d4-4836-959e-d936405cf2dd.png)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
