### PR TITLE
Course preview missing information (Degree and GCSE)

### DIFF
--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -1,13 +1,13 @@
 <h2 class="govuk-heading-m">Contents</h2>
 <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
-  <% if about_course.present? %>
+  <% if about_course.present? || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
     <li><%= govuk_link_to "Course summary", "#section-about" %></li>
   <% end %>
-  <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" %>
+  <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
     <li><%= govuk_link_to course.placements_heading, "#section-schools" %></li>
   <% end %>
   <li><%= govuk_link_to "Entry requirements", "#section-entry" %></li>
-  <% if provider.train_with_us.present? ||  about_accrediting_body.present? %>
+  <% if provider.train_with_us.present? || about_accrediting_body.present? || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
     <li><%= govuk_link_to "About the training provider", "#section-about-provider" %></li>
   <% end %>
   <% if salaried? %>

--- a/app/components/find/courses/contents_component/view.rb
+++ b/app/components/find/courses/contents_component/view.rb
@@ -18,6 +18,10 @@ module Find
           super
           @course = course
         end
+
+        def preview?
+          params[:action] == 'preview'
+        end
       end
     end
   end

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -14,27 +14,27 @@
             <%= helpers.markdown(course.degree_subject_requirements) %>
           </p>
       <% end %>
-     <% end %>
-    </p>
 
-    <% if course.secondary_course? %>
-      <% if course.engineers_teach_physics? %>
+      <% if course.secondary_course? %>
+        <% if course.engineers_teach_physics? %>
+          <p class="govuk-body">
+            This <%= govuk_link_to "Engineers teach physics", t("find.get_into_teaching.url_engineers_teach_physics") %> course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.
+          </p>
+        <% end %>
+      <% end %>
+
+      <% if subject_knowledge_enhancement_content? %>
         <p class="govuk-body">
-          This <%= govuk_link_to "Engineers teach physics", t("find.get_into_teaching.url_engineers_teach_physics") %> course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.
+          If you need to improve your subject knowledge, you may be asked to complete a <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
+        </p>
+      <% elsif primary_with_mathematics_subject? %>
+        <p class="govuk-body">
+          If you need to improve your primary mathematics knowledge, you may be asked to complete a
+          <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
         </p>
       <% end %>
-    <% end %>
-
-    <% if subject_knowledge_enhancement_content? %>
-      <p class="govuk-body">
-        If you need to improve your subject knowledge, you may be asked to complete a <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
-      </p>
-      <% elsif primary_with_mathematics_subject? %>
-      <p class="govuk-body">
-        If you need to improve your primary mathematics knowledge, you may be asked to complete a
-        <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
-      </p>
-    <% end %>
+     <% end %>
+    </p>
 
     <% if (course.accept_pending_gcse == nil || course.accept_gcse_equivalency == nil) && FeatureService.enabled?(:course_preview_missing_information) %>
 

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -40,22 +40,24 @@
       <%= required_gcse_content(course) %>
     </p>
 
-    <p class="govuk-body">
-      <%= pending_gcse_content(course) %>
-    </p>
+    <% if course.accept_pending_gcse == nil || course.accept_gcse_equivalency == nil %>
 
