### PR TITLE
Managing users in publish (Add user)

### DIFF
--- a/app/controllers/publish/providers/access_requests_controller.rb
+++ b/app/controllers/publish/providers/access_requests_controller.rb
@@ -15,7 +15,7 @@ module Publish
         @access_request = AccessRequestForm.new(params: access_request_params, user: current_user)
 
         if @access_request.save!
-          redirect_to users_publish_provider_path(params[:code]),
+          redirect_to publish_provider_users_path(params[:code]),
             flash: { success: "Your request for access has been submitted" }
         else
           @errors = @access_request.errors.messages

--- a/app/controllers/publish/users_check_controller.rb
+++ b/app/controllers/publish/users_check_controller.rb
@@ -1,10 +1,22 @@
 module Publish
   class UsersCheckController < PublishController
-
     def show
       authorize(provider)
+      @user_form = UserForm.new(current_user, user)
+    end
 
-      @users = provider.users
+    def update
+      @user_form = UserForm.new(current_user, user)
+      if @user_form.save!
+        UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
+        authorize(provider)
+        redirect_to users_publish_provider_path(params[:provider_code])
+        flash[:success] = "User added"
+      end
+    end
+
+    def user
+      User.find_or_initialize_by(email: params.dig(:publish_user_form, :email))
     end
   end
 end

--- a/app/controllers/publish/users_check_controller.rb
+++ b/app/controllers/publish/users_check_controller.rb
@@ -10,7 +10,7 @@ module Publish
       if @user_form.save!
         UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
         authorize(provider)
-        redirect_to users_publish_provider_path(params[:provider_code])
+        redirect_to publish_provider_users_path(params[:provider_code])
         flash[:success] = "User added"
       end
     end

--- a/app/controllers/publish/users_check_controller.rb
+++ b/app/controllers/publish/users_check_controller.rb
@@ -1,0 +1,10 @@
+module Publish
+  class UsersCheckController < PublishController
+
+    def show
+      authorize(provider)
+
+      @users = provider.users
+    end
+  end
+end

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -32,7 +32,7 @@ module Publish
     end
 
     def user_params
-      params.require(:publish_user_form).permit(:first_name, :last_name, :email, :code, :authenticity_token)
+      params.require(:publish_user_form).permit(:first_name, :last_name, :email).except(:code, :authenticity_token)
     end
   end
 end

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -17,7 +17,7 @@ module Publish
 
       @user_form = UserForm.new(current_user, user, params: user_params)
       if @user_form.stash
-        redirect_to publish_provider_check_user_path(provider_code: params[:code])
+        redirect_to publish_provider_check_user_path(provider_code: params[:provider_code])
       else
         render(:new)
       end

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -19,7 +19,7 @@ module Publish
       if @user_form.stash
         redirect_to publish_provider_check_user_path(provider_code: params[:code])
       else
-        redirect_to new_publish_provider_user_path(provider_code: params[:code])
+        render(:new)
       end
     end
 
@@ -32,7 +32,7 @@ module Publish
     end
 
     def user_params
-      params.permit(:first_name, :last_name, :email, :code, :authenticity_token)
+      params.require(:publish_user_form).permit(:first_name, :last_name, :email, :code, :authenticity_token)
     end
   end
 end

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -6,6 +6,10 @@ module Publish
       @users = provider.users
     end
 
+    def new
+      authorize(provider)
+    end
+
     def cycle_year
       session[:cycle_year] || params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
     end

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -8,10 +8,31 @@ module Publish
 
     def new
       authorize(provider)
+      @user_form = UserForm.new(current_user, user)
+      @user_form.clear_stash
+    end
+
+    def create
+      authorize(provider)
+
+      @user_form = UserForm.new(current_user, user, params: user_params)
+      if @user_form.stash
+        redirect_to publish_provider_check_user_path(provider_code: params[:code])
+      else
+        redirect_to new_publish_provider_user_path(provider_code: params[:code])
+      end
     end
 
     def cycle_year
       session[:cycle_year] || params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
+    end
+
+    def user
+      User.find_or_initialize_by(email: params.dig(:publish_user_form, :email))
+    end
+
+    def user_params
+      params.permit(:first_name, :last_name, :email, :code, :authenticity_token)
     end
   end
 end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -17,7 +17,7 @@ class Form
 
   def save!
     if valid?
-      assign_attributes_to_model # TODO: override this method on course_funding_form.rb
+      assign_attributes_to_model
       model.save!
       after_save
       clear_stash

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -16,10 +16,6 @@ module Publish
     validates :email, presence: true, format: { with: /\A.*@.*\z/, message: :format }
     validate :email_is_lowercase
 
-    def provider_code_or_code(params)
-      params[:code] || params[:provider_code]
-    end
-
     def compute_fields
       model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -1,29 +1,6 @@
 # frozen_string_literal: true
 
 module Publish
-  class UserForm < Form
-    FIELDS = %i[
-      first_name
-      last_name
-      email
-      id
-    ].freeze
-
-    attr_accessor(*FIELDS)
-
-    validates :first_name, presence: true
-    validates :last_name, presence: true
-    validates :email, presence: true, format: { with: /\A.*@.*\z/ }
-    validate :email_is_lowercase
-
-    def compute_fields
-      model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
-    end
-
-    def email_is_lowercase
-      if email.present? && email.downcase != email
-        errors.add(:email, :lowercase)
-      end
-    end
+  class UserForm < UserForm
   end
 end

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -20,10 +20,6 @@ module Publish
       model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end
 
-    def fields_to_ignore_before_save
-      %i[authenticity_token code]
-    end
-
     def email_is_lowercase
       if email.present? && email.downcase != email
         errors.add(:email, :lowercase)

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -13,7 +13,7 @@ module Publish
 
     validates :first_name, presence: true
     validates :last_name, presence: true
-    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: :format }
+    validates :email, presence: true, format: { with: /\A.*@.*\z/ }
     validate :email_is_lowercase
 
     def compute_fields

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -15,7 +15,7 @@ module Publish
 
     validates :first_name, presence: true
     validates :last_name, presence: true
