### PR TITLE
[1320] open course/closed course button

### DIFF
--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -3,6 +3,10 @@
 </span>
 
 <div class="govuk-button-group">
+  <% if FeatureService.enabled?(:open_and_closed_course_flow) %>
+    <%= govuk_link_to course.application_status_closed? ? "Open course" : "Close course", application_status_publish_provider_recruitment_cycle_course_path, class: "govuk-button govuk-!-margin-right-2" %>
+  <% end %>
+
   <% if course.has_unpublished_changes? %>
     <%= govuk_button_to("Publish course", publish_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                         class: "govuk-!-margin-right-2",

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -4,12 +4,15 @@ require 'rails_helper'
 
 feature 'Editing course application status', { can_edit_current_and_next_cycles: false } do
   before do
+    given_the_open_and_closed_course_flow_feature_is_active
     given_i_am_authenticated_as_a_provider_user
   end
 
-  scenario 'opening a course' do
+  scenario 'opening a closed course' do
     and_there_is_a_closed_course_i_want_to_open
-    when_i_visit_the_open_applications_confirm_page
+    when_i_visit_the_course_show_page
+    and_i_click_open_course_link
+    then_i_am_on_the_application_status_confirm_page
     and_i_click_open_course
     then_i_should_see_the_success_message
     and_i_should_be_back_on_the_course_page
@@ -18,11 +21,25 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
 
   scenario 'closing a course' do
     and_there_is_an_open_course_i_want_to_close
-    when_i_visit_the_open_applications_confirm_page
+    when_i_visit_the_course_show_page
+    and_i_click_close_course_link
+    then_i_am_on_the_application_status_confirm_page
     and_i_click_close_course
     then_i_should_see_the_closed_success_message
     and_i_should_be_back_on_the_course_page
     and_the_course_is_closed
+  end
+
+  def when_i_visit_the_course_show_page
+    visit publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.recruitment_cycle.year, course.course_code)
+  end
+
+  def and_i_click_open_course_link
+    click_link 'Open course'
+  end
+
+  def and_i_click_close_course_link
+    click_link 'Close course'
   end
 
   def and_i_should_be_back_on_the_course_page
@@ -47,8 +64,8 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
     expect(page).to have_text('Course closed')
   end
 
-  def when_i_visit_the_open_applications_confirm_page
-    visit application_status_publish_provider_recruitment_cycle_course_path(course.provider.provider_code, course.recruitment_cycle.year, course.course_code)
+  def then_i_am_on_the_application_status_confirm_page
+    expect(page).to have_current_path("/publish/organisations/#{course.provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/application_status")
   end
 
   def and_i_click_open_course
@@ -63,11 +80,17 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
     given_i_am_authenticated(user: create(:user, :with_provider))
   end
 
+  def given_the_open_and_closed_course_flow_feature_is_active
+    allow(Settings.features).to receive(:open_and_closed_course_flow).and_return(true)
+  end
+
   def and_there_is_a_closed_course_i_want_to_open
-    given_a_course_exists(name: 'Course', course_code: 'AAAA', application_status: 'closed')
+    given_a_course_exists(:published, application_status: 'closed')
+    given_a_site_exists(:findable)
   end
 
   def and_there_is_an_open_course_i_want_to_close
-    given_a_course_exists(name: 'Course', course_code: 'AAAA', application_status: 'open')
+    given_a_course_exists(:published, application_status: 'open')
+    given_a_site_exists(:findable)
   end
 end


### PR DESCRIPTION
### Context
User need

As a user, I want to be able to open or close my courses so candidates can be informed whether applications are open or not.
Why

We’re removing vacancies as research has shown they cause more confusion. We’re introducing a simple of concept to allow providers toggle whether courses are open or not.
What needs to be done

Implement the open course/closed course button
Done when

This is our definition of done

    When the feature flag is set to on
    Then when the course is closed there is open course button
    Then when the course is open there is close course button
    Then when it is clicked there is an appropriate open/close confirmation page

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
