### PR TITLE
Course preview missing information (about course)

### DIFF
--- a/app/components/find/course_preview_missing_information_component.html.erb
+++ b/app/components/find/course_preview_missing_information_component.html.erb
@@ -1,0 +1,2 @@
+
+<%= govuk_inset_text { govuk_link_to(text, link) } %>

--- a/app/components/find/course_preview_missing_information_component.rb
+++ b/app/components/find/course_preview_missing_information_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Find
+  class CoursePreviewMissingInformationComponent < ViewComponent::Base
+    attr_accessor :text, :link
+
+    def initialize(text, link)
+      super
+      @text = text
+      @link = link
+    end
+  end
+end

--- a/app/views/find/courses/_about_course.html.erb
+++ b/app/views/find/courses/_about_course.html.erb
@@ -1,6 +1,10 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-about">Course summary</h2>
   <div data-qa="course__about_course">
-    <%= render Find::CoursePreviewMissingInformationComponent.new("Enter course summary", root_path) %>
+    <% if course.about_course.present? %>
+      <%= markdown(course.about_course) %>
+    <% else %>
+      <%= render Find::CoursePreviewMissingInformationComponent.new("Enter course summary", root_path) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/find/courses/_about_course.html.erb
+++ b/app/views/find/courses/_about_course.html.erb
@@ -3,7 +3,7 @@
   <div data-qa="course__about_course">
     <% if course.about_course.present? %>
       <%= markdown(course.about_course) %>
-    <% else %>
+    <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
       <%= render Find::CoursePreviewMissingInformationComponent.new("Enter course summary", root_path) %>
     <% end %>
   </div>

--- a/app/views/find/courses/_about_course.html.erb
+++ b/app/views/find/courses/_about_course.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-about">Course summary</h2>
   <div data-qa="course__about_course">
-    <%= markdown(course.about_course) %>
+    <%= render Find::CoursePreviewMissingInformationComponent.new("Enter course summary", root_path) %>
   </div>
 </div>

--- a/app/views/find/courses/_about_course.html.erb
+++ b/app/views/find/courses/_about_course.html.erb
@@ -4,7 +4,7 @@
     <% if course.about_course.present? %>
       <%= markdown(course.about_course) %>
     <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
-      <%= render Find::CoursePreviewMissingInformationComponent.new("Enter course summary", root_path) %>
+      <%= render Find::CoursePreviewMissingInformationComponent.new("Enter course summary", about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -25,7 +25,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render Find::Courses::ContentsComponent::View.new(course) %>
 
-    <%= render partial: "find/courses/about_course", locals: { course: } %>
+    <% if course.about_course.present? || FeatureService.enabled?(:course_preview_missing_information) %>
+      <%= render partial: "find/courses/about_course", locals: { course: } %>
+    <% end %>
 
     <%= render Find::Courses::AboutSchoolsComponent::View.new(course) %>
 

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -25,9 +25,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render Find::Courses::ContentsComponent::View.new(course) %>
 
-    <% if course.about_course.present? %>
-      <%= render partial: "find/courses/about_course", locals: { course: } %>
-    <% end %>
+    <%= render partial: "find/courses/about_course", locals: { course: } %>
 
     <%= render Find::Courses::AboutSchoolsComponent::View.new(course) %>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -107,6 +107,7 @@ features:
     show_next_cycle_recruitment_page: false
   user_management: true
   add_multiple_locations: false
+  course_preview_missing_information: false
 
 cookies:
   session:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -18,3 +18,4 @@ use_ssl: true
 
 features:
   add_multiple_locations: true
+  course_preview_missing_information: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -17,3 +17,4 @@ authentication:
 
 features:
   add_multiple_locations: true
+  course_preview_missing_information: true


### PR DESCRIPTION
### Context

To give providers a clearer view on which information they provide and which is generated by the service, we’re updating the course preview page to show missing information before a course is published.

**This PR relates to do the “About the course” section.**

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
