### PR TITLE
[1364] Add study sites to rollover script

### DIFF
--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -28,11 +28,8 @@ module Courses
 
         copy_latest_enrichment_to_course(course, new_course)
 
-        course.sites.each do |site|
-          new_site = new_provider.sites.find_by(code: site.code)
-
-          @sites_copy_to_course.execute(new_site:, new_course:) if new_site.present?
-        end
+        copy_schools(course:, new_provider:, new_course:)
+        copy_study_sites(course:, new_provider:, new_course:)
       end
       new_course
     end
@@ -58,6 +55,22 @@ module Courses
       return course.applications_open_from if next_cycle.blank?
 
       [course.applications_open_from + year_differential.year, next_cycle.application_start_date].max
+    end
+
+    def copy_schools(course:, new_provider:, new_course:)
+      course.sites.each do |site|
+        new_site = new_provider.sites.find_by(code: site.code)
+
+        @sites_copy_to_course.call(new_site:, new_course:) if new_site.present?
+      end
+    end
+
+    def copy_study_sites(course:, new_provider:, new_course:)
+      course.study_sites.each do |site|
+        new_site = new_provider.study_sites.find_by(code: site.code)
+
+        @sites_copy_to_course.call(new_site:, new_course:) if new_site.present?
+      end
     end
 
     def next_cycle

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -11,6 +11,7 @@ module Providers
     def execute(provider:, new_recruitment_cycle:, course_codes: nil)
       providers_count = 0
       sites_count = 0
+      study_sites_count = 0
       courses_count = 0
 
       if provider.rollable? || force
@@ -31,6 +32,7 @@ module Providers
           # Order is important here. Sites should be copied over before courses
           # so that courses can link up to the correct sites in the new provider.
           sites_count = copy_sites_to_new_provider(provider, rolled_over_provider)
+          study_sites_count = copy_study_sites_to_new_provider(provider, rolled_over_provider)
           courses_count = copy_courses_to_new_provider(rolled_over_provider, courses_to_copy(provider, course_codes))
         end
       end
@@ -38,6 +40,7 @@ module Providers
       {
         providers: providers_count,
         sites: sites_count,
+        study_sites: study_sites_count,
         courses: courses_count
       }
     end
@@ -97,6 +100,17 @@ module Providers
       end
 
       sites_count
+    end
+
+    def copy_study_sites_to_new_provider(provider, new_provider)
+      study_sites_count = 0
+
+      provider.study_sites.each do |site|
+        new_site = @copy_site_to_provider_service.execute(site:, new_provider:)
+        study_sites_count += 1 if new_site.present?
+      end
+
+      study_sites_count
     end
   end
 end

--- a/app/services/rollover_provider_service.rb
+++ b/app/services/rollover_provider_service.rb
@@ -46,7 +46,7 @@ class RolloverProviderService
 
   def copy_courses_to_provider_service
     @copy_courses_to_provider_service ||= Courses::CopyToProviderService.new(
-      sites_copy_to_course: Sites::CopyToCourseService.new,
+      sites_copy_to_course: Sites::CopyToCourseService,
       enrichments_copy_to_course: Enrichments::CopyToCourseService.new,
       force:
     )

--- a/app/services/sites/copy_to_course_service.rb
+++ b/app/services/sites/copy_to_course_service.rb
@@ -2,11 +2,32 @@
 
 module Sites
   class CopyToCourseService
-    def execute(new_site:, new_course:)
+    include ServicePattern
+
+    def initialize(new_site:, new_course:)
+      @new_site = new_site
+      @new_course = new_course
+    end
+
+    def call
+      return copy_study_site if new_site.study_site?
+
+      copy_school
+    end
+
+    private
+
+    attr_reader :new_site, :new_course
+
+    def copy_school
       new_course.site_statuses.create(
         site: new_site,
         status: :new_status
       )
+    end
+
+    def copy_study_site
+      new_course.study_site_placements.create(site: new_site)
     end
   end
 end

--- a/app/services/sites/copy_to_provider_service.rb
+++ b/app/services/sites/copy_to_provider_service.rb
@@ -3,7 +3,7 @@
 module Sites
   class CopyToProviderService
     def execute(site:, new_provider:)
-      new_site = new_provider.sites.find_by(code: site.code)
+      new_site = new_provider.sites.find_by(code: site.code) || new_provider.study_sites.find_by(code: site.code)
 
       return if new_site.present?
 
@@ -11,6 +11,7 @@ module Sites
       new_site.provider_id = new_provider.id
       new_site.skip_geocoding = true
       new_site.uuid = SecureRandom.uuid
+      new_site.site_type = 'study_site' if site.study_site?
       new_site.save(validate: false)
       new_provider.reload
 

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 describe Providers::CopyToRecruitmentCycleService do
   describe '#execute' do
-    let(:site) { build(:site) }
+    let(:site) { build(:site, :school) }
+    let(:study_site) { build(:site, :study_site) }
     let(:published_course_enrichment) { build(:course_enrichment, :published) }
     let(:course_enrichments) { [published_course_enrichment] }
     let(:course) { create(:course, enrichments: course_enrichments, provider:) }
