### PR TITLE
Bulk uploads confirm and save csv locations

### DIFF
--- a/app/controllers/concerns/success_message.rb
+++ b/app/controllers/concerns/success_message.rb
@@ -8,4 +8,9 @@ module SuccessMessage
 
     flash[:success] = I18n.t('success.saved', value:)
   end
+
+  def schools_added_message(locations)
+    items_added = locations.size > 1 ? "#{locations.size} locations" : "Location #{locations.first.location_name}"
+    flash[:success] = I18n.t('success.added', items_added:)
+  end
 end

--- a/app/controllers/concerns/success_message.rb
+++ b/app/controllers/concerns/success_message.rb
@@ -10,7 +10,7 @@ module SuccessMessage
   end
 
   def schools_added_message(locations)
-    items_added = locations.size > 1 ? "#{locations.size} locations" : "Location #{locations.first.location_name}"
+    items_added = locations.size > 1 ? "#{locations.size} locations" : '1 location'
     flash[:success] = I18n.t('success.added', items_added:)
   end
 end

--- a/app/controllers/support/locations_controller.rb
+++ b/app/controllers/support/locations_controller.rb
@@ -72,8 +72,7 @@ module Support
     end
 
     def reset_csv_schools_forms
-      ParsedCSVSchoolsForm.new(provider).clear_stash
-      RawCSVSchoolsForm.new(provider).clear_stash
+      [ParsedCSVSchoolsForm.new(provider), RawCSVSchoolsForm.new(provider)].each(&:clear_stash)
     end
   end
 end

--- a/app/controllers/support/locations_controller.rb
+++ b/app/controllers/support/locations_controller.rb
@@ -2,8 +2,9 @@
 
 module Support
   class LocationsController < SupportController
+    before_action :reset_csv_schools_forms, only: %i[index]
+
     def index
-      reset_csv_schools_forms
       @sites = provider.sites.order(:location_name).page(params[:page] || 1)
       render layout: 'provider_record'
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/support/locations_controller.rb
+++ b/app/controllers/support/locations_controller.rb
@@ -3,6 +3,7 @@
 module Support
   class LocationsController < SupportController
     def index
+      reset_csv_schools_forms
       @sites = provider.sites.order(:location_name).page(params[:page] || 1)
       render layout: 'provider_record'
     rescue ActiveRecord::RecordNotFound
@@ -68,6 +69,11 @@ module Support
 
     def site
       @site ||= provider.sites.find(params[:id])
+    end
+
+    def reset_csv_schools_forms
+      ParsedCSVSchoolsForm.new(provider).clear_stash
+      RawCSVSchoolsForm.new(provider).clear_stash
     end
   end
 end

--- a/app/controllers/support/providers/locations/check_multiple_controller.rb
+++ b/app/controllers/support/providers/locations/check_multiple_controller.rb
@@ -22,7 +22,7 @@ module Support
         end
 
         def save
-          school_details.each(&:save)
+          school_details.each(&:save!)
 
           parsed_csv_school_form.clear_stash
           raw_csv_school_form.clear_stash

--- a/app/controllers/support/providers/locations/check_multiple_controller.rb
+++ b/app/controllers/support/providers/locations/check_multiple_controller.rb
@@ -4,6 +4,8 @@ module Support
   module Providers
     module Locations
       class CheckMultipleController < SupportController
+        include SuccessMessage
+
         def show
           school_details
         end
@@ -24,6 +26,8 @@ module Support
 
           parsed_csv_school_form.clear_stash
           raw_csv_school_form.clear_stash
+
+          schools_added_message(school_details)
         end
 
         def parsed_csv_school_form

