### PR TITLE
[1227] Providers add accredited provider (step 1 non js)

### DIFF
--- a/app/controllers/publish/providers/accredited_providers_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers_controller.rb
@@ -6,18 +6,18 @@ module Publish
       helper_method :query, :search_result_title_component
 
       def index
-        authorize :provider, :index?
+        authorize_provider
         provider
       end
 
       def new
-        authorize :provider, :new?
+        authorize_provider
         provider
         @accredited_provider_search_form = AccreditedProviderSearchForm.new
       end
 
       def create
-        authorize :provider, :create?
+        authorize_provider
 
         @accredited_provider_search_form = AccreditedProviderSearchForm.new(query:)
 
@@ -62,6 +62,10 @@ module Publish
           search_resource: 'accredited provider',
           caption_text: "Add accredited provider - #{provider.name_and_code}"
         )
+      end
+
+      def authorize_provider
+        authorize(provider)
       end
     end
   end

--- a/app/controllers/publish/providers/accredited_providers_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers_controller.rb
@@ -32,6 +32,20 @@ module Publish
         end
       end
 
+      def update
+        authorize_provider
+
+        @accredited_provider_select_form = AccreditedProviderSelectForm.new(provider_id: accredited_provider_select_params[:provider_id])
+
+        if @accredited_provider_select_form.valid?
+          redirect_to publish_provider_recruitment_cycle_accredited_providers_path(provider_code: provider.provider_code,
+            recruitment_cycle_year: provider.recruitment_cycle_year)
+        else
+          @accredited_provider_search = AccreditedProviders::SearchService.call(query:)
+          render :results
+        end
+      end
+
       def provider
         @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code] || params[:code])
       end

--- a/app/controllers/publish/providers/accredited_providers_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers_controller.rb
@@ -39,7 +39,7 @@ module Publish
 
         if @accredited_provider_select_form.valid?
           redirect_to publish_provider_recruitment_cycle_accredited_providers_path(provider_code: provider.provider_code,
-            recruitment_cycle_year: provider.recruitment_cycle_year)
+                                                                                   recruitment_cycle_year: provider.recruitment_cycle_year)
         else
           @accredited_provider_search = AccreditedProviders::SearchService.call(query:)
           render :results

--- a/app/controllers/publish/providers/accredited_providers_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers_controller.rb
@@ -3,13 +3,65 @@
 module Publish
   module Providers
     class AccreditedProvidersController < PublishController
+      helper_method :query, :search_result_title_component
+
       def index
         authorize :provider, :index?
         provider
       end
 
+      def new
+        authorize :provider, :new?
+        provider
+        @accredited_provider_search_form = AccreditedProviderSearchForm.new
+      end
+
+      def create
+        authorize :provider, :create?
+
+        @accredited_provider_search_form = AccreditedProviderSearchForm.new(query:)
+
+        if @accredited_provider_search_form.valid?
+          @accredited_provider_select_form = AccreditedProviderSelectForm.new
+          @accredited_provider_search = AccreditedProviders::SearchService.call(query:)
+
+          render :results
+        else
+          provider
+          render :new
+        end
+      end
+
       def provider
         @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code] || params[:code])
+      end
+
+      def query
+        # Order is important here so the query persists across each step.
+        @accredited_provider_search_form&.query || accredited_provider_search_params[:query] || accredited_provider_select_params[:query]
+      end
+
+      def accredited_provider_search_params
+        return {} unless params.key?(:accredited_provider_search_form)
+
+        params.require(:accredited_provider_search_form).permit(*AccreditedProviderSearchForm::FIELDS)
+      end
+
+      def accredited_provider_select_params
+        return {} unless params.key?(:accredited_provider_select_form)
+
+        params.require(:accredited_provider_select_form).permit(*AccreditedProviderSelectForm::FIELDS, *AccreditedProviderSearchForm::FIELDS)
+      end
+
+      def search_result_title_component
+        @search_result_title_component ||= SearchResultTitleComponent.new(
+          query:,
+          results_limit: @accredited_provider_search.limit,
+          results_count: @accredited_provider_search.providers.unscope(:limit).count,
+          return_path: publish_provider_recruitment_cycle_accredited_providers_path,
+          search_resource: 'accredited provider',
+          caption_text: "Add accredited provider - #{provider.name_and_code}"
+        )
       end
     end
   end