@@ -22,6 +23,7 @@ describe Providers::CopyToRecruitmentCycleService do
       create(:provider,
              :with_users,
              sites: [site],
+             study_sites: [study_site],
              ucas_preferences:,
              contacts:)
     end
@@ -160,6 +162,7 @@ describe Providers::CopyToRecruitmentCycleService do
       expect(output).to eq(
         providers: 1,
         sites: 1,
+        study_sites: 1,
         courses: 1
       )
     end
@@ -169,7 +172,7 @@ describe Providers::CopyToRecruitmentCycleService do
         create(:provider,
                :with_users,
                sites: [site],
-               ucas_preferences:,
+               study_sites: [study_site],
                contacts:)
       end
       let(:draft_course_enrichment) { build(:course_enrichment) }

--- a/spec/services/rollover_provider_service_spec.rb
+++ b/spec/services/rollover_provider_service_spec.rb
@@ -10,7 +10,7 @@ describe RolloverProviderService do
 
   before do
     allow(Courses::CopyToProviderService).to receive(:new).with(
-      sites_copy_to_course: instance_of(Sites::CopyToCourseService),
+      sites_copy_to_course: Sites::CopyToCourseService,
       enrichments_copy_to_course: instance_of(Enrichments::CopyToCourseService),
       force:
     ).and_return(copy_course_to_provider_service)

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -10,7 +10,7 @@ describe RolloverService do
 
   before do
     allow(Courses::CopyToProviderService).to receive(:new).with(
-      sites_copy_to_course: instance_of(Sites::CopyToCourseService),
+      sites_copy_to_course: Sites::CopyToCourseService,
       enrichments_copy_to_course: instance_of(Enrichments::CopyToCourseService),
       force:
     ).and_return(copy_course_to_provider_service)

--- a/spec/services/sites/copy_to_course_service_spec.rb
+++ b/spec/services/sites/copy_to_course_service_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 describe Sites::CopyToCourseService do
-  let(:site) { create(:site) }
   let(:course) { create(:course, provider: new_provider) }
-  let(:service) { described_class.new }
   let(:new_provider) do
     create(:provider,
            recruitment_cycle: new_recruitment_cycle)
@@ -13,21 +11,38 @@ describe Sites::CopyToCourseService do
   let(:new_recruitment_cycle) { create(:recruitment_cycle, :next) }
 
   before do
-    service.execute(new_site: site, new_course: course)
+    described_class.call(new_site: site, new_course: course)
   end
 
-  it 'copies the site' do
-    expect(course.sites.count).to eq(1)
+  context 'site is a school' do
+    let(:site) { create(:site, :school) }
+
+    it 'copies the site' do
+      expect(course.sites.count).to eq(1)
+    end
+
+    it 'has the same code as the original site' do
+      new_site = course.sites.last
+      expect(new_site.code).to eq(site.code)
+    end
+
+    describe "the new site's status" do
+      subject { course.site_statuses.first }
+
+      it { is_expected.to be_status_new_status }
+    end
   end
 
-  it 'has the same code as the original site' do
-    new_site = course.sites.last
-    expect(new_site.code).to eq(site.code)
-  end
+  context 'site is a study site' do
+    let(:site) { create(:site, :study_site) }
 
-  describe "the new site's status" do
-    subject { course.site_statuses.first }
+    it 'copies the study site' do
+      expect(course.study_sites.count).to eq(1)
+    end
 
-    it { is_expected.to be_status_new_status }
+    it 'has the same code as the original site' do
+      new_study_site = course.study_sites.last
+      expect(new_study_site.code).to eq(site.code)
+    end
   end
 end

--- a/spec/services/sites/copy_to_provider_service_spec.rb
+++ b/spec/services/sites/copy_to_provider_service_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 describe Sites::CopyToProviderService do
   describe '#copy_to_provider' do
-    let(:site) { build(:site) }
+    let(:site) { build(:site, :school) }
     let(:provider) { create(:provider, sites: [site]) }
     let(:recruitment_cycle) { find_or_create :recruitment_cycle }
     let(:next_recruitment_cycle) { create(:recruitment_cycle, :next) }
     let(:next_provider) do
       create(:provider,
              sites: [],
+             study_sites: [],
              provider_code: provider.provider_code,
              recruitment_cycle: next_recruitment_cycle)
     end
@@ -61,6 +62,18 @@ describe Sites::CopyToProviderService do
 
         next_site = next_provider.reload.sites.find_by(code: site.code)
         expect(next_site).not_to be_nil
+      end
+    end
+
+    context 'the site is a study site' do
+      let(:site) { build(:site, :study_site) }
+      let(:provider) { create(:provider, study_sites: [site]) }
+
+      it 'sets the site type to study site' do
+        service.execute(site:, new_provider: next_provider)
+
+        next_site = next_provider.reload.study_sites.find_by(code: site.code)
+        expect(next_site).to be_a_study_site
       end
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/TfW7KIQp/1364-add-study-sites-to-rollover-script

### Changes proposed in this pull request

- Adds a provider and course's study sites to the rollover process

### Guidance to review

Has to be tested manually.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
