### PR TITLE
929 placements content

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,19 @@ This repo is home to three services:
 
 ### New Find (while the migration is in progress)
 
-| Name        | URL                                                                    | Description
-| ----------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------
-| Production  | [www](https://www2.find-postgraduate-teacher-training.service.gov.uk)   | Public site
-| Staging     | [staging](https://staging2.find-postgraduate-teacher-training.service.gov.uk)| For internal use by DfE to test deploys
-| QA          | [qa](https://qa2.find-postgraduate-teacher-training.service.gov.uk)     | For internal use by DfE for testing. Automatically deployed from main
+| Name       | URL                                                                           | Description                                                           |
+| ---------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Production | [www](https://www2.find-postgraduate-teacher-training.service.gov.uk)         | Public site                                                           |
+| Staging    | [staging](https://staging2.find-postgraduate-teacher-training.service.gov.uk) | For internal use by DfE to test deploys                               |
+| QA         | [qa](https://qa2.find-postgraduate-teacher-training.service.gov.uk)           | For internal use by DfE for testing. Automatically deployed from main |
 
 ### Publish
 
-| Name        | URL                                                                | Description
-| ----------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------
-| Production  | [www](https://www.publish-teacher-training-courses.service.gov.uk) | Public site
-| Staging     | [staging](https://staging.publish-teacher-training-courses.service.gov.uk) | For internal use by DfE to test deploys
-| QA          | [qa](https://qa.publish-teacher-training-courses.service.gov.uk)  | For internal use by DfE for testing. Automatically deployed from main
-
+| Name       | URL                                                                        | Description                                                           |
+| ---------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Production | [www](https://www.publish-teacher-training-courses.service.gov.uk)         | Public site                                                           |
+| Staging    | [staging](https://staging.publish-teacher-training-courses.service.gov.uk) | For internal use by DfE to test deploys                               |
+| QA         | [qa](https://qa.publish-teacher-training-courses.service.gov.uk)           | For internal use by DfE for testing. Automatically deployed from main |
 
 ## Guides
 
@@ -52,7 +51,6 @@ This repo is home to three services:
 - [Disaster Recovery Plan](/guides/disaster-recovery.md)
 - [ADRs](/guides/adr/index.md)
 - [Support Playbook](/guides/support_playbook.md)
-
 
 ## License
 

--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -12,8 +12,7 @@
       <% end %>
     <% elsif course.program_type == "scitt_programme" && course.provider.provider_code != "E65" %>
       <%= render Find::Utility::AdviceComponent::View.new(title: "Where you will train") do %>
-        <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools
-          you want to be in, but your course will try to place you in schools you can commute to.</p>
+        <p class="govuk-body">You'll be placed in different schools during your training. You can't pick which schools you want to be in, but your training provider will place you in schools you can travel to.</p>
       <% end %>
     <% end %>
 
@@ -23,7 +22,7 @@
 
     <% if course.site_statuses.map(&:site).uniq.many? %>
       <h3 class="govuk-heading-m">Locations</h3>
-      <p class="govuk-body">You can select one of the following locations when you apply.</p>
+      <p class="govuk-body">You can select one of the following locations when you apply to indicate a preferred placement.</p>
       <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
         <caption class="govuk-visually-hidden">List of locations and vacancies</caption>
         <thead class="govuk-table__head">

--- a/app/views/publish/courses/course_information/edit.html.erb
+++ b/app/views/publish/courses/course_information/edit.html.erb
@@ -106,7 +106,7 @@
       <% elsif @course.program_type == 'scitt_programme' && @provider.provider_code != 'E65' %>
         <%= govuk_details(summary_text: "See the guidance we show in this section") do %>
           <h3 class="govuk-heading-m">Where you will train</h3>
-          <p class="govuk-body">You’ll be placed in different schools during your training. You cannot pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
+          <p class="govuk-body">You'll be placed in different schools during your training. You can't pick which schools you want to be in, but your training provider will place you in schools you can travel to.</p>
         <% end %>
       <% end %>
 

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -105,7 +105,7 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include("You’ll be placed in different schools during your training.")
+      expect(result.text).to include("You'll be placed in different schools during your training")
     end
 
     context "Provider is Educate Teacher Training" do


### PR DESCRIPTION
### Context
We need to update the content in Prod to match the prototype. We are changing the line of content that appears above the locations list in the 'School placement' section and the content that appears in the GIT 'Where you will train' box when the provider is a SCITT.

Because we are changing the content on Find, we'll also need to change it in the preview in Publish (see attached screenshot).

See attached card and let me know if you have any questions :)
Tech notes

    Make sure to have the counter work for new find in publish

### Changes proposed in this pull request
Content change in 2 files
### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