-    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: I18n.t("activemodel.errors.models.publish/user_form.attributes.email.format") }
+    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: :format }
     validate :email_is_lowercase
 
     def provider_code_or_code(params)
@@ -32,7 +32,7 @@ module Publish
 
     def email_is_lowercase
       if email.present? && email.downcase != email
-        errors.add(:email, I18n.t("activemodel.errors.models.publish/user_form.attributes.email.lowercase"))
+        errors.add(:email, :lowercase)
       end
     end
   end

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -18,6 +18,10 @@ module Publish
     validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "Enter an email address in the correct format, like name@example.com" }
     validate :email_is_lowercase
 
+    def provider_code_or_code(params)
+      params[:code] || params[:provider_code]
+    end
+
     def compute_fields
       model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -7,8 +7,6 @@ module Publish
       last_name
       email
       id
-      code
-      authenticity_token
     ].freeze
 
     attr_accessor(*FIELDS)

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -2,5 +2,34 @@
 
 module Publish
   class UserForm < Form
+    FIELDS = %i[
+      first_name
+      last_name
+      email
+      id
+      code
+      authenticity_token
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :first_name, presence: true
+    validates :last_name, presence: true
+    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "Enter an email address in the correct format, like name@example.com" }
+    validate :email_is_lowercase
+
+    def compute_fields
+      model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+
+    def fields_to_ignore_before_save
+      %i[authenticity_token code]
+    end
+
+    def email_is_lowercase
+      if email.present? && email.downcase != email
+        errors.add(:email, I18n.t("activemodel.errors.models.publish/user_form.attributes.email.lowercase"))
+      end
+    end
   end
 end

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -15,7 +15,7 @@ module Publish
 
     validates :first_name, presence: true
     validates :last_name, presence: true
-    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "Enter an email address in the correct format, like name@example.com" }
+    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: I18n.t("activemodel.errors.models.publish/user_form.attributes.email.format") }
     validate :email_is_lowercase
 
     def provider_code_or_code(params)

--- a/app/forms/publish/user_form.rb
+++ b/app/forms/publish/user_form.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Publish
+  class UserForm < Form
+  end
+end

--- a/app/forms/support/user_form.rb
+++ b/app/forms/support/user_form.rb
@@ -1,35 +1,12 @@
 # frozen_string_literal: true
 
 module Support
-  class UserForm < Form
-    FIELDS = %i[
-      first_name
-      last_name
-      email
-      id
-    ].freeze
-
-    attr_accessor(*FIELDS)
-
-    validates :first_name, presence: true
-    validates :last_name, presence: true
-    validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "Enter an email address in the correct format, like name@example.com" }
-    validate :email_is_lowercase
+  class UserForm < UserForm
 
   private
 
-    def compute_fields
-      model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
-    end
-
     def form_store_key
       :user
-    end
-
-    def email_is_lowercase
-      if email.present? && email.downcase != email
-        errors.add(:email, I18n.t("activemodel.errors.models.support/user_form.attributes.email.lowercase"))
-      end
     end
   end
 end

--- a/app/forms/support/user_form.rb
+++ b/app/forms/support/user_form.rb
@@ -2,7 +2,6 @@
 
 module Support
   class UserForm < UserForm
-
   private
 
     def form_store_key

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -10,7 +10,8 @@ class UserForm < Form
 
   validates :first_name, presence: true
   validates :last_name, presence: true
-  validates :email, presence: true, format: { with: /\A.*@.*\z/ }
+  validates :email, presence: true
+  validates :email, email_address: true
   validate :email_is_lowercase
 
   def compute_fields

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -1,10 +1,10 @@
 class UserForm < Form
   FIELDS = %i[
-      first_name
-      last_name
-      email
-      id
-    ].freeze
+    first_name
+    last_name
+    email
+    id
+  ].freeze
 
   attr_accessor(*FIELDS)
 

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -1,0 +1,25 @@
+class UserForm < Form
+  FIELDS = %i[
+      first_name
+      last_name
+      email
+      id
+    ].freeze
+
+  attr_accessor(*FIELDS)
+
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :email, presence: true, format: { with: /\A.*@.*\z/ }
+  validate :email_is_lowercase
+
+  def compute_fields
+    model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+  end
+
+  def email_is_lowercase
+    if email.present? && email.downcase != email
+      errors.add(:email, :lowercase)
+    end
+  end
+end

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -12,7 +12,6 @@ class UserForm < Form
   validates :last_name, presence: true
   validates :email, presence: true
   validates :email, email_address: true
-  validate :email_is_lowercase
 
   def compute_fields
     model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -16,10 +16,4 @@ class UserForm < Form
   def compute_fields
     model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
   end
-
-  def email_is_lowercase
-    if email.present? && email.downcase != email
-      errors.add(:email, :lowercase)
-    end
-  end
 end

--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -9,7 +9,7 @@ module NavigationBarHelper
     [
       { name: t("navigation_bar.courses"), url: publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year) },
       { name: t("navigation_bar.locations"), url: publish_provider_recruitment_cycle_locations_path(provider.provider_code, provider.recruitment_cycle_year) },
-      { name: t("navigation_bar.users"), url: users_publish_provider_path(code: provider.provider_code), additional_url: request_access_publish_provider_path(provider.provider_code) },
+      { name: t("navigation_bar.users"), url: publish_provider_users_path(provider_code: provider.provider_code), additional_url: request_access_publish_provider_path(provider.provider_code) },
       *([name: t("navigation_bar.training_partners"), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.accredited_body?),
       { name: t("navigation_bar.organisation_details"), url: details_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year) },
     ]

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -64,8 +64,4 @@ private
   def is_current_cycle(cycle_year)
     Settings.current_recruitment_cycle_year == cycle_year.to_i
   end
-
-  def provider_code_or_code(params)
-    params[:code] || params[:provider_code]
-  end
 end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -64,4 +64,8 @@ private
   def is_current_cycle(cycle_year)
     Settings.current_recruitment_cycle_year == cycle_year.to_i
   end
