### PR TITLE
Increase webapp disk quota to 2G

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -5,7 +5,7 @@ resource cloudfoundry_app web_app {
   health_check_http_endpoint = "/ping"
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
-  disk_quota                 = 1500
+  disk_quota                 = 2000
   docker_image               = var.docker_image
   strategy                   = local.deployment_strategy
   timeout                    = 300


### PR DESCRIPTION
### Context

Need to increase the disk quota for the webapp, as we alert at 60% usage, and we are now at 77%
i.e. using 1.1G of 1.5G
This PR increases the disk quota to 2G

### Changes proposed in this pull request

Increase webapp disk quota

### Guidance to review

make env deploy-plan
deploy review app

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
