### PR TITLE
Add guidance pages to the how to use this service page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,6 +9,7 @@ class PagesController < ApplicationController
     add_an_organisation
     add_and_remove_users
     change_an_accredited_provider_relationship
+    roll_over_courses_to_a_new_recruitment_cycle
     how_to_use_this_service
     course_summary_examples
     writing_descriptions_for_publish_teacher_training_courses
@@ -27,6 +28,7 @@ class PagesController < ApplicationController
   def add_an_organisation; end
   def add_and_remove_users; end
   def change_an_accredited_provider_relationship; end
+  def roll_over_courses_to_a_new_recruitment_cycle; end
   def how_to_use_this_service; end
   def course_summary_examples; end
   def writing_descriptions_for_publish_teacher_training_courses; end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,8 +11,8 @@ class PagesController < ApplicationController
     change_an_accredited_provider_relationship
     roll_over_courses_to_a_new_recruitment_cycle
     help_writing_course_descriptions
-    how_to_use_this_service
     course_summary_examples
+    how_to_use_this_service
   ]
 
   def accessibility; end
@@ -30,6 +30,6 @@ class PagesController < ApplicationController
   def change_an_accredited_provider_relationship; end
   def roll_over_courses_to_a_new_recruitment_cycle; end
   def help_writing_course_descriptions; end
-  def how_to_use_this_service; end
   def course_summary_examples; end
+  def how_to_use_this_service; end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,9 +10,9 @@ class PagesController < ApplicationController
     add_and_remove_users
     change_an_accredited_provider_relationship
     roll_over_courses_to_a_new_recruitment_cycle
+    help_writing_course_descriptions
     how_to_use_this_service
     course_summary_examples
-    writing_descriptions_for_publish_teacher_training_courses
   ]
 
   def accessibility; end
@@ -29,7 +29,7 @@ class PagesController < ApplicationController
   def add_and_remove_users; end
   def change_an_accredited_provider_relationship; end
   def roll_over_courses_to_a_new_recruitment_cycle; end
+  def help_writing_course_descriptions; end
   def how_to_use_this_service; end
   def course_summary_examples; end
-  def writing_descriptions_for_publish_teacher_training_courses; end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,7 @@ class PagesController < ApplicationController
     privacy
     terms
     add_an_organisation
+    add_and_remove_users
     how_to_use_this_service
     course_summary_examples
     writing_descriptions_for_publish_teacher_training_courses
@@ -23,6 +24,7 @@ class PagesController < ApplicationController
   def terms; end
 
   def add_an_organisation; end
+  def add_and_remove_users; end
   def how_to_use_this_service; end
   def course_summary_examples; end
   def writing_descriptions_for_publish_teacher_training_courses; end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,6 +8,7 @@ class PagesController < ApplicationController
     terms
     add_an_organisation
     add_and_remove_users
+    change_an_accredited_provider_relationship
     how_to_use_this_service
     course_summary_examples
     writing_descriptions_for_publish_teacher_training_courses
@@ -25,6 +26,7 @@ class PagesController < ApplicationController
 
   def add_an_organisation; end
   def add_and_remove_users; end
+  def change_an_accredited_provider_relationship; end
   def how_to_use_this_service; end
   def course_summary_examples; end
   def writing_descriptions_for_publish_teacher_training_courses; end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,6 +6,7 @@ class PagesController < ApplicationController
     performance_dashboard
     privacy
     terms
+    add_an_organisation
     how_to_use_this_service
     course_summary_examples
     writing_descriptions_for_publish_teacher_training_courses
@@ -21,6 +22,7 @@ class PagesController < ApplicationController
 
   def terms; end
 
+  def add_an_organisation; end
   def how_to_use_this_service; end
   def course_summary_examples; end
   def writing_descriptions_for_publish_teacher_training_courses; end

--- a/app/views/pages/add_an_organisation.html.erb
+++ b/app/views/pages/add_an_organisation.html.erb
@@ -1,7 +1,18 @@
 <% content_for :page_title, "Add an organisation" %>
 
+<%= content_for(:before_content) do %>
+
+  <%= govuk_breadcrumbs(breadcrumbs: [
+      govuk_breadcrumb_link_to("Home", root_path),
+      govuk_breadcrumb_link_to("How to use this service", how_to_use_this_service_path),
+      govuk_breadcrumb_link_to("Add an organisation", add_an_organisation_path)
+    ]) %>
+
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
     <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">How to use this service</span>
         Add an organisation

--- a/app/views/pages/add_an_organisation.html.erb
+++ b/app/views/pages/add_an_organisation.html.erb
@@ -1,0 +1,50 @@
+<% content_for :page_title, "Add an organisation" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">How to use this service</span>
+        Add an organisation
+    </h1>
+
+    <p class="govuk-body">
+        If you are a new initial teacher training (ITT) provider, we can set up your organisation on Publish teacher
+        training courses (Publish). You’ll then be able to publish courses to
+        <%= govuk_link_to("Find postgraduate teacher training courses (Find)", t("links.find_website_url")) %>.
+    </p>
+
+    <p class="govuk-body">To do this:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        contact us at
+          <a class="govuk-link" href="mailto:<%= Settings.support_email %>">
+          <%= Settings.support_email %></a> and we will send you a link to a form to complete
+      </li>
+      <li>enter the details and submit the form</li>
+      <li>look out for a welcome email from us that will be sent to the first user you specified on the form</li>
+    </ul>
+
+    <p class="govuk-body">
+      Once your organisation has been added, you’ll be able to add other users and create courses.
+    </p>
+
+    <p class="govuk-body">
+      We'll also add your organisation to
+      <a class="govuk-link" href="<%= Settings.apply_base_url %>/provider">
+        Manage teacher training applications (Manage)
+      </a>
+      at the same time.
+    </p>
+
+    <p class="govuk-body">
+      If you need to remove an organisation from Publish or Manage, contact us at
+      <a class="govuk-link" href="mailto:<%= Settings.support_email %>"><%= Settings.support_email %></a>.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to("Read more information about providing initial teacher training",
+                      t("links.initial_teacher_training_guidance")) %>.
+    </p>
+  </div>
+</div>