--- a/app/controllers/support/providers/locations/check_multiple_controller.rb
+++ b/app/controllers/support/providers/locations/check_multiple_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Support
+  module Providers
+    module Locations
+      class CheckMultipleController < SupportController
+        def show
+          school_details
+        end
+
+        def update
+          save
+          redirect_to support_recruitment_cycle_provider_locations_path
+        end
+
+        private
+
+        def provider
+          @provider ||= recruitment_cycle.providers.find(params[:provider_id])
+        end
+
+        def save
+          school_details.each(&:save)
+
+          parsed_csv_school_form.clear_stash
+          raw_csv_school_form.clear_stash
+        end
+
+        def parsed_csv_school_form
+          @parsed_csv_school_form ||= ParsedCSVSchoolsForm.new(provider)
+        end
+
+        def raw_csv_school_form
+          @raw_csv_school_form ||= RawCSVSchoolsForm.new(provider)
+        end
+
+        def school_details
+          @school_details ||= parsed_csv_school_form.school_details.map { |s| Site.new(s) }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/support/providers/locations/new_multiple_controller.rb
+++ b/app/controllers/support/providers/locations/new_multiple_controller.rb
@@ -13,15 +13,14 @@ module Support
           site.assign_attributes(site_params)
 
           if site.valid?
-
             school_details[current_site_index] = site
 
             ParsedCSVSchoolsForm.new(provider, params: { school_details: }).stash
 
-            if position < max
-              redirect_to support_recruitment_cycle_provider_locations_multiple_new_path(position: position + 1)
-            elsif position == max
+            if position == max || goto_confirmation?
               redirect_to support_recruitment_cycle_provider_locations_multiple_check_path
+            elsif position < max
+              redirect_to support_recruitment_cycle_provider_locations_multiple_new_path(position: position + 1)
             end
           else
             max
@@ -36,16 +35,18 @@ module Support
         end
 
         def site_params
-          params.require(:site).permit(
-            :location_name,
-            :urn,
-            :code,
-            :address1,
-            :address2,
-            :address3,
-            :address4,
-            :postcode
-          )
+          params.require(:site)
+                .except(:goto_confirmation)
+                .permit(
+                  :location_name,
+                  :urn,
+                  :code,
+                  :address1,
+                  :address2,
+                  :address3,
+                  :address4,
+                  :postcode
+                )
         end
 
         def provider
@@ -71,6 +72,8 @@ module Support
         def position
           @position ||= params[:position].to_i
         end
+
+        def goto_confirmation? = params.dig(:site, :goto_confirmation) == 'true'
       end
     end
   end

--- a/app/controllers/support/providers/locations/new_multiple_controller.rb
+++ b/app/controllers/support/providers/locations/new_multiple_controller.rb
@@ -21,7 +21,7 @@ module Support
             if position < max
               redirect_to support_recruitment_cycle_provider_locations_multiple_new_path(position: position + 1)
             elsif position == max
-              redirect_to support_recruitment_cycle_provider_locations_path
+              redirect_to support_recruitment_cycle_provider_locations_multiple_check_path
             end
           else
             max

--- a/app/decorators/provider_decorator.rb
+++ b/app/decorators/provider_decorator.rb
@@ -19,6 +19,10 @@ class ProviderDecorator < ApplicationDecorator
     address_lines.map { |line| ERB::Util.html_escape(line) }.join('<br> ').html_safe
   end
 
+  def name_and_code
+    "#{object.provider_name} (#{object.provider_code})"
+  end
+
   private
 
   def address_lines

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -3,7 +3,11 @@
 class SiteDecorator < Draper::Decorator
   delegate_all
 
-  def full_address
-    [object.address1, object.address2, object.address3, object.address4, object.postcode].select(&:present?).join(', ').html_safe
+  def full_address(join_on_separator = ', ')
+    [object.address1, object.address2, object.address3, object.address4, object.postcode].select(&:present?).join(join_on_separator).html_safe
+  end
+
+  def full_address_on_seperate_lines
+    full_address('<br>')
   end
 end

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -4,7 +4,7 @@ class SiteDecorator < Draper::Decorator
   delegate_all
 
   def full_address(join_on_separator = ', ')
-    [object.address1, object.address2, object.address3, object.address4, object.postcode].select(&:present?).join(join_on_separator).html_safe
+    [object.address1, object.address2, object.address3, object.address4, object.postcode].compact_blank.join(join_on_separator).html_safe
   end
 
   def full_address_on_seperate_lines

--- a/app/views/support/providers/locations/check_multiple/show.html.erb
+++ b/app/views/support/providers/locations/check_multiple/show.html.erb
@@ -12,7 +12,7 @@
         <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("support.providers.multiple_locations.check") %> </h1> </legend>
         <% @school_details.each.with_index(1) do |school_detail, position| %>
           <%= govuk_summary_card(title: "Location #{position}") do |card|