-    <p class="govuk-body">
-      <%= gcse_equivalency_content(course) %>
-    </p>
+      <%= render CoursePreview::MissingInformationComponent.new("Enter GCSE and equivalency test requirements",
+                                                                gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
+    <% else %>
+      <p class="govuk-body">
+        <%= pending_gcse_content(course) %>
+      </p>
+
+      <p class="govuk-body">
+        <%= gcse_equivalency_content(course) %>
+      </p>
+    <% end %>
 
     <% if course.additional_gcse_equivalencies.present? %>
       <p class="govuk-body">
         <%= helpers.markdown(course.additional_gcse_equivalencies) %>
       </p>
-    <% elsif !course.additional_gcse_equivalencies.present? && FeatureService.enabled?(:course_preview_missing_information) && params[:action] == "preview" %>
-
-      <%= render CoursePreview::MissingInformationComponent.new("Enter GCSE and equivalency test requirements",
-                                                                gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
     <% end %>
   </div>
 

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -2,20 +2,20 @@
   <h2 class="govuk-heading-l" id="section-entry">Entry requirements</h2>
   <h3 class="govuk-heading-m">Qualifications needed</h3>
   <div data-qa="course__required_qualifications">
-    <p class="govuk-body">
-    <% if degree_grade_content(course).blank? && FeatureService.enabled?(:course_preview_missing_information) %>
+
+    <% if course.degree_grade.nil? && course.additional_degree_subject_requirements.nil? && FeatureService.enabled?(:course_preview_missing_information) %>
       <%= render CoursePreview::MissingInformationComponent.new("Enter degree requirements",
       degrees_start_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
     <% else %>
-     ' <%= degree_grade_content(course) %>'
+     <%= degree_grade_content(course) %>
+
+        <% if course.degree_subject_requirements.present? %>
+        <p class="govuk-body">
+          <%= helpers.markdown(course.degree_subject_requirements) %>
+        </p>
+      <% end %>
      <% end %>
     </p>
-
-    <% if course.degree_subject_requirements.present? %>
-      <p class="govuk-body">
-        <%= helpers.markdown(course.degree_subject_requirements) %>
-      </p>
-    <% end %>
 
     <% if course.secondary_course? %>
       <% if course.engineers_teach_physics? %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -36,15 +36,16 @@
       </p>
     <% end %>
 
-    <p class="govuk-body">
-      <%= required_gcse_content(course) %>
-    </p>
-
     <% if course.accept_pending_gcse == nil || course.accept_gcse_equivalency == nil %>
 
       <%= render CoursePreview::MissingInformationComponent.new("Enter GCSE and equivalency test requirements",
                                                                 gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
     <% else %>
+
+      <p class="govuk-body">
+        <%= required_gcse_content(course) %>
+      </p>
+
       <p class="govuk-body">
         <%= pending_gcse_content(course) %>
       </p>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -15,9 +15,6 @@
       <p class="govuk-body">
         <%= helpers.markdown(course.degree_subject_requirements) %>
       </p>
-    <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
-     <%= render CoursePreview::MissingInformationComponent.new("Enter GCSE and equivalency test requirements",
-      gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
     <% end %>
 
     <% if course.secondary_course? %>
@@ -55,6 +52,10 @@
       <p class="govuk-body">
         <%= helpers.markdown(course.additional_gcse_equivalencies) %>
       </p>
+    <% elsif !course.additional_gcse_equivalencies.present? && FeatureService.enabled?(:course_preview_missing_information) && params[:action] == "preview" %>
+
+      <%= render CoursePreview::MissingInformationComponent.new("Enter GCSE and equivalency test requirements",
+                                                                gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
     <% end %>
   </div>
 

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -7,7 +7,7 @@
       <%= render CoursePreview::MissingInformationComponent.new("Enter degree requirements",
       degrees_start_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
     <% else %>
-     <%= degree_grade_content(course) %>
+      <p class="govuk-body"><%= degree_grade_content(course) %></p>
 
         <% if course.degree_subject_requirements.present? %>
         <p class="govuk-body">

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -3,13 +3,21 @@
   <h3 class="govuk-heading-m">Qualifications needed</h3>
   <div data-qa="course__required_qualifications">
     <p class="govuk-body">
-      <%= degree_grade_content(course) %>
+    <% if degree_grade_content(course).blank? && FeatureService.enabled?(:course_preview_missing_information) %>
+      <%= render CoursePreview::MissingInformationComponent.new("Enter degree requirements",
+      degrees_start_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
+    <% else %>
+     ' <%= degree_grade_content(course) %>'
+     <% end %>
     </p>
 
     <% if course.degree_subject_requirements.present? %>
       <p class="govuk-body">
         <%= helpers.markdown(course.degree_subject_requirements) %>
       </p>
+    <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
+     <%= render CoursePreview::MissingInformationComponent.new("Enter GCSE and equivalency test requirements",
+      gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>
     <% end %>
 
     <% if course.secondary_course? %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -10,9 +10,9 @@
       <p class="govuk-body"><%= degree_grade_content(course) %></p>
 
         <% if course.degree_subject_requirements.present? %>
-        <p class="govuk-body">
-          <%= helpers.markdown(course.degree_subject_requirements) %>
-        </p>
+          <p class="govuk-body">
+            <%= helpers.markdown(course.degree_subject_requirements) %>
+          </p>
       <% end %>
      <% end %>
     </p>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -36,7 +36,7 @@
       </p>
     <% end %>
 
-    <% if course.accept_pending_gcse == nil || course.accept_gcse_equivalency == nil %>
+    <% if (course.accept_pending_gcse == nil || course.accept_gcse_equivalency == nil) && FeatureService.enabled?(:course_preview_missing_information) %>
 
       <%= render CoursePreview::MissingInformationComponent.new("Enter GCSE and equivalency test requirements",
                                                                 gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code, goto_preview: true)) %>

--- a/app/controllers/publish/courses/degrees/grade_controller.rb
+++ b/app/controllers/publish/courses/degrees/grade_controller.rb
@@ -15,12 +15,21 @@ module Publish
 
           @grade_form = DegreeGradeForm.new(grade: grade_params)
 
-          if course.is_primary? && @grade_form.save(course)
+          if course.is_primary? && @grade_form.valid? && !goto_preview?
+            @grade_form.save(course)
             course_updated_message('Minimum degree classification')
 
             redirect_to publish_provider_recruitment_cycle_course_path
-          elsif @grade_form.save(course)
+
+          elsif course.is_primary? && @grade_form.valid? && goto_preview?
+            @grade_form.save(course)
+            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+          elsif @grade_form.valid? && !goto_preview?
+            @grade_form.save(course)
             redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
+          elsif @grade_form.valid? && goto_preview?
+            @grade_form.save(course)
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
           else
             @errors = @grade_form.errors.messages
             render :edit
@@ -36,8 +45,12 @@ module Publish
         def grade_params
           return if params[:publish_degree_grade_form].blank?
 
-          params.require(:publish_degree_grade_form).permit(:grade)[:grade]
+          params.require(:publish_degree_grade_form)
+                .except(:goto_preview)
+                .permit(:grade)[:grade]
         end
+
+        def goto_preview? = params.dig(:publish_degree_grade_form, :goto_preview) == 'true'
       end
     end
   end

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -17,14 +17,23 @@ module Publish
 
           @start_form = DegreeStartForm.new(degree_grade_required: grade_required_params)
 
-          if course.is_primary? && @start_form.save(course)
+          if course.is_primary? && @start_form.valid? && !goto_preview?
+            @start_form.save(course)
             course_updated_message('Minimum degree classification')
-
             redirect_to publish_provider_recruitment_cycle_course_path
-          elsif @start_form.save(course)
+          elsif course.is_primary? && @start_form.valid? && goto_preview?
+            @start_form.save(course)
+            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+          elsif @start_form.valid? && !goto_preview?
+            @start_form.save(course)
             redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
-          elsif @start_form.degree_grade_required.present?
+          elsif @start_form.valid? && goto_preview?
+            @start_form.save(course)
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
+          elsif @start_form.degree_grade_required.present? && !goto_preview?
             redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path
+          elsif @start_form.degree_grade_required.present? && goto_preview?
+            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path(goto_preview: true)
           else
             @errors = @start_form.errors.messages
             render :edit
@@ -32,6 +41,10 @@ module Publish
         end
 
         private
+
+        def goto_preview?
+          params.dig(:publish_degree_start_form, :goto_preview) == 'true'
+        end
 
         def course
           @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -24,16 +24,16 @@ module Publish
           elsif course.is_primary? && @start_form.valid? && goto_preview?
             @start_form.save(course)
             redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+          elsif @start_form.degree_grade_required.present? && !goto_preview?
+            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path
+          elsif @start_form.degree_grade_required.present? && goto_preview?
+            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path(goto_preview: true)
           elsif @start_form.valid? && !goto_preview?
             @start_form.save(course)
             redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
           elsif @start_form.valid? && goto_preview?
             @start_form.save(course)
             redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
-          elsif @start_form.degree_grade_required.present? && !goto_preview?
-            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path
-          elsif @start_form.degree_grade_required.present? && goto_preview?
-            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path(goto_preview: true)
           else
             @errors = @start_form.errors.messages
             render :edit

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -16,24 +16,23 @@ module Publish
           authorize(provider)
 
           @start_form = DegreeStartForm.new(degree_grade_required: grade_required_params)
-
-          if course.is_primary? && @start_form.valid? && !goto_preview?
+          if course.is_primary? && @start_form.valid? && !goto_preview? && @start_form.degree_grade_required.blank?
             @start_form.save(course)
             course_updated_message('Minimum degree classification')
             redirect_to publish_provider_recruitment_cycle_course_path
-          elsif course.is_primary? && @start_form.valid? && goto_preview?
+          elsif course.is_primary? && @start_form.valid? && goto_preview? && @start_form.degree_grade_required.blank?
             @start_form.save(course)
             redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+          elsif @start_form.valid? && !goto_preview? && @start_form.degree_grade_required.blank?
+            @start_form.save(course)
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
+          elsif @start_form.valid? && goto_preview? && @start_form.degree_grade_required.blank?
+            @start_form.save(course)
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
           elsif @start_form.degree_grade_required.present? && !goto_preview?
             redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path
           elsif @start_form.degree_grade_required.present? && goto_preview?
             redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path(goto_preview: true)
-          elsif @start_form.valid? && !goto_preview?
-            @start_form.save(course)
-            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
-          elsif @start_form.valid? && goto_preview?
-            @start_form.save(course)
-            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(goto_preview: true)
           else
             @errors = @start_form.errors.messages
             render :edit

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -40,7 +40,9 @@ module Publish
         def grade_required_params
           return if params[:publish_degree_start_form].blank?
 
-          params.require(:publish_degree_start_form).permit(:degree_grade_required)[:degree_grade_required]
+          params.require(:publish_degree_start_form)
+                .except(:goto_preview)
+                .permit(:degree_grade_required)[:degree_grade_required]
         end
       end
     end

--- a/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
@@ -55,9 +55,15 @@ module Publish
         def set_backlink
           @backlink = if course.degree_grade == 'not_required'
                         degrees_start_publish_provider_recruitment_cycle_course_path
+                      elsif gobackto_preview?
+                        degrees_grade_publish_provider_recruitment_cycle_course_path(goto_preview: true)
                       else
                         degrees_grade_publish_provider_recruitment_cycle_course_path
                       end
+        end
+
+        def gobackto_preview?
+          params.dig(:goto_preview) == 'true' || params.dig(:publish_subject_requirement_form, :goto_preview)
         end
 
         def redirect_to_course_details_page_if_course_is_primary

--- a/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
@@ -63,7 +63,7 @@ module Publish
         end
 
         def gobackto_preview?
-          params.dig(:goto_preview) == 'true' || params.dig(:publish_subject_requirement_form, :goto_preview)
+          params[:goto_preview] == 'true' || params.dig(:publish_subject_requirement_form, :goto_preview)
         end
 
         def redirect_to_course_details_page_if_course_is_primary

--- a/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
@@ -21,10 +21,13 @@ module Publish
 
           @subject_requirements_form = SubjectRequirementForm.new(subject_requirements_params)
 
-          if @subject_requirements_form.save(@course)
+          if @subject_requirements_form.valid? && !goto_preview?
+            @subject_requirements_form.save(@course)
             course_updated_message('Degree requirements')
-
             redirect_to publish_provider_recruitment_cycle_course_path
+          elsif @subject_requirements_form.valid? && goto_preview?
+            @subject_requirements_form.save(@course)
+            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
           else
             set_backlink
             @errors = @subject_requirements_form.errors.messages
@@ -34,6 +37,10 @@ module Publish
 
         private
 
+        def goto_preview?
+          params.dig(:publish_subject_requirement_form, :goto_preview) == 'true'
+        end
+
         def course
           @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
         end
@@ -41,6 +48,7 @@ module Publish
         def subject_requirements_params
           params
             .require(:publish_subject_requirement_form)
+            .except(:goto_preview)
             .permit(:additional_degree_subject_requirements, :degree_subject_requirements)
         end
 

--- a/app/controllers/publish/courses/gcse_requirements_controller.rb
+++ b/app/controllers/publish/courses/gcse_requirements_controller.rb
@@ -19,7 +19,6 @@ module Publish
 
         @gcse_requirements_form = GcseRequirementsForm.new(**gcse_requirements_form_params.merge(level: course.level))
 
-
         if @gcse_requirements_form.valid? && goto_preview?
           @gcse_requirements_form.save(course)
           redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)

--- a/app/controllers/publish/courses/gcse_requirements_controller.rb
+++ b/app/controllers/publish/courses/gcse_requirements_controller.rb
@@ -19,9 +19,13 @@ module Publish
 
         @gcse_requirements_form = GcseRequirementsForm.new(**gcse_requirements_form_params.merge(level: course.level))
 
-        if @gcse_requirements_form.save(course)
-          course_updated_message('GCSE requirements')
 
+        if @gcse_requirements_form.valid? && goto_preview?
+          @gcse_requirements_form.save(course)
+          redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, course.recruitment_cycle_year, course.course_code)
+        elsif @gcse_requirements_form.valid? && !goto_preview?
+          course_updated_message('GCSE requirements')
+          @gcse_requirements_form.save(course)
           redirect_to publish_provider_recruitment_cycle_course_path
         else
           @errors = @gcse_requirements_form.errors.messages
@@ -73,6 +77,8 @@ module Publish
           value == 'true'
         end
       end
+
+      def goto_preview? = params.dig(:publish_gcse_requirements_form, :goto_preview) == 'true'
     end
   end
 end

--- a/app/controllers/publish/courses/gcse_requirements_controller.rb
+++ b/app/controllers/publish/courses/gcse_requirements_controller.rb
@@ -50,15 +50,18 @@ module Publish
       end
 
       def publish_gcse_requirements_form_params
-        @publish_gcse_requirements_form_params ||= params.require(:publish_gcse_requirements_form).permit(
-          :accept_pending_gcse,
-          :accept_english_gcse_equivalency,
-          :accept_gcse_equivalency,
-          { accept_english_gcse_equivalency: [] },
-          { accept_maths_gcse_equivalency: [] },
-          { accept_science_gcse_equivalency: [] },
-          :additional_gcse_equivalencies
-        )
+        @publish_gcse_requirements_form_params ||= params
+                                                   .require(:publish_gcse_requirements_form)
+                                                   .except(:goto_preview)
+                                                   .permit(
+                                                     :accept_pending_gcse,
+                                                     :accept_english_gcse_equivalency,
+                                                     :accept_gcse_equivalency,
+                                                     { accept_english_gcse_equivalency: [] },
+                                                     { accept_maths_gcse_equivalency: [] },
+                                                     { accept_science_gcse_equivalency: [] },
+                                                     :additional_gcse_equivalencies
+                                                   )
       end
 
       def translate_params(value)

--- a/app/views/publish/courses/degrees/grade/edit.html.erb
+++ b/app/views/publish/courses/degrees/grade/edit.html.erb
@@ -2,7 +2,11 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @grade_form.errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(degrees_start_publish_provider_recruitment_cycle_course_path) %>
+  <% if params.dig(:goto_preview) == 'true' || params.dig(:publish_degree_grade_form, :goto_preview) %>
+    <%= govuk_back_link_to(degrees_start_publish_provider_recruitment_cycle_course_path(goto_preview: true)) %>
+  <% else %>
+    <%= govuk_back_link_to(degrees_start_publish_provider_recruitment_cycle_course_path) %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish/courses/degrees/grade/edit.html.erb
+++ b/app/views/publish/courses/degrees/grade/edit.html.erb
@@ -24,6 +24,8 @@
         <%= f.govuk_radio_button :grade, "third_class", label: { text: "Third or above (or equivalent)" }, data: { qa: "degree_grade__third_class" } %>
       <% end %>
 
+      <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_degree_grade_form, :goto_preview)) %>
+
       <%= f.govuk_submit @course.is_primary? ? "Save" : "Continue", data: { qa: "degree_grade__save" } %>
     <% end %>
   </div>

--- a/app/views/publish/courses/degrees/start/edit.html.erb
+++ b/app/views/publish/courses/degrees/start/edit.html.erb
@@ -3,7 +3,11 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @start_form.errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path) %>
+  <% if params.dig(:goto_preview) == 'true' || params.dig(:publish_degree_start_form, :goto_preview) %>
+  <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
+  <% else %>
+    <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path) %>
+  <% end %>
 <% end %>
 
 <%= render CaptionText.new(text: @course.name_and_code) %>
@@ -20,11 +24,12 @@
     ) do |f| %>
 
       <%= f.govuk_error_summary %>
-
       <%= f.govuk_radio_buttons_fieldset :degree_grade_required, legend: { text: page_title, size: "l", tag: "h1" }, hint: { text: "If you specify a minimum (for example, 2:1), candidates will be discouraged but not blocked from applying if they do not meet this level." } do %>
         <%= f.govuk_radio_button :degree_grade_required, true, label: { text: "Yes" }, data: { qa: "start__yes_radio" }, link_errors: true %>
         <%= f.govuk_radio_button :degree_grade_required, false, label: { text: "No" }, data: { qa: "start__no_radio" } %>
       <% end %>
+
+      <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_degree_start_form, :goto_preview)) %>
 
       <%= f.govuk_submit @course.is_primary? ? "Save" : "Continue", data: { qa: "start__save" } %>
     <% end %>

