### PR TITLE
[1119] Fix school urn empty text

### DIFF
--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -7,7 +7,7 @@
   </td>
   <% if urn_required?(@recruitment_cycle.year.to_i) %>
     <td class="govuk-table__cell urn">
-      <%= school.urn.presence || "<strong class='govuk-error-message govuk-!-display-inline'>(Missing)</strong>".html_safe %>
+      <%= course_value_provided?(school.urn) %>
     </td>
   <% end %>
 </tr>

--- a/app/views/publish/providers/schools/index.html.erb
+++ b/app/views/publish/providers/schools/index.html.erb
@@ -23,7 +23,11 @@
           <th class="govuk-table__header" scope="col">Name</th>
           <th class="govuk-table__header" scope="col">School code</th>
           <% if urn_required?(@recruitment_cycle.year.to_i) %>
-            <th class="govuk-table__header" scope="col">URN</th>
+            <th class="govuk-table__header" scope="col">
+              <abbr class="app-!-text-decoration-underline-dotted" title="Unique reference number">
+                URN
+              </abbr>
+            </th>
           <% end %>
         </tr>
       </thead>

--- a/app/views/support/schools/index.html.erb
+++ b/app/views/support/schools/index.html.erb
@@ -9,7 +9,11 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Name</th>
       <th scope="col" class="govuk-table__header">School code</th>
-      <th scope="col" class="govuk-table__header">URN</th>
+      <th scope="col" class="govuk-table__header">
+        <abbr class="app-!-text-decoration-underline-dotted" title="Unique reference number">
+          URN
+        </abbr>
+      </th>
     </tr>
   </thead>
 
@@ -29,7 +33,7 @@
           </td>
           <td class="govuk-table__cell urn">
             <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-              <%= site.urn.presence || "<strong class='govuk-error-message govuk-!-display-inline'>(Missing)</strong>".html_safe %>
+              <%= course_value_provided?(site.urn) %>
             </span>
           </td>
         </tr>


### PR DESCRIPTION
### Context

We used to show a red missing text for schools with no URN but we need to update to the default placeholder we're now using.

https://trello.com/c/aOJdtBAI/1199-bug-school-urn-placeholder-text

### Changes proposed in this pull request

Before:

<img width="689" alt="Screenshot 2023-03-30 at 11 49 40" src="https://user-images.githubusercontent.com/616080/228813485-a9787780-cedd-4289-9c0e-430e6849c33e.png">

After:

<img width="685" alt="Screenshot 2023-03-30 at 11 50 10" src="https://user-images.githubusercontent.com/616080/228813615-00f1ae57-2507-447e-82f2-b2ead1b0c869.png">

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
