### PR TITLE
Managing users in publish (Editing users)

### DIFF
--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -20,7 +20,9 @@ module Publish
     end
 
     def edit
-      user
+      provider
+      provider_user
+      @user_form = UserForm.new(current_user, provider_user)
     end
 
     def create
@@ -32,11 +34,24 @@ module Publish
       end
     end
 
+    def update
+      provider
+      @user_form = UserForm.new(current_user, provider_user, params: user_params)
+      if @user_form.save!
+        redirect_to publish_provider_user_path(id: params[:id])
+        flash[:success] = "User updated"
+      else
+        render(:edit)
+      end
+    end
+
+
     def destroy
       UserAssociationsService::Delete.call(user: provider_user, providers: provider)
       flash[:success] = I18n.t("success.user_removed")
       redirect_to publish_provider_users_path(params[:provider_code])
     end
+
 
   private
 

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -19,6 +19,10 @@ module Publish
       @user_form.clear_stash
     end
 
+    def edit
+      user
+    end
+
     def create
       @user_form = UserForm.new(current_user, user, params: user_params)
       if @user_form.stash

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -20,9 +20,8 @@ module Publish
     end
 
     def edit
-      provider
-      provider_user
       @user_form = UserForm.new(current_user, provider_user)
+      @user_form.clear_stash
     end
 
     def create

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -36,9 +36,8 @@ module Publish
     def update
       provider
       @user_form = UserForm.new(current_user, provider_user, params: user_params)
-      if @user_form.save!
-        redirect_to publish_provider_user_path(id: params[:id])
-        flash[:success] = "User updated"
+      if @user_form.stash
+        redirect_to publish_provider_user_edit_check_path(user_id: params[:id])
       else
         render(:edit)
       end

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -44,13 +44,11 @@ module Publish
       end
     end
 
-
     def destroy
       UserAssociationsService::Delete.call(user: provider_user, providers: provider)
       flash[:success] = I18n.t("success.user_removed")
       redirect_to publish_provider_users_path(params[:provider_code])
     end
-
 
   private
 

--- a/app/controllers/publish/users_edit_check_controller.rb
+++ b/app/controllers/publish/users_edit_check_controller.rb
@@ -10,7 +10,6 @@ module Publish
       @user_form = UserForm.new(current_user, user)
       if @user_form.save!
         UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
-        authorize(provider)
         redirect_to publish_provider_user_path(id: params[:user_id])
         flash[:success] = "User updated"
       end

--- a/app/controllers/publish/users_edit_check_controller.rb
+++ b/app/controllers/publish/users_edit_check_controller.rb
@@ -8,11 +8,6 @@ module Publish
 
     def create
       @user_form = UserForm.new(current_user, user, params: user_params)
-      if @user_form.stash
-        redirect_to publish_provider_user_edit_check_path(provider_code: params[:provider_code])
-      else
-        render(:edit) # #todo fix this
-      end
     end
 
     def update

--- a/app/controllers/publish/users_edit_check_controller.rb
+++ b/app/controllers/publish/users_edit_check_controller.rb
@@ -11,7 +11,7 @@ module Publish
       if @user_form.stash
         redirect_to publish_provider_user_edit_check_path(provider_code: params[:provider_code])
       else
-        render(:edit) ##todo fix this
+        render(:edit) # #todo fix this
       end
     end
 

--- a/app/controllers/publish/users_edit_check_controller.rb
+++ b/app/controllers/publish/users_edit_check_controller.rb
@@ -6,10 +6,6 @@ module Publish
       @user_form = UserForm.new(current_user, user)
     end
 
-    def create
-      @user_form = UserForm.new(current_user, user, params: user_params)
-    end
-
     def update
       @user_form = UserForm.new(current_user, user)
       if @user_form.save!
@@ -20,12 +16,10 @@ module Publish
       end
     end
 
+  private
+
     def user
       @user = User.find(params[:user_id])
-    end
-
-    def user_params
-      params.require(:publish_user_form).permit(:first_name, :last_name, :email).except(:code, :authenticity_token)
     end
 
     def authorize_provider

