### PR TITLE
[1314] rm vacancies on course index

### DIFF
--- a/app/views/publish/courses/_course_table.html.erb
+++ b/app/views/publish/courses/_course_table.html.erb
@@ -7,8 +7,11 @@
        Is it on <abbr class="app-!-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
       </th>
       <th class="govuk-table__header">Applications</th>
-      <% if @recruitment_cycle.current_and_open? %>
-        <th class="govuk-table__header">Vacancies</th>
+      <!-- TODO: to be removed with feature flag -->
+      <% unless FeatureService.enabled?(:open_and_closed_course_flow) %>
+        <% if @recruitment_cycle.current_and_open? %>
+          <th class="govuk-table__header">Vacancies</th>
+        <% end %>
       <% end %>
     </tr>
   </thead>

--- a/app/views/publish/courses/_course_table_row.html.erb
+++ b/app/views/publish/courses/_course_table_row.html.erb
@@ -26,15 +26,18 @@
       <%= course.open_or_closed_for_applications %>
     <% end %>
   </td>
-  <% if @recruitment_cycle.current_and_open? %>
-    <td class="govuk-table__cell" data-qa="courses-table__vacancies">
-      <% if course.is_running? || course.is_withdrawn? %>
-        <% if current_page?(publish_provider_recruitment_cycle_courses_path(@provider.provider_code, course.recruitment_cycle.year)) %>
-          <%= course.vacancies %>
-        <% else %>
-          <%= course.has_vacancies? ? "Yes" : "No" %>
+  <!-- TODO: to be removed with feature flag -->
+  <% unless FeatureService.enabled?(:open_and_closed_course_flow) %>
+    <% if @recruitment_cycle.current_and_open? %>
+      <td class="govuk-table__cell" data-qa="courses-table__vacancies">
+        <% if course.is_running? || course.is_withdrawn? %>
+          <% if current_page?(publish_provider_recruitment_cycle_courses_path(@provider.provider_code, course.recruitment_cycle.year)) %>
+            <%= course.vacancies %>
+          <% else %>
+            <%= course.has_vacancies? ? "Yes" : "No" %>
+          <% end %>
         <% end %>
-      <% end %>
-    </td>
+      </td>
+    <% end %>
   <% end %>
 </tr>


### PR DESCRIPTION
### Context
User need

As a user, I want to be able to open or close my courses so candidates can be informed whether applications are open or not.
Why

We’re removing vacancies as research has shown they cause more confusion. We’re introducing a simple of concept to allow providers toggle whether courses are open or not.
What needs to be done

Remove the ability to change vacancies on the course index
Done when

This is our definition of done

When the feature flag is set to on
Then there is no change vacancies on the course index

### Changes proposed in this pull request
![Screenshot 2023-05-26 at 08 17 59](https://github.com/DFE-Digital/publish-teacher-training/assets/4527528/82ec6a0e-31a7-4ac0-8f7a-1f40fe626a4e)

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
