### PR TITLE
[1375] return draft if enrichment is blank

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -484,7 +484,7 @@ class Course < ApplicationRecord
   end
 
   def content_status
-    services[:content_status].execute(enrichment: latest_enrichment, recruitment_cycle:)
+    services[:content_status].execute(enrichment: latest_enrichment)
   end
 
   def ucas_status

--- a/app/services/courses/content_status_service.rb
+++ b/app/services/courses/content_status_service.rb
@@ -2,8 +2,8 @@
 
 module Courses
   class ContentStatusService
-    def execute(enrichment:, recruitment_cycle:)
-      return :rolled_over if (recruitment_cycle.next? && enrichment.blank?) || enrichment&.rolled_over?
+    def execute(enrichment:)
+      return :rolled_over if enrichment&.rolled_over?
       return :published if enrichment&.published?
       return :withdrawn if enrichment&.withdrawn?
       return :published_with_unpublished_changes if enrichment&.has_been_published_before?

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -107,7 +107,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       when_i_click_the_rollover_course_button
       then_i_should_see_the_course_show_page_with_success_message
       when_i_click_the_view_rollover_link
-      then_i_should_see_the_rolled_over_course_show_page
+      then_i_should_see_the_draft_course_on_the_show_page
     end
   end
 
@@ -145,6 +145,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   def then_i_should_see_the_rolled_over_course_show_page
     expect(page).to have_content 'Rolled over'
+  end
+
+  def then_i_should_see_the_draft_course_on_the_show_page
+    expect(page).to have_content 'Draft'
   end
 
   def then_i_should_see_the_course_show_page_with_success_message

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1982,7 +1982,7 @@ describe Course do
       expect(course).to delegate_method_to_service(
         :content_status,
         'Courses::ContentStatusService'
-      ).with_arguments(enrichment: enrichment1, recruitment_cycle:)
+      ).with_arguments(enrichment: enrichment1)
     end
   end
 

--- a/spec/services/courses/content_status_service_spec.rb
+++ b/spec/services/courses/content_status_service_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 
 describe Courses::ContentStatusService do
   let(:service) { described_class.new }
-  let(:execute_service) { service.execute(enrichment:, recruitment_cycle:) }
-  let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
+  let(:execute_service) { service.execute(enrichment:) }
 
   context 'when the enrichment parameter is nil' do
     let(:enrichment) { nil }
@@ -14,7 +13,7 @@ describe Courses::ContentStatusService do
       let(:recruitment_cycle) { find_or_create(:recruitment_cycle, :next) }
 
       it 'returns rolled over' do
-        expect(execute_service).to eq :rolled_over
+        expect(execute_service).to eq :draft
       end
     end
 

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Courses::CopyToProviderService do
     expect(new_course.subjects.first.type).to eq course.subjects.first.type
     expect(new_course.subjects.first.subject_code).to eq course.subjects.first.subject_code
     expect(new_course.subjects.first.subject_name).to eq course.subjects.first.subject_name
-    expect(new_course.content_status).to eq :rolled_over
+    expect(new_course.content_status).to eq :draft
     expect(new_course.ucas_status).to eq :new
     expect(new_course.open_for_applications?).to be_falsey
     expect(new_course.can_sponsor_skilled_worker_visa).to eq course.can_sponsor_skilled_worker_visa


### PR DESCRIPTION
### Context

Currently when you create a new course in the new cycle it appears as rolled over. It should be draft.

### Changes proposed in this pull request

- Make new courses created in the new cycle draft by default 

### Guidance to review

🚢 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
