### PR TITLE
[1229] delete support accredited provider

### DIFF
--- a/app/controllers/publish/providers/accredited_providers_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers_controller.rb
@@ -42,11 +42,11 @@ module Publish
       end
 
       def delete
-        @cannot_delete = provider.courses.exists?(accredited_provider_code: accredited_provider.provider_code)
+        cannot_delete
       end
 
       def destroy
-        return if @cannot_delete
+        return if cannot_delete
 
         provider.accrediting_provider_enrichments = accrediting_provider_enrichments
         provider.save
@@ -57,6 +57,10 @@ module Publish
       end
 
       private
+
+      def cannot_delete
+        @cannot_delete ||= provider.courses.exists?(accredited_provider_code: accredited_provider.provider_code)
+      end
 
       def accredited_provider
         @accredited_provider ||= @recruitment_cycle.providers.find_by(provider_code: params[:accredited_provider_code])

--- a/app/controllers/support/providers/accredited_providers_controller.rb
+++ b/app/controllers/support/providers/accredited_providers_controller.rb
@@ -51,7 +51,6 @@ module Support
 
       def delete
         cannot_delete
-        # @cannot_delete = provider.courses.exists?(accredited_provider_code: accredited_provider.provider_code)
       end
 
       def destroy

--- a/app/controllers/support/providers/accredited_providers_controller.rb
+++ b/app/controllers/support/providers/accredited_providers_controller.rb
@@ -50,11 +50,12 @@ module Support
       end
 
       def delete
-        @cannot_delete = provider.courses.exists?(accredited_provider_code: accredited_provider.provider_code)
+        cannot_delete
+        # @cannot_delete = provider.courses.exists?(accredited_provider_code: accredited_provider.provider_code)
       end
 
       def destroy
-        return if @cannot_delete
+        return if cannot_delete
 
         provider.accrediting_provider_enrichments = accrediting_provider_enrichments
         provider.save
@@ -68,6 +69,10 @@ module Support
       end
 
       private
+
+      def cannot_delete
+        @cannot_delete ||= provider.courses.exists?(accredited_provider_code: accredited_provider.provider_code)
+      end
 
       def accrediting_provider_enrichments
         provider.accrediting_provider_enrichments.reject { |enrichment| enrichment.UcasProviderCode == params['accredited_provider_code'] }

--- a/app/controllers/support/providers/accredited_providers_controller.rb
+++ b/app/controllers/support/providers/accredited_providers_controller.rb
@@ -49,7 +49,29 @@ module Support
         end
       end
 
+      def delete
+        @cannot_delete = provider.courses.exists?(accredited_provider_code: accredited_provider.provider_code)
+      end
+
+      def destroy
+        return if @cannot_delete
+
+        provider.accrediting_provider_enrichments = accrediting_provider_enrichments
+        provider.save
+
+        flash[:success] = t('support.providers.accredited_providers.delete.updated')
+
+        redirect_to support_recruitment_cycle_provider_accredited_providers_path(
+          recruitment_cycle_year: @recruitment_cycle.year,
+          provider_id: @provider.id
+        )
+      end
+
       private
+
+      def accrediting_provider_enrichments
+        provider.accrediting_provider_enrichments.reject { |enrichment| enrichment.UcasProviderCode == params['accredited_provider_code'] }
+      end
 
       def accredited_provider
         @accredited_provider ||= @recruitment_cycle.providers.find_by(provider_code: params[:accredited_provider_code])

--- a/app/views/support/providers/accredited_providers/_can_remove.html.erb
+++ b/app/views/support/providers/accredited_providers/_can_remove.html.erb
@@ -1,0 +1,22 @@
+<%= content_for :page_title, t("support.providers.accredited_providers.delete.title") %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_recruitment_cycle_provider_accredited_providers_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-l"><%= @recruitment_cycle.providers.find_by(provider_code: params[:accredited_provider_code]).provider_name %></span>
+        <%= t("support.providers.accredited_providers.delete.title") %>
+    </h1>
+
+    <%= govuk_button_to "Remove accredited provider",
+                        delete_support_recruitment_cycle_provider_accredited_provider_path,
+        method: :delete,
+        class: "govuk-button--warning" %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_accredited_providers_path) %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/providers/accredited_providers/_can_remove.html.erb
+++ b/app/views/support/providers/accredited_providers/_can_remove.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-l"><%= @recruitment_cycle.providers.find_by(provider_code: params[:accredited_provider_code]).provider_name %></span>
+      <span class="govuk-caption-l"><%= @accredited_provider.provider_name %></span>
         <%= t("support.providers.accredited_providers.delete.title") %>
     </h1>
 

