### PR TITLE
[1133] Fix secondary subject not displaying

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,3 +2,4 @@ js: yarn build --watch
 css: yarn build:css --watch
 web: bin/rails server -p 3001
 worker: bundle exec sidekiq -t 25 -C config/sidekiq.yml
+caddy: caddy run

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -245,7 +245,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def selected_subject_ids
-    selectable_subject_ids = course.subjects.pluck('id')
+    selectable_subject_ids = course.subjects.map(&:id)
     selected_subject_ids = subjects.map(&:id)
 
     selectable_subject_ids & selected_subject_ids


### PR DESCRIPTION
### Context

When creating a new course and on the check your answers page, if you have selected two subjects and attempt to update them - you are taken back to the subjects form but the second subject is lost.

https://trello.com/c/EpcaUDU6/1133-bug-fix-subject-editing-in-new-course-flow

### Changes proposed in this pull request

- Fix call to get subject ids. For some reason `pluck` returns an empty array here (even when there are two records present). 

<img width="513" alt="Screenshot 2023-03-09 at 13 49 04" src="https://user-images.githubusercontent.com/616080/224045148-00a8dbc4-54cc-4556-ba8d-81916cb67c7e.png">

Given this will only be two subjects, switch to map to get the ids

- Have also moved the caddy process into the Procfile so it can all be fired up in one command

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
