### PR TITLE
Update results page ordering options

### DIFF
--- a/app/components/find/results/sort_by_component.html.erb
+++ b/app/components/find/results/sort_by_component.html.erb
@@ -7,7 +7,7 @@
       <%= form.label(:sortby, "Sorted by", class: "govuk-label govuk-!-display-inline-block") %>
       <%= form.select(
         :sortby,
-        options_for_select(results.sort_options, selected: params["sortby"] || "A"),
+        options_for_select(results.sort_options, selected: params["sortby"] || "course_asc"),
         {},
         {
           class: "govuk-select",

--- a/app/components/find/results/sort_by_component.html.erb
+++ b/app/components/find/results/sort_by_component.html.erb
@@ -7,7 +7,7 @@
       <%= form.label(:sortby, "Sorted by", class: "govuk-label govuk-!-display-inline-block") %>
       <%= form.select(
         :sortby,
-        options_for_select(results.sort_options, selected: params["sortby"].to_i || 0),
+        options_for_select(results.sort_options, selected: params["sortby"] || "A"),
         {},
         {
           class: "govuk-select",

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -176,6 +176,10 @@ class Course < ApplicationRecord
     joins(:provider).merge(Provider.by_name_descending).order(name: :asc, course_code: :asc)
   }
 
+  scope :order_by_name_then_provider_then_code_ascending, -> { order(name: :asc).joins(:provider).merge(Provider.by_name_ascending).order(course_code: :asc) }
+
+  scope :order_by_name_descending_then_provider_then_code_ascending, -> { order(name: :desc).joins(:provider).merge(Provider.by_name_ascending).order(course_code: :asc) }
+
   scope :accredited_body_order, lambda { |provider_name|
     joins(:provider).merge(Provider.by_provider_name(provider_name))
   }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -176,9 +176,9 @@ class Course < ApplicationRecord
     joins(:provider).merge(Provider.by_name_descending).order(name: :asc, course_code: :asc)
   }
 
-  scope :order_by_name_then_provider_then_code_ascending, -> { order(name: :asc).joins(:provider).merge(Provider.by_name_ascending).order(course_code: :asc) }
+  scope :ascending_course_canonical_order, -> { order(name: :asc).joins(:provider).merge(Provider.by_name_ascending).order(course_code: :asc) }
 
-  scope :order_by_name_descending_then_provider_then_code_ascending, -> { order(name: :desc).joins(:provider).merge(Provider.by_name_ascending).order(course_code: :asc) }
+  scope :descending_course_canonical_order, -> { order(name: :desc).joins(:provider).merge(Provider.by_name_ascending).order(course_code: :asc) }
 
   scope :accredited_body_order, lambda { |provider_name|
     joins(:provider).merge(Provider.by_provider_name(provider_name))

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -172,7 +172,7 @@ class Course < ApplicationRecord
     joins(:provider).merge(Provider.by_name_ascending).order(name: :asc, course_code: :asc)
   }
 
-  scope :descending_canonical_order, lambda {
+  scope :descending_provider_canonical_order, lambda {
     joins(:provider).merge(Provider.by_name_descending).order(name: :asc, course_code: :asc)
   }
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -168,7 +168,7 @@ class Course < ApplicationRecord
     order(name: :desc)
   }
 
-  scope :ascending_canonical_order, lambda {
+  scope :ascending_provider_canonical_order, lambda {
     joins(:provider).merge(Provider.by_name_ascending).order(name: :asc, course_code: :asc)
   }
 

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -11,9 +11,13 @@ class CourseSearchService
     @sort = Set.new(sort&.split(","))
   end
 
-  PROVIDER_ASCENDING = Set["name", "provider.provider_name"].freeze
+  COURSE_ASCENDING = Set["name", "provider.provider_name"].freeze
 
-  PROVIDER_DESCENDING = Set["name", "-provider.provider_name"].freeze
+  COURSE_DESCENDING = Set["-name", "provider.provider_name"].freeze
+
+  PROVIDER_ASCENDING = Set["provider.provider_name", "order"].freeze
+
+  PROVIDER_DESCENDING = Set["-provider.provider_name", "order"].freeze
 
   def call
     scope = course_scope
@@ -169,19 +173,19 @@ private
   end
 
   def sort_by_course_ascending?
-    sort == Set["0"]
+    sort == Set["A"] || sort == COURSE_ASCENDING
   end
 
   def sort_by_course_descending?
-    sort == Set["1"]
+    sort == Set["B"] || sort == COURSE_DESCENDING
   end
 
   def sort_by_provider_ascending?
-    sort == Set["2"] || sort == PROVIDER_ASCENDING
+    sort == Set["C"] || sort == PROVIDER_ASCENDING
   end
 
   def sort_by_provider_descending?
-    sort == Set["3"] || sort == PROVIDER_DESCENDING
+    sort == Set["D"] || sort == PROVIDER_DESCENDING
   end
 
   def sort_by_distance?

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -54,6 +54,10 @@ class CourseSearchService
     elsif sort_by_provider_descending?
       outer_scope = outer_scope.descending_canonical_order
       outer_scope = outer_scope.select("provider.provider_name", "course.*")
+    elsif sort_by_course_ascending?
+      outer_scope = outer_scope.order_by_name_then_provider_then_code_ascending
+    elsif sort_by_course_descending?
+      outer_scope = outer_scope.order_by_name_descending_then_provider_then_code_ascending
     elsif sort_by_distance?
       outer_scope = outer_scope.joins(courses_with_distance_from_origin)
       outer_scope = outer_scope.joins(:provider)
@@ -164,12 +168,20 @@ private
       filter.key?(:radius)
   end
 
+  def sort_by_course_ascending?
+    sort == Set["0"]
+  end
+
+  def sort_by_course_descending?
+    sort == Set["1"]
+  end
+
   def sort_by_provider_ascending?
-    sort == Set["0"] || sort == PROVIDER_ASCENDING
+    sort == Set["2"] || sort == PROVIDER_ASCENDING
   end
 
   def sort_by_provider_descending?
-    sort == Set["1"] || sort == PROVIDER_DESCENDING
+    sort == Set["3"] || sort == PROVIDER_DESCENDING
   end
 
   def sort_by_distance?

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -52,7 +52,7 @@ class CourseSearchService
       outer_scope = outer_scope.ascending_provider_canonical_order
       outer_scope = outer_scope.select("provider.provider_name", "course.*")
     elsif sort_by_provider_descending?
-      outer_scope = outer_scope.descending_canonical_order
+      outer_scope = outer_scope.descending_provider_canonical_order
       outer_scope = outer_scope.select("provider.provider_name", "course.*")
     elsif sort_by_course_ascending?
       outer_scope = outer_scope.order_by_name_then_provider_then_code_ascending

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -55,9 +55,9 @@ class CourseSearchService
       outer_scope = outer_scope.descending_provider_canonical_order
       outer_scope = outer_scope.select("provider.provider_name", "course.*")
     elsif sort_by_course_ascending?
-      outer_scope = outer_scope.order_by_name_then_provider_then_code_ascending
+      outer_scope = outer_scope.ascending_course_canonical_order
     elsif sort_by_course_descending?
-      outer_scope = outer_scope.order_by_name_descending_then_provider_then_code_ascending
+      outer_scope = outer_scope.descending_course_canonical_order
     elsif sort_by_distance?
       outer_scope = outer_scope.joins(courses_with_distance_from_origin)
       outer_scope = outer_scope.joins(:provider)

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -47,9 +47,9 @@ class CourseSearchService
     if provider_name.present?
       outer_scope = outer_scope
                       .accredited_body_order(provider_name)
-                      .ascending_canonical_order
+                      .ascending_provider_canonical_order
     elsif sort_by_provider_ascending?
-      outer_scope = outer_scope.ascending_canonical_order
+      outer_scope = outer_scope.ascending_provider_canonical_order
       outer_scope = outer_scope.select("provider.provider_name", "course.*")
     elsif sort_by_provider_descending?
       outer_scope = outer_scope.descending_canonical_order

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -165,19 +165,19 @@ private
   end
 
   def sort_by_course_ascending?
-    sort == "course_asc" || old_find_course_asc_requirement
+    sort == "course_asc" || course_asc_requirement
   end
 
   def sort_by_course_descending?
-    sort == "course_desc" || old_find_course_desc_requirement
+    sort == "course_desc" || course_desc_requirement
   end
 
   def sort_by_provider_ascending?
-    sort == "provider_asc" || old_find_provider_asc_requirement
+    sort == "provider_asc" || provider_asc_requirement
   end
 
   def sort_by_provider_descending?
-    sort == "provider_desc" || old_find_provider_desc_requirement
+    sort == "provider_desc" || provider_desc_requirement
   end
 
   def sort_by_distance?
@@ -286,21 +286,19 @@ private
     filter[:engineers_teach_physics].to_s.downcase == "true" || filter[:campaign_name] == "engineers_teach_physics"
   end
 
-  # The old_find methods below and their usages can be deleted along with the old find
-
-  def old_find_course_asc_requirement
+  def course_asc_requirement
     sort == "name,provider.provider_name".freeze
   end
 
-  def old_find_course_desc_requirement
+  def course_desc_requirement
     sort == "-name,provider.provider_name".freeze
   end
 
-  def old_find_provider_asc_requirement
+  def provider_asc_requirement
     sort == "provider.provider_name,name".freeze
   end
 
-  def old_find_provider_desc_requirement
+  def provider_desc_requirement
     sort == "-provider.provider_name,name".freeze
   end
 end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -8,16 +8,8 @@ class CourseSearchService
   )
     @filter = filter || {}
     @course_scope = course_scope
-    @sort = Set.new(sort&.split(","))
+    @sort = sort
   end
-
-  COURSE_ASCENDING = Set["name", "provider.provider_name"].freeze
-
-  COURSE_DESCENDING = Set["-name", "provider.provider_name"].freeze
-
-  PROVIDER_ASCENDING = Set["provider.provider_name", "order"].freeze
-
-  PROVIDER_DESCENDING = Set["-provider.provider_name", "order"].freeze
 
   def call
     scope = course_scope
@@ -173,23 +165,23 @@ private
   end
 
   def sort_by_course_ascending?
-    sort == Set["A"] || sort == COURSE_ASCENDING
+    sort == "course_asc" || old_find_course_asc_requirement
   end
 
   def sort_by_course_descending?
-    sort == Set["B"] || sort == COURSE_DESCENDING
+    sort == "course_desc" || old_find_course_desc_requirement
   end
 
   def sort_by_provider_ascending?
-    sort == Set["C"] || sort == PROVIDER_ASCENDING
+    sort == "provider_asc" || old_find_provider_asc_requirement
   end
 
   def sort_by_provider_descending?
-    sort == Set["D"] || sort == PROVIDER_DESCENDING
+    sort == "provider_desc" || old_find_provider_desc_requirement
   end
 
   def sort_by_distance?
-    sort == Set["distance"]
+    sort == "distance"
   end
 
   def origin
@@ -292,5 +284,23 @@ private
 
   def engineers_teach_physics_filter?
     filter[:engineers_teach_physics].to_s.downcase == "true" || filter[:campaign_name] == "engineers_teach_physics"
+  end
+
+  # The old_find methods below and their usages can be deleted along with the old find
+
+  def old_find_course_asc_requirement
+    sort == "name,provider.provider_name".freeze
+  end
+
+  def old_find_course_desc_requirement
+    sort == "-name,provider.provider_name".freeze
+  end
+
+  def old_find_provider_asc_requirement
+    sort == "provider.provider_name,order".freeze
+  end
+
+  def old_find_provider_desc_requirement
+    sort == "-provider.provider_name,order".freeze
   end
 end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -297,10 +297,10 @@ private
   end
 
   def old_find_provider_asc_requirement
-    sort == "provider.provider_name,order".freeze
+    sort == "provider.provider_name,name".freeze
   end
 
   def old_find_provider_desc_requirement
-    sort == "-provider.provider_name,order".freeze
+    sort == "-provider.provider_name,name".freeze
   end
 end

--- a/app/view_objects/find/results_view.rb
+++ b/app/view_objects/find/results_view.rb
@@ -137,8 +137,10 @@ module Find
 
     def sort_options
       [
-        ["Training provider (A-Z)", 0, { "data-qa": "sort-form__options__ascending" }],
-        ["Training provider (Z-A)", 1, { "data-qa": "sort-form__options__descending" }],
+        ["Course name (A-Z)", 0, { "data-qa": "sort-form__options__ascending_course" }],
+        ["Course name (Z-A)", 1, { "data-qa": "sort-form__options__descending_course" }],
+        ["Training provider (A-Z)", 2, { "data-qa": "sort-form__options__ascending_provider" }],
+        ["Training provider (Z-A)", 3, { "data-qa": "sort-form__options__descending_provider" }],
       ]
     end
 

--- a/app/view_objects/find/results_view.rb
+++ b/app/view_objects/find/results_view.rb
@@ -24,7 +24,7 @@ module Find
     def courses
       @courses ||= ::CourseSearchService.call(
         filter: query_parameters,
-        sort: query_parameters[:sortby] || "A",
+        sort: query_parameters[:sortby] || "course_asc",
         course_scope:,
       )
     end
@@ -137,10 +137,10 @@ module Find
 
     def sort_options
       [
-        ["Course name (A-Z)", "A", { "data-qa": "sort-form__options__ascending_course" }],
-        ["Course name (Z-A)", "B", { "data-qa": "sort-form__options__descending_course" }],
-        ["Training provider (A-Z)", "C", { "data-qa": "sort-form__options__ascending_provider" }],
-        ["Training provider (Z-A)", "D", { "data-qa": "sort-form__options__descending_provider" }],
+        ["Course name (A-Z)", "course_asc", { "data-qa": "sort-form__options__ascending_course" }],
+        ["Course name (Z-A)", "course_desc", { "data-qa": "sort-form__options__descending_course" }],
+        ["Training provider (A-Z)", "provider_asc", { "data-qa": "sort-form__options__ascending_provider" }],
+        ["Training provider (Z-A)", "provider_desc", { "data-qa": "sort-form__options__descending_provider" }],
       ]
     end
 

--- a/app/view_objects/find/results_view.rb
+++ b/app/view_objects/find/results_view.rb
@@ -24,7 +24,7 @@ module Find
     def courses
       @courses ||= ::CourseSearchService.call(
         filter: query_parameters,
-        sort: query_parameters[:sortby] || "0",
+        sort: query_parameters[:sortby] || "A",
         course_scope:,
       )
     end
@@ -137,10 +137,10 @@ module Find
 
     def sort_options
       [
-        ["Course name (A-Z)", 0, { "data-qa": "sort-form__options__ascending_course" }],
-        ["Course name (Z-A)", 1, { "data-qa": "sort-form__options__descending_course" }],
-        ["Training provider (A-Z)", 2, { "data-qa": "sort-form__options__ascending_provider" }],
-        ["Training provider (Z-A)", 3, { "data-qa": "sort-form__options__descending_provider" }],
+        ["Course name (A-Z)", "A", { "data-qa": "sort-form__options__ascending_course" }],
+        ["Course name (Z-A)", "B", { "data-qa": "sort-form__options__descending_course" }],
+        ["Training provider (A-Z)", "C", { "data-qa": "sort-form__options__ascending_provider" }],
+        ["Training provider (Z-A)", "D", { "data-qa": "sort-form__options__descending_provider" }],
       ]
     end
 

--- a/spec/features/find/sorted_by_filter_spec.rb
+++ b/spec/features/find/sorted_by_filter_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+feature "sorted by" do
+  before do
+    given_there_are_courses
+    and_i_visit_the_results_page
+  end
+
+  scenario "when I search the default sorting is by courses (A-Z)" do
+    then_the_results_should_be_ordered_by_course_name_ascending_then_provider_name_then_course_code
+  end
+
+  scenario "sorting results page by courses (Z-A)" do
+    given_that_i_select_the_option("Course name (Z-A)")
+    when_i_click_sort
+    then_the_results_should_be_ordered_by_course_name_descending_then_provider_name_then_course_code
+  end
+
+  scenario "when I sort the results page by provider (A-Z)" do
+    given_that_i_select_the_option("Training provider (A-Z)")
+    when_i_click_sort
+    then_the_results_should_be_ordered_by_provider_name_ascending_then_course_name_then_course_code
+  end
+
+  scenario "when I sort the results page by provider (Z-A)" do
+    given_that_i_select_the_option("Training provider (Z-A)")
+    when_i_click_sort
+    then_the_results_should_be_ordered_by_provider_name_descending_then_course_name_then_course_code
+  end
+
+  def given_there_are_courses
+    site1 = create(:site, location_name: "site1")
+    site2 = create(:site, location_name: "site2")
+    site3 = create(:site, location_name: "site3")
+    site4 = create(:site, location_name: "site4")
+    site_status1 = create(:site_status, :findable, site: site1)
+    site_status2 = create(:site_status, :findable, site: site2)
+    site_status3 = create(:site_status, :findable, site: site3)
+    site_status4 = create(:site_status, :findable, site: site4)
+    provider1 = create(:provider, provider_name: "Arandomprovider")
+    provider2 = create(:provider, provider_name: "Brandomprovider")
+    create(:course, name: "Brandomcoursename", course_code: "AAAA", site_statuses: [site_status2], provider: provider1)
+    create(:course, name: "Arandomcoursename", course_code: "AAAC", site_statuses: [site_status4], provider: provider1)
+    create(:course, name: "Arandomcoursename", course_code: "AAAB", site_statuses: [site_status3], provider: provider2)
+    create(:course, name: "Arandomcoursename", course_code: "AAAD", site_statuses: [site_status1], provider: provider1)
+  end
+
+  def and_i_visit_the_results_page
+    results_page.load
+  end
+
+  def then_the_results_should_be_ordered_by_course_name_ascending_then_provider_name_then_course_code
+    results_page.courses.first.then { |first_course| expect(first_course.course_name.text).to include("AAAC") }
+    results_page.courses.second.then { |second_course| expect(second_course.course_name.text).to include("AAAD") }
+    results_page.courses.third.then { |third_course| expect(third_course.course_name.text).to include("AAAB") }
+    results_page.courses.fourth.then { |fourth_course| expect(fourth_course.course_name.text).to include("AAAA") }
+  end
+
+  def then_the_results_should_be_ordered_by_course_name_descending_then_provider_name_then_course_code
+    results_page.courses.first.then { |first_course| expect(first_course.course_name.text).to include("AAAA") }
+    results_page.courses.second.then { |second_course| expect(second_course.course_name.text).to include("AAAC") }
+    results_page.courses.third.then { |third_course| expect(third_course.course_name.text).to include("AAAD") }
+    results_page.courses.fourth.then { |fourth_course| expect(fourth_course.course_name.text).to include("AAAB") }
+  end
+
+  def then_the_results_should_be_ordered_by_provider_name_ascending_then_course_name_then_course_code
+    results_page.courses.first.then { |first_course| expect(first_course.course_name.text).to include("AAAC") }
+    results_page.courses.second.then { |second_course| expect(second_course.course_name.text).to include("AAAD") }
+    results_page.courses.third.then { |third_course| expect(third_course.course_name.text).to include("AAAA") }
+    results_page.courses.fourth.then { |fourth_course| expect(fourth_course.course_name.text).to include("AAAB") }
+  end
+
+  def then_the_results_should_be_ordered_by_provider_name_descending_then_course_name_then_course_code
+    results_page.courses.first.then { |first_course| expect(first_course.course_name.text).to include("AAAB") }
+    results_page.courses.second.then { |second_course| expect(second_course.course_name.text).to include("AAAC") }
+    results_page.courses.third.then { |third_course| expect(third_course.course_name.text).to include("AAAD") }
+    results_page.courses.fourth.then { |fourth_course| expect(fourth_course.course_name.text).to include("AAAA") }
+  end
+
+  def given_that_i_select_the_option(selected_option)
+    select(selected_option, from: "sortby")
+  end
+
+  def when_i_click_sort
+    click_button "Sort"
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -314,8 +314,8 @@ describe Course do
         end
       end
 
-      describe "#order_by_name_then_provider_then_code_ascending" do
-        subject { described_class.order_by_name_then_provider_then_code_ascending }
+      describe "#ascending_course_canonical_order" do
+        subject { described_class.ascending_course_canonical_order }
 
         it "sorts in ascending order of course name" do
           expect(subject).to eq([course_a, course_b, course_c, course_d])
@@ -347,8 +347,8 @@ describe Course do
         end
       end
 
-      describe "#order_by_name_descending_then_provider_then_code_ascending" do
-        subject { described_class.order_by_name_descending_then_provider_then_code_ascending }
+      describe "#descending_course_canonical_order" do
+        subject { described_class.descending_course_canonical_order }
 
         it "sorts in descending order of course name" do
           expect(subject).to eq([course_d, course_c, course_b, course_a])

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -282,8 +282,8 @@ describe Course do
         course_b
       end
 
-      describe "#ascending_canonical_order" do
-        subject { described_class.ascending_canonical_order }
+      describe "#ascending_provider_canonical_order" do
+        subject { described_class.ascending_provider_canonical_order }
 
         it "sorts in ascending order of provider name and course name" do
           expect(subject).to eq([course_a, course_b, course_c, course_d])

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -236,6 +236,20 @@ describe Course do
           provider: provider_a)
       end
 
+      let(:course_a_with_provider_b) do
+        create(:course,
+          name: "Course A",
+          course_code: "AAA",
+          provider: provider_b)
+      end
+
+      let(:course_a_with_provider_b_with_different_course_code) do
+        create(:course,
+          name: "Course A",
+          course_code: "AAB",
+          provider: provider_b)
+      end
+
       let(:course_b) do
         create(
           :course,
@@ -296,6 +310,72 @@ describe Course do
 
           it "sorts by course_code" do
             expect(subject).to eq([course_c, course_d, course_a, another_course_a, course_b])
+          end
+        end
+      end
+
+      describe "#order_by_name_then_provider_then_code_ascending" do
+        subject { described_class.order_by_name_then_provider_then_code_ascending }
+
+        it "sorts in ascending order of course name" do
+          expect(subject).to eq([course_a, course_b, course_c, course_d])
+        end
+
+        context "when there are multiple courses with the same name" do
+          before do
+            course_a_with_provider_b
+            another_course_a
+          end
+
+          it "sorts by provider_name" do
+            expect(subject).to eq([course_a, another_course_a, course_a_with_provider_b, course_b, course_c, course_d])
+          end
+
+          context "when there are multiple providers with the same name" do
+            before { course_a_with_provider_b_with_different_course_code }
+
+            it "sorts by course_code" do
+              expect(subject).to eq([course_a,
+                                     another_course_a,
+                                     course_a_with_provider_b,
+                                     course_a_with_provider_b_with_different_course_code,
+                                     course_b,
+                                     course_c,
+                                     course_d])
+            end
+          end
+        end
+      end
+
+      describe "#order_by_name_descending_then_provider_then_code_ascending" do
+        subject { described_class.order_by_name_descending_then_provider_then_code_ascending }
+
+        it "sorts in descending order of course name" do
+          expect(subject).to eq([course_d, course_c, course_b, course_a])
+        end
+
+        context "when there are multiple courses with the same name" do
+          before do
+            course_a_with_provider_b
+            another_course_a
+          end
+
+          it "sorts by provider_name" do
+            expect(subject).to eq([course_d, course_c, course_b, course_a, another_course_a, course_a_with_provider_b])
+          end
+
+          context "when there are multiple providers with the same name" do
+            before { course_a_with_provider_b_with_different_course_code }
+
+            it "sorts by course_code" do
+              expect(subject).to eq([course_d,
+                                     course_c,
+                                     course_b,
+                                     course_a,
+                                     another_course_a,
+                                     course_a_with_provider_b,
+                                     course_a_with_provider_b_with_different_course_code])
+            end
           end
         end
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -298,8 +298,8 @@ describe Course do
         end
       end
 
-      describe "#descending_canonical_order" do
-        subject { described_class.descending_canonical_order }
+      describe "#descending_provider_canonical_order" do
+        subject { described_class.descending_provider_canonical_order }
 
         it "sorts in descending order of provider name" do
           expect(subject).to eq([course_c, course_d, course_a, another_course_a, course_b])

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -201,7 +201,7 @@ describe "GET v3/courses", :with_publish_constraint do
     end
 
     context "in ascending order" do
-      let(:request_path) { "/api/v3/courses?include=provider&sort=provider.provider_name,order" }
+      let(:request_path) { "/api/v3/courses?include=provider&sort=provider.provider_name,name" }
 
       it "returns an ordered list" do
         get request_path
@@ -214,7 +214,7 @@ describe "GET v3/courses", :with_publish_constraint do
     end
 
     context "in descending order" do
-      let(:request_path) { "/api/v3/courses?include=provider&sort=-provider.provider_name,order" }
+      let(:request_path) { "/api/v3/courses?include=provider&sort=-provider.provider_name,name" }
 
       it "returns an ordered list" do
         get request_path

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -201,7 +201,7 @@ describe "GET v3/courses", :with_publish_constraint do
     end
 
     context "in ascending order" do
-      let(:request_path) { "/api/v3/courses?include=provider&sort=name,provider.provider_name" }
+      let(:request_path) { "/api/v3/courses?include=provider&sort=provider.provider_name,order" }
 
       it "returns an ordered list" do
         get request_path
@@ -214,7 +214,7 @@ describe "GET v3/courses", :with_publish_constraint do
     end
 
     context "in descending order" do
-      let(:request_path) { "/api/v3/courses?include=provider&sort=name,-provider.provider_name" }
+      let(:request_path) { "/api/v3/courses?include=provider&sort=-provider.provider_name,order" }
 
       it "returns an ordered list" do
         get request_path

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CourseSearchService do
 
     describe "sort by" do
       context "ascending provider name and course name" do
-        let(:sort) { "provider.provider_name,order" }
+        let(:sort) { "provider.provider_name,name" }
 
         it "orders in ascending order" do
           expect(scope).to receive(:select).and_return(inner_query_scope)
@@ -58,7 +58,7 @@ RSpec.describe CourseSearchService do
       end
 
       context "descending provider name and course name" do
-        let(:sort) { "-provider.provider_name,order" }
+        let(:sort) { "-provider.provider_name,name" }
 
         it "orders in descending order" do
           expect(scope).to receive(:select).and_return(inner_query_scope)

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe CourseSearchService do
         it "orders in ascending order" do
           expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).with(id: inner_query_scope).and_return(outer_query_scope)
-          expect(outer_query_scope).to receive(:ascending_canonical_order).and_return(select_scope)
+          expect(outer_query_scope).to receive(:ascending_provider_canonical_order).and_return(select_scope)
           expect(select_scope).to receive(:select).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
@@ -211,7 +211,7 @@ RSpec.describe CourseSearchService do
           expect(course_ids_scope).to receive(:select).with(:id).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(accredited_body_scope)
           expect(accredited_body_scope).to receive(:accredited_body_order).and_return(order_scope)
-          expect(order_scope).to receive(:ascending_canonical_order).and_return(expected_scope)
+          expect(order_scope).to receive(:ascending_provider_canonical_order).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
       end

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CourseSearchService do
 
     describe "sort by" do
       context "ascending provider name and course name" do
-        let(:sort) { "name,provider.provider_name" }
+        let(:sort) { "provider.provider_name,order" }
 
         it "orders in ascending order" do
           expect(scope).to receive(:select).and_return(inner_query_scope)
@@ -58,7 +58,7 @@ RSpec.describe CourseSearchService do
       end
 
       context "descending provider name and course name" do
-        let(:sort) { "-provider.provider_name,name" }
+        let(:sort) { "-provider.provider_name,order" }
 
         it "orders in descending order" do
           expect(scope).to receive(:select).and_return(inner_query_scope)

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe CourseSearchService do
         it "orders in descending order" do
           expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(order_scope)
-          expect(order_scope).to receive(:descending_canonical_order).and_return(select_scope)
+          expect(order_scope).to receive(:descending_provider_canonical_order).and_return(select_scope)
           expect(select_scope).to receive(:select).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end

--- a/spec/view_objects/find/results_view_spec.rb
+++ b/spec/view_objects/find/results_view_spec.rb
@@ -120,10 +120,10 @@ module Find
     describe "#courses" do
       let(:query_parameters) { {} }
 
-      let(:course_ascending) { "A" }
-      let(:course_descending) { "B" }
-      let(:provider_ascending) { "C" }
-      let(:provider_descending)  { "D" }
+      let(:course_ascending) { "course_asc" }
+      let(:course_descending) { "course_desc" }
+      let(:provider_ascending) { "provider_asc" }
+      let(:provider_descending)  { "provider_desc" }
 
       subject { described_class.new(query_parameters:).courses }
 
@@ -144,8 +144,8 @@ module Find
         end
       end
 
-      context "sortby is set to A in query_parameters" do
-        let(:query_parameters) { { sortby: "A" } }
+      context "sortby is set to 'course_asc' in query_parameters" do
+        let(:query_parameters) { { sortby: "course_asc" } }
 
         before do
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
@@ -159,8 +159,8 @@ module Find
         end
       end
 
-      context "sortby is set to B in query_parameters" do
-        let(:query_parameters) { { sortby: "B" } }
+      context "sortby is set to 'course_desc' in query_parameters" do
+        let(:query_parameters) { { sortby: "course_desc" } }
 
         before do
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
@@ -174,8 +174,8 @@ module Find
         end
       end
 
-      context "sortby is set to C in query_parameters" do
-        let(:query_parameters) { { sortby: "C" } }
+      context "sortby is set to 'provider_asc' in query_parameters" do
+        let(:query_parameters) { { sortby: "provider_asc" } }
 
         before do
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
@@ -189,8 +189,8 @@ module Find
         end
       end
 
-      context "sortby is set to D in query_parameters" do
-        let(:query_parameters) { { sortby: "D" } }
+      context "sortby is set to 'provider_desc' in query_parameters" do
+        let(:query_parameters) { { sortby: "provider_desc" } }
 
         before do
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
@@ -616,10 +616,10 @@ module Find
         it {
           expect(results_view).to eq(
             [
-              ["Course name (A-Z)", "A", { "data-qa": "sort-form__options__ascending_course" }],
-              ["Course name (Z-A)", "B", { "data-qa": "sort-form__options__descending_course" }],
-              ["Training provider (A-Z)", "C", { "data-qa": "sort-form__options__ascending_provider" }],
-              ["Training provider (Z-A)", "D", { "data-qa": "sort-form__options__descending_provider" }],
+              ["Course name (A-Z)", "course_asc", { "data-qa": "sort-form__options__ascending_course" }],
+              ["Course name (Z-A)", "course_desc", { "data-qa": "sort-form__options__descending_course" }],
+              ["Training provider (A-Z)", "provider_asc", { "data-qa": "sort-form__options__ascending_provider" }],
+              ["Training provider (Z-A)", "provider_desc", { "data-qa": "sort-form__options__descending_provider" }],
             ],
           )
         }

--- a/spec/view_objects/find/results_view_spec.rb
+++ b/spec/view_objects/find/results_view_spec.rb
@@ -584,8 +584,10 @@ module Find
         it {
           expect(results_view).to eq(
             [
-              ["Training provider (A-Z)", 0, { "data-qa": "sort-form__options__ascending" }],
-              ["Training provider (Z-A)", 1, { "data-qa": "sort-form__options__descending" }],
+              ["Course name (A-Z)", 0, { "data-qa": "sort-form__options__ascending_course" }],
+              ["Course name (Z-A)", 1, { "data-qa": "sort-form__options__descending_course" }],
+              ["Training provider (A-Z)", 2, { "data-qa": "sort-form__options__ascending_provider" }],
+              ["Training provider (Z-A)", 3, { "data-qa": "sort-form__options__descending_provider" }],
             ],
           )
         }

--- a/spec/view_objects/find/results_view_spec.rb
+++ b/spec/view_objects/find/results_view_spec.rb
@@ -120,8 +120,10 @@ module Find
     describe "#courses" do
       let(:query_parameters) { {} }
 
-      let(:provider_ascending) { "0" }
-      let(:provider_descending)  { "1" }
+      let(:course_ascending) { "A" }
+      let(:course_descending) { "B" }
+      let(:provider_ascending) { "C" }
+      let(:provider_descending)  { "D" }
 
       subject { described_class.new(query_parameters:).courses }
 
@@ -134,16 +136,46 @@ module Find
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
         end
 
-        it "delegates to the CourseSearchService with sort set to provider_ascending" do
+        it "delegates to the CourseSearchService with sort set to course_ascending" do
           subject
           expect(CourseSearchService).to have_received(:call).with(
-            hash_including(filter: query_parameters, sort: provider_ascending),
+            hash_including(filter: query_parameters, sort: course_ascending),
           )
         end
       end
 
-      context "sortby is set to 0 in query_parameters" do
-        let(:query_parameters) { { sortby: "0" } }
+      context "sortby is set to A in query_parameters" do
+        let(:query_parameters) { { sortby: "A" } }
+
+        before do
+          allow(CourseSearchService).to receive(:call).and_return(Course.all)
+        end
+
+        it "delegates to the CourseSearchService with sort set to course_ascending" do
+          subject
+          expect(CourseSearchService).to have_received(:call).with(
+            hash_including(filter: query_parameters, sort: course_ascending),
+          )
+        end
+      end
+
+      context "sortby is set to B in query_parameters" do
+        let(:query_parameters) { { sortby: "B" } }
+
+        before do
+          allow(CourseSearchService).to receive(:call).and_return(Course.all)
+        end
+
+        it "delegates to the CourseSearchService with sort set to course_descending" do
+          subject
+          expect(CourseSearchService).to have_received(:call).with(
+            hash_including(filter: query_parameters, sort: course_descending),
+          )
+        end
+      end
+
+      context "sortby is set to C in query_parameters" do
+        let(:query_parameters) { { sortby: "C" } }
 
         before do
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
@@ -157,8 +189,8 @@ module Find
         end
       end
 
-      context "sortby is set to 1 in query_parameters" do
-        let(:query_parameters) { { sortby: "1" } }
+      context "sortby is set to D in query_parameters" do
+        let(:query_parameters) { { sortby: "D" } }
 
         before do
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
@@ -584,10 +616,10 @@ module Find
         it {
           expect(results_view).to eq(
             [
-              ["Course name (A-Z)", 0, { "data-qa": "sort-form__options__ascending_course" }],
-              ["Course name (Z-A)", 1, { "data-qa": "sort-form__options__descending_course" }],
-              ["Training provider (A-Z)", 2, { "data-qa": "sort-form__options__ascending_provider" }],
-              ["Training provider (Z-A)", 3, { "data-qa": "sort-form__options__descending_provider" }],
+              ["Course name (A-Z)", "A", { "data-qa": "sort-form__options__ascending_course" }],
+              ["Course name (Z-A)", "B", { "data-qa": "sort-form__options__descending_course" }],
+              ["Training provider (A-Z)", "C", { "data-qa": "sort-form__options__ascending_provider" }],
+              ["Training provider (Z-A)", "D", { "data-qa": "sort-form__options__descending_provider" }],
             ],
           )
         }


### PR DESCRIPTION
### Context

We are adding the ability to sort the results page on Find by course name.

### Changes proposed in this pull request

- **Add course ordering (A-Z) (default)**

If identical course, ordering falls back to the provider, if identical providers, ordering falls back to the course code

- **Add course ordering (Z-A)**

If identical course, ordering falls back to the provider, if identical providers, ordering falls back to the course code

- Remove the unnecessary use of Sort. This was probably added for future proofing, but there has been no need for it and it just causes confusion.

- Remove the constants and compare directly with strings encompassed within methods. This will make it easier to remove the code relating to old find when we delete it.

### Guidance to review

Search for a few courses and check that the hierarchy above is correct.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
