### PR TITLE
Fix non clickable checkbox labels

### DIFF
--- a/app/views/find/result_filters/_qualifications_filter.html.erb
+++ b/app/views/find/result_filters/_qualifications_filter.html.erb
@@ -16,7 +16,7 @@
         "qts",
         false
       ) %>
-      <%= form.label :qualification, value: "QtsOnly", class: "govuk-label govuk-checkboxes__label" do %>
+      <%= form.label :qualification, { for: "qualification_qts" }, value: "QtsOnly", class: "govuk-label govuk-checkboxes__label" do %>
         QTS only
       <% end %>
     </div>
@@ -33,7 +33,7 @@
         "pgce_with_qts",
         false
       ) %>
-      <%= form.label :qualification, value: "PgdePgceWithQts", class: "govuk-label govuk-checkboxes__label" do %>
+      <%= form.label :qualification, { for: "qualification_pgce_with_qts" }, value: "PgdePgceWithQts", class: "govuk-label govuk-checkboxes__label" do %>
         PGCE (or PGDE) with QTS
       <% end %>
     </div>
@@ -50,7 +50,7 @@
         ["pgce pgde"],
         false
       ) %>
-      <%= form.label :qualification, value: "Other", class: "govuk-label govuk-checkboxes__label" do %>
+      <%= form.label :qualification, { for: "qualification_pgce_pgde" }, value: "Other", class: "govuk-label govuk-checkboxes__label" do %>
         Further education (PGCE or PGDE without QTS)
       <% end %>
     </div>

--- a/app/views/find/result_filters/_study_type_filter.html.erb
+++ b/app/views/find/result_filters/_study_type_filter.html.erb
@@ -15,7 +15,7 @@
         "full_time",
         nil
       ) %>
-      <%= form.label :full_time, class: "govuk-label govuk-checkboxes__label" do %>
+      <%= form.label :full_time, { for: "study_type_full_time" }, class: "govuk-label govuk-checkboxes__label" do %>
         Full time (12 months)
       <% end %>
     </div>
@@ -32,7 +32,7 @@
         "part_time",
         nil
       ) %>
-      <%= form.label :part_time, class: "govuk-label govuk-checkboxes__label" do %>
+      <%= form.label :part_time, { for: "study_type_part_time" }, class: "govuk-label govuk-checkboxes__label" do %>
         Part time (18 to 24 months)
       <% end %>
     </div>

--- a/spec/features/find/result_page_filters/degree_required_spec.rb
+++ b/spec/features/find/result_page_filters/degree_required_spec.rb
@@ -30,15 +30,15 @@ RSpec.feature 'Degree required filter' do
   end
 
   def when_i_select_the_two_two_degree_radio
-    find_results_page.degree_grade.two_two.choose
+    page.choose('2:2')
   end
 
   def when_i_select_the_third_degree_radio
-    find_results_page.degree_grade.third_class.choose
+    page.choose('Third')
   end
 
   def when_i_select_the_pass_degree_radio
-    find_results_page.degree_grade.not_required.choose
+    page.choose('Pass (Ordinary degree)')
   end
 
   def then_i_see_that_the_two_two_degree_radio_is_selected

--- a/spec/features/find/result_page_filters/degree_required_spec.rb
+++ b/spec/features/find/result_page_filters/degree_required_spec.rb
@@ -30,15 +30,15 @@ RSpec.feature 'Degree required filter' do
   end
 
   def when_i_select_the_two_two_degree_radio
-    page.choose('2:2')
+    choose('2:2')
   end
 
   def when_i_select_the_third_degree_radio
-    page.choose('Third')
+    choose('Third')
   end
 
   def when_i_select_the_pass_degree_radio
-    page.choose('Pass (Ordinary degree)')
+    choose('Pass (Ordinary degree)')
   end
 
   def then_i_see_that_the_two_two_degree_radio_is_selected