--- a/app/controllers/publish/users_edit_check_controller.rb
+++ b/app/controllers/publish/users_edit_check_controller.rb
@@ -1,0 +1,40 @@
+module Publish
+  class UsersEditCheckController < PublishController
+    before_action :authorize_provider
+
+    def show
+      @user_form = UserForm.new(current_user, user)
+    end
+
+    def create
+      @user_form = UserForm.new(current_user, user, params: user_params)
+      if @user_form.stash
+        redirect_to publish_provider_user_edit_check_path(provider_code: params[:provider_code])
+      else
+        render(:edit) ##todo fix this
+      end
+    end
+
+    def update
+      @user_form = UserForm.new(current_user, user)
+      if @user_form.save!
+        UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
+        authorize(provider)
+        redirect_to publish_provider_user_path(id: params[:user_id])
+        flash[:success] = "User updated"
+      end
+    end
+
+    def user
+      @user = User.find(params[:user_id])
+    end
+
+    def user_params
+      params.require(:publish_user_form).permit(:first_name, :last_name, :email).except(:code, :authenticity_token)
+    end
+
+    def authorize_provider
+      authorize(provider)
+    end
+  end
+end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -10,6 +10,6 @@ module UserHelper
   end
 
   def email_changed?(user_form)
-    user_form.email != User.find(params[:user_id]).email
+    user_form.email.downcase != User.find(params[:user_id]).email
   end
 end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -8,4 +8,8 @@ module UserHelper
   def user_details(user)
     "#{user[:first_name]} #{user[:last_name]} <#{user[:email]}>"
   end
+
+  def email_changed?(user_form)
+    user_form.email != User.find(params[:user_id]).email
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,6 +103,10 @@ class User < ApplicationRecord
     admin? || has_multiple_providers_in_current_recruitment_cycle?
   end
 
+  def has_sign_in_account?
+    sign_in_user_id.present?
+  end
+
 private
 
   def downcase_email

--- a/app/views/publish/users/edit.html.erb
+++ b/app/views/publish/users/edit.html.erb
@@ -27,10 +27,10 @@
         <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: "full" %>
         <%= f.govuk_submit %>
       </fieldset>
-<% end %>
 
       <p class="govuk-body">
         <%= govuk_link_to(t("cancel"), publish_provider_user_path) %>
       </p>
     </div>
   </div>
+<% end %>

--- a/app/views/publish/users/edit.html.erb
+++ b/app/views/publish/users/edit.html.erb
@@ -29,8 +29,8 @@
       </fieldset>
 <% end %>
 
-<p class="govuk-body">
-  <%= govuk_link_to(t("cancel"), publish_provider_user_path) %>
-</p>
+      <p class="govuk-body">
+        <%= govuk_link_to(t("cancel"), publish_provider_user_path) %>
+      </p>
     </div>
   </div>

--- a/app/views/publish/users/edit.html.erb
+++ b/app/views/publish/users/edit.html.erb
@@ -32,5 +32,5 @@
 <p class="govuk-body">
   <%= govuk_link_to(t("cancel"), publish_provider_user_path) %>
 </p>
-</div>
-</div>
+    </div>
+  </div>

--- a/app/views/publish/users/edit.html.erb
+++ b/app/views/publish/users/edit.html.erb
@@ -1,0 +1,36 @@
+<% page_title = t("page_titles.users.edit") %>
+<%= content_for :page_title, title_with_error_prefix(page_title, @user_form.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_user_path(id: params[:id])) %>
+<% end %>
+
+<%= form_with(model: @user_form, url: publish_provider_user_path(params[:provider_code]), method: :put, local: true) do |f| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= f.govuk_error_summary %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-l"><%= @provider_user.full_name %></span>
+            <%= t("page_titles.users.edit") %>
+          </h1>
+        </legend>
+        <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: "two-thirds" %>
+        <%= f.govuk_text_field :last_name, label: { text: "Last name", size: "s" }, width: "two-thirds" %>
+        <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: "full" %>
+        <%= f.govuk_submit(t("users.edit")) %>
+      </fieldset>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to(t("cancel"), publish_provider_user_path(id: params[:id])) %>
+</p>
+</div>
+</div>