--- a/app/views/support/providers/accredited_providers/_cannot_remove.html.erb
+++ b/app/views/support/providers/accredited_providers/_cannot_remove.html.erb
@@ -17,11 +17,6 @@
     </p>
 
     <p class="govuk-body">
-      If you need to change an accredited provider for a course which is published, please contact us at
-      <%= bat_contact_mail_to %>.
-    </p>
-
-    <p class="govuk-body">
       <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_accredited_providers_path) %>
     </p>
   </div>

--- a/app/views/support/providers/accredited_providers/_cannot_remove.html.erb
+++ b/app/views/support/providers/accredited_providers/_cannot_remove.html.erb
@@ -1,0 +1,28 @@
+<% content_for :page_title, "You cannot remove this accredited provider" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_recruitment_cycle_provider_accredited_providers_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+     <span class="govuk-caption-l"><%= @accredited_provider.provider_name %></span>
+      You cannot remove this accredited provider
+    </h1>
+
+    <p class="govuk-body">
+      <%= @accredited_provider.provider_name %> is an
+      accredited provider for courses run by <%= @provider.provider_name %>. At least one of these courses is
+      currently published on Find.
+    </p>
+
+    <p class="govuk-body">
+      If you need to change an accredited provider for a course which is published, please contact us at
+      <%= bat_contact_mail_to %>.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), support_recruitment_cycle_provider_accredited_providers_path) %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/providers/accredited_providers/delete.html.erb
+++ b/app/views/support/providers/accredited_providers/delete.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: @cannot_delete ? "cannot_remove" : "can_remove" %>

--- a/app/views/support/providers/accredited_providers/edit.html.erb
+++ b/app/views/support/providers/accredited_providers/edit.html.erb
@@ -8,7 +8,7 @@
       text: "Back",
       href: support_recruitment_cycle_provider_accredited_providers_path(
         recruitment_cycle_year: @recruitment_cycle.year,
-        provider: @provider
+        provider_id: @provider.id
       )
     ) %>
   <% end %>

