### PR TITLE
[926] Add content about relocation payments to international candidates section

### DIFF
--- a/app/components/find/courses/international_students_component/view.html.erb
+++ b/app/components/find/courses/international_students_component/view.html.erb
@@ -14,7 +14,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>are an Irish citizen</li>
-      <li>have settled or pre-settled status under the <%= govuk_link_to("EU Settlement Scheme", "https://www.gov.uk/settled-status-eu-citizens-families") %> (you may still be able to apply)</li>
+      <li>have settled or pre-settled status under the <%= govuk_link_to("EU Settlement Scheme", t("links.eu_settlement_scheme")) %> (you may still be able to apply)</li>
       <li>have indefinite leave to remain in the UK</li>
     </ul>
 
@@ -24,7 +24,7 @@
       <%= t("find.international_candidates.entitlement.html") %>
     <% end %>
 
-    <p class="govuk-body">Learn more about <%= govuk_link_to("training to teach in England as an international student", "https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student") %>.</p>
+    <p class="govuk-body">Learn more about <%= govuk_link_to("training to teach in England as an international student", t("find.get_into_teaching.url_train_to_teach_as_international_candidate")) %>.</p>
 
     <h3 class="govuk-heading-m">International qualifications</h3>
     <p class="govuk-body">If your qualifications come from a non-UK institution, we may want to see a ‘statement of comparability’ from UK ENIC. This will show us how they compare to UK qualifications.</p>

--- a/app/components/find/courses/international_students_component/view.html.erb
+++ b/app/components/find/courses/international_students_component/view.html.erb
@@ -20,9 +20,11 @@
 
     <%= t("find.international_candidates.#{visa_type}.#{sponsorship_availability}.html") %>
 
-    <p class="govuk-body">Alternatively, check if you’re eligible for a different type of visa, such as a Graduate or Family visa, that allows you to train to be a teacher without being sponsored.</p>
+    <% if course_has_relocation_entitlement? %>
+      <%= t("find.international_candidates.entitlement.html") %>
+    <% end %>
 
-    <p class="govuk-body">Find out more about <%= govuk_link_to("training to teach in England", "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen") %>.</p>
+    <p class="govuk-body">Learn more about <%= govuk_link_to("training to teach in England as an international student", "https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student") %>.</p>
 
     <h3 class="govuk-heading-m">International qualifications</h3>
     <p class="govuk-body">If your qualifications come from a non-UK institution, we may want to see a ‘statement of comparability’ from UK ENIC. This will show us how they compare to UK qualifications.</p>

--- a/app/components/find/courses/international_students_component/view.rb
+++ b/app/components/find/courses/international_students_component/view.rb
@@ -45,7 +45,13 @@ module Find
         end
 
         def course_has_relocation_entitlement?
-          course.subjects.any? { |subject| SUBJECTS_WITH_RELOCATION_ENTITLEMENT.include?(subject.subject_code) }
+          return course_subject_codes.any? { |code| SUBJECTS_WITH_RELOCATION_ENTITLEMENT.include?(code) } if course.is_modern_language_course?
+
+          SUBJECTS_WITH_RELOCATION_ENTITLEMENT.include?(course_subject_codes.first)
+        end
+
+        def course_subject_codes
+          @course_subject_codes ||= course.subjects.pluck(:subject_code).compact
         end
       end
     end

--- a/app/components/find/courses/international_students_component/view.rb
+++ b/app/components/find/courses/international_students_component/view.rb
@@ -4,6 +4,21 @@ module Find
   module Courses
     module InternationalStudentsComponent
       class View < ViewComponent::Base
+        SUBJECTS_WITH_RELOCATION_ENTITLEMENT = %w[
+          A1
+          A2
+          15
+          17
+          18
+          19
+          A0
+          20
+          24
+          21
+          22
+          F3
+        ].freeze
+
         attr_reader :course
 
         delegate :apprenticeship?, to: :course
@@ -27,6 +42,10 @@ module Find
 
         def sponsorship_availability
           @sponsorship_availability ||= course.public_send("can_sponsor_#{visa_type}") ? :available : :not_available
+        end
+
+        def course_has_relocation_entitlement?
+          course.subjects.any? { |subject| SUBJECTS_WITH_RELOCATION_ENTITLEMENT.include?(subject.subject_code) }
         end
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -544,6 +544,10 @@ class Course < ApplicationRecord
     end
   end
 
+  def is_modern_language_course?
+    subjects.any? { |s| s == SecondarySubject.modern_languages }
+  end
+
   def sites=(desired_sites)
     existing_sites = sites
 

--- a/app/services/courses/generate_course_name_service.rb
+++ b/app/services/courses/generate_course_name_service.rb
@@ -64,7 +64,7 @@ module Courses
     end
 
     def generate_modern_language_title
