### PR TITLE
Remove efl from test

### DIFF
--- a/spec/features/publish/courses/editing_modern_languages_spec.rb
+++ b/spec/features/publish/courses/editing_modern_languages_spec.rb
@@ -69,7 +69,7 @@ feature 'selecting a subject', { can_edit_current_and_next_cycles: false } do
 
   def language
     @language ||= %i[
-      french english_as_a_second_language_or_other_language german
+      french german
       italian japanese mandarin russian spanish modern_languages_other
     ].sample
   end


### PR DESCRIPTION
### Context

Efl was previously removed from subjects, so its no longer a valid subject.

### Changes proposed in this pull request

Stop EFL from haunting us.

### Guidance to review

🚢 