### PR TITLE
Comply with rubocop (rspec.yml)

### DIFF
--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -1,9 +1,5 @@
 require: rubocop-rspec
 
-RSpec/NestedGroups:
-  Enabled: true
-  Max: 4
-
 RSpec/ExampleLength:
   Enabled: false
 

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -12,11 +12,6 @@ RSpec/ContextWording:
 RSpec/LetSetup:
   Enabled: false
 
-# This cop wants us to use `expect().to change(Candidate, :count)` instead
-# of `expect().to change { Candidate.count }`, which does not seem better.
-RSpec/ExpectChange:
-  Enabled: false
-
 RSpec/LeadingSubject:
   Enabled: false
 

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -12,9 +12,6 @@ RSpec/ContextWording:
 RSpec/LetSetup:
   Enabled: false
 
-RSpec/LeadingSubject:
-  Enabled: false
-
 # In acceptance tests it's often handy to user instance variables to keep track of state
 RSpec/InstanceVariable:
   Enabled: false

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -9,11 +9,6 @@ RSpec/MultipleExpectations:
 RSpec/ContextWording:
   Enabled: false
 
-# we have a property called "subject" in some factories
-RSpec/EmptyLineAfterSubject:
-  Exclude:
-    - 'spec/factories/*.rb'
-
 RSpec/LetSetup:
   Enabled: false
 

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -15,6 +15,7 @@ RSpec/LetSetup:
 RSpec/DescribedClass:
   Exclude:
     - 'spec/controllers/concerns/error_handlers_base_spec.rb'
+    - 'spec/models/site_status_spec.rb'
 
 RSpec/LeadingSubject:
   Exclude:

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -12,6 +12,14 @@ RSpec/ContextWording:
 RSpec/LetSetup:
   Enabled: false
 
+RSpec/DescribedClass:
+  Exclude:
+    - 'spec/controllers/concerns/error_handlers_base_spec.rb'
+
+RSpec/LeadingSubject:
+  Exclude:
+    - 'spec/validators/words_count_validator_spec.rb'
+
 # In acceptance tests it's often handy to user instance variables to keep track of state
 RSpec/InstanceVariable:
   Enabled: false

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -12,10 +12,6 @@ RSpec/ContextWording:
 RSpec/LetSetup:
   Enabled: false
 
-# It's better to be explicit about the class that's being tested
-RSpec/DescribedClass:
-  Enabled: false
-
 # This cop wants us to use `expect().to change(Candidate, :count)` instead
 # of `expect().to change { Candidate.count }`, which does not seem better.
 RSpec/ExpectChange:

--- a/docs/spec/govuk_tech_docs/open_api/renderer_spec.rb
+++ b/docs/spec/govuk_tech_docs/open_api/renderer_spec.rb
@@ -111,9 +111,9 @@ RSpec.describe GovukTechDocs::OpenApi::Renderer do
     end
 
     describe '#json_output' do
-      let(:document) { Openapi3Parser.load(spec) }
-
       subject { described_class.new(nil, document) }
+
+      let(:document) { Openapi3Parser.load(spec) }
 
       it 'renders first anyOf reference example' do
         schema = document.paths['/widgets'].get.node_data['responses']['200']['content']['application/json']['schema']

--- a/spec/components/notification_banner_spec.rb
+++ b/spec/components/notification_banner_spec.rb
@@ -6,7 +6,7 @@ describe NotificationBanner do
   alias_method :component, :page
 
   context 'with no arguments' do
-    before { render_inline(NotificationBanner.new) }
+    before { render_inline(described_class.new) }
 
     it 'adds the default class' do
       expect(component).to have_selector('.govuk-notification-banner')
@@ -34,7 +34,7 @@ describe NotificationBanner do
   end
 
   context 'when type is success' do
-    before { render_inline(NotificationBanner.new(type: :success)) }
+    before { render_inline(described_class.new(type: :success)) }
 
     it 'adds the success type class' do
       expect(component).to have_selector('.govuk-notification-banner--success')
@@ -50,24 +50,24 @@ describe NotificationBanner do
   end
 
   it 'supports custom title and text' do
-    render_inline(NotificationBanner.new(title_text: 'title', text: 'text'))
+    render_inline(described_class.new(title_text: 'title', text: 'text'))
     expect(component).to have_text('title')
     expect(component).to have_text('text')
   end
 
   it 'supports a custom role' do
-    render_inline(NotificationBanner.new(role: 'role'))
+    render_inline(described_class.new(role: 'role'))
     expect(banner['role']).to eq('role')
   end
 
   it 'supports a custom id on the title element and sets the ariaLabelledBy' do
-    render_inline(NotificationBanner.new(title_id: 'test-id'))
+    render_inline(described_class.new(title_id: 'test-id'))
     expect(component).to have_selector('.govuk-notification-banner__title#test-id')
     expect(banner['aria-labelledby']).to eq 'test-id'
   end
 
   it 'supports disabling autofocus' do
-    render_inline(NotificationBanner.new(disable_auto_focus: true))
+    render_inline(described_class.new(disable_auto_focus: true))
     expect(banner['data-disable-auto-focus']).to eq('true')
   end
 

--- a/spec/components/page_title_spec.rb
+++ b/spec/components/page_title_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PageTitle do
 
   context 'given a string that is not in the format of an i18n path' do
     it 'constructs a page title using the provided value' do
-      component = PageTitle.new(title: 'Some title')
+      component = described_class.new(title: 'Some title')
       page_title = component.build_page_title
       expect(page_title).to eq('Some title - Cool Service - GOV.UK')
     end
@@ -17,7 +17,7 @@ RSpec.describe PageTitle do
 
   context 'when has_errors is true' do
     it 'constructs a page title value with an error' do
-      component = PageTitle.new(title: 'Some title', has_errors: true)
+      component = described_class.new(title: 'Some title', has_errors: true)
       page_title = component.build_page_title
       expect(page_title).to eq('Error: Some title - Cool Service - GOV.UK')
     end
@@ -29,7 +29,7 @@ RSpec.describe PageTitle do
     end
 
     it 'constructs a page title value' do
-      component = PageTitle.new(title: 'sign_in.index')
+      component = described_class.new(title: 'sign_in.index')
       page_title = component.build_page_title
       expect(page_title).to eq('Sign in - Cool Service - GOV.UK')
     end

--- a/spec/controllers/concerns/error_handlers_base_spec.rb
+++ b/spec/controllers/concerns/error_handlers_base_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe ErrorHandlers::Base do
   controller(ActionController::Base) do
-    include ErrorHandlers::Base
+    include described_class
 
     def error
       raise hell

--- a/spec/controllers/concerns/error_handlers_base_spec.rb
+++ b/spec/controllers/concerns/error_handlers_base_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe ErrorHandlers::Base do
   controller(ActionController::Base) do
-    include described_class
+    include ErrorHandlers::Base
 
     def error
       raise hell

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -811,11 +811,11 @@ describe CourseDecorator do
   end
 
   describe '#cycle_range' do
+    subject { course.decorate.cycle_range }
+
     let(:expected_cycle_range) do
       "#{current_recruitment_cycle.year} to #{current_recruitment_cycle.year.to_i + 1}"
     end
-
-    subject { course.decorate.cycle_range }
 
     it 'states the correct cycle range' do
       expect(subject).to eq(expected_cycle_range)

--- a/spec/deserializers/api/v3/deserializable_site_spec.rb
+++ b/spec/deserializers/api/v3/deserializable_site_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe API::V3::DeserializableSite do
+  subject { described_class.new(site_jsonapi).to_h }
+
   let(:site) { build(:site) }
   let(:site_jsonapi) do
     JSON.parse(jsonapi_renderer.render(
@@ -13,8 +15,6 @@ describe API::V3::DeserializableSite do
     ).to_json)['data']
   end
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
-
-  subject { described_class.new(site_jsonapi).to_h }
 
   describe 'attributes' do
     it { is_expected.to include(address1: site.address1) }

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -13,7 +13,7 @@ module Support
     subject { described_class.new(course) }
 
     it 'can initalise an instance of itself' do
-      expect(subject).to be_instance_of(EditCourseForm)
+      expect(subject).to be_instance_of(described_class)
     end
 
     describe '#save' do

--- a/spec/forms/publish/course_funding_form_spec.rb
+++ b/spec/forms/publish/course_funding_form_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 describe Publish::CourseFundingForm, type: :model do
+  subject { described_class.new(course, params:) }
+
   let(:course) { create(:course, :fee_type_based) }
   let(:course_store) { double(Stores::CourseStore) }
   let(:params) { {} }
-
-  subject { described_class.new(course, params:) }
 
   before do
     allow(course_store).to receive(:get).and_return(nil)
@@ -161,8 +161,8 @@ describe Publish::CourseFundingForm, type: :model do
 
           it 'updates the course with the new details' do
             expect { subject.save! }
-              .to change { course.funding_type }.from('fee').to('apprenticeship')
-              .and change { course.can_sponsor_skilled_worker_visa }.from(false).to(true)
+              .to change(course, :funding_type).from('fee').to('apprenticeship')
+              .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
               .and change { course.enrichments.last.fee_details }.to(nil)
               .and change { course.enrichments.last.fee_international }.to(nil)
               .and change { course.enrichments.last.fee_uk_eu }.to(nil)
@@ -175,8 +175,8 @@ describe Publish::CourseFundingForm, type: :model do
 
           it 'updates the course with the new details' do
             expect { subject.save! }
-              .to change { course.funding_type }.from('fee').to('salary')
-              .and change { course.can_sponsor_skilled_worker_visa }.from(false).to(true)
+              .to change(course, :funding_type).from('fee').to('salary')
+              .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
               .and change { course.enrichments.last.fee_details }.to(nil)
               .and change { course.enrichments.last.fee_international }.to(nil)
               .and change { course.enrichments.last.fee_uk_eu }.to(nil)
@@ -193,8 +193,8 @@ describe Publish::CourseFundingForm, type: :model do
 
           it 'updates the course with the new details' do
             expect { subject.save! }
-              .to change { course.funding_type }.from('salary').to('apprenticeship')
-              .and change { course.can_sponsor_skilled_worker_visa }.from(false).to(true)
+              .to change(course, :funding_type).from('salary').to('apprenticeship')
+              .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
               .and change { course.enrichments.last.fee_details }.to(nil)
               .and change { course.enrichments.last.fee_international }.to(nil)
               .and change { course.enrichments.last.fee_uk_eu }.to(nil)
@@ -207,8 +207,8 @@ describe Publish::CourseFundingForm, type: :model do
 
           it 'updates the course with the new details' do
             expect { subject.save! }
-              .to change { course.funding_type }.from('salary').to('fee')
-              .and change { course.can_sponsor_student_visa }.from(false).to(true)
+              .to change(course, :funding_type).from('salary').to('fee')
+              .and change(course, :can_sponsor_student_visa).from(false).to(true)
               .and change { course.enrichments.last.salary_details }.to(nil)
           end
         end
@@ -222,8 +222,8 @@ describe Publish::CourseFundingForm, type: :model do
 
           it 'updates the course with the new details' do
             expect { subject.save! }
-              .to change { course.funding_type }.from('apprenticeship').to('salary')
-              .and change { course.can_sponsor_skilled_worker_visa }.from(false).to(true)
+              .to change(course, :funding_type).from('apprenticeship').to('salary')
+              .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
               .and change { course.enrichments.last.fee_details }.to(nil)
               .and change { course.enrichments.last.fee_international }.to(nil)
               .and change { course.enrichments.last.fee_uk_eu }.to(nil)
@@ -236,8 +236,8 @@ describe Publish::CourseFundingForm, type: :model do
 
           it 'updates the course with the new details' do
             expect { subject.save! }
-              .to change { course.funding_type }.from('apprenticeship').to('fee')
-              .and change { course.can_sponsor_student_visa }.from(false).to(true)
+              .to change(course, :funding_type).from('apprenticeship').to('fee')
+              .and change(course, :can_sponsor_student_visa).from(false).to(true)
               .and change { course.enrichments.last.salary_details }.to(nil)
           end
         end
@@ -248,7 +248,7 @@ describe Publish::CourseFundingForm, type: :model do
 
         it 'does not update the course with invalid details' do
           expect { subject.save! }
-            .not_to(change { course.funding_type })
+            .not_to(change(course, :funding_type))
         end
       end
 
@@ -257,7 +257,7 @@ describe Publish::CourseFundingForm, type: :model do
 
         it 'does not update the course with invalid details' do
           expect { subject.save! }
-            .not_to(change { course.can_sponsor_student_visa })
+            .not_to(change(course, :can_sponsor_student_visa))
         end
       end
 
@@ -267,7 +267,7 @@ describe Publish::CourseFundingForm, type: :model do
 
         it 'does not update the course with invalid details' do
           expect { subject.save! }
-            .not_to(change { course.can_sponsor_skilled_worker_visa })
+            .not_to(change(course, :can_sponsor_skilled_worker_visa))
         end
       end
     end

--- a/spec/forms/support/user_form_spec.rb
+++ b/spec/forms/support/user_form_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 describe Support::UserForm, type: :model do
+  subject { described_class.new(user, model, params:) }
+
   let(:user) { create(:user) }
   let(:model) { create(:user) }
   let(:user_store) { double(Stores::UserStore) }
   let(:params) { { email: 'foo@bar.com', first_name: 'Foo', last_name: 'Bar' } }