-                card.with_action { govuk_link_to("Change", support_recruitment_cycle_provider_locations_multiple_new_path(position:)) }
+                card.with_action { govuk_link_to("Change", support_recruitment_cycle_provider_locations_multiple_new_path(position:, goto_confirmation: true)) }
                 card.with_summary_list(rows: [{ key: { text: "Name" }, value: { text: school_detail.location_name } },
                                               { key: { text: "Unique reference number (URN)" }, value: { classes: ("govuk-hint" if school_detail.urn.blank?), text: (school_detail.urn.presence || "Not entered") } },
                                               { key: { text: "Address" }, value: { text: school_detail.decorate.full_address_on_seperate_lines } }])

--- a/app/views/support/providers/locations/check_multiple/show.html.erb
+++ b/app/views/support/providers/locations/check_multiple/show.html.erb
@@ -10,14 +10,14 @@
     <%= form_with(model: @parsed_csv_school_form, url: support_recruitment_cycle_provider_locations_multiple_check_path(provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year), method: :put, local: true) do |f| %>
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= "Add locations - #{@provider.decorate.name_and_code}" %></span>
         <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("support.providers.multiple_locations.check") %> </h1> </legend>
-        <% @school_details.each_with_index do |school_detail, index| %>
-          <%= govuk_summary_card(title: "Location #{index + 1}") do |card|
-                card.with_action { govuk_link_to("Change", "https://trello.com/c/BiPYisS2/1109-bulk-uploads-changing-locations-on-csv-confirm-page") }
+        <% @school_details.each.with_index(1) do |school_detail, position| %>
+          <%= govuk_summary_card(title: "Location #{position}") do |card|
+                card.with_action { govuk_link_to("Change", support_recruitment_cycle_provider_locations_multiple_new_path(position:)) }
                 card.with_summary_list(rows: [{ key: { text: "Name" }, value: { text: school_detail.location_name } },
                                               { key: { text: "Unique reference number (URN)" }, value: { classes: ("govuk-hint" if school_detail.urn.blank?), text: (school_detail.urn.presence || "Not entered") } },
                                               { key: { text: "Address" }, value: { text: school_detail.decorate.full_address_on_seperate_lines } }])
               end %>
-      <% end %>
+        <% end %>
       <%= f.govuk_submit("Add locations") %>
     <% end %>
 

--- a/app/views/support/providers/locations/check_multiple/show.html.erb
+++ b/app/views/support/providers/locations/check_multiple/show.html.erb
@@ -18,7 +18,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), root_path) %>
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_locations_path) %>
     </p>
   </div>
 </div>

--- a/app/views/support/providers/locations/check_multiple/show.html.erb
+++ b/app/views/support/providers/locations/check_multiple/show.html.erb
@@ -12,7 +12,7 @@
         <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("support.providers.multiple_locations.check") %> </h1> </legend>
         <% @school_details.each.with_index(1) do |school_detail, position| %>
           <%= govuk_summary_card(title: "Location #{position}") do |card|
-                card.with_action { govuk_link_to("Change", support_recruitment_cycle_provider_locations_multiple_new_path(position:, goto_confirmation: true)) }
+                card.with_action { govuk_link_to("Change", support_recruitment_cycle_provider_locations_multiple_new_path(position:, goto_confirmation: true), classes: "change-link-#{position}") }
                 card.with_summary_list(rows: [{ key: { text: "Name" }, value: { text: school_detail.location_name } },
                                               { key: { text: "Unique reference number (URN)" }, value: { classes: ("govuk-hint" if school_detail.urn.blank?), text: (school_detail.urn.presence || "Not entered") } },
                                               { key: { text: "Address" }, value: { text: school_detail.decorate.full_address_on_seperate_lines } }])

