### PR TITLE
[1362] Fix apply button logic

### DIFF
--- a/app/components/find/courses/apply_component/view.html.erb
+++ b/app/components/find/courses/apply_component/view.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8" id="section-apply">
   <% if Find::CycleTimetable.mid_cycle? %>
-    <% if has_vacancies? %>
+    <% if application_status_open? %>
       <p class="govuk-body">
         <%= govuk_start_button(
               text: "Apply for this course",
@@ -11,7 +11,7 @@
             ) %>
       </p>
     <% else %>
-      <%= govuk_warning_text(text: "You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only show courses with vacancies’.") %>
+      <%= govuk_warning_text(text: "You cannot apply for this course as it is closed for applications. To find courses open for applications, change your search to ‘Only show courses open for applications’.") %>
     <% end %>
   <% else %>
     <div data-qa="course__end_of_cycle_notice">

--- a/app/components/find/courses/apply_component/view.rb
+++ b/app/components/find/courses/apply_component/view.rb
@@ -6,7 +6,7 @@ module Find
       class View < ViewComponent::Base
         attr_reader :course
 
-        delegate :has_vacancies?, :provider, to: :course
+        delegate :application_status_open?, :provider, to: :course
 
         def initialize(course)
           super

--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -23,5 +23,5 @@
   <% end %>
   <li><%= govuk_link_to "Contact this training provider", "#section-contact" %></li>
   <li><%= govuk_link_to "Support and advice", "#section-advice" %></li>
-  <% if course.has_vacancies? %> <li><%= govuk_link_to "Apply", "#section-apply" %></li> <% end %>
+  <% if course.application_status_open? %> <li><%= govuk_link_to "Apply", "#section-apply" %></li> <% end %>
 </ul>

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -434,7 +434,7 @@ class Course < ApplicationRecord
   end
 
   def open_for_applications?
-    applications_open_from.present? && applications_open_from <= Time.now.utc && findable? && has_vacancies?
+    applications_open_from.present? && applications_open_from <= Time.now.utc && findable? && application_status_open?
   end
 
   def has_vacancies?

--- a/app/views/publish/courses/_course_table_row.html.erb
+++ b/app/views/publish/courses/_course_table_row.html.erb
@@ -22,6 +22,8 @@
     <% end %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__applications">
-    <%= course.application_status.titleize %>
+    <% if course.is_running? || course.is_withdrawn? %>
+      <%= course.open_or_closed_for_applications %>
+    <% end %>
   </td>
 </tr>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -21,7 +21,7 @@
 
 <!--The reason for the Apply component duplication here is because we want to keep the warning text at the top but Keep the Apply button and end of cycle text at the bottom-->
 
-<%= render Find::Courses::ApplyComponent::View.new(course) if course.has_vacancies? || !Find::CycleTimetable.mid_cycle? %>
+<%= render Find::Courses::ApplyComponent::View.new(course) if course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -55,6 +55,6 @@
 
     <%= render partial: "find/courses/advice", locals: { course: } %>
 
-    <%= render Find::Courses::ApplyComponent::View.new(course) unless course.has_vacancies? %>
+    <%= render Find::Courses::ApplyComponent::View.new(course) unless course.application_status_open? %>
   </div>
 </div>

--- a/spec/components/find/courses/apply_component/view_spec.rb
+++ b/spec/components/find/courses/apply_component/view_spec.rb
@@ -10,8 +10,8 @@ describe Find::Courses::ApplyComponent::View, type: :component do
       allow(Find::CycleTimetable).to receive(:mid_cycle?).and_return(true)
     end
 
-    it 'renders the apply button when there are vacancies' do
-      course = build(:course, provider:, site_statuses: [create(:site_status, :published, :running)])
+    it 'renders the apply button when the course is open' do
+      course = build(:course, :open, provider:)
 
       result = render_inline(described_class.new(course))
 
@@ -19,8 +19,8 @@ describe Find::Courses::ApplyComponent::View, type: :component do
     end
 
     context "using 'Find::CoursesController'" do
-      it 'renders the apply button when there are vacancies' do
-        course = build(:course, provider:, site_statuses: [create(:site_status, :published, :running)])
+      it 'renders the apply button when the course is open' do
+        course = build(:course, :open, provider:)
         result = with_controller_class(Find::CoursesController) do
           render_inline(described_class.new(course))
         end
@@ -29,12 +29,12 @@ describe Find::Courses::ApplyComponent::View, type: :component do
       end
     end
 
-    it "renders a 'no vacancies' warning when there are no vacancies" do
-      course = build(:course, provider:, site_statuses: [create(:site_status, :unpublished, :running)])
+    it "renders a 'closed for applications' warning when the course is closed" do
+      course = build(:course, :closed, provider:, site_statuses: [create(:site_status, :unpublished, :running)])
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('You cannot apply for this course because it currently has no vacancies.')
+      expect(result.text).to include('You cannot apply for this course as it is closed for applications.')
     end
   end
 
