### PR TITLE
[1332] Remove `with_vacancies` from reporting

### DIFF
--- a/app/services/course_reporting_service.rb
+++ b/app/services/course_reporting_service.rb
@@ -4,8 +4,8 @@ class CourseReportingService
   def initialize(courses_scope: Course)
     @courses = courses_scope.distinct
     @findable_courses = @courses.findable
-    @open_courses = @findable_courses.with_vacancies
-    @closed_courses = @findable_courses.where.not(id: @open_courses)
+    @open_courses = @findable_courses.application_status_open
+    @closed_courses = @findable_courses.application_status_closed
   end
 
   class << self

--- a/app/services/provider_reporting_service.rb
+++ b/app/services/provider_reporting_service.rb
@@ -5,7 +5,7 @@ class ProviderReportingService
     @providers = providers_scope.distinct
 
     @training_providers = @providers.where(id: Course.findable.select(:provider_id))
-    @open_providers = @providers.where(id: Course.with_vacancies.select(:provider_id))
+    @open_providers = @providers.where(id: Course.findable.application_status_open.select(:provider_id))
 
     @closed_providers = @training_providers.where.not(id: @open_providers)
   end

--- a/app/services/publish_reporting_service.rb
+++ b/app/services/publish_reporting_service.rb
@@ -109,8 +109,8 @@ class PublishReportingService
     courses_changed_recently = @courses.changed_at_since(days_ago)
 
     findable_courses = courses_changed_recently.findable.distinct
-    open_courses = findable_courses.with_vacancies
-    closed_courses = findable_courses.where.not(id: open_courses)
+    open_courses = findable_courses.application_status_open
+    closed_courses = findable_courses.application_status_closed
 
     courses_changed_recently_count = courses_changed_recently.count
     findable_courses_count = findable_courses.count

--- a/spec/services/course_reporting_service_spec.rb
+++ b/spec/services/course_reporting_service_spec.rb
@@ -103,8 +103,8 @@ describe CourseReportingService do
         expect(distinct_courses_scope).to receive(:count).and_return(courses_count)
         expect(distinct_courses_scope).to receive(:findable).and_return(findable_courses_scope)
 
-        expect(findable_courses_scope).to receive(:with_vacancies).and_return(open_courses_scope)
-        expect(findable_courses_scope).to receive_message_chain(:where, :not).and_return(closed_courses_scope)
+        expect(findable_courses_scope).to receive(:application_status_open).and_return(open_courses_scope)
+        expect(findable_courses_scope).to receive(:application_status_closed).and_return(closed_courses_scope)
 
         expect(findable_courses_scope).to receive(:count).and_return(findable_courses_count)
         expect(findable_courses_scope).to receive(:count).and_return(findable_courses_count)

--- a/spec/services/provider_reporting_service_spec.rb
+++ b/spec/services/provider_reporting_service_spec.rb
@@ -98,7 +98,7 @@ describe ProviderReportingService do
         expect(distinct_providers_scope).to receive(:where).with(id: Course.findable.select(:provider_id)).and_return(training_providers_scope)
 
         expect(distinct_providers_scope).to receive(:where)
-          .with(id: Course.findable.with_vacancies.select(:provider_id))
+          .with(id: Course.findable.application_status_open.select(:provider_id))
           .and_return(open_providers_scope)
 
         expect(training_providers_scope).to receive_message_chain(:where, :not).and_return(closed_providers_scope)

--- a/spec/services/publish_reporting_service_spec.rb
+++ b/spec/services/publish_reporting_service_spec.rb
@@ -102,8 +102,8 @@ describe PublishReportingService do
 
         expect(courses_scope).to receive(:changed_at_since).and_return(courses_changed_at_since_scope)
         expect(courses_changed_at_since_scope).to receive_message_chain(:findable, :distinct).and_return(courses_findable_scope)
-        expect(courses_findable_scope).to receive(:with_vacancies).and_return(open_courses_scope)
-        expect(courses_findable_scope).to receive_message_chain(:where, :not).with(id: open_courses_scope).and_return(closed_courses_scope)
+        expect(courses_findable_scope).to receive(:application_status_open).and_return(open_courses_scope)
+        expect(courses_findable_scope).to receive(:application_status_closed).and_return(closed_courses_scope)
         expect(courses_changed_at_since_scope).to receive(:count).and_return(courses_changed_at_since_count)
         expect(courses_findable_scope).to receive(:count).and_return(courses_findable_count)
         expect(open_courses_scope).to receive(:count).and_return(open_courses_count)


### PR DESCRIPTION
### Context
 `with_vacancies` from reporting

### Changes proposed in this pull request
Replace it with application_status

### Guidance to review
:ship: 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
