### PR TITLE
[0957] Remove the change links for courses in the withdrawn state

### DIFF
--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -1,219 +1,239 @@
-    <%= govuk_summary_list do |summary_list| %>
-      <% summary_list.row(html_attributes: { data: { qa: "course__level" } }) do |row| %>
-        <% row.key { "Level" } %>
-        <% row.value { course.level.humanize } %>
-        <% row.action %>
-      <% end %>
+<%= govuk_summary_list do |summary_list| %>
+ <% summary_list.row(html_attributes: { data: { qa: "course__level" } }) do |row|
+      row.key { "Level" }
+      row.value { course.level.humanize }
+      row.action
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__is_send" } }) do |row| %>
-        <% row.key { raw("<abbr class=\"app-!-text-decoration-underline-dotted\" title=\"Special educational needs and disability\">SEND</abbr>") } %>
-        <% row.value { course.is_send? } %>
-        <% if @course.edit_course_options[:show_is_send] %>
-          <% row.action(
-            # href: send_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-            visually_hidden_text: "SEND"
-          ) %>
-        <% else %>
-          <% row.action %>
-        <% end %>
-      <% end %>
+    summary_list.row(html_attributes: { data: { qa: "course__is_send" } }) do |row|
+      row.key { raw("<abbr class=\"app-!-text-decoration-underline-dotted\" title=\"Special educational needs and disability\">SEND</abbr>") }
+      row.value { course.is_send? }
+      if course.edit_course_options[:show_is_send] && !course.is_withdrawn?
+        row.action(
+          # href: send_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+          visually_hidden_text: "SEND"
+        )
+      else
+        row.action
+      end
+    end
 
-      <% unless course.further_education_course? %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__subjects" } }) do |row| %>
-          <% row.key { "Subject".pluralize(course.subjects.count) } %>
-          <% row.value { course.chosen_subjects } %>
-          <% row.action(
+    unless course.further_education_course?
+      summary_list.row(html_attributes: { data: { qa: "course__subjects" } }) do |row|
+        row.key { "Subject".pluralize(course.subjects.count) }
+        row.value { course.chosen_subjects }
+        if course.is_withdrawn?
+          row.action
+        else
+          row.action(
             href: subjects_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
             visually_hidden_text: "subjects"
-          ) %>
-        <% end %>
-      <% end %>
+          )
+        end
+      end
+    end
 
-      <% if course.applicable_for_engineers_teach_physics? %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__engineers_teach_physics" } }) do |row| %>
-          <% row.key { "Engineers Teach Physics" } %>
-          <% row.value { course.engineers_teach_physics? ? "Yes" : "No" } %>
-          <% row.action(
-            href: engineers_teach_physics_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code, course: { subjects_ids: course.subject_ids }, skip_languages_goto_confirmation: true),
-            visually_hidden_text: "Engineers Teach Physics"
-          ) %>
-        <% end %>
-      <% end %>
+    if course.applicable_for_engineers_teach_physics?
+      summary_list.row(html_attributes: { data: { qa: "course__engineers_teach_physics" } }) do |row|
+        row.key { "Engineers Teach Physics" }
+        row.value { course.engineers_teach_physics? ? "Yes" : "No" }
+        row.action(
+          href: engineers_teach_physics_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code, course: { subjects_ids: course.subject_ids }, skip_languages_goto_confirmation: true),
+          visually_hidden_text: "Engineers Teach Physics"
+        )
+      end
+    end
 
-      <% unless course.further_education_course? %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__age_range" } }) do |row| %>
-          <% row.key { "Age range" } %>
-          <% row.value { course.age_range } %>
-          <% row.action(
+    unless course.further_education_course?
+      summary_list.row(html_attributes: { data: { qa: "course__age_range" } }) do |row|
+        row.key { "Age range" }
+        row.value { course.age_range }
+        if course.is_withdrawn?
+          row.action
+        else
+          row.action(
             href: age_range_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
             visually_hidden_text: "age range"
-          ) %>
-        <% end %>
-      <% end %>
+          )
+        end
+      end
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__outcome" } }) do |row| %>
-        <% row.key { "Outcome" } %>
-        <% row.value { course.outcome } %>
-        <% row.action(
+    summary_list.row(html_attributes: { data: { qa: "course__outcome" } }) do |row|
+      row.key { "Outcome" }
+      row.value { course.outcome }
+      if course.is_withdrawn?
+        row.action
+      else
+        row.action(
           href: outcome_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
           visually_hidden_text: "outcome"
-        ) %>
-      <% end %>
+        )
+      end
+    end
 
