### PR TITLE
Tighten telephone validation

### DIFF
--- a/app/forms/publish/provider_contact_form.rb
+++ b/app/forms/publish/provider_contact_form.rb
@@ -12,7 +12,7 @@ module Publish
     delegate :recruitment_cycle_year, :provider_code, :provider_name, :lead_school?, to: :provider
 
     validates :email, email_address: { message: 'Enter an email address in the correct format, like name@example.com' }
-    validates :telephone, phone: { message: 'Enter a valid telephone number' }
+    validates :telephone, phone: true
     validates :website, presence: true, url: { message: 'Enter a website address in the correct format, like https://www.example.com' }
     validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: 'URN must be 5 or 6 numbers' }, if: :lead_school?
     validates :ukprn, ukprn_format: { allow_blank: false }

--- a/app/forms/support/provider_contact_form.rb
+++ b/app/forms/support/provider_contact_form.rb
@@ -16,7 +16,7 @@ module Support
     ].freeze
 
     validates :email, presence: true, email_address: true
-    validates :telephone, presence: true, phone: { message: :invalid_phone_number }
+    validates :telephone, phone: true
     validates :website, presence: true, url: true
     validates :address1, :town, presence: true
     validates :postcode, presence: true, postcode: true

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -145,7 +145,7 @@ class Provider < ApplicationRecord
 
   validates :provider_type, presence: true
 
-  validates :telephone, phone: { message: 'Enter a valid telephone number' }, if: :telephone_changed?
+  validates :telephone, phone: true, if: :telephone_changed?
 
   validates :ukprn, ukprn_format: { allow_blank: false }, on: :update
 

--- a/app/validators/phone_validator.rb
+++ b/app/validators/phone_validator.rb
@@ -1,15 +1,29 @@
 # frozen_string_literal: true
 
 class PhoneValidator < ActiveModel::EachValidator
-  PHONE_VALIDATION_ERROR_MESSAGE = '^Enter a valid telephone number'
-
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, message: options[:message] || PHONE_VALIDATION_ERROR_MESSAGE) if value.blank? || is_invalid_phone_number_format?(value)
+    if value.blank?
+      record.errors.add(attribute, :blank)
+    elsif invalid_phone_number_format?(value)
+      record.errors.add(attribute, :invalid)
+    elsif not_enough_digits?(value)
+      record.errors.add(attribute, :too_short)
+    elsif too_many_digits?(value)
+      record.errors.add(attribute, :too_long)
+    end
   end
 
   private
 
-  def is_invalid_phone_number_format?(value)
-    value.match?(/[^ext()+. 0-9]/)
+  def invalid_phone_number_format?(value)
+    value.match?(/[^ext\-()+.\s 0-9]/)
+  end
+
+  def not_enough_digits?(value)
+    value.gsub(/[^0-9]/, '').length < 8
+  end
+
+  def too_many_digits?(value)
+    value.gsub(/[^0-9]/, '').length > 15
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,10 @@ en:
             name:
               blank: "^Enter name"
             telephone:
-              blank: "^Enter a valid telephone number"
+              blank: Enter your telephone number
+              invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
+              too_long: Telephone number must contain 15 numbers or fewer
+              too_short: Telephone number must contain 8 numbers or more
         site:
           attributes:
             location_name:
@@ -442,7 +445,10 @@ en:
             website:
               blank: "^Enter website"
             telephone:
-              blank: "^Enter a valid telephone number"
+              blank: Enter your telephone number
+              invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
+              too_long: Telephone number must contain 15 numbers or fewer
+              too_short: Telephone number must contain 8 numbers or more
             address1:
               blank: "^Enter building or street"
             town:
@@ -555,8 +561,10 @@ en:
             email:
               blank: "Enter an email address"
             telephone:
-              blank: "Enter a telephone number"
-              invalid_phone_number: "Enter a real telephone number"
+              blank: Enter your telephone number
+              invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
+              too_long: Telephone number must contain 15 numbers or fewer
+              too_short: Telephone number must contain 8 numbers or more
             website:
               blank: "Enter a website address"
               url: "Enter a website address in the correct format, like https://www.example.com"