-
-  subject { described_class.new(user, model, params:) }
 
   before do
     allow(user_store).to receive(:get).and_return(nil)
@@ -55,9 +55,9 @@ describe Support::UserForm, type: :model do
     context 'valid form' do
       it 'updates the provider user with the new details' do
         expect { subject.save! }
-          .to change { model.first_name }.to('Foo')
-                                         .and change { model.last_name }.to('Bar')
-                                                                        .and change { model.email }.to('foo@bar.com')
+          .to change(model, :first_name).to('Foo')
+                                        .and change(model, :last_name).to('Bar')
+                                                                      .and change(model, :email).to('foo@bar.com')
       end
     end
 
@@ -66,7 +66,7 @@ describe Support::UserForm, type: :model do
 
       it 'does not update the provider user with invalid details' do
         expect { subject.save! }
-          .not_to(change { model.email })
+          .not_to(change(model, :email))
       end
     end
 
@@ -75,7 +75,7 @@ describe Support::UserForm, type: :model do
 
       it 'does not update the provider user with invalid details' do
         expect { subject.save! }
-          .not_to(change { model.first_name })
+          .not_to(change(model, :first_name))
       end
     end
 
@@ -84,7 +84,7 @@ describe Support::UserForm, type: :model do
 
       it 'does not update the provider user with invalid details' do
         expect { subject.save! }
-          .not_to(change { model.last_name })
+          .not_to(change(model, :last_name))
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -22,9 +22,9 @@ describe ApplicationHelper do
   end
 
   describe '#enrichment_summary' do
-    let(:summary_list) { GovukComponent::SummaryListComponent.new }
-
     subject { render(summary_list) }
+
+    let(:summary_list) { GovukComponent::SummaryListComponent.new }
 
     context 'with a value' do
       before do

--- a/spec/helpers/find/provider_helper_spec.rb
+++ b/spec/helpers/find/provider_helper_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 describe Find::ProviderHelper do
   describe '#select_provider_options' do
-    let(:providers) { build_list(:provider, 3) }
-
     subject { select_provider_options(providers) }
+
+    let(:providers) { build_list(:provider, 3) }
 
     it 'returns select provider options ids' do
       expect(subject.map(&:id)).to eql([''] + providers.map(&:provider_name))

--- a/spec/helpers/find/subject_helper_spec.rb
+++ b/spec/helpers/find/subject_helper_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 describe Find::SubjectHelper do
   describe '#secondary_subject_options' do
-    let(:subjects) { [find_or_create(:secondary_subject, :english)] }
-
     subject { secondary_subject_options(subjects) }
+
+    let(:subjects) { [find_or_create(:secondary_subject, :english)] }
 
     it 'returns secondary subject code' do
       expect(subject.first.code).to eq subjects.first.subject_code
@@ -82,9 +82,9 @@ describe Find::SubjectHelper do
   end
 
   describe '#primary_subject_options' do
-    let(:subjects) { [find_or_create(:primary_subject, :primary_with_english)] }
-
     subject { primary_subject_options(subjects) }
+
+    let(:subjects) { [find_or_create(:primary_subject, :primary_with_english)] }
 
     it 'returns primary subject code' do
       expect(subject.first.code).to eq subjects.first.subject_code

--- a/spec/helpers/publish/subject_helper_spec.rb
+++ b/spec/helpers/publish/subject_helper_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 describe Publish::SubjectHelper do
   describe '#primary_form_options' do
-    let(:subjects) { [find_or_create(:primary_subject, :primary_with_english)] }
-
     subject { primary_form_options(subjects) }
+
+    let(:subjects) { [find_or_create(:primary_subject, :primary_with_english)] }
 
     it 'returns primary subject code' do
       expect(subject.first.code).to eq 1 + subjects.first.subject_code.to_i

--- a/spec/helpers/vacancy_helper_spec.rb
+++ b/spec/helpers/vacancy_helper_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe VacancyHelper do
-  include VacancyHelper
+  include described_class
 
   describe '#vacancy_available_for_course_site_status' do
     let(:vacancy_study_mode) { nil }

--- a/spec/helpers/vacancy_helper_spec.rb
+++ b/spec/helpers/vacancy_helper_spec.rb
@@ -6,8 +6,6 @@ describe VacancyHelper do
   include described_class
 
   describe '#vacancy_available_for_course_site_status' do
-    let(:vacancy_study_mode) { nil }
-
     subject do
       vacancy_available_for_course_site_status?(
         course,
@@ -15,6 +13,8 @@ describe VacancyHelper do
         vacancy_study_mode
       )
     end
+
+    let(:vacancy_study_mode) { nil }
 
     context 'with a full time or part time course' do
       let(:course) { double(:course, study_mode: 'full_time_or_part_time') }

--- a/spec/jobs/geocode_job_spec.rb
+++ b/spec/jobs/geocode_job_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 describe GeocodeJob do
   include ActiveJob::TestHelper
 
+  subject(:job) { described_class.perform_later('Site', site.id) }
+
   after do
     clear_enqueued_jobs
     clear_performed_jobs
@@ -17,8 +19,6 @@ describe GeocodeJob do
           address4: nil,
           postcode: 'SO45 2PA')
   end
-
-  subject(:job) { described_class.perform_later('Site', site.id) }
 
   it 'queues the job' do
     expect { job }

--- a/spec/jobs/save_statistic_job_spec.rb
+++ b/spec/jobs/save_statistic_job_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 describe SaveStatisticJob do
   include ActiveJob::TestHelper
 
+  subject(:job) { described_class.perform_later }
+
   after do
     clear_enqueued_jobs
     clear_performed_jobs
   end
-
-  subject(:job) { described_class.perform_later }
 
   it 'queues the job' do
     expect { job }

