### PR TITLE
[868] Update course filter for ETP

### DIFF
--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -554,7 +554,11 @@
             "type": "string",
             "nullable": true,
             "description": "The course’s campaign code, corresponding to campaigns to help improve recruitment.",
-            "example": "engineers_teach_physics"
+            "example": "engineers_teach_physics",
+            "enum": [
+              "engineers_teach_physics",
+              "no_campaign"
+            ]
           }
         }
       },
@@ -695,10 +699,14 @@
             "type": "boolean",
             "example": true
           },
-          "engineers_teach_physics": {
-            "description": "Only return courses that are part of the engineers teach physics campaign.",
-            "type": "boolean",
-            "example": true
+          "campaign_name": {
+            "description": "Return courses which are part of a campaign.",
+            "type": "string",
+            "example": "engineers_teach_physics",
+            "enum": [
+              "engineers_teach_physics",
+              "no_campaign"
+            ]
           }
         }
       },
@@ -1255,9 +1263,9 @@
             "type": "string",
             "example": "scitt,lead_school",
             "enum": [
-                "lead_school",
-                "scitt",
-                "university"
+              "lead_school",
+              "scitt",
+              "university"
             ]
           },
           "region_code": {
@@ -1265,18 +1273,18 @@
             "type": "string",
             "example": "london,yorkshire_and_the_humber",
             "enum": [
-                "no_region",
-                "north_east",
-                "north_west",
-                "yorkshire_and_the_humber",
-                "east_midlands",
-                "west_midlands",
-                "eastern",
-                "london",
-                "south_east",
-                "south_west",
-                "scotland",
-                "wales"
+              "no_region",
+              "north_east",
+              "north_west",
+              "yorkshire_and_the_humber",
+              "east_midlands",
+              "west_midlands",
+              "eastern",
+              "london",
+              "south_east",
+              "south_west",
+              "scotland",
+              "wales"
             ]
           },
           "updated_since": {
@@ -2032,7 +2040,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle.",
-            "example": 2022,
+            "example": 2023,
             "schema": {
               "type": "string"
             }
@@ -2291,7 +2299,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle.",
-            "example": 2022,
+            "example": 2023,
             "schema": {
               "type": "string"
             }

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -396,3 +396,6 @@ properties:
     nullable: true
     description: "The course’s campaign code, corresponding to campaigns to help improve recruitment."
     example: "engineers_teach_physics"
+    enum:
+      - engineers_teach_physics
+      - no_campaign

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -116,7 +116,10 @@ properties:
     description: "Only return courses where a skilled worker or student visa can be sponsored."
     type: boolean
     example: true
-  engineers_teach_physics:
-    description: "Only return courses that are part of the engineers teach physics campaign."
-    type: boolean
-    example: true
+  campaign_name:
+    description: "Return courses which are part of a campaign."
+    type: string
+    example: "engineers_teach_physics"
+    enum:
+      - engineers_teach_physics
+      - no_campaign


### PR DESCRIPTION
### Context

We recently added the ability to filter courses by `campaign_name`. However, in the API it's called `engineers_teach_physics`. 

### Changes proposed in this pull request

- Change the CourseFilter param from `engineers_teach_physics` to `campaign_name`.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
