### PR TITLE
Bump libcrypto1.1 version to fix CVE-2023-2650

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
 # Remove once the base image ruby:3.1-alpine3.15 has been updated with the below pkgs
-RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.1.2-r0
+RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.1.2-r0 libcrypto1.1=1.1.1u-r1
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
### Context
Bump libcrypto1.1 version to fix CVE-2023-2650

### Changes proposed in this pull request
Update `libcrypto1.1` to version `1.1.1u-r0`

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