--- a/app/views/pages/add_and_remove_users.html.erb
+++ b/app/views/pages/add_and_remove_users.html.erb
@@ -1,0 +1,50 @@
+<% content_for :page_title, "Add and remove users " %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">How to use this service</span>
+        Add and remove users
+    </h1>
+
+    <p class="govuk-body">
+       Once an <%= govuk_link_to("organisation has been added to Publish", add_an_organisation_path) %>, any user can add other users. This means that more people can have access to the organisation’s courses to view and manage them.
+    </p>
+
+    <p class="govuk-body">
+      It might also be useful if you’re a training partner and want to give your accredited provider access.
+    </p>
+
+    <p class="govuk-body">
+      To add a new user, they must already have a <%= govuk_link_to("DfE Sign-in account", t("links.dfe_signin")) %>. You can then add the user to your organisation.
+    </p>
+
+    <h2 class="govuk-heading-m">Adding a user</h2>
+
+    <p class="govuk-body">To add a user:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>go to the ‘Users’ tab</li>
+      <li>select ‘Add user’</li>
+      <li>enter the user’s details - the email address must match the user’s DfE Sign-in account</li>
+    </ul>
+
+    <p class="govuk-body">
+      The user will be sent an email to let them know they’ve been added to the organisation.
+    </p>
+
+    <h2 class="govuk-heading-m">Removing a user</h2>
+
+    <p class="govuk-body">To remove a user:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>go to the ‘Users’ tab</li>
+      <li>select the name of the user you want to remove from the alphabetically ordered list</li>
+      <li>select ‘Remove user’</li>
+    </ul>
+
+    <p class="govuk-body">
+      The user will be sent an email to let them know they’ve been removed from the organisation.
+    </p>
+  </div>
+</div>

--- a/app/views/pages/add_and_remove_users.html.erb
+++ b/app/views/pages/add_and_remove_users.html.erb
@@ -1,7 +1,18 @@
-<% content_for :page_title, "Add and remove users " %>
+<% content_for :page_title, "Add and remove users" %>
+
+<%= content_for(:before_content) do %>
+
+  <%= govuk_breadcrumbs(breadcrumbs: [
+      govuk_breadcrumb_link_to("Home", root_path),
+      govuk_breadcrumb_link_to("How to use this service", how_to_use_this_service_path),
+      govuk_breadcrumb_link_to("Add and remove users", add_and_remove_users_path)
+    ]) %>
+
+  <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
     <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">How to use this service</span>
         Add and remove users

--- a/app/views/pages/change_an_accredited_provider_relationship.html.erb
+++ b/app/views/pages/change_an_accredited_provider_relationship.html.erb
@@ -48,7 +48,7 @@
     <h2 class="govuk-heading-m">Changing your accredited provider</h2>
 
     <p class="govuk-body">
-        If the organisation you were working with is no longer an accredited provider, you’ll need to select a different provider before publishing any new courses. You’ll be prompted to do this when <%= govuk_link_to("publishing rolled over courses", root_path) %>.
+        If the organisation you were working with is no longer an accredited provider, you’ll need to select a different provider before publishing any new courses. You’ll be prompted to do this when <%= govuk_link_to("publishing rolled over courses", roll_over_courses_to_a_new_recruitment_cycle_path) %>.
     </p>
 
     <p class="govuk-body">

--- a/app/views/pages/change_an_accredited_provider_relationship.html.erb
+++ b/app/views/pages/change_an_accredited_provider_relationship.html.erb
@@ -42,7 +42,7 @@
     </p>
 
     <p class="govuk-body">
-      If you want to give people at the accredited provider organisation access to your courses, you can <%= govuk_link_to("Add them as a user", add_and_remove_users_path) %>.
+      If you want to give people at the accredited provider organisation access to your courses, you can <%= govuk_link_to("add them as a user", add_and_remove_users_path) %>.
     </p>
 
     <h2 class="govuk-heading-m">Changing your accredited provider</h2>