--- a/app/views/support/providers/locations/check_multiple/show.html.erb
+++ b/app/views/support/providers/locations/check_multiple/show.html.erb
@@ -1,0 +1,24 @@
+<% page_title = t("support.providers.multiple_locations.check") %>
+<%= content_for :page_title, page_title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with(model: @parsed_csv_school_form, url: support_recruitment_cycle_provider_locations_multiple_check_path(provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year), method: :put, local: true) do |f| %>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"> <span class="govuk-caption-l"><%= "Add locations - #{@provider.decorate.name_and_code}" %></span>
+        <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("support.providers.multiple_locations.check") %> </h1> </legend>
+        <% @school_details.each_with_index do |school_detail, index| %>
+          <%= govuk_summary_card(title: "Location #{index + 1}") do |card|
+                card.with_action { govuk_link_to("Change", "https://trello.com/c/BiPYisS2/1109-bulk-uploads-changing-locations-on-csv-confirm-page") }
+                card.with_summary_list(rows: [{ key: { text: "Name" }, value: { text: school_detail.location_name } },
+                                              { key: { text: "Unique reference number (URN)" }, value: { classes: ("govuk-hint" if school_detail.urn.blank?), text: (school_detail.urn.presence || "Not entered") } },
+                                              { key: { text: "Address" }, value: { text: school_detail.decorate.full_address_on_seperate_lines } }])
+              end %>
+      <% end %>
+      <%= f.govuk_submit("Add locations") %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), root_path) %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/providers/locations/check_multiple/show.html.erb
+++ b/app/views/support/providers/locations/check_multiple/show.html.erb
@@ -12,7 +12,7 @@
         <h1 class="govuk-fieldset__heading govuk-!-margin-bottom-3"><%= t("support.providers.multiple_locations.check") %> </h1> </legend>
         <% @school_details.each.with_index(1) do |school_detail, position| %>
           <%= govuk_summary_card(title: "Location #{position}") do |card|
-                card.with_action { govuk_link_to("Change", support_recruitment_cycle_provider_locations_multiple_new_path(position:, goto_confirmation: true), classes: "change-link-#{position}") }
+                card.with_action { govuk_link_to("Change", support_recruitment_cycle_provider_locations_multiple_new_path(position:, goto_confirmation: true)) }
                 card.with_summary_list(rows: [{ key: { text: "Name" }, value: { text: school_detail.location_name } },
                                               { key: { text: "Unique reference number (URN)" }, value: { classes: ("govuk-hint" if school_detail.urn.blank?), text: (school_detail.urn.presence || "Not entered") } },
                                               { key: { text: "Address" }, value: { text: school_detail.decorate.full_address_on_seperate_lines } }])

--- a/app/views/support/providers/locations/check_multiple/show.html.erb
+++ b/app/views/support/providers/locations/check_multiple/show.html.erb
@@ -1,6 +1,10 @@
 <% page_title = t("support.providers.multiple_locations.check") %>
 <%= content_for :page_title, page_title %>
 
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_recruitment_cycle_provider_locations_multiple_new_path(position: @school_details.count)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @parsed_csv_school_form, url: support_recruitment_cycle_provider_locations_multiple_check_path(provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year), method: :put, local: true) do |f| %>

--- a/app/views/support/providers/locations/new_multiple/show.html.erb
+++ b/app/views/support/providers/locations/new_multiple/show.html.erb
@@ -1,7 +1,9 @@
 <%= render PageTitle.new(title: t("support.providers.multiple_locations.show", position: params[:position], max: @max)) %>
 
 <% content_for :before_content do %>
-  <% if params[:position] == "1" %>
+  <% if params.dig(:goto_confirmation) %>
+    <%= govuk_back_link_to(support_recruitment_cycle_provider_locations_multiple_check_path) %>
+  <% elsif params[:position] == "1" %>
     <%= govuk_back_link_to(new_support_recruitment_cycle_provider_locations_multiple_path) %>
   <% else %>
     <%= govuk_back_link_to(support_recruitment_cycle_provider_locations_multiple_new_path(position: params[:position].to_i - 1)) %>
@@ -12,6 +14,8 @@
               method: :patch,
               url: support_recruitment_cycle_provider_locations_multiple_new_path,
               local: true) do |f| %>
+              
+  <%= f.hidden_field(:goto_confirmation, value: params.dig(:goto_confirmation))%>
 
   <%= f.govuk_error_summary %>
 
@@ -28,7 +32,7 @@
                                width: 10) %>
 
         <p class="govuk-body govuk-!-margin-bottom-7">
