### PR TITLE
[1235] Remove a accredited provider (providers)

### DIFF
--- a/app/controllers/publish/providers/accredited_providers_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers_controller.rb
@@ -46,7 +46,7 @@ module Publish
       end
 
       def destroy
-        return_if_cannot_delete
+        return if @cannot_delete
 
         provider.accrediting_provider_enrichments = accrediting_provider_enrichments
         provider.save
@@ -57,10 +57,6 @@ module Publish
       end
 
       private
-
-      def return_if_cannot_delete
-        return if @cannot_delete
-      end
 
       def accredited_provider
         @accredited_provider ||= @recruitment_cycle.providers.find_by(provider_code: params[:accredited_provider_code])

--- a/app/views/publish/providers/accredited_providers/_can_remove.html.erb
+++ b/app/views/publish/providers/accredited_providers/_can_remove.html.erb
@@ -1,0 +1,23 @@
+<%= content_for :page_title, t("publish.providers.accredited_providers.delete.title") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_accredited_providers_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-l"><%= @recruitment_cycle.providers.find_by(provider_code: params[:accredited_provider_code]).provider_name %></span>
+        <%= t("publish.providers.accredited_providers.delete.title") %>
+    </h1>
+
+    <%= govuk_button_to "Remove accredited provider",
+                        delete_publish_provider_recruitment_cycle_accredited_provider_path,
+        method: :delete,
+        class: "govuk-button--warning" %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_accredited_providers_path) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/providers/accredited_providers/_can_remove.html.erb
+++ b/app/views/publish/providers/accredited_providers/_can_remove.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-l"><%= @recruitment_cycle.providers.find_by(provider_code: params[:accredited_provider_code]).provider_name %></span>
+      <span class="govuk-caption-l"> <%= @accredited_provider.provider_name %></span>
         <%= t("publish.providers.accredited_providers.delete.title") %>
     </h1>
 

--- a/app/views/publish/providers/accredited_providers/_cannot_remove.html.erb
+++ b/app/views/publish/providers/accredited_providers/_cannot_remove.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title, "You cannot remove this accredited provider" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_accredited_providers_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+     <span class="govuk-caption-l"><%= @accredited_provider.provider_name %></span>
+      You cannot remove this accredited provider
+    </h1>
+
+    <p class="govuk-body">
+      <%= @accredited_provider.provider_name %> is an
+      accredited provider for courses run by <%= @provider.provider_name %>. At least one of these courses is
+      currently published on Find.
+    </p>
+
+    <p class="govuk-body">
+      If you need to change an accredited provider for a course which is published, please contact us at
+      <%= bat_contact_mail_to %>.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_accredited_providers_path) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/providers/accredited_providers/delete.html.erb
+++ b/app/views/publish/providers/accredited_providers/delete.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: @cannot_delete ? "cannot_remove" : "can_remove" %>

--- a/app/views/publish/providers/accredited_providers/index.html.erb
+++ b/app/views/publish/providers/accredited_providers/index.html.erb
@@ -19,7 +19,7 @@
         <p class="govuk-body">There are no accredited providers for <%= @provider.provider_name %>.</p>
     <% else %>
       <% @provider.accredited_bodies.each do |accredited_body| %>
-        <%= render AccreditedProvider.new(provider_name: accredited_body[:provider_name], remove_path: root_path, about_accredited_provider: accredited_body[:description], change_about_accredited_provider_path: edit_publish_provider_recruitment_cycle_accredited_provider_path(accredited_provider_code: accredited_body[:provider_code])) %>
+        <%= render AccreditedProvider.new(provider_name: accredited_body[:provider_name], remove_path: delete_publish_provider_recruitment_cycle_accredited_provider_path(accredited_provider_code: accredited_body[:provider_code]), about_accredited_provider: accredited_body[:description], change_about_accredited_provider_path: edit_publish_provider_recruitment_cycle_accredited_provider_path(accredited_provider_code: accredited_body[:provider_code])) %>
       <% end %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,6 +292,10 @@ en:
           title: About the accredited provider
           hint: Tell candidates about the accredited provider. You could mention their academic specialities and achievements.
           updated: About the accredited provider updated
