### PR TITLE
Add validation to town city

### DIFF
--- a/app/forms/publish/location_form.rb
+++ b/app/forms/publish/location_form.rb
@@ -24,6 +24,7 @@ module Publish
     validate :location_name_unique_to_provider
     validates :location_name, presence: { message: 'Enter a name' }
     validates :address1, presence: { message: 'Enter a building and street' }
+    validates :address3, presence: { message: 'Enter a town or city' }
     validates :postcode, presence: { message: 'Enter a postcode' }
     validates :postcode, postcode: { message: 'Postcode is not valid (for example, BN1 1AA)' }
     validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: 'URN must be 5 or 6 numbers' }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -23,6 +23,7 @@ class Site < ApplicationRecord
   validates :location_name, uniqueness: { scope: :provider_id }
   validates :location_name,
             :address1,
+            :address3,
             :postcode,
             presence: true
   validates :postcode, postcode: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,6 +267,8 @@ en:
               taken: "is in use by another location"
             address1:
               blank: "Enter address line 1"
+            address3:
+              blank: "Enter a town or city"
             postcode:
               blank: "Enter a postcode"
         course:

--- a/spec/features/publish/managing_locations_spec.rb
+++ b/spec/features/publish/managing_locations_spec.rb
@@ -45,6 +45,7 @@ feature "Managing a provider's locations", { can_edit_current_and_next_cycles: f
 
     publish_location_new_page.name_field.set 'Some place'
     publish_location_new_page.address1_field.set '123 Test Street'
+    publish_location_new_page.address3_field.set 'London'
     publish_location_new_page.postcode_field.set 'KT8 9AU'
     publish_location_new_page.submit.click
 

--- a/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
+++ b/spec/features/support/providers/locations/creating_multiple_locations_spec.rb
@@ -45,6 +45,7 @@ feature 'Multiple locations' do
 
   def given_i_submit_a_valid_form
     fill_in 'Address line 1', with: '1 amazing street'
+    fill_in 'Town or city', with: 'London'
     fill_in 'Postcode', with: 'BN1 1AA'
     click_continue
   end

--- a/spec/features/support/providers/locations/managing_locations_spec.rb
+++ b/spec/features/support/providers/locations/managing_locations_spec.rb
@@ -66,6 +66,7 @@ feature "Managing a provider's locations" do
     support_provider_location_create_page.location_form.location_name.set('Acre woods')
     support_provider_location_create_page.location_form.urn.set('12345')
     support_provider_location_create_page.location_form.building_and_street.set('100 Acre Woods')
+    support_provider_location_create_page.location_form.town_or_city.set('London')
     support_provider_location_create_page.location_form.postcode.set('BN1 1AA')
   end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -15,6 +15,7 @@ describe Site do
 
   it { is_expected.to validate_presence_of(:location_name) }
   it { is_expected.to validate_presence_of(:address1) }
+  it { is_expected.to validate_presence_of(:address3) }
   it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }
   it { is_expected.to validate_uniqueness_of(:code).case_insensitive.scoped_to(:provider_id) }

--- a/spec/support/page_objects/publish/location_new.rb
+++ b/spec/support/page_objects/publish/location_new.rb
@@ -12,6 +12,7 @@ module PageObjects
 
       element :name_field, '#publish-location-form-location-name-field'
       element :address1_field, '#publish-location-form-address1-field'
+      element :address3_field, '#publish-location-form-address3-field'
       element :postcode_field, '#publish-location-form-postcode-field'
 
       element :submit, 'button.govuk-button[type="submit"]'

--- a/spec/support/page_objects/sections/location_form.rb
+++ b/spec/support/page_objects/sections/location_form.rb
@@ -9,6 +9,7 @@ module PageObjects
       element :urn, '#site-urn-field'
       element :code, '#site-code-field'
       element :building_and_street, '#site-address1-field'
+      element :town_or_city, '#site-address3-field'
       element :postcode, '#site-postcode-field'
     end
   end


### PR DESCRIPTION
### Context

Add a presense validation to the town or city field in locations.

### Changes proposed in this pull request

- Add presence validation to town or city field 
- Allow tests to pass validation

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
