### PR TITLE
1154 course preview training with disabilities and other needs

### DIFF
--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -18,7 +18,7 @@
     <li><%= govuk_link_to "Interview process", "#section-interviews" %></li>
   <% end %>
   <li><%= govuk_link_to "International candidates", "#section-international-students" %></li>
-  <% if provider.train_with_disability.present? %>
+  <% if provider.train_with_disability.present? || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
     <li><%= govuk_link_to "Training with disabilities and other needs", "#section-train-with-disabilities" %></li>
   <% end %>
   <li><%= govuk_link_to "Contact this training provider", "#section-contact" %></li>

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -116,6 +116,7 @@ module Publish
     def provider_params
       params
         .fetch(:publish_about_your_organisation_form, {})
+        .except(:goto_preview, :course_code)
         .permit(
           *AboutYourOrganisationForm::FIELDS,
           accredited_bodies: %i[provider_name provider_code description]

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -61,13 +61,13 @@ module Publish
 
       @about_form = AboutYourOrganisationForm.new(provider, params: provider_params)
 
-      if @about_form.save!
+      if @about_form.valid? && goto_preview?
+        @about_form.save!
+        redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle_year, (params.dig(:course_code) || params.dig(:publish_about_your_organisation_form, :course_code)))
+      elsif @about_form.valid? && !goto_preview?
+        @about_form.save!
         flash[:success] = I18n.t('success.published')
-        redirect_to(
-          details_publish_provider_recruitment_cycle_path(
-            provider.provider_code,
-            provider.recruitment_cycle_year
-          )
+        redirect_to(details_publish_provider_recruitment_cycle_path(provider.provider_code,provider.recruitment_cycle_year)
         )
       else
         @errors = @about_form.errors.messages
@@ -122,5 +122,7 @@ module Publish
           accredited_bodies: %i[provider_name provider_code description]
         )
     end
+
+    def goto_preview? = params.dig(:publish_about_your_organisation_form, :goto_preview) == 'true'
   end
 end

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -62,13 +62,13 @@ module Publish
 
       @about_form = AboutYourOrganisationForm.new(provider, params: provider_params)
 
-      if @about_form.valid? && goto_preview?
-        @about_form.save!
-        redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle_year, (params[:course_code] || params.dig(param_form_key, :course_code)))
-      elsif @about_form.valid? && !goto_preview?
-        @about_form.save!
-        flash[:success] = I18n.t('success.published')
-        redirect_to(details_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year))
+      if @about_form.save!
+        if goto_preview?
+          redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle_year, (params[:course_code] || params.dig(param_form_key, :course_code)))
+        else
+          flash[:success] = I18n.t('success.published')
+          redirect_to(details_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year))
+        end
       else
         @errors = @about_form.errors.messages
         render :about

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -3,6 +3,7 @@
 module Publish
   class ProvidersController < PublishController
     include RolloverHelper
+    include GotoPreview
     rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
     decorates_assigned :provider
 
@@ -63,7 +64,7 @@ module Publish
 
       if @about_form.valid? && goto_preview?
         @about_form.save!
-        redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle_year, (params[:course_code] || params.dig(:publish_about_your_organisation_form, :course_code)))
+        redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle_year, (params[:course_code] || params.dig(param_form_key, :course_code)))
       elsif @about_form.valid? && !goto_preview?
         @about_form.save!
         flash[:success] = I18n.t('success.published')
@@ -114,7 +115,7 @@ module Publish
 
     def provider_params
       params
-        .fetch(:publish_about_your_organisation_form, {})
+        .require(param_form_key)
         .except(:goto_preview, :course_code)
         .permit(
           *AboutYourOrganisationForm::FIELDS,
@@ -122,6 +123,6 @@ module Publish
         )
     end
 
-    def goto_preview? = params.dig(:publish_about_your_organisation_form, :goto_preview) == 'true'
+    def param_form_key = :publish_about_your_organisation_form
   end
 end

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -63,12 +63,11 @@ module Publish
 
       if @about_form.valid? && goto_preview?
         @about_form.save!
-        redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle_year, (params.dig(:course_code) || params.dig(:publish_about_your_organisation_form, :course_code)))
+        redirect_to preview_publish_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle_year, (params[:course_code] || params.dig(:publish_about_your_organisation_form, :course_code)))
       elsif @about_form.valid? && !goto_preview?
         @about_form.save!
         flash[:success] = I18n.t('success.published')
