### PR TITLE
Increase staging webapp memory

### DIFF
--- a/terraform/workspace_variables/staging.tfvars.json
+++ b/terraform/workspace_variables/staging.tfvars.json
@@ -3,7 +3,7 @@
     "paas_app_environment": "staging",
     "paas_web_app_host_name": "staging",
     "paas_web_app_instances": 2,
-    "paas_web_app_memory": 1024,
+    "paas_web_app_memory": 2048,
     "paas_worker_app_instances": 1,
     "paas_worker_app_memory": 512,
     "paas_postgres_service_plan": "small-11",


### PR DESCRIPTION
### Context
It alerts frequently as memory usage is frequently 60-80%

### Changes proposed in this pull request
Double staging webapp memory

### Guidance to review
Check memory usage on https://grafana-bat.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=bat-staging&var-Applications=publish-teacher-training-staging

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