--- a/app/views/pages/change_an_accredited_provider_relationship.html.erb
+++ b/app/views/pages/change_an_accredited_provider_relationship.html.erb
@@ -1,0 +1,53 @@
+<% content_for :page_title, "Change an accredited provider relationship" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">How to use this service</span>
+        Change an accredited provider relationship
+    </h1>
+
+    <p class="govuk-body">
+      If you’re a training partner (non-accredited provider), we need to know who you work with to run your courses.
+    </p>
+
+    <h2 class="govuk-heading-m">Adding and deleting an accredited provider</h2>
+
+    <p class="govuk-body">
+        You need to select which accredited provider ratifies a course before you can publish it. You’ll also need to write a short description about the accredited provider. It’s a good idea to ask the accredited provider to check this content and approve it.
+    </p>
+
+    <p class="govuk-body">Go to the ‘Accredited providers’ tab in your account to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>add new accredited providers</li>
+      <li>update descriptions</li>
+      <li>remove accredited providers from your account (unpublished courses only)</li>
+    </ul>
+
+    <p class="govuk-body">
+      You’ll be asked to specify which accredited provider you’re working with for each course before you can publish it.
+    </p>
+
+    <p class="govuk-body">
+      If you want to give people at the accredited provider organisation access to your courses, you can <%= govuk_link_to("Add them as a user", add_and_remove_users_path) %>.
+    </p>
+
+    <h2 class="govuk-heading-m">Changing your accredited provider</h2>
+
+    <p class="govuk-body">
+        If the organisation you were working with is no longer an accredited provider, you’ll need to select a different provider before publishing any new courses. You’ll be prompted to do this when <%= govuk_link_to("publishing rolled over courses", root_path) %>.
+    </p>
+
+    <p class="govuk-body">
+      If you need to change an accredited provider for a course that has already been published on Find, contact us at
+        <a class="govuk-link" href="mailto:<%= Settings.support_email %>">
+        <%= Settings.support_email %></a>.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to("Read more about forming partnerships to provide initial teacher training (ITT)", t("links.initial_teacher_training_forming_partnerships")) %>.
+    </p>
+
+  </div>
+</div>

--- a/app/views/pages/change_an_accredited_provider_relationship.html.erb
+++ b/app/views/pages/change_an_accredited_provider_relationship.html.erb
@@ -1,7 +1,19 @@
 <% content_for :page_title, "Change an accredited provider relationship" %>
 
+<%= content_for(:before_content) do %>
+
+  <%= govuk_breadcrumbs(breadcrumbs: [
+      govuk_breadcrumb_link_to("Home", root_path),
+      govuk_breadcrumb_link_to("How to use this service", how_to_use_this_service_path),
+      govuk_breadcrumb_link_to("Change an accredited provider relationship",
+                              change_an_accredited_provider_relationship_path)
+    ]) %>
+
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
     <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">How to use this service</span>
         Change an accredited provider relationship

--- a/app/views/pages/course_summary_examples.erb
+++ b/app/views/pages/course_summary_examples.erb
@@ -18,7 +18,7 @@
     </ul>
 
     <p class="govuk-body">
-      Based on our research into how candidates read course descriptions and our <%= govuk_link_to "guidance on writing descriptions for Publish", writing_descriptions_for_publish_teacher_training_courses_path %>, here are some ‘Course summary’ examples.
+      Based on our research into how candidates read course descriptions and our <%= govuk_link_to "guidance on writing descriptions for Publish", help_writing_course_descriptions_path %>, here are some ‘Course summary’ examples.
     </p>
     <p class="govuk-body">
       The examples are based on real descriptions that are currently live on Find postgraduate teacher training.
@@ -97,11 +97,12 @@
     <h3 class="govuk-heading-s">Primary (264 words)</h3>
 
     <p class="govuk-body">
-      The Becoming a Teacher (BAT) primary course leads to Qualified Teacher Status (QTS) and a Post-Graduate Certificate in Education (PGCE). You will train across the 5-11 age range, where you will learn from experienced practitioners, particularly your personal mentor.
-    </p>
+      The Becoming a Teacher (BAT) primary course leads to Qualified Teacher Status (QTS) and a 
+      Post-Graduate Certificate in Education (PGCE). You will train across the 5-11 age range, where you will learn 
+      from experienced practitioners, particularly your personal mentor.
 
-    <p class="govuk-body">
-      You’ll spend four days per week on placement in our partnership schools. In addition, you will join the rest of your cohort one day per week for training with the BAT SCITT.
+      You’ll spend four days per week on placement in our partnership schools. In addition, you will join the rest of 
+      your cohort one day per week for training with the BAT SCITT.
     </p>
 
     <p class="govuk-body">Our curriculum has six areas:</p>

--- a/app/views/pages/course_summary_examples.erb
+++ b/app/views/pages/course_summary_examples.erb
@@ -23,7 +23,7 @@
         <%= govuk_link_to "Example 1 - secondary art and design course provided by a university", "#example-1" %>
       </li>
       <li>
-        <%= govuk_link_to "Example 2 - primary course provided by a SCITT", "#example-2" %>
+        <%= govuk_link_to "Example 2 - primary course provided by a school centred initial teacher training", "#example-2" %>
       </li>
     </ul>
 
@@ -94,7 +94,7 @@
     </p>
 
     <h2 id="example-2" class="govuk-heading-m">
-      Example 2 - primary course provided by a SCITT
+      Example 2 - primary course provided by a school centred initial teacher training
     </h2>
 
     <p class="govuk-body">

--- a/app/views/pages/course_summary_examples.erb
+++ b/app/views/pages/course_summary_examples.erb
@@ -28,7 +28,7 @@
     </ul>
 
     <p class="govuk-body">
-      Based on our research into how candidates read course descriptions and our <%= govuk_link_to "guidance on writing descriptions for Publish", help_writing_course_descriptions_path %>, here are some ‘Course summary’ examples.
+      Based on our research into how candidates read course descriptions and our <%= govuk_link_to "guidance on writing descriptions for Publish teacher training courses", help_writing_course_descriptions_path %>, here are some ‘Course summary’ examples.
     </p>
     <p class="govuk-body">
       The examples are based on real descriptions that are currently live on Find postgraduate teacher training.

