### PR TITLE
[1297] single search result for schools and aps

### DIFF
--- a/app/controllers/publish/providers/school_search_controller.rb
+++ b/app/controllers/publish/providers/school_search_controller.rb
@@ -20,16 +20,6 @@ module Publish
           @school_select_form = Schools::SelectForm.new
           @school_search = Schools::SearchService.call(query:)
 
-          if @school_search.schools.size == 1
-            @school_select_form = Schools::SelectForm.new(school_id: @school_search.schools[0].id)
-            if @school_select_form.valid?
-              redirect_to new_publish_provider_recruitment_cycle_school_path(
-                provider_code: provider.provider_code,
-                school_id: @school_select_form.school_id
-              ) and return
-            end
-          end
-
           render :results
         else
           render :new

--- a/app/controllers/support/providers/accredited_provider_search_controller.rb
+++ b/app/controllers/support/providers/accredited_provider_search_controller.rb
@@ -17,13 +17,6 @@ module Support
           @accredited_provider_select_form = AccreditedProviderSelectForm.new
           @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:)
 
-          if @accredited_provider_search.providers.size == 1
-            @accredited_provider_select_form = AccreditedProviderSelectForm.new(provider_id: @accredited_provider_search.providers[0].id)
-            redirect_to new_support_recruitment_cycle_provider_accredited_provider_path(
-              provider_id: @accredited_provider_search.providers[0].id
-            ) and return
-          end
-
           render :results
         else
           provider

--- a/spec/features/publish/searching_for_a_school_spec.rb
+++ b/spec/features/publish/searching_for_a_school_spec.rb
@@ -14,7 +14,7 @@ feature 'Searching for a school from the GIAS list' do
     then_i_should_see_an_error_message
 
     when_i_search_for_a_school_with_a_valid_query
-    and_the_school_form_should_be_prefilled(@school)
+    then_i_should_see_a_single_radio_list
 
     when_i_visit_the_school_search_page
     when_i_search_for_a_school_with_a_partial_query
@@ -60,8 +60,15 @@ feature 'Searching for a school from the GIAS list' do
   end
 
   def then_i_should_see_a_radio_list
+    expect(page).not_to have_content @school.name
     expect(page).to have_content @school_two.name
     expect(page).to have_content @school_three.name
+  end
+
+  def then_i_should_see_a_single_radio_list
+    expect(page).to have_content @school.name
+    expect(page).not_to have_content @school_two.name
+    expect(page).not_to have_content @school_three.name
   end
 
   def when_i_search_for_a_school_with_a_valid_query

--- a/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -83,6 +83,8 @@ feature 'Searching for an accredited provider' do
 
   def then_i_see_a_single_provider_radio_list
     expect(page).to have_content(@accredited_provider.provider_name)
+    expect(page).not_to have_content(@accredited_provider_two.provider_name)
+    expect(page).not_to have_content(@accredited_provider_three.provider_name)
   end
 
   def when_i_select_the_provider

--- a/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -34,7 +34,7 @@ feature 'Searching for an accredited provider' do
   scenario 'I can search for an accredited provider by partial query' do
     when_i_visit_the_accredited_provider_search_page
     and_i_search_with_a_partial_query
-    then_i_am_on_the_new_page
+    then_i_see_a_single_provider_radio_list
   end
 
   scenario 'back links behaviour' do
@@ -75,14 +75,14 @@ feature 'Searching for an accredited provider' do
     click_continue
   end
 
-  def then_i_am_on_the_new_page
-    expect(page).to have_current_path("/support/2023/providers/#{@accredited_provider.id}/accredited-providers/new")
-  end
-
   def then_i_see_a_provider_radio_list
     expect(page).not_to have_content(@accredited_provider.provider_name)
     expect(page).to have_content(@accredited_provider_two.provider_name)
     expect(page).to have_content(@accredited_provider_three.provider_name)
+  end
+
+  def then_i_see_a_single_provider_radio_list
+    expect(page).to have_content(@accredited_provider.provider_name)
   end
 
   def when_i_select_the_provider


### PR DESCRIPTION
### Context
If there is only one search result from a non JS accredited provider or school search we should display a single radio button.
### Changes proposed in this pull request
Alter flow in `app/controllers/publish/providers/school_search_controller.rb` and `app/controllers/support/providers/accredited_provider_search_controller.rb` to remove single result check.
### Guidance to review
select unique search result from dropdown, next step should be a single radio button.
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
