### PR TITLE
[0997] Content changes to add edit flows course start date

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -261,14 +261,6 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
-  def return_start_date
-    if FeatureService.enabled?('rollover.can_edit_current_and_next_cycles')
-      start_date.presence || "September #{Settings.current_recruitment_cycle_year + 1}"
-    else
-      start_date.presence || "September #{Settings.current_recruitment_cycle_year}"
-    end
-  end
-
   def placements_heading
     if further_education?
       'Teaching placements'

--- a/app/models/concerns/courses/edit_options.rb
+++ b/app/models/concerns/courses/edit_options.rb
@@ -16,10 +16,6 @@ module Courses
     include EngineersTeachPhysicsConcern
 
     included do
-      # When changing edit options here be sure to update the edit_options in the
-      # courses factory in publish-teacher-training:
-      #
-      # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
       def edit_course_options
         {
           entry_requirements:,

--- a/app/models/concerns/courses/edit_options/age_range_concern.rb
+++ b/app/models/concerns/courses/edit_options/age_range_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module AgeRangeConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def age_range_options
           case level
           when 'primary'

--- a/app/models/concerns/courses/edit_options/applications_open_concern.rb
+++ b/app/models/concerns/courses/edit_options/applications_open_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module ApplicationsOpenConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def show_applications_open?
           !is_published?
         end

--- a/app/models/concerns/courses/edit_options/can_sponsor_skilled_worker_visa_concern.rb
+++ b/app/models/concerns/courses/edit_options/can_sponsor_skilled_worker_visa_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module CanSponsorSkilledWorkerVisaConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def can_sponsor_skilled_worker_visa_options
           [true, false]
         end

--- a/app/models/concerns/courses/edit_options/can_sponsor_student_visa_concern.rb
+++ b/app/models/concerns/courses/edit_options/can_sponsor_student_visa_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module CanSponsorStudentVisaConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def can_sponsor_student_visa_options
           [true, false]
         end

--- a/app/models/concerns/courses/edit_options/entry_requirements_concern.rb
+++ b/app/models/concerns/courses/edit_options/entry_requirements_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module EntryRequirementsConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def entry_requirements
           Course::ENTRY_REQUIREMENT_OPTIONS
             .keys

--- a/app/models/concerns/courses/edit_options/is_send_concern.rb
+++ b/app/models/concerns/courses/edit_options/is_send_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module IsSendConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def show_is_send?
           !is_published?
         end

--- a/app/models/concerns/courses/edit_options/qualification_concern.rb
+++ b/app/models/concerns/courses/edit_options/qualification_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module QualificationConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def qualification_options
           if level == 'further_education'
             qualifications_without_qts

--- a/app/models/concerns/courses/edit_options/start_date_concern.rb
+++ b/app/models/concerns/courses/edit_options/start_date_concern.rb
@@ -8,28 +8,38 @@ module Courses
         def start_date_options
           recruitment_year = provider.recruitment_cycle.year.to_i
 
-          ["October #{recruitment_year - 1}",
-           "November #{recruitment_year - 1}",
-           "December #{recruitment_year - 1}",
-           "January #{recruitment_year}",
-           "February #{recruitment_year}",
-           "March #{recruitment_year}",
-           "April #{recruitment_year}",
-           "May #{recruitment_year}",
-           "June #{recruitment_year}",
-           "July #{recruitment_year}",
-           "August #{recruitment_year}",
-           "September #{recruitment_year}",
-           "October #{recruitment_year}",
-           "November #{recruitment_year}",
-           "December #{recruitment_year}",
-           "January #{recruitment_year + 1}",
-           "February #{recruitment_year + 1}",
-           "March #{recruitment_year + 1}",
-           "April #{recruitment_year + 1}",
-           "May #{recruitment_year + 1}",
-           "June #{recruitment_year + 1}",
-           "July #{recruitment_year + 1}"]
+          available_options = ["October #{recruitment_year - 1}",
+                               "November #{recruitment_year - 1}",
+                               "December #{recruitment_year - 1}",
+
+                               "January #{recruitment_year}",
+                               "February #{recruitment_year}",
+                               "March #{recruitment_year}",
+                               "April #{recruitment_year}",
+                               "May #{recruitment_year}",
+                               "June #{recruitment_year}",
+                               "July #{recruitment_year}",
+                               "August #{recruitment_year}",
+                               "September #{recruitment_year}",
+                               "October #{recruitment_year}",
+                               "November #{recruitment_year}",
+                               "December #{recruitment_year}",
+
+                               "January #{recruitment_year + 1}",
+                               "February #{recruitment_year + 1}",
+                               "March #{recruitment_year + 1}",
+                               "April #{recruitment_year + 1}",
+                               "May #{recruitment_year + 1}",
+                               "June #{recruitment_year + 1}",
+                               "July #{recruitment_year + 1}"]
+
+          if instance_of?(Course) && persisted?
+            available_options
+          else
+            starting_index = available_options.find_index "#{Date::MONTHNAMES[DateTime.now.month]} #{DateTime.now.year}"
+
+            available_options[starting_index..available_options.size]
+          end
         end
 
         def show_start_date?

--- a/app/models/concerns/courses/edit_options/start_date_concern.rb
+++ b/app/models/concerns/courses/edit_options/start_date_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module StartDateConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def start_date_options
           recruitment_year = provider.recruitment_cycle.year.to_i
 

--- a/app/models/concerns/courses/edit_options/study_mode_concern.rb
+++ b/app/models/concerns/courses/edit_options/study_mode_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module StudyModeConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def study_mode_options
           Course.study_modes.keys
         end

--- a/app/models/concerns/courses/edit_options/subjects_concern.rb
+++ b/app/models/concerns/courses/edit_options/subjects_concern.rb
@@ -5,10 +5,6 @@ module Courses
     module SubjectsConcern
       extend ActiveSupport::Concern
       included do
-        # When changing anything here be sure to update the edit_options in the
-        # courses factory in publish-teacher-training:
-        #
-        # https://github.com/DFE-Digital/publish-teacher-training/blob/master/spec/factories/courses.rb
         def potential_subjects
           assignable_master_subjects&.sort_by(&:subject_name)
         end

--- a/app/views/publish/courses/start_date/_form_fields.html.erb
+++ b/app/views/publish/courses/start_date/_form_fields.html.erb
@@ -1,4 +1,18 @@
-<%= render "publish/shared/form_field",
-  form:, field: :start_date, label: { text: "Course start date", class: "govuk-label govuk-label--s" }  do |field, options| %>
-  <%= form.select field, options_for_select(@course.edit_course_options["start_dates"], course.return_start_date), { include_blank: true }, data: { qa: "start_date" }, class: "govuk-select" %>
+<%= render "publish/shared/error_wrapper", error_keys: [:start_date], data_qa: "course__start_date" do %>
+  <fieldset class="govuk-fieldset">
+
+  <%= render "publish/shared/error_messages", error_keys: [:start_date] %>
+    <% @course.edit_course_options["start_dates"].each do |value| %>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :start_date,
+                value,
+                checked: course.start_date == value,
+                class: "govuk-radios__input" %>
+        <%= form.label :start_date,
+                value,
+                value:,
+                class: "govuk-label govuk-radios__label" %>
+      </div>
+    <% end %>
+  </fieldset>
 <% end %>

--- a/app/views/publish/courses/start_date/_form_fields.html.erb
+++ b/app/views/publish/courses/start_date/_form_fields.html.erb
@@ -1,18 +1,21 @@
 <%= render "publish/shared/error_wrapper", error_keys: [:start_date], data_qa: "course__start_date" do %>
   <fieldset class="govuk-fieldset">
-
-  <%= render "publish/shared/error_messages", error_keys: [:start_date] %>
-    <% @course.edit_course_options["start_dates"].each do |value| %>
-      <div class="govuk-radios__item">
-        <%= form.radio_button :start_date,
+    <h1 class="govuk-heading-l">
+        <%= render CaptionText.new(text: course.course_code.present? ? course.name_and_code : t("course.add_course")) %>
+      Course start date
+    </h1>
+    <%= render "publish/shared/error_messages", error_keys: [:start_date] %>
+      <% @course.edit_course_options["start_dates"].each do |value| %>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :start_date,
                 value,
                 checked: course.start_date == value,
                 class: "govuk-radios__input" %>
-        <%= form.label :start_date,
+          <%= form.label :start_date,
                 value,
                 value:,
                 class: "govuk-label govuk-radios__label" %>
-      </div>
+        </div>
     <% end %>
   </fieldset>
 <% end %>

--- a/app/views/publish/courses/start_date/edit.html.erb
+++ b/app/views/publish/courses/start_date/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("When does the course start? – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Course start date – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -7,7 +7,7 @@
 <%= render "publish/shared/errors" %>
 
 <h1 class="govuk-heading-l">
-  When does the course start?
+  Course start date
 </h1>
 
 <div class="govuk-grid-row">

--- a/app/views/publish/courses/start_date/edit.html.erb
+++ b/app/views/publish/courses/start_date/edit.html.erb
@@ -6,10 +6,6 @@
 
 <%= render "publish/shared/errors" %>
 
-<h1 class="govuk-heading-l">
-  Course start date
-</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course,

--- a/app/views/publish/courses/start_date/new.html.erb
+++ b/app/views/publish/courses/start_date/new.html.erb
@@ -6,11 +6,6 @@
 
 <%= render "publish/shared/errors" %>
 
-<h1 class="govuk-heading-l">
-  <%= render CaptionText.new(text: t("course.add_course")) %>
-  Course start date
-</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course,

--- a/app/views/publish/courses/start_date/new.html.erb
+++ b/app/views/publish/courses/start_date/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("When does the course start?", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Course start date", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
@@ -8,7 +8,7 @@
 
 <h1 class="govuk-heading-l">
   <%= render CaptionText.new(text: t("course.add_course")) %>
-  When does the course start?
+  Course start date
 </h1>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,7 +279,7 @@ en:
               taken: "Course code is already taken"
               blank: "Course code cannot be blank"
             start_date:
-              blank: "Start date cannot have blank values"
+              blank: "Select a course start date"
             name:
               blank: "Course title cannot be blank"
             level:

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -708,32 +708,6 @@ describe CourseDecorator do
   #   end
   # end
 
-  describe 'return_start_date' do
-    context 'when the course has a start date' do
-      it "returns the course's start date" do
-        expect(decorated_course.return_start_date).to eq(course.start_date)
-      end
-    end
-
-    context 'when the course has no start date', { can_edit_current_and_next_cycles: false } do
-      let(:start_date) { nil }
-
-      it 'returns the September of the current cycle' do
-        expect(decorated_course.return_start_date).to eq("September #{current_recruitment_cycle.year}")
-      end
-    end
-
-    context 'during rollover' do
-      let(:start_date) { nil }
-
-      before { allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true) }
-
-      it 'returns the September of the next cycle' do
-        expect(decorated_course.return_start_date).to eq("September #{current_recruitment_cycle.year.to_i + 1}")
-      end
-    end
-  end
-
   describe '#other_course_length?' do
     before do
       allow(course.enrichments).to receive(:most_recent).and_return([course_enrichment])

--- a/spec/features/publish/courses/new_applications_open_spec.rb
+++ b/spec/features/publish/courses/new_applications_open_spec.rb
@@ -62,7 +62,7 @@ feature 'choosing an application open from date', { can_edit_current_and_next_cy
 
   def then_i_am_met_with_the_start_date_page
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/start-date/new", ignore_query: true)
-    expect(page).to have_content('When does the course start?')
+    expect(page).to have_content('Course start date')
   end
 
   def then_i_am_met_with_errors

--- a/spec/features/publish/courses/new_start_date_spec.rb
+++ b/spec/features/publish/courses/new_start_date_spec.rb
@@ -8,8 +8,8 @@ feature 'choosing a start date', { can_edit_current_and_next_cycles: false } do
     when_i_visit_the_publish_courses_new_start_date_page
   end
 
-  scenario 'selecting september' do
-    when_i_select_september
+  scenario 'selecting january' do
+    when_i_select_january
     and_i_click_continue
     then_i_am_met_with_the_confirmation_page
   end
@@ -26,8 +26,8 @@ feature 'choosing a start date', { can_edit_current_and_next_cycles: false } do
     publish_courses_new_start_date_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: start_date_params(provider))
   end
 
-  def when_i_select_september
-    publish_courses_new_start_date_page.choose("September #{Settings.current_recruitment_cycle_year}")
+  def when_i_select_january
+    publish_courses_new_start_date_page.choose("January #{Settings.current_recruitment_cycle_year.to_i + 1}")
   end
 
   def and_i_click_continue

--- a/spec/features/publish/courses/new_start_date_spec.rb
+++ b/spec/features/publish/courses/new_start_date_spec.rb
@@ -26,7 +26,9 @@ feature 'choosing a start date', { can_edit_current_and_next_cycles: false } do
     publish_courses_new_start_date_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: start_date_params(provider))
   end
 
-  def when_i_select_september; end
+  def when_i_select_september
+    publish_courses_new_start_date_page.choose("September #{Settings.current_recruitment_cycle_year}")
+  end
 
   def and_i_click_continue
     publish_courses_new_start_date_page.continue.click

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -216,7 +216,7 @@ feature 'new course', { can_edit_current_and_next_cycles: false } do
   def select_start_date(course_creation_params)
     course_creation_params[:start_date] = "September #{recruitment_cycle.year}"
 
-    publish_courses_new_start_date_page.select "September #{recruitment_cycle.year}"
+    publish_courses_new_start_date_page.choose "September #{recruitment_cycle.year}"
     publish_courses_new_start_date_page.continue.click
 
     # Addressable, the gem site-prism relies on, cannot match parameters containing a +

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -214,9 +214,9 @@ feature 'new course', { can_edit_current_and_next_cycles: false } do
   end
 
   def select_start_date(course_creation_params)
-    course_creation_params[:start_date] = "September #{recruitment_cycle.year}"
+    course_creation_params[:start_date] = "January #{recruitment_cycle.year.to_i + 1}"
 
-    publish_courses_new_start_date_page.choose "September #{recruitment_cycle.year}"
+    publish_courses_new_start_date_page.choose "January #{recruitment_cycle.year.to_i + 1}"
     publish_courses_new_start_date_page.continue.click
 
     # Addressable, the gem site-prism relies on, cannot match parameters containing a +

--- a/spec/features/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/features/support/providers/courses/editing_a_course_spec.rb
@@ -218,7 +218,7 @@ feature 'Edit provider course details' do
   def and_it_contains_blank_errors
     expect(support_provider_course_edit_page.error_summary.text).to include('Course code cannot be blank')
     expect(support_provider_course_edit_page.error_summary.text).to include('Course title cannot be blank')
-    expect(support_provider_course_edit_page.error_summary.text).to include('Start date cannot have blank values')
+    expect(support_provider_course_edit_page.error_summary.text).to include('Select a course start date')
     expect(support_provider_course_edit_page.error_summary.text).to include('Select when applications will open and enter the date if applicable')
   end
 end

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -80,7 +80,7 @@ module Support
           expect(subject.errors.messages.count).to eq(4)
           expect(subject.errors.messages[:course_code]).to include('Course code cannot be blank')
           expect(subject.errors.messages[:name]).to include('Course title cannot be blank')
-          expect(subject.errors.messages[:start_date]).to include('Start date cannot have blank values')
+          expect(subject.errors.messages[:start_date]).to include('Select a course start date')
           expect(subject.errors.messages[:applications_open_from]).to include('^Select when applications will open and enter the date if applicable')
         end
       end

--- a/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
@@ -3,49 +3,84 @@
 require 'rails_helper'
 
 describe Courses::EditOptions::StartDateConcern do
-  let(:example_model) do
-    klass = Class.new do
-      include Courses::EditOptions::StartDateConcern
-      attr_accessor :provider
+  let(:example_model) { create(:course) }
+
+  let(:year) { example_model.provider.recruitment_cycle.year.to_i }
+
+  context 'non presisted course' do
+    context 'start_date_options' do
+      it 'returns the correct options for the recruitment_cycle' do
+        expect(example_model.start_date_options).to eq(
+          ["October #{year - 1}",
+           "November #{year - 1}",
+           "December #{year - 1}",
+           "January #{year}",
+           "February #{year}",
+           "March #{year}",
+           "April #{year}",
+           "May #{year}",
+           "June #{year}",
+           "July #{year}",
+           "August #{year}",
+           "September #{year}",
+           "October #{year}",
+           "November #{year}",
+           "December #{year}",
+           "January #{year + 1}",
+           "February #{year + 1}",
+           "March #{year + 1}",
+           "April #{year + 1}",
+           "May #{year + 1}",
+           "June #{year + 1}",
+           "July #{year + 1}"]
+        )
+      end
+    end
+  end
+
+  context 'presisted course' do
+    let(:example_model) { build(:course) }
+    let(:month) { [*1..12].sample }
+    let(:expected_starting_options) do
+      [
+        nil,
+        "January #{year}",
+        "February #{year}",
+        "March #{year}",
+        "April #{year}",
+        "May #{year}",
+        "June #{year}",
+        "July #{year}",
+        "August #{year}",
+        "September #{year}",
+        "October #{year}",
+        "November #{year}",
+        "December #{year}"
+      ][month..12].compact
     end
 
-    klass.new
-  end
+    let(:expected_available_options) do
+      [
 
-  let(:provider) { build(:provider) }
+        *expected_starting_options,
+        "January #{year + 1}",
+        "February #{year + 1}",
+        "March #{year + 1}",
+        "April #{year + 1}",
+        "May #{year + 1}",
+        "June #{year + 1}",
+        "July #{year + 1}"
+      ]
+    end
 
-  before do
-    example_model.provider = provider
-  end
+    around do |example|
+      Timecop.freeze(Time.zone.local(Settings.current_recruitment_cycle_year, month, 1)) do
+        example.run
+      end
+    end
 
-  context 'start_date_options' do
-    let(:year) { provider.recruitment_cycle.year.to_i }
-
-    it 'returns the correct options for the recruitment_cycle' do
-      expect(example_model.start_date_options).to eq(
-        ["October #{year - 1}",
-         "November #{year - 1}",
-         "December #{year - 1}",
-         "January #{year}",
-         "February #{year}",
-         "March #{year}",
-         "April #{year}",
-         "May #{year}",
-         "June #{year}",
-         "July #{year}",
-         "August #{year}",
-         "September #{year}",
-         "October #{year}",
-         "November #{year}",
-         "December #{year}",
-         "January #{year + 1}",
-         "February #{year + 1}",
-         "March #{year + 1}",
-         "April #{year + 1}",
-         "May #{year + 1}",
-         "June #{year + 1}",
-         "July #{year + 1}"]
-      )
+    it 'returns the available options for the recruitment_cycle' do
+      expect(example_model.start_date_options).to eq(expected_available_options)
     end
   end
 end

--- a/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
@@ -7,7 +7,7 @@ describe Courses::EditOptions::StartDateConcern do
 
   let(:year) { example_model.provider.recruitment_cycle.year.to_i }
 
-  context 'non presisted course' do
+  context 'non persisted course' do
     context 'start_date_options' do
       it 'returns the correct options for the recruitment_cycle' do
         expect(example_model.start_date_options).to eq(
@@ -38,7 +38,7 @@ describe Courses::EditOptions::StartDateConcern do
     end
   end
 
-  context 'presisted course' do
+  context 'persisted course' do
     let(:example_model) { build(:course) }
     let(:month) { [*1..12].sample }
     let(:expected_starting_options) do


### PR DESCRIPTION
### Context

Start date for courses

### Changes proposed in this pull request

Change the drop down list to radio buttons
Also fixed error message as it is now very obvious

### Guidance to review
There is currently no edit functionality (change link)


https://publish-teacher-training-pr-3367.london.cloudapps.digital/publish/organisations/T92/2023/courses/start-date/new?course%5Bage_range_in_years%5D=3_to_7&course%5Bapplications_open_from%5D=2022-10-11&course%5Bcampaign_name%5D=&course%5Bcan_sponsor_skilled_worker_visa%5D=false&course%5Bfunding_type%5D=apprenticeship&course%5Bis_send%5D=0&course%5Blevel%5D=primary&course%5Bmaster_subject_id%5D=4&course%5Bqualification%5D=pgce_with_qts&course%5Bsites_ids%5D%5B%5D=11237736&course%5Bstudy_mode%5D=full_time&course%5Bsubjects_ids%5D%5B%5D=4

#### Without validation
![image](https://user-images.githubusercontent.com/470137/220072959-1443d14f-faa2-4e25-ac46-e4c28defd05c.png)

#### With validation
![image](https://user-images.githubusercontent.com/470137/220581790-4c691319-32cf-4a78-9f3a-80291e786922.png)




### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
