### PR TITLE
Comply with rubocop (lint.yml)

### DIFF
--- a/config/rubocop/lint.yml
+++ b/config/rubocop/lint.yml
@@ -1,9 +1,3 @@
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
 # NOTE: Cop Rails/LexicallyScopedActionFilter conflicts with Lint/UselessMethodDefinition
 # https://github.com/rubocop/rubocop-rails/issues/343
 Lint/UselessMethodDefinition:

--- a/config/rubocop/lint.yml
+++ b/config/rubocop/lint.yml
@@ -1,15 +1,3 @@
-Lint/AmbiguousBlockAssociation:
-  Exclude:
-    - 'spec/support/slack_notifications.rb'
-    - 'spec/system/support_interface/daily_report_spec.rb'
-    - 'spec/requests/vendor_api/api_authentication_spec.rb'
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
 Lint/RaiseException:
   Enabled: true
 


### PR DESCRIPTION
### Context

We have lots of tech debt because of cops not being enabled. This PR enables some of them and fixes the bad code. 

**This PR focuses on clearing out the `lint.yml` file.**

### Changes proposed in this pull request

See commits

### Guidance to review

- Recommend reviewing commit by commit, as in each commit  one particular cop is enabled and all the code is adjusted to pass the linter.
- I've kept the exclusions for `Lint/UselessMethodDefinition` as `Rails/LexicallyScopedActionFilter` conflicts with it.
- Play around with the review app in areas which relies on lots of code working together to ensure there are no (untested) hidden breakages.
- Check everywhere (Find/Publish/Support)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
