### PR TITLE
[873] Port GTM work from old ticket

### DIFF
--- a/app/controllers/cookie_preferences_controller.rb
+++ b/app/controllers/cookie_preferences_controller.rb
@@ -20,6 +20,6 @@ class CookiePreferencesController < ApplicationController
   private
 
   def cookie_preferences_params
-    params.require(:publish_cookie_preferences_form).permit(:consent)
+    params.require(:publish_cookie_preferences_form).permit(:analytics_consent)
   end
 end

--- a/app/controllers/find/cookie_preferences_controller.rb
+++ b/app/controllers/find/cookie_preferences_controller.rb
@@ -3,14 +3,14 @@
 module Find
   class CookiePreferencesController < ApplicationController
     def show
-      @cookie_preferences_form = Find::CookiePreferencesForm.new(cookies)
+      @cookie_preferences_form = CookiePreferencesForm.new(cookies)
     end
 
     def update
-      @cookie_preferences_form = Find::CookiePreferencesForm.new(cookies, cookie_preferences_params)
+      @cookie_preferences_form = CookiePreferencesForm.new(cookies, cookie_preferences_params)
 
       if @cookie_preferences_form.save
-        redirect_back(fallback_location: root_path, flash: { success: 'Your cookie preferences have been updated' })
+        redirect_back(fallback_location: root_path, flash: { success: I18n.t('cookies.preferences.success') })
       else
         render(:show)
       end
@@ -19,7 +19,7 @@ module Find
     private
 
     def cookie_preferences_params
-      params.require(:find_cookie_preferences_form).permit(:consent)
+      params.require(:find_cookie_preferences_form).permit(:analytics_consent)
     end
   end
 end

--- a/app/forms/find/cookie_preferences_form.rb
+++ b/app/forms/find/cookie_preferences_form.rb
@@ -4,19 +4,23 @@ module Find
   class CookiePreferencesForm
     include ActiveModel::Model
 
-    attr_accessor :consent, :cookies, :cookie_name, :expiry_date
+    ACCEPTED_VALUES = %w[granted denied].freeze
 
-    validates :consent, presence: true, inclusion: { in: %w[accepted rejected] }
+    attr_accessor :analytics_consent, :cookies, :analytics_cookie_name, :expiry_date
+
+    validates :analytics_consent, presence: true, inclusion: { in: ACCEPTED_VALUES }
 
     def initialize(cookies, params = {})
       @cookies = cookies
-      @cookie_name = Settings.cookies.consent.name
-      @expiry_date = Settings.cookies.consent.expire_after_days.days.from_now
-      @consent = params[:consent] || cookies[cookie_name]
+      @analytics_cookie_name = Settings.cookies.analytics.name
+      @expiry_date = Settings.cookies.expire_after_days.days.from_now
+      @analytics_consent = params[:analytics_consent] || cookies[analytics_cookie_name]
     end
 
     def save
-      cookies[cookie_name] = { value: consent, expires: expiry_date } if valid?
+      return unless valid?
+
+      cookies[analytics_cookie_name] = { value: analytics_consent, expires: expiry_date }
     end
   end
 end

--- a/app/forms/publish/cookie_preferences_form.rb
+++ b/app/forms/publish/cookie_preferences_form.rb
@@ -4,19 +4,23 @@ module Publish
   class CookiePreferencesForm
     include ActiveModel::Model
 
-    attr_accessor :consent, :cookies, :cookie_name, :expiry_date
+    ACCEPTED_VALUES = %w[granted denied].freeze
 
-    validates :consent, presence: true, inclusion: { in: %w[accepted rejected] }
+    attr_accessor :analytics_consent, :cookies, :analytics_cookie_name, :expiry_date
+
+    validates :analytics_consent, presence: true, inclusion: { in: ACCEPTED_VALUES }
 
     def initialize(cookies, params = {})
       @cookies = cookies
-      @cookie_name = Settings.cookies.consent.name
-      @expiry_date = Settings.cookies.consent.expire_after_days.days.from_now
-      @consent = params[:consent] || cookies[cookie_name]
+      @analytics_cookie_name = Settings.cookies.analytics.name
+      @expiry_date = Settings.cookies.expire_after_days.days.from_now
+      @analytics_consent = params[:analytics_consent] || cookies[analytics_cookie_name]
     end
 
     def save
-      cookies[cookie_name] = { value: consent, expires: expiry_date } if valid?
+      return unless valid?
+
+      cookies[analytics_cookie_name] = { value: analytics_consent, expires: expiry_date }
     end
   end
 end

--- a/app/helpers/cookies_helper.rb
+++ b/app/helpers/cookies_helper.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 module CookiesHelper
-  def hide_cookie_banner?
-    request.cookie_jar[Settings.cookies.consent.name] =~ /accepted|rejected/
+  def consented_to_analytics_cookie_value
+    request.cookie_jar[Settings.cookies.analytics.name]
   end
 
   def google_analytics_allowed?
-    request.cookie_jar[Settings.cookies.consent.name] == 'accepted'
+    consented_to_analytics_cookie_value == 'granted'
+  end
+
+  def hide_cookie_banner?
+    consented_to_analytics_cookie_value =~ /granted|denied/
   end
 end