--- a/app/views/pages/course_summary_examples.erb
+++ b/app/views/pages/course_summary_examples.erb
@@ -1,5 +1,15 @@
 <% content_for :page_title, "Course summary examples" %>
 
+<%= content_for(:before_content) do %>
+
+  <%= govuk_breadcrumbs(breadcrumbs: [
+      govuk_breadcrumb_link_to("Home", root_path),
+      govuk_breadcrumb_link_to("How to use this service", how_to_use_this_service_path),
+      govuk_breadcrumb_link_to("Course summary examples", course_summary_examples_path),
+    ]) %>
+
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">

--- a/app/views/pages/help_writing_course_descriptions.html.erb
+++ b/app/views/pages/help_writing_course_descriptions.html.erb
@@ -36,7 +36,7 @@
         <li>avoiding jargon and using common words</li>
         <li>using as few words as possible</li>
     </ul>
-    <p class="govuk-body">On Find postgraduate teacher training, the 'Course summary' is the first description candidates will read. See our <%= govuk_link_to "examples of course summaries", root_path %> that follow best practice for online content.</p>
+    <p class="govuk-body">On Find postgraduate teacher training, the 'Course summary' is the first description candidates will read. See our <%= govuk_link_to "examples of course summaries", course_summary_examples_path %> that follow best practice for online content.</p>
     <p class="govuk-body">Read more about <%= govuk_link_to "how to write for the web", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk" %>.</p>
   </div>
 </div>

--- a/app/views/pages/help_writing_course_descriptions.html.erb
+++ b/app/views/pages/help_writing_course_descriptions.html.erb
@@ -1,5 +1,15 @@
 <% content_for :page_title, "Help writing course descriptions" %>
 
+<%= content_for(:before_content) do %>
+
+  <%= govuk_breadcrumbs(breadcrumbs: [
+      govuk_breadcrumb_link_to("Home", root_path),
+      govuk_breadcrumb_link_to("How to use this service", how_to_use_this_service_path),
+      govuk_breadcrumb_link_to("Help writing course descriptions", help_writing_course_descriptions_path)
+    ]) %>
+
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">

--- a/app/views/pages/help_writing_course_descriptions.html.erb
+++ b/app/views/pages/help_writing_course_descriptions.html.erb
@@ -1,10 +1,10 @@
-<% content_for :page_title, "Writing descriptions for Publish teacher training courses" %>
+<% content_for :page_title, "Help writing course descriptions" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l">How to use this service</span>
-      Writing descriptions for Publish teacher training courses
+      Help writing course descriptions
     </h1>
     <p class="govuk-body">There are many things a candidate needs to consider before applying for a teacher training course. For example, how will they finance their training? Are they able to travel to the school or university? Do they have the right qualifications?</p>
 
@@ -26,7 +26,7 @@
         <li>avoiding jargon and using common words</li>
         <li>using as few words as possible</li>
     </ul>
-    <p class="govuk-body">On Find postgraduate teacher training, the 'Course summary' is the first description candidates will read. See our <%= govuk_link_to "examples of course summaries",  course_summary_examples_path %> that follow best practice for online content.</p>
+    <p class="govuk-body">On Find postgraduate teacher training, the 'Course summary' is the first description candidates will read. See our <%= govuk_link_to "examples of course summaries", root_path %> that follow best practice for online content.</p>
     <p class="govuk-body">Read more about <%= govuk_link_to "how to write for the web", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk" %>.</p>
   </div>
 </div>

--- a/app/views/pages/how_to_use_this_service.html.erb
+++ b/app/views/pages/how_to_use_this_service.html.erb
@@ -14,7 +14,7 @@
 
     <ul class="govuk-list govuk-list--spaced">
       <li><%= govuk_link_to "Add an organisation", add_an_organisation_path %></li>
-      <li><%= govuk_link_to "Add and remove users", root_path %></li>
+      <li><%= govuk_link_to "Add and remove users", add_and_remove_users_path %></li>
       <li><%= govuk_link_to "Change an accredited provider relationship", root_path %></li>
     </ul>
 

--- a/app/views/pages/how_to_use_this_service.html.erb
+++ b/app/views/pages/how_to_use_this_service.html.erb
@@ -13,7 +13,7 @@
     <h2 class="govuk-heading-m">Your account</h2>
 
     <ul class="govuk-list govuk-list--spaced">
-      <li><%= govuk_link_to "Add an organisation", root_path %></li>
+      <li><%= govuk_link_to "Add an organisation", add_an_organisation_path %></li>
       <li><%= govuk_link_to "Add and remove users", root_path %></li>
       <li><%= govuk_link_to "Change an accredited provider relationship", root_path %></li>
     </ul>

--- a/app/views/pages/how_to_use_this_service.html.erb
+++ b/app/views/pages/how_to_use_this_service.html.erb
@@ -24,7 +24,7 @@
       <li><%= govuk_link_to "Roll over courses to a new recruitment cycle", roll_over_courses_to_a_new_recruitment_cycle_path %></li>
       <li>
         <%= govuk_link_to "Help writing course descriptions",
-                          writing_descriptions_for_publish_teacher_training_courses_path %>
+                          help_writing_course_descriptions_path %>
       </li>
       <li><%= govuk_link_to "Course summary examples", course_summary_examples_path %></li>
     </ul>

