### PR TITLE
[xxx] Bump Ruby 3.2.0 and Node 18.x

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -14,10 +14,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Ruby 3.1.0
+    - name: Set up Ruby 3.2.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.0
+        ruby-version: 3.2.0
 
     - name: install bundler and gems
       shell: bash

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 ruby 3.2.0
 bundler 2.3.20
 yarn 1.22.4
-nodejs 16.14.0
+nodejs 18.15.0
 terraform 1.2.3
 adr-tools 3.0.0
 cf 7.4.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 3.1.0
+ruby 3.2.0
 bundler 2.3.20
 yarn 1.22.4
 nodejs 16.14.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN bundle exec middleman build --build-dir=../public
 
 ###
 
-FROM ruby:3.1-alpine3.15
+FROM ruby:3.2-alpine3.17
 
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
@@ -25,7 +25,7 @@ RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
 # Remove once the base image ruby:3.1-alpine3.15 has been updated with the below pkgs
-RUN apk add --no-cache libcrypto1.1=1.1.1t-r3
+RUN apk add --no-cache libcrypto1.1=1.1.1t-r2
 
 ENV APP_HOME /app
 
@@ -57,5 +57,6 @@ RUN ls /app/public/ && \
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
+ENV RUBY_YJIT_ENABLE=1
 
 CMD bundle exec rails db:migrate:with_data_migrations && bundle exec rails server -b 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN apk add --update --no-cache tzdata && \
 RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
-# Remove once the base image ruby:3.1-alpine3.15 has been updated with the below pkgs
-RUN apk add --no-cache libcrypto1.1=1.1.1t-r2
-
 ENV APP_HOME /app
 
 RUN mkdir $APP_HOME

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '~> 3.1.0'
+ruby '~> 3.2.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '7.0.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -726,6 +726,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
@@ -836,7 +837,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.1.0p0
+   ruby 3.2.0p0
 
 BUNDLED WITH
    2.3.20

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "teacher-training-api",
   "private": true,
   "engines": {
-    "node": "16.x"
+    "node": "18.x"
   },
   "scripts": {
     "build": "yarn run build:css && yarn run build:js",


### PR DESCRIPTION
### Context

Bumping to Ruby 3.2.0 to enable YJIT for performance improvements to the language. Also bumps Node to current stable LTS

### Changes proposed in this pull request

Bumps relevant files

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
