### PR TITLE
[1034] Handle missing provider/courses

### DIFF
--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -10,9 +10,7 @@ module Find
     before_action :redirect_to_cycle_has_ended_if_find_is_down
     before_action :redirect_to_maintenance_page_if_flag_is_active
 
-    rescue_from ActiveRecord::RecordNotFound do |_exception|
-      render_not_found
-    end
+    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
     def render_feedback_component
       @render_feedback_component = true

--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -10,6 +10,10 @@ module Find
     before_action :redirect_to_cycle_has_ended_if_find_is_down
     before_action :redirect_to_maintenance_page_if_flag_is_active
 
+    rescue_from ActiveRecord::RecordNotFound do |_exception|
+      render_not_found
+    end
+
     def render_feedback_component
       @render_feedback_component = true
     end
@@ -31,6 +35,10 @@ module Find
 
     def redirect_to_cycle_has_ended_if_find_is_down
       redirect_to find_cycle_has_ended_path if CycleTimetable.find_down?
+    end
+
+    def render_not_found
+      render 'errors/not_found', status: :not_found
     end
   end
 end

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -4,6 +4,8 @@ module Find
   class CoursesController < ApplicationController
     include ApplyRedirect
 
+    before_action -> { render_not_found if provider.nil? }
+
     before_action :render_feedback_component, only: :show
 
     def show

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -30,5 +30,16 @@ module Find
         expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{provider.provider_code}&courseCode=#{course.course_code}")
       end
     end
+
+    describe '#show' do
+      it 'renders the not found page' do
+        get :show, params: {
+          provider_code: 'ABC',
+          course_code: '123'
+        }
+
+        expect(response).to render_template('errors/not_found')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/xgujREEG/1034-bug-handle-missing-providers-courses-gracefully

### Changes proposed in this pull request

- Redirects to the not found page for missing providers/courses instead of blowing up

### Guidance to review

- Check `course/1A9/22J` (request which came into Sentry)
- Assert not found page is shown

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
