### PR TITLE
[1292] Fix school search bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,6 +732,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-js: yarn build --watch
+js: yarn build:js --watch
 css: yarn build:css --watch
 web: bin/rails server -p 3001
 worker: bundle exec sidekiq -t 25 -C config/sidekiq.yml

--- a/app/controllers/publish/providers/school_search_controller.rb
+++ b/app/controllers/publish/providers/school_search_controller.rb
@@ -15,6 +15,8 @@ module Publish
         @school_search_form = Schools::SearchForm.new(query:)
 
         if @school_search_form.valid?
+          redirect_to_next_step and return if school_search_params[:school_id].present?
+
           @school_select_form = Schools::SelectForm.new
           @school_search = Schools::SearchService.call(query:)
 
@@ -59,7 +61,7 @@ module Publish
       def school_search_params
         return {} unless params.key?(:publish_schools_search_form)
 
-        params.require(:publish_schools_search_form).permit(*Schools::SearchForm::FIELDS)
+        params.require(:publish_schools_search_form).permit(*Schools::SearchForm::FIELDS, :school_id)
       end
 
       def school_select_params
@@ -75,6 +77,13 @@ module Publish
           results_count: @school_search.schools.unscope(:limit).count,
           return_path: search_publish_provider_recruitment_cycle_schools_path,
           search_resource: 'school'
+        )
+      end
+
+      def redirect_to_next_step
+        redirect_to new_publish_provider_recruitment_cycle_school_path(
+          provider_code: provider.provider_code,
+          school_id: school_search_params[:school_id]
         )
       end
     end

--- a/app/javascript/publish/application.js
+++ b/app/javascript/publish/application.js
@@ -27,6 +27,15 @@ try {
   const schoolInput = document.getElementById('publish-schools-search-form-query-field')
   const schoolTemplate = (result) => result && `${result.name}`
   const schoolSuggestionsTemplate = (result) => result && `${result.name} (${result.town}, ${result.postcode})`
+  const schoolHiddenIdInput = document.getElementById('school-id')
+
+  const schoolConfirmCallback = (schoolId) => {
+    if (schoolId === undefined) {
+      return
+    }
+
+    schoolHiddenIdInput.value = schoolId
+  }
 
   if (autocomplete && providerInput) {
     initAutocomplete(autocomplete, providerInput, providerTemplate, {
@@ -37,7 +46,10 @@ try {
   if (schoolAutocomplete && schoolInput) {
     initAutocomplete(schoolAutocomplete, schoolInput, schoolTemplate, {
       path: '/api/school_suggestions',
-      template: schoolSuggestionsTemplate
+      template: schoolSuggestionsTemplate,
+      onConfirm: (option) => {
+        schoolConfirmCallback(option.id)
+      }
     })
   }
 } catch (err) {

--- a/app/javascript/publish/autocomplete.js
+++ b/app/javascript/publish/autocomplete.js
@@ -5,6 +5,7 @@ import { request } from '../utils/request_helper'
 export const initAutocomplete = ($el, $input, inputValueTemplate, options = {}) => {
   const path = options.path
   const suggestionTemplate = options.template
+  const onConfirmCallback = options.onConfirm || (() => {})
 
   accessibleAutocomplete({
     element: $el,
@@ -18,7 +19,10 @@ export const initAutocomplete = ($el, $input, inputValueTemplate, options = {}) 
       inputValue: inputValueTemplate,
       suggestion: suggestionTemplate
     },
-    onConfirm: (option) => ($input.value = option ? option.code : ''),
+    onConfirm: (option) => {
+      $input.value = option ? option.code : ''
+      onConfirmCallback(option)
+    },
     confirmOnBlur: false,
     autoselect: true
   })

--- a/app/views/publish/providers/school_search/new.html.erb
+++ b/app/views/publish/providers/school_search/new.html.erb
@@ -34,6 +34,9 @@
                               data: { qa: "schools-search" } %>
         <div id="school-autocomplete"></div>
       </div>
+
+      <%= f.hidden_field :school_id, id: "school-id", value: nil %>
+
       <p class="govuk-body govuk-!-margin-bottom-7">
         <%= govuk_link_to(t(".cannot_find"), new_publish_provider_recruitment_cycle_school_path(@provider.provider_code)) %>
       </p>


### PR DESCRIPTION
### Context

https://trello.com/c/fmC7d0ae/1292-bug-adding-a-school-in-publish

### Changes proposed in this pull request

Fixes a bug in the school autocomplete search where selecting a school from the dropdown can still trigger a search. The fix is to set the school id form the JS and skip the search all together unless a value isn't selected which should then trigger a search.

### Guidance to review

- Go to the school search
- Try searching for the URN `144065`
- Assert that if you select the provider it doesn't trigger search

I've left the current implementation in where if you do not select a school but search a query where we match on one result then also skip the search otherwise we'll just show the results page with one option.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
