### PR TITLE
1236 providers modify course flow based on ap availability

### DIFF
--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -27,9 +27,7 @@ module Courses
       course.assign_attributes(course_attributes.except(:subjects_ids))
 
       update_sites(course)
-      if course.provider.accredited_bodies.length == 1
-        course.accrediting_provider = course.provider.accrediting_providers.first
-      end
+      course.accrediting_provider = course.provider.accrediting_providers.first if course.provider.accredited_bodies.length == 1
       course.course_code = provider.next_available_course_code if next_available_course_code
 
       AssignSubjectsService.call(course:, subject_ids:)

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -27,7 +27,9 @@ module Courses
       course.assign_attributes(course_attributes.except(:subjects_ids))
 
       update_sites(course)
-
+      if course.provider.accredited_bodies.length == 1
+        course.accrediting_provider = course.provider.accrediting_providers.first
+      end
       course.course_code = provider.next_available_course_code if next_available_course_code
 
       AssignSubjectsService.call(course:, subject_ids:)

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -23,18 +23,17 @@ module Publish
     private
 
     def get_workflow_steps(course)
-      case
-      when course.provider.lead_school? && course.provider.accredited_bodies.length == 1
+      if course.provider.lead_school? && course.provider.accredited_bodies.length == 1
         school_direct_workflow_steps - [:accredited_provider]
-      when course.is_further_education?
+      elsif course.is_further_education?
         further_education_workflow_steps
-      when course.is_uni_or_scitt?
+      elsif course.is_uni_or_scitt?
         uni_or_scitt_workflow_steps - visas_to_remove(course)
-      when course.is_school_direct?
+      elsif course.is_school_direct?
         school_direct_workflow_steps - visas_to_remove(course)
       end
     end