-      return unless is_modern_language_course?
+      return unless course.is_modern_language_course?
 
       title = SecondarySubject.modern_languages.to_s
       official_languages = languages.reject { |language| language.subject_name.casecmp?('Modern languages (other)') }
@@ -83,10 +83,6 @@ module Courses
       when 3
         title + " (#{language_names.join(', ')})"
       end
-    end
-
-    def is_modern_language_course?
-      subjects.any? { |s| s == SecondarySubject.modern_languages }
     end
 
     def format_subject_name(subject)

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -72,10 +72,10 @@ en:
       skilled_worker_visa:
         not_available:
           html:
-            <p class="govuk-body">If you do not already have the right to work in the UK, you may need to apply for a visa. The main visa for salaried courses is the Skilled Worker visa.</p>
-            <p class="govuk-body">To apply for a Skilled Worker visa you need to be sponsored by your employer.</p>
-            <p class="govuk-body">Sponsorship is not available for this course.</p>
+            <p class="govuk-body">If you do not already have the right to work in the UK, you may need to apply for a visa. The main visa for salaried courses is the <a class="govuk-link" href="https://www.gov.uk/skilled-worker-visa">Skilled Worker visa.</a></p>
+            <p class="govuk-body">Sponsorship for a Skilled Worker visa is not available for this course.</p>
             <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
+            <p class="govuk-body">You can also <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#studying-and-working-as-a-teacher-in-the-uk-without-a-skilled-worker-visa-or-a-student-visa">learn more about different types of visa</a>  which allow you to train to be a teacher without being sponsored.</p>
         available:
           html:
             <p class="govuk-body">If you do not already have the right to work in the UK for the duration of this course, you may need to apply for a Skilled Worker visa.</p>
@@ -84,15 +84,18 @@ en:
       student_visa:
         not_available:
           html:
-            <p class="govuk-body">If you do not already have the right to study in the UK, you may need to apply for a visa. The main visa for fee-paying courses (those that you have to pay for) is the Student visa.</p>
-            <p class="govuk-body">To apply for a Student visa, you’ll need to be sponsored by your training provider.</p>
-            <p class="govuk-body">Sponsorship is not available for this course.</p>
+            <p class="govuk-body">If you do not already have the right to study in the UK, you may need to apply for a visa.</p>
+            <p class="govuk-body">Sponsorship for a student visa is not available for this course.</p>
             <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
+            <p class="govuk-body">You can also <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#studying-and-working-as-a-teacher-in-the-uk-without-a-skilled-worker-visa-or-a-student-visa">learn more about different types of visa</a>  which allow you to train to be a teacher without being sponsored.</p>
         available:
           html:
             <p class="govuk-body">If you do not already have the right to study in the UK for the duration of this course, you may need to apply for a Student visa.</p>
             <p class="govuk-body">To do this, you’ll need to be sponsored by your training provider.</p>
             <p class="govuk-body">Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.</p>
+      entitlement:
+        html:
+          <p class="govuk-body">You may be entitled  to £10,000 from the UK government to help with the financial costs of moving to England.</p>
     get_into_teaching:
       tel: 0800 389 2500
       opening_times: "Monday to Friday, 8.30am to 5.30pm"

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -75,7 +75,7 @@ en:
             <p class="govuk-body">If you do not already have the right to work in the UK, you may need to apply for a visa. The main visa for salaried courses is the <a class="govuk-link" href="https://www.gov.uk/skilled-worker-visa">Skilled Worker visa.</a></p>
             <p class="govuk-body">Sponsorship for a Skilled Worker visa is not available for this course.</p>
             <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
-            <p class="govuk-body">You can also <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#studying-and-working-as-a-teacher-in-the-uk-without-a-skilled-worker-visa-or-a-student-visa">learn more about different types of visa</a>  which allow you to train to be a teacher without being sponsored.</p>
+            <p class="govuk-body">You can also <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#studying-and-working-as-a-teacher-in-the-uk-without-a-skilled-worker-visa-or-a-student-visa">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
         available:
           html:
             <p class="govuk-body">If you do not already have the right to work in the UK for the duration of this course, you may need to apply for a Skilled Worker visa.</p>
@@ -87,7 +87,7 @@ en:
             <p class="govuk-body">If you do not already have the right to study in the UK, you may need to apply for a visa.</p>
             <p class="govuk-body">Sponsorship for a student visa is not available for this course.</p>
             <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
-            <p class="govuk-body">You can also <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#studying-and-working-as-a-teacher-in-the-uk-without-a-skilled-worker-visa-or-a-student-visa">learn more about different types of visa</a>  which allow you to train to be a teacher without being sponsored.</p>
+            <p class="govuk-body">You can also <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#studying-and-working-as-a-teacher-in-the-uk-without-a-skilled-worker-visa-or-a-student-visa">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
         available:
           html:
             <p class="govuk-body">If you do not already have the right to study in the UK for the duration of this course, you may need to apply for a Student visa.</p>
