### PR TITLE
Replace `rendered_component` with `page`

### DIFF
--- a/spec/components/find_interface/courses/financial_support/scholarship_and_bursary_component/view_spec.rb
+++ b/spec/components/find_interface/courses/financial_support/scholarship_and_bursary_component/view_spec.rb
@@ -49,8 +49,8 @@ describe Find::Courses::FinancialSupport::ScholarshipAndBursaryComponent::View, 
           it "renders link to scholarship body" do
             render_inline(described_class.new(course))
 
-            expect(rendered_component).to have_text("For a scholarship, you’ll need to apply through the #{scholarship_body}")
-            expect(rendered_component).to have_link("Check whether you’re eligible for a scholarship and find out how to apply", href: scholarship_url)
+            expect(page).to have_text("For a scholarship, you’ll need to apply through the #{scholarship_body}")
+            expect(page).to have_link("Check whether you’re eligible for a scholarship and find out how to apply", href: scholarship_url)
           end
         end
       end


### PR DESCRIPTION
### Context

Replace `rendered_component` with `page`. 

rendered_component is deprecated and will be removed in v3.0.0

### Changes proposed in this pull request

### Guidance to review

Did I miss anything?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