-          <%= t("links.urn_html").html_safe %>
+          <%= t("links.urn_html") %>
         </p>
 
         <%= f.govuk_fieldset legend: { text: "Address", size: "m" } do %>

--- a/app/views/support/providers/locations/new_multiple/show.html.erb
+++ b/app/views/support/providers/locations/new_multiple/show.html.erb
@@ -1,7 +1,11 @@
 <%= render PageTitle.new(title: t("support.providers.multiple_locations.show", position: params[:position], max: @max)) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(new_support_recruitment_cycle_provider_locations_multiple_path) %>
+  <% if params[:position] == "1" %>
+    <%= govuk_back_link_to(new_support_recruitment_cycle_provider_locations_multiple_path) %>
+  <% else %>
+    <%= govuk_back_link_to(support_recruitment_cycle_provider_locations_multiple_new_path(position: params[:position].to_i - 1)) %>
+  <% end %>
 <% end %>
 
 <%= form_with(model: @site,

--- a/app/views/support/providers/locations/new_multiple/show.html.erb
+++ b/app/views/support/providers/locations/new_multiple/show.html.erb
@@ -14,8 +14,8 @@
               method: :patch,
               url: support_recruitment_cycle_provider_locations_multiple_new_path,
               local: true) do |f| %>
-              
-  <%= f.hidden_field(:goto_confirmation, value: params.dig(:goto_confirmation))%>
+
+  <%= f.hidden_field(:goto_confirmation, value: params[:goto_confirmation]) %>
 
   <%= f.govuk_error_summary %>
 

--- a/app/views/support/providers/locations/new_multiple/show.html.erb
+++ b/app/views/support/providers/locations/new_multiple/show.html.erb
@@ -43,7 +43,7 @@
 <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), new_support_recruitment_cycle_provider_locations_multiple_path) %>
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_locations_path) %>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -553,6 +553,7 @@ en:
   success:
     published: "Your changes have been published"
     saved: "%{value} updated"
+    added: "%{items_added} added"
     changes_ttl: "Changes will appear on Find postgraduate teacher training within 15 minutes."
     visa_partner_warning: "Changing your answer will not change visa information for courses you or your training partners have already created."
     visa_warning: "Changing your answer will not change visa information for courses you have already created."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,6 +227,7 @@ en:
       multiple_locations:
         new: "Add locations"
         show: "Add location (%{position} of %{max})"
+        check: "Check your answers"
     flash:
       created: "%{resource} successfully created"
       updated: "%{resource} successfully updated"

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -17,6 +17,7 @@ namespace :support do
       resource :locations do
         resource :multiple, only: %i[new create], on: :member, controller: 'providers/locations/multiple' do
           resources :new, param: :position, only: %i[show update], controller: 'providers/locations/new_multiple'
+          resource :check, only: %i[show update], controller: 'providers/locations/check_multiple'
         end
       end
     end

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -17,7 +17,7 @@ namespace :support do
       resource :locations do
         scope module: :providers do
           scope module: :locations do
-            resource :multiple, only: %i[new create], on: :member, controller: 'multiple'  do
+            resource :multiple, only: %i[new create], on: :member, controller: 'multiple' do
               resources :new, param: :position, only: %i[show update], controller: 'new_multiple'
               resource :check, only: %i[show update], controller: 'check_multiple'
             end

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -15,9 +15,13 @@ namespace :support do
       resources :courses, only: %i[index edit update]
       resources :locations
       resource :locations do
-        resource :multiple, only: %i[new create], on: :member, controller: 'providers/locations/multiple' do
-          resources :new, param: :position, only: %i[show update], controller: 'providers/locations/new_multiple'
-          resource :check, only: %i[show update], controller: 'providers/locations/check_multiple'
+        scope module: :providers do
+          scope module: :locations do
+            resource :multiple, only: %i[new create], on: :member, controller: 'multiple'  do
+              resources :new, param: :position, only: %i[show update], controller: 'new_multiple'
+              resource :check, only: %i[show update], controller: 'check_multiple'
+            end
+          end
         end
       end
     end

--- a/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
+++ b/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
@@ -16,18 +16,24 @@ feature 'Multiple locations' do
     then_i_should_see_the_validation_error_message
   end
 
