### PR TITLE
Managing users in publish (removing users)

### DIFF
--- a/app/controllers/publish/users_check_controller.rb
+++ b/app/controllers/publish/users_check_controller.rb
@@ -1,7 +1,8 @@
 module Publish
   class UsersCheckController < PublishController
+    before_action :authorize_provider
+
     def show
-      authorize(provider)
       @user_form = UserForm.new(current_user, user)
     end
 
@@ -9,10 +10,15 @@ module Publish
       @user_form = UserForm.new(current_user, user)
       if @user_form.save!
         UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
-        authorize(provider)
         redirect_to publish_provider_users_path(params[:provider_code])
         flash[:success] = "User added"
       end
+    end
+
+  private
+
+    def authorize_provider
+      authorize(provider)
     end
 
     def user

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -29,16 +29,16 @@ module Publish
       end
     end
 
-  private
-
-    def authorize_provider
-      authorize(provider)
-    end
-
     def destroy
       UserAssociationsService::Delete.call(user: provider_user, providers: provider)
       flash[:success] = I18n.t("success.user_removed")
       redirect_to publish_provider_users_path(params[:provider_code])
+    end
+
+  private
+
+    def authorize_provider
+      authorize(provider)
     end
 
     def cycle_year

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -11,7 +11,6 @@ module Publish
     end
 
     def delete
-      authorize(provider)
       provider_user
     end
 

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -10,6 +10,11 @@ module Publish
       provider_user
     end
 
+    def delete
+      authorize(provider)
+      provider_user
+    end
+
     def new
       @user_form = UserForm.new(current_user, user)
       @user_form.clear_stash
@@ -28,6 +33,12 @@ module Publish
 
     def authorize_provider
       authorize(provider)
+    end
+
+    def destroy
+      UserAssociationsService::Delete.call(user: provider_user, providers: provider)
+      flash[:success] = I18n.t("success.user_removed")
+      redirect_to publish_provider_users_path(params[:provider_code])
     end
 
     def cycle_year

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -66,6 +66,7 @@ class ProviderPolicy
   alias_method :can_list_training_providers?, :show?
   alias_method :index?, :new?
   alias_method :create?, :show?
+  alias_method :delete?, :show?
 
   def permitted_provider_attributes
     if user.admin?

--- a/app/views/publish/users/delete.html.erb
+++ b/app/views/publish/users/delete.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "providers.users.delete") %>
+<%= content_for :page_title, t("page_titles.users.delete") %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_user_path(id: params[:id])) %>
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l"><%= @provider_user.full_name %></span>
-        <%= t("components.page_titles.providers.users.delete") %>
+        <%= t("page_titles.users.delete") %>
     </h1>
 
     <div class="govuk-warning-text">

--- a/app/views/publish/users/delete.html.erb
+++ b/app/views/publish/users/delete.html.erb
@@ -1,0 +1,31 @@
+<%= render PageTitle::View.new(title: "providers.users.delete") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_user_path(id: params[:id])) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @provider_user.full_name %></span>
+        <%= t("components.page_titles.providers.users.delete") %>
+    </h1>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        The user will be sent an email to tell them you removed them from the organisation.
+      </strong>
+    </div>
+
+    <%= govuk_button_to "Remove user",
+                        delete_publish_provider_user_path,
+        method: :delete,
+        class: "govuk-button--warning" %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_user_path(id: params[:id])) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -23,5 +23,9 @@
           end
         end %>
 
+    <p class="govuk-body">
+      <%= govuk_link_to("Remove user", delete_publish_provider_user_path, class: "app-link--destructive") %>
+    </p>
+
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
       index: "Users"
       new: "Personal details"
       check: "Check your answers"
+      delete: "Are you sure you want to remove this user?"
   publish_authentication:
     magic_link:
       invalid_token: "Magic link could not be verified, please request a new one"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -53,7 +53,12 @@ namespace :publish, as: :publish do
 
   resources :providers, path: "organisations", param: :code, only: [:show] do
     resource :check_user, only: %i[show update], controller: "users_check", path: "users/check"
-    resources :users, controller: "users"
+    resources :users, controller: "users" do
+      member do
+        get :delete
+        delete :delete, to: "users#destroy"
+      end
+    end
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"
     get "locations"

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -48,7 +48,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   describe "Removing a user in an organisation" do
     scenario "With an existing user" do
       given_i_visit_the_users_index_page
-      and_i_click_on_user_two
+      when_i_click_on_user_two
       and_i_click_remove_user
       and_i_confirm
       then_the_user_should_be_deleted
@@ -135,7 +135,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
 
   alias_method :when_i_click_on_the_user, :and_i_click_on_the_user
 
-  def and_i_click_on_user_two
+  def when_i_click_on_user_two
     click_link "Mr Cool"
   end
 

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -45,9 +45,20 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     end
   end
 
+  describe "Removing a user in an organisation" do
+    scenario "With an existing user" do
+      given_i_visit_the_users_index_page
+      and_i_click_on_user_two
+      and_i_click_remove_user
+      and_i_confirm
+      then_the_user_should_be_deleted
+    end
+  end
+
   def given_i_am_authenticated_as_a_provider_user
     @provider = create(:provider, provider_name: "Batman's Chocolate School")
     @user = create(:user, first_name: "Mr", last_name: "User", providers: [@provider])
+    @user2 = create(:user, first_name: "Mr", last_name: "Cool", providers: [@provider])
     given_i_am_authenticated(user: @user)
   end
 
@@ -124,11 +135,27 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
 
   alias_method :when_i_click_on_the_user, :and_i_click_on_the_user
 
+  def and_i_click_on_user_two
+    click_link "Mr Cool"
+  end
+
   def i_should_be_on_the_users_show_page
     expect(users_show_page).to be_displayed
   end
 
   def then_the_users_name_should_be_displayed
     expect(users_show_page).to have_text("Mr User")
+  end
+
+  def and_i_click_remove_user
+    users_show_page.remove_user_link.click
+  end
+
+  def and_i_confirm
+    users_delete_page.remove_user_button.click
+  end
+
+  def then_the_user_should_be_deleted
+    expect(provider_users_page).to_not have_text "Mr Cool"
   end
 end

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -156,6 +156,6 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def then_the_user_should_be_deleted
-    expect(provider_users_page).to_not have_text "Mr Cool"
+    expect(provider_users_page).not_to have_text "Mr Cool"
   end
 end

--- a/spec/support/page_objects/publish/users_delete.rb
+++ b/spec/support/page_objects/publish/users_delete.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class UsersDelete < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/users/{user_id}/delete"
+
+      element :remove_user_button, ".govuk-button", text: "Remove user"
+    end
+  end
+end

--- a/spec/support/page_objects/publish/users_show.rb
+++ b/spec/support/page_objects/publish/users_show.rb
@@ -4,6 +4,8 @@ module PageObjects
   module Publish
     class UsersShow < PageObjects::Base
       set_url "/publish/organisations/{provider_code}/users/{id}"
+
+      element :remove_user_link, ".govuk-link", text: "Remove user"
     end
   end
 end


### PR DESCRIPTION
### Context

Following on from #3159 and #3166. The next feature in the managing users epic is the ability for providers to remove other provider users.

### Changes proposed in this pull request

- Add routes for deleting
- Add the remove user link on the show page
- Add a `delete?` method to the provider policy

### Guidance to review

Try it out on the review app.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
