### PR TITLE
[1257] add validations to form

### DIFF
--- a/app/forms/publish/provider_contact_form.rb
+++ b/app/forms/publish/provider_contact_form.rb
@@ -13,8 +13,11 @@ module Publish
 
     validates :email, email_address: { message: 'Enter an email address in the correct format, like name@example.com' }
     validates :telephone, phone: { message: 'Enter a valid telephone number' }
+    validates :website, presence: true, url: { message: 'Enter a website address in the correct format, like https://www.example.com' }
     validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: 'URN must be 5 or 6 numbers' }, if: :lead_school?
     validates :ukprn, ukprn_format: { allow_blank: false }
+    validates :address1, :town, presence: true
+    validates :postcode, presence: true, postcode: true
 
     private
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -703,6 +703,14 @@ en:
             ukprn:
               blank: Enter a UK provider reference number (UKPRN)
               contains_eight_numbers_starting_with_one: Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678
+            website:
+              blank: "Enter a website"
+            address1:
+              blank: "Enter address line 1"
+            town:
+              blank: "Enter a town or city"
+            postcode:
+              blank: "Enter a postcode"
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/spec/forms/publish/provider_contact_form_spec.rb
+++ b/spec/forms/publish/provider_contact_form_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+require_relative '../shared_examples/blank_validation'
+
+module Publish
+  describe ProviderContactForm, type: :model do
+    subject { described_class.new(provider, params:) }
+
+    let(:provider) { create(:provider) }
+    let(:params) { {} }
+
+    describe 'validations' do
+      it { is_expected.to allow_value('12345').for(:urn) }
+      it { is_expected.not_to allow_value('1234').for(:urn).with_message('URN must be 5 or 6 numbers') }
+
+      include_examples 'blank validation', :email, 'Enter an email address in the correct format, like name@example.com'
+      include_examples 'blank validation', :address1, 'Enter address line 1'
+      include_examples 'blank validation', :town, 'Enter a town or city'
+      include_examples 'blank validation', :postcode, 'Enter a postcode'
+      include_examples 'blank validation', :website, 'Enter a website'
+
+      context 'email set to invalid' do
+        let(:params) do
+          {
+            email: 'jo@example'
+          }
+        end
+
+        it 'validates the email' do
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:email]).to match_array('Enter an email address in the correct format, like name@example.com')
+        end
+      end
+
+      context 'postcode set to invalid' do
+        let(:params) do
+          {
+            postcode: 'tr1'
+          }
+        end
+
+        it 'validates the postcode' do
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:postcode]).to match_array('Postcode is not valid (for example, BN1 1AA)')
+        end
+      end
+
+      context 'telephone set to invalid' do
+        let(:params) do
+          {
+            telephone: 'a'
+          }
+        end
+
+        it 'validates the telephone' do
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:telephone]).to match_array('Enter a valid telephone number')
+        end
+      end
+
+      context 'website set to invalid' do
+        let(:params) do
+          {
+            website: 'www.example.com'
+          }
+        end
+
+        it 'validates the website' do
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:website]).to match_array('Enter a website address in the correct format, like https://www.example.com')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
The provider details address form was recently updated to support address line 3. It was discovered that the form did not contain any validation.
What needs to be done

Add validation to the address. The following are required:

    address line 1
    town or city
    postcode
    website

Done when

This is our definition of done

the address form contains validation for address line 1, town or city, website and postcode
postcode is a valid format

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
