### PR TITLE
[1325] update study sites

### DIFF
--- a/app/controllers/publish/providers/study_sites_controller.rb
+++ b/app/controllers/publish/providers/study_sites_controller.rb
@@ -32,7 +32,7 @@ module Publish
       end
 
       def update
-        @study_site_form = SchoolForm.new(site, params: site_params(:publish_study_site_form))
+        @study_site_form = SchoolForm.new(site, params: site_params(:publish_school_form))
 
         if @study_site_form.save!
           course_updated_message('Study site')

--- a/app/forms/publish/school_form.rb
+++ b/app/forms/publish/school_form.rb
@@ -42,7 +42,7 @@ module Publish
     end
 
     def location_name_unique_to_provider
-      sibling_sites = if site_type == 'study_site'
+      sibling_sites = if site.study_site?
                         provider.study_sites - [site]
                       else
                         provider.sites - [site]

--- a/app/forms/publish/school_form.rb
+++ b/app/forms/publish/school_form.rb
@@ -26,10 +26,10 @@ module Publish
     validate :location_name_unique_to_provider
     validates :location_name, presence: true
     validates :address1, presence: true
-    validates :town, presence: { message: 'Enter a town or city' }
-    validates :postcode, presence: { message: 'Enter a postcode' }
-    validates :postcode, postcode: { message: 'Postcode is not valid (for example, BN1 1AA)' }
-    validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: 'URN must be 5 or 6 numbers' }
+    validates :town, presence: true
+    validates :postcode, presence: true
+    validates :postcode, postcode: true
+    validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: :format }
 
     private
 

--- a/app/forms/publish/school_form.rb
+++ b/app/forms/publish/school_form.rb
@@ -11,6 +11,7 @@ module Publish
       town
       address4
       postcode
+      site_type
     ].freeze
 
     attr_accessor(*FIELDS)
@@ -23,8 +24,8 @@ module Publish
     end
 
     validate :location_name_unique_to_provider
-    validates :location_name, presence: { message: 'Enter a name' }
-    validates :address1, presence: { message: 'Enter a building and street' }
+    validates :location_name, presence: true
+    validates :address1, presence: true
     validates :town, presence: { message: 'Enter a town or city' }
     validates :postcode, presence: { message: 'Enter a postcode' }
     validates :postcode, postcode: { message: 'Postcode is not valid (for example, BN1 1AA)' }
@@ -41,8 +42,11 @@ module Publish
     end
 
     def location_name_unique_to_provider
-      sibling_sites = provider.sites - [site]
-
+      sibling_sites = if site_type == 'study_site'
+                        provider.study_sites - [site]
+                      else
+                        provider.sites - [site]
+                      end
       errors.add(:location_name, 'Name is in use by another location') if location_name.in?(sibling_sites.pluck(:location_name))
     end
   end

--- a/app/forms/support/school_form.rb
+++ b/app/forms/support/school_form.rb
@@ -43,7 +43,7 @@ module Support
     private
 
     def location_name_unique_to_provider
-      sibling_sites = if site_type == 'study_site'
+      sibling_sites = if site.study_site?
                         provider.study_sites - [site]
                       else
                         provider.sites - [site]
@@ -52,7 +52,7 @@ module Support
     end
 
     def validate_code
-      return if site_type == 'study_site'
+      return if site.study_site?
 
       errors.add(:code, 'Code has already been taken') if provider.sites.exists?(code:)
     end

--- a/app/views/publish/providers/study_sites/_form.html.erb
+++ b/app/views/publish/providers/study_sites/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model:, local: true, url: form_url, class: "school-form" do |f| %>
+<%= form_with model:, local: true, url: form_url, method: form_method, class: "school-form" do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_text_field :location_name, label: { text: "Study site name", size: "s" } %>
@@ -26,5 +26,5 @@
     <%= f.govuk_text_field(:postcode, label: { text: "Postcode", size: "s" }, width: 10) %>
   <% end %>
 
