### PR TITLE
[1373] rm redundant allocations row

### DIFF
--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -214,16 +214,6 @@
             }) %>
           <% end %>
         <% end %>
-
-        <% if course.next_cycle? && course.has_fees? %>
-          <% summary_list.with_row(html_attributes: { data: { qa: "course__allocations" } }) do |row| %>
-            <% row.with_key { "Allocations" } %>
-            <% row.with_value do %>
-              Recruitment is not restricted
-            <% end %>
-            <% row.with_action %>
-          <% end %>
-        <% end %>
       <% end %>
 
       <%= f.govuk_submit "Add course", data: { qa: "course__save" } %>


### PR DESCRIPTION
### Context

We have a allocations row appearing on the summary page for fee paying rolled over courses. This is redundant and we no longer require it, so we are removing it.

### Guidance to review

:shipit: 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
