### PR TITLE
[1015] Configure asset host for Find

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,9 @@ gem 'data_migrate'
 # For outgoing http requests
 gem 'http'
 
+# For configuring domains and assets
+gem 'rack-cors'
+
 group :production, :qa, :sandbox, :staging do
   gem 'cloudfront-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,6 +500,8 @@ GEM
     raabro (1.4.0)
     racc (1.6.2)
     rack (2.2.6.2)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-oauth2 (1.21.3)
       activesupport
       attr_required
@@ -805,6 +807,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 6.0)
   pundit
+  rack-cors
   rails (= 7.0.4.2)
   rails-controller-testing
   rails-erd

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,9 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  config.action_controller.asset_host = proc do |_source, request|
+    Settings.find_assets_url if Settings.find_url.include?(request.host)
+  end
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins Settings.base_url, Settings.find_url
+    resource '*', headers: :any, methods: %i[get post patch put]
+  end
+end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+find_assets_url: https://assets.find-postgraduate-teacher-training.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+find_assets_url: https://qa-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+find_assets_url: https://sandbox-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
 environment:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+find_assets_url: https://staging-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:


### PR DESCRIPTION
### Context

The current find implements an asset host server to serve assets from so they're cached by Cloudfront. We're trying to maintain that functionality in Find running on Publish.

### Changes proposed in this pull request

This PR dynamically configures Find assets to be served from `{env}-assets.find-*`

### Guidance to review

Tested on QA:

<img width="876" alt="Screenshot 2023-02-02 at 13 08 13" src="https://user-images.githubusercontent.com/616080/216333808-ad7738e3-7d34-4bae-a210-ebd48f9c02a4.png">


