### PR TITLE
[1317] close course page

### DIFF
--- a/app/controllers/publish/courses/application_status_controller.rb
+++ b/app/controllers/publish/courses/application_status_controller.rb
@@ -14,13 +14,6 @@ module Publish
 
         course.update(application_status: new_status)
         flash[:success] = t("course.application_status.#{new_status}")
-        #         if course.application_status_closed?
-        #           course.update(application_status: 'open')
-        #           flash[:success] = t('course.application_status.opened')
-        #         else
-        #           course.update(application_status: 'closed')
-        #           flash[:success] = t('course.application_status.closed')
-        #         end
         redirect_to publish_provider_recruitment_cycle_course_path
       end
 

--- a/app/controllers/publish/courses/application_status_controller.rb
+++ b/app/controllers/publish/courses/application_status_controller.rb
@@ -10,9 +10,14 @@ module Publish
       end
 
       def update
-        course.update(application_status: 'open')
+        if course.application_status_closed?
+          course.update(application_status: 'open')
+          flash[:success] = t('course.application_status.opened')
+        else
+          course.update(application_status: 'closed')
+          flash[:success] = t('course.application_status.closed')
+        end
         redirect_to publish_provider_recruitment_cycle_course_path
-        flash[:success] = t('course.application_status.opened')
       end
 
       private

--- a/app/controllers/publish/courses/application_status_controller.rb
+++ b/app/controllers/publish/courses/application_status_controller.rb
@@ -10,13 +10,17 @@ module Publish
       end
 
       def update
-        if course.application_status_closed?
-          course.update(application_status: 'open')
-          flash[:success] = t('course.application_status.opened')
-        else
-          course.update(application_status: 'closed')
-          flash[:success] = t('course.application_status.closed')
-        end
+        new_status = course.application_status_closed? ? 'open' : 'closed'
+
+        course.update(application_status: new_status)
+        flash[:success] = t("course.application_status.#{new_status}")
+        #         if course.application_status_closed?
+        #           course.update(application_status: 'open')
+        #           flash[:success] = t('course.application_status.opened')
+        #         else
+        #           course.update(application_status: 'closed')
+        #           flash[:success] = t('course.application_status.closed')
+        #         end
         redirect_to publish_provider_recruitment_cycle_course_path
       end
 

--- a/app/views/publish/courses/application_status/_body_text.html.erb
+++ b/app/views/publish/courses/application_status/_body_text.html.erb
@@ -1,0 +1,12 @@
+ <p class="govuk-body">
+  <% if  @course.application_status_closed? %>
+  If the course has vacancies, open it so that candidates will be able to apply.
+  <% else %>
+  If the course does not have vacancies, close it so that candidates will not be able to apply. You&lsquo;ll be able to open the course again if any places become available.
+  <% end %>
+</p>
+<p class="govuk-body">
+  <% if @course.application_status_open? %>
+  The course will still be visible on Find, but candidates will not have the option to apply to it.
+  <% end %>
+</p>

--- a/app/views/publish/courses/application_status/_body_text.html.erb
+++ b/app/views/publish/courses/application_status/_body_text.html.erb
@@ -1,12 +1,12 @@
- <p class="govuk-body">
-  <% if @course.application_status_closed? %>
+<p class="govuk-body">
+<% if @course.application_status_closed? %>
   If the course has vacancies, open it so that candidates will be able to apply.
-  <% else %>
+<% else %>
   If the course does not have vacancies, close it so that candidates will not be able to apply. You&lsquo;ll be able to open the course again if any places become available.
-  <% end %>
+<% end %>
 </p>
 <p class="govuk-body">
-  <% if @course.application_status_open? %>
+<% if @course.application_status_open? %>
   The course will still be visible on Find, but candidates will not have the option to apply to it.
-  <% end %>
+<% end %>
 </p>

--- a/app/views/publish/courses/application_status/_body_text.html.erb
+++ b/app/views/publish/courses/application_status/_body_text.html.erb
@@ -1,5 +1,5 @@
  <p class="govuk-body">
-  <% if  @course.application_status_closed? %>
+  <% if @course.application_status_closed? %>
   If the course has vacancies, open it so that candidates will be able to apply.
   <% else %>
   If the course does not have vacancies, close it so that candidates will not be able to apply. You&lsquo;ll be able to open the course again if any places become available.

--- a/app/views/publish/courses/application_status/_headline.html.erb
+++ b/app/views/publish/courses/application_status/_headline.html.erb
@@ -1,8 +1,4 @@
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l"><%= @course.name_and_code %></span>
-  <% if  @course.application_status_closed? %>
-  Are you sure you want to open this course?
-  <% else %>
-  Are you sure you want to close this course?
-  <% end %>
+  Are you sure you want to <%= (@course.application_status_closed? ? "open" : "close").to_s %> this course?
 </h1>