@@ -95,7 +95,7 @@ en:
             <p class="govuk-body">Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.</p>
       entitlement:
         html:
-          <p class="govuk-body">You may be entitled  to £10,000 from the UK government to help with the financial costs of moving to England.</p>
+          <p class="govuk-body">You may be entitled to £10,000 from the UK government to help with the financial costs of moving to England.</p>
     get_into_teaching:
       tel: 0800 389 2500
       opening_times: "Monday to Friday, 8.30am to 5.30pm"

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -108,6 +108,7 @@ en:
       url_teacher_training_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_banner&utm_content=Spring23events
       url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
       url_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_start&utm_content=Spring23events
+      url_train_to_teach_as_international_candidate: https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student
     qualification:
       description_with_abbreviation:
         qts:

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -113,18 +113,43 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     end
   end
 
-  context 'when course has a subject with relocation entitlement' do
-    before do
-      course = build(
-        :course,
-        funding_type: 'fee',
-        subjects: [build(:secondary_subject, :french)]
-      )
-      render_inline(described_class.new(course: CourseDecorator.new(course)))
+  context 'relocation payment text' do
+    let(:relocation_text) { 'You may be entitled to £10,000 from the UK government to help with the financial costs of moving to England.' }
+
+    context 'when primary subject is a single subject with relocation entitlement' do
+      before do
+        course = create(
+          :course,
+          :secondary,
+          funding_type: 'fee',
+          subjects: [build(:secondary_subject, :physics)]
+        )
+        render_inline(described_class.new(course: CourseDecorator.new(course)))
+      end
+
+      it 'tells candidates they may be eligible for relocation support' do
+        expect(page).to have_text(relocation_text)
+      end
     end
 
-    it 'tells candidates they may be eligible for relocation support' do
-      expect(page).to have_text('You may be entitled to £10,000 from the UK government to help with the financial costs of moving to England.')
+    context 'when primary subject is modern language with secondary subject' do
+      before do
+        course = create(
+          :course,
+          :secondary,
+          funding_type: 'fee',
+          subjects: [
+            find_or_create(:secondary_subject, :modern_languages),
+            build(:secondary_subject, :biology),
+            find_or_create(:modern_languages_subject, :french)
+          ]
+        )
+        render_inline(described_class.new(course: CourseDecorator.new(course)))
+      end
+
+      it 'tells candidates they may be eligible for relocation support' do
+        expect(page).to have_text(relocation_text)
+      end
     end
   end
 end

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -124,7 +124,7 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     end
 
     it 'tells candidates they may be eligible for relocation support' do
-      expect(page).to have_text('You may be entitled  to £10,000 from the UK government to help with the financial costs of moving to England.')
+      expect(page).to have_text('You may be entitled to £10,000 from the UK government to help with the financial costs of moving to England.')
     end
   end
 end

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -18,7 +18,7 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     end
 
     it 'tells candidates sponsorship is not available' do
-      expect(page).to have_text('Sponsorship is not available for this course')
+      expect(page).to have_text('Sponsorship for a student visa is not available for this course')
     end
   end
 
@@ -83,7 +83,7 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     end
 
     it 'tells candidates visa sponsorship is not available' do
-      expect(page).to have_text('Sponsorship is not available for this course')
+      expect(page).to have_text('Sponsorship for a Skilled Worker visa is not available for this course')
     end
 
     it 'does not tell candidates the 3-year residency rule' do
@@ -110,6 +110,21 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
 
     it 'tells candidates about settled and pre-settled status' do
       expect(page).to have_text('EEA nationals with settled or pre-settled status under the')
+    end
+  end
+
+  context 'when course has a subject with relocation entitlement' do
+    before do
+      course = build(
+        :course,
+        funding_type: 'fee',
+        subjects: [build(:secondary_subject, :french)]
+      )
+      render_inline(described_class.new(course: CourseDecorator.new(course)))
+    end
+
+    it 'tells candidates they may be eligible for relocation support' do
+      expect(page).to have_text('You may be entitled  to £10,000 from the UK government to help with the financial costs of moving to England.')
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/Tu6wycNm/926-add-content-about-relocation-payments-to-international-candidates-section

### Changes proposed in this pull request

- Update the content for the international candidates component used via the Find course show page and the Publish course preview
- Also updates some existing content in this component to match with the prototype

### Guidance to review

Review app - https://find-pr-3370.london.cloudapps.digital

Check one of the qualifying courses for a relocation payment and one without. Assert the relocation text is shown correctly.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