--- a/spec/lib/find_constraint_spec.rb
+++ b/spec/lib/find_constraint_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 describe FindConstraint do
+  subject do
+    described_class.new.matches?(request)
+  end
+
   let(:request) do
     double(
       :request,
@@ -12,10 +16,6 @@ describe FindConstraint do
 
   let(:find_url) { 'find_url' }
   let(:host) { 'find_url' }
-
-  subject do
-    described_class.new.matches?(request)
-  end
 
   describe '#matched?' do
     before do

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -45,7 +45,7 @@ describe AccessRequest do
       let!(:access_request4) { create(:access_request, :approved) }
       let!(:access_request5) { create(:access_request, :completed) }
 
-      subject { AccessRequest.requested }
+      subject { described_class.requested }
 
       it { is_expected.to include access_request1, access_request2 }
       it { is_expected.not_to include access_request3, access_request4, access_request5 }
@@ -57,8 +57,8 @@ describe AccessRequest do
     let!(:access_request2) { create(:access_request, request_date_utc: 2.minutes.ago.utc) }
 
     it 'returns the new enrichment first' do
-      expect(AccessRequest.by_request_date.first).to eq access_request2
-      expect(AccessRequest.by_request_date.last).to eq access_request1
+      expect(described_class.by_request_date.first).to eq access_request2
+      expect(described_class.by_request_date.last).to eq access_request1
     end
   end
 
@@ -100,7 +100,7 @@ describe AccessRequest do
         access_request2.discard
       end
 
-      subject { AccessRequest.all }
+      subject { described_class.all }
 
       it { is_expected.to include access_request1, access_request3 }
     end

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -26,12 +26,12 @@ describe AccessRequest do
   end
 
   describe '#approve' do
-    let(:access_request) { build(:access_request) }
-
     subject { access_request.approve }
 
+    let(:access_request) { build(:access_request) }
+
     it 'marks the access request as completed' do
-      expect { subject }.to change { access_request.status }
+      expect { subject }.to change(access_request, :status)
         .from('requested')
         .to('completed')
     end
@@ -39,13 +39,13 @@ describe AccessRequest do
 
   describe '#index' do
     context 'with all types of access requests' do
+      subject { described_class.requested }
+
       let!(:access_request1) { create(:access_request, :requested) }
       let!(:access_request2) { create(:access_request, :requested) }
       let!(:access_request3) { create(:access_request, :declined) }
       let!(:access_request4) { create(:access_request, :approved) }
       let!(:access_request5) { create(:access_request, :completed) }
-
-      subject { described_class.requested }
 
       it { is_expected.to include access_request1, access_request2 }
       it { is_expected.not_to include access_request3, access_request4, access_request5 }
@@ -63,6 +63,8 @@ describe AccessRequest do
   end
 
   describe '#add_additional_attributes' do
+    subject { access_request }
+
     let(:user) { create(:user, organisations: [organisation]) }
     let(:organisation) { build(:organisation) }
     let(:access_request) do
@@ -83,8 +85,6 @@ describe AccessRequest do
       Timecop.return
     end
 
-    subject { access_request }
-
     its(:requester)         { is_expected.to eq user }
     its(:request_date_utc)  { is_expected.to be_within(1.second).of Time.now.utc }
     its(:status)            { is_expected.to eq 'requested' }
@@ -92,6 +92,8 @@ describe AccessRequest do
 
   describe 'default scope' do
     context 'discarded records should not be returned' do
+      subject { described_class.all }
+
       let(:access_request1) { create(:access_request) }
       let(:access_request2) { create(:access_request) }
       let(:access_request3) { create(:access_request) }
@@ -99,8 +101,6 @@ describe AccessRequest do
       before do
         access_request2.discard
       end
-
-      subject { described_class.all }
 
       it { is_expected.to include access_request1, access_request3 }
     end

--- a/spec/models/concerns/postcode_normalize_spec.rb
+++ b/spec/models/concerns/postcode_normalize_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 describe PostcodeNormalize do
   # TODO: Create a test object to use this on instead.
-  let(:object) { Site.new }
-
   subject { object }
+
+  let(:object) { Site.new }
 
   describe '#postcode' do
     let(:postcode) { 'sw1a1aa' }

--- a/spec/models/course/assign_program_type_spec.rb
+++ b/spec/models/course/assign_program_type_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe Course do
       end
 
       context 'a SCITTs self accredited courses' do
-        let(:provider) { build(:provider, :scitt) }
-
         subject { create(:course, provider:) }
+
+        let(:provider) { build(:provider, :scitt) }
 
         its(:program_type) do
           is_expected.to eq('scitt_programme')
@@ -55,9 +55,9 @@ RSpec.describe Course do
       end
 
       context 'a HEIs self accredited courses' do
-        let(:provider) { build(:provider, :university) }
-
         subject { create(:course, provider:) }
+
+        let(:provider) { build(:provider, :university) }
 
         its(:program_type) { is_expected.to eq('higher_education_programme') }
       end

--- a/spec/models/course/funding_type_spec.rb
+++ b/spec/models/course/funding_type_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Course do
     end
 
     describe 'Default' do
-      subject { Course.new(provider: create(:provider)) }
+      subject { described_class.new(provider: create(:provider)) }
 
       its(:funding_type) { is_expected.to be_nil }
     end

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 
 describe Course do
   describe '#publishable?' do
+    subject { course }
+
     let(:course) { create(:course) }
     let(:site) { create(:site) }
     let(:site_status) { create(:site_status, :new, site:) }
-
-    subject { course }
 
     its(:publishable?) { is_expected.to be_falsey }
 

--- a/spec/models/course/update_valid_spec.rb
+++ b/spec/models/course/update_valid_spec.rb
@@ -10,12 +10,12 @@ describe Course do
     let(:next_year)     { next_cycle.year.to_i }
 
     context 'applications_open_from' do
+      subject { course }
+
       let(:course) do
         create(:course,
                applications_open_from: current_cycle.application_start_date)
       end
-
-      subject { course }
 
       context 'for the current recruitment cycle' do
         context 'with a valid date' do
@@ -58,9 +58,9 @@ describe Course do
     end
 
     context 'start_date' do
-      let(:course) { create(:course, start_date: DateTime.new(current_year, 9, 1)) }
-
       subject { course }
+
+      let(:course) { create(:course, start_date: DateTime.new(current_year, 9, 1)) }
 
       context 'for the current recruitment cycle' do
         context 'with a valid start date' do

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -69,9 +69,9 @@ describe CourseEnrichment do
   end
 
   describe 'about_course attribute' do
-    let(:about_course_text) { 'this course is great' }
-
     subject { build(:course_enrichment, about_course: about_course_text) }
+
+    let(:about_course_text) { 'this course is great' }
 
     context 'with over 400 words' do
       let(:about_course_text) { Faker::Lorem.sentence(word_count: 400 + 1) }
@@ -91,9 +91,9 @@ describe CourseEnrichment do
   end
 
   describe 'course_length attribute' do
-    let(:course_length_text) { 'this course is great' }
-
     subject { build(:course_enrichment, course_length: course_length_text) }
+
+    let(:course_length_text) { 'this course is great' }
 
     context 'when nil' do
       let(:course_length_text) { nil }
@@ -107,9 +107,9 @@ describe CourseEnrichment do
   end
 
   describe 'how_school_placements_work attribute' do
-    let(:how_school_placements_work_text) { 'this course is great' }
-
     subject { build(:course_enrichment, how_school_placements_work: how_school_placements_work_text) }
+
+    let(:how_school_placements_work_text) { 'this course is great' }
 
     context 'with over 400 words' do
       let(:how_school_placements_work_text) { Faker::Lorem.sentence(word_count: 400 + 1) }
@@ -129,9 +129,9 @@ describe CourseEnrichment do
   end
 
   describe 'interview_process attribute' do
-    let(:interview_process_text) { 'this course is great' }
-
     subject { build(:course_enrichment, interview_process: interview_process_text) }
+
+    let(:interview_process_text) { 'this course is great' }
 
     context 'with over 250 words' do
       let(:interview_process_text) { Faker::Lorem.sentence(word_count: 250 + 1) }
@@ -141,12 +141,12 @@ describe CourseEnrichment do
   end
 
   describe 'required_qualifications attribute' do
+    subject { build(:course_enrichment, required_qualifications: required_qualifications_text, course:) }
+
     let(:required_qualifications_text) { 'this course is great' }
     let(:recruitment_cycle) { build(:recruitment_cycle, year: '2021') }
     let(:provider) { build(:provider, recruitment_cycle:) }
     let(:course) { build(:course, provider:) }
-
-    subject { build(:course_enrichment, required_qualifications: required_qualifications_text, course:) }
 
     context 'with over 100 words' do
       let(:required_qualifications_text) { Faker::Lorem.sentence(word_count: 100 + 1) }
@@ -174,9 +174,9 @@ describe CourseEnrichment do
   end
 
   describe 'personal_qualities attribute' do
-    let(:personal_qualities_text) { 'this course is great' }
-
     subject { build(:course_enrichment, personal_qualities: personal_qualities_text) }
+
+    let(:personal_qualities_text) { 'this course is great' }
 
     context 'with over 100 words' do
       let(:personal_qualities_text) { Faker::Lorem.sentence(word_count: 100 + 1) }
@@ -186,9 +186,9 @@ describe CourseEnrichment do
   end
 
   describe 'other_requirements attribute' do
-    let(:other_requirements_text) { 'this course is great' }
-
     subject { build(:course_enrichment, other_requirements: other_requirements_text) }
+
+    let(:other_requirements_text) { 'this course is great' }
 
     context 'with over 100 words' do
       let(:other_requirements_text) { Faker::Lorem.sentence(word_count: 100 + 1) }
@@ -198,11 +198,11 @@ describe CourseEnrichment do
   end
 
   describe 'salary_details attribute' do
+    subject { build(:course_enrichment, salary_details: salary_details_text, course: salaried_course) }
+
     let(:salary_details_text) { 'this course is great' }
 
     let(:salaried_course) { build(:course, :with_salary) }
-
-    subject { build(:course_enrichment, salary_details: salary_details_text, course: salaried_course) }
 
     context 'with over 250 words' do
       let(:salary_details_text) { Faker::Lorem.sentence(word_count: 250 + 1) }
@@ -222,9 +222,9 @@ describe CourseEnrichment do
   end
 
   describe 'validation for publish' do
-    let(:course_enrichment) { build(:course_enrichment, :with_fee_based_course) }
-
     subject { course_enrichment }
+
+    let(:course_enrichment) { build(:course_enrichment, :with_fee_based_course) }
 
     context 'fee based course' do
       it { is_expected.to validate_presence_of(:fee_uk_eu).on(:publish) }
@@ -294,15 +294,15 @@ describe CourseEnrichment do
   end
 
   describe '#unpublish' do
-    let(:provider) { create(:provider) }
-    let(:course) { create(:course, provider:) }
-    let(:last_published_timestamp_utc) { Date.new(2017, 1, 1) }
-
     subject do
       create(:course_enrichment, :published,
              last_published_timestamp_utc:,
              course:)
     end
+
+    let(:provider) { create(:provider) }
+    let(:course) { create(:course, provider:) }
+    let(:last_published_timestamp_utc) { Date.new(2017, 1, 1) }
 
     describe 'to initial draft' do
       it 'sets the course to draft' do

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -64,7 +64,7 @@ describe CourseEnrichment do
     let!(:new_enrichment) { create(:course_enrichment, :published) }
 
     it 'orders by created_at descending' do
-      expect(CourseEnrichment.most_recent).to eq([new_enrichment, old_enrichment])
+      expect(described_class.most_recent).to eq([new_enrichment, old_enrichment])
     end
   end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -472,7 +472,7 @@ describe Course do
     describe 'valid?' do
       context 'A new course' do
         let(:provider) { build(:provider) }
-        let(:course) { Course.new(provider:) }
+        let(:course) { described_class.new(provider:) }
         let(:errors) { course.errors.messages }
 
         before { course.valid?(:new) }
@@ -490,7 +490,7 @@ describe Course do
         end
 
         context 'With modern languages as a subject' do
-          let(:course) { Course.new(provider:, subjects: [modern_languages]) }
+          let(:course) { described_class.new(provider:, subjects: [modern_languages]) }
 
           it 'Requires a language to be selected' do
             error = errors[:modern_languages_subjects]
@@ -819,10 +819,10 @@ describe Course do
       it 'returns courses in range' do
         course1
         course2
-        courses_within_range = Course.within(16, origin: [0, 0])
+        courses_within_range = described_class.within(16, origin: [0, 0])
 
         expect(courses_within_range.count).to eq(1)
-        expect(Course.within(16, origin: [0, 0])).to match_array([course1])
+        expect(described_class.within(16, origin: [0, 0])).to match_array([course1])
       end
     end
 
@@ -1509,7 +1509,7 @@ describe Course do
 
       context 'with a site_statuses association that has not been loaded' do
         it 'uses #select on the association' do
-          course_with_site_statuses_not_loaded = Course.find(course.id)
+          course_with_site_statuses_not_loaded = described_class.find(course.id)
           allow(course_with_site_statuses_not_loaded.site_statuses)
             .to receive(:findable).and_return([])
 
@@ -1837,9 +1837,9 @@ describe Course do
         findable_course
         suspended_course_with_new_site
 
-        expect(Course.not_new.count).to eq(2)
-        expect(Course.not_new.first.sites.count).to eq(1)
-        expect(Course.not_new.second.sites.count).to eq(1)
+        expect(described_class.not_new.count).to eq(2)
+        expect(described_class.not_new.first.sites.count).to eq(1)
+        expect(described_class.not_new.second.sites.count).to eq(1)
       end
     end
 
@@ -1854,7 +1854,7 @@ describe Course do
       let!(:old_course) { create(:course, age: 1.hour.ago) }
       let!(:course) { create(:course, age: 1.hour.ago) }
 
-      subject { Course.changed_since(nil) }
+      subject { described_class.changed_since(nil) }
 
       it { is_expected.to include course }
       it { is_expected.to include old_course }
@@ -1866,7 +1866,7 @@ describe Course do
 
       before { course.touch }
 
-      subject { Course.changed_since(10.minutes.ago) }
+      subject { described_class.changed_since(10.minutes.ago) }
 
       it { is_expected.to include course }
       it { is_expected.not_to include old_course }
@@ -1876,7 +1876,7 @@ describe Course do
       let(:timestamp) { 5.minutes.ago }
       let(:course) { create(:course, changed_at: timestamp + 0.001.seconds) }
 
-      subject { Course.changed_since(timestamp) }
+      subject { described_class.changed_since(timestamp) }
 
       it { is_expected.to include course }
     end
@@ -1885,7 +1885,7 @@ describe Course do
       let(:timestamp) { 10.minutes.ago }
       let(:course) { create(:course, changed_at: timestamp) }
 
-      subject { Course.changed_since(timestamp) }
+      subject { described_class.changed_since(timestamp) }
 
       it { is_expected.not_to include course }
     end
@@ -2343,7 +2343,7 @@ describe Course do
 
   describe 'self.get_by_codes' do
     it 'returns the found course' do
-      expect(Course.get_by_codes(
+      expect(described_class.get_by_codes(
                course.recruitment_cycle.year,
                course.provider.provider_code,
                course.course_code
@@ -2663,7 +2663,7 @@ describe Course do
     end
 
     context 'when age_range_in_years not set' do
-      subject { Course.new }
+      subject { described_class.new }
 
       it 'returns nil' do
         expect(subject.age_minimum).to be_nil
@@ -2679,7 +2679,7 @@ describe Course do
     end
 
     context 'when age_range_in_years not set' do
-      subject { Course.new }
+      subject { described_class.new }
 
       it 'returns nil' do
         expect(subject.age_maximum).to be_nil

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe Course do
+  subject { course }
+
   let(:recruitment_cycle) { course.recruitment_cycle }
   let(:french) { find_or_create(:modern_languages_subject, :french) }
   let!(:financial_incentive) { create(:financial_incentive, subject: modern_languages) }
@@ -16,8 +18,6 @@ describe Course do
       subjects: [find_or_create(:secondary_subject, :biology)]
     )
   end
-
-  subject { course }
 
   its(:to_s) { is_expected.to eq("Biology (#{course.provider.provider_code}/3X9F) [#{course.recruitment_cycle}]") }
   its(:modular) { is_expected.to eq('') }
@@ -384,6 +384,8 @@ describe Course do
     end
 
     describe 'accredited_body_order' do
+      subject { described_class.accredited_body_order(provider.provider_name) }
+
       let(:provider) { create(:provider) }
       let(:delivered_course) { create(:course, provider:) }
       let(:accredited_course) { create(:course, accrediting_provider: provider) }
@@ -393,17 +395,15 @@ describe Course do
         delivered_course
       end
 
-      subject { described_class.accredited_body_order(provider.provider_name) }
-
       it 'returns courses accredited after courses delivered' do
         expect(subject).to eq([delivered_course, accredited_course])
       end
     end
 
     describe 'case_insensitive_search' do
-      let(:course) { create(:course, course_code: '2VvZ') }
-
       subject { described_class.case_insensitive_search('2vVZ') }
+
+      let(:course) { create(:course, course_code: '2VvZ') }
 
       it 'returns correct course with incorrect' do
         expect(subject).to eq([course])
@@ -586,12 +586,12 @@ describe Course do
       end
 
       context 'blank attribute' do
-        let(:course) { build(:course, **blank_field) }
-
         subject do
           course.valid?
           course.errors.full_messages.first
         end
+
+        let(:course) { build(:course, **blank_field) }
 
         context 'age_range_in_years' do
           let(:blank_field) { { age_range_in_years: nil } }
@@ -995,11 +995,11 @@ describe Course do
     end
 
     describe '.with_study_modes' do
+      subject { described_class.with_study_modes(study_modes) }
+
       let(:course_part_time) { create(:course, study_mode: :part_time) }
       let(:course_full_time) { create(:course, study_mode: :full_time) }
       let(:course_both) { create(:course, study_mode: :full_time_or_part_time) }
-
-      subject { described_class.with_study_modes(study_modes) }
 
       before do
         course_both
@@ -1033,13 +1033,13 @@ describe Course do
     end
 
     describe '.with_funding_types' do
+      subject { described_class.with_funding_types(funding_types) }
+
       let(:fee_course_higher_education) { create(:course, :with_higher_education) }
       let(:fee_course_scitt) { create(:course, :with_scitt) }
       let(:fee_course_school_direct) { create(:course, :with_school_direct) }
       let(:salary_course) { create(:course, :with_salary) }
       let(:apprenticeship_course) { create(:course, :with_apprenticeship) }
-
-      subject { described_class.with_funding_types(funding_types) }
 
       context 'fee courses' do
         let(:funding_types) { %w[fee] }
@@ -1087,11 +1087,11 @@ describe Course do
     end
 
     describe '.with_degree_grades' do
+      subject { described_class.with_degree_grades(degree_grades) }
+
       let(:two_two_course) { create(:course, degree_grade: :two_two) }
       let(:third_class_course) { create(:course, degree_grade: :third_class) }
       let(:minimum_degree_not_required_course) { create(:course, degree_grade: :not_required) }
-
-      subject { described_class.with_degree_grades(degree_grades) }
 
       before do
         two_two_course
@@ -1125,6 +1125,8 @@ describe Course do
     end
 
     describe '.with_salary' do
+      subject { described_class.with_salary }
+
       let(:course_higher_education_programme) do
         create(:course, program_type: :higher_education_programme)
       end
@@ -1142,8 +1144,6 @@ describe Course do
         create(:course, program_type: :pg_teaching_apprenticeship)
       end
 
-      subject { described_class.with_salary }
-
       before do
         course_higher_education_programme
         course_school_direct_training_programme
@@ -1158,13 +1158,13 @@ describe Course do
     end
 
     describe '.with_qualifications' do
+      subject { described_class.with_qualifications(qualifications) }
+
       let(:course_qts) { TestDataCache.get(:course, :resulting_in_qts) }
       let(:course_pgce_with_qts) { TestDataCache.get(:course, :resulting_in_pgce_with_qts) }
       let(:course_pgde_with_qts) { TestDataCache.get(:course, :resulting_in_pgde_with_qts) }
       let(:course_pgce) { TestDataCache.get(:course, :resulting_in_pgce) }
       let(:course_pgde) { TestDataCache.get(:course, :resulting_in_pgde) }
-
-      subject { described_class.with_qualifications(qualifications) }
 
       before do
         course_qts
@@ -1260,12 +1260,12 @@ describe Course do
 
     describe '.with_accredited_bodies' do
       context 'course with an accredited body' do
+        subject { described_class.with_accredited_bodies(accredited_provider.provider_code) }
+
         let!(:provider) { create(:provider) }
         let!(:course) { create(:course, provider:) }
         let!(:accredited_provider) { create(:provider, :accredited_body) }
         let!(:accredited_course) { create(:course, accrediting_provider: accredited_provider) }
-
-        subject { described_class.with_accredited_bodies(accredited_provider.provider_code) }
 
         it 'returns courses for which the provider is the accredited body' do
           expect(subject).to contain_exactly(accredited_course)
@@ -1389,14 +1389,14 @@ describe Course do
   end
 
   context 'with sites' do
+    subject { create(:course, provider:, site_statuses: [first_site_status, second_site_status]) }
+
     let(:provider) { build(:provider) }
     let(:first_site) { build(:site, provider:) }
     let(:first_site_status) { create(:site_status, :running, site: first_site) }
     let(:second_site) { build(:site, provider:) }
     let(:second_site_status) { create(:site_status, :suspended, site: second_site) }
     let(:new_site) { build(:site, provider:) }
-
-    subject { create(:course, provider:, site_statuses: [first_site_status, second_site_status]) }
 
     describe '#sites' do
       it 'onlies return new and running sites' do
@@ -1460,6 +1460,8 @@ describe Course do
   end
 
   context 'with site statuses' do
+    subject { create(:course, provider:, site_statuses:) }
+
     let(:provider) { build(:provider, sites: [site]) }
     let(:site) { build(:site) }
     let(:new_site_status) { build(:site_status, :new, site:) }
@@ -1475,8 +1477,6 @@ describe Course do
     let(:published_discontinued_with_any_vacancy) { build(:site_status, :published, :suspended, :with_any_vacancy, site:) }
     let(:published_discontinued_with_no_vacancies) { build(:site_status, :published, :suspended, :with_no_vacancies, site:) }
     let(:site_statuses) { [] }
-
-    subject { create(:course, provider:, site_statuses:) }
 
     describe '#findable_site_statuses' do
       context 'with a site_statuses association that have been loaded' do
@@ -1612,6 +1612,8 @@ describe Course do
     end
 
     describe '#open_for_applications?' do
+      subject { course }
+
       let(:site_statuses) { [] }
 
       let(:applications_open_from) { Time.now.utc }
@@ -1621,8 +1623,6 @@ describe Course do
                site_statuses:,
                applications_open_from:)
       end
-
-      subject { course }
 
       context 'no site statuses' do
         context 'applications_open_from is in present or past' do
@@ -1712,6 +1712,10 @@ describe Course do
     end
 
     describe 'open_for_applications? (when site_statuses not loaded)' do
+      subject do
+        course.reload
+      end
+
       let(:site_statuses) { [] }
 
       let(:applications_open_from) { Time.now.utc }
@@ -1720,10 +1724,6 @@ describe Course do
         create(:course,
                site_statuses:,
                applications_open_from:)
-      end
-
-      subject do
-        course.reload
       end
 
       context 'no site statuses' do
@@ -1803,17 +1803,17 @@ describe Course do
       end
 
       context 'with a new site_status' do
-        let(:new) { build(:site_status, :new) }
-
         subject { create(:course, site_statuses: [new]) }
+
+        let(:new) { build(:site_status, :new) }
 
         its(:ucas_status) { is_expected.to eq :new }
       end
 
       context 'with a not running site_status' do
-        let(:suspended) { build(:site_status, :suspended) }
-
         subject { create(:course, site_statuses: [suspended]) }
+
+        let(:suspended) { build(:site_status, :suspended) }
 
         its(:ucas_status) { is_expected.to eq :not_running }
       end
@@ -1851,41 +1851,41 @@ describe Course do
 
   describe '#changed_since' do
     context 'with no parameters' do
+      subject { described_class.changed_since(nil) }
+
       let!(:old_course) { create(:course, age: 1.hour.ago) }
       let!(:course) { create(:course, age: 1.hour.ago) }
-
-      subject { described_class.changed_since(nil) }
 
       it { is_expected.to include course }
       it { is_expected.to include old_course }
     end
 
     context 'with a course that was just updated' do
+      subject { described_class.changed_since(10.minutes.ago) }
+
       let(:course) { create(:course, age: 1.hour.ago) }
       let!(:old_course) { create(:course, age: 1.hour.ago) }
 
       before { course.touch }
-
-      subject { described_class.changed_since(10.minutes.ago) }
 
       it { is_expected.to include course }
       it { is_expected.not_to include old_course }
     end
 
     context 'with a course that has been changed less than a second after the given timestamp' do
+      subject { described_class.changed_since(timestamp) }
+
       let(:timestamp) { 5.minutes.ago }
       let(:course) { create(:course, changed_at: timestamp + 0.001.seconds) }
-
-      subject { described_class.changed_since(timestamp) }
 
       it { is_expected.to include course }
     end
 
     context 'with a course that has been changed exactly at the given timestamp' do
+      subject { described_class.changed_since(timestamp) }
+
       let(:timestamp) { 10.minutes.ago }
       let(:course) { create(:course, changed_at: timestamp) }
-
-      subject { described_class.changed_since(timestamp) }
 
       it { is_expected.not_to include course }
     end
@@ -2069,10 +2069,10 @@ describe Course do
   end
 
   context 'bursaries and scholarships' do
+    subject { create(:course, :skip_validate, level: 'secondary', subjects: [english]) }
+
     let(:english) { find_or_create(:secondary_subject, :english) }
     let!(:financial_incentive) { create(:financial_incentive, subject: english, bursary_amount: 255, scholarship: 1415, early_career_payments: 32) }
-
-    subject { create(:course, :skip_validate, level: 'secondary', subjects: [english]) }
 
     it { is_expected.to have_bursary }
     it { is_expected.to have_scholarship_and_bursary }
@@ -2109,14 +2109,14 @@ describe Course do
 
       context 'with modern languages' do
         context 'with a language as a second subject' do
+          subject { create(:course, :skip_validate, level: 'secondary', subjects: [modern_languages, french, german, spanish]) }
+
           let(:french) { create(:modern_languages_subject, :french) }
           let(:german) { create(:modern_languages_subject, :german) }
           let(:spanish) { create(:modern_languages_subject, :spanish) }
           let!(:french_financial_incentive) { create(:financial_incentive, subject: french, bursary_amount: '15000', scholarship: nil) }
           let!(:german_financial_incentive) { create(:financial_incentive, subject: german, bursary_amount: '14000', scholarship: nil) }
           let!(:spanish_financial_incentive) { create(:financial_incentive, subject: spanish, bursary_amount: '13000', scholarship: nil) }
-
-          subject { create(:course, :skip_validate, level: 'secondary', subjects: [modern_languages, french, german, spanish]) }
 
           it "reads financial incentives from only the first subject, and ignores the 'Modern Languages' subject" do
             expect(subject.bursary_amount).to eq french.financial_incentive.bursary_amount
@@ -2152,14 +2152,14 @@ describe Course do
   end
 
   describe 'adding and removing sites on a course' do
+    subject { create(:course, site_statuses: [existing_site_status]) }
+
     let(:provider) { build(:provider) }
     # this code will be removed and fixed properly in the next pr
     let(:new_site) { create(:site, provider:, code: 'A') }
     # this code will be removed and fixed properly in the next pr
     let(:existing_site) { create(:site, provider:, code: 'B') }
     let(:new_site_status) { subject.site_statuses.find_by!(site: new_site) }
-
-    subject { create(:course, site_statuses: [existing_site_status]) }
 
     context 'for running courses' do
       let(:existing_site_status) { create(:site_status, :running, :published, site: existing_site) }
@@ -2222,10 +2222,10 @@ describe Course do
   end
 
   describe '#accrediting_provider_description' do
+    subject { course.accrediting_provider_description }
+
     let(:accrediting_provider) { nil }
     let(:course) { create(:course, accrediting_provider:) }
-
-    subject { course.accrediting_provider_description }
 
     context 'for courses without accrediting provider' do
       it { is_expected.to be_nil }
@@ -2277,12 +2277,12 @@ describe Course do
           salary_details
         ].freeze
 
+      subject { course.enrichments.find_or_initialize_draft }
+
       let(:course) { create(:course, enrichments:) }
       let(:actual_enrichment_attributes) do
         subject.attributes.slice(*copyable_enrichment_attributes)
       end
-
-      subject { course.enrichments.find_or_initialize_draft }
 
       context 'no enrichments' do
         let(:enrichments) { [] }
@@ -2369,6 +2369,8 @@ describe Course do
 
   describe '#discard' do
     context 'new course' do
+      subject { course }
+
       let!(:course) do
         course = create(:course)
 
@@ -2377,8 +2379,6 @@ describe Course do
 
         course
       end
-
-      subject { course }
 
       context 'before discarding' do
         its(:discarded?) { is_expected.to be false }
@@ -2425,18 +2425,18 @@ describe Course do
 
   describe '#applications_open_from' do
     context 'a new course with a given date' do
-      let(:applications_open_from) { Time.zone.today }
-
       subject { create(:course, applications_open_from:) }
+
+      let(:applications_open_from) { Time.zone.today }
 
       its(:applications_open_from) { is_expected.to eq applications_open_from }
     end
 
     context 'a new course within a recruitment cycle' do
+      subject { create(:course, :applications_open_from_not_set, provider:) }
+
       let(:recruitment_cycle) { build(:recruitment_cycle, :next) }
       let(:provider)          { build(:provider, recruitment_cycle:) }
-
-      subject { create(:course, :applications_open_from_not_set, provider:) }
 
       its(:applications_open_from) { is_expected.to eq recruitment_cycle.application_start_date }
     end
@@ -2811,9 +2811,9 @@ describe Course do
 
   describe '#academic_year' do
     context 'when the course has a September 2021 start date' do
-      let(:start_date) { Date.new(2021, 9, 1) }
-
       subject { build(:course, start_date:) }
+
+      let(:start_date) { Date.new(2021, 9, 1) }
 
       it "returns the course's academic year" do
         expect(subject.academic_year).to eq('2021 to 2022')
@@ -2821,9 +2821,9 @@ describe Course do
     end
 
     context 'when the course has a December 2021 start date' do
-      let(:start_date) { Date.new(2021, 12, 1) }
-
       subject { build(:course, start_date:) }
+
+      let(:start_date) { Date.new(2021, 12, 1) }
 
       it "returns the course's academic year" do
         expect(subject.academic_year).to eq('2021 to 2022')
@@ -2831,9 +2831,9 @@ describe Course do
     end
 
     context 'when the course has a January 2022 start date' do
-      let(:start_date) { Date.new(2022, 1, 1) }
-
       subject { build(:course, start_date:) }
+
+      let(:start_date) { Date.new(2022, 1, 1) }
 
       it "returns the course's academic year" do
         expect(subject.academic_year).to eq('2021 to 2022')
@@ -2841,9 +2841,9 @@ describe Course do
     end
 
     context 'when the course has a January 2023 start date' do
-      let(:start_date) { Date.new(2023, 1, 1) }
-
       subject { build(:course, start_date:) }
+
+      let(:start_date) { Date.new(2023, 1, 1) }
 
       it "returns the course's academic year" do
         expect(subject.academic_year).to eq('2022 to 2023')
@@ -2851,9 +2851,9 @@ describe Course do
     end
 
     context 'when the course has an August 2023 start date' do
-      let(:start_date) { Date.new(2023, 8, 1) }
-
       subject { build(:course, start_date:) }
+
+      let(:start_date) { Date.new(2023, 8, 1) }
 
       it "returns the course's academic year" do
         expect(subject.academic_year).to eq('2022 to 2023')

--- a/spec/models/provider/accredited_bodies_spec.rb
+++ b/spec/models/provider/accredited_bodies_spec.rb
@@ -21,11 +21,11 @@ describe Provider do
   end
 
   describe '#accredited_bodies' do
-    let(:description) { 'Ye olde establishmente' }
-
     subject do
       provider.accredited_bodies
     end
+
+    let(:description) { 'Ye olde establishmente' }
 
     context 'with no accrediting provider (via courses)' do
       it { is_expected.to be_empty }

--- a/spec/models/provider/validation_spec.rb
+++ b/spec/models/provider/validation_spec.rb
@@ -76,10 +76,10 @@ describe Provider do
     end
 
     describe '#train_with_us' do
+      subject { build(:provider, train_with_us:) }
+
       let(:word_count) { 250 }
       let(:train_with_us) { Faker::Lorem.sentence(word_count:) }
-
-      subject { build(:provider, train_with_us:) }
 
       context 'word count within limit' do
         it { is_expected.to be_valid }
@@ -93,10 +93,10 @@ describe Provider do
     end
 
     describe '#train_with_disability' do
+      subject { build(:provider, train_with_disability:) }
+
       let(:word_count) { 250 }
       let(:train_with_disability) { Faker::Lorem.sentence(word_count:) }
-
-      subject { build(:provider, train_with_disability:) }
 
       context 'word count within limit' do
         it { is_expected.to be_valid }
@@ -111,6 +111,11 @@ describe Provider do
 
     context 'no accrediting_providers' do
       describe '#accrediting_provider_providers' do
+        subject do
+          provider.accrediting_provider_enrichments = accrediting_provider_enrichments
+          provider
+        end
+
         let(:word_count) { 100 }
 
         let(:accrediting_provider_enrichments) do
@@ -127,11 +132,6 @@ describe Provider do
 
         let(:provider) do
           create(:provider)
-        end
-
-        subject do
-          provider.accrediting_provider_enrichments = accrediting_provider_enrichments
-          provider
         end
 
         context 'word count within limit' do
@@ -152,6 +152,11 @@ describe Provider do
 
     context 'with accrediting_providers' do
       describe '#accrediting_provider_providers' do
+        subject do
+          provider.accrediting_provider_enrichments = accrediting_provider_enrichments
+          provider
+        end
+
         let(:word_count) { 100 }
 
         let(:accrediting_providers) do
@@ -179,11 +184,6 @@ describe Provider do
 
         let(:provider) do
           create(:provider, courses:)
-        end
-
-        subject do
-          provider.accrediting_provider_enrichments = accrediting_provider_enrichments
-          provider
         end
 
         context 'word count within limit' do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -62,7 +62,7 @@ describe Provider do
 
       it 'validates the presence of a ukprn' do
         # this means that rollover happens successfully; the record is created but it will be invalid on update, because of no ukprn
-        expect { provider }.to change { Provider.count }.by(1)
+        expect { provider }.to change { described_class.count }.by(1)
         expect(provider).not_to be_valid
       end
     end
@@ -140,7 +140,7 @@ describe Provider do
       it 'orders the providers by name in ascending order' do
         provider_a
         provider_b
-        expect(Provider.by_name_ascending).to eq([provider_a, provider_b])
+        expect(described_class.by_name_ascending).to eq([provider_a, provider_b])
       end
     end
 
@@ -148,7 +148,7 @@ describe Provider do
       it 'orders the providers by name in descending order' do
         provider_a
         provider_b
-        expect(Provider.by_name_descending).to eq([provider_b, provider_a])
+        expect(described_class.by_name_descending).to eq([provider_b, provider_a])
       end
     end
 
@@ -156,7 +156,7 @@ describe Provider do
       it 'orders the providers by name in descending order' do
         provider_a
         provider_b
-        expect(Provider.by_provider_name(provider_b.provider_name)).to eq([provider_b, provider_a])
+        expect(described_class.by_provider_name(provider_b.provider_name)).to eq([provider_b, provider_a])
       end
     end
   end
@@ -165,7 +165,7 @@ describe Provider do
     context 'with a provider that has been changed after the given timestamp' do
       let(:provider) { create(:provider, changed_at: 5.minutes.ago) }
 
-      subject { Provider.changed_since(10.minutes.ago) }
+      subject { described_class.changed_since(10.minutes.ago) }
 
       it { is_expected.to include provider }
     end
@@ -174,7 +174,7 @@ describe Provider do
       let(:timestamp) { 5.minutes.ago }
       let(:provider) { create(:provider, changed_at: timestamp + 0.001.seconds) }
 
-      subject { Provider.changed_since(timestamp) }
+      subject { described_class.changed_since(timestamp) }
 
       it { is_expected.to include provider }
     end
@@ -183,7 +183,7 @@ describe Provider do
       let(:publish_time) { 10.minutes.ago }
       let(:provider) { create(:provider, changed_at: publish_time) }
 
-      subject { Provider.changed_since(publish_time) }
+      subject { described_class.changed_since(publish_time) }
 
       it { is_expected.not_to include provider }
     end
@@ -191,7 +191,7 @@ describe Provider do
     context 'with a provider that has been changed before the given timestamp' do
       let(:provider) { create(:provider, changed_at: 1.hour.ago) }
 
-      subject { Provider.changed_since(10.minutes.ago) }
+      subject { described_class.changed_since(10.minutes.ago) }
 
       it { is_expected.not_to include provider }
     end
@@ -317,7 +317,7 @@ describe Provider do
       end
 
       context 'with .include_courses_counts' do
-        let(:provider_with_included) { Provider.include_courses_counts.first }
+        let(:provider_with_included) { described_class.include_courses_counts.first }
 
         it 'return course count using included_courses_count' do
           allow(provider_with_included).to receive(:included_courses_count).and_return(1)
@@ -330,7 +330,7 @@ describe Provider do
       end
 
       context 'with .include_accredited_courses_counts' do
-        let(:provider_with_included) { Provider.include_accredited_courses_counts(provider.provider_code).first }
+        let(:provider_with_included) { described_class.include_accredited_courses_counts(provider.provider_code).first }
 
         it 'return course count using included_accredited_courses_count' do
           allow(provider_with_included).to receive(:included_accredited_courses_count).and_return(1)

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 describe RecruitmentCycle do
+  subject { current_cycle }
+
   let(:current_cycle) { find_or_create(:recruitment_cycle) }
   let(:next_cycle) { find_or_create(:recruitment_cycle, :next) }
-
-  subject { current_cycle }
 
   its(:to_s) { is_expected.to eq('2023/24') }
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -54,7 +54,7 @@ describe RecruitmentCycle do
 
     describe '.current_recruitment_cycle' do
       it 'returns the first cycle, ordered by year' do
-        expect(RecruitmentCycle.current_recruitment_cycle).to eq(current_cycle)
+        expect(described_class.current_recruitment_cycle).to eq(current_cycle)
       end
     end
 
@@ -70,7 +70,7 @@ describe RecruitmentCycle do
 
     describe '.next_recruitment_cycle' do
       it 'returns the next cycle after the current one' do
-        expect(RecruitmentCycle.next_recruitment_cycle).to eq(next_cycle)
+        expect(described_class.next_recruitment_cycle).to eq(next_cycle)
       end
     end
 

--- a/spec/models/secondary_subject_spec.rb
+++ b/spec/models/secondary_subject_spec.rb
@@ -9,16 +9,16 @@ describe SecondarySubject do
     end
 
     it 'returns the modern language subject' do
-      expect(SecondarySubject.modern_languages).to eq(modern_languages)
+      expect(described_class.modern_languages).to eq(modern_languages)
     end
 
     it 'memoises the subject object' do
-      SecondarySubject.modern_languages
+      described_class.modern_languages
 
-      allow(SecondarySubject).to receive(:find_by)
+      allow(described_class).to receive(:find_by)
 
-      expect(SecondarySubject.modern_languages).to eq(modern_languages)
-      expect(SecondarySubject).not_to have_received(:find_by)
+      expect(described_class.modern_languages).to eq(modern_languages)
+      expect(described_class).not_to have_received(:find_by)
     end
   end
 
@@ -28,16 +28,16 @@ describe SecondarySubject do
     end
 
     it 'returns the physics subject' do
-      expect(SecondarySubject.physics).to eq(physics)
+      expect(described_class.physics).to eq(physics)
     end
 
     it 'memoises the subject object' do
-      SecondarySubject.physics
+      described_class.physics
 
-      allow(SecondarySubject).to receive(:find_by)
+      allow(described_class).to receive(:find_by)
 
-      expect(SecondarySubject.physics).to eq(physics)
-      expect(SecondarySubject).not_to have_received(:find_by)
+      expect(described_class.physics).to eq(physics)
+      expect(described_class).not_to have_received(:find_by)
     end
   end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 describe Site do
   include ActiveJob::TestHelper
 
-  let(:provider) { create(:provider) }
-
   subject { create(:site, provider_id: provider.id) }
+
+  let(:provider) { create(:provider) }
 
   describe 'auditing' do
     it { is_expected.to be_audited.associated_with(:provider) }
@@ -53,10 +53,10 @@ describe Site do
   end
 
   describe 'discarded behaviour for code' do
+    subject { create(:site, provider_id: provider.id, code: 'B') }
+
     let(:existing_code) { 'AB' }
     let(:site_with_code) { create(:site, code: existing_code, provider_id: provider.id) }
-
-    subject { create(:site, provider_id: provider.id, code: 'B') }
 
     before do
       site_with_code.discard!
@@ -88,10 +88,10 @@ describe Site do
   end
 
   describe 'after running validation' do
+    subject { site }
+
     let(:site) { build(:site, provider:, code: nil) }
     let(:provider) { build(:provider) }
-
-    subject { site }
 
     it 'is assigned a valid code by default' do
       expect { subject.valid? }.to change { subject.code.blank? }.from(true).to(false)

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SiteStatus do
 
   RSpec::Matchers.define :have_vacancies do
     match do |actual|
-      described_class.with_vacancies.include?(actual)
+      SiteStatus.with_vacancies.include?(actual)
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe SiteStatus do
   end
 
   describe 'findable scope' do
-    subject { described_class.findable }
+    subject { SiteStatus.findable }
 
     context 'with a course discontinued on UCAS' do
       it { is_expected.not_to include(create(:site_status, :discontinued)) }
@@ -162,7 +162,7 @@ RSpec.describe SiteStatus do
   end
 
   describe 'default_vac_status_given' do
-    subject { described_class }
+    subject { SiteStatus }
 
     it 'returns correct default_vac_status' do
       expect(subject.default_vac_status_given(study_mode: 'full_time')).to eq :full_time_vacancies

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe SiteStatus do
 
   describe 'has vacancies?' do
     describe 'if has part-time vacancies' do
-      let(:course) { build(:course, study_mode: :part_time) }
-
       subject { create(:site_status, :findable, :part_time_vacancies, course:) }
+
+      let(:course) { build(:course, study_mode: :part_time) }
 
       it { is_expected.to have_vacancies }
     end
@@ -94,9 +94,9 @@ RSpec.describe SiteStatus do
     end
 
     describe 'if has both full-time and part-time vacancies' do
-      let(:course) { build(:course, study_mode: :full_time_or_part_time) }
-
       subject { create(:site_status, :findable, :both_full_time_and_part_time_vacancies, course:) }
+
+      let(:course) { build(:course, study_mode: :full_time_or_part_time) }
 
       it { is_expected.to have_vacancies }
     end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SiteStatus do
 
   RSpec::Matchers.define :have_vacancies do
     match do |actual|
-      SiteStatus.with_vacancies.include?(actual)
+      described_class.with_vacancies.include?(actual)
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe SiteStatus do
   end
 
   describe 'findable scope' do
-    subject { SiteStatus.findable }
+    subject { described_class.findable }
 
     context 'with a course discontinued on UCAS' do
       it { is_expected.not_to include(create(:site_status, :discontinued)) }
@@ -162,7 +162,7 @@ RSpec.describe SiteStatus do
   end
 
   describe 'default_vac_status_given' do
-    subject { SiteStatus }
+    subject { described_class }
 
     it 'returns correct default_vac_status' do
       expect(subject.default_vac_status_given(study_mode: 'full_time')).to eq :full_time_vacancies

--- a/spec/models/user_notification_preferences_spec.rb
+++ b/spec/models/user_notification_preferences_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 describe UserNotificationPreferences do
   describe '#enabled' do
+    subject { described_class.new(user_id: user.id) }
+
     let(:user) { create(:user) }
     let(:preference) { false }
     let(:user_notification) do
@@ -14,8 +16,6 @@ describe UserNotificationPreferences do
         course_update: preference
       )
     end
-
-    subject { described_class.new(user_id: user.id) }
 
     describe 'enabled?' do
       context 'when there are no user notifications' do

--- a/spec/models/user_notification_spec.rb
+++ b/spec/models/user_notification_spec.rb
@@ -22,11 +22,11 @@ describe UserNotification do
   end
 
   describe 'associations' do
+    subject { described_class.new(user_id: user.id, provider_code: provider.provider_code) }
+
     let(:organisation) { create(:organisation, providers: [provider]) }
     let(:user) { create(:user, organisations: [organisation]) }
     let(:provider) { create(:provider) }
-
-    subject { described_class.new(user_id: user.id, provider_code: provider.provider_code) }
 
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to belong_to(:user) }
@@ -55,23 +55,23 @@ describe UserNotification do
     end
 
     describe '.course_publish_notification_requests' do
