### PR TITLE
Add find qa routes to terraform state and code

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,14 +1,14 @@
-data azurerm_key_vault key_vault {
+data "azurerm_key_vault" "key_vault" {
   name                = var.key_vault_name
   resource_group_name = var.key_vault_resource_group
 }
 
-data azurerm_key_vault_secret app_secrets {
+data "azurerm_key_vault_secret" "app_secrets" {
   key_vault_id = data.azurerm_key_vault.key_vault.id
   name         = var.key_vault_app_secret_name
 }
 
-data azurerm_key_vault_secret infra_secrets {
+data "azurerm_key_vault_secret" "infra_secrets" {
   key_vault_id = data.azurerm_key_vault.key_vault.id
   name         = var.key_vault_infra_secret_name
 }

--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -30,3 +30,8 @@ data cloudfoundry_service postgres {
 data cloudfoundry_service redis {
   name = "redis"
 }
+
+data cloudfoundry_app find_app {
+  name_or_id  = local.find_app_name
+  space       = data.cloudfoundry_space.space.id
+}

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -90,6 +90,33 @@ resource cloudfoundry_route web_app_find_gov_uk_route {
   hostname = each.value
 }
 
+locals {
+  target_app = var.find_route_target == "find" ? data.cloudfoundry_app.find_app.id : resource.cloudfoundry_app.web_app.id
+}
+
+resource cloudfoundry_route find_web_app_cloudapps_digital_route {
+  count = var.find_route_target != null ? 1 : 0
+
+  domain   = data.cloudfoundry_domain.london_cloudapps_digital.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = local.find_app_name
+
+  target {
+    app = local.target_app
+  }
+}
+
+resource cloudfoundry_route find_web_app_find_gov_uk_route {
+  for_each = toset(var.find_app_gov_uk_host_names)
+  domain   = data.cloudfoundry_domain.find_service_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = each.value
+
+  target {
+    app = local.target_app
+  }
+}
+
 resource cloudfoundry_service_instance postgres {
   name         = local.postgres_service_name
   space        = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -36,6 +36,13 @@ variable "find_gov_uk_host_names" {
   type = list
 }
 
+variable "find_app_gov_uk_host_names" {
+  default = []
+  type = list
+}
+
+variable "find_route_target" {}
+
 variable "restore_from_db_guid" {}
 
 variable "db_backup_before_point_in_time" {}
@@ -45,8 +52,8 @@ locals {
   app_name_suffix              = var.app_environment != "review" ? var.app_environment : "pr-${var.web_app_host_name}"
   web_app_name                 = "publish-teacher-training-${local.app_name_suffix}"
   publish_app_name             = "publish-${local.app_name_suffix}"
-  find2_app_name               = var.app_environment == "review" ? "find2-${local.app_name_suffix}" : ""
-  cloudapp_names               = var.app_environment == "review" ? [local.web_app_name, local.publish_app_name, local.find2_app_name] : [local.web_app_name, local.publish_app_name]
+  cloudapp_names               = var.app_environment == "review" ? [local.web_app_name, local.publish_app_name, "find2-${local.app_name_suffix}"] : [local.web_app_name, local.publish_app_name]
+  find_app_name                = "find-${local.app_name_suffix}"
   worker_app_name              = "publish-teacher-training-worker-${local.app_name_suffix}"
   postgres_service_name        = "publish-teacher-training-postgres-${local.app_name_suffix}"
   redis_worker_service_name    = "publish-teacher-training-worker-redis-${local.app_name_suffix}"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -37,7 +37,7 @@ provider "cloudfoundry" {
 }
 
 provider "statuscake" {
-  api_token   = local.infra_secrets.STATUSCAKE_PASSWORD
+  api_token  = local.infra_secrets.STATUSCAKE_PASSWORD
 }
 
 module "paas" {
@@ -59,6 +59,8 @@ module "paas" {
   app_environment_variables      = local.paas_app_environment_variables
   publish_gov_uk_host_names      = var.publish_gov_uk_host_names
   find_gov_uk_host_names         = var.find_gov_uk_host_names
+  find_app_gov_uk_host_names     = var.find_app_gov_uk_host_names
+  find_route_target              = var.find_route_target
   restore_from_db_guid           = var.paas_restore_from_db_guid
   db_backup_before_point_in_time = var.paas_db_backup_before_point_in_time
   enable_external_logging        = var.paas_enable_external_logging

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -56,6 +56,13 @@ variable "find_gov_uk_host_names" {
   type = list
 }
 
+variable find_app_gov_uk_host_names {
+  default = []
+  type = list
+}
+
+variable find_route_target { default = null }
+
 variable statuscake_alerts {
   type    = map
   default = {}

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -10,6 +10,8 @@
     "paas_redis_service_plan": "tiny-5_x",
     "publish_gov_uk_host_names": ["qa"],
     "find_gov_uk_host_names": ["qa2"],
+    "find_route_target": "find",
+    "find_app_gov_uk_host_names": ["qa","qa-assets"],
     "key_vault_resource_group": "s121d01-shared-rg",
     "key_vault_name": "s121d01-shared-kv-01",
     "key_vault_app_secret_name": "PUBLISH-APP-SECRETS-QA",

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -10,7 +10,7 @@
     "paas_redis_service_plan": "tiny-5_x",
     "publish_gov_uk_host_names": ["qa"],
     "find_gov_uk_host_names": ["qa2"],
-    "find_route_target": "find",
+    "find_route_target": "publish",
     "find_app_gov_uk_host_names": ["qa","qa-assets"],
     "key_vault_resource_group": "s121d01-shared-rg",
     "key_vault_name": "s121d01-shared-kv-01",


### PR DESCRIPTION
### Context
This is for the findpub merge
so that the routes can be managed by publish

Steps are 
- remove routes from find QA terraform state
- import find routes to publish QA terraform state
- merge this PR

### Changes proposed in this pull request

Add variables
- find_app_gov_uk_host_names (list of find service hostnames i.e. qa, qa-assets)
- find_route_target (where the find routes point to i.e. find or publish)
- find_cloudapp_names (list of cloudapps hostnames i.e. find-qa, find-pr-1234)
Add find webapp as a data resource
Add resources for the find routes that will point to the app as per find_route_target setting

### Guidance to review

make qa deploy-plan

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