--- a/spec/features/find/result_page_filters/qualifications_spec.rb
+++ b/spec/features/find/result_page_filters/qualifications_spec.rb
@@ -37,8 +37,8 @@ RSpec.feature 'Qualifications filter' do
   end
 
   def when_i_unselect_the_pgce_and_further_education_qualification_checkboxes
-    find_results_page.qualifications.pgce_with_qts.uncheck
-    find_results_page.qualifications.other.uncheck
+    page.uncheck('PGCE (or PGDE) with QTS')
+    page.uncheck('Further education (PGCE or PGDE without QTS)')
   end
 
   def and_the_qts_checkbox_is_selected
@@ -90,19 +90,19 @@ RSpec.feature 'Qualifications filter' do
   end
 
   def when_i_select_the_pgce_checkbox
-    find_results_page.qualifications.pgce_with_qts.check
+    page.check('PGCE (or PGDE) with QTS')
   end
 
   def when_i_select_the_further_education_checkbox
-    find_results_page.qualifications.other.check
+    page.check('Further education (PGCE or PGDE without QTS)')
   end
 
   def and_i_deselect_the_qts_checkbox
-    find_results_page.qualifications.qts.uncheck
+    page.uncheck('QTS only')
   end
 
   def and_i_deselect_the_pgce_checkbox
-    find_results_page.qualifications.pgce_with_qts.uncheck
+    page.uncheck('PGCE (or PGDE) with QTS')
   end
 
   def then_i_see_that_the_qts_and_further_education_checkboxes_are_still_unselected

--- a/spec/features/find/result_page_filters/qualifications_spec.rb
+++ b/spec/features/find/result_page_filters/qualifications_spec.rb
@@ -37,8 +37,8 @@ RSpec.feature 'Qualifications filter' do
   end
 
   def when_i_unselect_the_pgce_and_further_education_qualification_checkboxes
-    page.uncheck('PGCE (or PGDE) with QTS')
-    page.uncheck('Further education (PGCE or PGDE without QTS)')
+    uncheck('PGCE (or PGDE) with QTS')
+    uncheck('Further education (PGCE or PGDE without QTS)')
   end
 
   def and_the_qts_checkbox_is_selected
@@ -90,19 +90,19 @@ RSpec.feature 'Qualifications filter' do
   end
 
   def when_i_select_the_pgce_checkbox
-    page.check('PGCE (or PGDE) with QTS')
+    check('PGCE (or PGDE) with QTS')
   end
 
   def when_i_select_the_further_education_checkbox
-    page.check('Further education (PGCE or PGDE without QTS)')
+    check('Further education (PGCE or PGDE without QTS)')
   end
 
   def and_i_deselect_the_qts_checkbox
-    page.uncheck('QTS only')
+    uncheck('QTS only')
   end
 
   def and_i_deselect_the_pgce_checkbox
-    page.uncheck('PGCE (or PGDE) with QTS')
+    uncheck('PGCE (or PGDE) with QTS')
   end
 
   def then_i_see_that_the_qts_and_further_education_checkboxes_are_still_unselected

--- a/spec/features/find/result_page_filters/salary_spec.rb
+++ b/spec/features/find/result_page_filters/salary_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Funding filter' do
   end
 
   def when_i_select_the_salary_checkbox
-    find_results_page.funding.checkbox.check
+    page.check('Only show courses that come with a salary')
   end
 
   def then_i_see_that_the_salary_checkbox_is_selected

--- a/spec/features/find/result_page_filters/salary_spec.rb
+++ b/spec/features/find/result_page_filters/salary_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Funding filter' do
   end
 
   def when_i_select_the_salary_checkbox
-    page.check('Only show courses that come with a salary')
+    check('Only show courses that come with a salary')
   end
 
   def then_i_see_that_the_salary_checkbox_is_selected

--- a/spec/features/find/result_page_filters/send_spec.rb
+++ b/spec/features/find/result_page_filters/send_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'SEND filter' do
   end
 
   def when_i_select_the_send_checkbox
-    find_results_page.send.checkbox.check
+    page.check('Only show courses with a SEND specialism')
   end
 
   def then_i_see_that_the_send_checkbox_is_selected

