### PR TITLE
[1132] Fix location bug

### DIFF
--- a/app/controllers/publish/courses/engineers_teach_physics_controller.rb
+++ b/app/controllers/publish/courses/engineers_teach_physics_controller.rb
@@ -10,7 +10,7 @@ module Publish
         authorize(@provider, :can_create_course?)
         return if has_physics_subject?
 
-        if params[:goto_confirmation] && modern_languages_present?
+        if go_to_confirmation_params && modern_languages_present?
           redirect_to new_publish_provider_recruitment_cycle_courses_modern_languages_path(path_params)
           return
         end

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -112,7 +112,7 @@ module Publish
     end
 
     def continue_step
-      if params[:goto_confirmation] && %i[subjects apprenticeship funding_type].none?(current_step)
+      if go_to_confirmation_params && %i[subjects apprenticeship funding_type].none?(current_step)
         :confirmation
       else
         CourseCreationStepService.new.execute(current_step:, course: @course)[:next]
@@ -129,7 +129,7 @@ module Publish
 
     def addtional_params
       {
-        goto_confirmation: params[:goto_confirmation],
+        goto_confirmation: go_to_confirmation_params,
         goto_visa: params[:goto_visa]
       }.compact
     end
@@ -139,7 +139,7 @@ module Publish
     end
 
     def back_step
-      if params[:goto_confirmation]
+      if go_to_confirmation_params
         {
           modern_languages: :subjects,
           can_sponsor_student_visa: (@course.is_uni_or_scitt? ? :apprenticeship : :funding_type),
@@ -210,6 +210,10 @@ module Publish
       when :confirmation
         confirmation_publish_provider_recruitment_cycle_courses_path(path_params)
       end
+    end
+
+    def go_to_confirmation_params
+      params[:goto_confirmation] || params.dig(:course, :goto_confirmation)
     end
   end
 end

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -19,6 +19,14 @@ feature 'course confirmation', { can_edit_current_and_next_cycles: false } do
       then_it_displays_correctly
     end
 
+    scenario 'updating a section returns to confirmation' do
+      and_i_click_to_update_the_locations
+      and_i_am_met_with_the_publish_courses_new_locations_page
+      and_i_update_the_locations
+      and_i_click_continue
+      then_i_am_met_with_the_publish_course_confirmation_page
+    end
+
     scenario 'changing subject to modern languages' do
       when_i_click_change_subject
       and_i_select_modern_languages_and_maths
@@ -133,7 +141,7 @@ feature 'course confirmation', { can_edit_current_and_next_cycles: false } do
     providers = if provider_trait.present?
                   [build(:provider, provider_trait, sites: [build(:site)])]
                 else
-                  [build(:provider, sites: [build(:site)])]
+                  [build(:provider, sites: [build(:site), build(:site)])]
                 end
 
     @user = create(:user, providers:)
@@ -174,5 +182,21 @@ feature 'course confirmation', { can_edit_current_and_next_cycles: false } do
     expect(publish_course_confirmation_page.details.locations.value.text).to have_content(site.location_name)
     expect(publish_course_confirmation_page.details.applications_open.value.text).to eq("12 October #{Settings.current_recruitment_cycle_year.to_i - 1}")
     expect(publish_course_confirmation_page.details.start_date.value.text).to eq("October #{Settings.current_recruitment_cycle_year.to_i - 1}")
+  end
+
+  def and_i_click_to_update_the_locations
+    publish_course_confirmation_page.details.locations.change_link.click
+  end
+
+  def and_i_am_met_with_the_publish_courses_new_locations_page
+    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/locations/new")
+  end
+
+  def and_i_update_the_locations
+    publish_courses_new_locations_page.locations.first.checkbox.check
+  end
+
+  def then_i_am_met_with_the_publish_course_confirmation_page
+    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/confirmation")
   end
 end

--- a/spec/support/page_objects/publish/courses/new_locations.rb
+++ b/spec/support/page_objects/publish/courses/new_locations.rb
@@ -8,6 +8,11 @@ module PageObjects
 
         element :title, '[data-qa="page-heading"]'
 
+        sections :locations, '.govuk-checkboxes__item' do
+          element :name, '.govuk-checkboxes__label'
+          element :checkbox, '.govuk-checkboxes__input'
+        end
+
         element :continue, '[data-qa="course__save"]'
       end
     end


### PR DESCRIPTION
### Context

When attempting to update locations from the course confirmation page, if you click continue you're put back into the flow. It should return you back to the confirmation page.

https://trello.com/c/0lZZHfco/1132-bug-fix-location-editing-in-new-course-flow

### Changes proposed in this pull request

We seem to have two ways to retrieve `[:goto_confirmation]` have put behind a method for now as not yet confident if we can completely replace it with the one nested in a course eg `params[:course][:goto_confirmation]`

### Guidance to review

- Add a new course
- Edit locations
- Click continue, assert you're taken back to the confirmation page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