--- a/app/views/publish/providers/accredited_providers/index.html.erb
+++ b/app/views/publish/providers/accredited_providers/index.html.erb
@@ -7,7 +7,7 @@
       </h1>
 
       <%= govuk_button_link_to("Add accredited provider",
-      new_publish_provider_recruitment_cycle_accredited_provider_path(provider_code: @provider.provider_code,
+     new_publish_provider_recruitment_cycle_accredited_providers_path(provider_code: @provider.provider_code,
                                                                       recruitment_cycle_year: @provider.recruitment_cycle_year)) %>
 
     <p class="govuk-body">

--- a/app/views/publish/providers/accredited_providers/index.html.erb
+++ b/app/views/publish/providers/accredited_providers/index.html.erb
@@ -7,8 +7,8 @@
       </h1>
 
       <%= govuk_button_link_to("Add accredited provider",
-      root_path(provider_code: @provider.provider_code,
-                recruitment_cycle_year: @provider.recruitment_cycle_year)) %>
+      new_publish_provider_recruitment_cycle_accredited_provider_path(provider_code: @provider.provider_code,
+                                                                      recruitment_cycle_year: @provider.recruitment_cycle_year)) %>
 
     <p class="govuk-body">
       <% if @provider.accrediting_providers.none? %>

--- a/app/views/publish/providers/accredited_providers/new.html.erb
+++ b/app/views/publish/providers/accredited_providers/new.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title, title_with_error_prefix("Enter a provider name, UKPRN or postcode", nil) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with(
+            model: @accredited_provider_search_form,
+            url: publish_provider_recruitment_cycle_accredited_providers_path,
+            method: :post
+          ) do |f| %>
+
+          <%= f.govuk_text_field(
+            :query,
+            label: { text: "Enter a provider name, UKPRN or postcode", size: "l", tag: "h1" },
+            caption: { text: "Add accredited provider", size: "l" }
+          ) %>
+
+          <%= f.govuk_submit t("continue") %>
+        <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+    </p>
+</div>
+  </div>

--- a/app/views/publish/providers/accredited_providers/new.html.erb
+++ b/app/views/publish/providers/accredited_providers/new.html.erb
@@ -1,29 +1,31 @@
-<% content_for :page_title, title_with_error_prefix("Enter a provider name, UKPRN or postcode", nil) %>
+<% content_for :page_title, title_with_error_prefix("Enter a provider name, UKPRN or postcode", @accredited_provider_search_form.errors) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<%= form_with(
+        model: @accredited_provider_search_form,
+        url: publish_provider_recruitment_cycle_accredited_providers_path,
+        method: :post
+      ) do |f| %>
 
-    <%= form_with(
-            model: @accredited_provider_search_form,
-            url: publish_provider_recruitment_cycle_accredited_providers_path,
-            method: :post
-          ) do |f| %>
+  <%= f.govuk_error_summary %>
 
-          <%= f.govuk_text_field(
-            :query,
-            label: { text: "Enter a provider name, UKPRN or postcode", size: "l", tag: "h1" },
-            caption: { text: "Add accredited provider", size: "l" }
-          ) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-          <%= f.govuk_submit t("continue") %>
-        <% end %>
+      <%= f.govuk_text_field(
+        :query,
+        label: { text: "Enter a provider name, UKPRN or postcode", size: "l", tag: "h1" },
+        caption: { text: "Add accredited provider", size: "l" }
+      ) %>
 
-    <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
-    </p>
-</div>
+      <%= f.govuk_submit t("continue") %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+      </p>
+    </div>
   </div>
+<% end %>

--- a/app/views/publish/providers/accredited_providers/results.html.erb
+++ b/app/views/publish/providers/accredited_providers/results.html.erb
@@ -5,36 +5,35 @@
   <%= govuk_back_link_to(publish_provider_recruitment_cycle_accredited_providers_path) %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<%= form_with(
+    model: @accredited_provider_select_form,
+    url: publish_provider_recruitment_cycle_accredited_providers_path,
+    method: :put
+  ) do |f| %>
 
-    <%= form_with(
-        model: @accredited_provider_select_form,
-        url: publish_provider_recruitment_cycle_accredited_providers_path,
-        method: :put
-      ) do |f| %>
+    <%= f.govuk_error_summary %>
 
-      <%= f.govuk_error_summary %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
 
-      <%= render search_result_title_component %>
+        <%= render search_result_title_component %>
 
