### PR TITLE
[xxx] Update wording based on prototype for training partners

### DIFF
--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -12,7 +12,7 @@ module NavigationBarHelper
       { name: t('navigation_bar.courses'), url: publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year) },
       { name: t('navigation_bar.schools'), url: publish_provider_recruitment_cycle_schools_path(provider.provider_code, provider.recruitment_cycle_year) },
       { name: t('navigation_bar.users'), url: publish_provider_users_path(provider_code: provider.provider_code), additional_url: request_access_publish_provider_path(provider.provider_code) },
-      *([name: t('navigation_bar.accredited_bodies'), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.accredited_body?),
+      *([name: t('navigation_bar.training_partners'), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.accredited_body?),
       { name: t('navigation_bar.organisation_details'), url: details_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year) }
     ]
   end

--- a/app/views/publish/training_providers/courses/index.html.erb
+++ b/app/views/publish/training_providers/courses/index.html.erb
@@ -2,7 +2,7 @@
 <%= content_for :before_content, render_breadcrumbs(:training_provider_courses) %>
 
 <h1 class="govuk-heading-l">
-  <span class="govuk-caption-l">Accredited body</span>
+  <span class="govuk-caption-l">Training partner</span>
   <%= @training_provider.provider_name %>
 </h1>
 

--- a/app/views/publish/training_providers/index.html.erb
+++ b/app/views/publish/training_providers/index.html.erb
@@ -1,8 +1,8 @@
-<% content_for :page_title, "Accredited bodies" %>
+<% content_for :page_title, "Training partners" %>
 <%= content_for :before_content, render_breadcrumbs(:training_providers) %>
 
   <h1 class="govuk-heading-l">
-    Accredited bodies
+    Training partners
   </h1>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,7 @@ en:
     courses: "Courses"
     schools: "Schools"
     users: "Users"
-    accredited_bodies: "Accredited bodies"
+    training_partners: "Training partners"
     organisation_details: "Organisation details"
   edit_options:
     entry_requirements:

--- a/spec/features/publish/primary_nav_spec.rb
+++ b/spec/features/publish/primary_nav_spec.rb
@@ -10,8 +10,7 @@ feature 'Primary nav', { can_edit_current_and_next_cycles: false } do
     and_i_should_see_the_schools_link
     and_i_should_see_the_courses_link
     and_i_should_see_the_users_link
-    and_i_should_not_see_the_accredited_bodies_link
-    and_i_should_not_see_the_accredited_bodies_link
+    and_i_should_not_see_the_training_partners_link
   end
 
   scenario 'view page as Susy - user with accredited body' do
@@ -21,7 +20,7 @@ feature 'Primary nav', { can_edit_current_and_next_cycles: false } do
     and_i_should_see_the_schools_link
     and_i_should_see_the_courses_link
     and_i_should_see_the_users_link
-    and_i_should_see_the_accredited_bodies_link
+    and_i_should_see_the_training_partners_link
   end
 
   def and_i_am_authenticated_as_a_provider_user
@@ -52,15 +51,15 @@ feature 'Primary nav', { can_edit_current_and_next_cycles: false } do
     expect(publish_primary_nav_page).to have_users
   end
 
-  def and_i_should_see_the_accredited_bodies_link
-    expect(publish_primary_nav_page).to have_accredited_bodies
+  def and_i_should_see_the_training_partners_link
+    expect(publish_primary_nav_page).to have_training_partners
   end
 
-  def and_i_should_not_see_the_accredited_bodies_link
-    expect(publish_primary_nav_page).not_to have_accredited_bodies
+  def and_i_should_not_see_the_training_partners_link
+    expect(publish_primary_nav_page).not_to have_training_partners
   end
 
-  def and_i_should_not_see_the_accredited_bodies_link
+  def and_i_should_not_see_the_training_partners_link
     expect(page).not_to have_text 'Change organisation'
   end
 end

--- a/spec/support/page_objects/publish/primary_nav.rb
+++ b/spec/support/page_objects/publish/primary_nav.rb
@@ -7,7 +7,7 @@ module PageObjects
       element :schools, :link, 'Schools'
       element :courses, :link, 'Courses'
       element :users, :link, 'Users'
-      element :accredited_bodies, :link, 'Accredited bodies'
+      element :training_partners, :link, 'Training partners'
     end
   end
 end


### PR DESCRIPTION
### Context

For APs, we need to update the wording in the nav bar to view their **training partners**.

<img width="1059" alt="Screenshot 2023-04-13 at 13 44 02" src="https://user-images.githubusercontent.com/616080/231762136-7929a2be-3037-4a2e-a1d5-9ec6b4cee452.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
