### PR TITLE
[1223] Support: Add & Edit Accrediting Provider - Step 2 (About AP and Check Answers)

### DIFF
--- a/app/controllers/concerns/support/clear_stashable.rb
+++ b/app/controllers/concerns/support/clear_stashable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Support
+  module ClearStashable
+    extend ActiveSupport::Concern
+
+    def reset_accredited_provider_form
+      accredited_provider_form.clear_stash
+    end
+  end
+end

--- a/app/controllers/support/providers/accredited_provider_search_controller.rb
+++ b/app/controllers/support/providers/accredited_provider_search_controller.rb
@@ -15,7 +15,7 @@ module Support
 
         if @accredited_provider_search_form.valid?
           @accredited_provider_select_form = AccreditedProviderSelectForm.new
-          @accredited_provider_search = AccreditedProviders::SearchService.call(query:)
+          @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:)
 
           render :results
         else
@@ -28,9 +28,9 @@ module Support
         @accredited_provider_select_form = AccreditedProviderSelectForm.new(provider_id: accredited_provider_select_params[:provider_id])
 
         if @accredited_provider_select_form.valid?
-          redirect_to support_recruitment_cycle_provider_accredited_providers_path
+          redirect_to new_support_recruitment_cycle_provider_accredited_provider_path(accredited_provider_id: accredited_provider_select_params[:provider_id])
         else
-          @accredited_provider_search = AccreditedProviders::SearchService.call(query:)
+          @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:)
           render :results
         end
       end

--- a/app/controllers/support/providers/accredited_providers/checks_controller.rb
+++ b/app/controllers/support/providers/accredited_providers/checks_controller.rb
@@ -4,18 +4,26 @@ module Support
   module Providers
     module AccreditedProviders
       class ChecksController < SupportController
+        include ClearStashable
+
         def show
           provider
-          @accredited_provider_form = AccreditedProviderForm.new(current_user)
+          accredited_provider_form
         end
 
         def update
+          reset_accredited_provider_form
+
           redirect_to support_recruitment_cycle_provider_accredited_providers_path(
             recruitment_cycle.year, provider.id
           ), flash: { success: 'Accredited provider added' }
         end
 
         private
+
+        def accredited_provider_form
+          @accredited_provider_form ||= AccreditedProviderForm.new(current_user)
+        end
 
         def provider
           @provider ||= recruitment_cycle.providers.find(params[:provider_id])

--- a/app/controllers/support/providers/accredited_providers/checks_controller.rb
+++ b/app/controllers/support/providers/accredited_providers/checks_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Support
+  module Providers
+    module AccreditedProviders
+      class ChecksController < SupportController
+        def show
+          provider
+          @accredited_provider_form = AccreditedProviderForm.new(current_user)
+        end
+
+        def update
+          redirect_to support_recruitment_cycle_provider_accredited_providers_path(
+            recruitment_cycle.year, provider.id
+          ), flash: { success: 'Accredited provider added' }
+        end
+
+        private
+
+        def provider
+          @provider ||= recruitment_cycle.providers.find(params[:provider_id])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/support/providers/accredited_providers_controller.rb
+++ b/app/controllers/support/providers/accredited_providers_controller.rb
@@ -3,7 +3,11 @@
 module Support
   module Providers
     class AccreditedProvidersController < SupportController
+      include ClearStashable
+
       helper_method :accredited_provider_id
+
+      before_action :reset_accredited_provider_form, only: %i[index]
 
       def index
         @accredited_providers = provider.accrediting_providers.order(:provider_name).page(params[:page] || 1)
@@ -12,7 +16,7 @@ module Support
 
       def new
         provider
-        @accredited_provider_form = AccreditedProviderForm.new(current_user)
+        accredited_provider_form
       end
 
       def create
@@ -33,6 +37,10 @@ module Support
 
       def accredited_provider_id
         @accredited_provider_form.accredited_provider_id || params[:accredited_provider_id]
+      end
+
+      def accredited_provider_form
+        @accredited_provider_form ||= AccreditedProviderForm.new(current_user)
       end
 
       def accredited_provider_params

--- a/app/controllers/support/providers/accredited_providers_controller.rb
+++ b/app/controllers/support/providers/accredited_providers_controller.rb
@@ -3,16 +3,42 @@
 module Support
   module Providers
     class AccreditedProvidersController < SupportController