--- a/app/views/publish/users/edit.html.erb
+++ b/app/views/publish/users/edit.html.erb
@@ -1,11 +1,11 @@
-<% page_title = t("page_titles.users.new") %>
+<% page_title = t("page_titles.users.edit") %>
 <%= content_for :page_title, title_with_error_prefix(page_title, @user_form.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_user_path) %>
 <% end %>
 
-<%= form_with(model: @user_form, url: publish_provider_user_edit_check_path(user_id: params[:id]), local: true) do |f| %>
+<%= form_with(model: @user_form, url: publish_provider_user_path, method: :put, local: true) do |f| %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -19,7 +19,7 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
             <span class="govuk-caption-l"><%= @provider_user.full_name %></span>
-            <%= t("page_titles.users.new") %>
+            <%= t("page_titles.users.edit") %>
           </h1>
         </legend>
         <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: "two-thirds" %>

--- a/app/views/publish/users/edit.html.erb
+++ b/app/views/publish/users/edit.html.erb
@@ -1,11 +1,11 @@
-<% page_title = t("page_titles.users.edit") %>
+<% page_title = t("page_titles.users.new") %>
 <%= content_for :page_title, title_with_error_prefix(page_title, @user_form.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_user_path(id: params[:id])) %>
+  <%= govuk_back_link_to(publish_provider_user_path) %>
 <% end %>
 
-<%= form_with(model: @user_form, url: publish_provider_user_path(params[:provider_code]), method: :put, local: true) do |f| %>
+<%= form_with(model: @user_form, url: publish_provider_user_edit_check_path(user_id: params[:id]), local: true) do |f| %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -19,18 +19,18 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
             <span class="govuk-caption-l"><%= @provider_user.full_name %></span>
-            <%= t("page_titles.users.edit") %>
+            <%= t("page_titles.users.new") %>
           </h1>
         </legend>
         <%= f.govuk_text_field :first_name, label: { text: "First name", size: "s" }, width: "two-thirds" %>
         <%= f.govuk_text_field :last_name, label: { text: "Last name", size: "s" }, width: "two-thirds" %>
         <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: "full" %>
-        <%= f.govuk_submit(t("users.edit")) %>
+        <%= f.govuk_submit %>
       </fieldset>
 <% end %>
 
 <p class="govuk-body">
-  <%= govuk_link_to(t("cancel"), publish_provider_user_path(id: params[:id])) %>
+  <%= govuk_link_to(t("cancel"), publish_provider_user_path) %>
 </p>
 </div>
 </div>

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -10,16 +10,19 @@
           component.row do |row|
             row.key { "First name" }
             row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
+            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.first_name").downcase)
           end
 
           component.row do |row|
             row.key { "Last name" }
             row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
+            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.last_name").downcase)
           end
 
           component.row do |row|
             row.key { "Email address" }
             row.value(text: @provider_user.email, html_attributes: { id: "email" })
+            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.email").downcase)
           end
         end %>
 

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -10,19 +10,19 @@
           component.row do |row|
             row.key { "First name" }
             row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
-            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.first_name").downcase)
+            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.first_name").downcase) unless @provider_user.has_sign_in_account?
           end
 
           component.row do |row|
             row.key { "Last name" }
             row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
-            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.last_name").downcase)
+            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.last_name").downcase) unless @provider_user.has_sign_in_account?
           end
 
           component.row do |row|
             row.key { "Email address" }
             row.value(text: @provider_user.email, html_attributes: { id: "email" })
-            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.email").downcase)
+            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.email").downcase) unless @provider_user.has_sign_in_account?
           end
         end %>
 

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -10,19 +10,19 @@
           component.row do |row|
             row.key { "First name" }
             row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
-            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.first_name").downcase)
+            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.first_name").downcase) if @provider_user.has_sign_in_account?
           end
 
           component.row do |row|
             row.key { "Last name" }
             row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
-            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.last_name").downcase)
+            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.last_name").downcase) if @provider_user.has_sign_in_account?
           end
 
           component.row do |row|
             row.key { "Email address" }
             row.value(text: @provider_user.email, html_attributes: { id: "email" })
