### PR TITLE
Increase QA app instance memory

### DIFF
--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -3,7 +3,7 @@
     "paas_app_environment": "qa",
     "paas_web_app_host_name": "qa",
     "paas_web_app_instances": 2,
-    "paas_web_app_memory": 512,
+    "paas_web_app_memory": 1024,
     "paas_worker_app_instances": 1,
     "paas_worker_app_memory": 512,
     "paas_postgres_service_plan": "small-11",


### PR DESCRIPTION
### Context

Increase app memory for QA from 512M to 1024M per instance
Due to increase in "out of memory" errors since the merge with find

### Changes proposed in this pull request

Increase paas_web_app_memory in qa.tfvars.json

### Guidance to review

deploy-plan
Check QA after merge 

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