-  <%= f.govuk_submit(site.persisted? ? t("publish.providers.schools.update") : t("continue")) %>
+  <%= f.govuk_submit(site.persisted? ? t("publish.providers.study_sites.update") : t("continue")) %>
 <% end %>

--- a/app/views/publish/providers/study_sites/edit.html.erb
+++ b/app/views/publish/providers/study_sites/edit.html.erb
@@ -1,0 +1,19 @@
+<% page_title = @study_site_form.site.location_name %>
+<% content_for :page_title, title_with_error_prefix(page_title, @study_site_form.errors.any?) %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_study_site_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= @site.location_name_was %>
+    </h1>
+
+    <%= render partial: "form", locals: { model: @study_site_form, site: @site, form_url: publish_provider_recruitment_cycle_study_site_path, form_method: :patch } %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/providers/study_sites/new.html.erb
+++ b/app/views/publish/providers/study_sites/new.html.erb
@@ -12,7 +12,7 @@
         Study site details
       </h1>
 
-    <%= render partial: "publish/providers/study_sites/form", locals: { model: @study_site_form, site: @site, form_url: publish_provider_recruitment_cycle_study_sites_path } %>
+    <%= render partial: "publish/providers/study_sites/form", locals: { model: @study_site_form, site: @site, form_url: publish_provider_recruitment_cycle_study_sites_path, form_method: :post } %>
 
     <p class="govuk-body">
       <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -725,6 +725,20 @@ en:
               format: "URN must be 5 or 6 numbers"
         support/raw_csv_schools_form:
           blank: "Enter school details"
+        publish/school_form:
+          attributes:
+            location_name:
+              blank: "Enter a name"
+              taken: "Name is taken"
+            address1:
+              blank: "Enter address line 1"
+            town:
+              blank: "Enter a town or city"
+            postcode:
+              blank: "Enter a postcode"
+              invalid: "Enter a real postcode"
+            urn:
+              format: "URN must be 5 or 6 numbers"
         publish/course_information_form:
           attributes:
             about_course:

--- a/spec/features/publish/managing_study_sites_spec.rb
+++ b/spec/features/publish/managing_study_sites_spec.rb
@@ -32,6 +32,56 @@ feature "Managing a provider's study_sites", { can_edit_current_and_next_cycles:
     end
   end
 
+  describe 'edit study site' do
+    scenario 'with valid details' do
+      when_i_click_on_a_study_site
+      and_i_am_on_the_study_sites_show_page
+      and_i_click_a_change_link
+      and_i_change_the_name
+      and_the_updated_site_is_displayed
+      and_i_click_back
+      then_i_am_on_the_index_page
+      and_the_updated_site_is_displayed
+    end
+
+    scenario 'with invalid details' do
+      when_i_click_on_a_study_site
+      and_i_click_a_change_link
+      and_i_enter_invalid_details
+      then_i_see_an_error_message('Enter address line 1')
+    end
+  end
+
+  def and_i_click_back
+    click_link 'Back'
+  end
+
+  def and_i_enter_invalid_details
+    fill_in('Address line 1', with: '')
+    click_button 'Update study site'
+  end
+
+  def and_the_updated_site_is_displayed
+    expect(page).to have_text('Hogwarts')
+  end
+
+  def and_i_change_the_name
+    fill_in('Study site name', with: 'Hogwarts')
+    click_button 'Update study site'
+  end
+
+  def and_i_click_a_change_link
+    click_link(class: 'govuk-link location_name')
+  end
+
+  def and_i_am_on_the_study_sites_show_page
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study_sites/#{site.id}")
+  end
+
+  def when_i_click_on_a_study_site
+    click_link site.location_name
+  end
+
   def add_study_site_with_valid_details
     when_i_click_add_study_site
     and_i_click_the_link_to_enter_a_school_manually


### PR DESCRIPTION
### Context
What needs to be done

For this ticket we’ll need to add a way to update existing study sites from their show pages.
Done when

This is our definition of done

I can update any of my study site’s information from the study sites index page

### Changes proposed in this pull request

### Guidance to review
GOTO study sites index, click on the name link and update away!
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
