### PR TITLE
[1332] Remove `vac_status` from CopyToCourseService

### DIFF
--- a/app/services/sites/copy_to_course_service.rb
+++ b/app/services/sites/copy_to_course_service.rb
@@ -3,13 +3,8 @@
 module Sites
   class CopyToCourseService
     def execute(new_site:, new_course:)
-      new_vac_status = SiteStatus.default_vac_status_given(
-        study_mode: new_course.study_mode
-      )
-
       new_course.site_statuses.create(
         site: new_site,
-        vac_status: new_vac_status,
         status: :new_status
       )
     end

--- a/spec/services/sites/copy_to_course_service_spec.rb
+++ b/spec/services/sites/copy_to_course_service_spec.rb
@@ -28,7 +28,6 @@ describe Sites::CopyToCourseService do
   describe "the new site's status" do
     subject { course.site_statuses.first }
 
-    it { is_expected.to be_full_time_vacancies }
     it { is_expected.to be_status_new_status }
   end
 end


### PR DESCRIPTION
### Context
`vac_status` from CopyToCourseService
### Changes proposed in this pull request
Remove it
### Guidance to review
:shipit:
### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