-    
+
     def further_education_workflow_steps
       %i[
         courses_list

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'provider'
 
 module Publish
   class CourseCreationStepService
@@ -23,15 +24,18 @@ module Publish
     private
 
     def get_workflow_steps(course)
-      if course.is_further_education?
+      case
+      when course.provider.lead_school? && course.provider.accredited_bodies.length == 1
+        school_direct_workflow_steps - [:accredited_provider]
+      when course.is_further_education?
         further_education_workflow_steps
-      elsif course.is_uni_or_scitt?
+      when course.is_uni_or_scitt?
         uni_or_scitt_workflow_steps - visas_to_remove(course)
-      elsif course.is_school_direct?
+      when course.is_school_direct?
         school_direct_workflow_steps - visas_to_remove(course)
       end
     end
-
+    
     def further_education_workflow_steps
       %i[
         courses_list

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -3,12 +3,14 @@
 module Publish
   class CourseCreationStepService
     def execute(current_step:, course:)
-      workflow_steps = get_workflow_steps(course)
+      workflow_steps = WorkflowStepService.call(course)
       {
         next: get_next_step(workflow_steps, current_step),
         previous: get_previous_step(workflow_steps, current_step)
       }
     end
+
+    private
 
     def get_next_step(steps, current_step)
       next_step_index = steps.find_index(current_step).next
@@ -18,86 +20,6 @@ module Publish
     def get_previous_step(steps, current_step)
       previous_step_index = steps.find_index(current_step).pred
       steps[previous_step_index]
-    end
-
-    private
-
-    def get_workflow_steps(course)
-      if course.provider.lead_school? && course.provider.accredited_bodies.length == 1
-        school_direct_workflow_steps - [:accredited_provider]
-      elsif course.is_further_education?
-        further_education_workflow_steps
-      elsif course.is_uni_or_scitt?
-        uni_or_scitt_workflow_steps - visas_to_remove(course)
-      elsif course.is_school_direct?
-        school_direct_workflow_steps - visas_to_remove(course)
-      end
-    end
-
-    def further_education_workflow_steps
-      %i[
-        courses_list
-        level
-        outcome
-        full_or_part_time
-        school
-        applications_open
-        start_date
-        confirmation
-      ]
-    end
-
-    def school_direct_workflow_steps
-      %i[
-        courses_list
-        level
-        subjects
-        engineers_teach_physics
-        modern_languages
-        age_range
-        outcome
-        funding_type
-        full_or_part_time
-        school
-        accredited_provider
-        can_sponsor_student_visa
-        can_sponsor_skilled_worker_visa
-        applications_open
-        start_date
-        confirmation
-      ]
-    end
-
-    def uni_or_scitt_workflow_steps
-      %i[
-        courses_list
-        level
-        subjects
-        engineers_teach_physics
-        modern_languages
-        age_range
-        outcome
-        apprenticeship
-        full_or_part_time
-        school
-        can_sponsor_student_visa
-        can_sponsor_skilled_worker_visa
-        applications_open
-        start_date
-        confirmation
-      ]
-    end
-
-    def visas_to_remove(course)
-      if course.funding_type.present?
-        if course.is_fee_based?
-          [:can_sponsor_skilled_worker_visa]
-        elsif course.school_direct_salaried_training_programme? || course.pg_teaching_apprenticeship?
-          [:can_sponsor_student_visa]
-        end
-      else
-        %i[can_sponsor_student_visa can_sponsor_skilled_worker_visa]
-      end
     end
   end
 end

--- a/app/services/publish/course_creation_step_service.rb
+++ b/app/services/publish/course_creation_step_service.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'provider'
 
 module Publish
   class CourseCreationStepService

--- a/app/services/workflow_step_service.rb
+++ b/app/services/workflow_step_service.rb
@@ -1,93 +1,93 @@
 # frozen_string_literal: true
 
-    class WorkflowStepService
-      include ServicePattern
+class WorkflowStepService
+  include ServicePattern
 
-      def initialize(course)
-        @course = course
-      end
-  
-      def call
-        if course.provider.lead_school? && course.provider.accredited_bodies.length == 1
-          school_direct_workflow_steps - [:accredited_provider]
-        elsif course.is_further_education?
-          further_education_workflow_steps
-        elsif course.is_uni_or_scitt?
-          uni_or_scitt_workflow_steps - visas_to_remove(course)
-        elsif course.is_school_direct?
-          school_direct_workflow_steps - visas_to_remove(course)
-        end
-      end
-  
-      private
-  
-      attr_reader :course
-  
-      def further_education_workflow_steps
-        %i[
-          courses_list
-          level
-          outcome
-          full_or_part_time
-          school
-          applications_open
-          start_date
-          confirmation
-        ]
-      end
-  
-      def school_direct_workflow_steps
-        %i[
-          courses_list
-          level
-          subjects
-          engineers_teach_physics
-          modern_languages
-          age_range
-          outcome
-          funding_type
-          full_or_part_time
-          school
-          accredited_provider
-          can_sponsor_student_visa
-          can_sponsor_skilled_worker_visa
-          applications_open
-          start_date
-          confirmation
-        ]
-      end
-  
-      def uni_or_scitt_workflow_steps
-        %i[
-          courses_list
-          level
-          subjects
-          engineers_teach_physics
-          modern_languages
-          age_range
-          outcome
-          apprenticeship
-          full_or_part_time
-          school
-          can_sponsor_student_visa
-          can_sponsor_skilled_worker_visa
-          applications_open
-          start_date
-          confirmation
-        ]
-      end
-  
-      def visas_to_remove(course)
-        if course.funding_type.present?
-          if course.is_fee_based?
-            [:can_sponsor_skilled_worker_visa]
-          elsif course.school_direct_salaried_training_programme? || course.pg_teaching_apprenticeship?
-            [:can_sponsor_student_visa]
-          end
-        else
-          %i[can_sponsor_student_visa can_sponsor_skilled_worker_visa]
-        end
+  def initialize(course)
+    @course = course
+  end
+
+  def call
+    if course.is_further_education?
+      further_education_workflow_steps
+    elsif course.is_uni_or_scitt?
+      uni_or_scitt_workflow_steps - visas_to_remove(course)
+    elsif course.is_school_direct?
+      if course.provider.accredited_bodies.length == 1
+        school_direct_workflow_steps - (visas_to_remove(course) + [:accredited_provider])
+      else
+        school_direct_workflow_steps - visas_to_remove(course)
       end
     end
+  end
 
-  
+  private
+
+  attr_reader :course
+
+  def further_education_workflow_steps
+    %i[
+      courses_list
+      level
+      outcome
+      full_or_part_time
+      school
+      applications_open
+      start_date
+      confirmation
+    ]
+  end
+
+  def school_direct_workflow_steps
+    %i[
+      courses_list
+      level
+      subjects
+      engineers_teach_physics
+      modern_languages
+      age_range
+      outcome
+      funding_type
+      full_or_part_time
+      school
+      accredited_provider
+      can_sponsor_student_visa
+      can_sponsor_skilled_worker_visa
+      applications_open
+      start_date
+      confirmation
+    ]
+  end
+
+  def uni_or_scitt_workflow_steps
+    %i[
+      courses_list
+      level
+      subjects
+      engineers_teach_physics
+      modern_languages
+      age_range
+      outcome
+      apprenticeship
+      full_or_part_time
+      school
+      can_sponsor_student_visa
+      can_sponsor_skilled_worker_visa
+      applications_open
+      start_date
+      confirmation
+    ]
+  end
+
+  def visas_to_remove(course)
+    if course.funding_type.present?
+      if course.is_fee_based?
+        [:can_sponsor_skilled_worker_visa]
+      elsif course.school_direct_salaried_training_programme? || course.pg_teaching_apprenticeship?
+        [:can_sponsor_student_visa]
+      end
+    else
+      %i[can_sponsor_student_visa can_sponsor_skilled_worker_visa]
+    end
+  end
+end

--- a/app/services/workflow_step_service.rb
+++ b/app/services/workflow_step_service.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+    class WorkflowStepService
+      include ServicePattern
+
+      def initialize(course)
+        @course = course
+      end
+  
+      def call
+        if course.provider.lead_school? && course.provider.accredited_bodies.length == 1
+          school_direct_workflow_steps - [:accredited_provider]
+        elsif course.is_further_education?
+          further_education_workflow_steps
+        elsif course.is_uni_or_scitt?
+          uni_or_scitt_workflow_steps - visas_to_remove(course)
+        elsif course.is_school_direct?
+          school_direct_workflow_steps - visas_to_remove(course)
+        end
+      end
+  
+      private
+  
+      attr_reader :course
+  
+      def further_education_workflow_steps
+        %i[
+          courses_list
+          level
+          outcome
+          full_or_part_time
+          school
+          applications_open
+          start_date
+          confirmation
+        ]
+      end
+  
+      def school_direct_workflow_steps
+        %i[
+          courses_list
+          level
+          subjects
+          engineers_teach_physics
+          modern_languages
+          age_range
+          outcome
+          funding_type
+          full_or_part_time
+          school
+          accredited_provider
+          can_sponsor_student_visa
+          can_sponsor_skilled_worker_visa
+          applications_open
+          start_date
+          confirmation
+        ]
+      end
+  
+      def uni_or_scitt_workflow_steps
+        %i[
+          courses_list
+          level
+          subjects
+          engineers_teach_physics
+          modern_languages
+          age_range
+          outcome
+          apprenticeship
+          full_or_part_time
+          school
+          can_sponsor_student_visa
+          can_sponsor_skilled_worker_visa
+          applications_open
+          start_date
+          confirmation
+        ]
+      end
+  
+      def visas_to_remove(course)
+        if course.funding_type.present?
+          if course.is_fee_based?
+            [:can_sponsor_skilled_worker_visa]
+          elsif course.school_direct_salaried_training_programme? || course.pg_teaching_apprenticeship?
+            [:can_sponsor_student_visa]
+          end
+        else
+          %i[can_sponsor_student_visa can_sponsor_skilled_worker_visa]
+        end
+      end
+    end
+
+  

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -145,10 +145,8 @@
         if course.is_published? || course.is_withdrawn?
           row.with_action
         else
-          row.with_action(**{
-                        # href: accredited_provider_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                        # visually_hidden_text: "accredited provider",
-                      })
+          row.with_action(href: accredited_provider_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                          visually_hidden_text: "accredited provider")
         end
       end
     end

--- a/app/views/publish/courses/accredited_provider/edit.html.erb
+++ b/app/views/publish/courses/accredited_provider/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, title_with_error_prefix("Accredited provider – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
 <%= render "publish/shared/errors" %>
@@ -9,6 +9,7 @@
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
     <h1 class="govuk-fieldset__heading">
+      <%= render CaptionText.new(text: course.name_and_code) %>
       Accredited provider
     </h1>
   </legend>
@@ -16,40 +17,19 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= form_with model: course,
-                    url: accredited_provider_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+                    url: accredited_provider_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                     method: :put do |form| %>
 
         <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__accredited_provider">
-          <% if provider.accredited_bodies.length > 0 %>
-            <%= render partial: "provider_suggestion", collection: provider.accredited_bodies, locals: { form: } %>
-
-            <div class="govuk-radios__divider">or</div>
-
-            <div class="govuk-radios__item">
-              <%= form.radio_button :accredited_provider_code,
-                "other",
-                class: "govuk-radios__input",
-                data: { "aria-controls" => "other-container" },
-                checked: @errors && @errors[:accredited_provider]&.any? %>
-              <%= form.label :accredited_provider_code,
-                "Another accredited provider",
-                for: "course_accredited_provider_code_other",
-                value: false,
-                class: "govuk-label govuk-radios__label" %>
-            </div>
-
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
-              <%= render "provider_search_field", form: %>
-            </div>
-          <% else %>
-            <%= form.hidden_field :accredited_provider_code, value: :other %>
-            <%= render "provider_search_field", form: %>
-          <% end %>
+          <%= render partial: "provider_suggestion", collection: @provider.accredited_bodies, locals: { form: } %>
         </div>
 
-        <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
-                        class: "govuk-button govuk-!-margin-top-3", data: { qa: "course__save" } %>
+        <%= form.submit "Update accredited provider", class: "govuk-button govuk-!-margin-top-5", data: { qa: "course__save" } %>
       <% end %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t("cancel"), details_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+      </p>
     </div>
   </div>
 </fieldset>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -145,7 +145,6 @@
             <% else %>
               <% row.with_action %>
             <% end %>
-            <% end %>  
           <% end %>
         <% end %>
 

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -137,11 +137,14 @@
           <% summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row| %>
             <% row.with_key { "Accredited provider" } %>
             <% row.with_value { course.accrediting_provider.provider_name } %>
-            <% unless @provider.accredited_bodies.length == 1 %>
+            <% if @provider.accredited_bodies.length > 1 %>
               <% row.with_action(
                 href: new_publish_provider_recruitment_cycle_courses_accredited_provider_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
                 visually_hidden_text: "accredited provider"
               ) %>
+            <% else %>
+              <% row.with_action %>
+            <% end %>
             <% end %>  
           <% end %>
         <% end %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -137,10 +137,12 @@
           <% summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row| %>
             <% row.with_key { "Accredited provider" } %>
             <% row.with_value { course.accrediting_provider.provider_name } %>
-            <% row.with_action(
-              href: new_publish_provider_recruitment_cycle_courses_accredited_provider_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
-              visually_hidden_text: "accredited provider"
-            ) %>
+            <% unless @provider.accredited_bodies.length == 1 %>
+              <% row.with_action(
+                href: new_publish_provider_recruitment_cycle_courses_accredited_provider_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+                visually_hidden_text: "accredited provider"
+              ) %>
+            <% end %>  
           <% end %>
         <% end %>
 

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -69,7 +69,7 @@
                   rows: 10) %>
               <% end %>
             <% end %>
-        <% end %>  
+        <% end %>
       <% end %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -47,27 +47,29 @@
         max_words: 250,
         rows: 15) %>
 
-      <% if @about_form.accredited_bodies.present? %>
-        <% accredited_provider = "accredited provider".pluralize(@about_form.accredited_bodies.count) %>
+        <% if @provider.provider_type != 'lead_school' %>
+          <% if @about_form.accredited_bodies.present? %>
+            <% accredited_provider = "accredited provider".pluralize(@about_form.accredited_bodies.count) %>
 
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+            <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-        <h2 class="govuk-heading-m">About your <%= accredited_provider %></h2>
+            <h2 class="govuk-heading-m">About your <%= accredited_provider %></h2>
 
-        <p class="govuk-body">Tell candidates about your <%= accredited_provider %> – you could mention their academic specialities and achievements.</p>
-        <p class="govuk-body">Be specific with the claims you make, and support them with evidence.</p>
+            <p class="govuk-body">Tell candidates about your <%= accredited_provider %> – you could mention their academic specialities and achievements.</p>
+            <p class="govuk-body">Be specific with the claims you make, and support them with evidence.</p>
 
-        <% @about_form.accredited_bodies.each do |accredited_provider| %>
-          <%= f.fields_for :accredited_bodies, accredited_provider, index: nil do |abf| %>
-            <%= abf.hidden_field :provider_name %>
-            <%= abf.hidden_field :provider_code %>
-            <%= abf.govuk_text_area(:description,
-              form_group: { id: "accrediting-provider-#{accredited_provider.provider_code}" },
-              label: { text: "#{accredited_provider.provider_name} (optional)", size: "s" },
-              max_words: 100,
-              rows: 10) %>
-          <% end %>
-        <% end %>
+            <% @about_form.accredited_bodies.each do |accredited_provider| %>
+              <%= f.fields_for :accredited_bodies, accredited_provider, index: nil do |abf| %>
+                <%= abf.hidden_field :provider_name %>
+                <%= abf.hidden_field :provider_code %>
+                <%= abf.govuk_text_area(:description,
+                  form_group: { id: "accrediting-provider-#{accredited_provider.provider_code}" },
+                  label: { text: "#{accredited_provider.provider_name} (optional)", size: "s" },
+                  max_words: 100,
+                  rows: 10) %>
+              <% end %>
+            <% end %>
+        <% end %>  
       <% end %>
 
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -39,20 +39,21 @@
         action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-us",
         action_visually_hidden_text: "details about training with your organisation"
       ) %>