+
+  def provider_code_or_code(params)
+    params[:code] || params[:provider_code]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
   include PgSearch::Model
   include RolloverHelper
 
+  before_save :downcase_email
+
   has_many :organisation_users
 
   # dependent destroy because https://stackoverflow.com/questions/34073757/removing-relations-is-not-being-audited-by-audited-gem/34078860#34078860
@@ -40,7 +42,6 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "must contain @" }, uniqueness: true
-  validate :email_is_lowercase
 
   validates :email, if: :admin?, format: {
     with: /\A.*@(digital\.){0,1}education\.gov\.uk\z/,
@@ -104,10 +105,8 @@ class User < ApplicationRecord
 
 private
 
-  def email_is_lowercase
-    if email.present? && email.downcase != email
-      errors.add(:email, "must be lowercase")
-    end
+  def downcase_email
+    email&.downcase!
   end
 
   def current_page_acknowledgement_for(page)

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -44,7 +44,7 @@ class ProviderPolicy
   end
 
   def create?
-    user.admin?
+    user.admin? || user.providers.include?(provider)
   end
 
   def suggest?

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -27,6 +27,10 @@ class ProviderPolicy
     user.present?
   end
 
+  def new?
+    user.present?
+  end
+
   def search?
     user.admin?
   end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -23,10 +23,6 @@ class ProviderPolicy
     @provider = provider
   end
 
-  def index?
-    user.present?
-  end
-
   def new?
     user.present?
   end
@@ -41,10 +37,6 @@ class ProviderPolicy
 
   def show_any?
     user.present?
-  end
-
-  def create?
-    user.admin? || user.providers.include?(provider)
   end
 
   def suggest?
@@ -72,6 +64,8 @@ class ProviderPolicy
   alias_method :destroy?, :show?
   alias_method :build_new?, :show?
   alias_method :can_list_training_providers?, :show?
+  alias_method :index?, :new?
+  alias_method :create?, :show?
 
   def permitted_provider_attributes
     if user.admin?

--- a/app/views/publish/providers/access_requests/new.html.erb
+++ b/app/views/publish/providers/access_requests/new.html.erb
@@ -2,7 +2,7 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @access_request.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(users_publish_provider_path(params[:code])) %>
+  <%= govuk_back_link_to(publish_provider_users_path(params[:code])) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish/shared/_aside_information_box.html.erb
+++ b/app/views/publish/shared/_aside_information_box.html.erb
@@ -1,6 +1,6 @@
 <aside class="govuk-grid-column-one-third">
   <div class="app-status-box">
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%= govuk_link_to "Users", users_publish_provider_path(code: @provider.provider_code) %></h2>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%= govuk_link_to "Users", publish_provider_user_path(code: @provider.provider_code) %></h2>
     <p class="govuk-body">View users who manage your courses.</p>
 
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">

--- a/app/views/publish/users/index.html.erb
+++ b/app/views/publish/users/index.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("page_titles.users.index") %></h1>
     <% if FeatureService.enabled?(:user_management) %>
-      <%= govuk_button_link_to "Add user", request_access_publish_provider_path(code: @provider.provider_code) %>
+      <%= govuk_button_link_to "Add user", new_publish_provider_user_path(provider_code: @provider.provider_code) %>
       <table class="govuk-table app-table--vertical-align-middle">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/views/publish/users/index.html.erb
+++ b/app/views/publish/users/index.html.erb
@@ -4,6 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+<<<<<<< HEAD
     <h1 class="govuk-heading-l"><%= t("page_titles.users.index") %></h1>
     <% if FeatureService.enabled?(:user_management) %>
       <%= govuk_button_link_to "Add user", new_publish_provider_user_path(provider_code: @provider.provider_code) %>

--- a/app/views/publish/users/index.html.erb
+++ b/app/views/publish/users/index.html.erb
@@ -4,7 +4,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-<<<<<<< HEAD
     <h1 class="govuk-heading-l"><%= t("page_titles.users.index") %></h1>
     <% if FeatureService.enabled?(:user_management) %>
       <%= govuk_button_link_to "Add user", new_publish_provider_user_path(provider_code: @provider.provider_code) %>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -1,12 +1,12 @@
 <%= render PageTitle::View.new(title: "users.new") %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(users_publish_provider_path(provider_code_or_code(params))) %>
+  <%= govuk_back_link_to(publish_provider_users_path(provider_code_or_code(params))) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @user_form, url: new_publish_provider_user_path(provider_code_or_code(params)), local: true) do |f| %>
+    <%= form_with(model: @user_form, url: publish_provider_users_path(provider_code_or_code(params)), local: true) do |f| %>
       <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">Add user</span>
       <fieldset class="govuk-fieldset">
@@ -23,7 +23,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), users_publish_provider_path(provider_code_or_code(params))) %>
+      <%= govuk_link_to(t("cancel"), publish_provider_users_path(provider_code_or_code(params))) %>
     </p>
   </div>
 </div>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -3,3 +3,26 @@
 <% content_for :before_content do %>
   <%= govuk_back_link_to(users_publish_provider_path(params[:provider_code])) %>
 <% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with path: [:new_publish_provider_user, @user], local: true do |f| %>
+      <span class="govuk-caption-l">Add user</span>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h1 class="govuk-fieldset__heading">Personal details</h1>
+        </legend>
+
+        <%#= f.govuk_error_summary %>
+
+        <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: "two-thirds" %>
+        <%= f.govuk_text_field :last_name, label: { text: "Last name", size: "s" }, width: "two-thirds" %>
+        <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: "full" %>
+
+        <%= f.govuk_submit %>
+      </fieldset>
+    <% end %>
+
+    <%= govuk_link_to(t("cancel"), users_publish_provider_path(params[:provider_code])) %>
+  </div>
+</div>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "users.new") %>
+<%= render PageTitle::View.new(title: t("page_titles.users.new")) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_users_path(params[:provider_code])) %>
@@ -11,7 +11,7 @@
       <span class="govuk-caption-l">Add user</span>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 class="govuk-fieldset__heading">Personal details</h1>
