### PR TITLE
[0892] Add level next to age range if a secondary course

### DIFF
--- a/app/components/find_interface/courses/summary_component/view.html.erb
+++ b/app/components/find_interface/courses/summary_component/view.html.erb
@@ -9,7 +9,7 @@
   <%= render FindInterface::Courses::QualificationsSummaryComponent::View.new(find_outcome) %>
   <% if age_range_in_years.present? %>
     <dt class="app-description-list__label">Age range</dt>
-    <dd data-qa="course__age_range"><%= age_range_in_years.humanize %></dd>
+    <dd data-qa="course__age_range"><%= age_range_in_years_row %></dd>
   <% end %>
 
   <% if length.present? %>

--- a/app/components/find_interface/courses/summary_component/view.rb
+++ b/app/components/find_interface/courses/summary_component/view.rb
@@ -12,11 +12,21 @@ module FindInterface
         :length,
         :applications_open_from,
         :find_outcome,
-        :start_date, to: :course
+        :start_date,
+        :secondary_course?,
+        :level, to: :course
 
       def initialize(course)
         super
         @course = course
+      end
+
+      def age_range_in_years_row
+        if secondary_course?
+          "#{age_range_in_years.humanize} - #{level}"
+        else
+          age_range_in_years.humanize
+        end
       end
     end
   end

--- a/spec/components/find_interface/courses/sumary_component/view_preview.rb
+++ b/spec/components/find_interface/courses/sumary_component/view_preview.rb
@@ -8,15 +8,36 @@ module FindInterface::Courses::SummaryComponent
       render FindInterface::Courses::SummaryComponent::View.new(course)
     end
 
-    def with_all_columns
-      course = CourseDecorator.new(mock_course)
+    def primary_course_with_all_columns
+      course = CourseDecorator.new(mock_primary_course)
+
+      render FindInterface::Courses::SummaryComponent::View.new(course)
+    end
+
+    def secondary_course_with_all_columns
+      course = CourseDecorator.new(mock_secondary_course)
 
       render FindInterface::Courses::SummaryComponent::View.new(course)
     end
 
   private
 
-    def mock_course
+    def mock_secondary_course
+      accrediting_provider = Provider.new(provider_name: "University of BAT", accrediting_provider: "accredited_body", provider_type: "university")
+      FakeCourse.new(provider: Provider.new(provider_code: "DFE", website: "wwww.awesomeprovider@aol.com"),
+        accrediting_provider:,
+        has_bursary: false,
+        age_range_in_years: "11_to_18",
+        course_length: "OneYear",
+        applications_open_from: Time.zone.now,
+        start_date: Time.zone.now,
+        qualification: "pgce",
+        funding_type: "salaried",
+        subjects: nil,
+        level: :secondary)
+    end
+
+    def mock_primary_course
       accrediting_provider = Provider.new(provider_name: "University of BAT", accrediting_provider: "accredited_body", provider_type: "university")
       FakeCourse.new(provider: Provider.new(provider_code: "DFE", website: "wwww.awesomeprovider@aol.com"),
         accrediting_provider:,
@@ -27,12 +48,13 @@ module FindInterface::Courses::SummaryComponent
         start_date: Time.zone.now,
         qualification: "pgce",
         funding_type: "salaried",
-        subjects: nil)
+        subjects: nil,
+        level: :primary)
     end
 
     class FakeCourse
       include ActiveModel::Model
-      attr_accessor(:provider, :accrediting_provider, :has_bursary, :age_range_in_years, :course_length, :applications_open_from, :start_date, :qualification, :funding_type, :subjects)
+      attr_accessor(:provider, :accrediting_provider, :has_bursary, :age_range_in_years, :course_length, :applications_open_from, :start_date, :qualification, :funding_type, :subjects, :level)
 
       def has_bursary?
         has_bursary
@@ -40,6 +62,10 @@ module FindInterface::Courses::SummaryComponent
 
       def enrichment_attribute(params)
         send(params)
+      end
+
+      def secondary_course?
+        level.to_sym == :secondary
       end
     end
   end

--- a/spec/components/find_interface/courses/sumary_component/view_spec.rb
+++ b/spec/components/find_interface/courses/sumary_component/view_spec.rb
@@ -54,5 +54,32 @@ module FindInterface::Courses::SummaryComponent
                                    )
       end
     end
+
+    context "secondary course" do
+      it "render the age range and level" do
+        course = build(
+          :course,
+          :secondary,
+          provider: build(:provider),
+        ).decorate
+
+        result = render_inline(described_class.new(course))
+
+        expect(result.css('[data-qa="course__age_range"]').text).to have_text("11 to 18 - secondary")
+      end
+    end
+
+    context "non-secondary course" do
+      it "render the age range only" do
+        course = build(
+          :course,
+          provider: build(:provider),
+        ).decorate
+
+        result = render_inline(described_class.new(course))
+
+        expect(result.css('[data-qa="course__age_range"]').text).to eq("3 to 7")
+      end
+    end
   end
 end

--- a/spec/components/find_interface/courses/sumary_component/view_spec.rb
+++ b/spec/components/find_interface/courses/sumary_component/view_spec.rb
@@ -56,7 +56,7 @@ module FindInterface::Courses::SummaryComponent
     end
 
     context "secondary course" do
-      it "render the age range and level" do
+      it "renders the age range and level" do
         course = build(
           :course,
           :secondary,


### PR DESCRIPTION
### Context
Course level and age range

### Changes proposed in this pull request
Add level next to age range if a secondary course

### Guidance to review
`secondary` should show up on courses that has level secondary
https://publish-teacher-training-pr-3195.london.cloudapps.digital/find/course/2FD/C045

![image](https://user-images.githubusercontent.com/470137/208630968-86835f66-3f14-4508-9705-c0ae685e2b6d.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
