### PR TITLE
[1332] Remove `Vacancies` from accredited_course_list

### DIFF
--- a/app/services/exports/accredited_course_list.rb
+++ b/app/services/exports/accredited_course_list.rb
@@ -38,8 +38,7 @@ module Exports
           'Qualification' => c.outcome,
           'Status' => c.content_status&.to_s&.humanize,
           'View on Find' => c.find_url,
-          'Applications open from' => I18n.l(c.applications_open_from&.to_date),
-          'Vacancies' => c.has_vacancies? ? 'Yes' : 'No'
+          'Applications open from' => I18n.l(c.applications_open_from&.to_date)
         }
         if c.sites
           base_data.merge({ 'Campus Codes' => c.sites.pluck(:code).join(' ') })

--- a/spec/services/exports/accredited_course_list_spec.rb
+++ b/spec/services/exports/accredited_course_list_spec.rb
@@ -28,8 +28,7 @@ module Exports
           'Qualification' => course.outcome,
           'Status' => course.content_status&.to_s&.humanize,
           'View on Find' => course.find_url,
-          'Applications open from' => I18n.l(course.applications_open_from&.to_date),
-          'Vacancies' => 'Yes'
+          'Applications open from' => I18n.l(course.applications_open_from&.to_date)
         }
       end
 


### PR DESCRIPTION
### Context
`Vacancies` from accredited_course_list

### Changes proposed in this pull request
Remove it

### Guidance to review
Download CVS

### Checklist


- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
