### PR TITLE
[1284] Expose application status on the API

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -49,7 +49,8 @@ module API
                    :additional_gcse_equivalencies,
                    :can_sponsor_skilled_worker_visa,
                    :can_sponsor_student_visa,
-                   :campaign_name
+                   :campaign_name,
+                   :application_status
 
         attribute :about_accredited_body do
           @object.accrediting_provider_description

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -5,6 +5,10 @@ weight: 2
 
 # Release Notes
 
+## 31 May 2023
+
+- Add `application_status` field to `CourseAttributes`. This is a string, corresponding to whether applications are open or closed.
+
 ## 25 April 2023
 
 - We have introduced a new `Street address 3` attribute to the Provider schema. This is a string, referencing an optional address field.

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -292,7 +292,8 @@ RSpec.describe API::Public::V1::CoursesController do
                 salary_details
                 can_sponsor_skilled_worker_visa
                 can_sponsor_student_visa
-                campaign_name]
+                campaign_name
+                application_status]
           end
 
           before do

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:can_sponsor_skilled_worker_visa) }
   it { is_expected.to have_attribute(:can_sponsor_student_visa) }
   it { is_expected.to have_attribute(:campaign_name) }
+  it { is_expected.to have_attribute(:application_status) }
 
   context 'when bursary amount is present' do
     let(:course) { create(:course, :with_accrediting_provider, :secondary, enrichments: [enrichment], subjects: [find_or_create(:secondary_subject, :classics)]) }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -124,7 +124,7 @@
             "type": "string",
             "nullable": true,
             "format": "markdown",
-            "description": "Description of the accredited body for this course.",
+            "description": "Description of the accredited provider for this course.",
             "example": "UCL Institute of Education is the world’s leading centre for research and teaching in education and related social sciences."
           },
           "about_course": {
@@ -134,9 +134,9 @@
             "description": "Short factual summary of the course.",
             "example": "The Secondary PGCE consists of three core modules: two Master's-level modules, which are assessed through written assignments, and the Professional Practice module, which is assessed by the observation of practical teaching in placement schools."
           },
-          "accredited_body_code": {
+          "accredited_provider_code": {
             "type": "string",
-            "description": "Unique provider-code for the accredited body of this course. Only present if the provider delivering the course is not the accredited body.",
+            "description": "Unique provider-code for the accredited provider of this course. Only present if the provider delivering the course is not the accredited body.",
             "maxLength": 3,
             "minLength": 3,
             "nullable": true,
@@ -558,6 +558,16 @@
             "enum": [
               "engineers_teach_physics",
               "no_campaign"
+            ]
+          },
+          "application_status": {
+            "type": "string",
+            "nullable": false,
+            "description": "The courses application status, corresponding to whether applications are open or not",
+            "example": "open",
+            "enum": [
+              "open",
+              "closed"
             ]
           }
         }
@@ -1101,7 +1111,7 @@
         "properties": {
           "accredited_body": {
             "type": "boolean",
-            "description": "Is this provider an accredited body for other provider's courses.",
+            "description": "Is this provider an accredited provider for other provider's courses.",
             "example": "true"
           },
           "city": {
@@ -1269,7 +1279,7 @@
             "example": true
           },
           "is_accredited_body": {
-            "description": "Only return providers that are accredited bodies.",
+            "description": "Only return providers that are accredited providers.",
             "type": "boolean",
             "example": true
           },
@@ -1962,7 +1972,7 @@
             "description": "The associated data for this resource.",
             "schema": {
               "enum": [
-                "accredited_body",
+                "accredited_provider",
                 "provider",
                 "recruitment_cycle"
               ]
@@ -2201,7 +2211,7 @@
             "description": "The associated data for this resource.",
             "schema": {
               "enum": [
-                "accredited_body",
+                "accredited_provider",
                 "provider",
                 "recruitment_cycle"
               ]
@@ -2278,7 +2288,7 @@
             "description": "The associated data for this resource.",
             "schema": {
               "enum": [
-                "accredited_body",
+                "accredited_provider",
                 "provider",
                 "recruitment_cycle"
               ]

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -399,3 +399,11 @@ properties:
     enum:
       - engineers_teach_physics
       - no_campaign
+  application_status:
+    type: string
+    nullable: false
+    description: "The courses application status, corresponding to whether applications are open or not"
+    example: "open"
+    enum:
+      - open
+      - closed


### PR DESCRIPTION
### Context

We added `application_status` as a new column on the course table. This PR exposes the column on the public API.

### Changes proposed in this pull request

- Expose `application_status` column as an attribute on the public API.
- Update docs.

### Guidance to review

- Public API: `http://publish.localhost:3001/api/public/v1/recruitment_cycles/2023/providers/{provider_code}/courses/{course_code}`

- https://publish-teacher-training-pr-3605.london.cloudapps.digital/docs/api-reference.html#schema-courseattributes

### Screenshots

<img width="858" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/c6eca644-4456-42eb-8d64-481ccc2d16a4">


<img width="897" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/e4fc3e67-429d-4cae-93e1-73ac78f075c8">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
