### PR TITLE
Tighten UKPRN validation

### DIFF
--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -108,7 +108,7 @@ module Publish
     end
 
     def redirect_to_contact_page_with_ukprn_error
-      flash[:error] = { id: 'publish-provider-contact-form-ukprn-field', message: 'Please enter a UKPRN before continuing' }
+      flash[:error] = { id: 'publish-provider-contact-form-ukprn-field', message: 'Enter a UK provider reference number (UKPRN)' }
 
       redirect_to contact_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
     end

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -108,7 +108,7 @@ module Publish
     end
 
     def redirect_to_contact_page_with_ukprn_error
-      flash[:error] = { id: 'publish-provider-contact-form-ukprn-field', message: 'Enter a UK provider reference number (UKPRN)' }
+      flash[:error] = { id: 'publish-provider-contact-form-ukprn-field', message: 'Please enter a UKPRN before continuing' }
 
       redirect_to contact_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
     end

--- a/app/forms/publish/provider_contact_form.rb
+++ b/app/forms/publish/provider_contact_form.rb
@@ -14,7 +14,7 @@ module Publish
     validates :email, email_address: { message: 'Enter an email address in the correct format, like name@example.com' }
     validates :telephone, phone: { message: 'Enter a valid telephone number' }
     validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: 'URN must be 5 or 6 numbers' }, if: :lead_school?
-    validates :ukprn, ukprn_format: { allow_blank: true }
+    validates :ukprn, ukprn_format: { allow_blank: false }
 
     private
 

--- a/app/forms/publish/provider_contact_form.rb
+++ b/app/forms/publish/provider_contact_form.rb
@@ -14,7 +14,7 @@ module Publish
     validates :email, email_address: { message: 'Enter an email address in the correct format, like name@example.com' }
     validates :telephone, phone: { message: 'Enter a valid telephone number' }
     validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: 'URN must be 5 or 6 numbers' }, if: :lead_school?
-    validates :ukprn, reference_number_format: { allow_blank: false, minimum: 8, maximum: 8, message: 'UKPRN must be 8 numbers' }
+    validates :ukprn, ukprn_format: true
 
     private
 

--- a/app/forms/publish/provider_contact_form.rb
+++ b/app/forms/publish/provider_contact_form.rb
@@ -14,7 +14,7 @@ module Publish
     validates :email, email_address: { message: 'Enter an email address in the correct format, like name@example.com' }
     validates :telephone, phone: { message: 'Enter a valid telephone number' }
     validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: 'URN must be 5 or 6 numbers' }, if: :lead_school?
-    validates :ukprn, ukprn_format: true
+    validates :ukprn, ukprn_format: { allow_blank: true }
 
     private
 

--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -34,8 +34,8 @@ module Support
     validates :accredited_provider, presence: true
     validate :validate_accredited_provider_id
 
-    validates :ukprn, presence: true, reference_number_format: { allow_blank: true, minimum: 8, maximum: 8, message: :invalid }
-
+    validates :ukprn, ukprn_format: true
+    
     validates :provider_type, presence: true
     validate :provider_type_school_is_an_invalid_accredited_provider
 

--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -34,7 +34,7 @@ module Support
     validates :accredited_provider, presence: true
     validate :validate_accredited_provider_id
 
-    validates :ukprn, ukprn_format: true
+    validates :ukprn, ukprn_format: { allow_blank: true }
     
     validates :provider_type, presence: true
     validate :provider_type_school_is_an_invalid_accredited_provider

--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -35,7 +35,7 @@ module Support
     validate :validate_accredited_provider_id
 
     validates :ukprn, ukprn_format: { allow_blank: true }
-    
+
     validates :provider_type, presence: true
     validate :provider_type_school_is_an_invalid_accredited_provider
 

--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -34,7 +34,7 @@ module Support
     validates :accredited_provider, presence: true
     validate :validate_accredited_provider_id
 
