### PR TITLE
Comply with rubocop (rails.yml)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ Rails.application.load_tasks
 if %w[development test].include? Rails.env
   task lint: %w[lint:ruby lint:erb lint:js]
   task parallel: ['parallel:spec']
-  task :javascript_specs do
+  task javascript_specs: :environment do
     system 'yarn run test'
   end
 

--- a/app/controllers/concerns/errorable.rb
+++ b/app/controllers/concerns/errorable.rb
@@ -4,14 +4,14 @@ module Errorable
   extend ActiveSupport::Concern
 
   def not_found
-    render status: 404, template: 'errors/not_found'
+    render status: :not_found, template: 'errors/not_found'
   end
 
   def forbidden
-    render status: 403, template: 'errors/forbidden'
+    render status: :forbidden, template: 'errors/forbidden'
   end
 
   def internal_server_error
-    render status: 500, template: 'errors/internal_server_error'
+    render status: :internal_server_error, template: 'errors/internal_server_error'
   end
 end

--- a/app/controllers/publish/courses/sites_controller.rb
+++ b/app/controllers/publish/courses/sites_controller.rb
@@ -71,7 +71,7 @@ module Publish
         selected_site_ids = params.dig(:course, :site_statuses_attributes)
                                   .values
                                   .select { |field| field['selected'] == '1' }
-                                  .map { |field| field['id'] }
+                                  .pluck('id')
 
         params['course']['sites_ids'] = selected_site_ids
         params['course'].delete('site_statuses_attributes')

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -246,7 +246,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def selected_subject_ids
-    selectable_subject_ids = course.subjects.map { |subject| subject['id'] }
+    selectable_subject_ids = course.subjects.pluck('id')
     selected_subject_ids = subjects.map(&:id)
 
     selectable_subject_ids & selected_subject_ids

--- a/app/forms/publish/age_range_form.rb
+++ b/app/forms/publish/age_range_form.rb
@@ -74,7 +74,7 @@ module Publish
     end
 
     def process_custom_range?
-      age_range_in_years.present? && age_range_in_years != 'other' && !presets.include?(age_range_in_years)
+      age_range_in_years.present? && age_range_in_years != 'other' && presets.exclude?(age_range_in_years)
     end
 
     def extract_from_years

--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -2,7 +2,7 @@
 
 module NavigationBarHelper
   def render_navigation_bar?(provider)
-    !request.path.include?('support') &&
+    request.path.exclude?('support') &&
       provider && !current_page?(root_path) && !current_page?(publish_provider_path(provider.provider_code)) &&
       provider.recruitment_cycle
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -156,7 +156,7 @@ class Course < ApplicationRecord
   end
 
   has_one :latest_published_enrichment, -> { published.order('created_at DESC, id DESC').limit(1) },
-          class_name: 'CourseEnrichment'
+          class_name: 'CourseEnrichment', inverse_of: :course
 
   scope :within, lambda { |range, origin:|
     joins(site_statuses: :site).merge(SiteStatus.where(status: :running)).merge(Site.within(range, origin:))

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -914,7 +914,7 @@ class Course < ApplicationRecord
   def validate_applications_open_from
     if applications_open_from.blank? || applications_open_from.is_a?(Struct)
       errors.add(:applications_open_from, :blank)
-    elsif !valid_date_range.include?(applications_open_from)
+    elsif valid_date_range.exclude?(applications_open_from)
       chosen_date = short_date(applications_open_from)
       start_date = short_date(recruitment_cycle.application_start_date)
       end_date = short_date(recruitment_cycle.application_end_date)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -94,7 +94,7 @@ class Provider < ApplicationRecord
     if timestamp.present?
       where('provider.changed_at > ?', timestamp)
     else
-      where('changed_at is not null')
+      where.not(changed_at: nil)
     end.order(:changed_at, :id)
   }
 

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -52,7 +52,7 @@ class ProviderPolicy
   def can_show_training_provider?
     return true if user.admin?
 
-    accredited_bodies_codes = provider.accredited_bodies.map { |ab| ab[:provider_code] }
+    accredited_bodies_codes = provider.accredited_bodies.pluck(:provider_code)
     user_provider_codes = user.providers.pluck(:provider_code)
 
     !(accredited_bodies_codes & user_provider_codes).compact.empty?

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,9 +15,6 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/FindById:
-  Enabled: false
-
 Rails/MatchRoute:
   Enabled: false
 

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -1,7 +1,4 @@
 require: rubocop-rails
-Rails/Output:
-  Exclude:
-    - config/initializers/console.rb
 
 Rails/SkipsModelValidations:
   Enabled: false

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -8,15 +8,12 @@ Rails/SkipsModelValidations:
     - 'app/models/provider.rb'
     - 'app/services/subjects/financial_incentive_set_subject_knowledge_enhancement_course_available_service.rb'
     - 'lib/tasks/migrate_user_organisation_to_user_permission.rake'
