### PR TITLE
[994] Content changes to add/edit flows  - Success messages

### DIFF
--- a/app/controllers/concerns/success_message.rb
+++ b/app/controllers/concerns/success_message.rb
@@ -3,15 +3,9 @@
 module SuccessMessage
   extend ActiveSupport::Concern
 
-  def course_details_success_message(value)
+  def course_updated_message(value)
     raise TypeError unless value.is_a?(String)
 
-    flash[:success] = @course.is_published? ? I18n.t('success.value_published', value:) : I18n.t('success.value_saved', value:)
-  end
-
-  def course_description_success_message(value)
-    raise TypeError unless value.is_a?(String)
-
-    flash[:success] = @course.only_published? ? I18n.t('success.value_published', value:) : I18n.t('success.value_saved', value:)
+    flash[:success] = I18n.t('success.saved', value:)
   end
 end

--- a/app/controllers/publish/courses/age_range_controller.rb
+++ b/app/controllers/publish/courses/age_range_controller.rb
@@ -14,7 +14,7 @@ module Publish
 
       def update
         if form_object.valid?
-          course_details_success_message('age range')
+          course_updated_message('Age range')
 
           update_age_range_param
 

--- a/app/controllers/publish/courses/apprenticeship_controller.rb
+++ b/app/controllers/publish/courses/apprenticeship_controller.rb
@@ -8,6 +8,10 @@ module Publish
       def current_step
         :apprenticeship
       end
+
+      def section_key
+        'Teaching apprenticeship'
+      end
     end
   end
 end

--- a/app/controllers/publish/courses/course_information_controller.rb
+++ b/app/controllers/publish/courses/course_information_controller.rb
@@ -20,7 +20,7 @@ module Publish
         @course_information_form = CourseInformationForm.new(course_enrichment, params: course_information_params)
 
         if @course_information_form.save!