-      <% unless @accredited_provider_search.providers.empty? %>
-        <%= f.govuk_radio_buttons_fieldset(:provider_id, legend: { text: "Accredited provider", size: "m" }) do %>
-          <% @accredited_provider_search.providers.each_with_index do |provider, index| %>
-            <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code }, link_errors: index.zero? %>
+        <% unless @accredited_provider_search.providers.empty? %>
+          <%= f.govuk_radio_buttons_fieldset(:provider_id, legend: { text: "Accredited provider", size: "m" }) do %>
+            <% @accredited_provider_search.providers.each_with_index do |provider, index| %>
+              <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code }, link_errors: index.zero? %>
+            <% end %>
           <% end %>
+
+          <%= f.hidden_field :query, value: query %>
+          <%= f.govuk_submit t("continue") %>
         <% end %>
 
-        <%= f.hidden_field :query, value: query %>
-        <%= f.govuk_submit t("continue") %>
+      <% unless @accredited_provider_search.providers.empty? %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_accredited_providers_path) %>
+        </p>
       <% end %>
-
-    <% end %>
-
-     <% unless @accredited_provider_search.providers.empty? %>
-      <p class="govuk-body">
-        <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_accredited_providers_path) %>
-      </p>
-    <% end %>
-  </div>
-</div>
+      </div>
+    </div>
+  <% end %>

--- a/app/views/publish/providers/accredited_providers/results.html.erb
+++ b/app/views/publish/providers/accredited_providers/results.html.erb
@@ -33,7 +33,7 @@
 
      <% unless @accredited_provider_search.providers.empty? %>
       <p class="govuk-body">
-        <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_accredited_providers_path) %>
+        <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_accredited_providers_path) %>
       </p>
     <% end %>
   </div>

--- a/app/views/publish/providers/accredited_providers/results.html.erb
+++ b/app/views/publish/providers/accredited_providers/results.html.erb
@@ -1,0 +1,40 @@
+
+<% content_for :page_title, title_with_error_prefix(search_result_title_component.title, @accredited_provider_select_form.errors.present?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_accredited_providers_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with(
+        model: @accredited_provider_select_form,
+        url: publish_provider_recruitment_cycle_accredited_providers_path,
+        method: :put
+      ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <%= render search_result_title_component %>
+
+      <% unless @accredited_provider_search.providers.empty? %>
+        <%= f.govuk_radio_buttons_fieldset(:provider_id, legend: { text: "Accredited provider", size: "m" }) do %>
+          <% @accredited_provider_search.providers.each_with_index do |provider, index| %>
+            <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code }, link_errors: index.zero? %>
+          <% end %>
+        <% end %>
+
+        <%= f.hidden_field :query, value: query %>
+        <%= f.govuk_submit t("continue") %>
+      <% end %>
+
+    <% end %>
+
+     <% unless @accredited_provider_search.providers.empty? %>
+      <p class="govuk-body">
+        <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_accredited_providers_path) %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -227,6 +227,7 @@ namespace :publish, as: :publish do
 
       scope module: :providers do
         resources :accredited_providers, only: [:index], path: '/accredited-providers'
+        resource :accredited_providers, only: [:new, :create, :update], path: '/accredited-providers'
         resource :check_school, only: %i[show update], controller: 'schools_check', path: 'schools/check'
         resources :schools do
           member do

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -227,7 +227,7 @@ namespace :publish, as: :publish do
 
       scope module: :providers do
         resources :accredited_providers, only: [:index], path: '/accredited-providers'
-        resource :accredited_providers, only: [:new, :create, :update], path: '/accredited-providers'
+        resource :accredited_providers, only: %i[new create update], path: '/accredited-providers'
         resource :check_school, only: %i[show update], controller: 'schools_check', path: 'schools/check'
         resources :schools do
           member do

--- a/spec/features/publish/accredited_provider_spec.rb
+++ b/spec/features/publish/accredited_provider_spec.rb
@@ -6,25 +6,93 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   before do
     given_i_am_a_lead_school_provider_user
     and_the_accredited_provider_search_feature_is_on
+    and_i_visit_the_root_path
+    when_i_click_on_the_accredited_provider_tab
   end
 
   scenario 'i can view the accredited providers tab when there are none' do
-    when_i_visit_the_root_path
-    and_i_click_on_the_accredited_provider_tab
     then_i_see_the_correct_text_for_no_accredited_providers
   end
 