+      subject { described_class.course_publish_notification_requests(provider.provider_code) }
+
       before do
         user_notification_create
         user_notification_update
       end
-
-      subject { described_class.course_publish_notification_requests(provider.provider_code) }
 
       it { is_expected.to contain_exactly(user_notification_create) }
     end
 
     describe '.course_update_notification_requests' do
+      subject { described_class.course_update_notification_requests(provider.provider_code) }
+
       before do
         user_notification_create
         user_notification_update
       end
-
-      subject { described_class.course_update_notification_requests(provider.provider_code) }
 
       it { is_expected.to contain_exactly(user_notification_update) }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -121,10 +121,10 @@ describe User do
 
     describe '#associated_with_accredited_body?' do
       context 'user is associated with accredited body' do
+        subject { create(:user, providers: [accredited_body]) }
+
         let(:current_recruitment_cycle) { find_or_create(:recruitment_cycle) }
         let(:accredited_body) { create(:provider, :accredited_body, recruitment_cycle: current_recruitment_cycle) }
-
-        subject { create(:user, providers: [accredited_body]) }
 
         it 'returns true' do
           expect(subject.associated_with_accredited_body?).to be true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,11 +49,11 @@ describe User do
       its(:admin?) { is_expected.to be_truthy }
 
       it 'shows up in User.admins' do