-          course_description_success_message('course information')
+          course_updated_message('Course information')
 
           redirect_to publish_provider_recruitment_cycle_course_path(
             provider.provider_code,

--- a/app/controllers/publish/courses/degrees/grade_controller.rb
+++ b/app/controllers/publish/courses/degrees/grade_controller.rb
@@ -16,7 +16,7 @@ module Publish
           @grade_form = DegreeGradeForm.new(grade: grade_params)
 
           if course.is_primary? && @grade_form.save(course)
-            course_description_success_message('minimum degree classification')
+            course_updated_message('Minimum degree classification')
 
             redirect_to publish_provider_recruitment_cycle_course_path
           elsif @grade_form.save(course)

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -18,7 +18,7 @@ module Publish
           @start_form = DegreeStartForm.new(degree_grade_required: grade_required_params)
 
           if course.is_primary? && @start_form.save(course)
-            flash[:success] = I18n.t('success.value_saved', value: 'minimum degree classification')
+            course_updated_message('Minimum degree classification')
 
             redirect_to publish_provider_recruitment_cycle_course_path
           elsif @start_form.save(course)

--- a/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
@@ -22,7 +22,7 @@ module Publish
           @subject_requirements_form = SubjectRequirementForm.new(subject_requirements_params)
 
           if @subject_requirements_form.save(@course)
-            course_description_success_message('degree requirements')
+            course_updated_message('Degree requirements')
 
             redirect_to publish_provider_recruitment_cycle_course_path
           else

--- a/app/controllers/publish/courses/engineers_teach_physics_controller.rb
+++ b/app/controllers/publish/courses/engineers_teach_physics_controller.rb
@@ -28,6 +28,8 @@ module Publish
         if form_params[:skip_languages_goto_confirmation].present?
 
           if @engineers_teach_physics_form.save!
+            course_updated_message(section_key)
+
             course.update(name: course.generate_name)
             redirect_to(
               details_publish_provider_recruitment_cycle_course_path(
@@ -51,6 +53,7 @@ module Publish
             )
           )
         elsif @engineers_teach_physics_form.save!
+          course_updated_message(section_key)
           course.update(name: course.generate_name)
 
           redirect_to details_publish_provider_recruitment_cycle_course_path(
@@ -118,6 +121,10 @@ module Publish
             :skip_languages_goto_confirmation,
             subjects_ids: []
           )
+      end
+
+      def section_key
+        'Engineers Teach Physics'
       end
     end
   end

--- a/app/controllers/publish/courses/fees_controller.rb
+++ b/app/controllers/publish/courses/fees_controller.rb
@@ -20,7 +20,7 @@ module Publish
         @course_fee_form = CourseFeeForm.new(course_enrichment, params: formatted_params)
 
         if @course_fee_form.save!
-          course_description_success_message('course length and fees')
+          course_updated_message('Course length and fees')
 
           redirect_to publish_provider_recruitment_cycle_course_path(
             provider.provider_code,

--- a/app/controllers/publish/courses/funding_type_controller.rb
+++ b/app/controllers/publish/courses/funding_type_controller.rb
@@ -53,6 +53,8 @@ module Publish
           @course_funding_form.stash
           visa_page_path
         else
+          course_updated_message(section_key)
+
           course_page_path
         end
       end
@@ -85,6 +87,10 @@ module Publish
 
       def course_page_path
         details_publish_provider_recruitment_cycle_course_path(course_values)
+      end
+
+      def section_key
+        'Funding type'
       end
     end
   end

--- a/app/controllers/publish/courses/gcse_requirements_controller.rb
+++ b/app/controllers/publish/courses/gcse_requirements_controller.rb
@@ -20,7 +20,7 @@ module Publish
         @gcse_requirements_form = GcseRequirementsForm.new(**gcse_requirements_form_params.merge(level: course.level))
 
         if @gcse_requirements_form.save(course)
-          course_description_success_message('GCSE requirements')
+          course_updated_message('GCSE requirements')
 
           redirect_to publish_provider_recruitment_cycle_course_path
         else

--- a/app/controllers/publish/courses/modern_languages_controller.rb
+++ b/app/controllers/publish/courses/modern_languages_controller.rb
@@ -37,7 +37,7 @@ module Publish
         authorize(provider)
 
         if course_subjects_form.save!
-          flash[:success] = I18n.t('success.saved')
+          course_updated_message('Subjects')
           redirect_to(
             details_publish_provider_recruitment_cycle_course_path(
               @course.provider_code,

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -21,7 +21,7 @@ module Publish
         return render :edit if @errors.present?
 
         if @course.update(course_params)
-          course_details_success_message('course outcome')
+          course_updated_message('Qualification')
 
           redirect_to(
             details_publish_provider_recruitment_cycle_course_path(

--- a/app/controllers/publish/courses/requirements_controller.rb
+++ b/app/controllers/publish/courses/requirements_controller.rb
@@ -23,7 +23,7 @@ module Publish
         @course_requirement_form = CourseRequirementForm.new(course_enrichment, params: course_requirement_params)
 
         if @course_requirement_form.save!
-          flash[:success] = I18n.t('success.saved')
+          course_updated_message('Personal qualities and other requirements')
 
           redirect_to publish_provider_recruitment_cycle_course_path(
             provider.provider_code,

--- a/app/controllers/publish/courses/salary_controller.rb
+++ b/app/controllers/publish/courses/salary_controller.rb
@@ -16,7 +16,7 @@ module Publish
         @course_salary_form = CourseSalaryForm.new(course_enrichment, params: formatted_params)
 
         if @course_salary_form.save!
-          flash[:success] = I18n.t('success.saved')
+          course_updated_message('Course length and salary')
 
           redirect_to publish_provider_recruitment_cycle_course_path(
             provider.provider_code,

--- a/app/controllers/publish/courses/sites_controller.rb
+++ b/app/controllers/publish/courses/sites_controller.rb
@@ -31,7 +31,7 @@ module Publish
 
         @course_location_form = CourseLocationForm.new(@course, params: location_params)
         if @course_location_form.save!
-          course_details_success_message('course locations')
+          course_updated_message(section_key)
 
           redirect_to details_publish_provider_recruitment_cycle_course_path(
             provider.provider_code,
@@ -85,6 +85,10 @@ module Publish
 
       def build_course
         @course = provider.courses.find_by!(course_code: params[:code])
+      end
+
+      def section_key
+        'Location'.pluralize(location_params[:site_ids].compact_blank.count)
       end
     end
   end

--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -16,7 +16,7 @@ module Publish
 
         @course_study_mode_form = CourseStudyModeForm.new(@course, params: study_mode_params)
         if @course_study_mode_form.save!
-          course_description_success_message('full or part time')
+          course_updated_message('Full time or part time')
 
           redirect_to details_publish_provider_recruitment_cycle_course_path(
             provider.provider_code,

--- a/app/controllers/publish/courses/subjects_controller.rb
+++ b/app/controllers/publish/courses/subjects_controller.rb
@@ -41,8 +41,7 @@ module Publish
           )
 
         elsif course_subjects_form.save!
-          value = @course.is_primary? ? 'primary subject' : 'secondary subject'
-          course_details_success_message(value)
+          course_updated_message(section_key)
           # TODO: move this to the form?
           course.update(master_subject_id: params[:course][:master_subject_id])
           course.update(name: course.generate_name)
@@ -116,6 +115,10 @@ module Publish
 
       def available_languages_ids
         @course.edit_course_options[:modern_languages].map(&:id).map(&:to_s)
+      end
+
+      def section_key
+        'Subject'.pluralize(selected_subject_ids.count)
       end
     end
   end

--- a/app/controllers/publish/providers/locations_controller.rb
+++ b/app/controllers/publish/providers/locations_controller.rb
@@ -38,7 +38,7 @@ module Publish
         @location_form = LocationForm.new(site, params: site_params)
 
         if @location_form.save!
-          flash[:success] = I18n.t('success.value_published', value: 'location details')
+          course_updated_message('Location details')
 
           redirect_to publish_provider_recruitment_cycle_locations_path(
             @location_form.provider_code, @location_form.recruitment_cycle_year

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -30,7 +30,8 @@ module Publish
       return render :edit if @errors.present?
 
       if @course.update(course_params)
-        flash[:success] = I18n.t('success.saved')
+        course_updated_message(section_key)
+
         redirect_to(
           details_publish_provider_recruitment_cycle_course_path(
             @course.provider_code,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -968,11 +968,11 @@ class Course < ApplicationRecord
 
     case level
     when 'primary'
-      errors.add(:subjects, 'must be primary') unless PrimarySubject.exists?(id: subjects_excluding_discontinued.map(&:id))
+      errors.add(:subjects, 'Subject must be primary') unless PrimarySubject.exists?(id: subjects_excluding_discontinued.map(&:id))
     when 'secondary'
-      errors.add(:subjects, 'must be secondary') unless SecondarySubject.exists?(id: subjects_excluding_discontinued.map(&:id))
+      errors.add(:subjects, 'Subject must be secondary') unless SecondarySubject.exists?(id: subjects_excluding_discontinued.map(&:id))
     when 'further_education'
-      errors.add(:subjects, 'must be further education') unless FurtherEducationSubject.exists?(id: subjects_excluding_discontinued.map(&:id))
+      errors.add(:subjects, 'Subject must be further education') unless FurtherEducationSubject.exists?(id: subjects_excluding_discontinued.map(&:id))
     end
   end
 

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -10,7 +10,7 @@
   Anne is a course administrator who belongs to one school direct.
 </p>
 <%= render Persona.new(
-  email_address: "anonimized-user-10599@example.org",
+  email_address: "anonimized-user-12248@example.org",
   first_name: "Course administrator",
   last_name: "Anne"
 ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,9 +549,7 @@ en:
     overflow: "The requested page param was out of range and invalid for this request."
   success:
     published: "Your changes have been published"
-    value_published: "Changes to %{value} published"
-    value_saved: "Changes to %{value} saved"
-    saved: "Your changes have been saved"
+    saved: "%{value} updated"
     changes_ttl: "Changes will appear on Find postgraduate teacher training within 15 minutes."
     visa_partner_warning: "Changing your answer will not change visa information for courses you or your training partners have already created."
     visa_warning: "Changing your answer will not change visa information for courses you have already created."

--- a/spec/features/publish/courses/editing_age_range_spec.rb
+++ b/spec/features/publish/courses/editing_age_range_spec.rb
@@ -69,7 +69,7 @@ feature 'selecting an age range', { can_edit_current_and_next_cycles: false } do
   end
 
   def then_i_should_see_a_success_message
-    expect(page).to have_content(I18n.t('success.value_saved', value: 'age range'))
+    expect(page).to have_content(I18n.t('success.saved', value: 'Age range'))
   end
 
   def and_the_course_age_range_is_updated(age_range)

--- a/spec/features/publish/courses/editing_course_information_spec.rb
+++ b/spec/features/publish/courses/editing_course_information_spec.rb
@@ -112,7 +112,7 @@ feature 'Editing course information', { can_edit_current_and_next_cycles: false 
   end
 
   def then_i_should_see_a_success_message
-    expect(page).to have_content('Changes to course information saved')
+    expect(page).to have_content(I18n.t('success.saved', value: 'Course information'))
   end
 
   def and_the_course_information_is_updated

--- a/spec/features/publish/courses/editing_course_locations_spec.rb
+++ b/spec/features/publish/courses/editing_course_locations_spec.rb
@@ -66,7 +66,7 @@ feature 'Editing course locations', { can_edit_current_and_next_cycles: false } 
   end
 
   def then_i_should_see_a_success_message
-    expect(page).to have_content(I18n.t('success.value_saved', value: 'course locations'))
+    expect(page).to have_content(I18n.t('success.saved', value: 'Location'))
   end
 
   def and_the_course_locations_are_updated

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -59,7 +59,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   end
 
   def then_i_should_see_a_success_message
-    expect(page).to have_content(I18n.t('success.value_saved', value: 'course outcome'))
+    expect(page).to have_content(I18n.t('success.saved', value: 'Qualification'))
   end
 
   def and_the_course_outcome_is_updated

--- a/spec/features/publish/courses/editing_course_requirements_spec.rb
+++ b/spec/features/publish/courses/editing_course_requirements_spec.rb
@@ -127,7 +127,7 @@ feature 'Editing course requirements', { can_edit_current_and_next_cycles: false
   end
 
   def then_i_should_see_a_success_message
-    expect(page).to have_content(I18n.t('success.saved'))
+    expect(page).to have_content(I18n.t('success.saved', value: 'Personal qualities and other requirements'))
   end
 
   def and_the_course_requirements_are_updated

--- a/spec/features/publish/courses/editing_course_study_mode_spec.rb
+++ b/spec/features/publish/courses/editing_course_study_mode_spec.rb
@@ -51,7 +51,7 @@ feature 'Editing course study mode', { can_edit_current_and_next_cycles: false }
   end
 
   def then_i_should_see_a_success_message
-    expect(page).to have_content(I18n.t('success.value_saved', value: 'full or part time'))
+    expect(page).to have_content(I18n.t('success.saved', value: 'Full time or part time'))
   end
 
   def and_the_course_study_mode_is_updated

--- a/spec/features/publish/courses/editing_degree_requirements_spec.rb
+++ b/spec/features/publish/courses/editing_degree_requirements_spec.rb
@@ -16,7 +16,7 @@ feature 'Editing degree requirements', { can_edit_current_and_next_cycles: false
     then_i_should_see_the_subject_requirements_page
     then_i_should_see_the_reuse_content
     when_i_set_additional_requirements
-    then_i_should_see_a_success_message('degree requirements')
+    then_i_should_see_a_success_message('Degree requirements')
     and_the_required_grade_is_updated_with('two_one')
     and_the_additional_requirements_are_updated
   end
@@ -27,7 +27,7 @@ feature 'Editing degree requirements', { can_edit_current_and_next_cycles: false
     and_i_do_not_require_a_classification
     then_i_should_see_the_subject_requirements_page
     when_i_set_additional_requirements
-    then_i_should_see_a_success_message('degree requirements')
+    then_i_should_see_a_success_message('Degree requirements')
     and_the_required_grade_is_updated_with('not_required')
     and_the_additional_requirements_are_updated
   end
@@ -39,7 +39,7 @@ feature 'Editing degree requirements', { can_edit_current_and_next_cycles: false
       and_i_require_a_classification
       then_i_should_see_the_publish_degree_grade_page
       when_i_set_a_required_grade
-      then_i_should_see_a_success_message('minimum degree classification')
+      then_i_should_see_a_success_message('Minimum degree classification')
       and_the_required_grade_is_updated_with('two_one')
     end
 
@@ -47,7 +47,7 @@ feature 'Editing degree requirements', { can_edit_current_and_next_cycles: false
       and_there_is_a_primary_course_i_want_to_edit
       when_i_visit_the_degrees_start_page
       and_i_do_not_require_a_classification
-      then_i_should_see_a_success_message('minimum degree classification')
+      then_i_should_see_a_success_message('Minimum degree classification')
       and_the_required_grade_is_updated_with('not_required')
     end
   end
@@ -209,7 +209,7 @@ feature 'Editing degree requirements', { can_edit_current_and_next_cycles: false
   end
 
   def then_i_should_see_a_success_message(value)
-    expect(page).to have_content I18n.t('success.value_saved', value:)
+    expect(page).to have_content I18n.t('success.saved', value:)
   end
 
   def and_the_additional_requirements_are_updated

--- a/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
@@ -18,10 +18,10 @@ feature 'updating engineers teach physics', { can_edit_current_and_next_cycles: 
     and_i_select_an_option
     and_i_click_continue
     then_i_am_met_with_course_details_page
-    # TODO: success message?
+    and_i_should_see_a_success_message('Engineers Teach Physics')
   end
 
-  scenario 'updating subject to physics with modern languages' do
+  scenario 'back links return to correct pages' do
     and_there_is_a_secondary_course_i_want_to_edit
     when_i_visit_the_edit_course_subject_page
     when_i_select_a_subject(:physics)
@@ -35,8 +35,22 @@ feature 'updating engineers teach physics', { can_edit_current_and_next_cycles: 
     then_i_return_to_the_edit_engineers_teach_physics_with_languages_page
     when_i_go_back
     then_i_return_to_the_edit_course_subject_page
+  end
 
-    # TODO: success message?
+  scenario 'updating subject to physics with modern languages' do
+    and_there_is_a_secondary_course_i_want_to_edit
+    when_i_visit_the_edit_course_subject_page
+    when_i_select_a_subject(:physics)
+    and_i_select_subordinate_subject(:modern_languages)
+    and_i_click_continue
+    then_i_am_met_with_the_edit_engineers_teach_physics_with_languages_page
+    and_i_select_an_option
+    and_i_click_continue
+    then_i_am_met_with_the_edit_modern_languages_page
+    and_i_select_a_language
+    and_i_click_continue
+    then_i_am_met_with_course_details_page
+    and_i_should_see_a_success_message('Subjects')
   end
 
   scenario 'updating subject from physics to another subject resets campaign_name' do
@@ -75,7 +89,7 @@ feature 'updating engineers teach physics', { can_edit_current_and_next_cycles: 
   end
 
   def and_i_should_see_a_success_message(value)
-    expect(page).to have_content(I18n.t('success.value_saved', value:))
+    expect(page).to have_content(I18n.t('success.saved', value:))
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -136,6 +150,10 @@ feature 'updating engineers teach physics', { can_edit_current_and_next_cycles: 
   def then_i_am_met_with_the_edit_modern_languages_page
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/modern-languages?#{modern_languages_subject_ids}")
     expect(page).to have_content('Pick all the languages for this course')
+  end
+
+  def and_i_select_a_language
+    publish_courses_new_modern_languages_page.language_checkbox('German').click
   end
 
   def course_subject(subject_type)

--- a/spec/features/publish/courses/editing_modern_languages_spec.rb
+++ b/spec/features/publish/courses/editing_modern_languages_spec.rb
@@ -40,7 +40,7 @@ feature 'selecting a subject', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_should_see_a_success_message
-    expect(page).to have_content(I18n.t('success.saved'))
+    expect(page).to have_content(I18n.t('success.saved', value: 'Subjects'))
   end
 
   def modern_languages_subject

--- a/spec/features/publish/courses/editing_subject_spec.rb
+++ b/spec/features/publish/courses/editing_subject_spec.rb
@@ -13,7 +13,7 @@ feature 'updating a subject', { can_edit_current_and_next_cycles: false } do
     when_i_select_a_primary_subject('Primary with English')
     and_i_click_continue
     then_i_am_met_with_course_details_page
-    and_i_should_see_a_success_message('primary subject')
+    and_i_should_see_a_success_message
   end
 
   scenario 'updating secondary subject' do
@@ -22,7 +22,7 @@ feature 'updating a subject', { can_edit_current_and_next_cycles: false } do
     when_i_select_a_subject(:business_studies)
     and_i_click_continue
     then_i_am_met_with_course_details_page
-    and_i_should_see_a_success_message('secondary subject')
+    and_i_should_see_a_success_message
   end
 
   scenario 'updating secondary subject modern languages' do
@@ -35,8 +35,8 @@ feature 'updating a subject', { can_edit_current_and_next_cycles: false } do
 
   private
 
-  def and_i_should_see_a_success_message(value)
-    expect(page).to have_content(I18n.t('success.value_saved', value:))
+  def and_i_should_see_a_success_message
+    expect(page).to have_content(I18n.t('success.saved', value: 'Subject'))
   end
 
   def given_i_am_authenticated_as_a_provider_user

--- a/spec/features/publish/courses/gcse_equivalency_spec.rb
+++ b/spec/features/publish/courses/gcse_equivalency_spec.rb
@@ -186,6 +186,6 @@ feature 'GCSE equivalency requirements', { can_edit_current_and_next_cycles: fal
   end
 
   def and_i_see_the_success_summary
-    expect(publish_provider_courses_index_page.success_summary).to have_content(I18n.t('success.value_saved', value: 'GCSE requirements'))
+    expect(publish_provider_courses_index_page.success_summary).to have_content(I18n.t('success.saved', value: 'GCSE requirements'))
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -688,7 +688,7 @@ describe Course do
         it 'does not validate if the subject is not of that level' do
           course.subjects = [find_or_create(:primary_subject, :primary_with_mathematics)]
           expect(course.valid?).to be_falsey
-          expect(course.errors[:subjects]).to eq(['must be secondary'])
+          expect(course.errors[:subjects]).to eq(['Subject must be secondary'])
         end
 
         it 'validates if there are only 2 subjects' do
@@ -715,7 +715,7 @@ describe Course do
         it 'does not validate if the subject is not of that level' do
           course.subjects = [find_or_create(:secondary_subject, :mathematics)]
           expect(course.valid?).to be_falsey
-          expect(course.errors[:subjects]).to eq(['must be primary'])
+          expect(course.errors[:subjects]).to eq(['Subject must be primary'])
         end
 
         it 'does not validate if there is more than one subject' do
@@ -736,7 +736,7 @@ describe Course do
         it 'does not validate if the subject is not of that level' do
           course.subjects = [find_or_create(:secondary_subject, :biology)]
           expect(course.valid?).to be_falsey
-          expect(course.errors[:subjects]).to eq(['must be further education'])
+          expect(course.errors[:subjects]).to eq(['Subject must be further education'])
         end
 
         it 'does not validate if there is more than one subject' do


### PR DESCRIPTION
### Context

https://trello.com/c/0I8DvQZ8/994-content-changes-to-add-edit-flows-success-and-error-messages

### Changes proposed in this pull request

This PR specifically covers updating the flash messages to be aligned with the [following design history](https://bat-design-history.netlify.app/publish-teacher-training-courses/improving-the-content-on-the-add-and-edit-course-flows/#success-and-error-messages). 

A follow up ticket will handle updating the error messages.

- Update flash messages for course edit sections
- Update specs
- Fix a ropy persona (Anne) with a new lead school provider

### Guidance to review

- Create a course
- Edit some sections and assert the flash messages make sense relative to the design history

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