--- a/app/javascript/cookie_banner.js
+++ b/app/javascript/cookie_banner.js
@@ -1,7 +1,4 @@
-import {
-  getCookie,
-  setCookie
-} from './utils/cookie_helper'
+import { getCookie, setCookie } from './utils/cookie_helper'
 
 export default class CookieBanner {
   static init () {
@@ -10,16 +7,22 @@ export default class CookieBanner {
 
   constructor () {
     if (this.isConsentAnswerRequired()) {
-      this.$banner = document.querySelector('[data-module="govuk-cookie-banner"]')
+      this.$banner = document.querySelector(
+        '[data-module="govuk-cookie-banner"]'
+      )
 
       if (!this.$banner) return
 
-      this.cookieName = this.$banner.attributes['data-cookie-consent-name'].value
-      this.expiryAfterDays = this.$banner.attributes['data-cookie-consent-expiry-after-days'].value
-      this.$afterConsentBanner = document.querySelector('[data-module="govuk-cookie-after-consent-banner"]')
+      this.cookieName =
+        this.$banner.attributes['data-cookie-consent-name'].value
+      this.expiryAfterDays =
+        this.$banner.attributes['data-cookie-consent-expiry-after-days'].value
+      this.$afterConsentBanner = document.querySelector(
+        '[data-module="govuk-cookie-after-consent-banner"]'
+      )
 
-      this.$acceptButton = this.$banner.querySelector('[value="accepted"]')
-      this.$rejectButton = this.$banner.querySelector('[value="rejected"]')
+      this.$acceptButton = this.$banner.querySelector('[value="granted"]')
+      this.$rejectButton = this.$banner.querySelector('[value="denied"]')
       this.$hideButton = this.$afterConsentBanner.querySelector('button')
 
       this.bindEvents()
@@ -29,7 +32,9 @@ export default class CookieBanner {
   bindEvents () {
     this.$acceptButton.addEventListener('click', () => this.accept())
     this.$rejectButton.addEventListener('click', () => this.reject())
-    this.$hideButton.addEventListener('click', () => this.hideAfterConsentBanner())
+    this.$hideButton.addEventListener('click', () =>
+      this.hideAfterConsentBanner()
+    )
   }
 
   isConsentAnswerRequired () {
@@ -45,10 +50,12 @@ export default class CookieBanner {
 
   accept () {
     this.saveAnswer(this.$acceptButton.value)
+    this.updateConsent()
   }
 
   reject () {
     this.saveAnswer(this.$rejectButton.value)
+    this.updateConsent()
   }
 
   hideBanner () {
@@ -61,5 +68,16 @@ export default class CookieBanner {
 
   hideAfterConsentBanner () {
     this.$afterConsentBanner.hidden = true
+  }
+
+  consent () {
+    return {
+      analytics_storage: getCookie(this.cookieName) || 'denied',
+      ad_storage: getCookie(this.cookieName) || 'denied'
+    }
+  }
+
+  updateConsent () {
+    window.gtag('consent', 'update', this.consent())
   }
 }

--- a/app/javascript/cookie_banner.spec.js
+++ b/app/javascript/cookie_banner.spec.js
@@ -1,6 +1,6 @@
 import CookieBanner from './cookie_banner'
 
-const cookieName = '_consented_to_analytics_cookies'
+const cookieName = '_consented_to_anaytics_cookies'
 
 const templateHTML = `
 <div>
@@ -8,8 +8,8 @@ const templateHTML = `
       data-cookie-consent-name=${cookieName} data-cookie-consent-expiry-after-days="182">
     <div class="govuk-cookie-banner__message govuk-width-container">
       <div class="govuk-button-group">
-        <button value="accepted">Accept analytics cookies</button>
-        <button value="rejected">Reject analytics cookies</button>
+        <button value="granted">Accept analytics cookies</button>
+        <button value="denied">Reject analytics cookies</button>
       </div>
     </div>
   </div>
@@ -38,14 +38,16 @@ describe('CookieBanner', () => {
 
     describe('scenario where user has not given consent', () => {
       beforeEach(() => {
-        jest.spyOn(CookieBanner.prototype, 'isConsentAnswerRequired').mockImplementation(() => true)
+        jest
+          .spyOn(CookieBanner.prototype, 'isConsentAnswerRequired')
+          .mockImplementation(() => true)
       })
 
       describe('clicking accept', () => {
         it("it stores the user's answer on the cookie and hides banner", () => {
           const banner = CookieBanner.init()
           banner.$acceptButton.click()
-          expect(document.cookie).toEqual(`${cookieName}=accepted`)
+          expect(document.cookie).toEqual(`${cookieName}=granted`)
           expect(banner.$banner.hidden).toBeTruthy()
           expect(banner.$afterConsentBanner.hidden).toBeFalsy()
         })
@@ -55,7 +57,7 @@ describe('CookieBanner', () => {
         it("it stores the user's answer on the cookie and hides banner", () => {
           const banner = CookieBanner.init()
           banner.$rejectButton.click()
-          expect(document.cookie).toEqual(`${cookieName}=rejected`)
+          expect(document.cookie).toEqual(`${cookieName}=denied`)
           expect(banner.$banner.hidden).toBeTruthy()
           expect(banner.$afterConsentBanner.hidden).toBeFalsy()
         })

--- a/app/javascript/jestGlobalMocks.js
+++ b/app/javascript/jestGlobalMocks.js
@@ -1,0 +1,10 @@
+/** *********************************
+ * BROWSER MOCKS
+ ********************************** */
+
+Object.defineProperty(window, 'dataLayer', { value: [] })
+Object.defineProperty(window, 'gtag', {
+  value: () => {
+    window.dataLayer.push(arguments)
+  }
+})

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -6,15 +6,15 @@
 
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Cookies</h1>
+      <h1 class="govuk-heading-l">Cookies on <%= t("service_name.publish") %></h1>
 
       <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
 
-      <p class="govuk-body">We use cookies to make <%= t("service_name.publish") %> (Publish) work and collect information about how you use our service.</p>
+      <p class="govuk-body">We use cookies to make <%= t("service_name.publish") %> work and collect information about how you use our service.</p>
 
       <h2 class="govuk-heading-m">Essential cookies</h3>
 
-      <p class="govuk-body">Essential cookies keep your information secure while you use Publish.</p>
+      <p class="govuk-body">Essential cookies keep your information secure while you use ‘<%= t("service_name.publish") %>’. We do not need to ask permission to use them.</p>
 
       <table class="govuk-table app-table--vertical-align-middle" aria-describedby="essential_cookies_desc">
         <thead class="govuk-table__header">
@@ -27,8 +27,8 @@
         <tbody class="govuk-table__body">
           <tr scope="row" class="govuk-table__row">
             <td class="govuk-table__cell "><span class="break-word"><%= Settings.cookies.session.name %></span></td>
-            <td class="govuk-table__cell ">Remembers your identity when you are signed in</td>
-            <td class="govuk-table__cell ">After 6 hours or on signing out</td>
+            <td class="govuk-table__cell ">Stores encrypted session data</td>
+            <td class="govuk-table__cell ">When you close your browser</td>
           </tr>
           <tr scope="row" class="govuk-table__row">
             <td class="govuk-table__cell"><%= Settings.cookies.analytics.name %></td>
@@ -38,16 +38,16 @@
         </tbody>
       </table>
 
-      <h2 class="govuk-heading-m">Measuring website usage (Google Analytics)</h2>
+      <h2 class="govuk-heading-m">Cookies that measure website use (analytics)</h2>
 
-      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use Publish. This information helps us improve our service.</p>
+      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use ‘<%= t("service_name.publish") %>’. This information helps us improve our service.</p>
 
       <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
 
       <p class="govuk-body">Google Analytics stores anonymised information about:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>how you got to Publish</li>
+        <li>how you got to ‘<%= t("service_name.publish") %>’</li>
         <li>the pages you visit on this site and how long you spend on them</li>
         <li>what you click on while you’re visiting the site</li>
       </ul>
@@ -80,7 +80,12 @@
                                           :last,
                                           inline: true,
                                           legend: { text: "Do you want to accept Google Analytics cookies?", size: "s" } %>
+
       <%= f.govuk_submit("Save cookie settings") %>
+
+      <p class="govuk-body">Read more about who we are, how you can contact us and how we process personal data in our <%= govuk_link_to("privacy notice", find_privacy_path) %>.</p>
+
+      <p class="govuk-body">You can also <%= govuk_link_to("find out more about cookies in Google’s Privacy and Terms", t("google_privacy_policy_url"), target: "_blank") %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -10,11 +10,11 @@
 
       <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
 
-      <p class="govuk-body">We use cookies to make <%= t("service_name.publish") %> work and collect information about how you use our service.</p>
+      <p class="govuk-body">We use cookies to make <%= t("service_name.publish") %> (Publish) work and collect information about how you use our service.</p>
 
       <h2 class="govuk-heading-m">Essential cookies</h3>
 
-      <p class="govuk-body">Essential cookies keep your information secure while you use ‘<%= t("service_name.publish") %>’. We do not need to ask permission to use them.</p>
+      <p class="govuk-body">Essential cookies keep your information secure while you use Publish. We do not need to ask permission to use them.</p>
 
       <table class="govuk-table app-table--vertical-align-middle" aria-describedby="essential_cookies_desc">
         <thead class="govuk-table__header">
@@ -40,14 +40,14 @@
 
       <h2 class="govuk-heading-m">Cookies that measure website use (analytics)</h2>
 
-      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use ‘<%= t("service_name.publish") %>’. This information helps us improve our service.</p>
+      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use Publish. This information helps us improve our service.</p>
 
       <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
 
       <p class="govuk-body">Google Analytics stores anonymised information about:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>how you got to ‘<%= t("service_name.publish") %>’</li>
+        <li>how you got to Publish</li>
         <li>the pages you visit on this site and how long you spend on them</li>
         <li>what you click on while you’re visiting the site</li>
       </ul>

--- a/app/views/cookie_preferences/show.html.erb
+++ b/app/views/cookie_preferences/show.html.erb
@@ -31,7 +31,7 @@
             <td class="govuk-table__cell ">After 6 hours or on signing out</td>
           </tr>
           <tr scope="row" class="govuk-table__row">
-            <td class="govuk-table__cell"><%= Settings.cookies.consent.name %></td>
+            <td class="govuk-table__cell"><%= Settings.cookies.analytics.name %></td>
             <td class="govuk-table__cell">Saves your cookie consent settings</td>
             <td class="govuk-table__cell">6 months</td>
           </tr>
@@ -74,10 +74,11 @@
         </tbody>
       </table>
 
-      <%= f.govuk_collection_radio_buttons :consent,
-                                          [%w[accepted Yes], %w[rejected No]],
+      <%= f.govuk_collection_radio_buttons :analytics_consent,
+                                          [%w[granted Yes], %w[denied No]],
                                           :first,
                                           :last,
+                                          inline: true,
                                           legend: { text: "Do you want to accept Google Analytics cookies?", size: "s" } %>
       <%= f.govuk_submit("Save cookie settings") %>
     <% end %>

--- a/app/views/find/cookie_preferences/show.html.erb
+++ b/app/views/find/cookie_preferences/show.html.erb
@@ -6,7 +6,7 @@
 
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">Cookies on Find postgraduate teacher training</h1>
+      <h1 class="govuk-heading-l">Cookies on <%= t("service_name.find") %></h1>
 
       <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
 

--- a/app/views/find/cookie_preferences/show.html.erb
+++ b/app/views/find/cookie_preferences/show.html.erb
@@ -6,15 +6,15 @@
 
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Cookies</h1>
+      <h1 class="govuk-heading-l">Cookies on Find postgraduate teacher training</h1>
 
       <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
 
-      <p class="govuk-body">We use cookies to make <%= t("service_name.find") %> (Find) work and collect information about how you use our service.</p>
+      <p class="govuk-body">We use cookies to make <%= t("service_name.find") %> work and collect information about how you use our service.</p>
 
       <h2 class="govuk-heading-m">Essential cookies</h3>
 
-      <p class="govuk-body">Essential cookies keep your information secure while you use Find.</p>
+      <p class="govuk-body">Essential cookies keep your information secure while you use ‘<%= t("service_name.find") %>’. We do not need to ask permission to use them.</p>
 
       <table class="govuk-table app-table--vertical-align-middle" aria-describedby="essential_cookies_desc">
         <thead class="govuk-table__header">
@@ -31,25 +31,25 @@
             <td class="govuk-table__cell ">When you close your browser</td>
           </tr>
           <tr scope="row" class="govuk-table__row">
-            <td class="govuk-table__cell"><%= Settings.cookies.consent.name %></td>
+            <td class="govuk-table__cell"><%= Settings.cookies.analytics.name %></td>
             <td class="govuk-table__cell">Saves your cookie consent settings</td>
             <td class="govuk-table__cell">6 months</td>
           </tr>
         </tbody>
       </table>
 
-      <h2 class="govuk-heading-m">Analytic cookies (optional)</h2>
+      <h2 class="govuk-heading-m">Cookies that measure website use (analytics)</h2>
 
-      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use Find. This information helps us improve our service.</p>
+      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use ‘<%= t("service_name.find") %>’. This information helps us improve our service.</p>
 
       <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
 
       <p class="govuk-body">Google Analytics stores anonymised information about:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>how you got to Find</li>
+        <li>how you got to ‘<%= t("service_name.find") %>’</li>
         <li>the pages you visit on this site and how long you spend on them</li>
-        <li>what you click on while you&#8217;re visiting the site</li>
+        <li>what you click on while you’re visiting the site</li>
       </ul>
 
       <table class="govuk-table" aria-describedby="google_analytics_cookies_desc">
@@ -76,15 +76,31 @@
             <td class="govuk-table__cell">Limits requests</td>
             <td class="govuk-table__cell">10 minutes</td>
           </tr>
+          <tr scope="row" class="govuk-table__row">
+            <td class="govuk-table__cell">_gcl_aw, _gcl_dc & _gcl_au</td>
+            <td class="govuk-table__cell">Used to distinguish anonymous users</td>
+            <td class="govuk-table__cell">90 days</td>
+          </tr>
+          <tr scope="row" class="govuk-table__row">
+            <td class="govuk-table__cell">IDE, ANID, DSID, FLC, AID, TAID & exchange_uid</td>
+            <td class="govuk-table__cell">Used to distinguish which adverts Find users have seen and clicked on</td>
+            <td class="govuk-table__cell">13 months</td>
+          </tr>
         </tbody>
       </table>
 
-      <%= f.govuk_collection_radio_buttons :consent,
-                                          [%w[accepted Yes], %w[rejected No]],
+      <%= f.govuk_collection_radio_buttons :analytics_consent,
+                                          [%w[granted Yes], %w[denied No]],
                                           :first,
                                           :last,
+                                          inline: true,
                                           legend: { text: "Do you want to accept Google Analytics cookies?", size: "s" } %>
-      <%= f.govuk_submit("Save cookie settings") %>
+
+     <%= f.govuk_submit("Save cookie settings", data: { qa: "save-changes" }) %>
+
+      <p class="govuk-body">Read more about who we are, how you can contact us and how we process personal data in our <%= govuk_link_to("privacy notice", find_privacy_path) %>.</p>
+
+      <p class="govuk-body">You can also <%= govuk_link_to("find out more about cookies in Google’s Privacy and Terms", t("google_privacy_policy_url"), target: "_blank") %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/find/cookie_preferences/show.html.erb
+++ b/app/views/find/cookie_preferences/show.html.erb
@@ -10,11 +10,11 @@
 
       <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
 
-      <p class="govuk-body">We use cookies to make <%= t("service_name.find") %> work and collect information about how you use our service.</p>
+      <p class="govuk-body">We use cookies to make <%= t("service_name.find") %> (Find) work and collect information about how you use our service.</p>
 
       <h2 class="govuk-heading-m">Essential cookies</h3>
 
-      <p class="govuk-body">Essential cookies keep your information secure while you use ‘<%= t("service_name.find") %>’. We do not need to ask permission to use them.</p>
+      <p class="govuk-body">Essential cookies keep your information secure while you use Find. We do not need to ask permission to use them.</p>
 
       <table class="govuk-table app-table--vertical-align-middle" aria-describedby="essential_cookies_desc">
         <thead class="govuk-table__header">
@@ -40,14 +40,14 @@
 
       <h2 class="govuk-heading-m">Cookies that measure website use (analytics)</h2>
 
-      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use ‘<%= t("service_name.find") %>’. This information helps us improve our service.</p>
+      <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use Find. This information helps us improve our service.</p>
 
       <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
 
       <p class="govuk-body">Google Analytics stores anonymised information about:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>how you got to ‘<%= t("service_name.find") %>’</li>
+        <li>how you got to Find</li>
         <li>the pages you visit on this site and how long you spend on them</li>
         <li>what you click on while you’re visiting the site</li>
       </ul>

--- a/app/views/find/pages/accessibility.html.erb
+++ b/app/views/find/pages/accessibility.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Accessibility statement</h1>
+      <h1 class="govuk-heading-l">Accessibility statement</h1>
 
       <p class="govuk-body">This statement applies to the Find postgraduate teacher training service (Find).</p>
 

--- a/app/views/find/pages/privacy.html.erb
+++ b/app/views/find/pages/privacy.html.erb
@@ -2,17 +2,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Find postgraduate teacher training privacy notice</h1>
+    <h1 class="govuk-heading-l">Find postgraduate teacher training privacy notice</h1>
 
-    <h2 class="govuk-heading-l">Who we are</h2>
+    <h2 class="govuk-heading-m">Who we are</h2>
     <p class="govuk-body">
       This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of Find postgraduate teacher training (&#8216;Find&#8217;).
     </p>
 
-    <h2 class="govuk-heading-l">Why our use of your personal data is lawful</h2>
+    <h2 class="govuk-heading-m">Why our use of your personal data is lawful</h2>
     <p class="govuk-body">In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For the purpose of this service, this processing is necessary to complete a task in the public interest.</p>
 
-    <h2 class="govuk-heading-l">How we will use your information</h2>
+    <h2 class="govuk-heading-m">How we will use your information</h2>
     <p class="govuk-body">
       We receive your personal data in the form of your IP address and any postcode which you use to search for courses on the service. We use it to track traffic to the service and continuously improve our service to better meet users&#8217; needs.
     </p>
@@ -23,19 +23,19 @@
       In some instances, we may also collect your email address for similar purposes.
     </p>
 
-    <h2 class="govuk-heading-l">What personal information we will store</h2>
+    <h2 class="govuk-heading-m">What personal information we will store</h2>
     <p class="govuk-body">The personal data that we collect is:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>your pseudonymised Internet Protocol (IP) address</li>
       <li>the postcode used to search for courses</li>
     </ul>
 
-    <h2 class="govuk-heading-l">How long we will keep your personal data</h2>
+    <h2 class="govuk-heading-m">How long we will keep your personal data</h2>
     <p class="govuk-body">
       Neither DfE nor its contracted suppliers will keep your personal data longer than we need it for the purpose(s) of research, security and/or delivery of the service, and in any case not longer than 7 years. Your data will be securely deleted when DfE and its contracted suppliers no longer need it for these purposes, or when 7 years have passed, whichever comes first.
     </p>
 
-    <h2 class="govuk-heading-l">Your data protection rights</h2>
+    <h2 class="govuk-heading-m">Your data protection rights</h2>
     <p class="govuk-body">You have the right:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>to ask us for access to information about you that we hold</li>
@@ -49,7 +49,7 @@
       You can find more information about how we handle personal data in our <%= govuk_link_to("personal information charter", "https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter") %>.
     </p>
 
-    <h2 class="govuk-heading-l">Getting help and raising a concern</h2>
+    <h2 class="govuk-heading-m">Getting help and raising a concern</h2>
     <p class="govuk-body">
       If you would like to exercise any of your rights, you can email us at <%= bat_contact_mail_to %>.
     </p>
@@ -60,7 +60,7 @@
       If we cannot resolve your issue, you have the right to raise it with the Information Commissioner's Office (ICO) at <%= govuk_link_to "https://ico.org.uk/make-a-complaint/", "https://ico.org.uk/make-a-complaint/" %>.
     </p>
 
-    <h2 class="govuk-heading-l">Keeping our privacy notice up to date</h2>
+    <h2 class="govuk-heading-m">Keeping our privacy notice up to date</h2>
     <p class="govuk-body">
       We&#8217;ll update this privacy notice when required. You should regularly review the notice.
     </p>

--- a/app/views/find/pages/terms.html.erb
+++ b/app/views/find/pages/terms.html.erb
@@ -3,21 +3,21 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Terms and conditions</h1>
+      <h1 class="govuk-heading-l">Terms and conditions</h1>
 
-      <h2 class="govuk-heading-l">Using our website</h2>
+      <h2 class="govuk-heading-m">Using our website</h2>
       <p class="govuk-body">The &#8216;Find postgraduate teacher training&#8217; service is maintained for your personal use and viewing. Access and use by you of this site constitutes your acceptance of these terms and conditions. This takes effect from the date on which you first use this website.</p>
 
-      <h2 class="govuk-heading-l">Linking to Find postgraduate teacher training </h2>
+      <h2 class="govuk-heading-m">Linking to Find postgraduate teacher training </h2>
       <p class="govuk-body">We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The &#8216;Find postgraduate teacher training&#8217; pages must be displayed in the user&#8217;s entire browser window.</p>
 
-      <h2 class="govuk-heading-l">Linking from Find postgraduate teacher training</h2>
+      <h2 class="govuk-heading-m">Linking from Find postgraduate teacher training</h2>
       <p class="govuk-body">We are not responsible for the content or reliability of the websites we link to and do not necessarily endorse the views expressed within them. We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.</p>
 
-      <h2 class="govuk-heading-l">Virus protection</h2>
+      <h2 class="govuk-heading-m">Virus protection</h2>
       <p class="govuk-body">We make every effort to check and test material at all stages of production. It is always wise for you to run an anti-virus program on all material downloaded from the Internet. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.</p>
 
-      <h2 class="govuk-heading-l">Disclaimer</h2>
+      <h2 class="govuk-heading-m">Disclaimer</h2>
       <p class="govuk-body">Find postgraduate teacher training and material relating to government information, products and services (or to third party information, products and services), is provided &#8216;as is&#8217;, without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
       <p class="govuk-body">We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the &#8216;Find postgraduate teacher training&#8217;.</p>
       <p class="govuk-body">These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>

--- a/app/views/layouts/_add_js_enabled_class_to_body.html.erb
+++ b/app/views/layouts/_add_js_enabled_class_to_body.html.erb
@@ -1,3 +1,3 @@
-<script>
+<script nonce='<%= content_security_policy_nonce %>'>
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -1,8 +1,8 @@
 <%= render GovukComponent::CookieBannerComponent.new(
   html_attributes: {
     "data-module" => "govuk-cookie-banner",
-    "data-cookie-consent-name" => Settings.cookies.consent.name,
-    "data-cookie-consent-expiry-after-days" => Settings.cookies.consent.expire_after_days,
+    "data-cookie-consent-name" => Settings.cookies.analytics.name,
+    "data-cookie-consent-expiry-after-days" => Settings.cookies.expire_after_days,
     "data-qa" => "cookie-banner",
     "nosnippet" => true
   }
@@ -10,10 +10,10 @@
   <%= cookie_banner.with_message(heading_text: t("cookies.heading", service_name:),
                                  text: t("cookies.message_html")) do |message| %>
     <% message.with_action do %>
-      <button value="accepted" type="button" name="cookies" class="govuk-button app-js-only" data-module="govuk-button">
+      <button value="granted" type="button" name="cookies" class="govuk-button app-js-only" data-module="govuk-button">
         <%= t("cookies.accept") %>
       </button>
-      <button value="rejected" type="button" name="cookies" class="govuk-button app-js-only" data-module="govuk-button">
+      <button value="denied" type="button" name="cookies" class="govuk-button app-js-only" data-module="govuk-button">
         <%= t("cookies.reject") %>
       </button>
       <%= govuk_link_to(t("cookies.cookies_page_link"), cookies_path) %>

--- a/app/views/layouts/_gtm.html.erb
+++ b/app/views/layouts/_gtm.html.erb
@@ -1,0 +1,19 @@
+<script nonce='<%= content_security_policy_nonce %>'>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { window.dataLayer.push(arguments); }
+
+  window.gtag = window.gtag || gtag;
+
+  gtag('consent', 'default', {
+    'ad_storage': '<%= consented_to_analytics_cookie_value %>',
+    'analytics_storage': '<%= consented_to_analytics_cookie_value %>'
+  });
+</script>
+
+<!-- Google Tag Manager -->
+<script nonce='<%= content_security_policy_nonce %>'>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<%= tracking_id %>');</script>
+<!-- End Google Tag Manager -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,18 +19,12 @@
     <%= stylesheet_link_tag "publish_application" %>
     <%= javascript_include_tag "publish/application", "data-turbo-track": "reload", defer: true %>
 
-    <% if google_analytics_allowed? %>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','<%= Settings.google_tag_manager.tracking_id %>');</script>
-    <% end %>
+    <%= render("layouts/gtm", tracking_id: Settings.google_tag_manager.publish_tracking_id, consented_to_analytics_cookie_value:) %>
   </head>
 
   <body class="govuk-template__body <%= yield :body_class %>">
     <% if google_analytics_allowed? %>
-      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Settings.google_tag_manager.tracking_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Settings.google_tag_manager.publish_tracking_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <% end %>
 
     <%= render "layouts/add_js_enabled_class_to_body" %>

--- a/app/views/layouts/find_layout.html.erb
+++ b/app/views/layouts/find_layout.html.erb
@@ -16,10 +16,16 @@
     <%= favicon_link_tag "govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png", rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
     <%= stylesheet_link_tag "find_application" %>
     <%= javascript_include_tag "find/application", "data-turbo-track": "reload", defer: true %>
+
+    <%= render("layouts/gtm", tracking_id: Settings.google_tag_manager.find_tracking_id, consented_to_analytics_cookie_value:) %>
   </head>
 
   <body class="govuk-template__body">
     <%= render "layouts/add_js_enabled_class_to_body" %>
+
+    <% if google_analytics_allowed? %>
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Settings.google_tag_manager.find_tracking_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <% end %>
 
     <% unless hide_cookie_banner? %>
       <%= render("layouts/cookie_banner", service_name: t("service_name.find"), cookies_path: find_cookies_path) %>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Accessibility statement for Publish teacher training courses</h1>
+    <h1 class="govuk-heading-l">Accessibility statement for Publish teacher training courses</h1>
 
     <p class="govuk-body">This service is run by the Becoming a Teacher team at the Department for Education. We want as many people as possible to be able to use the service. For example, that means users should be able to:</p>
 
@@ -18,7 +18,7 @@
 
     <p class="govuk-body"><%= govuk_link_to "AbilityNet", t("links.ability_net") %> has advice on making your device easier to use if you have a disability.</p>
 
-    <h2 class="govuk-heading-l">Technical information about this service&#8217;s accessibility</h2>
+    <h2 class="govuk-heading-m">Technical information about this service&#8217;s accessibility</h2>
 
     <p class="govuk-body">The Becoming a Teacher team (DfE) is committed to making Publish teacher training courses accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
 
@@ -26,11 +26,11 @@
 
     <p class="govuk-body">The service was designed using the <%= govuk_link_to "GOV.UK design system", t("links.gov_design_accessibility") %>, which conforms to the WCAG 2.1 AA standard. To ensure the service fully meets the WCAG 2.1 AA standard, we are currently arranging an accessibility audit. We will update this page following the audit, and publish details of any accessibility issues identified.</p>
 
-    <h2 class="govuk-heading-l">Reporting accessibility problems with Publish teacher training courses</h2>
+    <h2 class="govuk-heading-m">Reporting accessibility problems with Publish teacher training courses</h2>
 
     <p class="govuk-body">If you think we&#8217;re not meeting accessibility requirements, or you&#8217;d like to access any information in a different format (such as accessible PDF, large print, easy read, audio recording or braille), contact <%= bat_contact_mail_to %>. Include &#8216;Accessibility issues&#8217; in the subject line of your email.</p>
 
-    <h2 class="govuk-heading-l">Enforcement procedure</h2>
+    <h2 class="govuk-heading-m">Enforcement procedure</h2>
 
     <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you&#8217;re not happy with how we respond to your complaint, <%= govuk_link_to "contact the Equality Advisory and Support Service (EASS)", t("links.equality_advisory_service") %>.</p>
 

--- a/app/views/pages/performance_dashboard.html.erb
+++ b/app/views/pages/performance_dashboard.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Service performance" %>
 
-<h1 class="govuk-heading-xl">
+<h1 class="govuk-heading-l">
   Service performance
 </h1>
 

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,19 +2,19 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Publish teacher training courses privacy notice</h1>
+    <h1 class="govuk-heading-l">Publish teacher training courses privacy notice</h1>
 
-    <h2 class="govuk-heading-l">Who we are</h2>
+    <h2 class="govuk-heading-m">Who we are</h2>
     <p class="govuk-body">
       This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of Publish teacher training courses (&#8216;Publish&#8217;).
     </p>
 
-    <h2 class="govuk-heading-l">Why our use of your personal data is lawful</h2>
+    <h2 class="govuk-heading-m">Why our use of your personal data is lawful</h2>
     <p class="govuk-body">
       In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For the purpose of this service, this processing is necessary to complete a task in the public interest as stated under GDPR Article 6 (1)(e).
     </p>
 
-    <h2 class="govuk-heading-l">What personal information we will store</h2>
+    <h2 class="govuk-heading-m">What personal information we will store</h2>
     <p class="govuk-body">For all users, we will store:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>your pseudonymised Internet Protocol (IP) address</li>
@@ -29,7 +29,7 @@
       <li>personal information, such as the name and email address of a contact person at your training provider or school, if you choose to share this in a course listing you post to Publish</li>
     </ul>
 
-    <h2 class="govuk-heading-l">How we will use your information</h2>
+    <h2 class="govuk-heading-m">How we will use your information</h2>
     <p class="govuk-body">
       We store your IP address in order to track traffic to the service and continuously improve our service to better meet users&#8217; needs. If you use other digital services for which the data controller is also the DfE (for example, Manage postgraduate teacher training applications), we may also use your IP address to understand how you are using these services. This allows us to ensure that public funds are being spent effectively.
     </p>
@@ -37,7 +37,7 @@
       Personally identifiable contact information that is published in course listings is available in the public domain via an application programming interface (API). We are not responsible for how a third party handles any personal information you choose to include in a course listing.
     </p>
 
-    <h2 class="govuk-heading-l">Sharing your personal data with other organisations</h2>
+    <h2 class="govuk-heading-m">Sharing your personal data with other organisations</h2>
     <p class="govuk-body">
       We sometimes need to make personal data available to other organisations. These might include contracted partners (who we have employed to process your personal data on our behalf) and/or other organisations (with whom we need to share your personal data for specific purposes).
     </p>
@@ -68,7 +68,7 @@
       <%= govuk_link_to "Visit the GOV.UK PaaS website to find out how they use and look after your data (“end user data”)", "https://www.cloud.service.gov.uk/privacy-notice/#what-data-we-collect-from-end-users" %>
     </p>
 
-    <h2 class="govuk-heading-l">How long we will keep your personal data</h2>
+    <h2 class="govuk-heading-m">How long we will keep your personal data</h2>
     <p class="govuk-body">
       Neither DfE nor its contracted suppliers will keep your personal data longer than we need it for the purpose(s) of research, security and/or delivery of the service, and in any case not longer than 7 years. Your data will be securely deleted when DfE and its contracted suppliers no longer need it for these purposes, or when 7 years have passed, whichever comes first.
     </p>
@@ -76,7 +76,7 @@
       If you share personal information in a course listing we will retain this while the course is live and for one year after it has expired.
     </p>
 
-    <h2 class="govuk-heading-l">Your data protection rights</h2>
+    <h2 class="govuk-heading-m">Your data protection rights</h2>
     <p class="govuk-body">You have the right:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>to ask us for access to information about you that we hold</li>
@@ -90,7 +90,7 @@
       You can find more information about how we handle personal data in our <%= govuk_link_to "personal information charter", "https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" %>.
     </p>
 
-    <h2 class="govuk-heading-l">Getting help and raising a concern</h2>
+    <h2 class="govuk-heading-m">Getting help and raising a concern</h2>
     <p class="govuk-body">
       If you would like to exercise any of your rights, you can email us at <%= bat_contact_mail_to %>.
     </p>
@@ -101,7 +101,7 @@
       If we cannot resolve your issue, you have the right to raise it with the Information Commissioner's Office (ICO) at <%= govuk_link_to "https://ico.org.uk/make-a-complaint/", "https://ico.org.uk/make-a-complaint/" %>.
     </p>
 
-    <h2 class="govuk-heading-l">Keeping our privacy notice up to date</h2>
+    <h2 class="govuk-heading-m">Keeping our privacy notice up to date</h2>
     <p class="govuk-body">
       We&#8217;ll update this privacy notice when required. You should regularly review the notice.
     </p>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -2,9 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Terms and conditions</h1>
+    <h1 class="govuk-heading-l">Terms and conditions</h1>
 
-    <h2 class="govuk-heading-l">Using our website</h2>
+    <h2 class="govuk-heading-m">Using our website</h2>
     <p class="govuk-body">
       Please read these Terms of Use (“General Terms”) carefully before using this Publish teacher training courses (the “Service”).
     </p>
@@ -15,7 +15,7 @@
       If we change these General Terms we will post the revised document here with an updated effective date. If we make significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on our home page.
     </p>
 
-    <h2 class="govuk-heading-l">Information About Us</h2>
+    <h2 class="govuk-heading-m">Information About Us</h2>
     <p class="govuk-body">
       This Service is operated by the Department for Education (“we”, “our”, or “us”). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, SW1P 3BT.
     </p>
@@ -23,7 +23,7 @@
       You can contact us using the following email address: <%= bat_contact_mail_to %>
     </p>
 
-    <h2 class="govuk-heading-l">Access to the Service</h2>
+    <h2 class="govuk-heading-m">Access to the Service</h2>
     <p class="govuk-body">
       We will not be liable if for any reason the Service is unavailable at any time or for any period. From time to time, we may restrict access to all or some parts of the Service to users who have registered with us.
     </p>
@@ -37,7 +37,7 @@
       The Department for Education withholds the right to withdraw without notice listings that breach these terms and to withdraw the access of users who breach them.
     </p>
 
-    <h2 class="govuk-heading-l">Hyperlinking to the Publish teacher training courses website</h2>
+    <h2 class="govuk-heading-m">Hyperlinking to the Publish teacher training courses website</h2>
     <p class="govuk-body">
       We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Publish teacher training courses’ pages must be displayed in the user's entire browser window.
     </p>
@@ -45,7 +45,7 @@
       You may not charge your website's users to click on a link to any page on the Service.
     </p>
 
-    <h2 class="govuk-heading-l">Third Party Content and Hyperlinking from the Service</h2>
+    <h2 class="govuk-heading-m">Third Party Content and Hyperlinking from the Service</h2>
     <p class="govuk-body">
       We are not liable or responsible for the third party content on the Service. Third party content includes, for example, material posted by other users of the Service and course listings.
     </p>
@@ -56,7 +56,7 @@
       We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.
     </p>
 
-    <h2 class="govuk-heading-l">Virus protection</h2>
+    <h2 class="govuk-heading-m">Virus protection</h2>
     <p class="govuk-body">
       We make every effort to check and test material at all stages of production. We do not guarantee our service will be secure or free from bugs or viruses. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.
     </p>
@@ -64,7 +64,7 @@
       We will report misuse, unauthorised access or other breaches of the Computer Misuse Act 1990 to the relevant law enforcement authorities and co-operate with them to determine your identity.
     </p>
 
-    <h2 class="govuk-heading-l">Disclaimer and Liability</h2>
+    <h2 class="govuk-heading-m">Disclaimer and Liability</h2>
     <p class="govuk-body">
       The content of this Service includes both content created by us (included but not limited to content that helps you use the Service) and third-party content (included but not limited to course listings). We do not:
     </p>
@@ -91,17 +91,17 @@
       These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.
     </p>
 
-    <h2 class="govuk-heading-l">Validity of these General Terms</h2>
+    <h2 class="govuk-heading-m">Validity of these General Terms</h2>
     <p class="govuk-body">
       If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the remaining terms and conditions will still apply.
     </p>
 
-    <h2 class="govuk-heading-l">Applicable Law and Jurisdiction</h2>
+    <h2 class="govuk-heading-m">Applicable Law and Jurisdiction</h2>
     <p class="govuk-body">
       These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms will be subject to the exclusive jurisdiction of the courts of England and Wales.
     </p>
 
-    <h2 class="govuk-heading-l">Using the Service</h2>
+    <h2 class="govuk-heading-m">Using the Service</h2>
     <p class="govuk-body">
       Access and use by you of this Service constitutes your acceptance of these Terms and Conditions. This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
     </p>
@@ -109,7 +109,7 @@
       By using Publish teacher training courses you agree to abide by the following terms and conditions.
     </p>
 
-    <h2 class="govuk-heading-l">Unacceptable Use</h2>
+    <h2 class="govuk-heading-m">Unacceptable Use</h2>
     <p class="govuk-body">
       You must not publish:
     </p>
@@ -137,7 +137,7 @@
       </li>
     </ul>
 
-    <h2 class="govuk-heading-l">Listing Data</h2>
+    <h2 class="govuk-heading-m">Listing Data</h2>
     <p class="govuk-body">
       Data ownership: training providers and schools have sole responsibility for maintaining the accuracy and appropriateness of the data contained in their listings.
     </p>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,26 +1,44 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
+# Define an application-wide content security policy
+# For further information see the following documentation
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    local_domains = %w[https://publish.localhost https://find.localhost]
+    prod_domains = [
+      'https://*.find-postgraduate-teacher-training.service.gov.uk',
+      'https://*.publish-teacher-training-courses.service.gov.uk'
+    ]
+    all_domains = local_domains + prod_domains
+
+    policy.default_src :self
+    policy.font_src    :self, :data, *all_domains
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self,
+                       'https://www.google-analytics.com',
+                       'https://www.googletagmanager.com',
+                       *all_domains
+
+    policy.connect_src :self,
+                       'https://stats.g.doubleclick.net',
+                       'https://*.sentry.io',
+                       'https://*.google-analytics.com',
+                       'https://*.analytics.google.com',
+                       *all_domains
+
+    policy.style_src   :self, *all_domains
+
+    policy.frame_src   :self, 'https://www.googletagmanager.com', *local_domains
+
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src]
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -690,7 +690,7 @@ en:
               invalid: "Enter a valid email address"
         publish/cookie_preferences_form:
           attributes:
-            consent:
+            analytics_consent:
               blank: Select yes if you want to accept Google Analytics cookies
         publish/schools/search_form:
           attributes:
@@ -701,11 +701,6 @@ en:
           attributes:
             school_id:
               blank: Select a school
-        find/confirm_environment:
-          attributes:
-            environment:
-              blank: Enter the environment to proceed
-              invalid_environment: "That's not %{environment}"
         publish/provider_contact_form:
           attributes:
             ukprn:
@@ -724,6 +719,15 @@ en:
               invalid: Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
               too_long: Telephone number must contain 15 numbers or fewer
               too_short: Telephone number must contain 8 numbers or more
+        find/confirm_environment:
+          attributes:
+            environment:
+              blank: Enter the environment to proceed
+              invalid_environment: "That's not %{environment}"
+        find/cookie_preferences_form:
+          attributes:
+            analytics_consent:
+              blank: Select yes if you want to accept Google Analytics cookies
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"
@@ -852,6 +856,8 @@ en:
     heading: Cookies on %{service_name}
     accept: Accept analytics cookies
     reject: Reject analytics cookies
+    preferences:
+      success: Your cookie preferences have been updated
     message_html:
       <p class="govuk-body">We use some essential cookies to make this service work.</p>
       <p class="govuk-body app-js-only">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
@@ -869,3 +875,4 @@ en:
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
     url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
     url: https://getintoteaching.education.gov.uk
+  google_privacy_policy_url: "https://policies.google.com/technologies/cookies?hl=en-US#types-of-cookies"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -115,8 +115,12 @@ features:
 cookies:
   session:
     name: _teacher_training_courses_session
-  consent:
-    name: _consented_to_analytics_cookies
-    expire_after_days: 182
+  analytics:
+    name: _consented_to_anaytics_cookies
+  expire_after_days: 182
+
+google_tag_manager:
+  find_tracking_id: change_me
+  publish_tracking_id: GTM-TSK2T46
 
 STATE_CHANGE_SLACK_URL: replace_me

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -121,6 +121,6 @@ cookies:
 
 google_tag_manager:
   find_tracking_id: change_me
-  publish_tracking_id: GTM-TSK2T46
+  publish_tracking_id: change_me
 
 STATE_CHANGE_SLACK_URL: replace_me

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -30,7 +30,8 @@ environment:
 render_json_errors: true
 
 google_tag_manager:
-  tracking_id: GTM-W56GPKW
+  find_tracking_id: GTM-K6NSLCM
+  publish_tracking_id: GTM-W56GPKW
 
 features:
   send_request_data_to_bigquery: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     '!<rootDir>/app/javascript/utils/test.js'
   ],
   reporters: ['default'],
+  setupFilesAfterEnv: ['<rootDir>/app/javascript/jestGlobalMocks.js'],
   transformIgnorePatterns: ['node_modules/*'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/app/javascript/$1'

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "globals": [
       "$",
       "google"
+    ],
+    "ignore": [
+      "app/javascript/jestGlobalMocks.js"
     ]
   },
   "dependencies": {

--- a/spec/features/find/cookie_preferences_spec.rb
+++ b/spec/features/find/cookie_preferences_spec.rb
@@ -49,7 +49,7 @@ feature 'Updating cookie preferences' do
   end
 
   def service_name
-    'Find postgraduate teacher training (Find)'
+    'Find postgraduate teacher training'
   end
 
   def find_cookie_preferences_page

--- a/spec/features/find/cookie_preferences_spec.rb
+++ b/spec/features/find/cookie_preferences_spec.rb
@@ -45,7 +45,7 @@ feature 'Updating cookie preferences' do
   end
 
   def and_i_can_see_the_the_use_of_cookies_for_service
-    expect(find_cookie_preferences_page).to have_content("We use cookies to make #{I18n.t('service_name.find')} work and collect information about how you use our service.")
+    expect(find_cookie_preferences_page).to have_content("We use cookies to make #{I18n.t('service_name.find')} (Find) work and collect information about how you use our service.")
   end
 
   def find_cookie_preferences_page

--- a/spec/features/find/cookie_preferences_spec.rb
+++ b/spec/features/find/cookie_preferences_spec.rb
@@ -45,11 +45,7 @@ feature 'Updating cookie preferences' do
   end
 
   def and_i_can_see_the_the_use_of_cookies_for_service
-    expect(find_cookie_preferences_page).to have_content("We use cookies to make #{service_name} work and collect information about how you use our service.")
-  end
-
-  def service_name
-    'Find postgraduate teacher training'
+    expect(find_cookie_preferences_page).to have_content("We use cookies to make #{I18n.t('service_name.find')} work and collect information about how you use our service.")
   end
 
   def find_cookie_preferences_page

--- a/spec/features/find/cookie_preferences_spec.rb
+++ b/spec/features/find/cookie_preferences_spec.rb
@@ -22,7 +22,7 @@ feature 'Updating cookie preferences' do
   end
 
   def when_i_give_consent_and_submit
-    find_cookie_preferences_page.yes_option.choose
+    find_cookie_preferences_page.analytics_cookie_accept.choose
     when_i_submit
   end
 

--- a/spec/features/publish/cookie_preferences_spec.rb
+++ b/spec/features/publish/cookie_preferences_spec.rb
@@ -45,10 +45,6 @@ feature 'Updating cookie preferences' do
   end
 
   def and_i_can_see_the_the_use_of_cookies_for_service
-    expect(publish_cookie_preferences_page).to have_content("We use cookies to make #{service_name} work and collect information about how you use our service.")
-  end
-
-  def service_name
-    'Publish teacher training courses (Publish)'
+    expect(publish_cookie_preferences_page).to have_content("We use cookies to make #{I18n.t('service_name.publish')} work and collect information about how you use our service.")
   end
 end

--- a/spec/features/publish/cookie_preferences_spec.rb
+++ b/spec/features/publish/cookie_preferences_spec.rb
@@ -22,7 +22,7 @@ feature 'Updating cookie preferences' do
   end
 
   def when_i_give_consent_and_submit
-    publish_cookie_preferences_page.yes_option.choose
+    publish_cookie_preferences_page.analytics_cookie_accept.choose
     when_i_submit
   end
 

--- a/spec/features/publish/cookie_preferences_spec.rb
+++ b/spec/features/publish/cookie_preferences_spec.rb
@@ -45,6 +45,6 @@ feature 'Updating cookie preferences' do
   end
 
   def and_i_can_see_the_the_use_of_cookies_for_service
-    expect(publish_cookie_preferences_page).to have_content("We use cookies to make #{I18n.t('service_name.publish')} work and collect information about how you use our service.")
+    expect(publish_cookie_preferences_page).to have_content("We use cookies to make #{I18n.t('service_name.publish')} (Publish) work and collect information about how you use our service.")
   end
 end

--- a/spec/support/page_objects/find/cookie_preferences.rb
+++ b/spec/support/page_objects/find/cookie_preferences.rb
@@ -9,8 +9,8 @@ module PageObjects
 
       element :heading, 'h1'
 
-      element :yes_option, '#find-cookie-preferences-form-consent-accepted-field'
-      element :no_option, '#find-cookie-preferences-form-consent-rejected-field'
+      element :analytics_cookie_accept, '#find-cookie-preferences-form-analytics-consent-granted-field'
+      element :analytics_cookie_deny, '#find-cookie-preferences-form-analytics-consent-denied-field'
 
       element :submit, 'button.govuk-button[type="submit"]'
 

--- a/spec/support/page_objects/publish/cookie_preferences.rb
+++ b/spec/support/page_objects/publish/cookie_preferences.rb
@@ -9,8 +9,8 @@ module PageObjects
 
       element :heading, 'h1'
 
-      element :yes_option, '#publish-cookie-preferences-form-consent-accepted-field'
-      element :no_option, '#publish-cookie-preferences-form-consent-rejected-field'
+      element :analytics_cookie_accept, '#publish-cookie-preferences-form-analytics-consent-granted-field'
+      element :analytics_cookie_deny, '#publish-cookie-preferences-form-analytics-consent-denied-field'
 
       element :submit, 'button.govuk-button[type="submit"]'
 


### PR DESCRIPTION
### Context

Ports the work from this old PR https://github.com/DFE-Digital/publish-teacher-training/pull/3184.

### Changes proposed in this pull request

- Update copy on cookie pages
- Sets up GTM and logic to correctly handle preferences
- Standardise heading levels in all static pages so they're consistent
- Also updates the existing analytics cookie to be clearly marked as analytics

### Guidance to review

- https://find-pr-3535.london.cloudapps.digital (for find)
- https://publish-teacher-training-pr-3535.london.cloudapps.digital (for publish)
- Go to the cookies page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
