### PR TITLE
[890] Add content about ske to entry requirements section

### DIFF
--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -21,7 +21,7 @@
           If your degree is not engineering or a related subject, please apply to our physics course.
         </p>
       <% else %>
-        <% unless subject_knowledge_enhancement_content?(course).present? || primary_with_mathematics_subject?(course) %>
+        <% unless subject_knowledge_enhancement_content? || primary_with_mathematics_subject? %>
           <p class="govuk-body">
             <%= secondary_advisory(course) %>
           </p>
@@ -29,12 +29,12 @@
       <% end %>
     <% end %>
 
-    <% if subject_knowledge_enhancement_content?(course).present? %>
+    <% if subject_knowledge_enhancement_content? %>
       <p class="govuk-body">
         If your degree is not in <%= course.computed_subject_name_or_names %>, or you’ve not used your subject knowledge in a while, you may be asked to complete a
         <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
       </p>
-      <% elsif primary_with_mathematics_subject?(course) %>
+      <% elsif primary_with_mathematics_subject? %>
       <p class="govuk-body">
         If you need to improve your primary mathematics knowledge, you may be asked to complete a
         <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -21,9 +21,11 @@
           If your degree is not engineering or a related subject, please apply to our physics course.
         </p>
       <% else %>
-        <p class="govuk-body">
-          <%= secondary_advisory(course) %>
-        </p>
+        <%unless subject_knowledge_enhancement_content?(course).present? || primary_with_mathematics_subject?(course)%>
+          <p class="govuk-body">
+            <%= secondary_advisory(course) %>
+          </p>
+        <%end%>
       <% end %>
     <% end %>
 
@@ -37,7 +39,8 @@
         If you need to improve your primary mathematics knowledge, you may be asked to complete a
         <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
       </p>
-    <% end %>
+    <% end %> 
+
 
     <p class="govuk-body">
       <%= required_gcse_content(course) %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -21,11 +21,11 @@
           If your degree is not engineering or a related subject, please apply to our physics course.
         </p>
       <% else %>
-        <%unless subject_knowledge_enhancement_content?(course).present? || primary_with_mathematics_subject?(course)%>
+        <% unless subject_knowledge_enhancement_content?(course).present? || primary_with_mathematics_subject?(course) %>
           <p class="govuk-body">
             <%= secondary_advisory(course) %>
           </p>
-        <%end%>
+        <% end %>
       <% end %>
     <% end %>
 
@@ -39,8 +39,7 @@
         If you need to improve your primary mathematics knowledge, you may be asked to complete a
         <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
       </p>
-    <% end %> 
-
+    <% end %>
 
     <p class="govuk-body">
       <%= required_gcse_content(course) %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -29,7 +29,7 @@
 
     <% if subject_knowledge_enhancement_content?(course).present? %>
       <p class="govuk-body">
-        If your degree is not in <%= course.name %>, or you’ve not used your subject knowledge in a while, you may be asked to complete a
+        If your degree is not in <%= course.name.include?("English") ? course.name : course.name.downcase %>, or you’ve not used your subject knowledge in a while, you may be asked to complete a
         <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
       </p>
       <% elsif primary_with_mathematics_subject?(course) %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -29,7 +29,7 @@
 
     <% if subject_knowledge_enhancement_content?(course).present? %>
       <p class="govuk-body">
-        If your degree is not in <%= course.name.include?("English") ? course.name : course.name.downcase %>, or you’ve not used your subject knowledge in a while, you may be asked to complete a
+        If your degree is not in <%= course.computed_subject_name_or_names %>, or you’ve not used your subject knowledge in a while, you may be asked to complete a
         <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
       </p>
       <% elsif primary_with_mathematics_subject?(course) %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -27,6 +27,18 @@
       <% end %>
     <% end %>
 
+    <% if subject_knowledge_enhancement_content?(course).present? %>
+      <p class="govuk-body">
+        If your degree is not in <%= course.name %>, or you’ve not used your subject knowledge in a while, you may be asked to complete a
+        <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
+      </p>
+      <% elsif primary_with_mathematics_subject?(course) %>
+      <p class="govuk-body">
+        If you need to improve your primary mathematics knowledge, you may be asked to complete a
+        <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
+      </p>
+    <% end %>
+
     <p class="govuk-body">
       <%= required_gcse_content(course) %>
     </p>

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -25,7 +25,7 @@ module Find
           }
 
           degree_grade_hash[course.degree_grade]