-      <% if @provider.accredited_body? %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__apprenticeship" } }) do |row| %>
-          <% row.key { "Apprenticeship" } %>
-          <% row.value { course.apprenticeship } %>
-          <% if course.is_published? %>
-            <% row.action %>
-          <% else %>
-            <% row.action(
-              href: course.draft_or_rolled_over? ? apprenticeship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) : nil,
-              visually_hidden_text: "if apprenticeship"
-            ) %>
-          <% end %>
-        <% end %>
-      <% else %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__funding" } }) do |row| %>
-          <% row.key { "Funding type" } %>
-          <% row.value { course.funding } %>
-          <% if course.is_published? %>
-            <% row.action %>
-          <% else %>
-            <% row.action(
-              href: course.draft_or_rolled_over? ? funding_type_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) : nil,
-              visually_hidden_text: "funding type"
-            ) %>
-          <% end %>
-        <% end %>
-      <% end %>
+    if @provider.accredited_body?
+      summary_list.row(html_attributes: { data: { qa: "course__apprenticeship" } }) do |row|
+        row.key { "Apprenticeship" }
+        row.value { course.apprenticeship }
+        if course.is_published? || course.is_withdrawn?
+          row.action
+        else
+          row.action(
+            href: course.draft_or_rolled_over? ? apprenticeship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) : nil,
+            visually_hidden_text: "if apprenticeship"
+          )
+        end
+      end
+    else
+      summary_list.row(html_attributes: { data: { qa: "course__funding" } }) do |row|
+        row.key { "Funding type" }
+        row.value { course.funding }
+        if course.is_published? || course.is_withdrawn?
+          row.action
+        else
+          row.action(
+            href: course.draft_or_rolled_over? ? funding_type_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code) : nil,
+            visually_hidden_text: "funding type"
+          )
+        end
+      end
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__study_mode" } }) do |row| %>
-        <% row.key { "Full or part time" } %>
-        <% row.value { course.study_mode&.humanize } %>
-        <% row.action(
+    summary_list.row(html_attributes: { data: { qa: "course__study_mode" } }) do |row|
+      row.key { "Full or part time" }
+      row.value { course.study_mode&.humanize }
+      if course.is_withdrawn?
+        row.action
+      else
+        row.action(
           href: full_part_time_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
           visually_hidden_text: "if full or part time"
-        ) %>
-      <% end %>
+        )
+      end
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__locations" } }) do |row| %>
-        <% row.key { "Locations" } %>
-        <% row.value do %>
-          <% if course.sites.nil? || course.sites.empty? %>
-            <span class="app-!-colour-muted">None</span>
-          <% elsif course.sites.size == 1 %>
-            <%= course.sites.first.location_name %>
-          <% else %>
-            <ul class="govuk-list">
-              <% course.alphabetically_sorted_sites.each do |site| %>
-                <li><%= site.location_name %></li>
-              <% end %>
-            </ul>
-          <% end %>
-        <% end %>
-        <% row.action(
+    summary_list.row(html_attributes: { data: { qa: "course__locations" } }) do |row|
+      row.key { "Locations" }
+      row.value do
+        if course.sites.blank?
+          raw("<span class=\"app-!-colour-muted\">None</span>")
+        elsif course.sites.size == 1
+          course.sites.first.location_name
+        else
+          location_names = course.alphabetically_sorted_sites.map do |site|
+            "<li>#{site.location_name}</li>"
+          end
+          raw("<ul class=\"govuk-list\">#{location_names.join}</ul>")
+        end
+      end
+
+      if course.is_withdrawn?
+        row.action
+      else
+        row.action(
           href: locations_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
           visually_hidden_text: "locations"
-        ) %>
-      <% end %>
+        )
+      end
+    end
 
