### PR TITLE
[1315] Add applications open confirm page

### DIFF
--- a/app/controllers/publish/courses/application_status_controller.rb
+++ b/app/controllers/publish/courses/application_status_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    class ApplicationStatusController < PublishController
+      before_action :authorize_provider
+
+      def new
+        course
+      end
+
+      def update
+        course.update(application_status: 'open')
+        redirect_to publish_provider_recruitment_cycle_course_path
+        flash[:success] = t('course.application_status.opened')
+      end
+
+      private
+
+      def course
+        @course ||= CourseDecorator.new(provider.courses.find_by(course_code: params[:code]))
+      end
+
+      def authorize_provider
+        authorize(provider)
+      end
+    end
+  end
+end

--- a/app/views/publish/courses/application_status/new.html.erb
+++ b/app/views/publish/courses/application_status/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, title_with_error_prefix("Are you sure you want to open this course?", nil) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+      Are you sure you want to open this course?
+    </h1>
+
+    <p class="govuk-body">If the course has vacancies, open it so that candidates will be able to apply.</p>
+
+    <%= govuk_button_to("Open course", open_publish_provider_recruitment_cycle_course_path) %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_course_path) %>
+    </p>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,8 @@ en:
           text: "Enter details about the accredited provider"
   value_not_entered: "Not entered"
   course:
+    application_status:
+      opened: "Course opened"
     add_course: "Add course"
     update_email:
       name: "title"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -156,6 +156,9 @@ namespace :publish, as: :publish do
         get '/apply', on: :member, to: 'courses#apply', as: :apply
         get '/details', on: :member, to: 'courses#details'
 
+        get '/open', on: :member, to: 'courses/application_status#new'
+        post '/open', on: :member, to: 'courses/application_status#update'
+
         get '/engineers_teach_physics', on: :member, to: 'courses/engineers_teach_physics#edit'
         put '/engineers_teach_physics', on: :member, to: 'courses/engineers_teach_physics#update'
 

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Editing course application status', { can_edit_current_and_next_cycles: false } do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario 'opening a course' do
+    and_there_is_a_closed_course_i_want_to_open
+    when_i_visit_the_open_applications_confirm_page
+    and_i_click_open_course
+    then_i_should_see_the_success_message
+    and_i_should_be_back_on_the_course_page
+  end
+
+  def and_i_should_be_back_on_the_course_page
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_course_path(course.provider.provider_code,
+                                                                                     course.recruitment_cycle.year,
+                                                                                     course.course_code))
+  end
+
+  def then_i_should_see_the_success_message
+    expect(page).to have_text('Course opened')
+  end
+
+  def when_i_visit_the_open_applications_confirm_page
+    visit open_publish_provider_recruitment_cycle_course_path(course.provider.provider_code,
+                                                              course.recruitment_cycle.year,
+                                                              course.course_code)
+  end
+
+  def and_i_click_open_course
+    click_button 'Open course'
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_closed_course_i_want_to_open
+    given_a_course_exists(name: 'Course', course_code: 'AAAA', application_status: 'open')
+  end
+end


### PR DESCRIPTION
### Context

This is the confirm page for opening a course. The open button is out of scope for this card but this card deals with updating the database. 

### Changes proposed in this pull request

- Add `get` and `post` route
- Add controller and view
- Add logic to update database on update action

### Guidance to review

Try it out on the review app by visiting `publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/open`


### Screenshot

<img width="1098" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/6f6d8135-adcd-468c-a17b-67107476342a">



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
