### PR TITLE
[1321] Remove change vacancies from course show page

### DIFF
--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -13,7 +13,7 @@ module FeatureService
 
       segments = feature_name.to_s.split('.')
 
-      segments.reduce(Settings.features) { |config, segment| config[segment] }
+      segments.reduce(Settings.features) { |config, segment| config[segment] } == true
     end
   end
 end

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -15,6 +15,9 @@
     <% end %>
   <% end %>
 
-  <%= govuk_link_to "Change vacancies", vacancies_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle.year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__has_vacancies" } %>
+  <% unless FeatureService.enabled?(:open_and_closed_course_flow) %>
+    <%= govuk_link_to "Change vacancies", vacancies_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle.year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__has_vacancies" } %>
+  <% end %>
+
   <%= govuk_link_to "Withdraw course", withdraw_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive govuk-!-margin-right-2", data: { qa: "course__withdraw-link" } %>
 </div>


### PR DESCRIPTION
### Context

`change vacancies` link on course show page

### Changes proposed in this pull request

Remove `change vacancies` link on course show page

### Guidance to review
#### Before
![image](https://github.com/DFE-Digital/publish-teacher-training/assets/470137/3eeb0bd4-737a-43b2-87bf-d3a6722d6fc1)

#### After
![image](https://github.com/DFE-Digital/publish-teacher-training/assets/470137/45bdd412-b3b1-4be6-bdbb-a644d995dc61)



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
