### PR TITLE
[xxx] - Fix flaky find spec

### DIFF
--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 feature 'Viewing a findable course' do
+  include PublishHelper
+
   before do
     FeatureFlag.activate(:bursaries_and_scholarships_announced)
   end
@@ -288,7 +290,7 @@ feature 'Viewing a findable course' do
     expect(find_course_show_page.school_placements).not_to have_content('Suspended site with vacancies')
 
     @course.site_statuses.new_or_running.map(&:site).uniq.each do |site|
-      expect(find_course_show_page).to have_content(site.decorate.full_address)
+      expect(find_course_show_page).to have_content(smart_quotes(site.decorate.full_address))
     end
 
     expect(find_course_show_page).to have_course_advice


### PR DESCRIPTION
### Context

Fixes 1 of 2 flaky specs where the site address can end up having smart quotes which breaks the assertion.

eg expecting `174 D'Amore Mission, Summer Oaks, Davisview, Pennsylvania, Y4G 0BN` to match `174 D’Amore Mission, Summer Oaks, Davisview, Pennsylvania, Y4G 0BN`