### PR TITLE
fallback for master subject id

### DIFF
--- a/app/views/publish/courses/subjects/_form_fields.html.erb
+++ b/app/views/publish/courses/subjects/_form_fields.html.erb
@@ -12,7 +12,7 @@
     <%= render "publish/shared/error_messages", error_keys: [:subjects] %>
     <div class="govuk-form-group">
       <%= form.label :master_subject_id, course.subject_input_label, class: "govuk-label" %>
-      <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, course.master_subject_id), { include_blank: true }, data: { qa: "course__master_subject" }, class: "govuk-select" %>
+      <%= form.select :master_subject_id, options_for_select(course.selectable_subjects, course.master_subject_id || course.selected_subject_ids.first), { include_blank: true }, data: { qa: "course__master_subject" }, class: "govuk-select" %>
     </div>
 
     <% if course.level == "secondary" %>


### PR DESCRIPTION
### Context
What happened?

We recently pushed a fix for the subject dropdown not listing subjects correctly [818 fix modern languages issue](https://github.com/DFE-Digital/publish-teacher-training/pull/3180/files). But we also need to handle courses who do not have a master_subject_id set.
**What was supposed to happen?**

Courses who do not have the field above set should also have their subjects displayed correctly in the dropdow
### Changes proposed in this pull request
Add fallback `selected_subject_ids.first` to select options
### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