+        delete: 
+          title: Are you sure you want to remove this accredited provider?
+          remove: Remove accredited provider
+          updated: Accredited provider removed
         checks:
           show:
             title:  *add_accredited_provider

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -226,7 +226,12 @@ namespace :publish, as: :publish do
       end
 
       scope module: :providers do
-        resources :accredited_providers, param: :accredited_provider_code, only: %i[index new edit create update], path: 'accredited-providers' do
+        resources :accredited_providers, param: :accredited_provider_code, only: %i[index new edit create update destroy], path: 'accredited-providers' do
+          member do
+            get :delete
+            delete :delete, to: 'accredited_providers#destroy'
+          end
+
           get '/search', on: :collection, to: 'accredited_provider_search#new'
           post '/search', on: :collection, to: 'accredited_provider_search#create'
           put '/search', on: :collection, to: 'accredited_provider_search#update'

--- a/spec/features/publish/accredited_provider_spec.rb
+++ b/spec/features/publish/accredited_provider_spec.rb
@@ -30,6 +30,21 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     and_i_see_the_success_message
   end
 
+  scenario 'i cannot delete accredited providers if they are attached to a course' do
+    and_my_provider_has_accrediting_providers
+    and_i_click_on_the_accredited_provider_tab
+    and_i_click_remove
+    then_i_should_see_the_cannot_remove_ap_text
+  end
+
+  scenario 'i can delete accredited providers if they are not attached to a course' do
+    and_i_create_a_new_accredited_provider
+    and_i_click_remove
+    and_i_click_remove_ap
+    and_i_see_the_remove_success_message
+    then_i_should_be_taken_to_the_index_page
+  end
+
   scenario 'i can search for an accredited provider when they are searchable' do
     given_there_are_accredited_providers_in_the_database_with_users
     when_i_click_add_accredited_provider
@@ -73,6 +88,27 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   private
+
+  def and_i_click_remove_ap
+    click_button 'Remove accredited provider'
+  end
+
+  def then_i_should_see_the_cannot_remove_ap_text
+    expect(page).to have_selector('h1', text: 'You cannot remove this accredited provider')
+  end
+
+  def and_i_click_remove
+    click_link 'Remove'
+  end
+
+  def and_i_create_a_new_accredited_provider
+    given_there_are_accredited_providers_in_the_database_with_users
+    when_i_click_add_accredited_provider
+    when_i_search_for_an_accredited_provider_with_a_valid_query
+    when_i_select_the_provider
+    when_i_input_some_information
+    when_i_confirm_the_changes
+  end
 
   def and_i_click_change
     click_link('Change')
@@ -127,6 +163,10 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
 
   def and_i_see_the_success_message
     expect(page).to have_content('About the accredited provider updated')
+  end
+
+  def and_i_see_the_remove_success_message
+    expect(page).to have_content('Accredited provider removed')
   end
 
   def then_i_should_be_taken_to_the_index_page


### PR DESCRIPTION
### Context

Following on from #3559, #3547, #3568 and #3573. This PR deals with removing an accredited provider which is already in the database. 

### Changes proposed in this pull request

- Add the ability to remove AP if they are **not** used by the provider.
- Show a "not possible" view if the user attempts to remove an AP which **is** in use by the provider.

### Screenshots

<img width="873" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/fd7c64ed-f370-4ef5-bc9a-a83009e35f97">

<img width="885" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/9c672af6-2cc0-4713-a712-ec4c616a83ba">


### Guidance to review

- Add a new AP on publish as a lead school and click the remove button to remove it. 
- Try to remove an AP on publish as a lead school where they accredit some courses.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