-            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.email").downcase)
+            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.email").downcase) if @provider_user.has_sign_in_account?
           end
         end %>
 

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -9,19 +9,19 @@
     <%= render GovukComponent::SummaryListComponent.new do |component|
           component.row do |row|
             row.key { "First name" }
-            row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
+            row.value(text: @provider_user.first_name)
             row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.first_name").downcase) unless @provider_user.has_sign_in_account?
           end
 
           component.row do |row|
             row.key { "Last name" }
-            row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
+            row.value(text: @provider_user.last_name)
             row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.last_name").downcase) unless @provider_user.has_sign_in_account?
           end
 
           component.row do |row|
             row.key { "Email address" }
-            row.value(text: @provider_user.email, html_attributes: { id: "email" })
+            row.value(text: @provider_user.email)
             row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.email").downcase) unless @provider_user.has_sign_in_account?
           end
         end %>

--- a/app/views/publish/users/show.html.erb
+++ b/app/views/publish/users/show.html.erb
@@ -10,19 +10,19 @@
           component.row do |row|
             row.key { "First name" }
             row.value(text: @provider_user.first_name, html_attributes: { id: "first_name" })
-            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.first_name").downcase) if @provider_user.has_sign_in_account?
+            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.first_name").downcase)
           end
 
           component.row do |row|
             row.key { "Last name" }
             row.value(text: @provider_user.last_name, html_attributes: { id: "last_name" })
-            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.last_name").downcase) if @provider_user.has_sign_in_account?
+            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.last_name").downcase)
           end
 
           component.row do |row|
             row.key { "Email address" }
             row.value(text: @provider_user.email, html_attributes: { id: "email" })
-            row.action(text: "Change", href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.email").downcase) if @provider_user.has_sign_in_account?
+            row.action(text: t("change"), href: edit_publish_provider_user_path(provider_code: @provider.provider_code), visually_hidden_text: t("users.email").downcase)
           end
         end %>
 

--- a/app/views/publish/users_edit_check/show.erb
+++ b/app/views/publish/users_edit_check/show.erb
@@ -10,7 +10,7 @@
     <%= form_with(model: @user_form, url: publish_provider_user_edit_check_path(params[:provider_code]), method: :put, local: true) do |f| %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= @user.full_name %></span>
-          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("page_titles.users.check") %> </h1> </legend>
+          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("page_titles.users.check") %></h1> </legend>
 
         <%= render GovukComponent::SummaryListComponent.new do |component|
           component.row do |row|

--- a/app/views/publish/users_edit_check/show.erb
+++ b/app/views/publish/users_edit_check/show.erb
@@ -1,0 +1,50 @@
+<% page_title = t("page_titles.users.check") %>
+<%= content_for :page_title, page_title %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(edit_publish_provider_user_path(id: params[:user_id])) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with(model: @user_form, url: publish_provider_user_edit_check_path(params[:provider_code]), method: :put, local: true) do |f| %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= @user.full_name %></span>
+          <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("page_titles.users.check") %> </h1> </legend>
+
+        <%= render GovukComponent::SummaryListComponent.new do |component|
+          component.row do |row|
+            row.key { t("users.first_name") }
+            row.value(text:  @user_form.first_name)
+            row.action(text: t("change"), href: edit_publish_provider_user_path(id: params[:user_id]), classes: "first_name", visually_hidden_text: t("users.first_name").downcase)
+          end
+
+          component.row do |row|
+            row.key { t("users.last_name") }
+            row.value(text: @user_form.last_name)
+            row.action(text: t("change"), href: edit_publish_provider_user_path(id: params[:user_id]), classes: "last_name", visually_hidden_text: t("users.last_name").downcase)
+          end
+
+          component.row do |row|
+            row.key { t("users.email") }
+            row.value(text:  @user_form.email)
+            row.action(text: t("change"), href: edit_publish_provider_user_path(id: params[:user_id]), classes: "email", visually_hidden_text: t("users.email").downcase)
+          end
+        end %>
+
+
+        <% if email_changed?(@user_form) %>
+          <div class="govuk-warning-text"> <span class="govuk-warning-text__icon" aria-hidden="true">!</span> <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span> The user will be sent an email to tell them you’ve added them to the organisation. </strong>
+          </div>
+        <% end %>
+
+        <%= f.govuk_submit(t("users.edit")) %>
+      </fieldset>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_user_path(id: params[:user_id])) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/users_edit_check/show.erb
+++ b/app/views/publish/users_edit_check/show.erb
@@ -39,7 +39,7 @@
           </div>
         <% end %>
 