--- a/app/views/pages/how_to_use_this_service.html.erb
+++ b/app/views/pages/how_to_use_this_service.html.erb
@@ -2,14 +2,31 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">How to use this service</h1>
+    <h1 class="govuk-heading-l">How to use this service</h1>
+
+    <p class="govuk-body">
+      Publish teacher training courses (Publish) gives initial teacher training providers a way to create courses and publish them to Find postgraduate teacher training (Find).
+    </p>
+
+    <p class="govuk-body">Candidates can then use Find to search for courses and apply to them.</p>
+
+    <h2 class="govuk-heading-m">Your account</h2>
+
     <ul class="govuk-list govuk-list--spaced">
+      <li><%= govuk_link_to "Add an organisation", root_path %></li>
+      <li><%= govuk_link_to "Add and remove users", root_path %></li>
+      <li><%= govuk_link_to "Change an accredited provider relationship", root_path %></li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Managing courses</h2>
+
+    <ul class="govuk-list govuk-list--spaced">
+      <li><%= govuk_link_to "Roll over courses to a new recruitment cycle", root_path %></li>
       <li>
-        <%= govuk_link_to "Course summary examples", course_summary_examples_path %>
+        <%= govuk_link_to "Help writing course descriptions",
+                          writing_descriptions_for_publish_teacher_training_courses_path %>
       </li>
-      <li>
-        <%= govuk_link_to "Writing descriptions for Publish teacher training courses", writing_descriptions_for_publish_teacher_training_courses_path %>
-      </li>
+      <li><%= govuk_link_to "Course summary examples", course_summary_examples_path %></li>
     </ul>
   </div>
 </div>

--- a/app/views/pages/how_to_use_this_service.html.erb
+++ b/app/views/pages/how_to_use_this_service.html.erb
@@ -1,5 +1,14 @@
 <% content_for :page_title, "How to use this service" %>
 
+ <%= content_for(:before_content) do %>
+
+  <%= govuk_breadcrumbs(breadcrumbs: [
+      govuk_breadcrumb_link_to("Home", root_path),
+      govuk_breadcrumb_link_to("How to use this service", how_to_use_this_service_path)
+    ]) %>
+
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">How to use this service</h1>

--- a/app/views/pages/how_to_use_this_service.html.erb
+++ b/app/views/pages/how_to_use_this_service.html.erb
@@ -21,7 +21,7 @@
     <h2 class="govuk-heading-m">Managing courses</h2>
 
     <ul class="govuk-list govuk-list--spaced">
-      <li><%= govuk_link_to "Roll over courses to a new recruitment cycle", root_path %></li>
+      <li><%= govuk_link_to "Roll over courses to a new recruitment cycle", roll_over_courses_to_a_new_recruitment_cycle_path %></li>
       <li>
         <%= govuk_link_to "Help writing course descriptions",
                           writing_descriptions_for_publish_teacher_training_courses_path %>

--- a/app/views/pages/how_to_use_this_service.html.erb
+++ b/app/views/pages/how_to_use_this_service.html.erb
@@ -15,7 +15,7 @@
     <ul class="govuk-list govuk-list--spaced">
       <li><%= govuk_link_to "Add an organisation", add_an_organisation_path %></li>
       <li><%= govuk_link_to "Add and remove users", add_and_remove_users_path %></li>
-      <li><%= govuk_link_to "Change an accredited provider relationship", root_path %></li>
+      <li><%= govuk_link_to "Change an accredited provider relationship", change_an_accredited_provider_relationship_path %></li>
     </ul>
 
     <h2 class="govuk-heading-m">Managing courses</h2>

--- a/app/views/pages/roll_over_courses_to_a_new_recruitment_cycle.html.erb
+++ b/app/views/pages/roll_over_courses_to_a_new_recruitment_cycle.html.erb
@@ -1,4 +1,14 @@
-<% content_for :page_title, "Roll over courses to a new recruitment cycle " %>
+<% content_for :page_title, "Roll over courses to a new recruitment cycle" %>
+
+<%= content_for(:before_content) do %>
+
+  <%= govuk_breadcrumbs(breadcrumbs: [
+      govuk_breadcrumb_link_to("Home", root_path),
+      govuk_breadcrumb_link_to("How to use this service", how_to_use_this_service_path),
+      govuk_breadcrumb_link_to("Roll over courses to a new recruitment cycle", roll_over_courses_to_a_new_recruitment_cycle_path)
+    ]) %>
+
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -6,7 +16,6 @@
        <span class="govuk-caption-l">How to use this service</span>
         Roll over courses to a new recruitment cycle
     </h1>
-
     <p class="govuk-body">
       At the beginning of July each year, we copy your courses over from one recruitment cycle to the next.
       This means you can update courses from the previous cycle, rather than having to create new ones.

--- a/app/views/pages/roll_over_courses_to_a_new_recruitment_cycle.html.erb
+++ b/app/views/pages/roll_over_courses_to_a_new_recruitment_cycle.html.erb
@@ -42,7 +42,7 @@
     </p>
 
     <p class="govuk-body">
-      There’ll be an additional section in Publish called ‘Recruitment cycles’ where you can manage rolled over courses
+      There’ll be an additional section in Publish teacher training courses called ‘Recruitment cycles’ where you can manage rolled over courses
       for the new cycle. You’ll be able to:
     </p>
 