-        redirect_to(details_publish_provider_recruitment_cycle_path(provider.provider_code,provider.recruitment_cycle_year)
-        )
+        redirect_to(details_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year))
       else
         @errors = @about_form.errors.messages
         render :about

--- a/app/views/find/courses/_train_with_disabilities.html.erb
+++ b/app/views/find/courses/_train_with_disabilities.html.erb
@@ -3,8 +3,7 @@
   <div data-qa="course__train_with_disabilities">
     <% if course.provider.train_with_disability.present? %>
       <%= markdown(course.provider.train_with_disability) %>
-    <% else %>
-      <% puts "@course.recruitment_cycle_year: #{@course.recruitment_cycle_year}" %>
+    <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
       <%= render CoursePreview::MissingInformationComponent.new("Enter details about training with disabilities and other needs", about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year, course_code: @course.course_code, goto_preview: true) + "#train-with-disability") %>
     <% end %>
   </div>

--- a/app/views/find/courses/_train_with_disabilities.html.erb
+++ b/app/views/find/courses/_train_with_disabilities.html.erb
@@ -4,7 +4,8 @@
     <% if course.provider.train_with_disability.present? %>
       <%= markdown(course.provider.train_with_disability) %>
     <% else %>
-      <%= render CoursePreview::MissingInformationComponent.new("Enter details about training with disabilities and other needs", about_publish_provider_recruitment_cycle_path(@provider.provider_code, @course.recruitment_cycle_year) + "#train-with-disability") %>
+      <% puts "@course.recruitment_cycle_year: #{@course.recruitment_cycle_year}" %>
+      <%= render CoursePreview::MissingInformationComponent.new("Enter details about training with disabilities and other needs", about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year, course_code: @course.course_code, goto_preview: true) + "#train-with-disability") %>
     <% end %>
   </div>
 </div>

--- a/app/views/find/courses/_train_with_disabilities.html.erb
+++ b/app/views/find/courses/_train_with_disabilities.html.erb
@@ -1,6 +1,10 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-train-with-disabilities">Training with disabilities and other needs</h2>
   <div data-qa="course__train_with_disabilities">
-    <%= markdown(course.provider.train_with_disability) %>
+    <% if course.provider.train_with_disability.present? %>
+      <%= markdown(course.provider.train_with_disability) %>
+    <% else %>
+      <%= render CoursePreview::MissingInformationComponent.new("Enter details about training with disabilities and other needs", about_publish_provider_recruitment_cycle_path(@provider.provider_code, @course.recruitment_cycle_year) + "#train-with-disability") %>
+    <% end %>
   </div>
 </div>

--- a/app/views/find/courses/_train_with_disabilities.html.erb
+++ b/app/views/find/courses/_train_with_disabilities.html.erb
@@ -4,7 +4,7 @@
     <% if course.provider.train_with_disability.present? %>
       <%= markdown(course.provider.train_with_disability) %>
     <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
-      <%= render CoursePreview::MissingInformationComponent.new("Enter details about training with disabilities and other needs", about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year, course_code: @course.course_code, goto_preview: true) + "#train-with-disability") %>
+      <%= render CoursePreview::MissingInformationComponent.new("Enter details about training with disabilities and other needs", "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year, course_code: @course.course_code, goto_preview: true)}#train-with-disability") %>
     <% end %>
   </div>
 </div>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -51,9 +51,7 @@
 
     <%= render Find::Courses::InternationalStudentsComponent::View.new(course:) %>
 
-    <% if course.provider.train_with_disability.present? %>
       <%= render partial: "find/courses/train_with_disabilities", locals: { course: } %>
-    <% end %>
 
     <%= render Find::Courses::ContactDetailsComponent::View.new(course) %>
 

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -51,7 +51,7 @@
 
     <%= render Find::Courses::InternationalStudentsComponent::View.new(course:) %>
 
-      <%= render partial: "find/courses/train_with_disabilities", locals: { course: } %>
+    <%= render partial: "find/courses/train_with_disabilities", locals: { course: } %>
 
     <%= render Find::Courses::ContactDetailsComponent::View.new(course) %>
 

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -10,7 +10,11 @@
     ) do |f| %>
 
       <% content_for :before_content do %>
-        <%= govuk_back_link_to(back_link_path(param_form_key: f.object_name.to_sym, params:, provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year, course_code: (params[:course_code] || params.dig(f.object_name.to_sym, :course_code)))) %>
+       <% if goto_preview?(param_form_key: f.object_name.to_sym, params:) %>
+        <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, (params[:course_code] || params.dig(f.object_name.to_sym, :course_code))))  %>
+        <% else %>
+          <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_error_summary %>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -1,14 +1,6 @@
 <% page_title = "About your organisation" %>
 <% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