-        <%= f.govuk_submit(t("users.edit")) %>
+        <%= f.govuk_submit(t("users.update")) %>
       </fieldset>
     <% end %>
 

--- a/app/views/publish/users_edit_check/show.erb
+++ b/app/views/publish/users_edit_check/show.erb
@@ -32,7 +32,6 @@
           end
         end %>
 
-
         <% if email_changed?(@user_form) %>
           <div class="govuk-warning-text"> <span class="govuk-warning-text__icon" aria-hidden="true">!</span> <strong class="govuk-warning-text__text">
             <span class="govuk-warning-text__assistive">Warning</span> The user will be sent an email to tell them you’ve changed their email address  </strong>

--- a/app/views/publish/users_edit_check/show.erb
+++ b/app/views/publish/users_edit_check/show.erb
@@ -35,7 +35,7 @@
 
         <% if email_changed?(@user_form) %>
           <div class="govuk-warning-text"> <span class="govuk-warning-text__icon" aria-hidden="true">!</span> <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span> The user will be sent an email to tell them you’ve added them to the organisation. </strong>
+            <span class="govuk-warning-text__assistive">Warning</span> The user will be sent an email to tell them you’ve changed their email address  </strong>
           </div>
         <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,7 +224,7 @@ en:
     last_name: "Last name"
     email: "Email address"
     add: "Add user"
-    edit: "Update user"
+    update: "Update user"
   support:
     data_exports:
       index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
       new: "Personal details"
       check: "Check your answers"
       delete: "Are you sure you want to remove this user?"
+      edit: "Personal details"
   publish_authentication:
     magic_link:
       invalid_token: "Magic link could not be verified, please request a new one"
@@ -223,6 +224,7 @@ en:
     last_name: "Last name"
     email: "Email address"
     add: "Add user"
+    edit: "Update user"
   support:
     data_exports:
       index:

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -60,7 +60,6 @@ namespace :publish, as: :publish do
         delete :delete, to: "users#destroy"
       end
     end
-  end
 
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -54,11 +54,14 @@ namespace :publish, as: :publish do
   resources :providers, path: "organisations", param: :code, only: [:show] do
     resource :check_user, only: %i[show update], controller: "users_check", path: "users/check"
     resources :users, controller: "users" do
+      resource :edit_check, controller: "users_edit_check", path: "edit/check"
       member do
         get :delete
         delete :delete, to: "users#destroy"
       end
     end
+  end
+
     get "/request-access", on: :member, to: "providers/access_requests#new"
     post "/request-access", on: :member, to: "providers/access_requests#create"
     get "locations"

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -315,6 +315,6 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def user_exists_in_db(first_name)
-    Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: first_name)
+    Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name:)
   end
 end

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -299,22 +299,22 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def then_the_first_name_should_have_updated_in_the_database
-    expect(user_exists_in_db("New first name")).to be(true)
+    expect(user_in_db_with_name("New first name")).to be(true)
   end
 
   def and_the_first_name_should_not_have_updated_in_the_database
-    expect(user_exists_in_db("New first name")).to be(false)
+    expect(user_in_db_with_name("New first name")).to be(false)
   end
 
   def then_the_last_name_should_have_updated_in_the_database
-    expect(user_exists_in_db("New last name")).to be(true)
+    expect(user_in_db_with_name("New last name")).to be(true)
   end
 
   def and_the_last_name_should_not_have_updated_in_the_database
-    expect(user_exists_in_db("New last name")).to be(false)
+    expect(user_in_db_with_name("New last name")).to be(false)
   end
 
-  def user_exists_in_db(first_name)
+  def user_in_db_with_name(first_name)
     Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name:)
   end
 end

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -68,8 +68,8 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
         scenario "with invalid details" do
           given_i_click_change_email_address
           when_i_enter_a_new_invalid_email