--- a/app/views/pages/roll_over_courses_to_a_new_recruitment_cycle.html.erb
+++ b/app/views/pages/roll_over_courses_to_a_new_recruitment_cycle.html.erb
@@ -1,0 +1,51 @@
+<% content_for :page_title, "Roll over courses to a new recruitment cycle " %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+       <span class="govuk-caption-l">How to use this service</span>
+        Roll over courses to a new recruitment cycle
+    </h1>
+
+    <p class="govuk-body">
+      At the beginning of July each year, we copy your courses over from one recruitment cycle to the next.
+      This means you can update courses from the previous cycle, rather than having to create new ones.
+    </p>
+
+    <h3 class="govuk-heading-m">Recruitment cycle</h2>
+
+    <p class="govuk-body">
+      The year in which candidates are applying for courses and recruited, for example,
+      ‘Recruitment cycle 2023 to 2024’.
+   </p>
+
+    <h3 class="govuk-heading-m">Academic year</h2>
+
+     <p class="govuk-body">
+        The year that follows the recruitment cycle in which candidates start their training, for example,
+        ‘Academic year 2024 to 2025’.
+    </p>
+
+    <h2 class="govuk-heading-m">Publishing rolled over courses</h2>
+
+    <p class="govuk-body">
+      We’ll email you at the beginning of July to let you know when we’ve rolled over your courses.
+    </p>
+
+    <p class="govuk-body">
+      There’ll be an additional section in Publish called ‘Recruitment cycles’ where you can manage rolled over courses
+      for the new cycle. You’ll be able to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>add courses</li>
+      <li>edit courses</li>
+      <li>remove courses</li>
+    </ul>
+
+    <p class="govuk-body">
+      When your course is ready, you can publish it. It will not go live on
+      <%= govuk_link_to("Find postgraduate teacher training courses (Find)", t("links.find_website_url")) %>
+      straight away. Instead, the course will be ‘Scheduled’ until Find opens at the beginning of October.
+      Candidates will then be able to search for your course.
+    </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -682,6 +682,7 @@ en:
     user_removed: "User removed"
   links:
     find_website_url: "https://www.find-postgraduate-teacher-training.service.gov.uk/"
+    dfe_signin: https://services.signin.education.gov.uk
     get_information_schools: "https://www.get-information-schools.service.gov.uk/"
     ability_net: "https://mcmw.abilitynet.org.uk/"
     equality_advisory_service: "https://www.equalityadvisoryservice.com/"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -691,6 +691,7 @@ en:
     ico_complaint: "https://ico.org.uk/make-a-complaint/"
     eu_settlement_scheme: "https://www.gov.uk/settled-status-eu-citizens-families"
     initial_teacher_training_guidance: https://www.gov.uk/education/initial-teacher-training-itt
+    initial_teacher_training_forming_partnerships: https://www.gov.uk/government/publications/initial-teacher-training-itt-forming-partnerships
     urn_html: |-
       Find URNs on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk" target="_blank">Get information about schools (opens in new tab)</a>
   edit_options:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -681,6 +681,7 @@ en:
     visa_changes: "Visa sponsorship updated"
     user_removed: "User removed"
   links:
+    find_website_url: "https://www.find-postgraduate-teacher-training.service.gov.uk/"
     get_information_schools: "https://www.get-information-schools.service.gov.uk/"
     ability_net: "https://mcmw.abilitynet.org.uk/"
     equality_advisory_service: "https://www.equalityadvisoryservice.com/"
@@ -688,6 +689,7 @@ en:
     gov_design_accessibility: "https://design-system.service.gov.uk/accessibility/"
     ico_complaint: "https://ico.org.uk/make-a-complaint/"
     eu_settlement_scheme: "https://www.gov.uk/settled-status-eu-citizens-families"
+    initial_teacher_training_guidance: https://www.gov.uk/education/initial-teacher-training-itt
     urn_html: |-
       Find URNs on <a class="govuk-link" href="https://www.get-information-schools.service.gov.uk" target="_blank">Get information about schools (opens in new tab)</a>
   edit_options:

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -24,6 +24,7 @@ get '/privacy', to: 'pages#privacy', as: :privacy
 get '/terms-conditions', to: 'pages#terms', as: :terms
 get '/how-to-use-this-service', to: 'pages#how_to_use_this_service'
 get '/how-to-use-this-service/add-an-organisation', to: 'pages#add_an_organisation', as: :add_an_organisation
+get '/how-to-use-this-service/add-and-remove-users', to: 'pages#add_and_remove_users', as: :add_and_remove_users
 get '/how-to-use-this-service/course-summary-examples', to: 'pages#course_summary_examples', as: :course_summary_examples
 get '/how-to-use-this-service/writing-descriptions-for-publish-teacher-training-courses', to: 'pages#writing_descriptions_for_publish_teacher_training_courses', as: :writing_descriptions_for_publish_teacher_training_courses
 

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -26,6 +26,7 @@ get '/how-to-use-this-service', to: 'pages#how_to_use_this_service'
 get '/how-to-use-this-service/add-an-organisation', to: 'pages#add_an_organisation', as: :add_an_organisation
 get '/how-to-use-this-service/add-and-remove-users', to: 'pages#add_and_remove_users', as: :add_and_remove_users
 get '/how-to-use-this-service/change-an-accredited-provider-relationship', to: 'pages#change_an_accredited_provider_relationship', as: :change_an_accredited_provider_relationship
+get '/how-to-use-this-service/roll-over-courses-to-a-new-recruitment-cycle', to: 'pages#roll_over_courses_to_a_new_recruitment_cycle', as: :roll_over_courses_to_a_new_recruitment_cycle
 get '/how-to-use-this-service/course-summary-examples', to: 'pages#course_summary_examples', as: :course_summary_examples
 get '/how-to-use-this-service/writing-descriptions-for-publish-teacher-training-courses', to: 'pages#writing_descriptions_for_publish_teacher_training_courses', as: :writing_descriptions_for_publish_teacher_training_courses
 

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -23,12 +23,15 @@ get '/performance-dashboard', to: 'pages#performance_dashboard', as: :performanc
 get '/privacy', to: 'pages#privacy', as: :privacy
 get '/terms-conditions', to: 'pages#terms', as: :terms
 get '/how-to-use-this-service', to: 'pages#how_to_use_this_service'