+  scenario 'i can search for an accredited provider when they are searchable' do
+    given_there_are_accredited_providers_in_the_database
+    when_i_click_add_accredited_provider
+    and_i_search_with_an_invalid_query
+    then_i_should_see_an_error_message
+
+    when_i_search_for_an_accredited_provider_with_a_valid_query
+    then_i_see_the_provider_i_searched_for
+
+    when_i_continue_without_selecting_an_accredited_provider
+    and_i_should_see_an_error_message('Select an accredited provider')
+    then_i_should_still_see_the_provider_i_searched_for
+
+    when_i_select_the_provider
+    then_i_should_be_taken_to_the_index_page
+  end
+
   private
+
+  def and_i_search_with_an_invalid_query
+    fill_in form_title, with: ''
+    click_continue
+  end
+
+  def then_i_should_be_taken_to_the_index_page
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year))
+  end
+
+  def when_i_select_the_provider
+    choose @accredited_provider.provider_name
+    click_continue
+  end
+
+  def then_i_should_still_see_the_provider_i_searched_for
+    expect(page).to have_content(@accredited_provider.provider_name)
+    expect(page).not_to have_content(@accredited_provider_two.provider_name)
+    expect(page).not_to have_content(@accredited_provider_three.provider_name)
+  end
+
+  def and_i_should_see_an_error_message(error_message = form_title)
+    expect(page).to have_content(error_message)
+  end
+
+  alias_method :then_i_should_see_an_error_message, :and_i_should_see_an_error_message
+
+  def when_i_continue_without_selecting_an_accredited_provider
+    click_continue
+  end
+
+  def then_i_see_the_provider_i_searched_for
+    expect(page).to have_content(@accredited_provider.provider_name)
+    expect(page).not_to have_content(@accredited_provider_two.provider_name)
+    expect(page).not_to have_content(@accredited_provider_three.provider_name)
+  end
+
+  def given_there_are_accredited_providers_in_the_database
+    @accredited_provider = create(:provider, :accredited_provider, provider_name: 'UCL')
+    @accredited_provider_two = create(:provider, :accredited_provider, provider_name: 'Accredited provider two')
+    @accredited_provider_three = create(:provider, :accredited_provider, provider_name: 'Accredited provider three')
+  end
+
+  def when_i_search_for_an_accredited_provider_with_a_valid_query
+    fill_in form_title, with: @accredited_provider.provider_name
+    click_continue
+  end
+
+  def when_i_click_add_accredited_provider
+    click_link 'Add accredited provider'
+  end
 
   def then_i_see_the_correct_text_for_no_accredited_providers
     expect(page).to have_text("There are no accredited providers for #{@provider.provider_name}")
   end
 
-  def and_i_click_on_the_accredited_provider_tab
+  def when_i_click_on_the_accredited_provider_tab
     click_link 'Accredited provider'
   end
 
-  def when_i_visit_the_root_path
+  def and_i_visit_the_root_path
     visit root_path
   end
 
@@ -37,9 +105,11 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     @provider = @current_user.providers.first
   end
 
-  # This method will be used in a follow up PR where the comment will be removed.
-  def and_my_provider_has_accredited_providers
-    @provider.courses << create(:course, :with_accrediting_provider)
-    @accrediting_provider = @provider.accrediting_providers.first
+  def form_title
+    'Enter a provider name, UKPRN or postcode'
+  end
+
+  def click_continue
+    click_on 'Continue'
   end
 end


### PR DESCRIPTION
### Context

Following from #3540, this PR builds out the `/new` pages. 

### Changes proposed in this pull request

- We have a button on the AP tab for a lead school, which takes you to a page that allows you to search for an accrediting provider without autocomplete.

- The search returns a list of possible AP to choose from or returns the user back to the search to try a new term.

- After selecting an AP the search takes you to the next step upon submission.

### Screenshots

<img width="926" alt="image" src="https://user-images.githubusercontent.com/50492247/236259123-b2f6776b-c70d-452d-ad1c-f64846478a08.png">

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/50492247/236449911-4ad7c2e3-b9fd-4c95-94e9-777bb8b36c6f.png">


<img width="941" alt="image" src="https://user-images.githubusercontent.com/50492247/236259186-ea066118-6689-4615-aec2-5d2af086c173.png">

<img width="944" alt="image" src="https://user-images.githubusercontent.com/50492247/236450277-ddf3b5d1-b792-4b21-acd0-ea4c45800446.png">


### Guidance to review

The continue button in the last screenshot will take you back to the accredited providers page but won't currently show the acccredited provider added. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
