### PR TITLE
[1272] Realign accrediting provider enrichment to be accredited bodies

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -326,7 +326,7 @@ class Provider < ApplicationRecord
           description: accrediting_provider_enrichment.Description || ''
         }
       end
-    end
+    end || []
   end
 
   def next_available_course_code

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -55,6 +55,7 @@ class Provider < ApplicationRecord
   has_many :courses, -> { kept }, inverse_of: false
   has_one :ucas_preferences, class_name: 'ProviderUCASPreference'
   has_many :contacts
+
   has_many :accredited_courses, # use current_accredited_courses to filter to courses in the same cycle as this provider
            -> { where(discarded_at: nil) },
            class_name: 'Course',
@@ -62,8 +63,11 @@ class Provider < ApplicationRecord
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
 
-  # the accredited_providers that this provider is a training_provider for
-  has_many :accrediting_providers, -> { distinct }, through: :courses
+  def accredited_providers
+    recruitment_cycle.providers.where(provider_code: accredited_provider_codes)
+  end
+
+  alias accrediting_providers accredited_providers
 
   delegate :year, to: :recruitment_cycle, prefix: true
 
@@ -310,7 +314,7 @@ class Provider < ApplicationRecord
   end
 
   def accredited_bodies
-    accrediting_provider_enrichments.filter_map do |accrediting_provider_enrichment|
+    accrediting_provider_enrichments&.filter_map do |accrediting_provider_enrichment|
       provider_code = accrediting_provider_enrichment.UcasProviderCode
 
       accredited_provider = recruitment_cycle.providers.find_by(provider_code:)
@@ -365,6 +369,9 @@ class Provider < ApplicationRecord
 
   private
 
+  def accredited_provider_codes
+    accrediting_provider_enrichments&.map(&:UcasProviderCode) || []
+  end
   scope :course_code_search, ->(course_code) { joins(:courses).merge(Course.case_insensitive_search(course_code)) }
 
   def searchable_vector_value

--- a/app/views/publish/providers/accredited_providers/index.html.erb
+++ b/app/views/publish/providers/accredited_providers/index.html.erb
@@ -12,10 +12,10 @@
     </div>
   </div>
 
-  <% if @provider.accrediting_providers.none? %>
+  <% if @provider.accredited_providers.none? %>
       There are no accredited providers for <%= @provider.provider_name %>.
   <% else %>
-    <% @provider.accrediting_providers.each do |ap| %>
+    <% @provider.accredited_providers.each do |ap| %>
       <%= render AccreditedProvider.new(provider_name: ap.provider_name, remove_path: root_path, about_accredited_provider: ap.train_with_us, change_about_accredited_provider_path: root_path) %>
     <% end %>
   <% end %>