-    validates :ukprn, ukprn_format: { allow_blank: true }
+    validates :ukprn, ukprn_format: { allow_blank: false }
 
     validates :provider_type, presence: true
     validate :provider_type_school_is_an_invalid_accredited_provider

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -147,7 +147,7 @@ class Provider < ApplicationRecord
 
   validates :telephone, phone: { message: 'Enter a valid telephone number' }, if: :telephone_changed?
 
-  validates :ukprn, ukprn_format: { allow_blank: true }
+  validates :ukprn, ukprn_format: { allow_blank: false }, on: :update
 
   validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: 'Provider URN must be 5 or 6 numbers' }, if: :lead_school?
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -147,15 +147,9 @@ class Provider < ApplicationRecord
 
   validates :telephone, phone: { message: 'Enter a valid telephone number' }, if: :telephone_changed?
 
-  # TODO: Remove this validation once the 2021 recruitment cycle is over
   validates :ukprn, reference_number_format: { allow_blank: true, minimum: 8, maximum: 8, message: 'UKPRN must be 8 numbers' }
 
-  validates :ukprn, reference_number_format: { allow_blank: false, minimum: 8, maximum: 8, message: 'UKPRN must be 8 numbers' }, if: -> { recruitment_cycle.after_2021? }, on: :update
-
-  # TODO: Remove this validation once the 2021 recruitment cycle is over
   validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: 'Provider URN must be 5 or 6 numbers' }, if: :lead_school?
-
-  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: 'Provider URN must be 5 or 6 numbers' }, if: -> { lead_school? && recruitment_cycle.after_2021? }, on: :update
 
   validates :train_with_us, presence: true, on: :update, if: :train_with_us_changed?
   validates :train_with_disability, presence: true, on: :update, if: :train_with_disability_changed?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -147,7 +147,7 @@ class Provider < ApplicationRecord
 
   validates :telephone, phone: { message: 'Enter a valid telephone number' }, if: :telephone_changed?
 
-  validates :ukprn, ukprn_format: true
+  validates :ukprn, ukprn_format: { allow_blank: true }
 
   validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: 'Provider URN must be 5 or 6 numbers' }, if: :lead_school?
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -147,7 +147,7 @@ class Provider < ApplicationRecord
 
   validates :telephone, phone: { message: 'Enter a valid telephone number' }, if: :telephone_changed?
 
-  validates :ukprn, reference_number_format: { allow_blank: true, minimum: 8, maximum: 8, message: 'UKPRN must be 8 numbers' }
+  validates :ukprn, ukprn_format: true
 
   validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: 'Provider URN must be 5 or 6 numbers' }, if: :lead_school?
 

--- a/app/validators/ukprn_format_validator.rb
+++ b/app/validators/ukprn_format_validator.rb
@@ -6,10 +6,8 @@ class UkprnFormatValidator < ActiveModel::EachValidator
 
     if value.blank?
       record.errors.add(attribute, :blank)
-    elsif value[0] != '1'
-      record.errors.add(attribute, :start_with_one)
-    elsif !value.match?(/\A\d{8}\Z/)
-      record.errors.add(attribute, :contains_eight_numbers)
+    elsif value[0] != '1' || !value.match?(/\A\d{8}\Z/)
+      record.errors.add(attribute, :contains_eight_numbers_starting_with_one)
     end
   end
 end

--- a/app/validators/ukprn_format_validator.rb
+++ b/app/validators/ukprn_format_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class UkprnFormatValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if options[:allow_blank] && value.blank?
+
+    if value.blank?
+      record.errors.add(attribute, :blank)
+    elsif value[0] != '1'
+      record.errors.add(attribute, :start_with_one)
+    elsif !value.match?(/\A\d{8}\Z/)
+      record.errors.add(attribute, :contains_eight_numbers)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -445,8 +445,7 @@ en:
             train_with_disability:
               blank: "^Enter details about training with a disability"
             ukprn:
-              start_with_one: "UKPRN must start with 1"
-              contains_eight_numbers: "UKPRN must contain 8 numbers"
+              contains_eight_numbers_starting_with_one: Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678
         organisation:
           attributes:
             name:
@@ -540,8 +539,8 @@ en:
               invalid: "Enter a valid provider code"
               taken: "Provider code already taken"
             ukprn:
-              blank: "Enter a UK provider reference number (UKPRN)"
-              invalid: "Enter a valid UK provider reference number (UKPRN)"
+              blank: Enter a UK provider reference number (UKPRN)
+              contains_eight_numbers_starting_with_one: Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678
             accredited_provider:
               blank: "Select if the organisation is an accredited provider"
             provider_type:
@@ -662,6 +661,10 @@ en:
             environment:
               blank: Enter the environment to proceed
               invalid_environment: "That's not %{environment}"
+        publish/provider_contact_form:
+          attributes:
+            ukprn:
+              contains_eight_numbers_starting_with_one: Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -445,6 +445,7 @@ en:
             train_with_disability:
               blank: "^Enter details about training with a disability"
             ukprn:
+              blank: Enter a UK provider reference number (UKPRN)
               contains_eight_numbers_starting_with_one: Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678
         organisation:
           attributes:
@@ -664,6 +665,7 @@ en:
         publish/provider_contact_form:
           attributes:
             ukprn:
+              blank: Enter a UK provider reference number (UKPRN)
               contains_eight_numbers_starting_with_one: Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678
   errors:
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,6 +444,9 @@ en:
               blank: "^Enter details about training with you"
             train_with_disability:
               blank: "^Enter details about training with a disability"
+            ukprn:
+              start_with_one: "UKPRN must start with 1"
+              contains_eight_numbers: "UKPRN must contain 8 numbers"
         organisation:
           attributes:
             name:

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     website { Faker::Internet.url }
     provider_type { :lead_school }
     urn { Faker::Number.number(digits: [5, 6].sample) }
-    ukprn { Faker::Number.within(range: 10000000..19999999) }
+    ukprn { Faker::Number.within(range: 10_000_000..19_999_999) }
     accrediting_provider { 'N' }
     region_code { 'london' }
     association :recruitment_cycle, strategy: :find_or_create

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     website { Faker::Internet.url }
     provider_type { :lead_school }
     urn { Faker::Number.number(digits: [5, 6].sample) }
-    ukprn { Faker::Number.number(digits: 8) }
+    ukprn { '12345678' }
     accrediting_provider { 'N' }
     region_code { 'london' }
     association :recruitment_cycle, strategy: :find_or_create

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     website { Faker::Internet.url }
     provider_type { :lead_school }
     urn { Faker::Number.number(digits: [5, 6].sample) }
-    ukprn { '12345678' }
+    ukprn { Faker::Number.within(range: 10000000..19999999) }
     accrediting_provider { 'N' }
     region_code { 'london' }
     association :recruitment_cycle, strategy: :find_or_create

--- a/spec/forms/support/provider_form_spec.rb
+++ b/spec/forms/support/provider_form_spec.rb
@@ -84,7 +84,7 @@ describe Support::ProviderForm, type: :model do
       it 'validates the ukprn' do
         expect(subject).not_to be_valid
 
-        expect(subject.errors[:ukprn]).to match_array('Enter a valid UK provider reference number (UKPRN)')
+        expect(subject.errors[:ukprn]).to match_array('Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678')
       end
     end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -75,22 +75,6 @@ describe Provider do
       end
     end
 
-    context 'when the provider updates their ukprn in the 2022 cycle' do
-      let(:provider) do
-        create(
-          :provider,
-          ukprn: '',
-          recruitment_cycle: create(:recruitment_cycle, year: '2022')
-        )
-      end
-
-      it 'validates the presence of a ukprn' do
-        # this means that rollover happens successfully; the record is created but it will be invalid on update, because of no ukprn
-        expect { provider }.to change(described_class, :count).by(1)
-        expect(provider).not_to be_valid
-      end
-    end
-
     describe 'provider code validations' do
       context 'when same recruitment cycle' do
         let(:provider) { create(:provider) }

