### PR TITLE
[xxx] Handle subject params coming in as a Hash for CourseSearchService

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -263,6 +263,7 @@ class CourseSearchService
   def subject_codes
     return [] if filter[:subjects].blank?
     return filter[:subjects] if filter[:subjects].is_a? Array
+    return filter[:subjects].values if filter[:subjects].is_a?(Hash)
 
     filter[:subjects].split(',')
   end

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -666,11 +666,12 @@ RSpec.describe CourseSearchService do
       end
 
       context 'when not a string' do
-        let(:filter) { { 'hello' => 'there' } }
+        let(:filter) { { subjects: { '0' => '22', '1' => 'W1', '2' => 'C1' } } }
+        let(:expected_scope) { double }
 
-        it "doesn't add the scope" do
-          expect(scope).not_to receive(:with_subjects)
-          expect(scope).to receive(:select).and_return(inner_query_scope)
+        it 'adds the subject scope' do
+          expect(scope).to receive(:with_subjects).with(%w[22 W1 C1]).and_return(course_ids_scope)
+          expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end


### PR DESCRIPTION
### Context

Fixes the following Sentry error https://dfe-teacher-services.sentry.io/issues/3936286223/?project=1377944&query=is%3Aunresolved&referrer=issue-stream