-      <% unless @provider.accredited_body? %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__accredited_body" } }) do |row| %>
-          <% row.key { "Accredited body" } %>
-          <% row.value { course.accrediting_provider&.provider_name } %>
-          <% if course.is_published? %>
-            <% row.action %>
-          <% else %>
-            <% row.action(**{
-              # href: accredited_body_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-              # visually_hidden_text: "accredited body",
-            }) %>
-          <% end %>
-        <% end %>
-      <% end %>
+    unless @provider.accredited_body?
+      summary_list.row(html_attributes: { data: { qa: "course__accredited_body" } }) do |row|
+        row.key { "Accredited body" }
+        row.value { course.accrediting_provider&.provider_name }
+        if course.is_published? || course.is_withdrawn?
+          row.action
+        else
+          row.action(**{
+                        # href: accredited_body_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                        # visually_hidden_text: "accredited body",
+                      })
+        end
+      end
+    end
 
-        <% if course.is_fee_based? %>
-          <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row| %>
-            <% row.key { "Student visas" } %>
-            <% row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-            <% if !course.changeable? %>
-              <% row.action %>
-            <% else %>
-              <% row.action(
-                href: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                visually_hidden_text: "can sponsor student visa"
-              ) %>
-            <% end %>
-          <% end %>
-        <% else %>
-          <% summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row| %>
-            <% row.key { "Skilled Worker visas" } %>
-            <% row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-            <% if !course.changeable? %>
-              <% row.action %>
-            <% else %>
-              <% row.action(
-                href: skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                visually_hidden_text: "can sponsor skilled_worker visa"
-              ) %>
-            <% end %>
-          <% end %>
-        <% end %>
+    if course.is_fee_based?
+      summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_student_visa" } }) do |row|
+        row.key { "Student visas" }
+        row.value { course.can_sponsor_student_visa ? "Yes - can sponsor " : "No - cannot sponsor" }
+        if course.changeable?
+          row.action(
+            href: student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+            visually_hidden_text: "can sponsor student visa"
+          )
+        else
+          row.action
+        end
+      end
+    else
+      summary_list.row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row|
+        row.key { "Skilled Worker visas" }
+        row.value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" }
+        if course.changeable?
+          row.action(
+            href: skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+            visually_hidden_text: "can sponsor skilled_worker visa"
+          )
+        else
+          row.action
+        end
+      end
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__applications_open" } }) do |row| %>
-        <% row.key { "Applications open" } %>
-        <% row.value { l(course.applications_open_from&.to_date) } %>
-        <% if @course.edit_course_options[:show_applications_open] %>
-          <% row.action(**{
-            # href: applications_open_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-            # visually_hidden_text: "date applications open",
-          }) %>
-        <% else %>
-          <% row.action %>
-        <% end %>
-      <% end %>
+    summary_list.row(html_attributes: { data: { qa: "course__applications_open" } }) do |row|
+      row.key { "Applications open" }
+      row.value { l(course.applications_open_from&.to_date) }
+      if course.edit_course_options[:show_applications_open]
+        row.action(**{
+                      # href: applications_open_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                      # visually_hidden_text: "date applications open",
+                    })
+      else
+        row.action
+      end
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__start_date" } }) do |row| %>
-        <% row.key { "Course starts" } %>
-        <% row.value do %>
-          <p class="govuk-body"><%= l(course.start_date&.to_date, format: :short) %></p>
-          <p class="govuk-hint govuk-!-margin-top-0">Academic year <%= course.academic_year %></p>
-        <% end %>
-        <% if @course.edit_course_options[:show_start_date] %>
-          <% row.action(**{
-            # href: start_date_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-            # visually_hidden_text: "date course starts",
-          }) %>
-        <% else %>
-          <% row.action %>
-        <% end %>
-      <% end %>
+    summary_list.row(html_attributes: { data: { qa: "course__start_date" } }) do |row|
+      row.key { "Course starts" }
+      row.value do
+        raw("<p class=\"govuk-body\">#{l(course.start_date&.to_date, format: :short)} </p>
+              <p class=\"govuk-hint govuk-!-margin-top-0\">Academic year #{course.academic_year} </p>")
+      end
+      if course.edit_course_options[:show_start_date]
+        row.action(**{
+                      # href: start_date_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                      # visually_hidden_text: "date course starts",
+                    })
+      else
+        row.action
+      end
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__name" } }) do |row| %>
-        <% row.key { "Title" } %>
-        <% row.value { course.name } %>
-        <% row.action %>
-      <% end %>
+    summary_list.row(html_attributes: { data: { qa: "course__name" } }) do |row|
+      row.key { "Title" }
+      row.value { course.name }
+      row.action
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__description" } }) do |row| %>
-        <% row.key { "Description" } %>
-        <% row.value { course.description } %>
-        <% row.action %>
-      <% end %>
+    summary_list.row(html_attributes: { data: { qa: "course__description" } }) do |row|
+      row.key { "Description" }
+      row.value { course.description }
+      row.action
+    end
 
