### PR TITLE
[1277] Providers render the accredited provider summary component

### DIFF
--- a/app/views/publish/providers/accredited_providers/index.html.erb
+++ b/app/views/publish/providers/accredited_providers/index.html.erb
@@ -9,10 +9,13 @@
       <%= govuk_button_link_to("Add accredited provider",
      new_publish_provider_recruitment_cycle_accredited_providers_path(provider_code: @provider.provider_code,
                                                                       recruitment_cycle_year: @provider.recruitment_cycle_year)) %>
-
-    <p class="govuk-body">
-      <% if @provider.accrediting_providers.none? %>
-          There are no accredited providers for <%= @provider.provider_name %>.
-      <% end %>
     </div>
   </div>
+
+  <% if @provider.accrediting_providers.none? %>
+      There are no accredited providers for <%= @provider.provider_name %>.
+  <% else %>
+    <% @provider.accrediting_providers.each do |ap| %>
+      <%= render AccreditedProvider.new(provider_name: ap.provider_name, remove_path: root_path, about_accredited_provider: ap.train_with_us, change_about_accredited_provider_path: root_path) %>
+    <% end %>
+  <% end %>

--- a/spec/features/publish/accredited_provider_spec.rb
+++ b/spec/features/publish/accredited_provider_spec.rb
@@ -14,6 +14,12 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     then_i_see_the_correct_text_for_no_accredited_providers
   end
 
+  scenario 'i can view accredited providers on the index page' do
+    and_my_provider_has_accrediting_providers
+    and_i_click_on_the_accredited_provider_tab
+    then_i_should_see_the_accredited_provider_name_displayed
+  end
+
   scenario 'i can search for an accredited provider when they are searchable' do
     given_there_are_accredited_providers_in_the_database
     when_i_click_add_accredited_provider
@@ -92,6 +98,8 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     click_link 'Accredited provider'
   end
 
+  alias_method :and_i_click_on_the_accredited_provider_tab, :when_i_click_on_the_accredited_provider_tab
+
   def and_i_visit_the_root_path
     visit root_path
   end
@@ -111,5 +119,15 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
 
   def click_continue
     click_on 'Continue'
+  end
+
+  def and_my_provider_has_accrediting_providers
+    course = build(:course, accrediting_provider: build(:provider, :accredited_provider, provider_name: 'Accrediting provider name'))
+
+    @provider.courses << course
+  end
+
+  def then_i_should_see_the_accredited_provider_name_displayed
+    expect(page).to have_selector('h2', text: 'Accrediting provider name')
   end
 end


### PR DESCRIPTION
### Context

We created the accredited provider summary component in #3542. This PR surfaces the component on the index page if there are accredited providers present.

### Changes proposed in this pull request

Surface the accredited provider component on the index page if there are accredited providers present.

### Guidance to review

- View a provider with accredited providers.
- View a provider without accredited providers.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