@@ -711,6 +719,11 @@ en:
               blank: "Enter a town or city"
             postcode:
               blank: "Enter a postcode"
+            telephone:
+              blank: Enter your telephone number
+              invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
+              too_long: Telephone number must contain 15 numbers or fewer
+              too_short: Telephone number must contain 8 numbers or more
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,7 @@ en:
             name:
               blank: "^Enter name"
             telephone:
-              blank: Enter your telephone number
+              blank: Enter a telephone number
               invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
               too_long: Telephone number must contain 15 numbers or fewer
               too_short: Telephone number must contain 8 numbers or more
@@ -445,7 +445,7 @@ en:
             website:
               blank: "^Enter website"
             telephone:
-              blank: Enter your telephone number
+              blank: Enter a telephone number
               invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
               too_long: Telephone number must contain 15 numbers or fewer
               too_short: Telephone number must contain 8 numbers or more
@@ -561,7 +561,7 @@ en:
             email:
               blank: "Enter an email address"
             telephone:
-              blank: Enter your telephone number
+              blank: Enter a telephone number
               invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
               too_long: Telephone number must contain 15 numbers or fewer
               too_short: Telephone number must contain 8 numbers or more
@@ -720,7 +720,7 @@ en:
             postcode:
               blank: "Enter a postcode"
             telephone:
-              blank: Enter your telephone number
+              blank: Enter a telephone number
               invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
               too_long: Telephone number must contain 15 numbers or fewer
               too_short: Telephone number must contain 8 numbers or more

--- a/spec/forms/publish/provider_contact_form_spec.rb
+++ b/spec/forms/publish/provider_contact_form_spec.rb
@@ -59,7 +59,7 @@ module Publish
         it 'validates the telephone' do
           expect(subject).not_to be_valid
 
-          expect(subject.errors[:telephone]).to match_array('Enter a valid telephone number')
+          expect(subject.errors[:telephone]).to match_array('Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
         end
       end
 

--- a/spec/forms/support/provider_contact_form_spec.rb
+++ b/spec/forms/support/provider_contact_form_spec.rb
@@ -13,7 +13,7 @@ module Support
 
     describe 'validations' do
       include_examples 'blank validation', :email, 'Enter an email address'
-      include_examples 'blank validation', :telephone, 'Enter your telephone number'
+      include_examples 'blank validation', :telephone, 'Enter a telephone number'
       include_examples 'blank validation', :website, 'Enter a website address'
       include_examples 'blank validation', :address1, 'Enter address line 1'
       include_examples 'blank validation', :town, 'Enter a town or city'
@@ -43,7 +43,7 @@ module Support
         it 'validates the telephone' do
           expect(subject).not_to be_valid
 
-          expect(subject.errors[:telephone]).to match_array('Enter your telephone number')
+          expect(subject.errors[:telephone]).to match_array('Enter a telephone number')
         end
       end
 

--- a/spec/forms/support/provider_contact_form_spec.rb
+++ b/spec/forms/support/provider_contact_form_spec.rb
@@ -13,7 +13,7 @@ module Support
 
     describe 'validations' do
       include_examples 'blank validation', :email, 'Enter an email address'
-      include_examples 'blank validation', :telephone, 'Enter a telephone number'
+      include_examples 'blank validation', :telephone, 'Enter your telephone number'
       include_examples 'blank validation', :website, 'Enter a website address'
       include_examples 'blank validation', :address1, 'Enter address line 1'
       include_examples 'blank validation', :town, 'Enter a town or city'
@@ -29,7 +29,49 @@ module Support
         it 'validates the telephone' do
           expect(subject).not_to be_valid
 
-          expect(subject.errors[:telephone]).to match_array('Enter a real telephone number')
+          expect(subject.errors[:telephone]).to match_array('Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+        end
+      end
+
+      context 'telephone set to nil' do
+        let(:params) do
+          {
+            telephone: nil
+          }
+        end
+
+        it 'validates the telephone' do
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:telephone]).to match_array('Enter your telephone number')
+        end
+      end
+
+      context 'telephone set to long number' do
+        let(:params) do
+          {
+            telephone: '123456791123456789'
+          }
+        end
+
+        it 'validates the telephone' do
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:telephone]).to match_array('Telephone number must contain 15 numbers or fewer')
+        end
+      end
+
+      context 'telephone set to short number' do
+        let(:params) do
+          {
+            telephone: '1234567'
+          }
+        end
+
+        it 'validates the telephone' do
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:telephone]).to match_array('Telephone number must contain 8 numbers or more')
         end
       end
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -42,7 +42,7 @@ describe Contact do
         contact.telephone = ''
         contact.valid?
 
