### PR TITLE
[xxx] Enable the sidekiq dashboard for admins

### DIFF
--- a/app/lib/system_admin_constraint.rb
+++ b/app/lib/system_admin_constraint.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SystemAdminConstraint
+  def matches?(request)
+    system_admin?(request)
+  end
+
+  def system_admin?(request)
+    signin_user = UserSession.load_from_session(request.session)
+    signin_user.present? && User.admins.kept.exists?(email: signin_user.email)
+  end
+end

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -1,3 +1,8 @@
+require "sidekiq/web"
+require "sidekiq/cron/web"
+
+mount Sidekiq::Web, at: "/sidekiq", constraints: SystemAdminConstraint.new
+
 root to: "publish/providers#index"
 
 scope via: :all do


### PR DESCRIPTION
### Context

Publish has had sidekiq setup for a while but we have never enabled the web interface to be available. This PR does that so we can diagnose jobs. Using the same constraint from Register.