-          # and_i_continue
-          # expect(page).to have_text("Enter an email address in the correct format, like name@example.com") #todo make this work
+          and_i_continue
+          then_i_should_see_a_validation_error_message
         end
       end
 
@@ -286,5 +286,9 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
 
   def and_click_update_user
     click_button "Update user"
+  end
+
+  def then_i_should_see_a_validation_error_message
+    expect(page).to have_text("Enter an email address in the correct format, like name@example.com")
   end
 end

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -61,7 +61,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
           and_the_new_email_is_displayed
           and_the_warning_email_text_should_be_displayed
           and_the_user_should_not_have_changed_in_the_database
-          and_click_update_user
+          and_i_click_update_user
           then_the_user_should_have_changed_in_the_database
         end
 
@@ -78,7 +78,10 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
         when_i_edit_and_enter_a_new_first_name
         and_i_continue
         and_i_see_the_new_first_name_is_displayed
-        then_the_warning_email_text_should_not_be_displayed
+        and_the_warning_email_text_should_not_be_displayed
+        and_the_first_name_should_not_have_updated_in_the_database
+        and_i_click_update_user
+        then_the_first_name_should_have_updated_in_the_database
       end
 
       scenario "Changing a last name" do
@@ -86,7 +89,10 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
         when_i_edit_and_enter_a_new_last_name
         and_i_continue
         and_i_see_the_new_last_name_is_displayed
-        then_the_warning_email_text_should_not_be_displayed
+        and_the_warning_email_text_should_not_be_displayed
+        and_the_last_name_should_not_have_updated_in_the_database
+        and_i_click_update_user
+        then_the_last_name_should_have_updated_in_the_database
       end
     end
 
@@ -160,11 +166,11 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def and_the_user_should_not_have_changed_in_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "achangedemail@address.com")).to be(false)
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "a-changed-email@address.com")).to be(false)
   end
 
   def then_the_user_should_have_changed_in_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "achangedemail@address.com")).to be(true)
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "a-changed-email@address.com")).to be(true)
   end
 
   def given_i_click_change_first_name
@@ -176,7 +182,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def when_i_enter_a_new_valid_email
-    users_edit_page.email.set("achangedemail@address.com")
+    users_edit_page.email.set("a-changed-email@address.com")
   end
 
   def when_i_edit_and_enter_a_new_first_name
@@ -188,7 +194,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def and_the_warning_email_text_should_be_displayed
-    expect(page).to have_text("Warning The user will be sent an email to tell them you’ve added them to the organisation.")
+    expect(page).to have_text("Warning The user will be sent an email to tell them you’ve changed their email address")
   end
 
   def when_i_enter_a_new_invalid_email
@@ -199,8 +205,8 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     expect(page).to have_text("New first name")
   end
 
-  def then_the_warning_email_text_should_not_be_displayed
-    expect(page).not_to have_text("Warning The user will be sent an email to tell them you’ve added them to the organisation.")
+  def and_the_warning_email_text_should_not_be_displayed
+    expect(page).not_to have_text("Warning The user will be sent an email to tell them you’ve changed their email address")
   end
 
   def and_i_see_the_new_last_name_is_displayed
@@ -281,14 +287,30 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def and_the_new_email_is_displayed
-    expect(page).to have_text("achangedemail@address.com")
+    expect(page).to have_text("a-changed-email@address.com")
   end
 
-  def and_click_update_user
+  def and_i_click_update_user
     click_button "Update user"
   end
 
   def then_i_should_see_a_validation_error_message
     expect(page).to have_text("Enter an email address in the correct format, like name@example.com")
+  end
+
+  def then_the_first_name_should_have_updated_in_the_database
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: "New first name")).to be(true)
+  end
+
+  def and_the_first_name_should_not_have_updated_in_the_database
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: "New first name")).to be(false)
+  end
+
+  def then_the_last_name_should_have_updated_in_the_database
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: "New last name")).to be(true)
+  end
+
+  def and_the_last_name_should_not_have_updated_in_the_database
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: "New last name")).to be(false)
   end
 end

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -45,6 +45,61 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     end
   end
 