@@ -42,7 +42,7 @@ describe Find::Courses::ApplyComponent::View, type: :component do
     it 'displays that courses are currently closed' do
       allow(Find::CycleTimetable).to receive(:mid_cycle?).and_return(false)
 
-      course = build(:course, provider:, site_statuses: [create(:site_status, :unpublished, :running)])
+      course = build(:course, :closed, provider:)
 
       result = render_inline(described_class.new(course))
 

--- a/spec/components/find/courses/contents_component/view_preview.rb
+++ b/spec/components/find/courses/contents_component/view_preview.rb
@@ -18,19 +18,19 @@ module Find
                          about_accrediting_provider: 'foo',
                          salaried: true,
                          interview_process: 'bar',
-                         has_vacancies: true)
+                         application_status_open: true)
         end
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:provider, :about_course, :how_school_placements_work, :placements_heading, :about_accrediting_provider, :salaried, :interview_process, :has_vacancies)
+          attr_accessor(:provider, :about_course, :how_school_placements_work, :placements_heading, :about_accrediting_provider, :salaried, :interview_process, :application_status_open)
 
           def has_bursary?
             has_bursary
           end
 
-          def has_vacancies?
-            has_vacancies
+          def application_status_open?
+            application_status_open
           end
 
           def salaried?

--- a/spec/components/find/courses/contents_component/view_spec.rb
+++ b/spec/components/find/courses/contents_component/view_spec.rb
@@ -50,20 +50,20 @@ describe Find::Courses::ContentsComponent::View, type: :component do
     end
   end
 
-  context 'when the course has vacancies' do
+  context 'when the course is open' do
     it 'does render the apply link' do
       provider = build(:provider)
-      course = build(:course, site_statuses: [create(:site_status, :published, :running)], provider:).decorate
+      course = build(:course, :open, provider:).decorate
       result = render_inline(described_class.new(course))
 
       expect(result.text).to include('Apply')
     end
   end
 
-  context 'when the course does not have vacancies' do
+  context 'when the course is not open' do
     it 'does not render the apply link' do
       provider = build(:provider)
-      course = build(:course, site_statuses: [create(:site_status, :unpublished, :running)], provider:).decorate
+      course = build(:course, :closed, provider:).decorate
 
       result = render_inline(described_class.new(course))
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -228,5 +228,13 @@ FactoryBot.define do
     trait :engineers_teach_physics do
       campaign_name { :engineers_teach_physics }
     end
+
+    trait :open do
+      application_status { :open }
+    end
+
+    trait :closed do
+      application_status { :closed }
+    end
   end
 end

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -313,11 +313,15 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     course_subject = find_or_create(:secondary_subject, :mathematics)
 
     course = build(
-      :course, :secondary, :fee_type_based, accrediting_provider:,
-                                            site_statuses:, enrichments: [course_enrichment],
-                                            degree_grade: 'two_one',
-                                            degree_subject_requirements: 'Maths A level',
-                                            subjects: [course_subject]
+      :course,
+      :open,
+      :secondary,
+      :fee_type_based,
+      accrediting_provider:,
+      site_statuses:, enrichments: [course_enrichment],
+      degree_grade: 'two_one',
+      degree_subject_requirements: 'Maths A level',
+      subjects: [course_subject]
     )
     accrediting_provider_enrichment = {
       'UcasProviderCode' => accrediting_provider.provider_code,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1619,10 +1619,12 @@ describe Course do
       let(:site_statuses) { [] }
 
       let(:applications_open_from) { Time.now.utc }
+      let(:application_status) { :open }
 
       let(:course) do
         create(:course,
                site_statuses:,
+               application_status:,
                applications_open_from:)
       end
 
@@ -1700,12 +1702,14 @@ describe Course do
 
           context 'findable course with no vacancies' do
             let(:site_statuses) { [findable_without_vacancies] }
+            let(:application_status) { :closed }
 
             its(:open_for_applications?) { is_expected.to be false }
           end
 
           context 'non findable course with no vacancies' do
             let(:site_statuses) { [published_discontinued_with_no_vacancies] }
+            let(:application_status) { :closed }
 
             its(:open_for_applications?) { is_expected.to be false }
           end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1725,10 +1725,12 @@ describe Course do
       let(:site_statuses) { [] }
 
       let(:applications_open_from) { Time.now.utc }
+      let(:application_status) { :open }
 
       let(:course) do
         create(:course,
                site_statuses:,
+               application_status:,
                applications_open_from:)
       end
 


### PR DESCRIPTION
### Context

https://trello.com/c/tMH6Iwbq/1362-issue-with-publish-closed-courses-are-open-and-open-open-courses-closed

The apply button is still lingering off some old vacancy logic so causing confusion to providers with a warning message being incorrectly shown.

### Changes proposed in this pull request

- Update the logic to render apply button
- Also revert the view logic to align application status but update the underlying method as it contains some other rules around the open date and the course being findable

### Guidance to review

- Open/Close a course and check apply button/warning text is shown as expected

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
