### PR TITLE
[0958] Amended documentation typos

### DIFF
--- a/spec/docs/providers/locations_spec.rb
+++ b/spec/docs/providers/locations_spec.rb
@@ -24,9 +24,9 @@ describe "API", :with_publish_constraint do
         required: false,
         description: "The associated data for this resource.",
         schema: {
-          enum: %w[recruitment_cycle provider course location_status],
+          enum: %w[recruitment_cycle provider],
         },
-        example: "recruitment_cycle,provider,course,location_status"
+        example: "recruitment_cycle,provider"
 
       response "200", "The collection of locations for the specified provider." do
         let(:provider) { create(:provider) }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -2332,12 +2332,10 @@
             "schema": {
               "enum": [
                 "recruitment_cycle",
-                "provider",
-                "course",
-                "location_status"
+                "provider"
               ]
             },
-            "example": "recruitment_cycle,provider,course,location_status"
+            "example": "recruitment_cycle,provider"
           }
         ],
         "responses": {


### PR DESCRIPTION
### Context
Invalid values from the API docs for provider locations include param

### Changes proposed in this pull request
Remove invalid values from the API docs for provider locations include param

### Guidance to review
https://publish-teacher-training-pr-3263.london.cloudapps.digital/docs/api-reference.html#recruitment_cycles-year-providers-provider_code-locations-get

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
