### PR TITLE
[0892] Added filter for is_accredited_body

### DIFF
--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -49,6 +49,10 @@ module API
           @can_sponsor_student_visa ||= params.dig(:filter, :can_sponsor_student_visa)&.to_s&.downcase == "true"
         end
 
+        def is_accredited_body?
+          @is_accredited_body ||= params.dig(:filter, :is_accredited_body)&.to_s&.downcase == "true"
+        end
+
         def providers
           @providers = recruitment_cycle.providers
 
@@ -57,6 +61,8 @@ module API
           @providers = @providers.with_region_codes(region_codes) if region_codes.present?
           @providers = @providers.with_can_sponsor_skilled_worker_visa(true) if can_sponsor_skilled_worker_visa?
           @providers = @providers.with_can_sponsor_student_visa(true) if can_sponsor_student_visa?
+
+          @providers = @providers.accredited_body if is_accredited_body?
 
           @providers = if sort_by_provider_ascending?
                          @providers.by_name_ascending

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -378,6 +378,14 @@ RSpec.describe API::Public::V1::ProvidersController do
           end
         end
 
+        context "passing in is_accredited_body param" do
+          let(:filter) { { is_accredited_body: true } }
+
+          it "returns 'Second' provider only" do
+            expect(provider_names_in_response).to eq([provider2.provider_name])
+          end
+        end
+
         context "passing in region_code param" do
           let(:filter) { { region_code: "yorkshire_and_the_humber" } }
 

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe API::Public::V1::ProvidersController do
         context "passing in is_accredited_body param" do
           let(:filter) { { is_accredited_body: true } }
 
-          it "returns 'Second' provider only" do
+          it "only returns the second provider" do
             expect(provider_names_in_response).to eq([provider2.provider_name])
           end
         end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1250,6 +1250,11 @@
             "type": "boolean",
             "example": true
           },
+          "is_accredited_body": {
+            "description": "Only return providers that is accredited body.",
+            "type": "boolean",
+            "example": true
+          },
           "provider_type": {
             "description": "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used.",
             "type": "string",

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1251,7 +1251,7 @@
             "example": true
           },
           "is_accredited_body": {
-            "description": "Only return providers that is accredited body.",
+            "description": "Only return providers that are accredited bodies.",
             "type": "boolean",
             "example": true
           },

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -10,6 +10,10 @@ properties:
     description: "Only return providers that can sponsor a Student visa."
     type: boolean
     example: true
+  is_accredited_body:
+    description: "Only return providers that is accredited body."
+    type: boolean
+    example: true
   provider_type:
     description: "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
     type: string

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -11,7 +11,7 @@ properties:
     type: boolean
     example: true
   is_accredited_body:
-    description: "Only return providers that is accredited body."
+    description: "Only return providers that are accredited bodies."
     type: boolean
     example: true
   provider_type:


### PR DESCRIPTION
### Context
Filter for is_accredited_body

### Changes proposed in this pull request
Added filter for is_accredited_body

### Guidance to review
https://publish-teacher-training-pr-3203.london.cloudapps.digital/api/public/v1/recruitment_cycles/2023/providers?filter[is_accredited_body]=true

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