+
 Rails/OutputSafety:
   Enabled: false
 
 Rails/HasManyOrHasOneDependent:
   Enabled: false
-
-Rails/InverseOf:
-  Exclude:
-    - app/models/course.rb
 
 Rails/HttpStatus:
   Enabled: false

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -1,8 +1,13 @@
 require: rubocop-rails
 
 Rails/SkipsModelValidations:
-  Enabled: false
-
+  Exclude:
+    - 'spec/**/*'
+    - 'db/**/*'
+    - 'app/models/course.rb'
+    - 'app/models/provider.rb'
+    - 'app/services/subjects/financial_incentive_set_subject_knowledge_enhancement_course_available_service.rb'
+    - 'lib/tasks/migrate_user_organisation_to_user_permission.rake'
 Rails/OutputSafety:
   Enabled: false
 

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,9 +15,6 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/NegateInclude:
-  Enabled: false
-
 Rails/Pluck:
   Enabled: false
 

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -21,4 +21,3 @@ Rails/UnknownEnv:
     - development
     - test
     - sandbox
-    - research

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -1,25 +1,4 @@
 require: rubocop-rails
-
-# We do not want to subclass from ApplicationController. This enables separation
-# between the namespaces, and allows subclassing from ActionController::API in
-# the Vendor API.
-Rails/ApplicationController:
-  Enabled: false
-
-# Rails does not actually allow "dynamic find_by", so this cop yields false positives
-# like `VendorApiToken.find_by_unhashed_token` (which we implement ourselves)
-Rails/DynamicFindBy:
-  Enabled: false
-
-# Not all rake tasks need :environment
-Rails/RakeEnvironment:
-  Enabled: false
-
-# This cop demands a default value for not-null columns, which is not possible
-# when dealing with references
-Rails/NotNullColumn:
-  Enabled: false
-
 Rails/Output:
   Exclude:
     - config/initializers/console.rb

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,17 +15,8 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/AfterCommitOverride:
-  Enabled: true
-
 Rails/FindById:
   Enabled: false
-
-Rails/Inquiry:
-  Enabled: true
-
-Rails/MailerName:
-  Enabled: true
 
 Rails/MatchRoute:
   Enabled: false
@@ -36,23 +27,8 @@ Rails/NegateInclude:
 Rails/Pluck:
   Enabled: false
 
-Rails/PluckInWhere:
-  Enabled: true
-
-Rails/RenderInline:
-  Enabled: true
-
-Rails/RenderPlainText:
-  Enabled: true
-
-Rails/ShortI18n:
-  Enabled: true
-
 Rails/SquishedSQLHeredocs:
   Enabled: false
-
-Rails/WhereExists:
-  Enabled: true
 
 Rails/WhereNot:
   Enabled: false

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -1,8 +1,5 @@
 require: rubocop-rails
 
-Rails/BulkChangeTable:
-  Enabled: false
-
 # We do not want to subclass from ApplicationController. This enables separation
 # between the namespaces, and allows subclassing from ActionController::API in
 # the Vendor API.

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,9 +15,6 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/ActiveRecordCallbacksOrder:
-  Enabled: true
-
 Rails/AfterCommitOverride:
   Enabled: true
 

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,9 +15,6 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/Pluck:
-  Enabled: false
-
 Rails/SquishedSQLHeredocs:
   Enabled: false
 

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,9 +15,6 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/HttpStatus:
-  Enabled: false
-
 Rails/ActiveRecordCallbacksOrder:
   Enabled: true
 

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,9 +15,6 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/WhereNot:
-  Enabled: false
-
 Rails/UnknownEnv:
   Environments:
     - production

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,9 +15,6 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/SquishedSQLHeredocs:
-  Enabled: false
-
 Rails/WhereNot:
   Enabled: false
 

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -15,9 +15,6 @@ Rails/OutputSafety:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Rails/MatchRoute:
-  Enabled: false
-
 Rails/NegateInclude:
   Enabled: false
 

--- a/db/migrate/20190626132627_add_course_ref_to_course_enrichment.rb
+++ b/db/migrate/20190626132627_add_course_ref_to_course_enrichment.rb
@@ -4,7 +4,7 @@ class AddCourseRefToCourseEnrichment < ActiveRecord::Migration[5.2]
   def up
     add_reference :course_enrichment, :course, index: true, type: :int
 