-        expect(User.admins).to eq([subject])
+        expect(described_class.admins).to eq([subject])
       end
 
       it "doesn't show up in User.non_admins" do
-        expect(User.non_admins).to be_empty
+        expect(described_class.non_admins).to be_empty
       end
     end
 
@@ -64,11 +64,11 @@ describe User do
         its(:admin?) { is_expected.to be_falsey }
 
         it 'is a non-admin user' do
-          expect(User.non_admins).to eq([subject])
+          expect(described_class.non_admins).to eq([subject])
         end
 
         it 'is not an admin' do
-          expect(User.admins).to be_empty
+          expect(described_class.admins).to be_empty
         end
       end
     end
@@ -79,7 +79,7 @@ describe User do
     let!(:active_user) { create(:user, accept_terms_date_utc: Date.yesterday) }
 
     it 'includes active users and excludes inactive users' do
-      expect(User.active).to eq([active_user])
+      expect(described_class.active).to eq([active_user])
     end
   end
 
@@ -175,11 +175,11 @@ describe User do
       its(:discarded?) { is_expected.to be false }
 
       it 'is in kept' do
-        expect(User.kept).to eq([subject])
+        expect(described_class.kept).to eq([subject])
       end
 
       it 'is not in discarded' do
-        expect(User.discarded).to be_empty
+        expect(described_class.discarded).to be_empty
       end
     end
 
