### PR TITLE
[0999] Content changes on the check your answers page for locations

### DIFF
--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -136,6 +136,8 @@
               href: new_publish_provider_recruitment_cycle_courses_locations_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
               visually_hidden_text: "locations"
             ) %>
+          <% else %>
+            <% row.action %>
           <% end %>
         <% end %>
 

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -111,10 +111,10 @@
         <% summary_list.row(html_attributes: { data: { qa: "course__locations" } }) do |row| %>
           <% row.key { "Location".pluralize(course.sites.length) } %>
           <% row.value do %>
-            <% if course.object.sites.nil? || course.object.sites.empty? %>
+            <% if course.sites.nil? || course.sites.empty? %>
               <span class="app-!-colour-muted">None</span>
-            <% elsif course.object.sites.size == 1 %>
-              <%= course.object.sites.first.location_name %>
+            <% elsif course.sites.size == 1 %>
+              <%= course.sites.first.location_name %>
             <% else %>
               <ul class="govuk-list">
                 <% course.alphabetically_sorted_sites.each do |site| %>
@@ -192,7 +192,7 @@
 
         <% summary_list.row(html_attributes: { data: { qa: "course__name" } }) do |row| %>
           <% row.key { "Title" } %>
-          <% row.value { course.object.generate_name } %>
+          <% row.value { course.generate_name } %>
           <% row.action %>
         <% end %>
 
@@ -240,7 +240,7 @@
         <%= govuk_inset_text do %>
           <h3 class="govuk-heading-m" data-qa="course__name">
             <span class="govuk-heading-s govuk-!-margin-bottom-0"><%= @provider.provider_name %></span>
-            <%= course.object.generate_name %>
+            <%= course.generate_name %>
           </h3>
           <p class="govuk-body" data-qa="course__description">Course: <%= course.description %></p>
         <% end %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -109,7 +109,7 @@
         <% end %>
 
         <% summary_list.row(html_attributes: { data: { qa: "course__locations" } }) do |row| %>
-          <% row.key { "Locations" } %>
+          <% row.key { "Location".pluralize(course.sites.length) } %>
           <% row.value do %>
             <% if course.object.sites.nil? || course.object.sites.empty? %>
               <span class="app-!-colour-muted">None</span>
@@ -121,14 +121,6 @@
                   <li><%= site.location_name %></li>
                 <% end %>
               </ul>
-            <% end %>
-            <% if course.provider.sites.count < 2 %>
-              <p class="govuk-body" data-qa="course__locations__help">
-                You can’t change this because you only have 1 location.
-              </p>
-              <p class="govuk-body">
-                <%= govuk_link_to "Manage your locations", publish_provider_recruitment_cycle_locations_path(course.provider.provider_code, course.recruitment_cycle.year), target: "_blank", rel: "noopener noreferrer" %>
-              </p>
             <% end %>
           <% end %>
           <% if @course.provider.sites.count > 1 %>


### PR DESCRIPTION
### Context
Content changes on the check your answers page for locations

### Changes proposed in this pull request

Update content on the check your answers page for locations

### Guidance to review

Find a provider that has one location, and go thro the motion

Removed uneeded text

Plural `Locations` vs singular `Location`
#### Before
![image](https://user-images.githubusercontent.com/470137/216349278-e4dc3463-f2c7-4c76-ab8e-5d6fcf4f4284.png)

#### After
![image](https://user-images.githubusercontent.com/470137/216360535-c5145c8e-f7a4-418d-bea2-c6783f249e11.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