--- a/app/views/publish/courses/application_status/_headline.html.erb
+++ b/app/views/publish/courses/application_status/_headline.html.erb
@@ -1,0 +1,8 @@
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+  <% if  @course.application_status_closed? %>
+  Are you sure you want to open this course?
+  <% else %>
+  Are you sure you want to close this course?
+  <% end %>
+</h1>

--- a/app/views/publish/courses/application_status/new.html.erb
+++ b/app/views/publish/courses/application_status/new.html.erb
@@ -11,7 +11,7 @@
 
     <%= render partial: "publish/courses/application_status/body_text" %>
 
-    <%= govuk_button_to(@course.application_status_closed? ? "Open course" : "Close course", open_publish_provider_recruitment_cycle_course_path) %>
+    <%= govuk_button_to(@course.application_status_closed? ? "Open course" : "Close course", application_status_publish_provider_recruitment_cycle_course_path) %>
 
     <p class="govuk-body">
       <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_course_path) %>

--- a/app/views/publish/courses/application_status/new.html.erb
+++ b/app/views/publish/courses/application_status/new.html.erb
@@ -7,14 +7,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= @course.name_and_code %></span>
-      Are you sure you want to open this course?
-    </h1>
+    <%= render partial: "publish/courses/application_status/headline" %>
 
-    <p class="govuk-body">If the course has vacancies, open it so that candidates will be able to apply.</p>
+    <%= render partial: "publish/courses/application_status/body_text" %>
 
-    <%= govuk_button_to("Open course", open_publish_provider_recruitment_cycle_course_path) %>
+    <%= govuk_button_to(@course.application_status_closed? ? "Open course" : "Close course", open_publish_provider_recruitment_cycle_course_path) %>
 
     <p class="govuk-body">
       <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_course_path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,7 +222,7 @@ en:
   value_not_entered: "Not entered"
   course:
     application_status:
-      opened: "Course opened"
+      open: "Course opened"
       closed: "Course closed"
     add_course: "Add course"
     update_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,7 @@ en:
   course:
     application_status:
       opened: "Course opened"
+      closed: "Course closed"
     add_course: "Add course"
     update_email:
       name: "title"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -156,11 +156,11 @@ namespace :publish, as: :publish do
         get '/apply', on: :member, to: 'courses#apply', as: :apply
         get '/details', on: :member, to: 'courses#details'
 
-        get '/open', on: :member, to: 'courses/application_status#new'
-        get '/close', on: :member, to: 'courses/application_status#new'
+        get '/application_status', on: :member, to: 'courses/application_status#new'
+        # get '/close', on: :member, to: 'courses/application_status#new'
 
-        post '/open', on: :member, to: 'courses/application_status#update'
-        post '/close', on: :member, to: 'courses/application_status#update'
+        post '/application_status', on: :member, to: 'courses/application_status#update'
+        # post '/close', on: :member, to: 'courses/application_status#update'
 
         get '/engineers_teach_physics', on: :member, to: 'courses/engineers_teach_physics#edit'
         put '/engineers_teach_physics', on: :member, to: 'courses/engineers_teach_physics#update'

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -157,7 +157,10 @@ namespace :publish, as: :publish do
         get '/details', on: :member, to: 'courses#details'
 
         get '/open', on: :member, to: 'courses/application_status#new'
+        get '/close', on: :member, to: 'courses/application_status#new'
+
         post '/open', on: :member, to: 'courses/application_status#update'
+        post '/close', on: :member, to: 'courses/application_status#update'
 
         get '/engineers_teach_physics', on: :member, to: 'courses/engineers_teach_physics#edit'
         put '/engineers_teach_physics', on: :member, to: 'courses/engineers_teach_physics#update'

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -157,10 +157,7 @@ namespace :publish, as: :publish do
         get '/details', on: :member, to: 'courses#details'
 
         get '/application_status', on: :member, to: 'courses/application_status#new'
-        # get '/close', on: :member, to: 'courses/application_status#new'
-
         post '/application_status', on: :member, to: 'courses/application_status#update'
-        # post '/close', on: :member, to: 'courses/application_status#update'
 
         get '/engineers_teach_physics', on: :member, to: 'courses/engineers_teach_physics#edit'
         put '/engineers_teach_physics', on: :member, to: 'courses/engineers_teach_physics#update'

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -26,19 +26,17 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
   end
 
   def and_i_should_be_back_on_the_course_page
