### PR TITLE
Removed pinned pkg versions as now in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
 # Remove once the base image ruby:3.1-alpine3.15 has been updated with the below pkgs
-RUN apk add --no-cache libcrypto1.1=1.1.1t-r1 pkgconf=1.8.1-r0 git=2.34.7-r0
+RUN apk add --no-cache libcrypto1.1=1.1.1t-r3
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
### Context

Current libcrypto version has a snyk vulnerability
Updated to 1.1.1t-r3, and removed the pinned versions for pkgconf and git, as fixed in the base image

### Changes proposed in this pull request

Update Dockerfile

### Guidance to review

Check build passes SNYK scan

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
