### PR TITLE
[944] Set up different DFE namespace for Find

### DIFF
--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -1,5 +1,7 @@
 module Find
   class ApplicationController < ActionController::Base
+    include DfE::Analytics::Requests
+
     layout "find_layout"
     default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
@@ -8,6 +10,16 @@ module Find
 
     def render_feedback_component
       @render_feedback_component = true
+    end
+
+    # For DfE::Analytics as Find doesn't have a current_user
+    def current_user
+      nil
+    end
+
+    # DFE Analytics namespace
+    def current_namespace
+      "find"
     end
 
   private

--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -12,11 +12,6 @@ module Find
       @render_feedback_component = true
     end
 
-    # For DfE::Analytics as Find doesn't have a current_user
-    def current_user
-      nil
-    end
-
     # DFE Analytics namespace
     def current_namespace
       "find"

--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -9,6 +9,11 @@ module Publish
 
     after_action :verify_authorized
 
+    # DFE Analytics namespace
+    def current_namespace
+      "publish"
+    end
+
   private
 
     def provider

--- a/app/controllers/support/support_controller.rb
+++ b/app/controllers/support/support_controller.rb
@@ -3,6 +3,11 @@ module Support
     layout "support"
     before_action :check_user_is_admin
 
+    # DFE Analytics namespace
+    def current_namespace
+      "support"
+    end
+
   private
 
     def check_user_is_admin

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -1,15 +1,15 @@
 DfE::Analytics.configure do |config|
   # Whether to log events instead of sending them to BigQuery.
   #
-  # config.log_only = true
+  config.log_only = false
 
   # Whether to use ActiveJob or dispatch events immediately.
   #
-  # config.async = true
+  config.async = true
 
   # Which ActiveJob queue to put events on
   #
-  # config.queue = :default
+  config.queue = :low_priority
 
   # The name of the BigQuery table we’re writing to.
   #


### PR DESCRIPTION
### Context

With Find being merged into Publish, we're going to stream events into one table but setup a different namespace for Find. 

https://trello.com/c/6nkOr3CU/944-handle-dfe-analytics-configuration

### Changes proposed in this pull request

- Sets up a namespace for Find
- Tweaks the DFE config to send jobs async via diff. queue 

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
