### PR TITLE
[xxx] Enable Find routes in prod

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,8 @@ Rails.application.routes.draw do
     match '/(*path)' => redirect { |_, req| "#{Settings.base_url}#{req.fullpath}" }, via: %i[get post put]
   end
 
-  unless Rails.env.production?
-    constraints(FindConstraint.new) do
-      draw(:find)
-    end
+  constraints(FindConstraint.new) do
+    draw(:find)
   end
 
   constraints(PublishConstraint.new) do


### PR DESCRIPTION
### Context

We're going live today. We'll need to enable the Find routes before the domain switch so the app can handle requests from it. These routes won't be accessible until the domain switch has happened.