--- a/spec/validators/ukprn_format_validator_spec.rb
+++ b/spec/validators/ukprn_format_validator_spec.rb
@@ -47,7 +47,7 @@ describe UkprnFormatValidator do
 
       it 'adds an error' do
         expect(model).to be_invalid
-        expect(model.errors.first.type.to_s == 'start_with_one').to be(true)
+        expect(model.errors.first.type.to_s == 'contains_eight_numbers_starting_with_one').to be(true)
       end
     end
 
@@ -56,7 +56,7 @@ describe UkprnFormatValidator do
 
       it 'adds an error' do
         expect(model).to be_invalid
-        expect(model.errors.first.type.to_s == 'contains_eight_numbers').to be(true)
+        expect(model.errors.first.type.to_s == 'contains_eight_numbers_starting_with_one').to be(true)
       end
     end
 
@@ -65,7 +65,7 @@ describe UkprnFormatValidator do
 
       it 'adds an error' do
         expect(model).to be_invalid
-        expect(model.errors.first.type.to_s == 'contains_eight_numbers').to be(true)
+        expect(model.errors.first.type.to_s == 'contains_eight_numbers_starting_with_one').to be(true)
       end
     end
 
@@ -74,7 +74,7 @@ describe UkprnFormatValidator do
 
       it 'adds an error' do
         expect(model).to be_invalid
-        expect(model.errors.first.type.to_s == 'contains_eight_numbers').to be(true)
+        expect(model.errors.first.type.to_s == 'contains_eight_numbers_starting_with_one').to be(true)
       end
     end
   end

--- a/spec/validators/ukprn_format_validator_spec.rb
+++ b/spec/validators/ukprn_format_validator_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class UkprnFormatValidatorTest
+  include ActiveModel::Validations
+
+  attr_accessor :ukprn
+
+  validates :ukprn, ukprn_format: { allow_blank: true }
+end
+
+describe UkprnFormatValidator do
+  let(:ukprn) { '12345678' }
+
+  let(:model) do
+    model = UkprnFormatValidatorTest.new
+    model.ukprn = ukprn
+    model
+  end
+
+  describe 'UKPRN validation' do
+    context 'with a valid reference number' do
+      it 'does not add an error' do
+        expect(model).to be_valid
+      end
+    end
+
+    context 'without a value' do
+      let(:ukprn) { nil }
+
+      it 'does not add an error' do
+        expect(model).to be_valid
+      end
+    end
+
+    context 'with an empty string' do
+      let(:ukprn) { '' }
+
+      it 'does not add an error' do
+        expect(model).to be_valid
+      end
+    end
+
+    context 'with a number not beginning with a 1' do
+      let(:ukprn) { '22345678' }
+
+      it 'adds an error' do
+        expect(model).to be_invalid
+        expect(model.errors.first.type.to_s == 'start_with_one').to be(true)
+      end
+    end
+
+    context 'with a short UKPRN beginning with 1' do
+      let(:ukprn) { '1234' }
+
+      it 'adds an error' do
+        expect(model).to be_invalid
+        expect(model.errors.first.type.to_s == 'contains_eight_numbers').to be(true)
+      end
+    end
+
+    context 'with a long UKPRN beginning with 1' do
+      let(:ukprn) { '123456789' }
+
+      it 'adds an error' do
+        expect(model).to be_invalid
+        expect(model.errors.first.type.to_s == 'contains_eight_numbers').to be(true)
+      end
+    end
+
+    context 'with a UKPRN begining with 1 then 7 letters' do
+      let(:ukprn) { '1AAAAAA' }
+
+      it 'adds an error' do
+        expect(model).to be_invalid
+        expect(model.errors.first.type.to_s == 'contains_eight_numbers').to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We are tightening the validation for UKPRN, as these should begin with a 1. There are several instances in the database where they do not. Tightened validation should try to help prevent these from getting into the database in future. 

### Changes proposed in this pull request

- Tighten validation on UKPRN, preventing any value that does not begin with a 1 and is not 8 integers from being saved. 
- Change the content on the validation message

### Guidance to review

- Attempt to change the UKPRN to a non valid entry in the various places that we ask the question. 
 
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
