### PR TITLE
Downcase non language subjects

### DIFF
--- a/app/services/courses/generate_course_name_service.rb
+++ b/app/services/courses/generate_course_name_service.rb
@@ -49,10 +49,10 @@ module Courses
       "#{formatted_subjects.first} with #{downcase_if_not_language(formatted_subjects.last)}"
     end
 
-    def downcase_if_not_language(str)
-      return str if LANGUAGES.any? { |s| str.match s }
+    def downcase_if_not_language(subject_name)
+      return subject_name if LANGUAGES.any? { |s| subject_name.match s }
 
-      str.downcase
+      subject_name.downcase
     end
 
     def formatted_subjects

--- a/app/services/courses/generate_course_name_service.rb
+++ b/app/services/courses/generate_course_name_service.rb
@@ -4,6 +4,20 @@ module Courses
   class GenerateCourseNameService
     include ServicePattern
 
+    LANGUAGES = %w[
+      English
+      German
+      Italian
+      Japanese
+      Mandarin
+      Russian
+      Spanish
+      French
+      Ancient Greek
+      Ancient Hebrew
+      Latin
+    ].freeze
+
     ENGINEERS_TEACH_PHYSICS_TITLE = I18n.t('courses.generate_course_name_service.etp_title')
     FURTHER_EDUCATION_TITLE = I18n.t('courses.generate_course_name_service.further_education_title')
 
@@ -32,7 +46,13 @@ module Courses
 
       return formatted_subjects.first if formatted_subjects.length == 1
 
-      "#{formatted_subjects.first} with #{formatted_subjects.last}"
+      "#{formatted_subjects.first} with #{downcase_if_not_language(formatted_subjects.last)}"
+    end
+
+    def downcase_if_not_language(str)
+      return str if LANGUAGES.any? { |s| str.match s }
+
+      str.downcase
     end
 
     def formatted_subjects

--- a/spec/services/courses/assign_subjects_service_spec.rb
+++ b/spec/services/courses/assign_subjects_service_spec.rb
@@ -72,7 +72,7 @@ describe Courses::AssignSubjectsService do
       end
 
       it 'sets the name' do
-        expect(subject.name).to eq('English with Biology')
+        expect(subject.name).to eq('English with biology')
       end
     end
   end

--- a/spec/services/courses/generate_course_name_service_spec.rb
+++ b/spec/services/courses/generate_course_name_service_spec.rb
@@ -92,7 +92,7 @@ describe Courses::GenerateCourseNameService do
             end
 
             it 'Returns the title Media studies' do
-              expect(subject).to eq('Media studies with Mathematics')
+              expect(subject).to eq('Media studies with mathematics')
             end
           end
         end
@@ -298,7 +298,7 @@ describe Courses::GenerateCourseNameService do
           end
 
           it 'Returns a name modern language with both languages and the additional subject' do
-            expect(subject).to eq('Modern Languages (French and Spanish) with Mathematics')
+            expect(subject).to eq('Modern Languages (French and Spanish) with mathematics')
           end
 
           include_examples 'with SEND'


### PR DESCRIPTION
### Context
When creating course names, the second subject should be lowercase unless it is a noun.

https://publish-courses-prototype.herokuapp.com/course-names
What needs to be done

Update the course name generator to be sentence case unless the subject is a noun (e.g., English, French, Spanish, etc)
### Changes proposed in this pull request
Add downcasing method
### Guidance to review
Covered by existing tests I think
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
