### PR TITLE
[1326] Add study sites to find course show page

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
+  <h2 class="govuk-heading-l" id="training-locations">Training locations</h2>
   <div data-qa="course__about_schools">
     <% if course.program_type == "higher_education_programme" && course.provider.provider_code != "B31" %>
       <%= render Find::Utility::AdviceComponent::View.new(title: "Where you will train") do %>
@@ -18,34 +18,48 @@
 
     <% if course.how_school_placements_work.present? %>
       <%= markdown(course.how_school_placements_work) %>
-
-      <% if course.site_statuses.map(&:site).uniq.many? %>
-        <h3 class="govuk-heading-m">Schools</h3>
-        <p class="govuk-body">We work with the following schools to provide your school placements.</p>
-        <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_school">
-          <caption class="govuk-visually-hidden">List of schools</caption>
-          <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">School</th>
-          </tr>
-          </thead>
-
-          <tbody class="govuk-table__body">
-          <% course.preview_site_statuses.each do |site_status| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
-                <strong><%= smart_quotes(site_status.site.location_name) %></strong>
-                <br>
-                <%= smart_quotes(site_status.site.decorate.full_address) %>
-              </td>
-            </tr>
-          <% end %>
-          </tbody>
-        </table>
-      <% end %>
-
     <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :how_school_placements_work, is_preview: preview?(params)) %>
+    <% end %>
+
+    <% if course.study_sites.any? %>
+      <h3 class="govuk-heading-m">
+        Study sites
+      </h3>
+
+      <p class="govuk-body">
+        The theoretical learning part of your course will be at the following location.
+      </p>
+
+      <ul class="govuk-list govuk-list--spaced" id="course_study_sites">
+        <% course.study_sites.each do |study_site| %>
+          <li>
+            <strong><%= smart_quotes(study_site.location_name) %></strong>
+            <br>
+            <%= smart_quotes(study_site.decorate.full_address) %>
+          </li>
+      <% end %>
+      </ul>
+    <% end %>
+
+    <% if course.site_statuses.map(&:site).uniq.many? %>
+      <h3 class="govuk-heading-m">
+        School placements
+      </h3>
+
+      <p class="govuk-body">
+        We work with the following schools to provide your school placements.
+      </p>
+
+      <ul class="govuk-list govuk-list--spaced" id="course_school_placements">
+        <% course.preview_site_statuses.each do |site_status| %>
+          <li>
+            <strong><%= smart_quotes(site_status.site.location_name) %></strong>
+            <br>
+            <%= smart_quotes(site_status.site.decorate.full_address) %>
+          </li>
+        <% end %>
+      </ul>
     <% end %>
   </div>
 </div>

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -11,6 +11,7 @@ module Find
 
         delegate :how_school_placements_work,
                  :program_type,
+                 :study_sites,
                  :site_statuses, to: :course
 
         def initialize(course)
@@ -22,6 +23,7 @@ module Find
           how_school_placements_work.present? ||
             program_type == 'higher_education_programme' ||
             program_type == 'scitt_programme' ||
+            study_sites.any? ||
             site_statuses.map(&:site).uniq.many? ||
             FeatureService.enabled?(:course_preview_missing_information)
         end

--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -4,7 +4,7 @@
     <li><%= govuk_link_to "Course summary", "#section-about" %></li>
   <% end %>
   <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
-    <li><%= govuk_link_to course.placements_heading, "#section-schools" %></li>
+    <li><%= govuk_link_to "Training locations", "#training-locations" %></li>
   <% end %>
   <li><%= govuk_link_to "Entry requirements", "#section-entry" %></li>
   <% if provider.train_with_us.present? || about_accrediting_provider.present? || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -196,7 +196,7 @@ RSpec/IndexedLet:
     - 'spec/controllers/api/public/v1/providers_controller_spec.rb'
     - 'spec/controllers/api/accredited_provider_suggestions_controller_spec.rb'
 
-Rspec/Rails/HaveHttpStatus:
+RSpec/Rails/HaveHttpStatus:
   Exclude:
     - 'spec/smoke/api/v1/courses_spec.rb'
     - 'spec/smoke/api/v1/healthcheck_spec.rb'

--- a/spec/components/find/courses/about_schools_component/view_preview.rb
+++ b/spec/components/find/courses/about_schools_component/view_preview.rb
@@ -35,6 +35,7 @@ module Find
                          how_school_placements_work: 'you will go on placement and learn more',
                          placements_heading: 'Teaching placements',
                          program_type: 'scitt_programme',
+                         study_sites: [fake_study_site],
                          site_statuses: [SiteStatus.new(id: 2_245_455, course_id: 12_983_436, publish: 'published', site_id: 11_228_658, status: 'running', vac_status: 'part_time_vacancies'), SiteStatus.new(id: 22_454_556, course_id: 12_983_436, publish: 'published', site_id: 11_228_659, status: 'running', vac_status: 'part_time_vacancies')])
         end
 
@@ -43,12 +44,17 @@ module Find
                          how_school_placements_work: 'you will go on placement and learn more',
                          placements_heading: 'Teaching placements',
                          program_type: 'higher_education_programme',
+                         study_sites: [fake_study_site],
                          site_statuses: [SiteStatus.new(id: 2_245_455, course_id: 12_983_436, publish: 'published', site_id: 11_228_658, status: 'running', vac_status: 'part_time_vacancies'), SiteStatus.new(id: 22_454_556, course_id: 12_983_436, publish: 'published', site_id: 11_228_659, status: 'running', vac_status: 'part_time_vacancies')])
