### PR TITLE
[1254] Add guard to prevent rendering on Find

### DIFF
--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -2,14 +2,15 @@
 
 module CoursePreview
   class MissingInformationComponent < ViewComponent::Base
-    attr_accessor :information_type, :course
+    attr_accessor :information_type, :course, :is_preview
 
     delegate :course_code, :recruitment_cycle_year, :provider_code, :accrediting_provider, to: :course
 
-    def initialize(course:, information_type:)
+    def initialize(course:, information_type:, is_preview:)
       super
       @information_type = information_type
       @course = course
+      @is_preview = is_preview
     end
 
     def text
@@ -21,7 +22,7 @@ module CoursePreview
     end
 
     def render?
-      FeatureService.enabled?(:course_preview_missing_information)
+      FeatureService.enabled?(:course_preview_missing_information) && @is_preview
     end
 
     private

--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -2,7 +2,7 @@
 
 module CoursePreview
   class MissingInformationComponent < ViewComponent::Base
-    attr_accessor :information_type, :course, :is_preview
+    attr_reader :information_type, :course, :is_preview
 
     delegate :course_code, :recruitment_cycle_year, :provider_code, :accrediting_provider, to: :course
 
@@ -22,7 +22,7 @@ module CoursePreview
     end
 
     def render?
-      FeatureService.enabled?(:course_preview_missing_information) && @is_preview
+      FeatureService.enabled?(:course_preview_missing_information) && is_preview
     end
 
     private

--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -49,7 +49,7 @@
       <% end %>
 
     <% else %>
-      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :how_school_placements_work) %>
+      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :how_school_placements_work, is_preview: preview?(params)) %>
     <% end %>
   </div>
 </div>

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -5,6 +5,7 @@ module Find
     module AboutSchoolsComponent
       class View < ViewComponent::Base
         include PublishHelper
+        include PreviewHelper
 
         attr_reader :course
 

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -4,7 +4,7 @@
   <div data-qa="course__required_qualifications">
 
     <% if course.degree_grade.nil? && course.additional_degree_subject_requirements.nil? %>
-        <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :degree) %>
+        <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :degree, is_preview: preview?(params)) %>
     <% else %>
       <p class="govuk-body"><%= degree_grade_content(course) %></p>
 
@@ -36,7 +36,7 @@
     </p>
 
     <% if (course.accept_pending_gcse.nil? || course.accept_gcse_equivalency.nil?) %>
-      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :gcse) %>
+      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :gcse, is_preview: preview?(params)) %>
     <% else %>
 
       <p class="govuk-body">

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -4,6 +4,8 @@ module Find
   module Courses
     module EntryRequirementsComponent
       class View < ViewComponent::Base
+        include PreviewHelper
+
         attr_accessor :course
 
         SUBJECT_KNOWLEDGE_ENHANCEMENTS_SUBJECT_CODES = %w[C1 F1 11 DT Q3 G1 F3 V6 15 17 22 24].freeze

--- a/app/components/find/courses/fees_component/view.html.erb
+++ b/app/components/find/courses/fees_component/view.html.erb
@@ -36,6 +36,6 @@
       </div>
     <% end %>
   <% else %>
-    <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :fee_uk_eu) %>
+    <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :fee_uk_eu, is_preview: preview?(params)) %>
   <% end %>
 </div>

--- a/app/components/find/courses/fees_component/view.rb
+++ b/app/components/find/courses/fees_component/view.rb
@@ -5,6 +5,8 @@ module Find
     module FeesComponent
       class View < ViewComponent::Base
         include PublishHelper
+        include PreviewHelper
+
         attr_reader :course
 
         delegate :fee_uk_eu,

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PreviewHelper
+  def preview?(params)
+    params[:action] == 'preview' || params[:action].nil?
+  end
+end

--- a/app/views/find/courses/_about_course.html.erb
+++ b/app/views/find/courses/_about_course.html.erb
@@ -4,7 +4,7 @@
     <% if course.about_course.present? %>
       <%= markdown(course.about_course) %>
     <% else %>
-      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :about_course) %>
+      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :about_course, is_preview: preview?(params)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/find/courses/_about_the_provider.html.erb
+++ b/app/views/find/courses/_about_the_provider.html.erb
@@ -5,7 +5,7 @@
       <%= markdown(course.provider.train_with_us) %>
     </div>
     <% else %>
-      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :train_with_us) %>
+      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :train_with_us, is_preview: preview?(params)) %>
   <% end %>
 
   <% if course.accrediting_provider.present? %>
@@ -16,7 +16,7 @@
         <%= markdown(course.about_accrediting_provider) %>
       </div>
     <% else %>
-      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :about_accrediting_provider) %>
+      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :about_accrediting_provider, is_preview: preview?(params)) %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/find/courses/_train_with_disabilities.html.erb
+++ b/app/views/find/courses/_train_with_disabilities.html.erb
@@ -4,7 +4,7 @@
     <% if course.provider.train_with_disability.present? %>
       <%= markdown(course.provider.train_with_disability) %>
     <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
-      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :train_with_disability) %>
+      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :train_with_disability, is_preview: preview?(params)) %>
     <% end %>
   </div>
 </div>

--- a/spec/components/course_preview/missing_information_component_preview.rb
+++ b/spec/components/course_preview/missing_information_component_preview.rb
@@ -14,7 +14,7 @@ module CoursePreview
         provider = Provider.new(provider_code: 'BAT', recruitment_cycle: RecruitmentCycle.current)
         accrediting_provider = Provider.new(provider_code: 'CAT', recruitment_cycle: RecruitmentCycle.current)
         course = Course.new(provider:, course_code: '2KT', accrediting_provider:)
-        render CoursePreview::MissingInformationComponent.new(course:, information_type:)
+        render CoursePreview::MissingInformationComponent.new(course:, information_type:, is_preview: true)
       end
     end
   end

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -41,7 +41,7 @@ module CoursePreview
         end
 
         it "renders link for missing #{information_type}" do
-          render_inline(described_class.new(course:, information_type:))
+          render_inline(described_class.new(course:, information_type:, is_preview: true))
 
           expect(page).to have_link(text, href: hrefs[information_type])
         end


### PR DESCRIPTION
### Context

The incomplete section inset link was found on Find. This component is for preview only.

### Changes proposed in this pull request

Add a gaurd to prevent the component rendering on Find

### Guidance to review

Check that the component no longer renders in the review app. 

- Course on preview: https://publish-teacher-training-pr-3534.london.cloudapps.digital/publish/organisations/17B/2023/courses/Q902/preview

- Find the course above on Find, following this link and ensure the component does not render: https://find-pr-3534.london.cloudapps.digital

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
