### PR TITLE
Activate user management in production

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -114,7 +114,7 @@ features:
     # state: open # Users can make requests for allocations
     # state: closed # Readonly - Users can see if they have or have not made request (does not show number of places)
     state: confirmed # final allocation places are displayed to users in a readonly state
-  user_management: false
+  user_management: true
 
 cookies:
   consent:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -31,7 +31,6 @@ basic_auth:
 
 features:
   send_request_data_to_bigquery: true
-  user_management: true
 
 find_valid_referers:
   - https://qa2.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -21,4 +21,3 @@ allocations_close_date: 2022-07-02
 features:
   allocations:
     state: confirmed
-  user_management: true

--- a/spec/features/publish/viewing_provider_users_spec.rb
+++ b/spec/features/publish/viewing_provider_users_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+# This file can be deleted once the "user_management" feature flag is removed
+
 require "rails_helper"
 
 feature "Viewing provider users" do
   before do
     given_i_am_authenticated_as_a_provider_user
+    and_the_user_management_feature_flag_is_inactive
     when_i_visit_the_provider_users_page
   end
 
@@ -43,5 +46,9 @@ private
 
   def provider
     @current_user.providers.first
+  end
+
+  def and_the_user_management_feature_flag_is_inactive
+    allow(Settings.features).to receive(:user_management).and_return(false)
   end
 end


### PR DESCRIPTION
### Context

Merging this PR will activate the user_management feature in production.

### Changes proposed in this pull request

- Set feature flag to true in `Settings.yml`
- Remove feature flag from qa.yml and review.yml
- Deactivate the feature flag in a test for the old flow

### Guidance to review

:shipit: 

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
