### PR TITLE
Content changes to add edit flows applications open date

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -233,7 +233,7 @@ class CourseDecorator < ApplicationDecorator
 
   def applications_open_from_message_for(recruitment_cycle)
     if current_cycle?
-      'As soon as the course is on Find (recommended)'
+      'As soon as the course is on Find - recommended'
     else
       year = recruitment_cycle.year.to_i
       day_month = recruitment_cycle.application_start_date.strftime('%-d %B')

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -231,13 +231,12 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
-  def applications_open_from_message_for(recruitment_cycle)
+  def applications_open_first_label(recruitment_cycle)
     if current_cycle?
       'As soon as the course is on Find - recommended'
     else
-      year = recruitment_cycle.year.to_i
-      day_month = recruitment_cycle.application_start_date.strftime('%-d %B')
-      "On #{day_month} when applications for the #{year - 1} to #{year} cycle open"
+      application_start_date = recruitment_cycle.application_start_date.strftime('%-d %B %Y')
+      "On #{application_start_date} when Apply opens - recommended"
     end
   end
 

--- a/app/views/publish/courses/applications_open/_form_fields.html.erb
+++ b/app/views/publish/courses/applications_open/_form_fields.html.erb
@@ -10,7 +10,7 @@
       <div class="govuk-radios__item govuk-!-margin-top-4">
         <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
               class: "govuk-radios__input", data: { qa: "applications_open_from" } %>
-        <%= form.label :applications_open_from, course.applications_open_from_message_for(@recruitment_cycle),
+        <%= form.label :applications_open_from, course.applications_open_first_label(@recruitment_cycle),
               for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
               class: "govuk-label govuk-radios__label" %>
       </div>

--- a/app/views/publish/courses/applications_open/_form_fields.html.erb
+++ b/app/views/publish/courses/applications_open/_form_fields.html.erb
@@ -4,7 +4,7 @@
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading" id="applications_open_from-error">
           <%= render CaptionText.new(text: t("course.add_course")) %>
-          When will applications open?
+          Applications open date
         </h1>
       </legend>
       <div class="govuk-radios__item">

--- a/app/views/publish/courses/applications_open/_form_fields.html.erb
+++ b/app/views/publish/courses/applications_open/_form_fields.html.erb
@@ -29,8 +29,8 @@
     <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date %>" id="other-container">
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend">
-            What date will applications open?
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            When will applications open?
           </legend>
           <span class="govuk-hint">
             For example, 30 9 <%= @recruitment_cycle.year %>

--- a/app/views/publish/courses/applications_open/_form_fields.html.erb
+++ b/app/views/publish/courses/applications_open/_form_fields.html.erb
@@ -7,7 +7,7 @@
           Applications open date
         </h1>
       </legend>
-      <div class="govuk-radios__item">
+      <div class="govuk-radios__item govuk-!-margin-top-4">
         <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
               class: "govuk-radios__input", data: { qa: "applications_open_from" } %>
         <%= form.label :applications_open_from, course.applications_open_from_message_for(@recruitment_cycle),
@@ -21,7 +21,7 @@
               aria: { controls: "other-container" }, data: { qa: "applications_open_from_other" } %>
         <%= form.label :applications_open_from,
               for: "course_applications_open_from_other",
-              value: "On a specific date",
+              value: "Another date",
               class: "govuk-label govuk-radios__label",
               data: { qa: "applications_open_field_from_other_label" } %>
       </div>

--- a/app/views/publish/courses/applications_open/edit.html.erb
+++ b/app/views/publish/courses/applications_open/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("When will applications open? – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Applications open date – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>

--- a/app/views/publish/courses/applications_open/new.html.erb
+++ b/app/views/publish/courses/applications_open/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("When will applications open?", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Applications open date", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/spec/features/publish/courses/new_accredited_body_spec.rb
+++ b/spec/features/publish/courses/new_accredited_body_spec.rb
@@ -47,7 +47,7 @@ feature 'selection accredited_bodies', { can_edit_current_and_next_cycles: false
 
   def then_i_am_met_with_the_applications_open_page
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/applications-open/new", ignore_query: true)
-    expect(page).to have_content('When will applications open?')
+    expect(page).to have_content('Applications open date')
   end
 
   def then_i_am_met_with_errors


### PR DESCRIPTION
### Context

Updating the radio buttons on the applications open page in line with the prototype. 

### Changes proposed in this pull request

See commits.

### Guidance to review

- Have a look at the screenshots.
- Launch the review app and create a course, until you get to the applications open page (you can only see the non rollover page)
- If you want to see the rollover version and the screenshot doesn't provide sufficient context, message me. 

### Screenshot (non rollover)

<img width="759" alt="image" src="https://user-images.githubusercontent.com/50492247/218134048-6f62a613-a61c-41df-bde7-5c11bb8a1dfb.png">

### Screenshot (rollover)

<img width="654" alt="image" src="https://user-images.githubusercontent.com/50492247/218163083-e582a048-f1fa-41ec-b699-b021e8535b76.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
