### PR TITLE
[1318] `status_tag` depend on `application_status`

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -21,8 +21,10 @@ class ApplicationDecorator < Draper::Decorator
   end
 
   def status_tags
-    if current_recruitment_cycle_year?
+    if current_recruitment_cycle_year? && !FeatureService.enabled?(:open_and_closed_course_flow)
       object.has_vacancies? ? status_tags_for_vacancies : status_tags_for_no_vacancies
+    elsif current_recruitment_cycle_year? && FeatureService.enabled?(:open_and_closed_course_flow)
+      object.application_status_open? ? status_tags_for_vacancies : status_tags_for_no_vacancies
     else
       status_tags_for_rolled_over_courses
     end

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -49,11 +49,13 @@ feature 'Editing course application status', { can_edit_current_and_next_cycles:
   def and_the_course_is_open
     course.reload
     expect(course).to be_application_status_open
+    expect(page).to have_css('.govuk-tag--turquoise')
   end
 
   def and_the_course_is_closed
     course.reload
     expect(course).to be_application_status_closed
+    expect(page).to have_css('.govuk-tag--purple')
   end
 
   def then_i_should_see_the_success_message


### PR DESCRIPTION
### Context

In line with the removing vacancies epic, this PR uses the new `application_status` to determine whether we render the open or closed status labels. 

### Changes proposed in this pull request

If feature flag is enabled, use the new column to decide which status tags to render.

### Guidance to review

Open and close a course

### Screenshots

#### Open

<img width="560" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/d09ba160-586a-49fc-b50a-e1f974e2bf73">

#### Closed

<img width="602" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/ba708792-ab7d-46a1-a34e-04045c006e16">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