-  scenario 'submitting an form with two locations' do
+  scenario 'submitting a form with two locations' do
     and_the_multiple_locations_feature_flag_is_active
     when_i_visit_the_multiple_locations_new_page
     and_i_submit_the_form_with_two_locations
     and_i_see_the_text_one_of_two
-    then_i_should_see_that_the_text_field_has_been_prepopulated('Name', 'A')
+    then_i_should_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham')
 
     given_i_submit_a_valid_form
     and_i_see_the_text_two_of_two
-    and_i_see_that_the_text_field_has_been_prepopulated('Name', 'B')
+    and_i_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham Hotspur')
     and_i_submit_a_valid_form
-    then_i_should_be_redirected_to_the_provider_location_page
+    and_i_am_redirected_to_the_multiple_location_confirm_page
+    then_the_database_should_not_have_updated_with_the_new_location
+
+    given_i_add_the_locations
+    when_i_am_redirected_to_the_locations_page
+    and_i_see_the_text_two_locations_added
+    then_the_database_should_have_updated_with_the_new_locations
   end
 
   scenario 'feature flag off' do
@@ -35,8 +41,23 @@ feature 'Multiple locations' do
     then_i_should_not_see_the_add_multiple_locations_link
   end
 
-  def then_i_should_be_redirected_to_the_provider_location_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_locations_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+  def then_the_database_should_have_updated_with_the_new_locations
+    expect(Site.find_by(location_name: 'Tottenham').present?).to be true
+    expect(Site.find_by(location_name: 'Tottenham Hotspur').present?).to be true
+  end
+
+  def then_the_database_should_not_have_updated_with_the_new_location
+    expect(Site.find_by(location_name: 'Tottenham').present?).to be false
+    expect(Site.find_by(location_name: 'Tottenham Hotspur').present?).to be false
+  end
+
+  def and_i_see_the_text_two_locations_added
+    expect(page).to have_text('2 locations added')
+  end
+
+  def and_i_am_redirected_to_the_multiple_location_confirm_page
+    expect(page).to have_current_path support_recruitment_cycle_provider_locations_multiple_check_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+    expect(page).to have_text 'Check your answers'
   end
 
   def then_i_should_see_that_the_text_field_has_been_prepopulated(name, text)
@@ -44,9 +65,9 @@ feature 'Multiple locations' do
   end
 
   def given_i_submit_a_valid_form
-    fill_in 'Address line 1', with: '1 amazing street'
+    fill_in 'Address line 1', with: '782 High Road'
     fill_in 'Town or city', with: 'London'
-    fill_in 'Postcode', with: 'BN1 1AA'
+    fill_in 'Postcode', with: 'N17 0BX'
     click_continue
   end
 
@@ -59,7 +80,7 @@ feature 'Multiple locations' do
   end
 
   def and_i_submit_the_form_with_two_locations
-    fill_in 'Location details', with: "A\nB"
+    fill_in 'Location details', with: "Tottenham\nTottenham Hotspur"
     click_continue
   end
 
@@ -91,8 +112,16 @@ feature 'Multiple locations' do
     click_button 'Continue'
   end
 
+  def given_i_add_the_locations
+    click_button 'Add locations'
+  end
+
   def then_i_should_see_the_validation_error_message
     expect(page).to have_text('Enter location details')
+  end
+
+  def when_i_am_redirected_to_the_locations_page
+    expect(page).to have_current_path support_recruitment_cycle_provider_locations_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
   end
 
   alias_method :and_i_submit_a_valid_form, :given_i_submit_a_valid_form

--- a/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
+++ b/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
@@ -65,6 +65,39 @@ feature 'Multiple locations' do
     and_i_should_be_on_the_provider_locations_page
   end
 
