### PR TITLE
Revert Find TTL, remove environment_tag

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/find_pentest.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_pentest.tfvars.json
@@ -7,17 +7,16 @@
         "pen2"
       ],
       "environment_short": "pt",
-      "environment_tag": "pt",
       "origin_hostname": "d192luriw5sv7r.cloudfront.net",
       "null_host_header": false,
       "cnames": {
         "pen": {
           "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_fbd7691abf32da09ef59c558aca7867b.pen": {
           "target": "_e1c446a4b80718a2d40ed83d9dc46821.lwzrbtbdjq.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       }
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
@@ -7,33 +7,32 @@
         "www3"
       ],
       "environment_short": "pd",
-      "environment_tag": "pd",
       "origin_hostname": "d3kffbwt0ldx12.cloudfront.net",
       "null_host_header": false,
       "cnames": {
         "www": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_9357f29512431b51b0be15b92f4492ab.www": {
           "target": "_46045336ca9b4525aa640b14d88627f1.bsgbmzkfwj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "www2": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_c68d2a349fa147282368dc07a5fc4dc0.www2": {
           "target": "_68aa7b43974c039690db1cb53522e77c.bsgbmzkfwj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "assets": {
           "target": "dxhwikmjcbucp.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_6d15c33c355ac134edba53d48a3f40c5.assets": {
           "target": "_6008fa4bac8572a8e6762d0d3b774a40.tjxrvlrcqj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       }
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_qa.tfvars.json
@@ -7,41 +7,40 @@
         "qa3"
       ],
       "environment_short": "qa",
-      "environment_tag": "qa",
       "origin_hostname": "d1g6p51l52so6s.cloudfront.net",
       "null_host_header": false,
       "cnames": {
         "qa-assets": {
           "target": "d3o8h99fub56wx.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_726e3e7a4fe7f031753f263a79752196.qa-assets": {
           "target": "_4c48ed2d6f1c52b816b4ceab6e4944c6.tjxrvlrcqj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "qa": {
           "target": "d1g6p51l52so6s.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_05cc28b6a8575651297b1f9200e98539.qa": {
           "target": "_8c4a2c29360023c1279ad79c710a5961.bsgbmzkfwj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "www2.qa": {
           "target": "d1lqzmyk49s2hr.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_113cde0e61cee481000aabd93fb63c1b.www2.qa": {
           "target": "_58d7c1dd9f41a5b4d70a919f616c211b.bsgbmzkfwj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "qa2": {
           "target": "d1g6p51l52so6s.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_d1f9a5a41bf90de6d78ff2fd1cad52ba.qa2": {
           "target": "_3964953cd41c65f254be85bfa5c16454.zxwlrjxpwn.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       }
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
@@ -7,33 +7,32 @@
         "sandbox3"
       ],
       "environment_short": "sbx",
-      "environment_tag": "sbx",
       "origin_hostname": "d3kffbwt0ldx12.cloudfront.net",
       "null_host_header": false,
       "cnames": {
         "sandbox-assets": {
           "target": "dxhwikmjcbucp.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_22a0e2097a2b837d2ef2ce075b5942c9.sandbox-assets": {
           "target": "_26726e941fc8a9ae7eba93d7351c0a15.tjxrvlrcqj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "sandbox": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_09cba63498801fac38cb744aeba235f0.sandbox": {
           "target": "_7158ce184053826b11bad77bddba8327.vtqfhvjlcp.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "sandbox2": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_5859a8d3e9a00a9089e6d90ef5b5811a.sandbox2": {
           "target": "_97a9fcda01308115d6852e78a92e539a.fpktwqqglf.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       }
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
@@ -7,33 +7,32 @@
         "staging3"
       ],
       "environment_short": "stg",
-      "environment_tag": "stg",
       "origin_hostname": "d192luriw5sv7r.cloudfront.net",
       "null_host_header": false,
       "cnames": {
         "staging-assets": {
           "target": "d325g8v033lilj.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_cdbda462948c3cb8ed45d63692a7ed85.staging-assets": {
           "target": "_178a0720a90428ab7b6a1cdd99c9d80c.tjxrvlrcqj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "staging": {
           "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_48d5780dfc0f00802dbda96478d1f21a.staging": {
           "target": "_3393a8bc155665a9a5351baf2ef27ea5.bsgbmzkfwj.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "staging2": {
           "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_e68dbfcf360ee71cd5d1d70fbc1edaa2.staging2": {
           "target": "_98e138b99aa32a45298fc9d490648530.fpktwqqglf.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       }
     }


### PR DESCRIPTION
### Context
Tidy-up the domain configuration post Find DNS migration to Azure.

### Changes proposed in this pull request
Revert the TTL for the Find domain to pre-migration values.
Remove the environment_tag which is no longer used.

### Guidance to review
Confirmed no changes apart from TTL values by running `make find ENV domains-plan`

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
