### PR TITLE
[0896] Add provider name to ProviderFilter

### DIFF
--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -23,6 +23,10 @@ module API
 
       private
 
+        def provider_name
+          @provider_name ||= params.dig(:filter, :provider_name) if params.dig(:filter, :provider_name)&.length&. > 2
+        end
+
         def updated_since
           @updated_since ||= params.dig(:filter, :updated_since)
         end
@@ -56,6 +60,7 @@ module API
         def providers
           @providers = recruitment_cycle.providers
 
+          @providers = @providers.provider_name_search(provider_name) if provider_name.present?
           @providers = @providers.changed_since(updated_since) if updated_since.present?
           @providers = @providers.with_provider_types(provider_types) if provider_types.present?
           @providers = @providers.with_region_codes(region_codes) if region_codes.present?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -174,6 +174,10 @@ class Provider < ApplicationRecord
       courses: %i[course_code],
     }, using: { tsearch: { prefix: true } }
 
+  pg_search_scope :provider_name_search,
+    against: %i[provider_name],
+    using: { tsearch: { prefix: true } }
+
   accepts_nested_attributes_for :sites
   accepts_nested_attributes_for :organisations
 

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -5,7 +5,11 @@ weight: 2
 
 # Release Notes
 
-# 1 November 2022
+## 19 January 2023
+
+- Add `provider_name` field to `ProviderFilter`. Returns the providers that has the specific provider name.
+
+## 1 November 2022
 
 - Add `campaign_name` field to `CourseAttributes`. This is a string, corresponding to campaigns created to help improve recruitment.
 

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -7,7 +7,7 @@ weight: 2
 
 ## 19 January 2023
 
-- Add `provider_name` field to `ProviderFilter`. Returns the providers that has the specific provider name.
+- Add `provider_name` field to `ProviderFilter`. Return providers where the name matches some or all of the input string.
 
 ## 1 November 2022
 

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -7,7 +7,7 @@ weight: 2
 
 ## 19 January 2023
 
-- Add `provider_name` field to `ProviderFilter`. Return providers where the name matches some or all of the input string.
+- Add `provider_name` field to `ProviderFilter`. Return providers where the provider name includes the input string.
 
 ## 1 November 2022
 

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -354,6 +354,14 @@ RSpec.describe API::Public::V1::ProvidersController do
           end
         end
 
+        context "passing in provider_name param" do
+          let(:filter) { { provider_name: "Sec" } }
+
+          it "returns 'Second' provider only" do
+            expect(provider_names_in_response).to eq([provider2.provider_name])
+          end
+        end
+
         context "passing in provider_type param" do
           let(:filter) { { provider_type: "university" } }
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -210,6 +210,21 @@ describe Provider do
     end
   end
 
+  describe "#provider_name_search" do
+    let!(:provider)  { create(:provider, provider_name: "Ford school", provider_code: "A01", courses: [build(:course, course_code: "2VVZ")]) }
+    let!(:provider2) { create(:provider, provider_name: "Almost forgotten school", provider_code: "A02", courses: [build(:course, course_code: "2VVZ")]) }
+
+    subject { described_class.provider_name_search(provider_name) }
+
+    context "when partial provider name is given" do
+      let(:provider_name) { "FOR" }
+
+      it "returns the correct list of providers" do
+        expect(subject).to match_array([provider, provider2])
+      end
+    end
+  end
+
   describe "#course_search" do
     let!(:provider) { create(:provider, provider_name: "Really big school", provider_code: "A01", courses: [build(:course, course_code: "2VVZ")]) }
     let!(:provider2) { create(:provider, provider_name: "Slightly smaller school", provider_code: "A02", courses: [build(:course, course_code: "2VVZ")]) }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1263,6 +1263,11 @@
             "type": "boolean",
             "example": true
           },
+          "provider_name": {
+            "description": "Returns the providers that has the specific provider name.",
+            "type": "string",
+            "example": "oxf"
+          },
           "provider_type": {
             "description": "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used.",
             "type": "string",

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1264,7 +1264,7 @@
             "example": true
           },
           "provider_name": {
-            "description": "Return providers where the name matches some or all of the input string.",
+            "description": "Return providers where the provider name includes the input string.",
             "type": "string",
             "example": "oxf"
           },

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1264,7 +1264,7 @@
             "example": true
           },
           "provider_name": {
-            "description": "Returns the providers that has the specific provider name.",
+            "description": "Return providers where the name matches some or all of the input string.",
             "type": "string",
             "example": "oxf"
           },

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -14,6 +14,10 @@ properties:
     description: "Only return providers that are accredited bodies."
     type: boolean
     example: true
+  provider_name:
+    description: "Returns the providers that has the specific provider name."
+    type: "string"
+    example: "oxf"
   provider_type:
     description: "Return providers based on their provider type. This is a comma delimited string. If multiple provider types are provided then any provider matching any one of the options provider will be returned, i.e. the OR operator is used."
     type: string

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -15,7 +15,7 @@ properties:
     type: boolean
     example: true
   provider_name:
-    description: "Return providers where the name matches some or all of the input string."
+    description: "Return providers where the provider name includes the input string."
     type: "string"
     example: "oxf"
   provider_type:

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -15,7 +15,7 @@ properties:
     type: boolean
     example: true
   provider_name:
-    description: "Returns the providers that has the specific provider name."
+    description: "Return providers where the name matches some or all of the input string."
     type: "string"
     example: "oxf"
   provider_type:


### PR DESCRIPTION
### Context
On the api to be able to search via the provider name, similar to the the provider suggestions

### Changes proposed in this pull request
Add provider name to ProviderFilter

### Guidance to review


https://publish-teacher-training-pr-3261.london.cloudapps.digital/docs/api-reference.html#schema-providerfilter

#### Javascript

``` Javascript

let response = await fetch("https://publish-teacher-training-pr-3261.london.cloudapps.digital/api/public/v1/recruitment_cycles/2023/providers?filter[provider_name]=oxf", { 
  method: "GET",
});

let data = await response.text();
console.log(data);

```


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