+  scenario 'cancel from multiple locations new page' do
+    given_the_multiple_locations_feature_flag_is_active
+    and_i_visit_the_multiple_locations_new_page
+
+    when_i_click_cancel
+    then_i_should_be_on_the_provider_locations_page
+  end
+
+  scenario 'cancel from multiple locations new page for a location' do
+    given_the_multiple_locations_feature_flag_is_active
+    and_i_visit_the_multiple_locations_new_page
+    and_i_submit_the_form_with_two_locations
+    and_i_see_the_text_one_of_two
+    and_i_should_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham')
+
+    when_i_click_cancel
+    then_i_should_be_on_the_provider_locations_page
+  end
+
+  scenario 'cancel from multiple location confirm page' do
+    given_the_multiple_locations_feature_flag_is_active
+    and_i_visit_the_multiple_locations_new_page
+    and_i_submit_the_form_with_two_locations
+    and_i_submit_a_valid_form
+    and_i_see_the_text_two_of_two
+    and_i_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham Hotspur')
+    and_i_submit_a_valid_form
+    and_i_am_redirected_to_the_multiple_location_confirm_page
+
+    when_i_click_cancel
+    then_i_should_be_on_the_provider_locations_page
+  end
+
   scenario 'feature flag off' do
     when_i_visit_a_provider_locations_page
     then_i_should_not_see_the_add_multiple_locations_link
@@ -145,6 +178,10 @@ feature 'Multiple locations' do
     click_link 'Back'
   end
 
+  def when_i_click_cancel
+    click_link 'Cancel'
+  end
+
   def given_i_add_the_locations
     click_button 'Add locations'
   end
@@ -169,6 +206,7 @@ feature 'Multiple locations' do
   alias_method :and_the_database_should_not_have_updated_with_the_new_location, :then_the_database_should_not_have_updated_with_the_new_location
   alias_method :given_the_multiple_locations_feature_flag_is_active, :and_the_multiple_locations_feature_flag_is_active
 
+  alias_method :then_i_should_be_on_the_provider_locations_page, :when_i_am_redirected_to_the_locations_page
   alias_method :and_i_should_be_on_the_provider_locations_page, :when_i_am_redirected_to_the_locations_page
   alias_method :and_i_submit_a_valid_form, :given_i_submit_a_valid_form
   alias_method :and_i_see_that_the_text_field_has_been_prepopulated, :then_i_should_see_that_the_text_field_has_been_prepopulated

--- a/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
+++ b/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
@@ -104,13 +104,13 @@ feature 'Multiple locations' do
   end
 
   def then_the_database_should_have_updated_with_the_new_locations
-    expect(Site.find_by(location_name: 'Tottenham').present?).to be true
-    expect(Site.find_by(location_name: 'Tottenham Hotspur').present?).to be true
+    expect(Site.exists?(location_name: 'Tottenham')).to be true
+    expect(Site.exists?(location_name: 'Tottenham Hotspur')).to be true
   end
 
   def then_the_database_should_not_have_updated_with_the_new_location
-    expect(Site.find_by(location_name: 'Tottenham').present?).to be false
-    expect(Site.find_by(location_name: 'Tottenham Hotspur').present?).to be false
+    expect(Site.exists?(location_name: 'Tottenham')).to be false
+    expect(Site.exists?(location_name: 'Tottenham Hotspur')).to be false
   end
 
   def and_i_see_the_text_two_locations_added

--- a/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
+++ b/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
@@ -48,6 +48,13 @@ feature 'Multiple locations' do
     and_i_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham Hotspur')
     and_i_submit_a_valid_form
     and_i_am_redirected_to_the_multiple_location_confirm_page
+    and_i_click_change
+    and_the_text_field_is_prepopulated
+    and_i_click_back
+    and_i_am_redirected_to_the_multiple_location_confirm_page
+    and_i_click_back
+    and_i_submit_the_form
+    and_i_am_redirected_to_the_multiple_location_confirm_page
     and_the_database_should_not_have_updated_with_the_new_location
 
     when_i_click_back
@@ -101,6 +108,14 @@ feature 'Multiple locations' do
   scenario 'feature flag off' do
     when_i_visit_a_provider_locations_page
     then_i_should_not_see_the_add_multiple_locations_link
+  end
+
+  def and_i_click_change
+    page.all('.govuk-summary-card__action')[1].click_link
+  end
+
+  def and_the_text_field_is_prepopulated
+    expect(page).to have_field('Name', with: 'Tottenham Hotspur')
   end
 
   def then_the_database_should_have_updated_with_the_new_locations
@@ -211,4 +226,5 @@ feature 'Multiple locations' do
   alias_method :and_i_submit_a_valid_form, :given_i_submit_a_valid_form
   alias_method :and_i_see_that_the_text_field_has_been_prepopulated, :then_i_should_see_that_the_text_field_has_been_prepopulated
   alias_method :click_continue, :given_i_submit_an_empty_form