--- a/spec/features/find/result_page_filters/send_spec.rb
+++ b/spec/features/find/result_page_filters/send_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'SEND filter' do
   end
 
   def when_i_select_the_send_checkbox
-    page.check('Only show courses with a SEND specialism')
+    check('Only show courses with a SEND specialism')
   end
 
   def then_i_see_that_the_send_checkbox_is_selected

--- a/spec/features/find/result_page_filters/study_type_spec.rb
+++ b/spec/features/find/result_page_filters/study_type_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Study type filter' do
   end
 
   def when_i_unselect_the_part_time_study_checkbox
-    page.uncheck('Part time (18 to 24 months)')
+    uncheck('Part time (18 to 24 months)')
   end
 
   def then_i_see_that_the_full_time_study_checkbox_is_still_selected
@@ -48,7 +48,7 @@ RSpec.feature 'Study type filter' do
   end
 
   def when_i_unselect_the_full_time_study_checkbox
-    page.uncheck('Full time (12 months)')
+    uncheck('Full time (12 months)')
   end
 
   def and_i_select_the_part_time_study_checkbox

--- a/spec/features/find/result_page_filters/study_type_spec.rb
+++ b/spec/features/find/result_page_filters/study_type_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Study type filter' do
   end
 
   def when_i_unselect_the_part_time_study_checkbox
-    find_results_page.study_type.part_time.uncheck
+    page.uncheck('Part time (18 to 24 months)')
   end
 
   def then_i_see_that_the_full_time_study_checkbox_is_still_selected
@@ -48,7 +48,7 @@ RSpec.feature 'Study type filter' do
   end
 
   def when_i_unselect_the_full_time_study_checkbox
-    find_results_page.study_type.full_time.uncheck
+    page.uncheck('Full time (12 months)')
   end
 
   def and_i_select_the_part_time_study_checkbox

--- a/spec/features/find/result_page_filters/vacancies_spec.rb
+++ b/spec/features/find/result_page_filters/vacancies_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Results page new vacancies filter' do
   end
 
   def when_i_unselect_the_vacancies_checkbox
-    find_results_page.vacancies.checkbox.uncheck
+    page.uncheck('Only show courses with vacancies')
   end
 
   def then_i_see_that_the_vacancies_checkbox_is_still_unselected

--- a/spec/features/find/result_page_filters/vacancies_spec.rb
+++ b/spec/features/find/result_page_filters/vacancies_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Results page new vacancies filter' do
   end
 
   def when_i_unselect_the_vacancies_checkbox
-    page.uncheck('Only show courses with vacancies')
+    uncheck('Only show courses with vacancies')
   end
 
   def then_i_see_that_the_vacancies_checkbox_is_still_unselected

--- a/spec/features/find/result_page_filters/visa_spec.rb
+++ b/spec/features/find/result_page_filters/visa_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Visa filter' do
   end
 
   def when_i_select_the_visa_checkbox
-    find_results_page.visa.checkbox.check
+    page.check('Only show courses with visa sponsorship')
   end
 
   def then_i_see_that_the_visa_checkbox_is_selected

--- a/spec/features/find/result_page_filters/visa_spec.rb
+++ b/spec/features/find/result_page_filters/visa_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Visa filter' do
   end
 
   def when_i_select_the_visa_checkbox
-    page.check('Only show courses with visa sponsorship')
+    check('Only show courses with visa sponsorship')
   end
 
   def then_i_see_that_the_visa_checkbox_is_selected


### PR DESCRIPTION
### Context

Some of the labels for the Find filters are not clickable, they should be.

### Changes proposed in this pull request

- Fix non clickable checkbox labels on Find.
- Click the labels instead of the checkbox in tests (in order to catch these in the future).

### Guidance to review

The label text should be clickable as well as the checkboxes

![image](https://user-images.githubusercontent.com/50492247/220605364-939cb37c-8e67-4ec2-b2c1-974c747629eb.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