--- a/app/views/support/providers/accredited_providers/index.html.erb
+++ b/app/views/support/providers/accredited_providers/index.html.erb
@@ -8,7 +8,9 @@
   <% @provider.accredited_bodies.each do |accredited_body| %>
     <%= render AccreditedProvider.new(
       provider_name: accredited_body[:provider_name],
-      remove_path: root_path,
+      remove_path: delete_support_recruitment_cycle_provider_accredited_provider_path(
+        accredited_provider_code: accredited_body[:provider_code]
+      ),
       about_accredited_provider: accredited_body[:description],
       change_about_accredited_provider_path: edit_support_recruitment_cycle_provider_accredited_provider_path(
         accredited_provider_code: accredited_body[:provider_code]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -352,6 +352,10 @@ en:
           hint: Tell candidates about the accredited provider. You could mention their academic specialities and achievements.
           caption: "%{provider_name}"
           updated: About the accredited provider updated
+        delete: 
+          title: Are you sure you want to remove this accredited provider?
+          remove: Remove accredited provider
+          updated: Accredited provider removed
         checks:
           show:
             caption: *accredited_provider_caption

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -41,6 +41,10 @@ namespace :support do
 
       scope module: :providers do
         resources :accredited_providers, param: :accredited_provider_code, only: %i[index new edit create update], path: 'accredited-providers' do
+          member do
+            get :delete
+            delete :delete, to: 'accredited_providers#destroy'
+          end
           get '/search', on: :collection, to: 'accredited_provider_search#new'
           post '/search', on: :collection, to: 'accredited_provider_search#create'
           put '/search', on: :collection, to: 'accredited_provider_search#update'

--- a/spec/features/support/providers/accredited_providers_spec.rb
+++ b/spec/features/support/providers/accredited_providers_spec.rb
@@ -29,7 +29,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     then_i_return_to_the_index_page
     and_i_click_change
 
-    when_i_input_updated_information
+    when_i_input_updated_description
     then_i_should_see_the_updated_description
     and_i_see_the_success_message
   end
@@ -142,7 +142,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     expect(page).to have_text('update the AP description')
   end
 
-  def when_i_input_updated_information
+  def when_i_input_updated_description
     fill_in 'About the accredited provider', with: 'update the AP description'
     click_on 'Update description'
   end

--- a/spec/features/support/providers/accredited_providers_spec.rb
+++ b/spec/features/support/providers/accredited_providers_spec.rb
@@ -29,12 +29,77 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     then_i_return_to_the_index_page
     and_i_click_change
 
-    when_i_input_updated_description
+    when_i_input_updated_information
     then_i_should_see_the_updated_description
     and_i_see_the_success_message
   end
 
+  scenario 'i cannot delete accredited providers attached to a course' do
+    and_my_provider_has_accrediting_providers
+    and_i_click_on_the_accredited_provider_tab
+    and_i_click_remove
+    then_i_should_see_the_cannot_remove_text
+  end
+
+  scenario 'i can delete accredited providers not attached to a course' do
+    and_i_click_on_the_accredited_provider_tab
+    and_i_click_add_accredited_provider
+    and_i_search_for_an_accredited_provider_with_a_valid_query
+    and_i_select_the_provider
+    when_i_input_new_information
+    and_i_confirm_the_changes
+    and_i_click_remove
+    and_i_click_remove_ap
+    then_i_return_to_the_index_page
+    and_i_see_the_remove_success_message
+  end
+
   private
+
+  def and_i_see_the_remove_success_message
+    expect(page).to have_content('Accredited provider removed')
+  end
+
+  def and_i_see_the_remove_success_message; end
+
+  def and_i_click_remove_ap
+    click_button 'Remove accredited provider'
+  end
+
+  def and_i_confirm_the_changes
+    click_button 'Add accredited provider'
+  end
+
+  def when_i_input_new_information
+    fill_in 'About the accredited provider', with: 'New AP description'
+    click_on 'Continue'
+  end
+
+  def and_i_select_the_provider
+    choose @accredited_provider.provider_name
+    click_button 'Continue'
+  end
+
+  def form_title
+    'Enter a provider name, UKPRN or postcode'
+  end
+
+  def and_i_search_for_an_accredited_provider_with_a_valid_query
+    fill_in form_title, with: @accredited_provider.provider_name
+    click_button 'Continue'
+  end
+
+  def and_i_click_add_accredited_provider
+    click_link 'Add accredited provider'
+  end
+
+  def and_i_click_remove
+    click_link 'Remove'
+  end
+
+  def then_i_should_see_the_cannot_remove_text
+    expect(page).to have_selector('h1', text: 'You cannot remove this accredited provider')
+  end
 
   def given_i_am_authenticated_as_an_admin_user
     given_i_am_authenticated(user: create(:user, :admin))
@@ -48,7 +113,10 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def then_i_return_to_the_index_page
-    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers/#{@provider.id}/accredited-providers?provider=#{@provider.id}")
+    expect(page).to have_current_path(support_recruitment_cycle_provider_accredited_providers_path(
+                                        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+                                        provider_id: @provider.id
+                                      ))
   end
 
   def and_i_visit_the_index_page
@@ -71,11 +139,11 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def then_i_should_see_the_updated_description
-    expect(page).to have_text('updates to the AP description')
+    expect(page).to have_text('update the AP description')
   end
 
-  def when_i_input_updated_description
-    fill_in 'About the accredited provider', with: 'updates to the AP description'
+  def when_i_input_updated_information
+    fill_in 'About the accredited provider', with: 'update the AP description'
     click_on 'Update description'
   end
 


### PR DESCRIPTION
### Context
User need

As a user, I want to easily add accrediting providers to lead schools, so that these providers can be setup correctly in Publish
Why

This will give users and providers flexibility in managing their APs.
What needs to be done

We need to implement the delete functionality for an AP in the new AP tab so they can be removed from the lead school
Done when

This is our definition of done

If an AP is removable, we are able to click the delete link and see a confirm page and remove the AP upon form submission
If an AP is not removable, we see a page with some content telling us the AP cannot be removed

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