-<% content_for :before_content do %>
-  <% if (params.dig(:goto_preview) == 'true' || params.dig(:publish_about_your_organisation_form, :goto_preview)) && (params.dig(:course_code).present? || params.dig(:publish_about_your_organisation_form, :course_code).present?) %>
-    <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, (params.dig(:course_code) || params.dig(:publish_about_your_organisation_form, :course_code)))) %>
-  <% else %>
-      <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
-  <% end %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
@@ -16,6 +8,10 @@
       url: about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
       method: :put
     ) do |f| %>
+
+      <% content_for :before_content do %>
+        <%= govuk_back_link_to(back_link_path(param_form_key: f.object_name.to_sym, params: params, provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year, course_code: (params.dig(:course_code) || params.dig(:publish_about_your_organisation_form, :course_code)))) %>
+      <% end %>
 
       <%= f.govuk_error_summary %>
 
@@ -87,7 +83,8 @@
         max_words: 250,
         rows: 15) %>
         
-      <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_about_your_organisation_form, :goto_preview)) %>
+      <%# <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_about_your_organisation_form, :goto_preview)) %> %>
+      <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>
       <%= f.hidden_field(:course_code, value: params[:course_code] || params.dig(:publish_about_your_organisation_form, :course_code)) %>
 
       <%= f.govuk_submit "Save and publish" %>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -11,7 +11,7 @@
 
       <% content_for :before_content do %>
        <% if goto_preview?(param_form_key: f.object_name.to_sym, params:) %>
-        <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, (params[:course_code] || params.dig(f.object_name.to_sym, :course_code))))  %>
+        <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, (params[:course_code] || params.dig(f.object_name.to_sym, :course_code)))) %>
         <% else %>
           <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
         <% end %>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -10,7 +10,7 @@
     ) do |f| %>
 
       <% content_for :before_content do %>
-        <%= govuk_back_link_to(back_link_path(param_form_key: f.object_name.to_sym, params:, provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year, course_code: (params[:course_code] || params[f.object_name.to_sym][:course_code]))) %>
+        <%= govuk_back_link_to(back_link_path(param_form_key: f.object_name.to_sym, params:, provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year, course_code: (params[:course_code] || params.dig(f.object_name.to_sym, :course_code)))) %>
       <% end %>
 
       <%= f.govuk_error_summary %>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -10,7 +10,7 @@
     ) do |f| %>
 
       <% content_for :before_content do %>
-        <%= govuk_back_link_to(back_link_path(param_form_key: f.object_name.to_sym, params: params, provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year, course_code: (params.dig(:course_code) || params.dig(:publish_about_your_organisation_form, :course_code)))) %>
+        <%= govuk_back_link_to(back_link_path(param_form_key: f.object_name.to_sym, params:, provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year, course_code: (params[:course_code] || params[f.object_name.to_sym][:course_code]))) %>
       <% end %>
 
       <%= f.govuk_error_summary %>
@@ -82,10 +82,8 @@
         label: { text: "Training with disabilities and other needs", size: "s" },
         max_words: 250,
         rows: 15) %>
-        
-      <%# <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_about_your_organisation_form, :goto_preview)) %> %>
       <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>
-      <%= f.hidden_field(:course_code, value: params[:course_code] || params.dig(:publish_about_your_organisation_form, :course_code)) %>
+      <%= f.hidden_field(:course_code, value: params[:course_code] || params.dig(f.object_name.to_sym, :course_code)) %>
 
       <%= f.govuk_submit "Save and publish" %>
     <% end %>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -2,7 +2,11 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+  <% if (params.dig(:goto_preview) == 'true' || params.dig(:publish_about_your_organisation_form, :goto_preview)) && (params.dig(:course_code).present? || params.dig(:publish_about_your_organisation_form, :course_code).present?) %>
+    <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, (params.dig(:course_code) || params.dig(:publish_about_your_organisation_form, :course_code)))) %>
+  <% else %>
+      <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -82,6 +86,9 @@
         label: { text: "Training with disabilities and other needs", size: "s" },
         max_words: 250,
         rows: 15) %>
