### PR TITLE
[1323] Implement study site removal

### DIFF
--- a/app/helpers/study_sites_helper.rb
+++ b/app/helpers/study_sites_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module StudySitesHelper
+  def study_site_has_courses?(provider, study_site)
+    provider.courses.includes(:study_site_placements).where(study_site_placements: { site_id: study_site.id }).any?
+  end
+end

--- a/app/models/study_site_placement.rb
+++ b/app/models/study_site_placement.rb
@@ -3,4 +3,14 @@
 class StudySitePlacement < ApplicationRecord
   belongs_to :course, inverse_of: :study_site_placements
   belongs_to :site, inverse_of: :study_site_placements
+
+  validate :site_type_cannot_be_school
+
+  private
+
+  def site_type_cannot_be_school
+    return unless site.present? && site.school?
+
+    errors.add(:site, 'cannot be a school')
+  end
 end

--- a/app/views/publish/providers/study_sites/delete.html.erb
+++ b/app/views/publish/providers/study_sites/delete.html.erb
@@ -24,8 +24,7 @@
     <%= govuk_button_to "Remove study site",
       delete_publish_provider_recruitment_cycle_study_site_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id),
       method: :delete,
-      class: "govuk-button--warning"
-    %>
+      class: "govuk-button--warning" %>
     <% end %>
     <p class="govuk-body">
       <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_study_site_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id)) %>

--- a/app/views/publish/providers/study_sites/delete.html.erb
+++ b/app/views/publish/providers/study_sites/delete.html.erb
@@ -1,0 +1,34 @@
+<%= render PageTitle.new(title: "publish.providers.study_sites.delete") %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_study_site_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @site.location_name %></span>
+    <% if study_site_has_courses?(@provider, @site) %>
+      <%= t("components.page_titles.publish.providers.study_sites.no_delete") %>
+    </h1>
+
+    <p class="govuk-body">
+      <%= "#{@site.location_name} is a study site for courses run by #{@provider.provider_name}." %>
+    </p>
+    <p class="govuk-body">
+      To remove <%= @site.location_name.to_s %>, you must first remove the study site from those courses.
+    </p>
+    <% else %>
+      <%= t("components.page_titles.publish.providers.study_sites.delete") %>
+    </h1>
+
+    <%= govuk_button_to "Remove study site",
+      delete_publish_provider_recruitment_cycle_study_site_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id),
+      method: :delete,
+      class: "govuk-button--warning"
+    %>
+    <% end %>
+    <p class="govuk-body">
+      <%= govuk_link_to("Cancel", publish_provider_recruitment_cycle_study_site_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id)) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/providers/study_sites/index.html.erb
+++ b/app/views/publish/providers/study_sites/index.html.erb
@@ -16,14 +16,9 @@
     <% end %>
 
     <% if @study_sites.none? %>
-      <p class='govuk-body'>
-        A study site, such as a university campus, is where trainees do theoretical training. Add study sites for your organisation and then link one or more to a course from the &lsquo;Basic details&rsquo; tab on the course page.
-      </p>
-      <p class='govuk-body'>
-        Candidates will see a list of the selected study sites in the &lsquo;Training locations&rsquo; section on the course page on Find.
-      </p>
+      <p class="govuk-body">A study site, such as a university campus, is where trainees do theoretical training. Add study sites for your organisation and then link one or more to a course from the ‘Basic details’ tab on the course page.</p>
 
-      <!-- TODO: find out more link -->
+      <p class="govuk-body">Candidates will see a list of the selected study sites in the Training locations' section on the course page on Find.</p>
     <% else %>
       <table class="govuk-table app-table--vertical-align-middle">
         <thead class="govuk-table__head">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,14 @@ en:
             show: "Show school"
             delete: "Are you sure you want to remove this school?"
             no_delete: "You cannot remove this school"
+          study_sites:
+            index: "Study sites"
+            new: "Add study site"
+            edit: "Edit study site details"
+            check: "Check your answers"
+            show: "Show study site"
+            delete: "Are you sure you want to remove this study site?"
+            no_delete: "You cannot remove this study site"
       support:
         rollover:
           index: "Recruitment Cycles"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -259,11 +259,11 @@ namespace :publish, as: :publish do
           put '/search', on: :collection, to: 'school_search#update'
         end
 
-        resource :check_study_site, only: %i[show update], controller: 'study_sites_check', path: 'study_sites/check'
-        resources :study_sites do
+        resource :check_study_site, only: %i[show update], controller: 'study_sites_check', path: 'study-sites/check'
+        resources :study_sites, path: 'study-sites' do
           member do
             get :delete
-            delete :delete, to: 'schools#destroy'
+            delete :delete, to: 'study_sites#destroy'
           end
 
           get '/search', on: :collection, to: 'study_site_search#new'

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -193,7 +193,7 @@ RSpec/IndexedLet:
     - 'spec/controllers/api/public/v1/providers_controller_spec.rb'
     - 'spec/controllers/api/accredited_provider_suggestions_controller_spec.rb'
 