--- a/spec/features/publish/courses/new_accredited_provider_spec.rb
+++ b/spec/features/publish/courses/new_accredited_provider_spec.rb
@@ -22,10 +22,12 @@ feature 'selection accredited_bodies', { can_edit_current_and_next_cycles: false
   private
 
   def given_i_am_authenticated_as_a_provider_user
-    @user = create(:user, :with_provider)
-    course = create(:course, :with_accrediting_provider)
+    provider = create(:provider)
+    course = create(:course, :with_accrediting_provider, provider:)
     @accredited_provider_code = course.accredited_provider_code
-    @user.providers.first.courses << course
+    provider.accrediting_provider_enrichments = [{ UcasProviderCode: @accredited_provider_code }]
+    @user = create(:user, providers: [provider])
+
     given_i_am_authenticated(user: @user)
   end
 

--- a/spec/features/publish/edit_provider_details_spec.rb
+++ b/spec/features/publish/edit_provider_details_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'About Your Organisation section', { can_edit_current_and_next_cycles: false } do
   scenario 'Provider user edits provider details' do
     given_i_am_a_provider_user_as_a_provider_user
-    and_my_provider_has_accrediting_providers
     when_i_visit_the_details_page
     then_i_can_edit_info_about_training_with_us
     then_i_can_edit_info_about_our_accredited_bodies
@@ -13,12 +12,13 @@ feature 'About Your Organisation section', { can_edit_current_and_next_cycles: f
   end
 
   def given_i_am_a_provider_user_as_a_provider_user
-    given_i_am_authenticated(user: create(:user, :with_provider))
-    @provider = @current_user.providers.first
-  end
+    @provider = create(:provider)
+    course = create(:course, :with_accrediting_provider, provider: @provider)
 
-  def and_my_provider_has_accrediting_providers
-    @provider.courses << create(:course, :with_accrediting_provider)
+    accredited_provider_code = course.accredited_provider_code
+    @provider.accrediting_provider_enrichments = [{ UcasProviderCode: accredited_provider_code }]
+
+    given_i_am_authenticated(user: create(:user, providers: [@provider]))
     @accrediting_provider = @provider.accrediting_providers.first
   end
 

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -368,13 +368,17 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def user_with_no_course_enrichments
-    course = build(
-      :course, :secondary, :fee_type_based, :with_accrediting_provider, degree_grade: nil, additional_degree_subject_requirements: nil
+    provider = create(
+      :provider, train_with_disability: nil, train_with_us: nil
     )
 
-    provider = build(
-      :provider, courses: [course], train_with_disability: nil, train_with_us: nil
+    course = create(
+      :course, :secondary, :fee_type_based, :with_accrediting_provider, provider:, degree_grade: nil, additional_degree_subject_requirements: nil
     )
+
+    accredited_provider_code = course.accredited_provider_code
+
+    provider.accrediting_provider_enrichments = [{ UcasProviderCode: accredited_provider_code }]
 
     create(
       :user,

--- a/spec/models/provider/accredited_providers_spec.rb
+++ b/spec/models/provider/accredited_providers_spec.rb
@@ -46,6 +46,11 @@ describe Provider do
     context 'with an accrediting provider (via courses)' do
       let(:accrediting_provider) { build(:provider, provider_code: 'AP1') }
       let(:courses) { [build(:course, course_code: 'P33P', accrediting_provider:)] }
+      let(:accredited_provider) { accrediting_provider }
+
+      let(:accrediting_provider_enrichments) do
+        [{ UcasProviderCode: accredited_provider.provider_code }]
+      end
 
       its(:length) { is_expected.to be(1) }
 
@@ -84,15 +89,7 @@ describe Provider do
           }]
         end
 
-        its(:length) { is_expected.to be(1) }
-
-        describe 'the returned accredited provider' do
-          subject { provider.accredited_bodies.first }
-
-          its([:description]) { is_expected.to eq('') }
-          its([:provider_code]) { is_expected.to eq(accrediting_provider.provider_code) }
-          its([:provider_name]) { is_expected.to eq(accrediting_provider.provider_name) }
-        end
+        its(:length) { is_expected.to be(0) }
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -371,15 +371,25 @@ describe Provider do
     end
   end
 
-  describe 'accrediting_providers' do
-    let(:provider) { create(:provider, accrediting_provider: 'N') }
+  describe '#accrediting_providers' do
+    let(:provider) { create(:provider, accrediting_provider: 'N', accrediting_provider_enrichments:) }
 
     let(:accrediting_provider) { create(:provider, accrediting_provider: 'Y') }
+    let(:accredited_provider) { accrediting_provider }
     let!(:course1) { create(:course, accrediting_provider:, provider:) }
     let!(:course2) { create(:course, accrediting_provider:, provider:) }
 
+    let(:accrediting_provider_enrichments) do
+      [{ UcasProviderCode: accredited_provider.provider_code },
+       { UcasProviderCode: accredited_provider.provider_code }]
+    end
+
     it "returns the course's accrediting provider" do
       expect(provider.accrediting_providers.first).to eq(accrediting_provider)
+    end
+
+    it 'is aliased' do
+      expect(provider.accrediting_providers).to eq(provider.accredited_providers)
     end
 
     it 'does not duplicate data' do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -924,4 +924,38 @@ describe Provider do
       it { is_expected.to contain_exactly(matching_provider) }
     end
   end
+
+  describe '#accredited_bodies' do
+    it 'returns empty array' do
+      expect(subject.accredited_bodies).to match([])
+    end
+
+    context 'with accredited provider' do
+      let(:accredited_provider_one) { create(:provider, provider_code: 'AP1') }
+      let(:accredited_provider_two) { create(:provider, :previous_recruitment_cycle, provider_code: 'AP2') }
+      let(:accredited_provider_three) { create(:provider, provider_code: 'AP3') }
+
+      let(:accrediting_provider_enrichments) do
+        [{ UcasProviderCode: accredited_provider_one.provider_code,
+           Description: 'about the accredited provider' },
+         { UcasProviderCode: accredited_provider_two.provider_code },
+         { UcasProviderCode: accredited_provider_three.provider_code }]
+      end
+
+      it 'returns the current recruitment accredited bodies' do
+        expect(subject.accredited_bodies).to match([
+                                                     {
+                                                       provider_name: accredited_provider_one.provider_name,
+                                                       provider_code: accredited_provider_one.provider_code,
+                                                       description: 'about the accredited provider'
+                                                     },
+                                                     {
+                                                       provider_name: accredited_provider_three.provider_name,
+                                                       provider_code: accredited_provider_three.provider_code,
+                                                       description: ''
+                                                     }
+                                                   ])
+      end
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -953,18 +953,20 @@ describe Provider do
       end
 
       it 'returns the current recruitment accredited bodies' do
-        expect(subject.accredited_bodies).to match([
-                                                     {
-                                                       provider_name: accredited_provider_one.provider_name,
-                                                       provider_code: accredited_provider_one.provider_code,
-                                                       description: 'about the accredited provider'
-                                                     },
-                                                     {
-                                                       provider_name: accredited_provider_three.provider_name,
-                                                       provider_code: accredited_provider_three.provider_code,
-                                                       description: ''
-                                                     }
-                                                   ])
+        expect(subject.accredited_bodies).to match(
+          [
+            {
+              provider_name: accredited_provider_one.provider_name,
+              provider_code: accredited_provider_one.provider_code,
+              description: 'about the accredited provider'
+            },
+            {
+              provider_name: accredited_provider_three.provider_name,
+              provider_code: accredited_provider_three.provider_code,
+              description: ''
+            }
+          ]
+        )
       end
     end
   end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -31,12 +31,19 @@ describe ProviderPolicy do
   end
 
   permissions :can_show_training_provider? do
+    let(:accrediting_provider_enrichments) { [{ UcasProviderCode: course.accredited_provider_code }] }
+
     let(:allowed_user) { create(:user, providers: [provider]) }
     let(:not_allowed_user) { create(:user) }
 
-    let(:provider) { course.accrediting_provider }
-    let(:training_provider) { course.provider }
     let(:course) { create(:course, :with_accrediting_provider) }
+
+    let(:provider) { course.accrediting_provider }
+    let(:training_provider) do
+      course.provider
+      course.provider.accrediting_provider_enrichments = accrediting_provider_enrichments
+      course.provider
+    end
 
     it { is_expected.to permit(admin, training_provider) }
     it { is_expected.to permit(allowed_user, training_provider) }


### PR DESCRIPTION
### Context
Accredited bodies

### Changes proposed in this pull request
Realign accrediting provider enrichment to be accredited bodies

### Guidance to review

The data flow direction has been reversed.

Instead of the course being the driver for who is the accredited provider, it is now from the the enrichments.

Course will no longer create relationship, dealt with by other PRs.
Enrichment will be creating the relationship, dealt with by other PRs.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