@@ -191,11 +191,11 @@ describe User do
       its(:discarded?) { is_expected.to be true }
 
       it 'is not in kept' do
-        expect(User.kept).to be_empty
+        expect(described_class.kept).to be_empty
       end
 
       it 'is in discarded' do
-        expect(User.discarded).to eq([subject])
+        expect(described_class.discarded).to eq([subject])
       end
     end
   end
@@ -254,7 +254,7 @@ describe User do
       end
 
       it 'returns users who are subscribed to course update notifications for a given accredited body' do
-        expect(User.course_update_subscribers(course.accredited_body_code)).to eq([subscribed_user])
+        expect(described_class.course_update_subscribers(course.accredited_body_code)).to eq([subscribed_user])
       end
     end
 
@@ -287,7 +287,7 @@ describe User do
       end
 
       it 'includes user who are subscribed to course publish notifications for a given accredited body' do
-        expect(User.course_publish_subscribers(course.accredited_body_code)).to eq([subscribed_user])
+        expect(described_class.course_publish_subscribers(course.accredited_body_code)).to eq([subscribed_user])
       end
     end
   end
@@ -304,7 +304,7 @@ describe User do
     end
 
     it 'orders alphabetically by first_name then last name' do
-      expect(User.in_name_order).to eq([user1, user4, user2, user3])
+      expect(described_class.in_name_order).to eq([user1, user4, user2, user3])
     end
   end
 end

--- a/spec/policies/contact_policy_spec.rb
+++ b/spec/policies/contact_policy_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 describe ContactPolicy do
+  subject { described_class }
+
   let(:user) { create(:user) }
   let(:provider) { create(:provider) }
   let(:contact) { create(:contact, provider:) }
-
-  subject { described_class }
 
   permissions :show?, :update? do
     context 'a user that belongs to the provider' do

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 describe CoursePolicy do
-  let(:user) { create(:user) }
-
   subject { described_class }
+
+  let(:user) { create(:user) }
 
   permissions :index?, :new? do
     it { is_expected.to permit(user, Course) }
@@ -93,12 +93,12 @@ describe CoursePolicy do
   end
 
   describe CoursePolicy::Scope do
+    subject { described_class.new(user, Course).resolve }
+
     let(:accredited_body) { create(:provider, :accredited_body, users: [user]) }
     let(:training_provider) { create(:provider) }
     let!(:course) { create(:course, provider: training_provider, accrediting_provider: accredited_body) }
     let!(:other_course) { create(:course) }
-
-    subject { described_class.new(user, Course).resolve }
 
     context 'user from the accredited_body' do
       it { is_expected.to contain_exactly(course) }

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe ProviderPolicy do
+  subject { described_class }
+
   let(:user) { build(:user) }
   let(:admin) { build(:user, :admin) }
 
@@ -14,8 +16,6 @@ describe ProviderPolicy do
       expect(Pundit.policy_scope(user, Provider.all)).to eq [provider1]
     end
   end
-
-  subject { described_class }
 
   permissions :index?, :suggest?, :new? do
     it { is_expected.to permit user }

--- a/spec/policies/recruitment_cycle_policy_spec.rb
+++ b/spec/policies/recruitment_cycle_policy_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe RecruitmentCyclePolicy do
+  subject { described_class }
+
   let(:current_recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
 
@@ -17,8 +19,6 @@ describe RecruitmentCyclePolicy do
         .to match_array [current_recruitment_cycle, next_recruitment_cycle]
     end
   end
-
-  subject { described_class }
 
   permissions :index? do
     let(:user) { create(:user) }

--- a/spec/policies/site_policy_spec.rb
+++ b/spec/policies/site_policy_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 describe SitePolicy do
-  let(:user) { create(:user) }
-
   subject { described_class }
+
+  let(:user) { create(:user) }
 
   permissions :index? do
     it 'allows the :index action for any authenticated user' do

--- a/spec/policies/site_status_policy_spec.rb
+++ b/spec/policies/site_status_policy_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 describe SiteStatusPolicy do
+  subject { described_class }
+
   let(:provider) { site_status.course.provider }
   let(:site_status) { create(:site_status) }
-
-  subject { described_class }
 
   permissions :update? do
     let(:user) { create(:user).tap { |u| provider.users << u } }

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe 'GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_code/courses', :with_publish_constraint do
+  subject { response }
+
   let(:course_subject_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
 
   let(:current_cycle) { find_or_create :recruitment_cycle }
@@ -46,8 +48,6 @@ describe 'GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
   let(:site_status)    { findable_open_course.site_statuses.first }
   let(:site)           { site_status.site }
 
-  subject { response }
-
   describe 'GET index' do
     def perform_request
       findable_open_course
@@ -57,9 +57,9 @@ describe 'GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
 
     describe 'JSON generated for courses' do
       context 'with a specified provider' do
-        let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/#{provider.provider_code}/courses" }
-
         subject { perform_request }
+
+        let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/providers/#{provider.provider_code}/courses" }
 
         it { is_expected.to have_http_status(:success) }
 

--- a/spec/requests/api/v3/providers/index_spec.rb
+++ b/spec/requests/api/v3/providers/index_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 describe 'GET v3/recruitment_cycle/:recruitment_cycle_year/providers', :with_publish_constraint do
+  subject do
+    perform_request
+
+    response
+  end
+
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
 
   let!(:provider) do
@@ -18,12 +24,6 @@ describe 'GET v3/recruitment_cycle/:recruitment_cycle_year/providers', :with_pub
 
   def perform_request
     get request_path
-  end
-
-  subject do
-    perform_request
-
-    response
   end
 
   describe 'JSON generated for a providers' do

--- a/spec/requests/api/v3/providers/show_spec.rb
+++ b/spec/requests/api/v3/providers/show_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 describe 'GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_code', :with_publish_constraint do
+  subject do
+    perform_request
+    response
+  end
+
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:request_path) { "/api/v3/recruitment_cycles/#{recruitment_cycle.year}/providers/#{provider.provider_code}" }
   let(:request_params) { {} }
@@ -63,11 +68,6 @@ describe 'GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
   end
 
   let(:json_response) { JSON.parse(response.body) }
-
-  subject do
-    perform_request
-    response
-  end
 
   def perform_request
     get request_path, params: request_params

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe API::Public::V1::SerializableCourse do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:enrichment) { build(:course_enrichment, :published) }
   let(:course) { create(:course, :with_accrediting_provider, enrichments: [enrichment]) }
   let(:resource) { described_class.new(object: course) }
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it 'sets type to courses' do
     expect(resource.jsonapi_type).to eq(:courses)

--- a/spec/serializers/api/public/v1/serializable_location_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_location_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::Public::V1::SerializableLocation do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:location) { create(:site) }
   let(:resource) { described_class.new(object: location) }
 
   it 'sets type to locations' do
     expect(resource.jsonapi_type).to eq(:locations)
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'locations' }
 

--- a/spec/serializers/api/public/v1/serializable_provider_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_provider_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::Public::V1::SerializableProvider do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:provider) { create(:provider) }
   let(:resource) { described_class.new object: provider }
 
   it 'sets type to providers' do
     expect(resource.jsonapi_type).to eq :providers
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'providers' }
 

--- a/spec/serializers/api/public/v1/serializable_recruitment_cycle_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_recruitment_cycle_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe API::Public::V1::SerializableRecruitmentCycle do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:cycle) { create(:recruitment_cycle) }
   let(:resource) { described_class.new(object: cycle) }
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it 'sets type to courses' do
     expect(resource.jsonapi_type).to eq(:recruitment_cycles)

--- a/spec/serializers/api/public/v1/serializable_subject_area_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_subject_area_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::Public::V1::SerializableSubjectArea do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:subject_area) { find_or_create(:subject_area, :primary) }
   let(:resource) { described_class.new(object: subject_area) }
 
   it 'sets type to subject_areas' do
     expect(resource.jsonapi_type).to eq(:subject_areas)
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'subject_areas' }
 

--- a/spec/serializers/api/public/v1/serializable_subject_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_subject_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe API::Public::V1::SerializableSubject do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:non_bursary_subject) { find_or_create(:primary_subject, :primary_with_english) }
   let(:resource) { described_class.new(object: non_bursary_subject) }
 
   it 'sets type to users' do
     expect(resource.jsonapi_type).to eq(:subjects)
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'subjects' }
   it { is_expected.to have_attribute(:name).with_value(non_bursary_subject.subject_name) }

--- a/spec/serializers/api/v3/serializable_course_spec.rb
+++ b/spec/serializers/api/v3/serializable_course_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe API::V3::SerializableCourse do
+  subject { parsed_json['data'] }
+
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
   let(:draft_enrichment) { build(:course_enrichment) }
   let(:published_enrichment) { build(:course_enrichment, :published) }
@@ -20,8 +22,6 @@ describe API::V3::SerializableCourse do
     ).to_json
   end
   let(:parsed_json) { JSON.parse(course_json) }
-
-  subject { parsed_json['data'] }
 
   it { is_expected.to have_type('courses') }
   it { is_expected.to have_attribute(:start_date).with_value(time_now.strftime('%B %Y')) }
@@ -194,10 +194,10 @@ describe API::V3::SerializableCourse do
   end
 
   context 'a new course' do
+    subject { parsed_json['data'] }
+
     let(:provider) { create(:provider) }
     let(:course) { Course.new(provider:) }
-
-    subject { parsed_json['data'] }
 
     it { is_expected.to have_attribute(:start_date).with_value(nil) }
   end

--- a/spec/serializers/api/v3/serializable_course_spec.rb
+++ b/spec/serializers/api/v3/serializable_course_spec.rb
@@ -15,7 +15,7 @@ describe API::V3::SerializableCourse do
     jsonapi_renderer.render(
       course,
       class: {
-        Course: API::V3::SerializableCourse
+        Course: described_class
       }
     ).to_json
   end