-        end
+        end      
 
         def subject_knowledge_enhancement_content?(course)
           course.subjects.any? { |subject| subject.subject_code if SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(subject.subject_code) }

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -28,7 +28,7 @@ module Find
         end
 
         def subject_knowledge_enhancement_content?(course)
-          SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(course.subjects.first.subject_code)
+          course.subjects.any? { |subject| subject.subject_code.in?(SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES) }
         end
 
         def primary_with_mathematics_subject?(course)

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -27,7 +27,7 @@ module Find
           degree_grade_hash[course.degree_grade]
         end
 
-        def subject_knowledge_enhancement_content?(course)
+        def subject_knowledge_enhancement_content?
           if course.subjects.first.subject_code.nil?
             course.subjects.any? { |subject| SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(subject.subject_code) }
           else
@@ -35,7 +35,7 @@ module Find
           end
         end
 
-        def primary_with_mathematics_subject?(course)
+        def primary_with_mathematics_subject?
           PRIMARY_WITH_MATHEMATICS_SUBJECT_CODES.include?(course.subjects.first.subject_code)
         end
 

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -14,6 +14,8 @@ module Find
           @course = course
         end
 
+        private
+
         def degree_grade_content(course)
           degree_grade_hash = {
             'two_one' => 'An undergraduate degree at class 2:1 or above, or equivalent.',
@@ -23,9 +25,7 @@ module Find
           }
 
           degree_grade_hash[course.degree_grade]
-        end
-
-        private
+        end      
 
         def subject_knowledge_enhancement_content?(course)
           course.subjects.any? { |subject| subject.subject_code if SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(subject.subject_code) }

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -25,7 +25,7 @@ module Find
           }
 
           degree_grade_hash[course.degree_grade]
-        end      
+        end
 
         def subject_knowledge_enhancement_content?(course)
           course.subjects.any? { |subject| subject.subject_code if SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(subject.subject_code) }

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -28,7 +28,11 @@ module Find
         end
 
         def subject_knowledge_enhancement_content?(course)
-          SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(course.subjects.first.subject_code)
+          if course.subjects.first.subject_code.nil?
+            course.subjects.any? { |subject| SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(subject.subject_code) }
+          else
+            SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(course.subjects.first.subject_code)
+          end
         end
 
         def primary_with_mathematics_subject?(course)

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -28,7 +28,7 @@ module Find
         end
 
         def subject_knowledge_enhancement_content?(course)
-          course.subjects.any? { |subject| subject.subject_code if SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(subject.subject_code) }
+          course.subjects.any? { |subject| subject.subject_code.in?(SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES) }
         end
 
         def primary_with_mathematics_subject?(course)

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -28,7 +28,7 @@ module Find
         end
 
         def subject_knowledge_enhancement_content?(course)
-          course.subjects.any? { |subject| subject.subject_code.in?(SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES) }
+          SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(course.subjects.first.subject_code)
         end
 
         def primary_with_mathematics_subject?(course)

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -6,12 +6,13 @@ module Find
       class View < ViewComponent::Base
         attr_accessor :course
 
+        SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES = %w[C1 F1 11 DT Q3 G1 F3 V6 15 17 22].freeze
+        PRIMARY_WITH_MATHEMATICS_SUBJECT_CODES = %w[03].freeze
+
         def initialize(course:)
           super
           @course = course
         end
-
-        private
 
         def degree_grade_content(course)
           degree_grade_hash = {
@@ -22,6 +23,16 @@ module Find
           }
 
           degree_grade_hash[course.degree_grade]
+        end
+
+        private
+
+        def subject_knowledge_enhancement_content?(course)
+          course.subjects.any? { |subject| subject.subject_code if SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES.include?(subject.subject_code) }
+        end
+
+        def primary_with_mathematics_subject?(course)
+          PRIMARY_WITH_MATHEMATICS_SUBJECT_CODES.include?(course.subjects.first.subject_code)
         end
 
         def required_gcse_content(course)

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -103,6 +103,7 @@ en:
       url_bursaries_and_scholarships: https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships
       url_improve_your_subject_knowledge: https://getintoteaching.education.gov.uk/improve-your-subject-knowledge
       url_teacher_training_events: https://getintoteaching.education.gov.uk/events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_banner
+      url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
     qualification:
       description_with_abbreviation:
         qts:

--- a/spec/components/find/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_preview.rb
@@ -4,14 +4,9 @@ module Find
   module Courses
     module EntryRequirementsComponent
       class ViewPreview < ViewComponent::Preview