-        expect(contact.errors[:telephone]).to include('^Enter a valid telephone number')
+        expect(contact.errors[:telephone]).to include('Enter your telephone number')
       end
 
       it 'Correctly validates valid phone numbers' do
@@ -53,7 +53,19 @@ describe Contact do
       it 'Correctly invalidates invalid phone numbers' do
         contact.telephone = '123foo456'
         expect(contact.valid?).to be false
-        expect(contact.errors[:telephone]).to include('^Enter a valid telephone number')
+        expect(contact.errors[:telephone]).to include('Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+      end
+
+      it 'Correctly invalidates short phone numbers' do
+        contact.telephone = '1234567'
+        expect(contact.valid?).to be false
+        expect(contact.errors[:telephone]).to include('Telephone number must contain 8 numbers or more')
+      end
+
+      it 'Correctly invalidates long phone numbers' do
+        contact.telephone = '123456791123456789'
+        expect(contact.valid?).to be false
+        expect(contact.errors[:telephone]).to include('Telephone number must contain 15 numbers or fewer')
       end
     end
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -42,7 +42,7 @@ describe Contact do
         contact.telephone = ''
         contact.valid?
 
-        expect(contact.errors[:telephone]).to include('Enter your telephone number')
+        expect(contact.errors[:telephone]).to include('Enter a telephone number')
       end
 
       it 'Correctly validates valid phone numbers' do

--- a/spec/models/provider/validation_spec.rb
+++ b/spec/models/provider/validation_spec.rb
@@ -44,7 +44,7 @@ describe Provider do
           provider.telephone = ''
           provider.valid? :update
 
-          expect(provider.errors[:telephone]).to include('Enter a valid telephone number')
+          expect(provider.errors[:telephone]).to include('Enter your telephone number')
         end
 
         it 'Correctly validates valid phone numbers' do
@@ -55,7 +55,19 @@ describe Provider do
         it 'Correctly invalidates invalid phone numbers' do
           provider.telephone = '123cat456'
           expect(provider.valid?(:update)).to be false
-          expect(provider.errors[:telephone]).to include('Enter a valid telephone number')
+          expect(provider.errors[:telephone]).to include('Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192')
+        end
+
+        it 'Correctly invalidates short phone numbers' do
+          provider.telephone = '1234567'
+          expect(provider.valid?(:update)).to be false
+          expect(provider.errors[:telephone]).to include('Telephone number must contain 8 numbers or more')
+        end
+
+        it 'Correctly invalidates long phone numbers' do
+          provider.telephone = '123456791123456789'
+          expect(provider.valid?(:update)).to be false
+          expect(provider.errors[:telephone]).to include('Telephone number must contain 15 numbers or fewer')
         end
 
         it 'Does not validate the telephone if it is not present' do

--- a/spec/models/provider/validation_spec.rb
+++ b/spec/models/provider/validation_spec.rb
@@ -44,7 +44,7 @@ describe Provider do
           provider.telephone = ''
           provider.valid? :update
 
-          expect(provider.errors[:telephone]).to include('Enter your telephone number')
+          expect(provider.errors[:telephone]).to include('Enter a telephone number')
         end
 
         it 'Correctly validates valid phone numbers' do

--- a/spec/validators/phone_validator_spec.rb
+++ b/spec/validators/phone_validator_spec.rb
@@ -15,37 +15,29 @@ describe PhoneValidator do
     PhoneValidatorTest.new
   end
 
-  describe 'With nil phone number address' do
+  context 'when nil' do
     before do
       model.phone_number = nil
       model.validate(:no_context)
     end
 
-    it 'Returns invalid' do
+    it 'returns invalid' do
       expect(model.valid?(:no_context)).to be false
-    end
-
-    it 'Returns the correct error message' do
-      expect(model.errors[:phone_number]).to include('^Enter a valid telephone number')
     end
   end
 
-  describe 'With empty phone number address supplied' do
+  context 'when empty' do
     before do
       model.phone_number = ''
       model.validate(:no_context)
     end
 
-    it 'Returns invalid' do
+    it 'returns invalid' do
       expect(model.valid?(:no_context)).to be false
-    end
-
-    it 'Returns the correct error message' do
-      expect(model.errors[:phone_number]).to include('^Enter a valid telephone number')
     end
   end
 
-  describe 'With an phone number address in an invalid format' do
+  context 'when invalid' do
     let(:invalid_telephone_numbers) do
       [
         '12 3 4 cat',
@@ -53,7 +45,7 @@ describe PhoneValidator do
       ]
     end
 
-    it 'Correctly invalidates invalid phone numbers' do
+    it 'returns invalid' do
       invalid_telephone_numbers.each do |number|
         model.phone_number = number
         expect(model.valid?(:no_context)).to(be(false), "Expected phone number #{number} to be invalid")
@@ -61,13 +53,15 @@ describe PhoneValidator do
     end
   end
 
-  describe 'With a valid phone number address' do
+  context 'when valid' do
     let(:valid_telephone_numbers) do
       [
         '+447123 123 123',
+        '+407123 123 123',
+        '+1 7123 123 123',
         '+447123123123',
         '07123123123',
-        '01234 123 123 ext123',
+        '01234 123 123 --()+ ',
         '01234 123 123 ext 123',
         '01234 123 123 x123',
         '(01234) 123123',
@@ -90,11 +84,33 @@ describe PhoneValidator do
       ]
     end
 
-    it 'Correctly validates valid phone numbers' do
+    it 'returns valid' do
       valid_telephone_numbers.each do |number|
         model.phone_number = number
         expect(model.valid?(:no_context)).to(be(true), "Expected phone number #{number} to be valid")
       end
+    end
+  end
+
+  context 'when over 15 numbers' do
+    before do
+      model.phone_number = '123456791123456789'
+      model.validate(:no_context)
+    end
+
+    it 'returns invalid' do
+      expect(model.valid?(:no_context)).to be false
+    end
+  end
+
+  context 'when 7 numbers or less' do
+    before do
+      model.phone_number = '1234567'
+      model.validate(:no_context)
+    end
+
+    it 'returns invalid' do
+      expect(model.valid?(:no_context)).to be false
     end
   end
 end


### PR DESCRIPTION
### Context

Tighten telephone validation and improve error messages. 

For consistency, we are bring our telephone validation pattern in line with Notify and Apply.

### Changes proposed in this pull request

- Prevent users submitting the form without entering a phone number
- Prevent users entering invalid phone numbers, e.g letters
- Prevent users entering numbers which contain 15 numbers or more
- Prevent users entering numbers which contain 8 numbers or less
- Add new custom content in the validation for the errors above.

### Guidance to review

**Examples of telephone numbers which are permitted** 

```
        '+447123 123 123',
        '+407123 123 123',
        '+1 7123 123 123',
        '+447123123123',
        '07123123123',
        '01234 123 123 --()+ ',
        '01234 123 123 ext 123',
        '01234 123 123 x123',
        '(01234) 123123',
        '(12345) 123123',
        '(+44) (0)1234 123456',
        '+44 (0) 123 4567 123',
        '123 1234 1234 ext 123',
        '12345 123456 ext 123',
        '12345 123456 ext. 123',
        '12345 123456 ext123',
        '01234123456 ext 123',
        '123 1234 1234 x123',
        '12345 123456 x123',
        '12345123456 x123',
        '(1234) 123 1234',
        '1234 123 1234 x123',
        '1234 123 1234 ext 1234',
        '1234 123 1234  ext 123',
        '+44(0)123 12 12345'
```


**Examples of telephone numbers which are not permitted**

```
   ''
   '12 3 4 cat',
   '12dog34'
   '1234567'
   '123456791123456789'
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
