### PR TITLE
[1332] Fixed `vacancies` text on notifications page

### DIFF
--- a/app/views/publish/notifications/index.html.erb
+++ b/app/views/publish/notifications/index.html.erb
@@ -14,7 +14,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l" data-qa="page-heading">
-        <span class="govuk-caption-l">Notifications for accredited bodies</span>
+        <span class="govuk-caption-l">Notifications for accredited providers</span>
         Changes to courses
       </h1>
 
@@ -25,7 +25,6 @@
         <li>publishes a new course on Find postgraduate teacher training</li>
         <li>makes a change to an existing course</li>
         <li>withdraws a course</li>
-        <li>changes the vacancy status of a course</li>
       </ul>
 
       <%= f.hidden_field :provider_code, value: @notifications_view.provider_code %>


### PR DESCRIPTION
### Context
 `vacancies` text on notifications page

### Changes proposed in this pull request
Fixed it

### Guidance to review
It reads right

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
