### PR TITLE
Add study_mode to course show page

### DIFF
--- a/app/components/find_interface/courses/summary_component/view.html.erb
+++ b/app/components/find_interface/courses/summary_component/view.html.erb
@@ -14,7 +14,7 @@
 
   <% if length.present? %>
     <dt class="app-description-list__label">Course length</dt>
-    <dd data-qa="course__length"><%= length %></dd>
+    <dd data-qa="course__length"><%= course_length_with_study_mode_row %></dd>
   <% end %>
 
   <% if applications_open_from.present? %>

--- a/app/components/find_interface/courses/summary_component/view.rb
+++ b/app/components/find_interface/courses/summary_component/view.rb
@@ -14,7 +14,8 @@ module FindInterface
         :find_outcome,
         :start_date,
         :secondary_course?,
-        :level, to: :course
+        :level,
+        :study_mode, to: :course
 
       def initialize(course)
         super
@@ -27,6 +28,10 @@ module FindInterface
         else
           age_range_in_years.humanize
         end
+      end
+
+      def course_length_with_study_mode_row
+        "#{length} - #{study_mode.humanize.downcase}"
       end
     end
   end

--- a/spec/components/find_interface/courses/sumary_component/view_preview.rb
+++ b/spec/components/find_interface/courses/sumary_component/view_preview.rb
@@ -67,6 +67,10 @@ module FindInterface::Courses::SummaryComponent
       def secondary_course?
         level.to_sym == :secondary
       end
+
+      def study_mode
+        "full_time"
+      end
     end
   end
 end

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -169,7 +169,7 @@ private
     )
 
     expect(course_show_page.length).to have_content(
-      @course.decorate.length,
+      "1 year - full time",
     )
 
     expect(course_show_page.applications_open_from).to have_content(

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -74,7 +74,7 @@ private
     )
 
     expect(course_preview_page.length).to have_content(
-      decorated_course.length,
+      "Up to 2 years - full time",
     )
 
     expect(course_preview_page.applications_open_from).to have_content(


### PR DESCRIPTION
### Context

A recent accessibility update on Find to expand PGCE, PGDE and QTS abbreviations has meant we have removed the study mode (full-time and part-time) from the lede paragraph.

### Changes proposed in this pull request

Add the study mode tadjacent to the course length in the summary list on the course details.

### Guidance to review

Take a look at the show page for various study modes and course lengths.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