+  alias_method :and_i_submit_the_form, :given_i_submit_an_empty_form
 end

--- a/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
+++ b/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
@@ -36,6 +36,35 @@ feature 'Multiple locations' do
     then_the_database_should_have_updated_with_the_new_locations
   end
 
+  scenario 'clicking back' do
+    given_the_multiple_locations_feature_flag_is_active
+    and_i_visit_the_multiple_locations_new_page
+    and_i_submit_the_form_with_two_locations
+    and_i_see_the_text_one_of_two
+    and_i_should_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham')
+
+    and_i_submit_a_valid_form
+    and_i_see_the_text_two_of_two
+    and_i_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham Hotspur')
+    and_i_submit_a_valid_form
+    and_i_am_redirected_to_the_multiple_location_confirm_page
+    and_the_database_should_not_have_updated_with_the_new_location
+
+    when_i_click_back
+    then_i_see_the_text_two_of_two
+    and_i_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham Hotspur')
+    and_i_click_back
+    and_i_see_the_text_one_of_two
+    and_i_should_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham')
+
+    and_i_click_back
+    and_i_am_on_the_new_multiple_locations_page
+
+    and_i_click_back
+
+    and_i_should_be_on_the_provider_locations_page
+  end
+
   scenario 'feature flag off' do
     when_i_visit_a_provider_locations_page
     then_i_should_not_see_the_add_multiple_locations_link
@@ -112,6 +141,10 @@ feature 'Multiple locations' do
     click_button 'Continue'
   end
 
+  def when_i_click_back
+    click_link 'Back'
+  end
+
   def given_i_add_the_locations
     click_button 'Add locations'
   end
@@ -124,6 +157,19 @@ feature 'Multiple locations' do
     expect(page).to have_current_path support_recruitment_cycle_provider_locations_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
   end
 
+  def and_i_am_on_the_new_multiple_locations_page
+    expect(page).to have_current_path new_support_recruitment_cycle_provider_locations_multiple_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+  end
+
+  alias_method :and_i_click_back, :when_i_click_back
+
+  alias_method :then_i_see_the_text_two_of_two, :and_i_see_the_text_two_of_two
+  alias_method :and_i_should_see_that_the_text_field_has_been_prepopulated, :then_i_should_see_that_the_text_field_has_been_prepopulated
+  alias_method :and_i_visit_the_multiple_locations_new_page, :when_i_visit_the_multiple_locations_new_page
+  alias_method :and_the_database_should_not_have_updated_with_the_new_location, :then_the_database_should_not_have_updated_with_the_new_location
+  alias_method :given_the_multiple_locations_feature_flag_is_active, :and_the_multiple_locations_feature_flag_is_active
+
+  alias_method :and_i_should_be_on_the_provider_locations_page, :when_i_am_redirected_to_the_locations_page
   alias_method :and_i_submit_a_valid_form, :given_i_submit_a_valid_form
   alias_method :and_i_see_that_the_text_field_has_been_prepopulated, :then_i_should_see_that_the_text_field_has_been_prepopulated
   alias_method :click_continue, :given_i_submit_an_empty_form


### PR DESCRIPTION
### Context

The confirm page for the multiple locations flow and felshing out the change links and back links on the confirm and show pages. 

### Changes proposed in this pull request

- Add view, routes, controller
- Save and update db on submission of confirm form
- Cancel the operation on clicking the cancel button
- Enable the back links to redirect to the correct page.
- Enable the change links to work correctly

### Screenshot

<img width="842" alt="image" src="https://user-images.githubusercontent.com/50492247/225719050-822766d3-f8cf-4e0b-94d9-8fd17f85edd5.png">

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/50492247/225931539-6d1bfa8b-5637-40e1-b92f-4b5922db84b7.png">

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/50492247/225931696-38b4bf78-8bba-43b2-aeb3-c41ca9a75454.png">

### Guidance to review

Click `Add multiple locations` on support, enter a couple of rows of information. Submit the form, ensure the subsequent forms pass validation and submit those too. You should then arrive at the confirm page (as shown in the screenshot).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