+  describe "Editing a user in an organisation" do
+    context "User does not have a dfe sign in account" do
+      before do
+        given_that_the_user_does_not_have_a_dfe_signin_account
+        when_i_visit_the_users_index_page
+        and_i_click_on_the_user
+      end
+
+      context "Changing an email address" do
+        scenario "with valid details" do
+          given_i_click_change_email_address
+          when_i_enter_a_new_valid_email
+          and_i_continue
+          and_the_new_email_is_displayed
+          and_the_warning_email_text_should_be_displayed
+          and_the_user_should_not_have_changed_in_the_database
+          and_click_update_user
+          then_the_user_should_have_changed_in_the_database
+        end
+
+        scenario "with invalid details" do
+          given_i_click_change_email_address
+          when_i_enter_a_new_invalid_email
+          # and_i_continue
+          # expect(page).to have_text("Enter an email address in the correct format, like name@example.com") #todo make this work
+        end
+      end
+
+      scenario "Changing a first name" do
+        given_i_click_change_first_name
+        when_i_edit_and_enter_a_new_first_name
+        and_i_continue
+        and_i_see_the_new_first_name_is_displayed
+        then_the_warning_email_text_should_not_be_displayed
+      end
+
+      scenario "Changing a last name" do
+        given_i_click_change_last_name
+        when_i_edit_and_enter_a_new_last_name
+        and_i_continue
+        and_i_see_the_new_last_name_is_displayed
+        then_the_warning_email_text_should_not_be_displayed
+      end
+    end
+
+    context "User has a dfe signin account" do
+      scenario "Changing any details" do
+        given_the_user_has_an_associated_dfe_signin_account
+        when_i_visit_the_users_index_page
+        and_i_click_on_the_user
+        then_i_should_not_see_any_change_links
+      end
+    end
+  end
+
   describe "Removing a user in an organisation" do
     scenario "With an existing user" do
       given_i_visit_the_users_index_page
@@ -53,6 +108,10 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
       and_i_confirm
       then_the_user_should_be_deleted
     end
+  end
+
+  def given_that_the_user_does_not_have_a_dfe_signin_account
+    @user.update(sign_in_user_id: nil)
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -65,6 +124,8 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   def given_i_visit_the_users_index_page
     users_index_page.load(provider_code: @provider.provider_code)
   end
+
+  alias_method :when_i_visit_the_users_index_page, :given_i_visit_the_users_index_page
 
   def when_the_user_i_want_to_add_has_not_already_been_added
     expect(users_index_page).not_to have_text("willy.wonka@bat-school.com")
@@ -87,7 +148,7 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def and_i_continue
-    users_new_page.continue.click
+    click_button "Continue"
   end
 
   def and_i_am_on_the_check_page
@@ -98,12 +159,60 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "willy.wonka@bat-school.com")).to be(false)
   end
 
+  def and_the_user_should_not_have_changed_in_the_database
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "achangedemail@address.com")).to be(false)
+  end
+
+  def then_the_user_should_have_changed_in_the_database
+    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(email: "achangedemail@address.com")).to be(true)
+  end
+
   def given_i_click_change_first_name
     users_check_page.change_first_name.click
   end
 
   def when_i_enter_a_new_first_name
     users_new_page.first_name.set("Willy")
+  end
+
+  def when_i_enter_a_new_valid_email
+    users_edit_page.email.set("achangedemail@address.com")
+  end
+
+  def when_i_edit_and_enter_a_new_first_name
+    users_edit_page.first_name.set("New first name")
+  end
+
+  def when_i_edit_and_enter_a_new_last_name
+    users_edit_page.first_name.set("New last name")
+  end
+
+  def and_the_warning_email_text_should_be_displayed
+    expect(page).to have_text("Warning The user will be sent an email to tell them you’ve added them to the organisation.")
+  end
+
+  def when_i_enter_a_new_invalid_email
+    fill_in "Email address", with: "invalid_email@"
+  end
+
+  def and_i_see_the_new_first_name_is_displayed
+    expect(page).to have_text("New first name")
+  end
+
+  def then_the_warning_email_text_should_not_be_displayed
+    expect(page).not_to have_text("Warning The user will be sent an email to tell them you’ve added them to the organisation.")
+  end
+
+  def and_i_see_the_new_last_name_is_displayed
+    expect(page).to have_text("New last name")
+  end
+
+  def given_the_user_has_an_associated_dfe_signin_account
+    @user.update(sign_in_user_id: "SOME-SORT-OF-IDENTIFICATION-CODE")
+  end
+
+  def then_i_should_not_see_any_change_links
+    expect(page).not_to have_link "Change"
   end
 
   def and_i_click_add_user