-        def with_ske_subject
-          course = Course.new(subjects: [subject_name: 'Biology', subject_code: 'C1'] )
-          
-          render Find::Courses::EntryRequirementsComponent::View.new(course: course.decorate)
-        end
-
         def qualifications_needed_only
           course = Course.new(course_code: 'FIND',
+                              subjects: [Subject.new(subject_name: 'Foo', subject_code: '1')],
                               name: 'Super cool awesome course',
                               provider: Provider.new(provider_code: 'DFE'),
                               additional_degree_subject_requirements: true,
@@ -30,14 +25,38 @@ module Find
           render Find::Courses::EntryRequirementsComponent::View.new(course: mock_etp_course)
         end
 
+        def fully_populated_with_ske_subject
+          render Find::Courses::EntryRequirementsComponent::View.new(course: mock_ske_course)
+        end
+
+        def fully_populated_with_primary_maths_subject
+          render Find::Courses::EntryRequirementsComponent::View.new(course: mock_primary_maths_ske_course)
+        end
+
         private
 
         def mock_etp_course
           FakeCourse.new(**mock_etp_course_attributes)
         end
 
+        def mock_ske_course
+          FakeCourse.new(**mock_ske_course_attributes)
+        end
+
+        def mock_primary_maths_ske_course
+          FakeCourse.new(**mock_primary_maths_ske_course_attributes)
+        end
+
         def mock_etp_course_attributes
           mock_course_attributes.merge({ campaign_name: :engineers_teach_physics })
+        end
+
+        def mock_ske_course_attributes
+          mock_course_attributes.merge({ subjects: [Subject.new(subject_name: 'SKE Subject', subject_code: 'C1')] })
+        end
+
+        def mock_primary_maths_ske_course_attributes
+          mock_course_attributes.merge({ subjects: [Subject.new(subject_name: 'Primary Maths SKE Subject', subject_code: '03')] })
         end
 
         def mock_course_attributes
@@ -55,7 +74,7 @@ module Find
             personal_qualities: 'Personal Qualities Text Goes Here',
             other_requirements: 'Other Requirements Text Goes Here',
             computed_subject_name_or_names: 'Biology',
-            subjects: [subject_name: 'Biology', subject_code: 'C1']}
+            subjects: [Subject.new(subject_name: 'foo', subject_code: 'sc')] }
         end
 
         def mock_course
@@ -64,7 +83,7 @@ module Find
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :computed_subject_name_or_names, :campaign_name, :subjects, :subject_name)
+          attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :computed_subject_name_or_names, :campaign_name, :subjects)
 
           def enrichment_attribute(params)
             send(params)

--- a/spec/components/find/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_preview.rb
@@ -4,6 +4,12 @@ module Find
   module Courses
     module EntryRequirementsComponent
       class ViewPreview < ViewComponent::Preview
+        def with_ske_subject
+          course = Course.new(subjects: [subject_name: 'Biology', subject_code: 'C1'] )
+          
+          render Find::Courses::EntryRequirementsComponent::View.new(course: course.decorate)
+        end
+
         def qualifications_needed_only
           course = Course.new(course_code: 'FIND',
                               name: 'Super cool awesome course',
@@ -48,7 +54,8 @@ module Find
             additional_gcse_equivalencies: 'much much more',
             personal_qualities: 'Personal Qualities Text Goes Here',
             other_requirements: 'Other Requirements Text Goes Here',
-            computed_subject_name_or_names: 'Biology' }
+            computed_subject_name_or_names: 'Biology',
+            subjects: [subject_name: 'Biology', subject_code: 'C1']}
         end
 
         def mock_course
@@ -57,7 +64,7 @@ module Find
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :computed_subject_name_or_names, :campaign_name)
+          attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :personal_qualities, :other_requirements, :computed_subject_name_or_names, :campaign_name, :subjects, :subject_name)
 
           def enrichment_attribute(params)
             send(params)

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -16,7 +16,6 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
       expect(result.text).to include('English')
-      expect(course.name).to eq('English')
       then_i_should_see_the_ske_link
     end
   end
@@ -29,7 +28,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       )
       result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
-      #expect(result.text).to include('mathematics')
+      expect(result.text).to include('mathematics')
       then_i_should_see_the_ske_link
     end
   end

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -7,7 +7,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     expect(page).to have_link('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')
   end
 