-    execute <<-SQL
+    execute <<-SQL.squish
     UPDATE course_enrichment
     SET    course_id =
            (

--- a/db/migrate/20190627151832_add_provider_ref_to_provider_enrichment.rb
+++ b/db/migrate/20190627151832_add_provider_ref_to_provider_enrichment.rb
@@ -4,7 +4,7 @@ class AddProviderRefToProviderEnrichment < ActiveRecord::Migration[5.2]
   def up
     add_reference :provider_enrichment, :provider, index: true, type: :int
 
-    execute <<-SQL
+    execute <<-SQL.squish
     UPDATE provider_enrichment
     SET    provider_id =
            (

--- a/db/migrate/20210527145331_add_visa_columns_to_the_database.rb
+++ b/db/migrate/20210527145331_add_visa_columns_to_the_database.rb
@@ -2,7 +2,9 @@
 
 class AddVisaColumnsToTheDatabase < ActiveRecord::Migration[6.1]
   def change
-    add_column :provider, :can_sponsor_skilled_worker_visa, :boolean
-    add_column :provider, :can_sponsor_student_visa, :boolean
+    change_table :provider, bulk: true do |t|
+      t.column :can_sponsor_skilled_worker_visa, :boolean
+      t.column :can_sponsor_student_visa, :boolean
+    end
   end
 end

--- a/db/migrate/20210609081246_add_structured_degree_columns_to_the_course_table.rb
+++ b/db/migrate/20210609081246_add_structured_degree_columns_to_the_course_table.rb
@@ -2,8 +2,10 @@
 
 class AddStructuredDegreeColumnsToTheCourseTable < ActiveRecord::Migration[6.1]
   def change
-    add_column :course, :degree_grade, :integer
-    add_column :course, :additional_degree_subject_requirements, :boolean
-    add_column :course, :degree_subject_requirements, :string
+    change_table :course, bulk: true do |t|
+      t.column :degree_grade, :integer
+      t.column :additional_degree_subject_requirements, :boolean
+      t.column :degree_subject_requirements, :string
+    end
   end
 end

--- a/db/migrate/20210614130500_add_structured_gcse_columns_to_course_table.rb
+++ b/db/migrate/20210614130500_add_structured_gcse_columns_to_course_table.rb
@@ -2,11 +2,13 @@
 
 class AddStructuredGcseColumnsToCourseTable < ActiveRecord::Migration[6.1]
   def change
-    add_column :course, :accept_pending_gcse, :boolean, default: false
-    add_column :course, :accept_gcse_equivalency, :boolean, default: false
-    add_column :course, :accept_english_gcse_equivalency, :boolean, default: false
-    add_column :course, :accept_maths_gcse_equivalency, :boolean, default: false
-    add_column :course, :accept_science_gcse_equivalency, :boolean, default: false
-    add_column :course, :additional_gcse_equivalencies, :string
+    change_table :course, bulk: true do |t|
+      t.column :accept_pending_gcse, :boolean, default: false
+      t.column :accept_gcse_equivalency, :boolean, default: false
+      t.column :accept_english_gcse_equivalency, :boolean, default: false
+      t.column :accept_maths_gcse_equivalency, :boolean, default: false
+      t.column :accept_science_gcse_equivalency, :boolean, default: false
+      t.column :additional_gcse_equivalencies, :string
+    end
   end
 end

--- a/db/migrate/20210623150714_remove_structured_gcse_columns_from_course_table.rb
+++ b/db/migrate/20210623150714_remove_structured_gcse_columns_from_course_table.rb
@@ -2,17 +2,19 @@
 
 class RemoveStructuredGcseColumnsFromCourseTable < ActiveRecord::Migration[6.1]
   def change
-    remove_column :course, :accept_pending_gcse, :boolean
-    remove_column :course, :accept_gcse_equivalency, :boolean
-    remove_column :course, :accept_english_gcse_equivalency, :boolean
-    remove_column :course, :accept_maths_gcse_equivalency, :boolean
-    remove_column :course, :accept_science_gcse_equivalency, :boolean
-    remove_column :course, :additional_gcse_equivalencies, :string
-    add_column :course, :accept_pending_gcse, :boolean
-    add_column :course, :accept_gcse_equivalency, :boolean
-    add_column :course, :accept_english_gcse_equivalency, :boolean
-    add_column :course, :accept_maths_gcse_equivalency, :boolean
-    add_column :course, :accept_science_gcse_equivalency, :boolean
-    add_column :course, :additional_gcse_equivalencies, :string
+    change_table :course, bulk: true do |t|
+      t.remove :accept_pending_gcse, type: :boolean
+      t.remove :accept_gcse_equivalency, type: :boolean
+      t.remove :accept_english_gcse_equivalency, type: :boolean
+      t.remove :accept_maths_gcse_equivalency, type: :boolean
+      t.remove :accept_science_gcse_equivalency, type: :boolean
+      t.remove :additional_gcse_equivalencies, type: :string
+      t.column :accept_pending_gcse, :boolean
+      t.column :accept_gcse_equivalency, :boolean
+      t.column :accept_english_gcse_equivalency, :boolean
+      t.column :accept_maths_gcse_equivalency, :boolean
+      t.column :accept_science_gcse_equivalency, :boolean
+      t.column :additional_gcse_equivalencies, :string
+    end
   end
 end

--- a/db/migrate/20210712082658_remove_london_borough_and_travel_to_work_area_from_site.rb
+++ b/db/migrate/20210712082658_remove_london_borough_and_travel_to_work_area_from_site.rb
@@ -2,7 +2,9 @@
 
 class RemoveLondonBoroughAndTravelToWorkAreaFromSite < ActiveRecord::Migration[6.1]
   def change
-    remove_column :site, :travel_to_work_area, :string
-    remove_column :site, :london_borough, :string
+    change_table :site, bulk: true do |t|
+      t.remove :travel_to_work_area, type: :string
+      t.remove :london_borough, type: :string
+    end
   end
 end

--- a/db/migrate/20220825093437_add_visa_fields_to_course.rb
+++ b/db/migrate/20220825093437_add_visa_fields_to_course.rb
@@ -2,9 +2,11 @@
 
 class AddVisaFieldsToCourse < ActiveRecord::Migration[7.0]
   def change
-    add_column :course, :can_sponsor_skilled_worker_visa, :boolean, default: false
-    add_column :course, :can_sponsor_student_visa, :boolean, default: false
-    add_index :course, :can_sponsor_skilled_worker_visa
-    add_index :course, :can_sponsor_student_visa
+    change_table :course, bulk: true do |t|
+      t.column :can_sponsor_skilled_worker_visa, :boolean, default: false
+      t.column :can_sponsor_student_visa, :boolean, default: false
+      t.index :can_sponsor_skilled_worker_visa
+      t.index :can_sponsor_student_visa
+    end
   end
 end

--- a/db/migrate/20221018084448_update_etp_field.rb
+++ b/db/migrate/20221018084448_update_etp_field.rb
@@ -2,8 +2,10 @@
 
 class UpdateEtpField < ActiveRecord::Migration[7.0]
   def change
-    remove_column :course, :campaign_name, :string
-    add_column :course, :campaign_name, :integer
-    add_index :course, :campaign_name
+    change_table :course, bulk: true do |t|
+      t.remove :campaign_name, type: :string
+      t.column :campaign_name, :integer
+      t.index :campaign_name
+    end
   end
 end

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -105,7 +105,7 @@ module GovukTechDocs
           # Must be a schema be referenced by another schema
           # And not a property of a schema
           if property.node_context.referenced_by.to_s.include?('#/components/schemas') &&
-             !property.node_context.source_location.to_s.include?('/properties/')
+             property.node_context.source_location.to_s.exclude?('/properties/')
             schema_name = get_schema_name(property.node_context.source_location.to_s)
           end
           schemas.push schema_name unless schema_name.nil?

--- a/spec/support/matchers/have_courses.rb
+++ b/spec/support/matchers/have_courses.rb
@@ -4,7 +4,7 @@ RSpec::Matchers.define :have_courses do |*expected_courses|
   expected_courses = expected_courses.flatten
   def course_codes(server_response_body)
     json = JSON.parse(server_response_body)
-    json.map { |course| course['course_code'] }
+    json.pluck('course_code')
   end
 
   match do |server_response_body|

--- a/spec/support/matchers/have_providers.rb
+++ b/spec/support/matchers/have_providers.rb
@@ -4,7 +4,7 @@ RSpec::Matchers.define :have_providers do |*expected_providers|
   expected_providers = expected_providers.flatten
   def provider_codes(server_response_body)
     json = JSON.parse(server_response_body)
-    json.map { |provider| provider['institution_code'] }
+    json.pluck('institution_code')
   end
 
   match do |server_response_body|

--- a/spec/support/parse_text_table.rb
+++ b/spec/support/parse_text_table.rb
@@ -69,7 +69,7 @@ RSpec::Matchers.define :have_cell_containing do |text|
     elsif @at_row
       text_table[@at_row]
     elsif @at_column
-      text_table.map { |row| row[@at_column] }
+      text_table.pluck(@at_column)
     end
   end
 


### PR DESCRIPTION
### Context

We have lots of tech debt because of cops not being enabled. This PR enables some of them and fixes the bad code. 

**This PR focuses on clearing out the `rails.yml` file.**

### Changes proposed in this pull request

See commits

### Guidance to review

- Recommend reviewing commit by commit, as in each commit  one particular cop is enabled and all the code is adjusted to pass the linter.

- Do we want to keep any of these cops disabled?

- Play around with the review app in areas which relies on lots of code working together to ensure there are no (untested) hidden breakages.

- Check everywhere (Find/Publish/Support)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