-      <% summary_list.row(html_attributes: { data: { qa: "course__course_code" } }) do |row| %>
-        <% row.key { "Course code" } %>
-        <% row.value { course.course_code } %>
-        <% row.action %>
-      <% end %>
-      <% if course.next_cycle? && course.has_fees? %>
-        <% summary_list.row(html_attributes: { data: { qa: "course__allocations" } }) do |row| %>
-          <% row.key { "Allocations" } %>
-          <% row.value do %>
-            Recruitment is not restricted
-          <% end %>
-          <% row.action %>
-        <% end %>
-      <% end %>
-    <% end %>
+    summary_list.row(html_attributes: { data: { qa: "course__course_code" } }) do |row|
+      row.key { "Course code" }
+      row.value { course.course_code }
+      row.action
+    end
+    if course.next_cycle? && course.has_fees?
+      summary_list.row(html_attributes: { data: { qa: "course__allocations" } }) do |row|
+        row.key { "Allocations" }
+        row.value do
+          "Recruitment is not restricted"
+        end
+        row.action
+      end
+    end %>
+<% end %>

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -7,7 +7,7 @@
     "About this course",
     course_value_provided?(course.about_course),
     %w[about_course],
-    action_path: about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+    action_path: course.is_withdrawn? ? nil : about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
     action_visually_hidden_text: "details about this course"
   ) %>
 
@@ -17,7 +17,7 @@
     "Interview process",
     course_value_provided?(course.interview_process),
     %w[interview_process],
-    action_path: "#{about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#interview-process",
+    action_path: course.is_withdrawn? ? nil : "#{about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#interview-process",
     action_visually_hidden_text: "details about the interview process"
   ) %>
 
@@ -27,7 +27,7 @@
     course.placements_heading,
     course_value_provided?(course.how_school_placements_work),
     %w[how_school_placements_work],
-    action_path: "#{about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#how-school-placements-work",
+    action_path: course.is_withdrawn? ? nil : "#{about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#how-school-placements-work",
     action_visually_hidden_text: "details about how school placements work"
   ) %>
 <% end %>
@@ -47,7 +47,7 @@
       "Course length",
       course_value_provided?(course.length),
       %w[course_length],
-      action_path: "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
+      action_path: course.is_withdrawn? ? nil : "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
       action_visually_hidden_text: "course length"
     ) %>
 
@@ -57,7 +57,7 @@
       "Fee for UK students",
       course_value_provided?(number_to_currency(course.fee_uk_eu)),
       %w[fee_uk_eu],
-      action_path: "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-uk",
+      action_path: course.is_withdrawn? ? nil : "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-uk",
       action_visually_hidden_text: "fee for UK students"
     ) %>
 
@@ -67,7 +67,7 @@
       "Fee for international students",
       course_value_provided?(number_to_currency(course.fee_international)),
       %w[fee_international],
-      action_path: "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-international",
+      action_path: course.is_withdrawn? ? nil : "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-international",
       action_visually_hidden_text: "fee for international students"
     ) %>
 
@@ -77,7 +77,7 @@
       "Fee details",
       course_value_provided?(course.fee_details),
       %w[fee_details],
-      action_path: "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-details",
+      action_path: course.is_withdrawn? ? nil : "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#fee-details",
       action_visually_hidden_text: "fee details"
     ) %>
 
@@ -87,7 +87,7 @@
       "Financial support you offer",
       course_value_provided?(course.financial_support),
       %w[financial_support],