+          <h1 class="govuk-fieldset__heading"><%= t("page_titles.users.new") %></h1>
         </legend>
 
         <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: "two-thirds" %>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @user_form, url: publish_provider_users_path(params[:provider_code]), local: true) do |f| %>
       <%= f.govuk_error_summary %>
-      <span class="govuk-caption-l">Add user</span>
+      <span class="govuk-caption-l"><%= t("users.add") %></span>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading"><%= t("page_titles.users.new") %></h1>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with path: [:new_publish_provider_user, @user], local: true do |f| %>
+    <%= form_with path: [:publish_provider_user_new, @user], local: true do |f| %>
       <span class="govuk-caption-l">Add user</span>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -23,6 +23,8 @@
       </fieldset>
     <% end %>
 
-    <%= govuk_link_to(t("cancel"), users_publish_provider_path(params[:provider_code])) %>
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), users_publish_provider_path(params[:provider_code])) %>
+    </p>
   </div>
 </div>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -5,20 +5,26 @@
   <%= govuk_back_link_to(publish_provider_users_path(params[:provider_code])) %>
 <% end %>
 
+<%= form_with(model: @user_form, url: publish_provider_users_path(params[:provider_code]), local: true) do |f| %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= f.govuk_error_summary %>
+  </div>
+</div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @user_form, url: publish_provider_users_path(params[:provider_code]), local: true) do |f| %>
-      <%= f.govuk_error_summary %>
-      <span class="govuk-caption-l"><%= t("users.add") %></span>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 class="govuk-fieldset__heading"><%= t("page_titles.users.new") %></h1>
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-l"><%= t("users.add") %></span>
+            <%= t("page_titles.users.new") %>
+          </h1>
         </legend>
-
         <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: "two-thirds" %>
         <%= f.govuk_text_field :last_name, label: { text: "Last name", size: "s" }, width: "two-thirds" %>
         <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: "full" %>
-
         <%= f.govuk_submit %>
       </fieldset>
     <% end %>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -1,19 +1,18 @@
 <%= render PageTitle::View.new(title: "users.new") %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(users_publish_provider_path(params[:provider_code])) %>
+  <%= govuk_back_link_to(users_publish_provider_path(provider_code_or_code(params))) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with path: [:publish_provider_user_new, @user], local: true do |f| %>
+    <%= form_with(model: @user_form, url: new_publish_provider_user_path(provider_code_or_code(params)), local: true) do |f| %>
+      <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">Add user</span>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">Personal details</h1>
         </legend>
-
-        <%#= f.govuk_error_summary %>
 
         <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: "two-thirds" %>
         <%= f.govuk_text_field :last_name, label: { text: "Last name", size: "s" }, width: "two-thirds" %>
@@ -24,7 +23,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), users_publish_provider_path(params[:provider_code])) %>
+      <%= govuk_link_to(t("cancel"), users_publish_provider_path(provider_code_or_code(params))) %>
     </p>
   </div>
 </div>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -1,0 +1,5 @@
+<%= render PageTitle::View.new(title: "users.new") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(users_publish_provider_path(params[:provider_code])) %>
+<% end %>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -1,4 +1,5 @@
-<%= render PageTitle::View.new(title: t("page_titles.users.new")) %>
+<% page_title = t("page_titles.users.new") %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @user_form.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_users_path(params[:provider_code])) %>

--- a/app/views/publish/users/new.html.erb
+++ b/app/views/publish/users/new.html.erb
@@ -1,12 +1,12 @@
 <%= render PageTitle::View.new(title: "users.new") %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_users_path(provider_code_or_code(params))) %>
+  <%= govuk_back_link_to(publish_provider_users_path(params[:provider_code])) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @user_form, url: publish_provider_users_path(provider_code_or_code(params)), local: true) do |f| %>
+    <%= form_with(model: @user_form, url: publish_provider_users_path(params[:provider_code]), local: true) do |f| %>
       <%= f.govuk_error_summary %>
       <span class="govuk-caption-l">Add user</span>
       <fieldset class="govuk-fieldset">
@@ -23,7 +23,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), publish_provider_users_path(provider_code_or_code(params))) %>
+      <%= govuk_link_to(t("cancel"), publish_provider_users_path(params[:provider_code])) %>
     </p>
   </div>
 </div>

--- a/app/views/publish/users_check/show.html.erb
+++ b/app/views/publish/users_check/show.html.erb
@@ -1,4 +1,5 @@
-<%= render PageTitle::View.new(title: t("page_titles.users.check")) %>
+<% page_title = t("page_titles.users.check") %>
+<%= content_for :page_title, page_title %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(new_publish_provider_user_path) %>

--- a/app/views/publish/users_check/show.html.erb
+++ b/app/views/publish/users_check/show.html.erb
@@ -1,0 +1,48 @@
+<%= render PageTitle::View.new(title: t("components.page_titles.users.show")) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(new_publish_provider_user_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with(model: @user_form, url: publish_provider_check_user_path, method: :put, local: true) do |f| %>
+
+      <%= f.hidden_field(:email, value: "johnsmith@aol.com") %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= t("users.new") %></span>
+          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("users.check") %> </h1> </legend>
+
+        <%= render GovukComponent::SummaryListComponent.new do |component|
+          component.row do |row|
+            row.key { t("users.first_name") }
+            row.value(text:  "John")
+            row.action(text: t("change"), href: new_publish_provider_user_path, classes: "first_name", visually_hidden_text: t("users.first_name"))
+          end
+
+          component.row do |row|
+            row.key { t("users.last_name") }
+            row.value(text: "Smith")
+            row.action(text: t("change"), href: new_publish_provider_user_path, classes: "last_name", visually_hidden_text: t("users.last_name"))
+          end
+
+          component.row do |row|
+            row.key { t("users.email") }
+            row.value(text: "johnsmith@aol.com")
+            row.action(text: t("change"), href: new_publish_provider_user_path, classes: "email", visually_hidden_text: t("users.email"))
+          end
+        end %>
+
+        <div class="govuk-warning-text"> <span class="govuk-warning-text__icon" aria-hidden="true">!</span> <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span> The user will be sent an email to tell them you’ve added them to the organisation. </strong> </div>
+
+        <%= f.govuk_submit(t("users.new")) %>
+      </fieldset>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), users_publish_provider_path(params[:provider_code])) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/users_check/show.html.erb
+++ b/app/views/publish/users_check/show.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @user_form, url: publish_provider_check_user_path, method: :put, local: true) do |f| %>
 
