### PR TITLE
add back link to check your answers page

### DIFF
--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -2,7 +2,7 @@
 <% content_for :page_title, title_with_error_prefix(page_title, course.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(request.referer) %>
+  <%= govuk_back_link_to(new_publish_provider_recruitment_cycle_courses_start_date_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true))) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -1,6 +1,10 @@
 <% page_title = "Check your answers" %>
 <% content_for :page_title, title_with_error_prefix(page_title, course.errors.any?) %>
 
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(request.referer) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(


### PR DESCRIPTION
### Context
We recently changed the titles of several pages in the ‘Add course’ and edit course flows. These changes impacted the check your answers and course details summary lists.

We also made improvements to the sub-navigation and summary lists.

### Changes proposed in this pull request
Add a back link to check your answers page 

### Guidance to review
https://bat-design-history.netlify.app/publish-teacher-training-courses/updating-the-check-your-answers-and-course-details-pages/

### Checklist

✅ Make sure all information from the Trello card is in here
✅ Attach to Trello card
✅ Rebased main
✅ Cleaned commit history
✅ Tested by running locally