+        end
+
+        def fake_study_site
+          Site.new(id: 11_228_658, location_name: 'Study site', code: '1', address1: '1 Main Street', address2: 'Mainland', address3: 'Mainford', address4: 'Mainsville', postcode: 'MN1 1AA', region_code: 'london', site_type: :study_site)
         end
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:provider, :how_school_placements_work, :placements_heading, :program_type, :site_statuses)
+          attr_accessor(:provider, :how_school_placements_work, :placements_heading, :program_type, :study_sites, :site_statuses)
 
           def preview_site_statuses
             site_statuses.sort_by { |status| status.site.location_name }

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -45,6 +45,21 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
     end
   end
 
+  context 'course with study sites' do
+    it 'renders the component' do
+      provider = build(:provider)
+      course = build(:course,
+                     provider:,
+                     study_sites: [
+                       build(:site, :study_site)
+                     ]).decorate
+
+      result = render_inline(described_class.new(course))
+
+      expect(result.text).to include(course.placements_heading)
+    end
+  end
+
   context 'course without multiple sites' do
     it 'renders the component' do
       provider = build(:provider)

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -13,7 +13,7 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
 
         result = render_inline(described_class.new(course))
 
-        expect(result.text).to include(course.placements_heading)
+        expect(result.text).to include('Training locations')
       end
     end
   end
@@ -56,7 +56,7 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include(course.placements_heading)
+      expect(result.text).to include('Study sites')
     end
   end
 

--- a/spec/components/find/courses/contents_component/view_spec.rb
+++ b/spec/components/find/courses/contents_component/view_spec.rb
@@ -15,7 +15,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('School placements')
+      expect(result.text).to include('Training locations')
     end
   end
 
@@ -31,7 +31,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('School placements')
+      expect(result.text).to include('Training locations')
     end
   end
 
@@ -46,7 +46,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).not_to include('School placements')
+      expect(result.text).not_to include('Training locations')
     end
   end
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -738,24 +738,6 @@ describe CourseDecorator do
     end
   end
 
-  describe '#placements_heading' do
-    context 'when the subject is not further education' do
-      let(:course) { build_stubbed(:course) }
-
-      it 'returns school placements' do
-        expect(decorated_course.placements_heading).to eq('School placements')
-      end
-    end
-
-    context 'when the subject is further education' do
-      let(:course) { build_stubbed(:course, level: 'further_education') }
-
-      it 'returns teaching placements' do
-        expect(decorated_course.placements_heading).to eq('School placements')
-      end
-    end
-  end
-
   describe '#subject_page_title' do
     let(:subject_page_title) { course.decorate.subject_page_title }
 

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -267,7 +267,8 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       provider.address4
     )
 
-    expect(publish_course_preview_page).to have_choose_a_training_school_table
+    expect(publish_course_preview_page).to have_study_sites_table
+    expect(publish_course_preview_page).to have_school_placements_table
 
     expect(publish_course_preview_page).to have_course_advice
 
@@ -294,6 +295,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     site3 = build(:site, location_name: 'New site with vacancies')
     site4 = build(:site, location_name: 'New site with no vacancies')
     site5 = build(:site, location_name: 'Running site with no vacancies')
+    study_site = build(:site, :study_site, location_name: 'Study site')
 
     site_status1 = build(:site_status, :published, :full_time_vacancies, :running, site: site1)
     site_status2 = build(:site_status, :published, :full_time_vacancies, :suspended, site: site2)
@@ -319,6 +321,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       :fee_type_based,
       accrediting_provider:,
       site_statuses:, enrichments: [course_enrichment],
+      study_sites: [study_site],
       degree_grade: 'two_one',
       degree_subject_requirements: 'Maths A level',
       subjects: [course_subject]
@@ -329,7 +332,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     }
 
     provider = build(
-      :provider, sites:, courses: [course], accrediting_provider_enrichments: [accrediting_provider_enrichment]
+      :provider, sites:, study_sites: [study_site], courses: [course], accrediting_provider_enrichments: [accrediting_provider_enrichment]
     )
 
     create(
@@ -423,8 +426,8 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_submit_a_valid_form
-    fill_in 'About this course',   with: 'great course'
-    fill_in 'School placements',   with: 'great placement'
+    fill_in 'About this course', with: 'great course'
+    fill_in 'School placements', with: 'great placement'
 
     click_button 'Update course information'
   end

--- a/spec/support/page_objects/publish/course_preview.rb
+++ b/spec/support/page_objects/publish/course_preview.rb
@@ -40,7 +40,8 @@ module PageObjects
       element :contact_address, '[data-qa=provider__address]'
       element :course_advice, '#section-advice'
       element :course_apply, '#section-apply'
-      element :choose_a_training_school_table, '[data-qa=course__choose_a_training_school]'
+      element :study_sites_table, '#course_study_sites'
+      element :school_placements_table, '#course_school_placements'
       element :salary_details, '[data-qa=course__salary_details]'
       element :age_range_in_years, '[data-qa=course__age_range]'
     end


### PR DESCRIPTION
### Context

https://trello.com/c/UI9KpAab/1326-show-study-sites-in-publish-course-preview-page

### Changes proposed in this pull request

- Updates the course preview and find course details page to show study sites
- Also updates the section copy based on the prototype/design history

### Guidance to review

- Add study site sites
- Add to course (manual as ticket is in flight) 
- Check the preview

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