-    expect(page).to have_current_path(publish_provider_recruitment_cycle_course_path(course.provider.provider_code,
-                                                                                     course.recruitment_cycle.year,
-                                                                                     course.course_code))
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.recruitment_cycle.year, course.course_code))
   end
 
   def and_the_course_is_open
     course.reload
-    expect(course.application_status_open?).to be true
+    expect(course).to be_application_status_open
   end
 
   def and_the_course_is_closed
     course.reload
-    expect(course.application_status_closed?).to be true
+    expect(course).to be_application_status_closed
   end
 
   def then_i_should_see_the_success_message
@@ -50,9 +48,7 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
   end
 
   def when_i_visit_the_open_applications_confirm_page
-    visit open_publish_provider_recruitment_cycle_course_path(course.provider.provider_code,
-                                                              course.recruitment_cycle.year,
-                                                              course.course_code)
+    visit application_status_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.recruitment_cycle.year, course.course_code)
   end
 
   def and_i_click_open_course

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -15,6 +15,14 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
     and_i_should_be_back_on_the_course_page
   end
 
+  scenario 'closing a course' do
+    and_there_is_an_open_course_i_want_to_close
+    when_i_visit_the_open_applications_confirm_page
+    and_i_click_close_course
+    then_i_should_see_the_closed_success_message
+    and_i_should_be_back_on_the_course_page
+  end
+
   def and_i_should_be_back_on_the_course_page
     expect(page).to have_current_path(publish_provider_recruitment_cycle_course_path(course.provider.provider_code,
                                                                                      course.recruitment_cycle.year,
@@ -23,6 +31,10 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
 
   def then_i_should_see_the_success_message
     expect(page).to have_text('Course opened')
+  end
+
+  def then_i_should_see_the_closed_success_message
+    expect(page).to have_text('Course closed')
   end
 
   def when_i_visit_the_open_applications_confirm_page
@@ -35,11 +47,19 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
     click_button 'Open course'
   end
 
+  def and_i_click_close_course
+    click_button 'Close course'
+  end
+
   def given_i_am_authenticated_as_a_provider_user
     given_i_am_authenticated(user: create(:user, :with_provider))
   end
 
   def and_there_is_a_closed_course_i_want_to_open
+    given_a_course_exists(name: 'Course', course_code: 'AAAA', application_status: 'closed')
+  end
+
+  def and_there_is_an_open_course_i_want_to_close
     given_a_course_exists(name: 'Course', course_code: 'AAAA', application_status: 'open')
   end
 end

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -13,6 +13,7 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
     and_i_click_open_course
     then_i_should_see_the_success_message
     and_i_should_be_back_on_the_course_page
+    and_the_course_is_open
   end
 
   scenario 'closing a course' do
@@ -21,12 +22,23 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
     and_i_click_close_course
     then_i_should_see_the_closed_success_message
     and_i_should_be_back_on_the_course_page
+    and_the_course_is_closed
   end
 
   def and_i_should_be_back_on_the_course_page
     expect(page).to have_current_path(publish_provider_recruitment_cycle_course_path(course.provider.provider_code,
                                                                                      course.recruitment_cycle.year,
                                                                                      course.course_code))
+  end
+
+  def and_the_course_is_open
+    course.reload
+    expect(course.application_status_open?).to be true
+  end
+
+  def and_the_course_is_closed
+    course.reload
+    expect(course.application_status_closed?).to be true
   end
 
   def then_i_should_see_the_success_message


### PR DESCRIPTION
### Context
User need

As a user, I want to be able to open or close my courses so candidates can be informed whether applications are open or not.
Why

We’re removing vacancies as research has shown they cause more confusion. We’re introducing a simple of concept to allow providers toggle whether courses are open or not.
What needs to be done

Implement close course confirmation page
Done when

This is our definition of done

    When the feature flag is set to on
    Then there is a route for /publish/organisations/#{provider_code}/#{recruitment_cycle_year}/courses/#{course_code}/close
    Then there is an close course confirmation page
    Then there is an ability to set a course to be close
    Then there is an appropriate business logic to prevent setting a course to be close
    Then on success it will redirect to the course show page with flash message

### Changes proposed in this pull request
Routes for GET and PUT close, conditional text display in new view
### Guidance to review
GOTO /publish/organisations/:provider_code/:recruitment_cycle_year/courses/:code with an open course, should display:
![Screenshot 2023-05-26 at 16 30 06](https://github.com/DFE-Digital/publish-teacher-training/assets/4527528/b4d87e08-a922-40bf-b616-a8f2ea5fb702)

Clicking on 'Close course' will direct to show page with success message
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
