### PR TITLE
[xxx] Enable Find routes in staging

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     match '/(*path)' => redirect { |_, req| "#{Settings.base_url}#{req.fullpath}" }, via: %i[get post put]
   end
 
-  if %w[development test review qa].include?(Rails.env)
+  unless Rails.env.production?
     constraints(FindConstraint.new) do
       draw(:find)
     end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /
+Allow: https://www.find-postgraduate-teacher-training.service.gov.uk/sitemap.xml
+Sitemap: https://www.find-postgraduate-teacher-training.service.gov.uk/sitemap.xml


### PR DESCRIPTION
### Context

We're now pointing https://staging.find-postgraduate-teacher-training.service.gov.uk/ to publish. We need to activate the routes so the app handles the incoming request.

This PR also disallows crawling of any page except for the Find sitemap in prod as staging/prod for Find are publicly available.