-get '/how-to-use-this-service/add-an-organisation', to: 'pages#add_an_organisation', as: :add_an_organisation
-get '/how-to-use-this-service/add-and-remove-users', to: 'pages#add_and_remove_users', as: :add_and_remove_users
-get '/how-to-use-this-service/change-an-accredited-provider-relationship', to: 'pages#change_an_accredited_provider_relationship', as: :change_an_accredited_provider_relationship
-get '/how-to-use-this-service/roll-over-courses-to-a-new-recruitment-cycle', to: 'pages#roll_over_courses_to_a_new_recruitment_cycle', as: :roll_over_courses_to_a_new_recruitment_cycle
-get '/how-to-use-this-service/help-writing-course-descriptions', to: 'pages#help_writing_course_descriptions', as: :help_writing_course_descriptions
-get '/how-to-use-this-service/course-summary-examples', to: 'pages#course_summary_examples', as: :course_summary_examples
+
+scope path: 'how-to-use-this-service' do
+  get '/add-an-organisation', to: 'pages#add_an_organisation', as: :add_an_organisation
+  get '/add-and-remove-users', to: 'pages#add_and_remove_users', as: :add_and_remove_users
+  get '/change-an-accredited-provider-relationship', to: 'pages#change_an_accredited_provider_relationship', as: :change_an_accredited_provider_relationship
+  get '/roll-over-courses-to-a-new-recruitment-cycle', to: 'pages#roll_over_courses_to_a_new_recruitment_cycle', as: :roll_over_courses_to_a_new_recruitment_cycle
+  get '/help-writing-course-descriptions', to: 'pages#help_writing_course_descriptions', as: :help_writing_course_descriptions
+  get '/course-summary-examples', to: 'pages#course_summary_examples', as: :course_summary_examples
+end
 
 resource :cookie_preferences, only: %i[show update], path: '/cookies', as: :cookies
 

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -25,6 +25,7 @@ get '/terms-conditions', to: 'pages#terms', as: :terms
 get '/how-to-use-this-service', to: 'pages#how_to_use_this_service'
 get '/how-to-use-this-service/add-an-organisation', to: 'pages#add_an_organisation', as: :add_an_organisation
 get '/how-to-use-this-service/add-and-remove-users', to: 'pages#add_and_remove_users', as: :add_and_remove_users
+get '/how-to-use-this-service/change-an-accredited-provider-relationship', to: 'pages#change_an_accredited_provider_relationship', as: :change_an_accredited_provider_relationship
 get '/how-to-use-this-service/course-summary-examples', to: 'pages#course_summary_examples', as: :course_summary_examples
 get '/how-to-use-this-service/writing-descriptions-for-publish-teacher-training-courses', to: 'pages#writing_descriptions_for_publish_teacher_training_courses', as: :writing_descriptions_for_publish_teacher_training_courses
 

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -27,8 +27,8 @@ get '/how-to-use-this-service/add-an-organisation', to: 'pages#add_an_organisati
 get '/how-to-use-this-service/add-and-remove-users', to: 'pages#add_and_remove_users', as: :add_and_remove_users
 get '/how-to-use-this-service/change-an-accredited-provider-relationship', to: 'pages#change_an_accredited_provider_relationship', as: :change_an_accredited_provider_relationship
 get '/how-to-use-this-service/roll-over-courses-to-a-new-recruitment-cycle', to: 'pages#roll_over_courses_to_a_new_recruitment_cycle', as: :roll_over_courses_to_a_new_recruitment_cycle
+get '/how-to-use-this-service/help-writing-course-descriptions', to: 'pages#help_writing_course_descriptions', as: :help_writing_course_descriptions
 get '/how-to-use-this-service/course-summary-examples', to: 'pages#course_summary_examples', as: :course_summary_examples
-get '/how-to-use-this-service/writing-descriptions-for-publish-teacher-training-courses', to: 'pages#writing_descriptions_for_publish_teacher_training_courses', as: :writing_descriptions_for_publish_teacher_training_courses
 
 resource :cookie_preferences, only: %i[show update], path: '/cookies', as: :cookies
 

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -23,6 +23,7 @@ get '/performance-dashboard', to: 'pages#performance_dashboard', as: :performanc
 get '/privacy', to: 'pages#privacy', as: :privacy
 get '/terms-conditions', to: 'pages#terms', as: :terms
 get '/how-to-use-this-service', to: 'pages#how_to_use_this_service'
+get '/how-to-use-this-service/add-an-organisation', to: 'pages#add_an_organisation', as: :add_an_organisation
 get '/how-to-use-this-service/course-summary-examples', to: 'pages#course_summary_examples', as: :course_summary_examples
 get '/how-to-use-this-service/writing-descriptions-for-publish-teacher-training-courses', to: 'pages#writing_descriptions_for_publish_teacher_training_courses', as: :writing_descriptions_for_publish_teacher_training_courses
 