-      <% if @provider.accredited_bodies.present? %>
-        <% @provider.accredited_bodies.each do |accredited_provider| %>
-          <% enrichment_summary(
-            summary_list,
-            :provider,
-            "#{accredited_provider[:provider_name]} (optional)",
-            accredited_provider[:description],
-            ["accrediting_provider_#{accredited_provider[:provider_code]}"],
-            action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{accredited_provider[:provider_code]}",
-            action_visually_hidden_text: "details about #{accredited_provider[:provider_name]}"
-          ) %>
+      <% if @provider.provider_type != 'lead_school' %>
+        <% if @provider.accredited_bodies.present? %>
+          <% @provider.accredited_bodies.each do |accredited_provider| %>
+            <% enrichment_summary(
+              summary_list,
+              :provider,
+              "#{accredited_provider[:provider_name]} (optional)",
+              accredited_provider[:description],
+              ["accrediting_provider_#{accredited_provider[:provider_code]}"],
+              action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{accredited_provider[:provider_code]}",
+              action_visually_hidden_text: "details about #{accredited_provider[:provider_name]}"
+            ) %>
+          <% end %>
         <% end %>
       <% end %>
-
       <% enrichment_summary(
         summary_list,
         :provider,

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -39,19 +39,17 @@
         action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-us",
         action_visually_hidden_text: "details about training with your organisation"
       ) %>