-  context 'with a single subject_knowledge_enhancement_subject' do
+  context 'when English is selected' do
     it 'renders correct message' do
       course = build(
         :course,
@@ -15,6 +15,21 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       )
       result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      expect(result.text).to include('English')
+      expect(course.name).to eq('English')
+      then_i_should_see_the_ske_link
+    end
+  end
+
+  context 'when mathematics is selected' do
+    it 'renders correct message' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :mathematics)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      #expect(result.text).to include('mathematics')
       then_i_should_see_the_ske_link
     end
   end

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -3,6 +3,48 @@
 require 'rails_helper'
 
 describe Find::Courses::EntryRequirementsComponent::View, type: :component do
+  def then_i_should_see_the_ske_link
+    expect(page).to have_link('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')
+  end
+
+  context 'with a single subject_knowledge_enhancement_subject' do
+    it 'renders correct message' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :english)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      then_i_should_see_the_ske_link
+    end
+  end
+
+  context 'with multiple subject_knowledge_enhancement_subjects' do
+    it 'renders correct message' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :german), build(:secondary_subject, :spanish)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      then_i_should_see_the_ske_link
+    end
+  end
+
+  context 'with a primary maths subject_knowledge_enhancement_subject' do
+    it 'renders correct message' do
+      course = build(
+        :course,
+        subjects: [build(:primary_subject, :primary_with_mathematics)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include('If you need to improve your primary mathematics knowledge, you may be asked to complete a')
+      then_i_should_see_the_ske_link
+    end
+  end
+
   context 'when the provider accepts pending GCSEs' do
     it 'renders correct message' do
       course = build(

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -3,11 +3,7 @@
 require 'rails_helper'
 
 describe Find::Courses::EntryRequirementsComponent::View, type: :component do
-  def then_i_should_see_the_ske_link
-    expect(page).to have_link('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')
-  end
-
-  context 'when English is selected' do
+  context 'when english is selected' do
     it 'renders correct message' do
       course = build(
         :course,
@@ -15,21 +11,53 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       )
       result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+    end
+
+    it 'renders the correct course case' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :english)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('English')
-      then_i_should_see_the_ske_link
+    end
+
+    it 'renders the correct link' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :english)]
+      )
+      render_inline(described_class.new(course: course.decorate))
+      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end
   end
 
   context 'when mathematics is selected' do
-    it 'renders correct message' do
+    it 'renders the correct message' do
       course = build(
         :course,
         subjects: [build(:secondary_subject, :mathematics)]
       )
       result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+    end
+
+    it 'renders the correct course case' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :mathematics)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('mathematics')
-      then_i_should_see_the_ske_link
+    end
+
+    it 'renders the correct link' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :mathematics)]
+      )
+      render_inline(described_class.new(course: course.decorate))
+      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end
   end
 
@@ -42,7 +70,56 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       result = render_inline(described_class.new(course: course.decorate))
 
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
-      then_i_should_see_the_ske_link
+    end
+
+    it 'renders the correct course case' do
+      course = build(
+        :course,
+        subjects: [build(:modern_languages_subject, :german), build(:modern_languages_subject, :spanish)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include('German with Spanish')
+    end
+
+    it 'renders the correct link' do
+      course = build(
+        :course,
+        subjects: [build(:modern_languages_subject, :german), build(:modern_languages_subject, :spanish)]
+      )
+      render_inline(described_class.new(course: course.decorate))
+      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
+    end
+  end
+
+  context 'with english as the second subject_knowledge_enhancement_subject' do
+    it 'renders correct message' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+    end
+
+    it 'renders the correct course case' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include('mathematics with English')
+    end
+
+    it 'renders the correct link' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)]
+      )
+      render_inline(described_class.new(course: course.decorate))
+      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end
   end
 
@@ -55,7 +132,25 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       result = render_inline(described_class.new(course: course.decorate))
 
       expect(result.text).to include('If you need to improve your primary mathematics knowledge, you may be asked to complete a')
