### PR TITLE
Remove find2 routes

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -83,13 +83,6 @@ resource cloudfoundry_route web_app_publish_gov_uk_route {
   hostname = each.value
 }
 
-resource cloudfoundry_route web_app_find_gov_uk_route {
-  for_each = toset(var.find_gov_uk_host_names)
-  domain   = data.cloudfoundry_domain.find_service_gov_uk.id
-  space    = data.cloudfoundry_space.space.id
-  hostname = each.value
-}
-
 resource cloudfoundry_route find_web_app_cloudapps_digital_route {
   count = var.enable_find == true ? 1 : 0
 

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -31,11 +31,6 @@ variable "publish_gov_uk_host_names" {
   type = list
 }
 
-variable "find_gov_uk_host_names" {
-  default = []
-  type = list
-}
-
 variable "find_app_gov_uk_host_names" {
   default = []
   type = list
@@ -52,7 +47,7 @@ locals {
   app_name_suffix              = var.app_environment != "review" ? var.app_environment : "pr-${var.web_app_host_name}"
   web_app_name                 = "publish-teacher-training-${local.app_name_suffix}"
   publish_app_name             = "publish-${local.app_name_suffix}"
-  cloudapp_names               = var.app_environment == "review" ? [local.web_app_name, local.publish_app_name, "find2-${local.app_name_suffix}"] : [local.web_app_name, local.publish_app_name]
+  cloudapp_names               = [local.web_app_name, local.publish_app_name]
   find_app_name                = "find-${local.app_name_suffix}"
   worker_app_name              = "publish-teacher-training-worker-${local.app_name_suffix}"
   postgres_service_name        = "publish-teacher-training-postgres-${local.app_name_suffix}"
@@ -91,7 +86,6 @@ locals {
     values(cloudfoundry_route.web_app_cloudapps_digital_route),
     cloudfoundry_route.web_app_service_gov_uk_route,
     values(cloudfoundry_route.web_app_publish_gov_uk_route),
-    values(cloudfoundry_route.web_app_find_gov_uk_route),
     cloudfoundry_route.find_web_app_cloudapps_digital_route,
     values(cloudfoundry_route.find_web_app_find_gov_uk_route)
   ])

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -58,7 +58,6 @@ module "paas" {
   redis_service_plan             = var.paas_redis_service_plan
   app_environment_variables      = local.paas_app_environment_variables
   publish_gov_uk_host_names      = var.publish_gov_uk_host_names
-  find_gov_uk_host_names         = var.find_gov_uk_host_names
   find_app_gov_uk_host_names     = var.find_app_gov_uk_host_names
   enable_find                    = var.enable_find
   restore_from_db_guid           = var.paas_restore_from_db_guid

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,11 +51,6 @@ variable "publish_gov_uk_host_names" {
   type = list
 }
 
-variable "find_gov_uk_host_names" {
-  default = []
-  type = list
-}
-
 variable find_app_gov_uk_host_names {
   default = []
   type = list

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -9,7 +9,6 @@
     "paas_postgres_service_plan": "large-ha-11",
     "paas_redis_service_plan": "micro-ha-5_x",
     "publish_gov_uk_host_names": ["www"],
-    "find_gov_uk_host_names": ["www2"],
     "enable_find": true,
     "find_app_gov_uk_host_names": ["www","assets"],
     "key_vault_resource_group": "s121p01-shared-rg",

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -9,7 +9,6 @@
     "paas_postgres_service_plan": "small-11",
     "paas_redis_service_plan": "tiny-5_x",
     "publish_gov_uk_host_names": ["qa"],
-    "find_gov_uk_host_names": ["qa2"],
     "enable_find": true,
     "find_app_gov_uk_host_names": ["qa","qa-assets"],
     "key_vault_resource_group": "s121d01-shared-rg",

--- a/terraform/workspace_variables/sandbox.tfvars.json
+++ b/terraform/workspace_variables/sandbox.tfvars.json
@@ -9,7 +9,6 @@
     "paas_postgres_service_plan": "small-11",
     "paas_redis_service_plan": "micro-5_x",
     "publish_gov_uk_host_names": ["sandbox"],
-    "find_gov_uk_host_names": ["sandbox2"],
     "enable_find": true,
     "find_app_gov_uk_host_names": ["sandbox","sandbox-assets"],
     "key_vault_resource_group": "s121p01-shared-rg",

--- a/terraform/workspace_variables/staging.tfvars.json
+++ b/terraform/workspace_variables/staging.tfvars.json
@@ -9,7 +9,6 @@
     "paas_postgres_service_plan": "small-11",
     "paas_redis_service_plan": "tiny-5_x",
     "publish_gov_uk_host_names": ["staging"],
-    "find_gov_uk_host_names": ["staging2"],
     "enable_find": true,
     "find_app_gov_uk_host_names": ["staging","staging-assets"],
     "key_vault_resource_group": "s121t01-shared-rg",


### PR DESCRIPTION
### Context

find2 routes were used for the find migration to publish,
but they can be removed now as that's complete.

### Changes proposed in this pull request

Remove find2 routes from terraform

### Guidance to review

make env deploy-plan 
deploy review app

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
