### PR TITLE
[1269] Added accredited body summary card component

### DIFF
--- a/app/components/accredited_provider.html.erb
+++ b/app/components/accredited_provider.html.erb
@@ -1,0 +1,6 @@
+<%= govuk_summary_card(title: provider_name) do |card|
+      card.with_action { govuk_link_to("Remove", remove_path, class: "app-link--destructive") }
+      card.with_summary_list(rows: [{ key: { text: "About the accredited provider" },
+                                      value: { text: about_accredited_provider },
+                                      actions: [{ href: change_about_accredited_provider_path }] }])
+    end %>

--- a/app/components/accredited_provider.rb
+++ b/app/components/accredited_provider.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AccreditedProvider < ViewComponent::Base
+  attr_reader :provider_name, :remove_path, :about_accredited_provider, :change_about_accredited_provider_path
+
+  def initialize(provider_name:, remove_path:, about_accredited_provider:, change_about_accredited_provider_path:)
+    super
+    @provider_name = provider_name
+    @remove_path = remove_path
+    @about_accredited_provider = about_accredited_provider
+    @change_about_accredited_provider_path = change_about_accredited_provider_path
+  end
+end

--- a/spec/components/accredited_provider_preview.rb
+++ b/spec/components/accredited_provider_preview.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AccreditedProviderPreview < ViewComponent::Preview
+  def default
+    render(AccreditedProvider.new(
+             provider_name: 'Provider name',
+             remove_path: 'remove_path',
+             about_accredited_provider: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc imperdiet nunc ex, eget faucibus eros mattis dictum. Pellentesque odio augue, commodo in consectetur sit amet, feugiat vel leo. Nulla ullamcorper, purus sit amet lobortis sollicitudin, justo leo congue sem, nec cursus mauris justo et est. In convallis mi id libero pulvinar aliquet. In eu mi vel nunc venenatis efficitur. Etiam eget rutrum lacus, nec finibus justo. Integer sed augue sit amet libero ornare elementum. Aenean accumsan sapien vitae lacus condimentum, non finibus ex malesuada. Proin in nisi lacus.',
+             change_about_accredited_provider_path: 'change_about_accredited_provider_path'
+           ))
+  end
+end

--- a/spec/components/accredited_provider_spec.rb
+++ b/spec/components/accredited_provider_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AccreditedProvider do
+  alias_method :component, :page
+
+  before do
+    render_inline(described_class.new(provider_name: 'Provider name SCITT',
+                                      remove_path: 'remove_path',
+                                      about_accredited_provider: 'Enter some random text here',
+                                      change_about_accredited_provider_path: 'change_about_accredited_provider_path'))
+  end
+
+  it 'renders the about_accredited_provider text' do
+    expect(component).to have_css '.govuk-summary-list__value', text: 'Enter some random text here'
+  end
+
+  it 'renders the about_accredited_provider key' do
+    expect(component).to have_css '.govuk-summary-list__key', text: 'About the accredited provider'
+  end
+
+  it 'renders the about_accredited_provider change link' do
+    expect(component).to have_link 'Change'
+  end
+
+  it 'renders the provider_name title' do
+    expect(component).to have_css 'h2.govuk-summary-card__title', text: 'Provider name SCITT'
+  end
+
+  it 'renders the provider_name remove link' do
+    expect(component).to have_link 'Remove'
+  end
+end


### PR DESCRIPTION
### Context
Accredited body summary card component

### Changes proposed in this pull request
Added accredited body summary card component

### Guidance to review

https://publish-teacher-training-pr-3542.london.cloudapps.digital/view_components/accredited_provider/default

![image](https://user-images.githubusercontent.com/470137/235910884-aeb62a61-1452-4da9-8d35-ca1a89596a77.png)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
