### PR TITLE
Increase disk quota for worker app

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -40,6 +40,7 @@ resource cloudfoundry_app worker_app {
   health_check_type    = "process"
   instances            = var.worker_app_instances
   memory               = var.worker_app_memory
+  disk_quota           = 1500
   docker_image         = var.docker_image
   strategy             = local.deployment_strategy
   command              = local.worker_app_start_command


### PR DESCRIPTION
### Context

Worker app deploy failing with

2023-03-16T10:28:30.13+0000 [CELL/0] ERR Cell 2fe28b9e-5dd4-4388-87e0-73737373 failed to create container for instance c02bd359-82d6-427c-7373-7373: running image plugin create: making image: creating image: applying disk limits: disk limit is smaller than volume size
   2023-03-16T10:28:30.13+0000 [CELL/0] ERR : exit status 

Currently worker app uses default quota of 1G

current usage
     state     since                  cpu    memory           disk         details
#0   running   2023-03-15T17:06:12Z   0.4%   211.2M of 512M   **856M of 1G**

failing pr wants
     state     since                  cpu    memory           disk           details
#0   running   2023-03-15T18:39:19Z   0.2%   157.3M of 512M   **1.1G of 1.5G**

### Changes proposed in this pull request

Add disk_quota = 1500 to worker app

### Guidance to review

make env deploy-plan
deploy review app

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
