### PR TITLE
Prevent numbers in names

### DIFF
--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -8,8 +8,8 @@ class UserForm < Form
 
   attr_accessor(*FIELDS)
 
-  validates :first_name, presence: true
-  validates :last_name, presence: true
+  validates :first_name, presence: true, name: { message: "Enter a valid first name" }
+  validates :last_name, presence: true, name: { message: "Enter a valid last name" }
   validates :email, presence: true
   validates :email, email_address: true
 

--- a/app/validators/name_validator.rb
+++ b/app/validators/name_validator.rb
@@ -1,0 +1,13 @@
+class NameValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if is_invalid_name_format?(value)
+      record.errors.add(attribute, message: options[:message])
+    end
+  end
+
+private
+
+  def is_invalid_name_format?(value)
+    !value.match?(/^([^0-9]*)$/)
+  end
+end

--- a/spec/forms/support/user_form_spec.rb
+++ b/spec/forms/support/user_form_spec.rb
@@ -18,7 +18,7 @@ describe Support::UserForm, type: :model do
     before { subject.validate }
 
     context "blank first_name" do
-      let(:params) { { first_name: nil } }
+      let(:params) { { first_name: "" } }
 
       it "is invalid" do
         expect(subject.errors[:first_name]).to include("Enter a first name")
@@ -27,7 +27,7 @@ describe Support::UserForm, type: :model do
     end
 
     context "blank last_name" do
-      let(:params) { { last_name: nil } }
+      let(:params) { { last_name: "" } }
 
       it "is invalid" do
         expect(subject.errors[:last_name]).to include("Enter a last name")
@@ -40,6 +40,24 @@ describe Support::UserForm, type: :model do
 
       it "is invalid" do
         expect(subject.errors[:email]).to include("Enter an email address in the correct format, like name@example.com")
+        expect(subject.valid?).to be(false)
+      end
+    end
+
+    context "number in first name" do
+      let(:params) { { first_name: "foo12" } }
+
+      it "is invalid" do
+        expect(subject.errors[:first_name]).to include("Enter a valid first name")
+        expect(subject.valid?).to be(false)
+      end
+    end
+
+    context "number in last name" do
+      let(:params) { { last_name: "foo12" } }
+
+      it "is invalid" do
+        expect(subject.errors[:last_name]).to include("Enter a valid last name")
         expect(subject.valid?).to be(false)
       end
     end


### PR DESCRIPTION
### Context

We are preventing users from including numbers in names.


### Screenshot

<img width="582" alt="image" src="https://user-images.githubusercontent.com/50492247/211078855-f87c1e20-a4c9-4b78-8716-488fc104bac8.png">


### Changes proposed in this pull request

Add a validation that prevents the addition of numbers in first name and last name

### Guidance to review

Is the content in the error message correct?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
