### PR TITLE
Remove incorrectly displayed hint text

### DIFF
--- a/app/views/publish/courses/accredited_body/_provider_search_field.html.erb
+++ b/app/views/publish/courses/accredited_body/_provider_search_field.html.erb
@@ -2,9 +2,7 @@
   <%= form.label :accredited_body,
     for: "course_accredited_body",
     class: "govuk-label" do %>
-    Name of accredited body
-    <%= render "publish/shared/error_messages", error_keys: [:accredited_body] %>
-    <span class="govuk-hint">Enter the name or provider code</span>
+      Enter the provider name or code <%= render "publish/shared/error_messages", error_keys: [:accredited_body] %>
   <% end %>
   <%= form.text_field :accredited_body,
     autocomplete: "off",


### PR DESCRIPTION
### Context

Hint text is incorrectly displayed on the accredited provider (AP) page. 

This is a quick temp fix as adding another AP will be removed from here soon.

### Screenshot (before)

<img width="837" alt="image" src="https://user-images.githubusercontent.com/50492247/233107479-7f598511-705b-413a-8cd8-04a9abe71c55.png">


### Screenshot (after)

<img width="908" alt="image" src="https://user-images.githubusercontent.com/50492247/233107607-37f56dde-0854-4c64-aea2-2cd05719d947.png">

### Guidance to review

:shipit: 