### PR TITLE
[1033] Amended to only change name when valid

### DIFF
--- a/app/services/courses/assign_subjects_service.rb
+++ b/app/services/courses/assign_subjects_service.rb
@@ -16,11 +16,12 @@ module Courses
 
       update_subjects
 
-      old_course_name = course.name
-      course.name = course.generate_name
+      if course.persisted?
+        course.name = course.generate_name if course.valid?
+      else
+        course.name = course.generate_name
+      end
 
-      # This was added to fix a bug where the course name was missing in the legend if no subjects were chosen
-      course.name = old_course_name if course.name.blank?
       course
     end
 

--- a/spec/services/courses/assign_subjects_service_spec.rb
+++ b/spec/services/courses/assign_subjects_service_spec.rb
@@ -20,6 +20,20 @@ describe Courses::AssignSubjectsService do
     end
   end
 
+  context 'no subject' do
+    let(:course) { create(:course) }
+    let(:subject_ids) { [] }
+
+    it 'have creation subject errors' do
+      expect(subject.errors[:subjects].first).to include('^Select at least one subject')
+    end
+
+    it 'have not updated course name' do
+      expect { subject }
+        .to not_change(course, :name)
+    end
+  end
+
   context 'primary course' do
     let(:subject_ids) { [primary_subject.id] }
     let(:course) { Course.new(level: :primary) }


### PR DESCRIPTION
### Context
Course name and subjects and persisted status

### Changes proposed in this pull request
Persisted course name can only be updated if it is valid
Non persisted course can be updated regardless

### Guidance to review
It works for both new course and existing courses

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
