### PR TITLE
[1152] Course preview fees and financial support

### DIFF
--- a/app/components/find/courses/fees_component/view.html.erb
+++ b/app/components/find/courses/fees_component/view.html.erb
@@ -35,5 +35,7 @@
         <%= markdown(fee_details) %>
       </div>
     <% end %>
+  <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
+    <%= render CoursePreview::MissingInformationComponent.new("Enter details about fees and financial support", "#{fees_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.recruitment_cycle_year, course.course_code, goto_preview: true)}#fee-uk") %>
   <% end %>
 </div>

--- a/app/components/find/courses/fees_component/view.html.erb
+++ b/app/components/find/courses/fees_component/view.html.erb
@@ -36,6 +36,6 @@
       </div>
     <% end %>
   <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
-    <%= render CoursePreview::MissingInformationComponent.new("Enter details about fees and financial support", "#{fees_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.recruitment_cycle_year, course.course_code, goto_preview: true)}#fee-uk") %>
+    <%= render CoursePreview::MissingInformationComponent.new("Enter details about fees and financial support", "#{fees_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.recruitment_cycle_year, course.course_code, goto_preview: true)}") %>
   <% end %>
 </div>

--- a/app/controllers/publish/courses/base_funding_type_controller.rb
+++ b/app/controllers/publish/courses/base_funding_type_controller.rb
@@ -16,7 +16,9 @@ module Publish
       end
 
       def funding_type_params
-        params.require(funding_type).permit(*funding_type_fields)
+        params.require(funding_type)
+              .except(:goto_preview)
+              .permit(*funding_type_fields)
       end
 
       def formatted_params
@@ -36,6 +38,8 @@ module Publish
       def funding_type_fields
         raise NotImplementedError
       end
+
+      def goto_preview? = params.dig(funding_type, :goto_preview) == 'true'
     end
   end
 end

--- a/app/controllers/publish/courses/fees_controller.rb
+++ b/app/controllers/publish/courses/fees_controller.rb
@@ -20,13 +20,18 @@ module Publish
         @course_fee_form = CourseFeeForm.new(course_enrichment, params: formatted_params)
 
         if @course_fee_form.save!
-          course_updated_message('Course length and fees')
+          if goto_preview?
+            redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, recruitment_cycle.year, course.course_code)
+          else
+            course_updated_message('Course length and fees')
 
-          redirect_to publish_provider_recruitment_cycle_course_path(
-            provider.provider_code,
-            recruitment_cycle.year,
-            course.course_code
-          )
+            redirect_to publish_provider_recruitment_cycle_course_path(
+              provider.provider_code,
+              recruitment_cycle.year,
+              course.course_code
+            )
+          end
+
         else
           render :edit
         end

--- a/app/views/publish/courses/fees/edit.html.erb
+++ b/app/views/publish/courses/fees/edit.html.erb
@@ -2,7 +2,11 @@
 <% content_for :page_title, title_with_error_prefix("#{page_title} – #{@course.name_and_code}", @course_fee_form.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
+  <% if params.dig(:goto_preview) == 'true' || params.dig(:publish_course_fee_form, :goto_preview) %>
+    <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
+  <% else %>
+    <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
+  <% end %>
 <% end %>
 
 <% if params[:copy_from].present? %>
@@ -71,6 +75,8 @@
         rows: 15,
         max_words: 250,
         data: { qa: "course_financial_support" }) %>
+
+      <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_course_fee_form, :goto_preview)) %>
 
       <%= f.govuk_submit "Update #{page_title.downcase}" %>
     <% end %>

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -67,6 +67,18 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       and_i_see_the_correct_banner
       then_i_should_be_back_on_the_preview_page
     end
+
+    scenario 'blank fees uk eu' do
+      given_i_am_authenticated(user: user_with_no_course_enrichments)
+      when_i_visit_the_publish_course_preview_page
+      and_i_click_enter_details_about_fees_and_financial_support
+      and_i_click_back
+      and_i_click_enter_details_about_fees_and_financial_support
+      and_i_submit_a_valid_course_fees
+      and_i_see_the_correct_banner
+      and_i_see_the_the_course_fee
+      then_i_should_be_back_on_the_preview_page
+    end
   end
 
   context 'bursaries and scholarships is not announced' do
@@ -315,7 +327,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   def user_with_no_course_enrichments
     course = build(
-      :course, :secondary, degree_grade: nil, additional_degree_subject_requirements: nil
+      :course, :secondary, :fee_type_based, degree_grade: nil, additional_degree_subject_requirements: nil
     )
 
     provider = build(
@@ -344,12 +356,20 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     click_link 'Enter details about school placements'
   end
 
+  def and_i_click_enter_details_about_fees_and_financial_support
+    click_link 'Enter details about fees and financial support'
+  end
+
   def and_i_click_enter_degree_requirements
     click_link 'Enter degree requirements'
   end
 
   def then_i_should_see_the_updated_content_on_the_preview_page
     expect(page).to have_content('An undergraduate degree, or equivalent.')
+  end
+
+  def and_i_see_the_the_course_fee
+    expect(page).to have_text "The course fees for UK students in #{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1} are £100."
   end
 
   def and_i_submit_and_continue_through_the_two_forms
@@ -395,6 +415,13 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     fill_in 'School placements',   with: 'great placement'
 
     click_button 'Update course information'
+  end
+
+  def and_i_submit_a_valid_course_fees
+    choose '1 year'
+    fill_in 'Fee for UK students', with: '100'
+
+    click_button 'Update course length and fees'
   end
 
   def and_i_click_back


### PR DESCRIPTION
### Context
Course preview

### Changes proposed in this pull request

Added missing information component

### Guidance to review

1. Create a fee-based course and preview it
2. Click on the `Enter details about fees and financial support`
3. The ` Course length and fees ` page 
  - Check the `back` link  
  - Check the valid form submission take you to the preview page
  - Check after invalid form submission that the above two items still works

https://publish-teacher-training-pr-3456.london.cloudapps.digital/publish/organisations/2A2/2023/courses

![image](https://user-images.githubusercontent.com/470137/228551436-7cd8db59-5e49-4ab7-8f9d-a4933e68ca57.png)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