-      action_path: "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#financial-support",
+      action_path: course.is_withdrawn? ? nil : "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#financial-support",
       action_visually_hidden_text: "details of financial support you offer"
     ) %>
 
@@ -103,7 +103,7 @@
       "Course length",
       course_value_provided?(course.length),
       %w[course_length],
-      action_path: "#{salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
+      action_path: course.is_withdrawn? ? nil : "#{salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
       action_visually_hidden_text: "course length"
     ) %>
 
@@ -113,7 +113,7 @@
       "Salary",
       course_value_provided?(course.salary_details),
       %w[salary_details],
-      action_path: "#{salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#salary",
+      action_path: course.is_withdrawn? ? nil : "#{salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#salary",
       action_visually_hidden_text: "salary"
     ) %>
   <% end %>
@@ -129,7 +129,7 @@
       (render DegreeRowContent.new(course:, errors: @errors)),
       %w[degree_grade degree_subject_requirements],
       truncate_value: false,
-      action_path: course.degree_section_complete? ? degrees_start_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+      action_path: !course.is_withdrawn? && course.degree_section_complete? ? degrees_start_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
       action_visually_hidden_text: "degree"
     ) %>
 
@@ -140,7 +140,7 @@
       (render GcseRowContent.new(course:, errors: @errors)),
       %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
       truncate_value: false,
-      action_path: course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+      action_path: !course.is_withdrawn? && course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
       action_visually_hidden_text: "GCSEs"
     ) %>
 
@@ -150,7 +150,7 @@
     "Personal qualities",
     course_value_provided?(course.personal_qualities),
     %w[personal_qualities],
-    action_path: "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities",
+    action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities",
     action_visually_hidden_text: "personal qualities"
   ) %>
 
@@ -160,7 +160,7 @@
     "Other requirements",
     course_value_provided?(course.other_requirements),
     %w[other_requirements],
-    action_path: "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements",
+    action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements",
     action_visually_hidden_text: "other requirements"
   ) %>
 <% end %>

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -89,6 +89,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       and_i_should_see_the_course_button_panel
       and_i_should_see_the_unpublished_partial
       and_i_should_see_the_rollover_button
+      and_there_are_change_links
       when_i_click_the_rollover_button
       then_i_should_see_the_rollover_form_page
       when_i_click_the_rollover_course_button
@@ -128,7 +129,18 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       when_i_visit_the_course_page
       then_i_should_see_the_course_button_panel
       and_i_should_see_the_course_withdrawn_date_and_preview_link
+      and_there_is_no_change_links
     end
+  end
+
+  private
+
+  def and_there_are_change_links
+    expect(page.find_all('.govuk-summary-list__actions a').all? { |actions| actions.text.include?('Change ') }).to be(true)
+  end
+
+  def and_there_is_no_change_links
+    expect(page.find_all('.govuk-summary-list__actions a').any?).to be(false)
   end
 
   def then_i_should_see_the_rolled_over_course_show_page
@@ -154,8 +166,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   def when_i_click_the_rollover_course_button
     rollover_form_page.rollover_course_button.click
   end
-
-  def when_i_visit_the_rollover_form_page; end
 
   def then_i_should_see_the_rollover_form_page
     rollover_form_page.load(


### PR DESCRIPTION
### Context
Change links for courses

### Changes proposed in this pull request
Remove the change links for courses in the withdrawn state

### Guidance to review
No change links for withdrawn course

Go and withdraw a course or find a withdrawn course
https://publish-teacher-training-pr-3316.london.cloudapps.digital/publish/organisations/1QN/2023/courses/V163
https://publish-teacher-training-pr-3316.london.cloudapps.digital/publish/organisations/1QN/2023/courses/V163/details

#### Before
![image](https://user-images.githubusercontent.com/470137/216346369-ffcbc8a4-6c28-4335-8389-68846d5a3cc6.png)
![image](https://user-images.githubusercontent.com/470137/216346437-3546954f-10b5-48b3-bf11-61bbd73adbe8.png)


#### After
![image](https://user-images.githubusercontent.com/470137/216346256-934b6269-ac34-4890-adfc-725cb2588ea2.png)
![image](https://user-images.githubusercontent.com/470137/216346310-180619e8-34f9-4c00-bb06-3d573d4b6fa5.png)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
