### PR TITLE
[1299] Default spec `authentication_mode` to `nil`

### DIFF
--- a/spec/support/authentication/mode/magic_link.rb
+++ b/spec/support/authentication/mode/magic_link.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This is required as a workaround for failing tests when DfE sign in is down and magic links are active
+
+RSpec.configure do |config|
+  config.around do |example|
+    magic_link = Settings.authentication.mode == 'magic_link'
+
+    if magic_link == true
+      old_value = Settings.authentication.mode
+
+      Settings.authentication.mode = nil
+      Rails.application.reload_routes!
+
+      example.run
+
+      Settings.authentication.mode = old_value
+      Rails.application.reload_routes!
+    else
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
### Context

Lots of specs were failing when magic links was enabled. This prevented us from merging and deploying when DfE Sign in was down. This is the fix, so next time we can raise a PR to turn magic links on and successfully merge and deploy it.

### Changes proposed in this pull request

Default spec `authentication_mode` to `nil`

### Guidance to review

- Run the tests with magic links active.
- Run the tests with magic links inactive.
- Test out on QA

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