-      <% if @provider.provider_type != 'lead_school' %>
-        <% if @provider.accredited_bodies.present? %>
-          <% @provider.accredited_bodies.each do |accredited_provider| %>
-            <% enrichment_summary(
-              summary_list,
-              :provider,
-              "#{accredited_provider[:provider_name]} (optional)",
-              accredited_provider[:description],
-              ["accrediting_provider_#{accredited_provider[:provider_code]}"],
-              action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{accredited_provider[:provider_code]}",
-              action_visually_hidden_text: "details about #{accredited_provider[:provider_name]}"
-            ) %>
-          <% end %>
+      <% if !@provider.lead_school? && @provider.accredited_bodies.present? %>
+        <% @provider.accredited_bodies.each do |accredited_provider| %>
+          <% enrichment_summary(
+            summary_list,
+            :provider,
+            "#{accredited_provider[:provider_name]} (optional)",
+            accredited_provider[:description],
+            ["accrediting_provider_#{accredited_provider[:provider_code]}"],
+            action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{accredited_provider[:provider_code]}",
+            action_visually_hidden_text: "details about #{accredited_provider[:provider_name]}"
+          ) %>
         <% end %>
       <% end %>
       <% enrichment_summary(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   notification_banner:
     success: "Success"
+    info: "Info"
   cycles:
     updated: "Cycle schedule updated"
   service_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  notification_banner:
+    success: "Success"
   cycles:
     updated: "Cycle schedule updated"
   service_name:

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -226,6 +226,9 @@ namespace :publish, as: :publish do
 
         get '/apprenticeship', on: :member, to: 'courses/apprenticeship#edit'
         put '/apprenticeship', on: :member, to: 'courses/apprenticeship#update'
+
+        get '/accredited-provider', on: :member, to: 'courses/accredited_provider#edit'
+        put '/accredited-provider', on: :member, to: 'courses/accredited_provider#update'
       end
 
       scope module: :providers do

--- a/spec/features/publish/courses/new_accredited_provider_spec.rb
+++ b/spec/features/publish/courses/new_accredited_provider_spec.rb
@@ -23,9 +23,11 @@ feature 'selection accredited_bodies', { can_edit_current_and_next_cycles: false
 
   def given_i_am_authenticated_as_a_provider_user
     provider = create(:provider)
-    course = create(:course, :with_accrediting_provider, provider:)
-    @accredited_provider_code = course.accredited_provider_code
-    provider.accrediting_provider_enrichments = [{ UcasProviderCode: @accredited_provider_code }]
+    course_one = create(:course, :with_accrediting_provider, provider:)
+    course_two = create(:course, :with_accrediting_provider, provider:)
+    @accredited_provider_code = course_one.accredited_provider_code
+    accredited_provider_code_two = course_two.accredited_provider_code
+    provider.accrediting_provider_enrichments = [{ UcasProviderCode: @accredited_provider_code }, { UcasProviderCode: accredited_provider_code_two }]
     @user = create(:user, providers: [provider])
 
     given_i_am_authenticated(user: @user)

--- a/spec/features/publish/edit_provider_details_spec.rb
+++ b/spec/features/publish/edit_provider_details_spec.rb
@@ -7,7 +7,6 @@ feature 'About Your Organisation section', { can_edit_current_and_next_cycles: f
     given_i_am_a_provider_user_as_a_provider_user
     when_i_visit_the_details_page
     then_i_can_edit_info_about_training_with_us
-    then_i_can_edit_info_about_our_accredited_bodies
     then_i_can_edit_info_about_disabilities_and_other_needs
   end
 
@@ -48,18 +47,6 @@ feature 'About Your Organisation section', { can_edit_current_and_next_cycles: f
     expect(page).to have_content 'Your changes have been published'
     within_summary_row 'Training with your organisation' do
       expect(page).to have_content 'Updated: Training with you'
-    end
-  end
-
-  def then_i_can_edit_info_about_our_accredited_bodies
-    click_link "Change details about #{@accrediting_provider.provider_name}"
-
-    publish_provider_details_edit_page.accredited_provider_description_field.set 'Updated: accredited provider description'
-    publish_provider_details_edit_page.save_and_publish.click
-
-    expect(page).to have_content 'Your changes have been published'
-    within_summary_row @accrediting_provider.provider_name do
-      expect(page).to have_content 'Updated: accredited provider description'
     end
   end
 

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -21,19 +21,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       allow(Settings.features).to receive(:course_preview_missing_information).and_return(true)
     end
 
-    scenario 'blank about the accredited provider' do
-      given_i_am_authenticated(user: user_with_no_course_enrichments)
-      when_i_visit_the_publish_course_preview_page
-      and_i_click_link('Enter details about the accredited provider')
-      then_i_should_be_on_about_your_organisation_page
-      and_i_click_link('Back')
-      then_i_should_be_back_on_the_preview_page
-      and_i_click_link('Enter details about the accredited provider')
-      and_i_submit_a_valid_about_your_organisation
-      then_i_should_be_back_on_the_preview_page
-      then_i_should_see_the_updated_content('test accredited provider')
-    end
-
     scenario 'blank about the training provider' do
       given_i_am_authenticated(user: user_with_no_course_enrichments)
       when_i_visit_the_publish_course_preview_page
@@ -445,7 +432,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   def and_i_submit_a_valid_about_your_organisation
     fill_in 'Training with your organisation', with: 'test training with your organisation'
     fill_in 'Training with disabilities and other needs', with: 'test training with disabilities'
-    fill_in "#{accrediting_provider.provider_name} (optional)", with: 'test accredited provider'
 
     click_button 'Save and publish'
   end

--- a/spec/services/workflow_step_service_spec.rb
+++ b/spec/services/workflow_step_service_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WorkflowStepService do
+  let(:accredited_provider) { build(:provider, :accredited_provider) }
+
+  let(:provider) do
+    build(
+      :provider,
+      :lead_school,
+      provider_name: 'Provider 1',
+      accrediting_provider_enrichments: [{
+        'Description' => 'Something great about the accredited provider',
+        'UcasProviderCode' => accredited_provider.provider_code
+      }]
+    )
+  end
+  
+  subject do
+    described_class.call(course)
+    end
+
+  describe '#call' do
+    context 'when course.provider.lead_school? && course.provider.accredited_bodies.length == 1' do
+    let(:course) { create(:course, accrediting_provider: accredited_provider, provider: provider) }
+      it 'returns the expected workflow steps' do
+        expected_steps = [
+          :courses_list,
+          :level,
+          :subjects,
+          :engineers_teach_physics,
+          :modern_languages,
+          :age_range,
+          :outcome,
+          :funding_type,
+          :full_or_part_time,
+          :school,
+          :can_sponsor_student_visa,
+          :can_sponsor_skilled_worker_visa,
+          :applications_open,
+          :start_date,
+          :confirmation
+        ]
+
+        expect(subject).to eq(expected_steps)
+      end
+    end
+
+    # context 'when course.is_further_education?' do
+    # let(:course) { create(:course, :further_education) }
+    # it 'returns the expected workflow steps' do
+    #     expected_steps = [
+    #       :courses_list,
+    #       :level,
+    #       :outcome,
+    #       :full_or_part_time,
+    #       :school,
+    #       :applications_open,
+    #       :start_date,
+    #       :confirmation
+    #     ]
+
+    #     expect(subject).to eq(expected_steps)
+    #   end        
+    # end
+
+    # context 'when course.is_uni_or_scitt?' do
+    #     binding.pry
+    #     let(:course) { create(:course, :uni_or_scitt) }
+  
+    #     it 'returns the expected workflow steps' do
+    #       expected_steps = [
+    #         :courses_list,
+    #         :level,
+    #         :subjects,
+    #         :engineers_teach_physics,
+    #         :modern_languages,
+    #         :age_range,
+    #         :outcome,
+    #         :apprenticeship,
+    #         :full_or_part_time,
+    #         :school,
+    #         :can_sponsor_student_visa,
+    #         :can_sponsor_skilled_worker_visa,
+    #         :applications_open,
+    #         :start_date,
+    #         :confirmation
+    #       ]
+  
+    #       expect(subject).to eq(expected_steps)
+    #     end
+    #   end
+  end
+end

--- a/spec/services/workflow_step_service_spec.rb
+++ b/spec/services/workflow_step_service_spec.rb
@@ -3,93 +3,121 @@
 require 'rails_helper'
 
 describe WorkflowStepService do
-  let(:accredited_provider) { build(:provider, :accredited_provider) }
-
-  let(:provider) do
-    build(
-      :provider,
-      :lead_school,
-      provider_name: 'Provider 1',
-      accrediting_provider_enrichments: [{
-        'Description' => 'Something great about the accredited provider',
-        'UcasProviderCode' => accredited_provider.provider_code
-      }]
-    )
-  end
-  
   subject do
     described_class.call(course)
-    end
+  end
 
   describe '#call' do
-    context 'when course.provider.lead_school? && course.provider.accredited_bodies.length == 1' do
-    let(:course) { create(:course, accrediting_provider: accredited_provider, provider: provider) }
+    context 'when course.is_school_direct? && when course.provider.accredited_bodies.length == 0' do
+      let(:provider) do
+        build(
+          :provider,
+          accrediting_provider_enrichments:
+        )
+      end
+      let(:course) { create(:course, accrediting_provider: accredited_provider, provider:) }
+      let(:accrediting_provider_enrichments) { nil }
+      let(:accredited_provider) { nil }
+
       it 'returns the expected workflow steps' do
-        expected_steps = [
-          :courses_list,
-          :level,
-          :subjects,
-          :engineers_teach_physics,
-          :modern_languages,
-          :age_range,
-          :outcome,
-          :funding_type,
-          :full_or_part_time,
-          :school,
-          :can_sponsor_student_visa,
-          :can_sponsor_skilled_worker_visa,
-          :applications_open,
-          :start_date,
-          :confirmation
+        expected_steps = %i[
+          courses_list
+          level
+          subjects
+          engineers_teach_physics
+          modern_languages
+          age_range
+          outcome
+          funding_type
+          full_or_part_time
+          school
+          accredited_provider
+          can_sponsor_skilled_worker_visa
+          applications_open
+          start_date
+          confirmation
         ]
 
         expect(subject).to eq(expected_steps)
       end
     end
 
-    # context 'when course.is_further_education?' do
-    # let(:course) { create(:course, :further_education) }
-    # it 'returns the expected workflow steps' do
-    #     expected_steps = [
-    #       :courses_list,
-    #       :level,
-    #       :outcome,
-    #       :full_or_part_time,
-    #       :school,
-    #       :applications_open,
-    #       :start_date,
-    #       :confirmation
-    #     ]
+    context 'when course.is_school_direct? && course.provider.accredited_bodies.length == 1' do
+      let(:provider) do
+        build(
+          :provider,
+          accrediting_provider_enrichments:
+        )
+      end
+      let(:course) { create(:course, accrediting_provider: accredited_provider, provider:) }
+      let(:accrediting_provider_enrichments) { [{ 'Description' => 'Something great about the accredited provider', 'UcasProviderCode' => accredited_provider.provider_code }] }
+      let(:accredited_provider) { build(:provider, :accredited_provider) }
 
-    #     expect(subject).to eq(expected_steps)
-    #   end        
-    # end
+      it 'returns the expected workflow steps' do
+        expected_steps = %i[
+          courses_list
+          level
+          subjects
+          engineers_teach_physics
+          modern_languages
+          age_range
+          outcome
+          funding_type
+          full_or_part_time
+          school
+          can_sponsor_skilled_worker_visa
+          applications_open
+          start_date
+          confirmation
+        ]
 
-    # context 'when course.is_uni_or_scitt?' do
-    #     binding.pry
-    #     let(:course) { create(:course, :uni_or_scitt) }
-  
-    #     it 'returns the expected workflow steps' do
-    #       expected_steps = [
-    #         :courses_list,
-    #         :level,
-    #         :subjects,
-    #         :engineers_teach_physics,
-    #         :modern_languages,
-    #         :age_range,
-    #         :outcome,
-    #         :apprenticeship,
-    #         :full_or_part_time,
-    #         :school,
-    #         :can_sponsor_student_visa,
-    #         :can_sponsor_skilled_worker_visa,
-    #         :applications_open,
-    #         :start_date,
-    #         :confirmation
-    #       ]
-  
-    #       expect(subject).to eq(expected_steps)
-    #     end
-    #   end
+        expect(subject).to eq(expected_steps)
+      end
+    end
+  end
+
+  context 'when course.is_further_education?' do
+    let(:course) { create(:course, level: 'further_education', subjects: [find_or_create(:further_education_subject)]) }
+
+    it 'returns the expected workflow steps' do
+      expected_steps = %i[
+        courses_list
+        level
+        outcome
+        full_or_part_time
+        school
+        applications_open
+        start_date
+        confirmation
+      ]
+
+      expect(subject).to eq(expected_steps)
+    end
+  end
+
+  context 'when course.is_uni_or_scitt?' do
+    let(:provider) { create(:provider, :accredited_provider) }
+    let(:course) { create(:course, provider:) }
+
+    it 'returns the expected workflow steps' do
+      expected_steps = %i[
+        courses_list
+        level
+        subjects
+        engineers_teach_physics
+        modern_languages
+        age_range
+        outcome
+        apprenticeship
+        full_or_part_time
+        school
+        can_sponsor_skilled_worker_visa
+        applications_open
+        start_date
+        confirmation
+      ]
+
+      expect(subject).to eq(expected_steps)
+    end
   end
 end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
If only one AP is associated with a lead school, when adding a course the AP step should be skipped. On the summary page there should not be a change link to change the AP

If there is more than one AP associated with a lead school, when adding a course the AP step should be shown as per normal behaviour. On the summary page there should be a change link to change the AP.

Both of the above should apply to their respective edit pages (course details edit)

Remove the existing row for adding information about their AB from the org details page for a lead school

### Guidance to review
Links to research, designs, etc

The prototype for this work can be found [here](https://publish-courses-prototype.herokuapp.com/organisations/96d90282-3ce7-4fc7-aa60-e03d7bf8a0f1/cycles/2023/schools). To be able to see this functionality:

Sign in as Anne and click on the Accrediting providers tab

Add the AP and then view the index page
### Checklist

✅ Make sure all information from the Trello card is in here
✅ Attach to Trello card
✅ Rebased main
✅ Cleaned commit history
✅ Tested by running locally
n/a Inform data insights team due to database changes
