### PR TITLE
Bump libcurl version to fix CVE-2023-28322

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
 # Remove once the base image ruby:3.1-alpine3.15 has been updated with the below pkgs
-RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2
+RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.1.2-r0
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
### Context
Fix for:
https://security.snyk.io/vuln/SNYK-ALPINE315-CURL-5561304
https://security.snyk.io/vuln/SNYK-ALPINE315-CURL-5561305
https://security.snyk.io/vuln/SNYK-ALPINE315-CURL-5561307

### Changes proposed in this pull request
Manually install the fixed version of libcurl `libcurl=8.1.2-r0`

### Guidance to review
- [ ] Synk doesn't report the vulnerability

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