-      layout 'provider_record'
+      helper_method :accredited_provider_id
 
       def index
         @accredited_providers = provider.accrediting_providers.order(:provider_name).page(params[:page] || 1)
+        render layout: 'provider_record'
+      end
+
+      def new
+        provider
+        @accredited_provider_form = AccreditedProviderForm.new(current_user)
+      end
+
+      def create
+        @accredited_provider_form = AccreditedProviderForm.new(current_user, params: accredited_provider_params)
+        if @accredited_provider_form.stash
+          redirect_to check_support_recruitment_cycle_provider_accredited_providers_path
+        else
+          provider
+          render :new
+        end
       end
 
       private
 
       def provider
         @provider ||= recruitment_cycle.providers.find(params[:provider_id])
+      end
+
+      def accredited_provider_id
+        @accredited_provider_form.accredited_provider_id || params[:accredited_provider_id]
+      end
+
+      def accredited_provider_params
+        params.require(:support_accredited_provider_form)
+              .except(:goto_confirmation)
+              .permit(AccreditedProviderForm::FIELDS)
       end
     end
   end

--- a/app/forms/support/accredited_provider_form.rb
+++ b/app/forms/support/accredited_provider_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Support
+  class AccreditedProviderForm < BaseForm
+    delegate :provider_name, to: :accredited_provider
+
+    FIELDS = %i[
+      description
+      accredited_provider_id
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :description, presence: true
+
+    alias compute_fields new_attributes
+
+    def accredited_provider
+      @accredited_provider ||= RecruitmentCycle.current.providers.find(accredited_provider_id)
+    end
+  end
+end

--- a/app/helpers/support/goto_confirmation_helper.rb
+++ b/app/helpers/support/goto_confirmation_helper.rb
@@ -19,5 +19,15 @@ module Support
         new_support_recruitment_cycle_providers_onboarding_path(recruitment_cycle_year)
       end
     end
+
+    def back_link_for_adding_accrediting_provider_path(param_form_key:, params:, recruitment_cycle_year:, provider:)
+      if goto_confirmation?(param_form_key:, params:)
+        check_support_recruitment_cycle_provider_accredited_providers_path(recruitment_cycle_year, provider)
+      elsif param_form_key == :support_accredited_provider_form
+        search_support_recruitment_cycle_provider_accredited_providers_path
+      else
+        support_recruitment_cycle_provider_accredited_providers_path(recruitment_cycle_year, provider)
+      end
+    end
   end
 end

--- a/app/services/stores/user_store.rb
+++ b/app/services/stores/user_store.rb
@@ -6,6 +6,7 @@ module Stores
       user
       provider
       provider_contact
+      accredited_provider
     ].freeze
 
     def store_keys

--- a/app/views/support/providers/accredited_providers/checks/show.html.erb
+++ b/app/views/support/providers/accredited_providers/checks/show.html.erb
@@ -30,7 +30,7 @@
             end
           end %>
 
-      <%= govuk_warning_text(text: "All users at #{@accredited_provider_form.provider_name} will be sent an email to let them know they've been added.") %>
+      <%= govuk_warning_text(text: "All users at #{@accredited_provider_form.provider_name} will be sent an email to let them know they’ve been added.") %>
 
       <%= f.govuk_submit(t(".add")) %>
     <% end %>