@@ -151,11 +260,31 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
     users_show_page.remove_user_link.click
   end
 
+  def given_i_click_change_email_address
+    users_show_page.change_email_address.click
+  end
+
+  def given_i_click_change_first_name
+    users_show_page.change_first_name.click
+  end
+
+  def given_i_click_change_last_name
+    users_show_page.change_last_name.click
+  end
+
   def and_i_confirm
     users_delete_page.remove_user_button.click
   end
 
   def then_the_user_should_be_deleted
     expect(provider_users_page).not_to have_text "Mr Cool"
+  end
+
+  def and_the_new_email_is_displayed
+    expect(page).to have_text("achangedemail@address.com")
+  end
+
+  def and_click_update_user
+    click_button "Update user"
   end
 end

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -299,18 +299,22 @@ feature "Adding user to organisation as a provider user", { can_edit_current_and
   end
 
   def then_the_first_name_should_have_updated_in_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: "New first name")).to be(true)
+    expect(user_exists_in_db("New first name")).to be(true)
   end
 
   def and_the_first_name_should_not_have_updated_in_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: "New first name")).to be(false)
+    expect(user_exists_in_db("New first name")).to be(false)
   end
 
   def then_the_last_name_should_have_updated_in_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: "New last name")).to be(true)
+    expect(user_exists_in_db("New last name")).to be(true)
   end
 
   def and_the_last_name_should_not_have_updated_in_the_database
-    expect(Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: "New last name")).to be(false)
+    expect(user_exists_in_db("New last name")).to be(false)
+  end
+
+  def user_exists_in_db(first_name)
+    Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name: first_name)
   end
 end

--- a/spec/support/page_objects/publish/users_edit.rb
+++ b/spec/support/page_objects/publish/users_edit.rb
@@ -9,8 +9,6 @@ module PageObjects
       element :last_name, "#publish-user-form-last-name-field"
       element :last_name, "#publish-user-form-last-name-field"
       element :email, "#publish-user-form-email-field"
-
-      element :error_summary, ".govuk-error-summary"
     end
   end
 end

--- a/spec/support/page_objects/publish/users_edit.rb
+++ b/spec/support/page_objects/publish/users_edit.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class UsersEdit < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/users/edit"
+
+      element :first_name, "#publish-user-form-first-name-field"
+      element :last_name, "#publish-user-form-last-name-field"
+      element :last_name, "#publish-user-form-last-name-field"
+      element :email, "#publish-user-form-email-field"
+
+      element :error_summary, ".govuk-error-summary"
+    end
+  end
+end

--- a/spec/support/page_objects/publish/users_show.rb
+++ b/spec/support/page_objects/publish/users_show.rb
@@ -6,6 +6,10 @@ module PageObjects
       set_url "/publish/organisations/{provider_code}/users/{id}"
 
       element :remove_user_link, ".govuk-link", text: "Remove user"
+
+      element :change_first_name, "a.govuk-link", text: "Change last name"
+      element :change_last_name, "a.govuk-link", text: "Change first name"
+      element :change_email_address, "a.govuk-link", text: "Change email address"
     end
   end
 end


### PR DESCRIPTION
### Context

Following on from #3159, #3166, #3171. The final feature in the managing users epic is the ability for providers to edit other provider users.

### Changes proposed in this pull request

- Add change links on the show page (only render these if the user does not have an associated DfE Sign in account)
- Add an edit view
- When the edit view is submitted, you are taken to a `/edit/check` page where you will be presented with your new details. 
- You can then confirm these details and the database is updated and an email is sent. 

### Guidance to review

Have a play around with the review app.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