-      then_i_should_see_the_ske_link
+    end
+
+    it 'renders the correct course case' do
+      course = build(
+        :course,
+        subjects: [build(:primary_subject, :primary_with_mathematics)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include('primary mathematics')
+    end
+
+    it 'renders the correct link' do
+      course = build(
+        :course,
+        subjects: [build(:primary_subject, :primary_with_mathematics)]
+      )
+      render_inline(described_class.new(course: course.decorate))
+      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end
   end
 

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -78,7 +78,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
   context 'with a none subject_knowledge subject as the first subject and a subject_knowledge subject as the second' do
     let(:subjects) { [build(:secondary_subject, :art_and_design), build(:secondary_subject, :english)] }
 
-    it 'renders correct message' do
+    it 'does not render the ske message' do
       expect(result.text).not_to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
     end
   end
@@ -92,6 +92,24 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct course case' do
       expect(result.text).to include('primary mathematics')
+    end
+
+    it 'renders the correct link' do
+      render_inline(described_class.new(course: course.decorate))
+      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
+    end
+  end
+
+  context 'with a modern language subject' do
+    let(:course_subject) { build(:secondary_subject, :modern_languages) }
+    let(:subjects) { [course_subject, build(:modern_languages_subject, :french)] }
+
+    it 'renders correct message' do
+      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+    end
+
+    it 'renders the correct course case' do
+      expect(result.text).to include('French')
     end
 
     it 'renders the correct link' do

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -6,12 +6,15 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
   let(:course) { build(:course, subjects:) }
   let(:subjects) { [build(:secondary_subject, subject_name)] }
   let(:result) { render_inline(described_class.new(course: course.decorate)) }
+  let(:ske_text) { 'or you’ve not used your subject knowledge in a while, you may be asked to complete a' }
+  let(:ske_url_name) { 'subject knowledge enhancement (SKE) course.' }
+  let(:ske_url) { 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement' }
 
   context 'when english is selected' do
     let(:subject_name) { :english }
 
     it 'renders correct message' do
-      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      expect(result.text).to include(ske_text)
     end
 
     it 'renders the correct course case' do
@@ -20,7 +23,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
+      expect(result).to have_link(ske_url_name, href: ske_url)
     end
   end
 
@@ -28,7 +31,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     let(:subject_name) { :mathematics }
 
     it 'renders the correct message' do
-      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      expect(result.text).to include(ske_text)
     end
 
     it 'renders the correct course case' do
@@ -37,7 +40,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
+      expect(result).to have_link(ske_url_name, href: ske_url)
     end
   end
 
@@ -45,7 +48,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     let(:subjects) { [build(:secondary_subject, :german), build(:secondary_subject, :spanish)] }
 
     it 'renders correct message' do
-      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      expect(result.text).to include(ske_text)
     end
 
     it 'renders the correct course case' do
@@ -54,7 +57,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
+      expect(result).to have_link(ske_url_name, href: ske_url)
     end
   end
 
@@ -62,7 +65,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     let(:subjects) { [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)] }
 
     it 'renders correct message' do
-      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      expect(result.text).to include(ske_text)
     end
 
     it 'renders the correct course case' do
@@ -71,7 +74,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
+      expect(result).to have_link(ske_url_name, href: ske_url)
     end
   end
 
@@ -79,7 +82,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     let(:subjects) { [build(:secondary_subject, :art_and_design), build(:secondary_subject, :english)] }
 
     it 'does not render the ske message' do
-      expect(result.text).not_to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      expect(result.text).not_to include(ske_text)
     end
   end
 
@@ -96,7 +99,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
+      expect(result).to have_link(ske_url_name, href: ske_url)
     end
   end
 
@@ -105,7 +108,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     let(:subjects) { [course_subject, build(:modern_languages_subject, :french)] }
 
     it 'renders correct message' do
-      expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+      expect(result.text).to include(ske_text)
     end
 
     it 'renders the correct course case' do
@@ -114,7 +117,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
+      expect(result).to have_link(ske_url_name, href: ske_url)
     end
   end
 

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -123,6 +123,18 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     end
   end
 
+  context 'with a none subject_knowledge subject as the first subject and a subject_knowledge subject as the second' do
+    it 'renders correct message' do
+      course = build(
+        :course,
+        subjects: [build(:secondary_subject, :art_and_design), build(:secondary_subject, :english)]
+      )
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).not_to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
+    end
+  end
+
   context 'with a primary maths subject_knowledge_enhancement_subject' do
     it 'renders correct message' do
       course = build(

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -3,164 +3,98 @@
 require 'rails_helper'
 
 describe Find::Courses::EntryRequirementsComponent::View, type: :component do
+  let(:course) { build(:course, subjects:) }
+  let(:subjects) { [build(:secondary_subject, subject_name)] }
+  let(:result) { render_inline(described_class.new(course: course.decorate)) }
+
   context 'when english is selected' do
+    let(:subject_name) { :english }
+
     it 'renders correct message' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :english)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
     end
 
     it 'renders the correct course case' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :english)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('English')
     end
 
     it 'renders the correct link' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :english)]