-      <%= f.hidden_field(:email, value: "johnsmith@aol.com") %>
+      <%= f.hidden_field(:email, value: @user_form.email) %>
 
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= t("users.new") %></span>
@@ -17,19 +17,19 @@
         <%= render GovukComponent::SummaryListComponent.new do |component|
           component.row do |row|
             row.key { t("users.first_name") }
-            row.value(text:  "John")
+            row.value(text:  @user_form.first_name)
             row.action(text: t("change"), href: new_publish_provider_user_path, classes: "first_name", visually_hidden_text: t("users.first_name"))
           end
 
           component.row do |row|
             row.key { t("users.last_name") }
-            row.value(text: "Smith")
+            row.value(text: @user_form.last_name)
             row.action(text: t("change"), href: new_publish_provider_user_path, classes: "last_name", visually_hidden_text: t("users.last_name"))
           end
 
           component.row do |row|
             row.key { t("users.email") }
-            row.value(text: "johnsmith@aol.com")
+            row.value(text:  @user_form.email)
             row.action(text: t("change"), href: new_publish_provider_user_path, classes: "email", visually_hidden_text: t("users.email"))
           end
         end %>

--- a/app/views/publish/users_check/show.html.erb
+++ b/app/views/publish/users_check/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: t("components.page_titles.users.show")) %>
+<%= render PageTitle::View.new(title: t("page_titles.users.check")) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(new_publish_provider_user_path) %>
@@ -11,8 +11,8 @@
       <%= f.hidden_field(:email, value: @user_form.email) %>
 
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= t("users.new") %></span>
-          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("users.check") %> </h1> </legend>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= t("users.add") %></span>
+          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("page_titles.users.check") %> </h1> </legend>
 
       <%= render GovukComponent::SummaryListComponent.new do |component|
             component.row do |row|
@@ -37,7 +37,7 @@
         <div class="govuk-warning-text"> <span class="govuk-warning-text__icon" aria-hidden="true">!</span> <strong class="govuk-warning-text__text">
           <span class="govuk-warning-text__assistive">Warning</span> The user will be sent an email to tell them you’ve added them to the organisation. </strong> </div>
 
-        <%= f.govuk_submit(t("users.new")) %>
+        <%= f.govuk_submit(t("users.add")) %>
       </fieldset>
     <% end %>
 

--- a/app/views/publish/users_check/show.html.erb
+++ b/app/views/publish/users_check/show.html.erb
@@ -14,25 +14,25 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= t("users.new") %></span>
           <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("users.check") %> </h1> </legend>
 
-        <%= render GovukComponent::SummaryListComponent.new do |component|
-          component.row do |row|
-            row.key { t("users.first_name") }
-            row.value(text:  @user_form.first_name)
-            row.action(text: t("change"), href: new_publish_provider_user_path, classes: "first_name", visually_hidden_text: t("users.first_name"))
-          end
+      <%= render GovukComponent::SummaryListComponent.new do |component|
+            component.row do |row|
+              row.key { t("users.first_name") }
+              row.value(text:  @user_form.first_name)
+              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "first_name", visually_hidden_text: t("users.first_name"))
+            end
 
-          component.row do |row|
-            row.key { t("users.last_name") }
-            row.value(text: @user_form.last_name)
-            row.action(text: t("change"), href: new_publish_provider_user_path, classes: "last_name", visually_hidden_text: t("users.last_name"))
-          end
+            component.row do |row|
+              row.key { t("users.last_name") }
+              row.value(text: @user_form.last_name)
+              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "last_name", visually_hidden_text: t("users.last_name"))
+            end
 
-          component.row do |row|
-            row.key { t("users.email") }
-            row.value(text:  @user_form.email)
-            row.action(text: t("change"), href: new_publish_provider_user_path, classes: "email", visually_hidden_text: t("users.email"))
-          end
-        end %>
+            component.row do |row|
+              row.key { t("users.email") }
+              row.value(text:  @user_form.email)
+              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "email", visually_hidden_text: t("users.email"))
+            end
+          end %>
 
         <div class="govuk-warning-text"> <span class="govuk-warning-text__icon" aria-hidden="true">!</span> <strong class="govuk-warning-text__text">
           <span class="govuk-warning-text__assistive">Warning</span> The user will be sent an email to tell them you’ve added them to the organisation. </strong> </div>

--- a/app/views/publish/users_check/show.html.erb
+++ b/app/views/publish/users_check/show.html.erb
@@ -42,7 +42,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), users_publish_provider_path(params[:provider_code])) %>
+      <%= govuk_link_to(t("cancel"), publish_provider_users_path(params[:provider_code])) %>
     </p>
   </div>
 </div>

--- a/app/views/publish/users_check/show.html.erb
+++ b/app/views/publish/users_check/show.html.erb
@@ -19,19 +19,19 @@
             component.row do |row|
               row.key { t("users.first_name") }
               row.value(text:  @user_form.first_name)
-              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "first_name", visually_hidden_text: t("users.first_name"))
+              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "first_name", visually_hidden_text: t("users.first_name").downcase)
             end
 
             component.row do |row|
               row.key { t("users.last_name") }
               row.value(text: @user_form.last_name)
-              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "last_name", visually_hidden_text: t("users.last_name"))
+              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "last_name", visually_hidden_text: t("users.last_name").downcase)
             end
 
             component.row do |row|
               row.key { t("users.email") }
               row.value(text:  @user_form.email)
