### PR TITLE
Add/Fix page captions when validation is triggered

### DIFF
--- a/app/services/courses/assign_subjects_service.rb
+++ b/app/services/courses/assign_subjects_service.rb
@@ -16,7 +16,11 @@ module Courses
 
       update_subjects
 
+      old_course_name = course.name
       course.name = course.generate_name
+
+      # This was added to fix a bug where the course name was missing in the legend if no subjects were chosen
+      course.name = old_course_name if course.name.blank?
       course
     end
 

--- a/app/views/publish/courses/age_range/new.html.erb
+++ b/app/views/publish/courses/age_range/new.html.erb
@@ -9,7 +9,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render CaptionText.new(text: t("course.add_course")) %>
     <%= form_with url: continue_publish_provider_recruitment_cycle_courses_age_range_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year
@@ -18,6 +17,7 @@
 
       <%= render "publish/courses/new_fields_holder", form:, except_keys: [:age_range_in_years] do |fields| %>
         <%= render "publish/shared/error_wrapper", error_keys: [:age_range_in_years], data_qa: "course__age_range_in_years" do %>
+          <%= render CaptionText.new(text: t("course.add_course")) %>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h1 class="govuk-fieldset__heading">

--- a/app/views/publish/courses/age_range/new.html.erb
+++ b/app/views/publish/courses/age_range/new.html.erb
@@ -17,10 +17,10 @@
 
       <%= render "publish/courses/new_fields_holder", form:, except_keys: [:age_range_in_years] do |fields| %>
         <%= render "publish/shared/error_wrapper", error_keys: [:age_range_in_years], data_qa: "course__age_range_in_years" do %>
-          <%= render CaptionText.new(text: t("course.add_course")) %>
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h1 class="govuk-fieldset__heading">
+                <%= render CaptionText.new(text: t("course.add_course")) %>
                 <%= page_title %>
               </h1>
             </legend>

--- a/app/views/publish/courses/applications_open/_form_fields.html.erb
+++ b/app/views/publish/courses/applications_open/_form_fields.html.erb
@@ -3,6 +3,7 @@
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading" id="applications_open_from-error">
+          <%= render CaptionText.new(text: t("course.add_course")) %>
           When will applications open?
         </h1>
       </legend>

--- a/app/views/publish/courses/applications_open/new.html.erb
+++ b/app/views/publish/courses/applications_open/new.html.erb
@@ -8,7 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render CaptionText.new(text: t("course.add_course")) %>
     <%= form_with url: continue_publish_provider_recruitment_cycle_courses_applications_open_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year

--- a/app/views/publish/courses/apprenticeship/_form_fields.html.erb
+++ b/app/views/publish/courses/apprenticeship/_form_fields.html.erb
@@ -1,5 +1,10 @@
 <%= render "publish/shared/error_wrapper", error_keys: %i[funding_type program_type], data_qa: "course__funding_type" do %>
   <h1 class="govuk-heading-l">
+    <% if course.course_code %>
+      <%= render CaptionText.new(text: course.name_and_code) %>
+    <% else %>
+      <%= render CaptionText.new(text: t("course.add_course")) %>
+    <% end %>
     Teaching apprenticeship
   </h1>
 

--- a/app/views/publish/courses/apprenticeship/edit.html.erb
+++ b/app/views/publish/courses/apprenticeship/edit.html.erb
@@ -8,7 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render CaptionText.new(text: course.name_and_code) %>
     <%= form_with model: @course_funding_form,
                   url: apprenticeship_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                   method: :put do |form| %>

--- a/app/views/publish/courses/apprenticeship/new.html.erb
+++ b/app/views/publish/courses/apprenticeship/new.html.erb
@@ -8,7 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render CaptionText.new(text: t("course.add_course")) %>
     <%= form_with url: continue_publish_provider_recruitment_cycle_courses_apprenticeship_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year

--- a/app/views/publish/courses/funding_type/_form_fields.html.erb
+++ b/app/views/publish/courses/funding_type/_form_fields.html.erb
@@ -2,6 +2,11 @@
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
+        <% if course.course_code %>
+          <%= render CaptionText.new(text: course.name_and_code) %>
+        <% else %>
+          <%= render CaptionText.new(text: t("course.add_course")) %>
+        <% end %>
         Funding type
       </h1>
     </legend>

--- a/app/views/publish/courses/funding_type/new.html.erb
+++ b/app/views/publish/courses/funding_type/new.html.erb
@@ -8,7 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render CaptionText.new(text: t("course.add_course")) %>
     <%= form_with url: continue_publish_provider_recruitment_cycle_courses_funding_type_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year