+        
+      <%= f.hidden_field(:goto_preview, value: params[:goto_preview] || params.dig(:publish_about_your_organisation_form, :goto_preview)) %>
+      <%= f.hidden_field(:course_code, value: params[:course_code] || params.dig(:publish_about_your_organisation_form, :course_code)) %>
 
       <%= f.govuk_submit "Save and publish" %>
     <% end %>

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -21,11 +21,17 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       allow(Settings.features).to receive(:course_preview_missing_information).and_return(true)
     end
 
-    scenario 'blank raining with disabilities and other needs' do
+    scenario 'blank training with disabilities and other needs' do
       given_i_am_authenticated(user: user_with_no_course_enrichments)
       when_i_visit_the_publish_course_preview_page
       and_i_click_enter_details_about_training_with_disabilities_and_other_needs
       then_i_should_be_on_about_your_organisation_page
+      and_i_click_back
+      then_i_should_be_back_on_the_preview_page
+      and_i_click_enter_details_about_training_with_disabilities_and_other_needs
+      and_i_submit_a_valid_about_your_organisation
+      then_i_should_be_back_on_the_preview_page
+      and_i_should_see_the_updated_content
     end
 
     scenario 'blank course summary' do
@@ -338,7 +344,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     )
 
     provider = build(
-      :provider, courses: [course]
+      :provider, courses: [course], train_with_disability: nil
     )
 
     create(
@@ -373,6 +379,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   def and_i_click_enter_degree_requirements
     click_link 'Enter degree requirements'
+  end
+
+  def and_i_should_see_the_updated_content
+    expect(page).to have_content('test training with disabilities')
   end
 
   def then_i_should_see_the_updated_content_on_the_preview_page
@@ -423,6 +433,13 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   def then_i_should_be_back_on_the_preview_page
     expect(page).to have_current_path "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{course.course_code}/preview"
+  end
+
+  def and_i_submit_a_valid_about_your_organisation
+    fill_in 'Training with your organisation', with: 'test training with disabilities'
+    fill_in 'Training with disabilities and other needs', with: 'test training with disabilities'
+
+    click_button 'Save and publish'
   end
 
   def and_i_submit_a_valid_form

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -21,6 +21,13 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       allow(Settings.features).to receive(:course_preview_missing_information).and_return(true)
     end
 
+    scenario 'blank raining with disabilities and other needs' do
+      given_i_am_authenticated(user: user_with_no_course_enrichments)
+      when_i_visit_the_publish_course_preview_page
+      and_i_click_enter_details_about_training_with_disabilities_and_other_needs
+      then_i_should_be_on_about_your_organisation_page
+    end
+
     scenario 'blank course summary' do
       given_i_am_authenticated(user: user_with_no_course_enrichments)
       when_i_visit_the_publish_course_preview_page
@@ -348,6 +355,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     )
   end
 
+  def and_i_click_enter_details_about_training_with_disabilities_and_other_needs
+    click_link 'Enter details about training with disabilities and other needs'
+  end
+
   def and_i_click_enter_course_summary
     click_link 'Enter course summary'
   end
@@ -404,6 +415,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   def and_i_see_the_new_course_text
     expect(page).to have_text('great course')
+  end
+
+  def then_i_should_be_on_about_your_organisation_page
+    expect(page).to have_text('About your organisation')
   end
 
   def then_i_should_be_back_on_the_preview_page

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -31,7 +31,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       and_i_click_enter_details_about_training_with_disabilities_and_other_needs
       and_i_submit_a_valid_about_your_organisation
       then_i_should_be_back_on_the_preview_page
-      and_i_should_see_the_updated_content
+      then_i_should_see_the_updated_content
     end
 
     scenario 'blank course summary' do
@@ -381,7 +381,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     click_link 'Enter degree requirements'
   end
 
-  def and_i_should_see_the_updated_content
+  def then_i_should_see_the_updated_content
     expect(page).to have_content('test training with disabilities')
   end
 


### PR DESCRIPTION
### Context

To give providers a clearer view on which information they provide and which is generated by the service, we’re updating the course preview page to show missing information before a course is published.

### Changes proposed in this pull request

Within the “Training with disabilities and other needs” section, we need to create a component which will render information about the course provider’s Training with disabilities and other needs field.

### Guidance to review

https://publish-courses-prototype.herokuapp.com/sign-in

### Checklist

✅ Make sure all information from the Trello card is in here
✅ Attach to Trello card
✅ Rebased main
✅ Cleaned commit history
✅ Tested by running locally
n/a Inform data insights team due to database changes
