### PR TITLE
[1168] Fixed missing footer

### DIFF
--- a/app/views/layouts/_find_footer.html.erb
+++ b/app/views/layouts/_find_footer.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_footer do |footer| %>
-  <%= footer.meta do %>
+  <%= footer.with_meta do %>
     <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
       <h2 class="govuk-heading-m">Get help</h2>
 


### PR DESCRIPTION
### Context
Fallout from govuk component major version bump

### Changes proposed in this pull request
Changed it

### Guidance to review
The footer is there.

https://find-pr-3433.london.cloudapps.digital/

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