@@ -49,7 +49,7 @@ describe API::V3::SerializableCourse do
       jsonapi_renderer.render(
         course,
         class: {
-          Course: API::V3::SerializableCourse,
+          Course: described_class,
           Provider: API::V3::SerializableProvider
         },
         include: [
@@ -73,7 +73,7 @@ describe API::V3::SerializableCourse do
       jsonapi_renderer.render(
         course,
         class: {
-          Course: API::V3::SerializableCourse,
+          Course: described_class,
           Subject: API::V3::SerializableSubject,
           PrimarySubject: API::V3::SerializableSubject
         },
@@ -93,7 +93,7 @@ describe API::V3::SerializableCourse do
       jsonapi_renderer.render(
         course,
         class: {
-          Course: API::V3::SerializableCourse,
+          Course: described_class,
           Provider: API::V3::SerializableProvider
         },
         include: [
@@ -112,7 +112,7 @@ describe API::V3::SerializableCourse do
       jsonapi_renderer.render(
         course,
         class: {
-          Course: API::V3::SerializableCourse,
+          Course: described_class,
           Provider: API::V3::SerializableProvider
         },
         include: [
@@ -131,7 +131,7 @@ describe API::V3::SerializableCourse do
       jsonapi_renderer.render(
         course,
         class: {
-          Course: API::V3::SerializableCourse,
+          Course: described_class,
           Provider: API::V3::SerializableProvider
         },
         include: [

--- a/spec/serializers/api/v3/serializable_provider_spec.rb
+++ b/spec/serializers/api/v3/serializable_provider_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::V3::SerializableProvider do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:provider) { create(:provider) }
   let(:resource) { described_class.new object: provider }
 
   it 'sets type to providers' do
     expect(resource.jsonapi_type).to eq :providers
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'providers' }
   it { is_expected.to have_attribute(:provider_code).with_value(provider.provider_code) }

--- a/spec/serializers/api/v3/serializable_recruitment_cycle_spec.rb
+++ b/spec/serializers/api/v3/serializable_recruitment_cycle_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::V3::SerializableRecruitmentCycle do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:recruitment_cycle) { create(:recruitment_cycle) }
   let(:resource) { described_class.new object: recruitment_cycle }
 
   it 'sets type to recruitment_cycles' do
     expect(resource.jsonapi_type).to eq :recruitment_cycles
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'recruitment_cycles' }
   it { is_expected.to have_attribute(:year).with_value(recruitment_cycle.year) }

--- a/spec/serializers/api/v3/serializable_site_spec.rb
+++ b/spec/serializers/api/v3/serializable_site_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe API::V3::SerializableSite do
   let(:site)     { create(:site) }
-  let(:resource) { API::V3::SerializableSite.new object: site }
+  let(:resource) { described_class.new object: site }
 
   it 'sets type to sites' do
     expect(resource.jsonapi_type).to eq :sites

--- a/spec/serializers/api/v3/serializable_site_spec.rb
+++ b/spec/serializers/api/v3/serializable_site_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::V3::SerializableSite do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:site)     { create(:site) }
   let(:resource) { described_class.new object: site }
 
   it 'sets type to sites' do
     expect(resource.jsonapi_type).to eq :sites
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'sites' }
   it { is_expected.to have_attribute(:location_name).with_value(site.location_name) }

--- a/spec/serializers/api/v3/serializable_site_status_spec.rb
+++ b/spec/serializers/api/v3/serializable_site_status_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::V3::SerializableSiteStatus do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:site_status) { create(:site_status) }
   let(:resource) { described_class.new object: site_status }
 
   it 'sets type to site_statuses' do
     expect(resource.jsonapi_type).to eq :site_statuses
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'site_statuses' }
 end

--- a/spec/serializers/api/v3/serializable_site_status_spec.rb
+++ b/spec/serializers/api/v3/serializable_site_status_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe API::V3::SerializableSiteStatus do
   let(:site_status) { create(:site_status) }
-  let(:resource) { API::V3::SerializableSiteStatus.new object: site_status }
+  let(:resource) { described_class.new object: site_status }
 
   it 'sets type to site_statuses' do
     expect(resource.jsonapi_type).to eq :site_statuses

--- a/spec/serializers/api/v3/serializable_subject_area_spec.rb
+++ b/spec/serializers/api/v3/serializable_subject_area_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::V3::SerializableSubjectArea do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:subject_area) { SubjectArea.first }
   let(:resource) { described_class.new(object: subject_area) }
 
   it 'sets type to subject_areas' do
     expect(resource.jsonapi_type).to eq(:subject_areas)
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'subject_areas' }
   it { is_expected.to have_attribute(:typename).with_value(subject_area.typename) }

--- a/spec/serializers/api/v3/serializable_subject_spec.rb
+++ b/spec/serializers/api/v3/serializable_subject_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe API::V3::SerializableSubject do
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
   let(:non_bursary_subject) { find_or_create :primary_subject, :primary_with_english }
   let(:resource) { described_class.new object: non_bursary_subject }
 
   it 'sets type to users' do
     expect(resource.jsonapi_type).to eq :subjects
   end
-
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   it { is_expected.to have_type 'subjects' }
   it { is_expected.to have_attribute(:subject_name).with_value(non_bursary_subject.subject_name) }

--- a/spec/serializers/api/v3/serializable_subject_spec.rb
+++ b/spec/serializers/api/v3/serializable_subject_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe API::V3::SerializableSubject do
   let(:non_bursary_subject) { find_or_create :primary_subject, :primary_with_english }
-  let(:resource) { API::V3::SerializableSubject.new object: non_bursary_subject }
+  let(:resource) { described_class.new object: non_bursary_subject }
 
   it 'sets type to users' do
     expect(resource.jsonapi_type).to eq :subjects
@@ -25,7 +25,7 @@ describe API::V3::SerializableSubject do
 
   context 'when a bursary subject with subject knowledge enhancement course available' do
     let(:bursary_subject) { find_or_create(:secondary_subject, :mathematics) }
-    let(:resource) { API::V3::SerializableSubject.new object: bursary_subject }
+    let(:resource) { described_class.new object: bursary_subject }
 
     it { is_expected.to have_attribute(:bursary_amount).with_value(bursary_subject.financial_incentive.bursary_amount) }
     it { is_expected.to have_attribute(:early_career_payments).with_value(bursary_subject.financial_incentive.early_career_payments) }

--- a/spec/services/access_request_approval_service_spec.rb
+++ b/spec/services/access_request_approval_service_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 
 describe AccessRequestApprovalService do
   describe '.call' do
-    let!(:access_request) { create(:access_request) }
-
     subject(:call_service!) { described_class.call(access_request) }
+
+    let!(:access_request) { create(:access_request) }
 
     context 'for a new user' do
       let(:target_user) { User.find_by(email: access_request.email_address) }
 
       it 'creates the new user' do
-        expect { call_service! }.to change { User.count }.by(1)
+        expect { call_service! }.to change(User, :count).by(1)
       end
 
       it 'sets the email address' do
@@ -36,7 +36,7 @@ describe AccessRequestApprovalService do
       end
 
       it 'is marked completed' do
-        expect { call_service! }.to change { access_request.status }
+        expect { call_service! }.to change(access_request, :status)
           .from('requested')
           .to('completed')
       end
@@ -57,7 +57,7 @@ describe AccessRequestApprovalService do
       let!(:target_user) { create(:user, email: access_request.email_address) }
 
       it 'does not create a new user' do
-        expect { call_service! }.not_to(change { User.count })
+        expect { call_service! }.not_to(change(User, :count))
       end
 
       it "sets the target user's providers to the requesting user's providers" do
@@ -130,7 +130,7 @@ describe AccessRequestApprovalService do
       let(:requester_provider_count) { access_request.requester.providers.count }
 
       it 'successfully writes to user_permission' do
-        expect { call_service! }.to change { UserPermission.count }.by(requester_provider_count)
+        expect { call_service! }.to change(UserPermission, :count).by(requester_provider_count)
       end
     end
   end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 describe AuthenticationService do
   describe '#execute' do
+    subject { service.execute(token) }
+
     let(:user) { create(:user) }
     let(:email) { user.email }
     let(:first_name) { user.first_name }
@@ -21,8 +23,6 @@ describe AuthenticationService do
     let(:token) { build_jwt(:apiv2, payload:) }
 
     let(:service) { described_class.new(logger: logger_spy) }
-
-    subject { service.execute(token) }
 
     context 'with a valid DfE-SignIn ID and email' do
       let(:first_name) { "#{user.first_name}_new" }

--- a/spec/services/course_attribute_formatter_service_spec.rb
+++ b/spec/services/course_attribute_formatter_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CourseAttributeFormatterService do
-  subject { CourseAttributeFormatterService.call(name:, value:) }
+  subject { described_class.call(name:, value:) }
 
   shared_examples_for 'value is nil' do
     context 'with an unknown value' do

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe CourseSearchService do
   describe '.call' do
+    subject do
+      described_class.call(filter:, sort:, course_scope: scope)
+    end
+
     let(:course_with_includes) { class_double(Course) }
     let(:scope) { class_double(Course) }
     let(:select_scope) { class_double(Course) }
@@ -40,10 +44,6 @@ RSpec.describe CourseSearchService do
         expect(course_with_includes).to receive(:where).and_return(expected_scope)
         expect(subject).to eq(expected_scope)
       end
-    end
-
-    subject do
-      described_class.call(filter:, sort:, course_scope: scope)
     end
 
     describe 'sort by' do

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 describe Courses::CreationService do
+  subject do
+    described_class.call(
+      course_params: valid_course_params, provider:,
+      next_available_course_code:
+    )
+  end
+
   let(:provider) { create(:provider, sites: [site]) }
 
   let(:site) { build(:site) }
@@ -10,13 +17,6 @@ describe Courses::CreationService do
   let(:recruitment_cycle) { provider.recruitment_cycle }
 
   let(:next_available_course_code) { false }
-
-  subject do
-    described_class.call(
-      course_params: valid_course_params, provider:,
-      next_available_course_code:
-    )
-  end
 
   context 'primary course' do
     let(:primary_subject) { find_or_create(:primary_subject, :primary) }

--- a/spec/services/courses/generate_course_name_service_spec.rb
+++ b/spec/services/courses/generate_course_name_service_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe Courses::GenerateCourseNameService do
+  subject(:generated_title) { described_class.call(course:) }
+
   let(:subjects) { [] }
   let(:is_send) { false }
   let(:level) { 'primary' }
   let(:campaign_name) { 'no_campaign' }
   let(:course) { Course.new(level:, subjects:, is_send:, campaign_name:) }
   let(:modern_languages) { find_or_create(:secondary_subject, :modern_languages) }
-
-  subject(:generated_title) { described_class.call(course:) }
 
   before do
     SecondarySubject.clear_cache

--- a/spec/services/csv_imports/fake_providers_import_spec.rb
+++ b/spec/services/csv_imports/fake_providers_import_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CSVImports::FakeProvidersImport do
     it 'creates two providers' do
       expect do
         described_class.new('csv_file.csv').execute
-      end.to change { Provider.count }.by(2)
+      end.to change(Provider, :count).by(2)
     end
 
     it 'reports on both created providers' do

--- a/spec/services/enrichments/copy_to_course_service_spec.rb
+++ b/spec/services/enrichments/copy_to_course_service_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe Enrichments::CopyToCourseService do
+  subject { new_course.enrichments }
+
   let(:service) { described_class.new }
   let(:course) { create(:course) }
   let(:new_course) { create(:course) }
@@ -11,8 +13,6 @@ describe Enrichments::CopyToCourseService do
   end
 
   before { service.execute(enrichment: published_enrichment, new_course:) }
-
-  subject { new_course.enrichments }
 
   its(:length) { is_expected.to eq 1 }
 

--- a/spec/services/feature_service_spec.rb
+++ b/spec/services/feature_service_spec.rb
@@ -11,7 +11,7 @@ describe FeatureService do
       end
 
       it 'returns true' do
-        response = FeatureService.require(:rspec_testing)
+        response = described_class.require(:rspec_testing)
 
         expect(response).to be_truthy
       end
@@ -24,7 +24,7 @@ describe FeatureService do
       end
 
       it 'raises an error' do
-        expect { FeatureService.require(:rspec_testing) }
+        expect { described_class.require(:rspec_testing) }
           .to raise_error(RuntimeError, 'Feature rspec_testing is disabled')
       end
     end
@@ -36,7 +36,7 @@ describe FeatureService do
       end
 
       it 'returns true' do
-        response = FeatureService.require('rspec_testing.nested')
+        response = described_class.require('rspec_testing.nested')
 
         expect(response).to be_truthy
       end
@@ -49,7 +49,7 @@ describe FeatureService do
       end
 
       it 'raises an error' do
-        expect { FeatureService.require('rspec_testing.nested') }
+        expect { described_class.require('rspec_testing.nested') }
           .to raise_error(RuntimeError, 'Feature rspec_testing.nested is disabled')
       end
     end
@@ -63,7 +63,7 @@ describe FeatureService do
       end
 
       it 'returns true' do
-        response = FeatureService.enabled?(:rspec_testing)
+        response = described_class.enabled?(:rspec_testing)
 
         expect(response).to be_truthy
       end
@@ -76,7 +76,7 @@ describe FeatureService do
       end
 
       it 'returns false' do
-        response = FeatureService.enabled?(:rspec_testing)
+        response = described_class.enabled?(:rspec_testing)
 
         expect(response).to be_falsey
       end
@@ -89,7 +89,7 @@ describe FeatureService do
       end
 
       it 'looks up the feature using dot-separated segments' do
-        response = FeatureService.enabled?('rspec_testing.nested')
+        response = described_class.enabled?('rspec_testing.nested')
 
         expect(response).to be_truthy
       end
@@ -102,7 +102,7 @@ describe FeatureService do
       end
 
       it 'looks up the feature using dot-separated segments' do
-        response = FeatureService.enabled?('rspec_testing.nested')
+        response = described_class.enabled?('rspec_testing.nested')
 
         expect(response).to be_falsey
       end
@@ -119,7 +119,7 @@ describe FeatureService do
       end
 
       it 'returns false' do
-        response = FeatureService.enabled?(:rspec_testing)
+        response = described_class.enabled?(:rspec_testing)
 
         expect(response).to be_falsey
       end

--- a/spec/services/geocoder_service_spec.rb
+++ b/spec/services/geocoder_service_spec.rb
@@ -36,7 +36,7 @@ describe GeocoderService do
 
     context 'a valid object' do
       it 'geocodes a valid object' do
-        expect { GeocoderService.geocode(obj: valid_site) }
+        expect { described_class.geocode(obj: valid_site) }
           .to change { valid_site.reload.latitude }.from(nil).to(50.8312522)
                                                    .and change { valid_site.longitude }.from(nil).to(-1.3792036)
                                                                                        .and change { valid_site.region_code }.from(nil).to('south_east')