-              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "email", visually_hidden_text: t("users.email"))
+              row.action(text: t("change"), href: new_publish_provider_user_path, classes: "email", visually_hidden_text: t("users.email").downcase)
             end
           end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,7 +442,6 @@ en:
           attributes:
             email:
               blank: "Enter an email address"
-              lowercase: "Enter an email address that is lowercase, like name@example.com"
               invalid: "Enter an email address in the correct format, like name@example.com"
             first_name:
               blank: "Enter a first name"
@@ -452,7 +451,6 @@ en:
           attributes:
             email:
               blank: "Enter an email address"
-              lowercase: "Enter an email address that is lowercase, like name@example.com"
               invalid: "Enter an email address in the correct format, like name@example.com"
             first_name:
               blank: "Enter a first name"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -446,6 +446,7 @@ en:
             email:
               blank: "Enter an email address"
               lowercase: "Enter an email address that is lowercase, like name@example.com"
+              format: "Enter an email address in the correct format, like name@example.com"
             first_name:
               blank: "Enter a first name"
             last_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,8 @@ en:
       change_cycle: "Change recruitment cycle"
     users:
       index: "Users"
+      new: "Personal details"
+      check: "Check your answers"
   publish_authentication:
     magic_link:
       invalid_token: "Magic link could not be verified, please request a new one"
@@ -168,10 +170,6 @@ en:
           edit: "Edit Allocation Uplift"
         data_exports:
           index: "Data exports"
-      users:
-        index: "Users"
-        new: "Personal details"
-        show: "Check your answers"
     filter:
       providers:
         provider_search: "Provider name or code"
@@ -223,8 +221,7 @@ en:
     first_name: "First name"
     last_name: "Last name"
     email: "Email address"
-    new: "Add user"
-    check: "Check your answers"
+    add: "Add user"
   support:
     data_exports:
       index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,6 +168,9 @@ en:
           edit: "Edit Allocation Uplift"
         data_exports:
           index: "Data exports"
+      users:
+        index: "Users"
+        new: "Personal details"
     filter:
       providers:
         provider_search: "Provider name or code"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,6 +441,15 @@ en:
               blank: "Enter their organisation"
             reason:
               blank: "Enter why they need access"
+        publish/user_form:
+          attributes:
+            email:
+              blank: "Enter an email address"
+              lowercase: "Enter an email address that is lowercase, like name@example.com"
+            first_name:
+              blank: "Enter a first name"
+            last_name:
+              blank: "Enter a last name"
         support/user_form:
           attributes:
             email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -456,6 +456,7 @@ en:
             email:
               blank: "Enter an email address"
               lowercase: "Enter an email address that is lowercase, like name@example.com"
+              invalid: "Enter an email address in the correct format, like name@example.com"
             first_name:
               blank: "Enter a first name"
             last_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,7 @@ en:
       users:
         index: "Users"
         new: "Personal details"
+        show: "Check your answers"
     filter:
       providers:
         provider_search: "Provider name or code"
@@ -218,6 +219,12 @@ en:
   provider_suggestion:
     errors:
       bad_request: "Unknown provider code or name, please check the query string."
+  users:
+    first_name: "First name"
+    last_name: "Last name"
+    email: "Email address"
+    new: "Add user"
+    check: "Check your answers"
   support:
     data_exports:
       index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -446,7 +446,7 @@ en:
             email:
               blank: "Enter an email address"
               lowercase: "Enter an email address that is lowercase, like name@example.com"
-              format: "Enter an email address in the correct format, like name@example.com"
+              invalid: "Enter an email address in the correct format, like name@example.com"
             first_name:
               blank: "Enter a first name"
             last_name:

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -52,10 +52,8 @@ namespace :publish, as: :publish do
   end
 
   resources :providers, path: "organisations", param: :code, only: [:show] do
-    get "/users", on: :member, to: "users#index"
-    post "/users/new", on: :member, to: "users#create"
-    resources :users, only: [:new]
     resource :check_user, only: %i[show update], controller: "users_check", path: "users/check"
+    resources :users, controller: "users"
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"
     get "locations"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -54,6 +54,7 @@ namespace :publish, as: :publish do
   resources :providers, path: "organisations", param: :code, only: [:show] do
     get "/users", on: :member, to: "users#index"
     resources :users, only: [:new]
+    resource :check_user, only: %i[show update], controller: "users_check", path: "users/check"
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"
     get "locations"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -53,6 +53,7 @@ namespace :publish, as: :publish do
 
   resources :providers, path: "organisations", param: :code, only: [:show] do
     get "/users", on: :member, to: "users#index"
+    post "/users/new", on: :member, to: "users#create"
     resources :users, only: [:new]
     resource :check_user, only: %i[show update], controller: "users_check", path: "users/check"
     get "/request-access", on: :member, to: "providers/access_requests#new"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -53,6 +53,7 @@ namespace :publish, as: :publish do
 
   resources :providers, path: "organisations", param: :code, only: [:show] do
     get "/users", on: :member, to: "users#index"
+    resources :users, only: [:new]
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"
     get "locations"

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -22,4 +22,4 @@ features:
   allocations:
     state: confirmed
   engineers_teach_physics_on_course: true
-  user_management: false
+  user_management: true

--- a/spec/features/publish/users/adding_user_to_provider_spec.rb
+++ b/spec/features/publish/users/adding_user_to_provider_spec.rb
@@ -11,22 +11,20 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   describe "Adding user to organisation" do
     scenario "With valid details" do
       given_i_visit_the_users_index_page
-      and_the_user_i_want_to_add_has_not_already_been_added
+      when_the_user_i_want_to_add_has_not_already_been_added
       and_i_click_add_user
       and_i_fill_in_first_name
       and_i_fill_in_last_name
       and_i_fill_in_email
       and_i_continue
-      then_i_should_be_on_the_check_page
-      and_the_user_should_not_be_in_the_database
+      and_i_am_on_the_check_page
+      then_the_user_should_not_be_in_the_database
 
-      when_i_click_change_first_name
-      and_i_enter_a_new_first_name
+      given_i_click_change_first_name
+      when_i_enter_a_new_first_name
       and_i_continue
       and_i_click_add_user