-Rspec/HaveHttpStatus:
+Rspec/Rails/HaveHttpStatus:
   Exclude:
     - 'spec/smoke/api/v1/courses_spec.rb'
     - 'spec/smoke/api/v1/healthcheck_spec.rb'

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -16,6 +16,4 @@ authentication:
   mode: persona
 
 features:
-  support_new_provider_creation_flow: true
-  accredited_provider_search: true
-
+  study_sites: true

--- a/spec/factories/study_site_placements.rb
+++ b/spec/factories/study_site_placements.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :study_site_placements do
+  factory :study_site_placement do
     association(:course)
     association(:site)
   end

--- a/spec/features/publish/managing_study_sites_spec.rb
+++ b/spec/features/publish/managing_study_sites_spec.rb
@@ -52,6 +52,29 @@ feature "Managing a provider's study_sites", { can_edit_current_and_next_cycles:
     end
   end
 
+  describe 'delete study site' do
+    scenario 'with no associated courses' do
+      when_i_click_on_a_study_site
+      and_i_click_to_remove
+      then_i_am_on_the_study_sites_delete_page
+      when_i_click_cancel
+      then_i_am_on_the_study_site_show_page
+
+      and_i_click_to_remove
+      and_i_click_the_remove_study_site_button
+      then_i_am_on_the_index_page
+      and_the_study_site_is_deleted
+    end
+
+    scenario 'with associcated course' do
+      given_there_is_an_associated_course
+      when_i_click_on_a_study_site
+      and_i_click_to_remove
+      then_i_am_on_the_study_sites_delete_page
+      and_i_cannot_delete_the_study_site
+    end
+  end
+
   def and_i_click_back
     click_link 'Back'
   end
@@ -75,8 +98,9 @@ feature "Managing a provider's study_sites", { can_edit_current_and_next_cycles:
   end
 
   def and_i_am_on_the_study_sites_show_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study_sites/#{site.id}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites/#{site.id}")
   end
+  alias_method :then_i_am_on_the_study_site_show_page, :and_i_am_on_the_study_sites_show_page
 
   def when_i_click_on_a_study_site
     click_link site.location_name
@@ -111,7 +135,7 @@ feature "Managing a provider's study_sites", { can_edit_current_and_next_cycles:
   end
 
   def then_i_am_on_the_index_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study_sites")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites")
   end
 
   def and_i_click_add_study_site
@@ -119,7 +143,7 @@ feature "Managing a provider's study_sites", { can_edit_current_and_next_cycles:
   end
 
   def and_i_am_on_the_study_sites_check_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study_sites/check")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites/check")
   end
 
   def and_i_click_the_link_to_enter_a_school_manually
@@ -174,6 +198,36 @@ feature "Managing a provider's study_sites", { can_edit_current_and_next_cycles:
     given_i_am_authenticated(
       user: create(:user, providers: [create(:provider, sites: [build(:site, :study_site)])])
     )
+  end
+
+  def and_i_click_to_remove
+    click_link 'Remove study site'
+  end
+
+  def then_i_am_on_the_study_sites_delete_page
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites/#{site.id}/delete")
+  end
+
+  def when_i_click_cancel
+    click_link 'Cancel'
+  end
+
+  def and_i_click_the_remove_study_site_button
+    click_button 'Remove study site'
+  end
+
+  def and_the_study_site_is_deleted
+    expect(provider.study_sites.count).to eq 0
+  end
+
+  def given_there_is_an_associated_course
+    @course = create(:course, provider:)
+    @course.study_sites << @site
+  end
+
+  def and_i_cannot_delete_the_study_site
+    expect(page).to have_content('You cannot remove this study site')
+    expect(page).not_to have_button('Remove study site')
   end
 
   private

--- a/spec/features/publish/searching_for_a_study_site_spec.rb
+++ b/spec/features/publish/searching_for_a_study_site_spec.rb
@@ -45,7 +45,7 @@ feature 'Searching for a study site from the GIAS list' do
 
   def then_i_should_be_taken_to_the_add_study_site_page
     URI(current_url).then do |uri|
-      expect(uri.path).to eq("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study_sites/new")
+      expect(uri.path).to eq("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites/new")
       expect(uri.query).to eq("school_id=#{@school_two.id}")
     end
   end

--- a/spec/models/study_site_placement_spec.rb
+++ b/spec/models/study_site_placement_spec.rb
@@ -5,4 +5,14 @@ require 'rails_helper'
 describe StudySitePlacement do
   it { is_expected.to belong_to(:course) }
   it { is_expected.to belong_to(:site) }
+
+  describe 'validations' do
+    subject { build(:study_site_placement) }
+
+    context 'when site is a school' do
+      before { allow(subject.site).to receive(:school?).and_return(true) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/lzMP9YbB/1323-remove-study-sites

### Changes proposed in this pull request

- Implements study site removal logic

### Guidance to review

- Add a study site
- Assign it to the course (not done yet, needs to be manual in the console)
- Try to remove it (then do the same without assigning it to any course)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes