### PR TITLE
[1026] Fix parameter bug

### DIFF
--- a/app/controllers/find/search/age_groups_controller.rb
+++ b/app/controllers/find/search/age_groups_controller.rb
@@ -35,7 +35,11 @@ module Find
       def form_params
         params
           .require(:find_age_groups_form)
-          .permit(:age_group, :c, :has_vacancies, :l, :latitude, :longitude, :loc, :lq, :radius, :send_courses, :sortby, :prev_l, :prev_lat, :prev_lng, :prev_loc, :prev_lq, :prev_query, :prev_rad, 'provider.provider_name', :degree_required, :can_sponsor_visa, :funding, subjects: [], qualification: [], study_type: [])
+          .permit(
+            :age_group, :c, :has_vacancies, :l, :latitude, :longitude, :loc, :lq, :radius, :send_courses, :sortby,
+            :prev_l, :prev_lat, :prev_lng, :prev_loc, :prev_lq, :prev_query, :prev_rad, 'provider.provider_name',
+            :degree_required, :can_sponsor_visa, :funding, subjects: [], qualification: [], study_type: [], c: []
+          )
       end
 
       def build_backlink_query_parameters

--- a/app/controllers/find/search/subjects_controller.rb
+++ b/app/controllers/find/search/subjects_controller.rb
@@ -32,7 +32,11 @@ module Find
 
       def form_params
         params.require(:find_subjects_form)
-              .permit(:c, :latitude, :longitude, :loc, :lq, :radius, :sortby, :age_group, :has_vacancies, :l, :send_courses, :prev_l, :prev_lat, :prev_lng, :prev_loc, :prev_lq, :prev_query, :prev_rad, 'provider.provider_name', :degree_required, :can_sponsor_visa, :funding, qualification: [], subjects: [], study_type: [])
+              .permit(
+                :c, :latitude, :longitude, :loc, :lq, :radius, :sortby, :age_group, :has_vacancies, :l, :send_courses,
+                :prev_l, :prev_lat, :prev_lng, :prev_loc, :prev_lq, :prev_query, :prev_rad, 'provider.provider_name',
+                :degree_required, :can_sponsor_visa, :funding, qualification: [], subjects: [], study_type: [], c: []
+              )
       end
 
       def build_backlink_query_parameters

--- a/spec/features/find/search/location_options_spec.rb
+++ b/spec/features/find/search/location_options_spec.rb
@@ -26,6 +26,11 @@ feature 'Searching by location' do
     and_the_location_radio_button_is_selected
   end
 
+  scenario 'searching for a location with no results' do
+    when_i_enter_an_invalid_location_with_some_options
+    then_should_see_the_no_results_text
+  end
+
   private
 
   def given_i_visit_the_start_page
@@ -69,5 +74,16 @@ feature 'Searching by location' do
 
   def and_the_location_radio_button_is_selected
     expect(find_courses_by_location_or_training_provider_page.by_city_town_or_postcode_radio).to be_checked
+  end
+
+  def when_i_enter_an_invalid_location_with_some_options
+    find_courses_by_location_or_training_provider_page.location.set('invalid location')
+    find_courses_by_location_or_training_provider_page.continue.click
+    choose 'Further education'
+    click_button 'Continue'
+  end
+
+  def then_should_see_the_no_results_text
+    expect(page).to have_content('No courses found')
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/IxI9RYJl/1026-bug-no-js-and-giberish-broke-it

The country parameter (`c`) can also default to a list of values if some invalid location is used. We only whitelisted the non-list version.

### Changes proposed in this pull request

- Handle un-permitted parameter
- Add a test

### Guidance to review

- Try to location search some gibberish 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