--- a/app/views/publish/courses/outcome/_form_fields.html.erb
+++ b/app/views/publish/courses/outcome/_form_fields.html.erb
@@ -1,7 +1,11 @@
 <% legend = capture do %>
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
     <h1 class="govuk-fieldset__heading">
-      <%= course_name_and_code %>
+      <% if course.course_code %>
+        <%= render CaptionText.new(text: course.name_and_code) %>
+      <% else %>
+        <%= render CaptionText.new(text: t("course.add_course")) %>
+      <% end %>
       Pick a course outcome
     </h1>
   </legend>

--- a/app/views/publish/courses/outcome/new.html.erb
+++ b/app/views/publish/courses/outcome/new.html.erb
@@ -8,7 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render CaptionText.new(text: t("course.add_course")) %>
     <%= form_with url: continue_publish_provider_recruitment_cycle_courses_outcome_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year

--- a/app/views/publish/courses/study_mode/_form_fields.html.erb
+++ b/app/views/publish/courses/study_mode/_form_fields.html.erb
@@ -2,6 +2,7 @@
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
+        <%= render CaptionText.new(text: t("course.add_course")) %>
         Full time or part time?
       </h1>
     </legend>

--- a/app/views/publish/courses/study_mode/edit.html.erb
+++ b/app/views/publish/courses/study_mode/edit.html.erb
@@ -25,9 +25,7 @@
 
       <%= f.govuk_error_summary %>
 
-      <%= render CaptionText.new(text: course.name_and_code) %>
-
-      <%= f.govuk_radio_buttons_fieldset(:study_mode, legend: { text: "Full time or part time?", tag: "h1", size: "l" }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:study_mode, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Full time or part time?".html_safe, tag: "h1", size: "l" }) do %>
         <% course.edit_course_options["study_modes"].each_with_index do |study_mode, index| %>
           <%= f.govuk_radio_button(
             :study_mode,

--- a/app/views/publish/courses/study_mode/new.html.erb
+++ b/app/views/publish/courses/study_mode/new.html.erb
@@ -8,7 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render CaptionText.new(text: t("course.add_course")) %>
     <%= form_with url: continue_publish_provider_recruitment_cycle_courses_study_mode_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year

--- a/app/views/publish/courses/subjects/_primary_form.html.erb
+++ b/app/views/publish/courses/subjects/_primary_form.html.erb
@@ -4,6 +4,8 @@
       <h1 class="govuk-fieldset__heading" data-qa="page-heading">
         <% if course.course_code %>
           <%= render CaptionText.new(text: course.name_and_code) %>
+        <% else %>
+          <%= render CaptionText.new(text: t("course.add_course")) %>
         <% end %>
         <%= course.subject_page_title %>
       </h1>

--- a/app/views/publish/courses/subjects/_secondary_form.html.erb
+++ b/app/views/publish/courses/subjects/_secondary_form.html.erb
@@ -4,6 +4,8 @@
       <h1 class="govuk-fieldset__heading" data-qa="page-heading">
         <% if course.course_code %>
           <%= render CaptionText.new(text: course.name_and_code) %>
+        <% else %>
+          <%= render CaptionText.new(text: t("course.add_course")) %>
         <% end %>
         <%= course.subject_page_title %>
       </h1>

--- a/app/views/publish/courses/subjects/new.html.erb
+++ b/app/views/publish/courses/subjects/new.html.erb
@@ -8,7 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render CaptionText.new(text: t("course.add_course")) %>
     <%= form_with url: continue_publish_provider_recruitment_cycle_courses_subjects_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year


### PR DESCRIPTION
### Context

We have page captions on the Add and Edit course flows. Some were missing and some were incorrectly indented when validation was triggered. 

### Changes proposed in this pull request

- Add captions to the Add/Edit course flow where they were missing
- Fix the indentation of page captions when validation is triggered
- Fix a bug which prevented the course name from appearing in the page caption (edit secondary subjects page)

### Guidance to review

- Check that page captions are correct
- Check that the bug fix is sensible. Suggestions are welcome.

- In some places i've used an `else` to render the "Add new course" caption. I dont't think there are any situations when this would render when we didn't intend for it to render? See below.

```
<% if course.course_code %>
          <%= render CaptionText.new(text: course.name_and_code) %>
        <% else %>
          <%= render CaptionText.new(text: t("course.add_course")) %>
        <% end %>
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
