### PR TITLE
236 find pub dns fixes

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/find_pentest.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_pentest.tfvars.json
@@ -1,11 +1,10 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
       "domains": [
-        "pen"
+        "pen2"
       ],
       "environment_short": "pt",
       "environment_tag": "pt",

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
@@ -1,11 +1,10 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
       "domains": [
-        "www2"
+        "www3"
       ],
       "environment_short": "pd",
       "environment_tag": "pd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_qa.tfvars.json
@@ -1,11 +1,10 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
       "domains": [
-        "qa2"
+        "qa3"
       ],
       "environment_short": "qa",
       "environment_tag": "qa",

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
@@ -1,11 +1,10 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
       "domains": [
-        "sandbox2"
+        "sandbox3"
       ],
       "environment_short": "sbx",
       "environment_tag": "sbx",

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
@@ -1,11 +1,10 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
       "domains": [
-        "staging2"
+        "staging3"
       ],
       "environment_short": "stg",
       "environment_tag": "stg",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_pentest.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_pentest.tfvars.json
@@ -1,5 +1,4 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
@@ -1,5 +1,4 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_qa.tfvars.json
@@ -1,5 +1,4 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
@@ -1,5 +1,4 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
@@ -1,5 +1,4 @@
 {
-  "multiple_hosted_zones": true,
   "hosted_zone": {
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",

--- a/terraform/custom_domains/infrastructure/workspace_variables/find.tfvars.json
+++ b/terraform/custom_domains/infrastructure/workspace_variables/find.tfvars.json
@@ -1,6 +1,6 @@
 {
   "hosted_zone": {
-    "publish-teacher-training-courses.service.gov.uk": {
+    "find-postgraduate-teacher-training.service.gov.uk": {
       "caa_records": {},
       "txt_records": {
         "_dmarc": {


### PR DESCRIPTION
### Context
Remove the `multiple_hosted_zones` variable as the find and publish domains don't have education.gov.uk equivalents.

### Changes proposed in this pull request

1. Remove the `multiple_hosted_zones` variable from the find and publish DNS zone configuration
2. Fix the find DNS zone name

### Guidance to review
Check for typos

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