--- a/spec/features/publish/how_to_use_this_service_spec.rb
+++ b/spec/features/publish/how_to_use_this_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Guidance pages', :with_publish_constraint do
+  scenario 'Navigating through how to use this service pages' do
+    given_i_visit_the_root_path
+    when_i_click_how_to_use_this_service
+    then_i_should_see_the_h1_how_to_use_this_service
+
+    given_i_click_add_an_organisation
+    then_i_should_see_the_h1_add_an_organisation
+
+    given_i_click_on_the_how_to_use_this_service_breadcrumb
+    when_i_click_on_add_and_remove_users
+    then_i_should_see_the_h1_add_and_remove_users
+
+    given_i_click_on_the_how_to_use_this_service_breadcrumb
+    when_i_click_on_change_an_accredited_provider_relationship
+    then_i_should_see_the_h1_change_an_accredited_provider_relationship
+
+    given_i_click_on_the_how_to_use_this_service_breadcrumb
+    when_i_click_on_roll_over_courses_to_a_new_recruitment_cycle
+    then_i_should_see_the_h1_roll_over_courses_to_a_new_recruitment_cycle
+
+    given_i_click_on_the_how_to_use_this_service_breadcrumb
+    when_click_on_help_writing_course_descriptions
+    then_i_should_see_the_h1_help_writing_course_descriptions
+
+    given_i_click_on_the_how_to_use_this_service_breadcrumb
+    when_i_click_on_course_summary_examples
+    then_i_should_see_the_h1_course_summary_examples
+  end
+
+  def given_i_visit_the_root_path
+    visit root_path
+  end
+
+  def when_i_click_how_to_use_this_service
+    click_link 'How to use this service'
+  end
+
+  def then_i_should_see_the_h1_how_to_use_this_service
+    expect(page).to have_selector('h1', text: 'How to use this service')
+  end
+
+  def given_i_click_add_an_organisation
+    click_link 'Add an organisation'
+  end
+
+  def then_i_should_see_the_h1_add_an_organisation
+    expect(page).to have_selector('h1', text: 'Add an organisation')
+  end
+
+  def given_i_click_on_the_how_to_use_this_service_breadcrumb
+    click_link 'How to use this service', match: :first
+  end
+
+  def when_i_click_on_add_and_remove_users
+    click_link 'Add and remove users'
+  end
+
+  def then_i_should_see_the_h1_add_and_remove_users
+    expect(page).to have_selector('h1', text: 'Add and remove users')
+  end
+
+  def when_i_click_on_change_an_accredited_provider_relationship
+    click_link 'Change an accredited provider relationship'
+  end
+
+  def then_i_should_see_the_h1_change_an_accredited_provider_relationship
+    expect(page).to have_selector('h1', text: 'Change an accredited provider relationship')
+  end
+
+  def when_i_click_on_roll_over_courses_to_a_new_recruitment_cycle
+    click_link 'Roll over courses to a new recruitment cycle'
+  end
+
+  def then_i_should_see_the_h1_roll_over_courses_to_a_new_recruitment_cycle
+    expect(page).to have_selector('h1', text: 'Roll over courses to a new recruitment cycle')
+  end
+
+  def when_click_on_help_writing_course_descriptions
+    click_link 'Help writing course descriptions'
+  end
+
+  def then_i_should_see_the_h1_help_writing_course_descriptions
+    expect(page).to have_selector('h1', text: 'Help writing course descriptions')
+  end
+
+  def when_i_click_on_course_summary_examples
+    click_link 'Course summary examples'
+  end
+
+  def then_i_should_see_the_h1_course_summary_examples
+    expect(page).to have_selector('h1', text: 'Course summary examples')
+  end
+end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -24,21 +24,6 @@ feature 'View pages', :with_publish_constraint do
     expect(page).to have_selector('h1', text: 'Publish teacher training courses privacy notice')
   end
 
-  scenario 'Navigate to /how-to-use-this-service' do
-    visit '/how-to-use-this-service'
-    expect(page).to have_selector('h1', text: 'How to use this service')
-  end
-
-  scenario 'Navigate to /how-to-use-this-service/course-summary-examples' do
-    visit '/how-to-use-this-service/course-summary-examples'
-    expect(page).to have_selector('h1', text: ' Course summary examples')
-  end
-
-  scenario 'Navigate to /how-to-use-this-service/writing-descriptions-for-publish-teacher-training-courses' do
-    visit '/how-to-use-this-service/writing-descriptions-for-publish-teacher-training-courses'
-    expect(page).to have_selector('h1', text: ' Writing descriptions for Publish teacher training courses')
-  end
-
   scenario 'Navigate to /accessibility' do
     visit '/accessibility'
     expect(page).to have_selector('h1', text: 'Accessibility statement for Publish teacher training courses')


### PR DESCRIPTION
### Context

Updating the structure and content of our guidance pages. The link for this sits in the footer of Publish.

### Changes proposed in this pull request

- Reorganise guidance pages within a single index page
- Link to each guidance page from the index page
- Add breadcrumbs on guidance pages
- Skip authentication for these pages
- Add feature test to test H1's and breadcrumbs


### Screenshot

<img width="919" alt="image" src="https://user-images.githubusercontent.com/50492247/231835793-8dc0c4d2-ce7e-4cc2-8915-3ccfa10a604d.png">


### Guidance to review

- Click on [this link](https://publish-teacher-training-pr-3491.london.cloudapps.digital/how-to-use-this-service)
- Click on `How to use this service` in the footer in Publish
- Try out all the links
- Check if the content is correct
- Check that the breadcrumbs work as expected
- Check that new URL's are what we want them to be

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