@@ -45,25 +45,25 @@ describe GeocoderService do
       it 'geocodes UK (gb) addresses only' do
         expect(Geokit::Geocoders::GoogleGeocoder).to receive(:geocode).with(valid_site.full_address, bias: 'gb')
 
-        GeocoderService.geocode(obj: valid_site)
+        described_class.geocode(obj: valid_site)
       end
     end
 
     context 'invalid object' do
       it 'does not geocode an invalid object by default' do
-        expect { GeocoderService.geocode(obj: invalid_site) }
+        expect { described_class.geocode(obj: invalid_site) }
           .to raise_error(ActiveRecord::RecordInvalid)
       end
 
       it 'geocodes an invalid object if forced' do
-        expect { GeocoderService.geocode(obj: invalid_site, force: true) }
+        expect { described_class.geocode(obj: invalid_site, force: true) }
           .to change { invalid_site.reload.latitude }.from(nil).to(51.4524877)
                                                      .and change { invalid_site.longitude }.from(nil).to(-0.1204749)
                                                                                            .and change { invalid_site.region_code }.from(nil).to('london')
       end
 
       it 'does not save to database if Geocoder returns an unsuccessful response' do
-        expect { GeocoderService.geocode(obj: site_with_no_address, force: true) }
+        expect { described_class.geocode(obj: site_with_no_address, force: true) }
           .to not_change { site_with_no_address.latitude }
           .and(not_change { site_with_no_address.longitude })
           .and(not_change { site_with_no_address.region_code })

--- a/spec/services/geocoder_service_spec.rb
+++ b/spec/services/geocoder_service_spec.rb
@@ -38,8 +38,8 @@ describe GeocoderService do
       it 'geocodes a valid object' do
         expect { described_class.geocode(obj: valid_site) }
           .to change { valid_site.reload.latitude }.from(nil).to(50.8312522)
-                                                   .and change { valid_site.longitude }.from(nil).to(-1.3792036)
-                                                                                       .and change { valid_site.region_code }.from(nil).to('south_east')
+                                                   .and change(valid_site, :longitude).from(nil).to(-1.3792036)
+                                                                                      .and change(valid_site, :region_code).from(nil).to('south_east')
       end
 
       it 'geocodes UK (gb) addresses only' do
@@ -58,8 +58,8 @@ describe GeocoderService do
       it 'geocodes an invalid object if forced' do
         expect { described_class.geocode(obj: invalid_site, force: true) }
           .to change { invalid_site.reload.latitude }.from(nil).to(51.4524877)
-                                                     .and change { invalid_site.longitude }.from(nil).to(-0.1204749)
-                                                                                           .and change { invalid_site.region_code }.from(nil).to('london')
+                                                     .and change(invalid_site, :longitude).from(nil).to(-0.1204749)
+                                                                                          .and change(invalid_site, :region_code).from(nil).to('london')
       end
 
       it 'does not save to database if Geocoder returns an unsuccessful response' do

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -186,12 +186,12 @@ describe Providers::CopyToRecruitmentCycleService do
       end
 
       context 'with force as true' do
-        let(:force) { true }
-        let(:course_codes) { nil }
-
         subject do
           service.execute(provider:, new_recruitment_cycle:, course_codes:)
         end
+
+        let(:force) { true }
+        let(:course_codes) { nil }
 
         it 'still copies the provider' do
           expect do

--- a/spec/services/providers/create_fake_provider_service_spec.rb
+++ b/spec/services/providers/create_fake_provider_service_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe Providers::CreateFakeProviderService do
   it 'creates providers' do
     expect do
       service.execute
-    end.to change { Provider.count }.by(1).and \
-      change { Organisation.count }.by(1).and \
-        change { Site.count }.by(1)
+    end.to change(Provider, :count).by(1).and \
+      change(Organisation, :count).by(1).and \
+        change(Site, :count).by(1)
   end
 
   context 'a provider with that code already exists' do

--- a/spec/services/publish_reporting_service_spec.rb
+++ b/spec/services/publish_reporting_service_spec.rb
@@ -80,12 +80,12 @@ describe PublishReportingService do
 
   describe '.call' do
     describe 'when scope is passed' do
+      subject { described_class.call(recruitment_cycle_scope:) }
+
       before do
         allow(recruitment_cycle_scope).to receive(:courses).and_return(courses_scope)
         allow(recruitment_cycle_scope).to receive(:providers).and_return(providers_scope)
       end
-
-      subject { described_class.call(recruitment_cycle_scope:) }
 
       it 'applies the scopes' do
         expect(User).to receive(:count).and_return(666)

--- a/spec/services/recruitment_cycle_creation_service_spec.rb
+++ b/spec/services/recruitment_cycle_creation_service_spec.rb
@@ -7,7 +7,7 @@ describe RecruitmentCycleCreationService do
     subject { described_class.call(year: 2030, application_start_date: '2031-09-01', application_end_date: '2032-09-01') }
 
     it 'calls the recruitment cycle creation service' do
-      expect(RecruitmentCycleCreationService).to receive(:call)
+      expect(described_class).to receive(:call)
       subject
     end
 

--- a/spec/services/sites/code_generator_spec.rb
+++ b/spec/services/sites/code_generator_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 describe Sites::CodeGenerator do
-  let(:provider) { create(:provider) }
-
   subject { described_class.call(provider:) }
+
+  let(:provider) { create(:provider) }
 
   it 'generates a UCAS style code (one of A-Z, 0-9 or -)' do
     expect(subject).to match(/\A[A-Z0-9-]{1}\z/)

--- a/spec/services/support/data_exports/data_export_spec.rb
+++ b/spec/services/support/data_exports/data_export_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Support::DataExports::DataExport do
-  subject { Support::DataExports::DataExport }
+  subject { described_class }
 
   describe '#all' do
     it 'returns all export types' do

--- a/spec/services/token/decode_service_spec.rb
+++ b/spec/services/token/decode_service_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 describe Token::DecodeService do
+  subject do
+    described_class.call(encoded_token:,
+                         secret: Settings.authentication.secret,
+                         algorithm: Settings.authentication.algorithm,
+                         audience: Settings.authentication.audience,
+                         issuer: Settings.authentication.issuer,
+                         subject: Settings.authentication.subject)
+  end
+
   let(:email) { 'bat@localhost' }
   let(:payload) { { 'email' => email } }
 
@@ -30,15 +39,6 @@ describe Token::DecodeService do
               audience: encode_service_audience,
               issuer: encode_service_issuer,
               subject: encode_service_subject)
-  end
-
-  subject do
-    described_class.call(encoded_token:,
-                         secret: Settings.authentication.secret,
-                         algorithm: Settings.authentication.algorithm,
-                         audience: Settings.authentication.audience,
-                         issuer: Settings.authentication.issuer,
-                         subject: Settings.authentication.subject)
   end
 
   describe '#call' do

--- a/spec/services/user_associations_service/create_spec.rb
+++ b/spec/services/user_associations_service/create_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe UserAssociationsService::Create, { can_edit_current_and_next_cycl
 
   describe '#call' do
     context 'when adding to a single organisation' do
-      let(:accredited_body) { create(:provider, :accredited_body, users: [user]) }
-
-      let(:new_accredited_body) { create(:provider, :accredited_body, provider_code: 'AAA') }
-
-      let(:action_mailer) { double }
-
       subject do
         described_class.call(
           provider: new_accredited_body,
           user:
         )
       end
+
+      let(:accredited_body) { create(:provider, :accredited_body, users: [user]) }
+
+      let(:new_accredited_body) { create(:provider, :accredited_body, provider_code: 'AAA') }
+
+      let(:action_mailer) { double }
 
       before do
         allow(NewUserAddedBySupportTeamMailer).to receive(:user_added_to_provider_email).and_return(action_mailer)

--- a/spec/services/v3/course_search_service_spec.rb
+++ b/spec/services/v3/course_search_service_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 RSpec.describe V3::CourseSearchService do
   describe '.call' do
-    before do
-      allow(CourseSearchService).to receive(:call)
-    end
-
     subject do
       described_class.call
+    end
+
+    before do
+      allow(CourseSearchService).to receive(:call)
     end
 
     it 'call ::CourseSearchService' do

--- a/spec/services/vacancy_status_determination_service_spec.rb
+++ b/spec/services/vacancy_status_determination_service_spec.rb
@@ -4,9 +4,6 @@ require 'spec_helper'
 
 describe VacancyStatusDeterminationService do
   describe '.call' do
-    let(:vacancy_status_full_time) { '0' }
-    let(:vacancy_status_part_time) { '0' }
-
     subject do
       described_class.call(
         vacancy_status_full_time:,
@@ -14,6 +11,9 @@ describe VacancyStatusDeterminationService do
         course:
       )
     end
+
+    let(:vacancy_status_full_time) { '0' }
+    let(:vacancy_status_part_time) { '0' }
 
     context 'with a full time or part time course' do
       let(:course) { build_stubbed(:course, :full_time_or_part_time) }

--- a/spec/smoke/api/v1/courses_spec.rb
+++ b/spec/smoke/api/v1/courses_spec.rb
@@ -3,9 +3,9 @@
 require 'spec_helper_smoke'
 
 describe 'V1 Public API Smoke Tests', :aggregate_failures, smoke: true do
-  let(:base_url) { Settings.publish_api_url }
-
   subject(:response) { HTTParty.get(url) }
+
+  let(:base_url) { Settings.publish_api_url }
 
   context 'courses' do
     describe 'GET /api/public/v1/recruitment_cycles/:recruitment_year/courses' do

--- a/spec/smoke/api/v1/healthcheck_spec.rb
+++ b/spec/smoke/api/v1/healthcheck_spec.rb
@@ -3,9 +3,9 @@
 require 'spec_helper_smoke'
 
 describe 'V1 Public API Smoke Tests', :aggregate_failures, smoke: true do
-  let(:base_url) { Settings.publish_api_url }
-
   subject(:response) { HTTParty.get(url) }
+
+  let(:base_url) { Settings.publish_api_url }
 
   describe 'GET /healthcheck' do
     let(:url) { "#{base_url}/healthcheck" }

--- a/spec/smoke/api/v1/providers_spec.rb
+++ b/spec/smoke/api/v1/providers_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper_smoke'
 
 describe 'V1 Public API Smoke Tests', :aggregate_failures, smoke: true do
+  subject(:response) { HTTParty.get(url) }
+
   let(:recruitment_year) { Settings.current_recruitment_cycle_year }
   let(:base_url) { Settings.publish_api_url }
-
-  subject(:response) { HTTParty.get(url) }
 
   context 'providers' do
     describe 'GET /v1/recruitment_cycles/:recruitment_year/providers' do

--- a/spec/validators/email_address_validator_spec.rb
+++ b/spec/validators/email_address_validator_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe EmailAddressValidator do
+  subject { instance.valid?(:no_context) }
+
   let(:model) do
     Class.new do
       include ActiveRecord::Validations
@@ -19,8 +21,6 @@ describe EmailAddressValidator do
     instance.validate(:no_context)
     instance.email = email_string
   end
-
-  subject { instance.valid?(:no_context) }
 
   shared_examples 'an invalid email address' do |value|
     let(:email_string) { value }

--- a/spec/validators/words_count_validator_spec.rb
+++ b/spec/validators/words_count_validator_spec.rb
@@ -5,10 +5,6 @@ require 'rails_helper'
 describe WordsCountValidator do
   maximum = 10
 
-  subject! do
-    model.valid?
-  end
-
   before do
     stub_const('Validatable', Class.new).class_eval do
       include ActiveModel::Validations
@@ -25,6 +21,10 @@ describe WordsCountValidator do
   end
 
   let(:expected_errors) { ['^Reduce the word count for some words'] }
+
+  subject! do
+    model.valid?
+  end
 
   context 'with max valid number of words' do
     let(:some_words_field) { (%w[word] * maximum).join(' ') }

--- a/spec/validators/words_count_validator_spec.rb
+++ b/spec/validators/words_count_validator_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 describe WordsCountValidator do
   maximum = 10
 
+  subject! do
+    model.valid?
+  end
+
   before do
     stub_const('Validatable', Class.new).class_eval do
       include ActiveModel::Validations
@@ -21,10 +25,6 @@ describe WordsCountValidator do
   end
 
   let(:expected_errors) { ['^Reduce the word count for some words'] }
-
-  subject! do
-    model.valid?
-  end
 
   context 'with max valid number of words' do
     let(:some_words_field) { (%w[word] * maximum).join(' ') }


### PR DESCRIPTION
### Context

We have lots of tech debt because of cops not being enabled. This PR enables some of them and fixes the bad code. 

**This PR focuses on clearing out the `rspec.yml` file.**

### Changes proposed in this pull request

See commits

### Guidance to review

- Recommend reviewing commit by commit, as in each commit  one particular cop is enabled and all the code is adjusted to pass the linter.

- Do we want to keep any of these cops disabled?

- Do we want to enable any other cops?

- Do we want to remove any of the exlusions?

- Play around with the review app in areas which relies on lots of code working together to ensure there are no (untested) hidden breakages.

- Check everywhere (Find/Publish/Support)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