-      )
       render_inline(described_class.new(course: course.decorate))
       expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end
   end
 
   context 'when mathematics is selected' do
+    let(:subject_name) { :mathematics }
+
     it 'renders the correct message' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :mathematics)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
     end
 
     it 'renders the correct course case' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :mathematics)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
       expect(result.text).to include('mathematics')
     end
 
     it 'renders the correct link' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :mathematics)]
-      )
       render_inline(described_class.new(course: course.decorate))
       expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end
   end
 
   context 'with multiple subject_knowledge_enhancement_subjects' do
-    it 'renders correct message' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :german), build(:secondary_subject, :spanish)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
+    let(:subjects) { [build(:secondary_subject, :german), build(:secondary_subject, :spanish)] }
 
+    it 'renders correct message' do
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
     end
 
     it 'renders the correct course case' do
-      course = build(
-        :course,
-        subjects: [build(:modern_languages_subject, :german), build(:modern_languages_subject, :spanish)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
-
       expect(result.text).to include('German with Spanish')
     end
 
     it 'renders the correct link' do
-      course = build(
-        :course,
-        subjects: [build(:modern_languages_subject, :german), build(:modern_languages_subject, :spanish)]
-      )
       render_inline(described_class.new(course: course.decorate))
       expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end
   end
 
   context 'with english as the second subject_knowledge_enhancement_subject' do
-    it 'renders correct message' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
+    let(:subjects) { [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)] }
 
+    it 'renders correct message' do
       expect(result.text).to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
     end
 
     it 'renders the correct course case' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
-
       expect(result.text).to include('mathematics with English')
     end
 
     it 'renders the correct link' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)]
-      )
       render_inline(described_class.new(course: course.decorate))
       expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end
   end
 
   context 'with a none subject_knowledge subject as the first subject and a subject_knowledge subject as the second' do
-    it 'renders correct message' do
-      course = build(
-        :course,
-        subjects: [build(:secondary_subject, :art_and_design), build(:secondary_subject, :english)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
+    let(:subjects) { [build(:secondary_subject, :art_and_design), build(:secondary_subject, :english)] }
 
+    it 'renders correct message' do
       expect(result.text).not_to include('or you’ve not used your subject knowledge in a while, you may be asked to complete a')
     end
   end
 
   context 'with a primary maths subject_knowledge_enhancement_subject' do
-    it 'renders correct message' do
-      course = build(
-        :course,
-        subjects: [build(:primary_subject, :primary_with_mathematics)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
+    let(:subjects) { [build(:primary_subject, :primary_with_mathematics)] }
 
+    it 'renders correct message' do
       expect(result.text).to include('If you need to improve your primary mathematics knowledge, you may be asked to complete a')
     end
 
     it 'renders the correct course case' do
-      course = build(
-        :course,
-        subjects: [build(:primary_subject, :primary_with_mathematics)]
-      )
-      result = render_inline(described_class.new(course: course.decorate))
-
       expect(result.text).to include('primary mathematics')
     end
 
     it 'renders the correct link' do
-      course = build(
-        :course,
-        subjects: [build(:primary_subject, :primary_with_mathematics)]
-      )
       render_inline(described_class.new(course: course.decorate))
       expect(page.has_link?('subject knowledge enhancement (SKE) course.', href: 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement')).to be true
     end


### PR DESCRIPTION
Context

We need to add some content about SKE to the entry requirements section for certain subjects as documented in this DH: https://bat-design-history.netlify.app/find-teacher-training/including-information-about-subject-knowledge-enhancement-ske-courses/

We need to add this content: "If your degree is not in [subject], or you’ve not used your subject knowledge in a while, you may be asked to complete a [subject knowledge enhancement (SKE) course](https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement)." for these courses:

biology
chemistry
computing
design and technology
English
languages (german spanish french)
mathematics
physics
religious education

For primary mathematics, we need to add:

"If you need to improve your primary mathematics knowledge, you may be asked to complete a [subject knowledge enhancement (SKE) course](https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement)."

### Changes proposed in this pull request

two methods added to view.rb, html paragraphs and 3 tests

### Guidance to review

https://bat-design-history.netlify.app/find-teacher-training/including-information-about-subject-knowledge-enhancement-ske-courses/

### Checklist

✅ Make sure all information from the Trello card is in here
✅ Attach to Trello card
✅ Rebased main
✅ Cleaned commit history (let me know if this is needed)
✅ Tested by running locally