### PR TITLE
Managing users in publish (viewing users)

### DIFF
--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -1,31 +1,33 @@
 module Publish
   class UsersController < PublishController
-    def index
-      authorize(provider)
+    before_action :authorize_provider
 
+    def index
       @users = provider.users
     end
 
     def show
-      authorize(provider)
       provider_user
     end
 
     def new
-      authorize(provider)
       @user_form = UserForm.new(current_user, user)
       @user_form.clear_stash
     end
 
     def create
-      authorize(provider)
-
       @user_form = UserForm.new(current_user, user, params: user_params)
       if @user_form.stash
         redirect_to publish_provider_check_user_path(provider_code: params[:provider_code])
       else
         render(:new)
       end
+    end
+
+  private
+
+    def authorize_provider
+      authorize(provider)
     end
 
     def cycle_year

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -6,6 +6,11 @@ module Publish
       @users = provider.users
     end
 
+    def show
+      authorize(provider)
+      provider_user
+    end
+
     def new
       authorize(provider)
       @user_form = UserForm.new(current_user, user)
@@ -33,6 +38,10 @@ module Publish
 
     def user_params
       params.require(:publish_user_form).permit(:first_name, :last_name, :email).except(:code, :authenticity_token)
+    end
+
+    def provider_user
+      @provider_user ||= provider.users.find(params[:id])
     end
   end
 end

--- a/app/views/publish/users/index.html.erb
+++ b/app/views/publish/users/index.html.erb
@@ -18,7 +18,7 @@
         <% @users.each do |user| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <a class="govuk-link govuk-heading-s govuk-!-margin-bottom-0"> <%= govuk_link_to("#{user.first_name} #{user.last_name}", root_path) %></a>
+              <a class="govuk-link govuk-heading-s govuk-!-margin-bottom-0"> <%= govuk_link_to("#{user.first_name} #{user.last_name}", publish_provider_user_path(id: user.id)) %></a>
             </td>
             <td class="govuk-table__cell">
               <%= user.email %>

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -1,0 +1,27 @@
+<%= render PageTitle::View.new(title: "providers.users.show") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= @provider_user.full_name %>
+    </h1>
+
+    <%= render GovukComponent::SummaryListComponent.new do |component|
+          component.row do |row|
+            row.key { "First name" }
+            row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
+          end
+
+          component.row do |row|
+            row.key { "Last name" }
+            row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
+          end
+
+          component.row do |row|
+            row.key { "Email address" }
+            row.value(text: @provider_user.email, html_attributes: { id: "email" })
+          end
+        end %>
+
+  </div>
+</div>

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "providers.users.show") %>
+<%= render PageTitle::View.new(title: t("page_titles.users.show")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: t("page_titles.users.show")) %>
+<%= content_for :page_title, @provider_user.full_name %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,6 @@ en:
       index: "Users"
       new: "Personal details"
       check: "Check your answers"
-      show: "View a provider"
   publish_authentication:
     magic_link:
       invalid_token: "Magic link could not be verified, please request a new one"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
       index: "Users"
       new: "Personal details"
       check: "Check your answers"
+      show: "View a provider"
   publish_authentication:
     magic_link:
       invalid_token: "Magic link could not be verified, please request a new one"
@@ -138,9 +139,6 @@ en:
         index: "Sign in"
         new: "User not found"
         personas: Teacher Training API Personas
-      providers:
-        users:
-          show: "View a provider"
       support:
         rollover:
           index: "Recruitment Cycles"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,9 @@ en:
         index: "Sign in"
         new: "User not found"
         personas: Teacher Training API Personas
+      providers:
+        users:
+          show: "View a provider"
       support:
         rollover:
           index: "Recruitment Cycles"

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -39,9 +39,9 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   describe "Viewing a user in an organisation" do
     scenario "With an existing user" do
       given_i_visit_the_users_index_page
-      and_i_click_on_the_user
-      then_i_should_be_on_the_user_show_page
-      and_the_users_name_should_be_displayed
+      when_i_click_on_the_user
+      i_should_be_on_the_user_show_page
+      then_the_users_name_should_be_displayed
     end
   end
 
@@ -122,11 +122,13 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     click_link "Mr User"
   end
 
-  def then_i_should_be_on_the_user_show_page
+  alias_method :when_i_click_on_the_user, :and_i_click_on_the_user
+
+  def i_should_be_on_the_user_show_page
     expect(users_show_page).to be_displayed
   end
 
-  def and_the_users_name_should_be_displayed
+  def then_the_users_name_should_be_displayed
     expect(users_show_page).to have_text("Mr User")
   end
 end

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -40,7 +40,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     scenario "With an existing user" do
       given_i_visit_the_users_index_page
       when_i_click_on_the_user
-      i_should_be_on_the_user_show_page
+      i_should_be_on_the_users_show_page
       then_the_users_name_should_be_displayed
     end
   end
@@ -124,7 +124,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
 
   alias_method :when_i_click_on_the_user, :and_i_click_on_the_user
 
-  def i_should_be_on_the_user_show_page
+  def i_should_be_on_the_users_show_page
     expect(users_show_page).to be_displayed
   end
 

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -36,9 +36,18 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     end
   end
 
+  describe "Viewing a user in an organisation" do
+    scenario "With an existing user" do
+      given_i_visit_the_users_index_page
+      and_i_click_on_the_user
+      then_i_should_be_on_the_user_show_page
+      and_the_users_name_should_be_displayed
+    end
+  end
+
   def given_i_am_authenticated_as_a_provider_user
     @provider = create(:provider, provider_name: "Batman's Chocolate School")
-    @user = create(:user, providers: [@provider])
+    @user = create(:user, first_name: "Mr", last_name: "User", providers: [@provider])
     given_i_am_authenticated(user: @user)
   end
 
@@ -107,5 +116,17 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     expect(users_new_page.error_summary).to have_text("Enter a first name")
     expect(users_new_page.error_summary).to have_text("Enter a last name")
     expect(users_new_page.error_summary).to have_text("Enter an email address")
+  end
+
+  def and_i_click_on_the_user
+    click_link "Mr User"
+  end
+
+  def then_i_should_be_on_the_user_show_page
+    expect(users_show_page).to be_displayed
+  end
+
+  def and_the_users_name_should_be_displayed
+    expect(users_show_page).to have_text("Mr User")
   end
 end

--- a/spec/support/page_objects/publish/users_show.rb
+++ b/spec/support/page_objects/publish/users_show.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class UsersShow < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/users/{id}"
+    end
+  end
+end


### PR DESCRIPTION
### Context

As a follow up to #3159 where we add the ability for provider users to add new provider users to organisations, this PR allow providers to to view these provider users. 

### Changes proposed in this pull request

- Add a show page
- Link to the show page from the users list

### Guidance to review

- Checkout the show page `publish/organisations/1CS/users/{user_id}`
- There's a separate ticket for change links: https://trello.com/c/y70qffV4/864-managing-users-in-publish-edit-user

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