--- a/app/views/support/providers/accredited_providers/checks/show.html.erb
+++ b/app/views/support/providers/accredited_providers/checks/show.html.erb
@@ -1,0 +1,42 @@
+
+<%= render PageTitle.new(
+  title: "Check your answers - #{t('.caption', provider_name: @provider.provider_name, code: @provider.provider_code)}"
+) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(new_support_recruitment_cycle_provider_accredited_provider_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <%= form_with(url: check_support_recruitment_cycle_provider_accredited_providers_path, method: :put, local: true) do |f| %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= t(".caption", provider_name: @provider.provider_name, code: @provider.provider_code) %></span>
+        Check your answers
+      </h1>
+
+      <%= render GovukComponent::SummaryListComponent.new do |component|
+            component.with_row do |row|
+              row.with_key { "Accredited provider" }
+              row.with_value { @accredited_provider_form.provider_name }
+              row.with_action(text: "Change", href: search_support_recruitment_cycle_provider_accredited_providers_path(goto_confirmation: true), visually_hidden_text: "accredited provider name")
+            end
+
+            component.with_row do |row|
+              row.with_key { "About the accredited provider" }
+              row.with_value { @accredited_provider_form.description }
+              row.with_action(text: "Change", href: new_support_recruitment_cycle_provider_accredited_provider_path(goto_confirmation: true), visually_hidden_text: "accredited provider description")
+            end
+          end %>
+
+      <%= govuk_warning_text(text: "All users at #{@accredited_provider_form.provider_name} will be sent an email to let them know they've been added.") %>
+
+      <%= f.govuk_submit(t(".add")) %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_accredited_providers_path) %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/providers/accredited_providers/new.html.erb
+++ b/app/views/support/providers/accredited_providers/new.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, title_with_error_prefix(t(".title"), @accredited_provider_search_form.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Add accredited provider - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <%= form_with(
-        model: @accredited_provider_search_form,
-        url: search_support_recruitment_cycle_provider_accredited_providers_path,
+        model: @accredited_provider_form,
+        url: support_recruitment_cycle_provider_accredited_providers_path,
         method: :post
       ) do |f| %>
 
@@ -18,12 +18,16 @@
 
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field(
-        :query,
+      <%= f.govuk_text_area(
+        :description,
         label: { text: t(".title"), size: "l", tag: "h1" },
-        caption: { text: t(".caption", provider_name: @provider.provider_name, code: @provider.provider_code), size: "l" }
+        hint: { text: t(".hint") },
+        caption: { text: t(".caption", provider_name: @provider.provider_name, code: @provider.provider_code), size: "l" },
+        max_words: 100,
+        rows: 10
       ) %>
 
+      <%= f.hidden_field :accredited_provider_id, value: accredited_provider_id %>
       <%= f.govuk_submit t("continue") %>
     <% end %>
 

--- a/app/views/support/providers/accredited_providers/new.html.erb
+++ b/app/views/support/providers/accredited_providers/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("Add accredited provider - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("About the accredited provider - Add accredited provider - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,7 +318,16 @@ en:
       accredited_provider_search:
         new:
           title: Enter a provider name, UKPRN or postcode
+          caption: &accredited_provider_caption "Add accredited provider - %{provider_name} (%{code})"
+      accredited_providers:
+        new:
+          title: About the accredited provider
+          hint: Tell candidates about the accredited provider. You could mention their academic specialities and achievements.
           caption: "Add accredited provider - %{provider_name} (%{code})"
+        checks:
+          show:
+            caption: *accredited_provider_caption
+            add: Add accredited provider
       provider_type:
         lead_school: "School"
         scitt: "School centred initial teacher training (SCITT)"
@@ -619,6 +628,10 @@ en:
               invalid: "Enter a real postcode"
             urn:
               format: "Site URN must be 5 or 6 numbers"
+        support/accredited_provider_form:
+          attributes:
+            description:
+              blank: Enter details about the accredited provider
         support/raw_csv_schools_form:
           blank: "Enter school details"
         publish/course_information_form:

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -43,6 +43,9 @@ namespace :support do
           get '/search', on: :collection, to: 'accredited_provider_search#new'
           post '/search', on: :collection, to: 'accredited_provider_search#create'
           put '/search', on: :collection, to: 'accredited_provider_search#update'
+
+          get '/check', on: :collection, to: 'accredited_providers/checks#show'
+          put '/check', on: :collection, to: 'accredited_providers/checks#update'
         end
       end
     end

--- a/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -22,7 +22,27 @@ feature 'Searching for an accredited provider' do
     and_i_should_still_see_the_provider_i_searched_for
 
     when_i_select_the_provider
+    and_i_continue_without_entering_a_description
+    then_i_should_see_an_error_message('Enter details about the accredited provider')
+
+    when_i_enter_a_description
+    and_i_confirm_the_changes
     then_i_should_be_taken_to_the_index_page
+    and_i_should_see_a_success_message
+  end
+
+  scenario 'back links behaviour' do
+    when_i_am_on_the_confirm_page
+    and_i_click_the_change_link_for('accredited provider name')
+    then_i_should_be_taken_to_the_accredited_provider_search_page
+    when_i_click_the_back_link
+    then_i_should_be_taken_back_to_the_confirm_page
+
+    when_i_am_on_the_confirm_page
+    and_i_click_the_change_link_for('accredited provider description')
+    then_i_should_be_taken_to_the_accredited_provider_description_page
+    when_i_click_the_back_link
+    then_i_should_be_taken_back_to_the_confirm_page
   end
 
   private
@@ -60,6 +80,10 @@ feature 'Searching for an accredited provider' do
     click_continue
   end
 
+  def and_i_continue_without_entering_a_description
+    click_continue
+  end
+
   def then_i_should_be_taken_to_the_index_page
     expect(page).to have_current_path(
       support_recruitment_cycle_provider_accredited_providers_path(
@@ -88,8 +112,67 @@ feature 'Searching for an accredited provider' do
     expect(page).not_to have_content(@accredited_provider_three.provider_name)
   end
 
+  def when_i_enter_a_description
+    fill_in 'About the accredited provider', with: 'This is a description'
+    click_continue
+  end
+
+  def and_i_confirm_the_changes
+    click_on 'Add accredited provider'
+  end
+
+  def and_i_should_see_a_success_message
+    expect(page).to have_content('Accredited provider added')
+  end
+
   def click_continue
     click_on 'Continue'
+  end
+
+  def when_i_am_on_the_confirm_page
+    when_i_visit_the_accredited_provider_search_page
+    when_i_search_for_an_accredited_provider_with_a_valid_query
+    when_i_select_the_provider
+    when_i_enter_a_description
+  end
+
+  def and_i_click_the_change_link_for(field)
+    within '.govuk-summary-list' do
+      click_on "Change #{field}"
+    end
+  end
+
+  def then_i_should_be_taken_to_the_accredited_provider_search_page
+    expect(page).to have_current_path(
+      search_support_recruitment_cycle_provider_accredited_providers_path(
+        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        provider_id: provider.id,
+        goto_confirmation: true
+      )
+    )
+  end
+
+  def then_i_should_be_taken_to_the_accredited_provider_description_page
+    expect(page).to have_current_path(
+      new_support_recruitment_cycle_provider_accredited_provider_path(
+        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        provider_id: provider.id,
+        goto_confirmation: true
+      )
+    )
+  end
+
+  def when_i_click_the_back_link
+    click_on 'Back'
+  end
+
+  def then_i_should_be_taken_back_to_the_confirm_page
+    expect(page).to have_current_path(
+      check_support_recruitment_cycle_provider_accredited_providers_path(
+        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        provider_id: provider.id
+      )
+    )
   end
 
   def provider

--- a/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -80,10 +80,6 @@ feature 'Searching for an accredited provider' do
     click_continue
   end
 
-  def and_i_continue_without_entering_a_description
-    click_continue
-  end
-
   def then_i_should_be_taken_to_the_index_page
     expect(page).to have_current_path(
       support_recruitment_cycle_provider_accredited_providers_path(
@@ -182,4 +178,6 @@ feature 'Searching for an accredited provider' do
   def form_title
     'Enter a provider name, UKPRN or postcode'
   end
+
+  alias_method :and_i_continue_without_entering_a_description, :click_continue
 end

--- a/spec/services/stores/user_store_spec.rb
+++ b/spec/services/stores/user_store_spec.rb
@@ -6,6 +6,6 @@ require_relative 'shared_examples/store'
 
 module Stores
   describe UserStore do
-    include_examples 'store', :user, %i[user provider provider_contact]
+    include_examples 'store', :user, %i[user provider provider_contact accredited_provider]
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/unxQot6W/1223-support-add-edit-accrediting-provider-step-2-about-ap

### Changes proposed in this pull request

- Implements the second and final step of adding accredited providers in support
- Saving (final bit) is not implemented here, will be done in upcoming ticket

### Guidance to review

https://publish-teacher-training-pr-3546.london.cloudapps.digital/support/2023/providers/18689/accredited-providers

- Sign in as admin and search for an AP, enter some description and check the information is shown on the check your answers page
- Check you can change the info and return with updated information

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