--- a/app/views/publish/courses/degrees/subject_requirements/edit.html.erb
+++ b/app/views/publish/courses/degrees/subject_requirements/edit.html.erb
@@ -31,6 +31,8 @@
 
       <%= render partial: "publish/courses/degrees/additional_degree_subject_requirements", locals: { f:, course_object: @source_course ? source_course : @course } %>
 
+      <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_subject_requirement_form, :goto_preview)) %>
+
       <%= f.govuk_submit "Update degree requirements", data: { qa: "degree_subject_requirements__save" } %>
 
     <% end %>

--- a/app/views/publish/courses/gcse_requirements/edit.html.erb
+++ b/app/views/publish/courses/gcse_requirements/edit.html.erb
@@ -3,7 +3,11 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
+  <% if params.dig(:goto_preview) == 'true' || params.dig(:publish_gcse_requirements_form, :goto_preview) %>
+    <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
+  <% else %>
   <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
+  <% end %>
 <% end %>
 
 <% if params[:copy_from].present? %>
@@ -32,6 +36,8 @@
     </h1>
 
      <%= render partial: "publish/courses/gcse_requirements", locals: { f:, course_object: @source_course ? source_course : @course } %>
+
+      <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_gcse_requirements_form, :goto_preview)) %>
 
       <%= f.submit "Update #{page_title}", class: "govuk-button", data: { qa: "gcse_requirements__save" } %>
     <% end %>