-
-      then_i_should_see_the_users_name_listed
-      and_i_should_see_the_users_email_listed
+      then_i_should_see_the_users_name_and_email_listed
       and_the_user_should_be_added_to_the_database
     end
 
@@ -48,12 +46,12 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     users_index_page.load(provider_code: @provider.provider_code)
   end
 
-  def and_the_user_i_want_to_add_has_not_already_been_added
+  def when_the_user_i_want_to_add_has_not_already_been_added
     expect(users_index_page).not_to have_text("willy.wonka@bat_school.com")
   end
 
   def and_i_click_add_user
-    provider_users_index_page.add_user.click
+    users_index_page.add_user.click
   end
 
   def and_i_fill_in_first_name
@@ -72,19 +70,19 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     users_new_page.continue.click
   end
 
-  def then_i_should_be_on_the_check_page
+  def and_i_am_on_the_check_page
     expect(users_check_page).to be_displayed(provider_code: @provider.provider_code)
   end
 
-  def and_the_user_should_not_be_in_the_database
+  def then_the_user_should_not_be_in_the_database
     expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "willy.wonka@bat_school.com")).to be(false)
   end
 
-  def when_i_click_change_first_name
+  def given_i_click_change_first_name
     users_check_page.change_first_name.click
   end
 
-  def and_i_enter_a_new_first_name
+  def when_i_enter_a_new_first_name
     users_new_page.first_name.set("Willy")
   end
 
@@ -92,11 +90,8 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     users_check_page.add_user.click
   end
 
-  def then_i_should_see_the_users_name_listed
+  def then_i_should_see_the_users_name_and_email_listed
     expect(users_check_page).to have_text("Willy Wonka")
-  end
-
-  def and_i_should_see_the_users_email_listed
     expect(users_check_page).to have_text("willy.wonka@bat_school.com")
   end
 

--- a/spec/features/publish/users/adding_user_to_provider_spec.rb
+++ b/spec/features/publish/users/adding_user_to_provider_spec.rb
@@ -69,7 +69,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def and_i_continue
-    users_new_page.submit.click
+    users_new_page.continue.click
   end
 
   def then_i_should_be_on_the_check_page
@@ -86,10 +86,6 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
 
   def and_i_enter_a_new_first_name
     users_new_page.first_name.set("Willy")
-  end
-
-  def and_i_continue
-    users_new_page.submit.click
   end
 
   def and_i_click_add_user

--- a/spec/features/publish/users/adding_user_to_provider_spec.rb
+++ b/spec/features/publish/users/adding_user_to_provider_spec.rb
@@ -47,7 +47,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def when_the_user_i_want_to_add_has_not_already_been_added
-    expect(users_index_page).not_to have_text("willy.wonka@bat_school.com")
+    expect(users_index_page).not_to have_text("willy.wonka@bat-school.com")
   end
 
   def and_i_click_add_user
@@ -63,7 +63,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def and_i_fill_in_email
-    users_new_page.email.set("willy.wonka@bat_school.com")
+    users_new_page.email.set("willy.wonka@bat-school.com")
   end
 
   def and_i_continue
@@ -75,7 +75,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def then_the_user_should_not_be_in_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "willy.wonka@bat_school.com")).to be(false)
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "willy.wonka@bat-school.com")).to be(false)
   end
 
   def given_i_click_change_first_name
@@ -92,11 +92,11 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
 
   def then_i_should_see_the_users_name_and_email_listed
     expect(users_check_page).to have_text("Willy Wonka")
-    expect(users_check_page).to have_text("willy.wonka@bat_school.com")
+    expect(users_check_page).to have_text("willy.wonka@bat-school.com")
   end
 
   def and_the_user_should_be_added_to_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.where(email: "willy.wonka@bat_school.com").blank?).to be(false)
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.where(email: "willy.wonka@bat-school.com").blank?).to be(false)
   end
 
   def given_i_visit_the_users_new_page

--- a/spec/features/publish/users/adding_user_to_provider_spec.rb
+++ b/spec/features/publish/users/adding_user_to_provider_spec.rb
@@ -77,7 +77,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def and_the_user_should_not_be_in_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.where(email: "willy.wonka@bat_school.com").blank?).to be(true)
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "willy.wonka@bat_school.com")).to be(false)
   end
 
   def when_i_click_change_first_name

