### PR TITLE
1079 update entry content

### DIFF
--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -15,24 +15,14 @@
     <% if course.secondary_course? %>
       <% if course.engineers_teach_physics? %>
         <p class="govuk-body">
-          Your degree subject should be in engineering, materials science or a related subject, otherwise you’ll need to prove your subject knowledge in some other way.
+          This <%= govuk_link_to "Engineers teach physics", "https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics"  %> course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.
         </p>
-        <p class="govuk-body">
-          If your degree is not engineering or a related subject, please apply to our physics course.
-        </p>
-      <% else %>
-        <% unless subject_knowledge_enhancement_content? || primary_with_mathematics_subject? %>
-          <p class="govuk-body">
-            <%= secondary_advisory(course) %>
-          </p>
-        <% end %>
       <% end %>
     <% end %>
 
     <% if subject_knowledge_enhancement_content? %>
       <p class="govuk-body">
-        If your degree is not in <%= course.computed_subject_name_or_names %>, or you’ve not used your subject knowledge in a while, you may be asked to complete a
-        <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
+        If you need to improve your subject knowledge, you may be asked to complete a <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
       </p>
       <% elsif primary_with_mathematics_subject? %>
       <p class="govuk-body">

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -48,9 +48,9 @@ module Find
           end
         end
 
-        def secondary_advisory(course)
-          "Your degree subject should be in #{course.computed_subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
-        end
+        # def secondary_advisory(course)
+        # "Your degree subject should be in #{course.computed_subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
+        #  end
 
         def pending_gcse_content(course)
           if course.accept_pending_gcse


### PR DESCRIPTION
### Context
User need

As a... candidate
I want to... understand what qualifications I need
So that... I can feel confident to apply to an ITT course
What

In line with ITT policy, we need to make some changes to the ‘Entry requirements’ section on Find.

We need to:

    Remove the paragraph that stipulates the degree subject requirements: E.g. “Your degree subject should be in art and design or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way.”
    Update the SKE content. It should read: “If you need to improve your subject knowledge, you may be asked to complete a [subject knowledge enhancement](https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement) course.” This will be displayed for the following subjects (when the subject is the FIRST subject):
    - Biology
    - Chemistry
    - Computing
    - Design and technology
    - English
    - French
    - German
    - Mathematics
    - Modern languages (other)
    - Physics
    - [Engineers teach physics](https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics)
    - Primary with mathematics
    - Religious education
    - Spanish
    For Engineers teach physics courses, we need to update the content that appears and where it appears in the ‘Entry requirements’ section. For all ETP we need to add: “This Engineers teach physics course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.”
### Changes proposed in this pull request
rm scondary_advisory method
### Guidance to review
On find, search for courses, click on any course title and then entry requirements link
### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