--- a/spec/components/find/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_preview.rb
@@ -8,7 +8,7 @@ module Find
           course = Course.new(course_code: 'FIND',
                               subjects: [Subject.new(subject_name: 'Foo', subject_code: '1')],
                               name: 'Super cool awesome course',
-                              provider: Provider.new(provider_code: 'DFE'),
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current),
                               additional_degree_subject_requirements: true,
                               degree_subject_requirements: 'Degree Subject Requirements Text',
                               level: 'secondary',

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -109,10 +109,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     it 'renders correct message' do
       course = build(
         :course,
-        accept_pending_gcse: true
+        accept_pending_gcse: true,
+        accept_gcse_equivalency: false
       )
       result = render_inline(described_class.new(course: course.decorate))
-
       expect(result.text).to include(
         'We’ll consider candidates with pending GCSEs'
       )
@@ -123,7 +123,8 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     it 'renders correct message' do
       course = build(
         :course,
-        accept_pending_gcse: false
+        accept_pending_gcse: false,
+        accept_gcse_equivalency: false
       )
       result = render_inline(described_class.new(course: course.decorate))
 
@@ -210,6 +211,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       course = build(
         :course,
         accept_gcse_equivalency: false,
+        accept_pending_gcse: false,
         accept_english_gcse_equivalency: false,
         accept_maths_gcse_equivalency: false,
         accept_science_gcse_equivalency: false
@@ -227,6 +229,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       course = build(
         :course,
         accept_gcse_equivalency: true,
+        accept_pending_gcse: false,
         accept_english_gcse_equivalency: false,
         accept_maths_gcse_equivalency: true,
         accept_science_gcse_equivalency: true

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Find::Courses::EntryRequirementsComponent::View, type: :component do
-  let(:course) { build(:course, subjects:) }
+  let(:course) { build(:course, subjects:, accept_gcse_equivalency: false, accept_pending_gcse: false) }
   let(:subjects) { [build(:secondary_subject, subject_name)] }
   let(:result) { render_inline(described_class.new(course: course.decorate)) }
   let(:ske_text) { 'If you need to improve your subject knowledge, you may be asked to complete a' }
@@ -138,6 +138,8 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     it 'renders correct message' do
       course = build(
         :course,
+        accept_gcse_equivalency: false,
+        accept_pending_gcse: false,
         provider: build(:provider, provider_code: 'ABC'),
         level: 'primary'
       )
@@ -156,6 +158,8 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     it 'renders correct message' do
       raw_course = build(
         :course,
+        accept_gcse_equivalency: false,
+        accept_pending_gcse: false,
         provider: build(:provider, provider_code: 'U80'),
         level: 'secondary'
       )
@@ -192,6 +196,8 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
         accrediting_provider = build(:provider, provider_code: 'U80')
         course = build(
           :course,
+          accept_gcse_equivalency: false,
+          accept_pending_gcse: false,
           provider: build(:provider),
           accrediting_provider:,
           level: 'secondary'

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -40,6 +40,9 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       and_i_am_on_the_degree_requirements_page
       and_i_click_back
       then_i_should_be_back_on_the_preview_page
+      and_i_click_enter_degree_requirements
+      and_i_submit_and_continue_through_the_two_forms
+      then_i_should_see_the_updated_content_on_the_preview_page
     end
 
     scenario 'blank gcse requirements' do
@@ -312,7 +315,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   def user_with_no_course_enrichments
     course = build(
-      :course, :secondary, degree_grade: nil
+      :course, :secondary, degree_grade: nil, additional_degree_subject_requirements: nil
     )
 
     provider = build(
@@ -343,6 +346,17 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   def and_i_click_enter_degree_requirements
     click_link 'Enter degree requirements'
+  end
+
+  def then_i_should_see_the_updated_content_on_the_preview_page
+    expect(page).to have_content('An undergraduate degree, or equivalent.')
+  end
+
+  def and_i_submit_and_continue_through_the_two_forms
+    choose('No')
+    click_button('Continue')
+    choose('No')
+    click_button('Update degree requirements')
   end
 
   def and_i_am_on_the_degree_requirements_page

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -28,7 +28,29 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       and_i_click_back
       and_i_click_enter_course_summary
       and_i_submit_a_valid_form
-      and_i_see_the_correct_banner_and_text
+      and_i_see_the_correct_banner
+      and_i_see_the_new_course_text
+      then_i_should_be_back_on_the_preview_page
+    end
+
+    scenario 'blank degree requirements' do
+      given_i_am_authenticated(user: user_with_no_course_enrichments)
+      when_i_visit_the_publish_course_preview_page
+      and_i_click_enter_degree_requirements
+      and_i_am_on_the_degree_requirements_page
+      and_i_click_back
+      then_i_should_be_back_on_the_preview_page
+    end
+
+    scenario 'blank gcse requirements' do
+      given_i_am_authenticated(user: user_with_no_course_enrichments)
+      when_i_visit_the_publish_course_preview_page
+      and_i_click_enter_enter_gcse_and_equivalency_test_requirements
+      and_i_click_back
+      and_i_click_enter_enter_gcse_and_equivalency_test_requirements
+      and_i_choose_no_and_submit
+      and_i_see_the_correct_banner
+      and_i_see_the_correct_gcse_text
       then_i_should_be_back_on_the_preview_page
     end
 
@@ -289,31 +311,12 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def user_with_no_course_enrichments
-    site1 = build(:site, location_name: 'Running site with vacancies')
-
-    site_status1 = build(:site_status, :published, :full_time_vacancies, :running, site: site1)
-
-    sites = [site1]
-    site_statuses = [site_status1]
-
-    accrediting_provider = build(:provider)
-
-    course_subject = find_or_create(:secondary_subject, :mathematics)
-
     course = build(
-      :course, :secondary, :fee_type_based, accrediting_provider:,
-                                            site_statuses:, enrichments: [],
-                                            degree_grade: 'two_one',
-                                            degree_subject_requirements: 'Maths A level',
-                                            subjects: [course_subject]
+      :course, :secondary, degree_grade: nil
     )
-    accrediting_provider_enrichment = {
-      'UcasProviderCode' => accrediting_provider.provider_code,
-      'Description' => Faker::Lorem.sentence
-    }
 
     provider = build(
-      :provider, sites:, courses: [course], accrediting_provider_enrichments: [accrediting_provider_enrichment]
+      :provider, courses: [course]
     )
 
     create(
@@ -338,9 +341,35 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     click_link 'Enter details about school placements'
   end
 
-  def and_i_see_the_correct_banner_and_text
+  def and_i_click_enter_degree_requirements
+    click_link 'Enter degree requirements'
+  end
+
+  def and_i_am_on_the_degree_requirements_page
+    expect(page).to have_text 'Do you require a minimum degree classification?'
+  end
+
+  def and_i_click_enter_enter_gcse_and_equivalency_test_requirements
+    click_link 'Enter GCSE and equivalency test requirements'
+  end
+
+  def and_i_see_the_correct_gcse_text
+    expect(page).to have_text 'We will not consider candidates with pending GCSEs.'
+    expect(page).to have_text 'We will not consider candidates who need to take a GCSE equivalency test.'
+  end
+
+  def and_i_choose_no_and_submit
+    page.all('.govuk-radios__item')[1].choose
+    page.all('.govuk-radios__item')[3].choose
+    click_button 'Update GCSEs and equivalency tests'
+  end
+
+  def and_i_see_the_correct_banner
     expect(page).to have_text 'This is a preview of how your course will appear on Find.'
-    expect(page).to have_text 'great course'
+  end
+
+  def and_i_see_the_new_course_text
+    expect(page).to have_text('great course')
   end
 
   def then_i_should_be_back_on_the_preview_page

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -61,7 +61,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       and_i_click_back
       and_i_click_enter_details_about_school_placements
       and_i_submit_a_valid_form
-      and_i_see_the_correct_banner_and_text
+      and_i_see_the_correct_banner
       then_i_should_be_back_on_the_preview_page
     end
   end


### PR DESCRIPTION
### Context

To give providers a clearer view on which information they provide and which is generated by the service, we’re updating the course preview page to show missing information before a course is published.

**This PR relates to do the entry requirement section for "Degree and GCSE".**

### Changes proposed in this pull request

- Utilise `course_preview_missing_information` feature flag
- Use the `MissingInformationComponent` to generate inset text linking to the relevant page on Publish if there is no content.
- Add dynamic back link (dependent on whether you come from preview or description)

### Guidance to review

Create a bare bones course and click the preview button. Check that the inset text is displayed. Click the link and fill in some information. Now the information you filled in should be displayed.

Should we gaurd against showing this on live Find, i'm not sure we need to as we can't publish a course without "about course" information. 
<img width="548" alt="image" src="https://user-images.githubusercontent.com/50492247/226719068-ed233ca3-8cdd-4230-81f2-1d935805bf81.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