--- a/spec/features/publish/users/adding_user_to_provider_spec.rb
+++ b/spec/features/publish/users/adding_user_to_provider_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Adding user to organisation as a provider user", { can_edit_current_and_next_cycles: false } do
+  before do
+    allow(Settings.features).to receive(:user_management).and_return(true)
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  describe "Adding user to organisation" do
+    scenario "With valid details" do
+      given_i_visit_the_users_index_page
+      and_the_user_i_want_to_add_has_not_already_been_added
+      and_i_click_add_user
+      and_i_fill_in_first_name
+      and_i_fill_in_last_name
+      and_i_fill_in_email
+      and_i_continue
+      then_i_should_be_on_the_check_page
+      and_the_user_should_not_be_in_the_database
+
+      when_i_click_change_first_name
+      and_i_enter_a_new_first_name
+      and_i_continue
+      and_i_click_add_user
+
+      then_i_should_see_the_users_name_listed
+      and_i_should_see_the_users_email_listed
+      and_the_user_should_be_added_to_the_database
+    end
+
+    scenario "With invalid details" do
+      given_i_visit_the_users_new_page
+      and_i_continue
+
+      then_it_should_display_the_correct_error_messages
+    end
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    @provider = create(:provider, provider_name: "Batman's Chocolate School")
+    @user = create(:user, providers: [@provider])
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_i_visit_the_users_index_page
+    users_index_page.load(provider_code: @provider.provider_code)
+  end
+
+  def and_the_user_i_want_to_add_has_not_already_been_added
+    expect(users_index_page).not_to have_text("willy.wonka@bat_school.com")
+  end
+
+  def and_i_click_add_user
+    provider_users_index_page.add_user.click
+  end
+
+  def and_i_fill_in_first_name
+    users_new_page.first_name.set("Silly")
+  end
+
+  def and_i_fill_in_last_name
+    users_new_page.last_name.set("Wonka")
+  end
+
+  def and_i_fill_in_email
+    users_new_page.email.set("willy.wonka@bat_school.com")
+  end
+
+  def and_i_continue
+    users_new_page.submit.click
+  end
+
+  def then_i_should_be_on_the_check_page
+    expect(users_check_page).to be_displayed(provider_code: @provider.provider_code)
+  end
+
+  def and_the_user_should_not_be_in_the_database
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.where(email: "willy.wonka@bat_school.com").blank?).to be(true)
+  end
+
+  def when_i_click_change_first_name
+    users_check_page.change_first_name.click
+  end
+
+  def and_i_enter_a_new_first_name
+    users_new_page.first_name.set("Willy")
+  end
+
+  def and_i_continue
+    users_new_page.submit.click
+  end
+
+  def and_i_click_add_user
+    users_check_page.add_user.click
+  end
+
+  def then_i_should_see_the_users_name_listed
+    expect(users_check_page).to have_text("Willy Wonka")
+  end
+
+  def and_i_should_see_the_users_email_listed
+    expect(users_check_page).to have_text("willy.wonka@bat_school.com")
+  end
+
+  def and_the_user_should_be_added_to_the_database
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.where(email: "willy.wonka@bat_school.com").blank?).to be(false)
+  end
+
+  def given_i_visit_the_users_new_page
+    users_new_page.load(provider_code: @provider.provider_code)
+  end
+
+  def then_it_should_display_the_correct_error_messages
+    expect(users_new_page.error_summary).to have_text("Enter a first name")
+    expect(users_new_page.error_summary).to have_text("Enter a last name")
+    expect(users_new_page.error_summary).to have_text("Enter an email address")
+  end
+end

--- a/spec/forms/support/user_form_spec.rb
+++ b/spec/forms/support/user_form_spec.rb
@@ -44,15 +44,6 @@ describe Support::UserForm, type: :model do
       end
     end
 
-    context "uppercase email" do
-      let(:params) { { email: "FOOBAR@BAT.COM" } }
-
-      it "is invalid" do
-        expect(subject.errors[:email]).to include("Enter an email address that is lowercase, like name@example.com")
-        expect(subject.valid?).to be(false)
-      end
-    end
-
     context "valid params" do
       it "is valid" do
         expect(subject.valid?).to be(true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,7 +13,6 @@ describe User do
   describe "validations" do
     it { is_expected.to validate_presence_of(:email).with_message("must contain @") }
     it { is_expected.to validate_uniqueness_of(:email) }
-    it { is_expected.not_to allow_value("CAPS_IN_EMAIL@ACME.ORG").for(:email) }
     it { is_expected.not_to allow_value("email_without_at").for(:email) }
     it { is_expected.not_to allow_value(nil).for(:first_name) }
     it { is_expected.not_to allow_value(nil).for(:last_name) }
@@ -21,6 +20,7 @@ describe User do
     it { is_expected.not_to allow_value("").for(:last_name) }
     it { is_expected.not_to allow_value("  ").for(:first_name) }
     it { is_expected.not_to allow_value("  ").for(:last_name) }
+    it { is_expected.to allow_value("CAPS_IN_EMAIL@ACME.ORG").for(:email) }
 
     context "for an admin-user" do
       subject { create(:user, :admin) }

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -15,7 +15,7 @@ describe ProviderPolicy do
 
   subject { described_class }
 
-  permissions :index?, :suggest? do
+  permissions :index?, :suggest?, :new? do
     it { is_expected.to permit user }
   end
 

--- a/spec/support/page_objects/publish/users_check.rb
+++ b/spec/support/page_objects/publish/users_check.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class UsersCheck < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/users/check"
+
+      element :add_user, ".govuk-button", text: "Add user"
+
+      element :change_first_name, "a.govuk-link.first_name", text: "Change"
+      element :change_last_name, "a.govuk-link.last_name", text: "Change"
+      element :change_email, "a.govuk-link.email", text: "Change"
+    end
+  end
+end

--- a/spec/support/page_objects/publish/users_index.rb
+++ b/spec/support/page_objects/publish/users_index.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class UsersIndex < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/users"
+
+      element :add_user, ".govuk-button", text: "Add user"
+    end
+  end
+end

--- a/spec/support/page_objects/publish/users_new.rb
+++ b/spec/support/page_objects/publish/users_new.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class UsersNew < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/users/new"
+
+      element :first_name, "#publish-user-form-first-name-field"
+      element :last_name, "#publish-user-form-last-name-field"
+      element :last_name, "#publish-user-form-last-name-field"
+      element :email, "#publish-user-form-email-field"
+
+      element :error_summary, ".govuk-error-summary"
+
+      element :submit, 'button.govuk-button[type="submit"]'
+    end
+  end
+end

--- a/spec/support/page_objects/publish/users_new.rb
+++ b/spec/support/page_objects/publish/users_new.rb
@@ -12,7 +12,7 @@ module PageObjects
 
       element :error_summary, ".govuk-error-summary"
 
-      element :submit, 'button.govuk-button[type="submit"]'
+      element :continue, 'button.govuk-button[type="submit"]'
     end
   end
 end


### PR DESCRIPTION
### Context

Introducing a feature for providers to create Publish users and associate them with specific organisations. The users will also be sent an email, with the link and inviting them to sign up to DfE Sign in, if they haven't already.

### Changes proposed in this pull request

- Create new views, routes, controllers and form.
- Store changes in redis when submitting the form and going to the check page.
- Update the database with the changes stored in redis on submission of the check page.
- Values in the form are persisted if you cancel or go back from the check page. If you have accidently gone to the wrong provider, when you go to the correct one the form will be prefilled.
- Utilise the `UserAssociationService`.
- If the user does not exist on Publish, create the user and associate them with the provider.
- If the user does exist on Publish, find them and associate them with the provider.

### Guidance to review

Have a play around in the review app, compare with prototype, are there any differences or bugs?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
