### PR TITLE
1139 locations error

### DIFF
--- a/app/controllers/publish/courses/sites_controller.rb
+++ b/app/controllers/publish/courses/sites_controller.rb
@@ -3,11 +3,12 @@
 module Publish
   module Courses
     class SitesController < PublishController
-      before_action :build_course_params, only: %i[continue]
+      # before_action :build_course_params, only: %i[continue]
 
       include CourseBasicDetailConcern
 
       def continue
+        params[:course][:sites_ids].compact_blank!
         super
       end
 

--- a/app/controllers/publish/courses/sites_controller.rb
+++ b/app/controllers/publish/courses/sites_controller.rb
@@ -3,8 +3,6 @@
 module Publish
   module Courses
     class SitesController < PublishController
-      # before_action :build_course_params, only: %i[continue]
-
       include CourseBasicDetailConcern
 
       def continue
@@ -66,16 +64,6 @@ module Publish
       def set_default_site
         params['course'] ||= {}
         params['course']['sites_ids'] = [@provider.sites.first.id]
-      end
-
-      def build_course_params
-        selected_site_ids = params.dig(:course, :site_statuses_attributes)
-                                  .values
-                                  .select { |field| field['selected'] == '1' }
-                                  .pluck('id')
-
-        params['course']['sites_ids'] = selected_site_ids
-        params['course'].delete('site_statuses_attributes')
       end
 
       def location_params

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -7,6 +7,10 @@ class CourseDecorator < ApplicationDecorator
 
   LANGUAGE_SUBJECT_CODES = %w[Q3 A0 15 16 17 18 19 20 21 22].freeze
 
+  def sites_ids
+    object.site_ids.compact_blank
+  end
+
   def name_and_code
     "#{object.name} (#{object.course_code})"
   end

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -47,7 +47,7 @@ module Courses
     end
 
     def sites
-      @sites ||= provider.sites.find(site_ids)
+      @sites ||= provider.sites.find(site_ids.compact_blank)
     end
 
     def subject_ids

--- a/app/views/publish/courses/sites/new.html.erb
+++ b/app/views/publish/courses/sites/new.html.erb
@@ -22,20 +22,17 @@
 
         <div class="govuk-form-group govuk-!-margin-top-2">
           <div class="govuk-hint">Select all that apply</div>
-          <div class="govuk-checkboxes">
-            <%= fields.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sfields| %>
-                <% site = sfields.object %>
-                <div class="govuk-checkboxes__item">
-                  <%= sfields.check_box "selected", checked: course.has_site?(site), class: "govuk-checkboxes__input" %>
-                  <%= sfields.label "selected", class: "govuk-label govuk-checkboxes__label"  do %>
-                    <%= site.location_name %>
-                  <% end %>
-                  <span class="govuk-hint govuk-checkboxes__hint">
-                    <%= site.full_address %>
-                  </span>
-                </div>
-              <% end %>
-          </div>
+
+          <%= form.govuk_check_boxes_fieldset :sites_ids, legend: nil do %>
+            <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
+                <%= form.govuk_check_box :sites_ids,
+                    site.id,
+                    label: { text: site.location_name },
+                    hint: { text: site.full_address },
+                    link_errors: index.zero? %>
+            <% end %>
+          <% end %>
+
         </div>
       </fieldset>
     <% end %>


### PR DESCRIPTION
### Context
User - provider(2A6) with a large number of locations encounters cloudfront URL length error 494 when continuing from locations new page, as the URL created hits Cloudfronts hard limit.

This occurs even if only a single option is selected, as the unselected option still enter the url query.

In qa testing, a 413 error was raised rather than a 494?
![Screenshot 2023-03-15 at 11 35 39](https://user-images.githubusercontent.com/4527528/225297746-4fe555be-072d-4885-ba79-89ab4b1cdf78.png)
 
### Changes proposed in this pull request
Alter the locations/new view to present sites_ids[] rather than site_statuses_attributes. This will not fix the issue if the user selects all locations from a very long list, but will help if only a portion of options are selected.
### Guidance to review
test in qa, create a new course with provider 2A6
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
