### PR TITLE
[263] Add a notification banner to publish

### DIFF
--- a/app/views/publish/courses/details.html.erb
+++ b/app/views/publish/courses/details.html.erb
@@ -1,6 +1,18 @@
 <% content_for :page_title, "#{course.name_and_code} - Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:course) %>
 
+<%= govuk_notification_banner(title_text: t("notification_banner.info")) do |notification_banner| %>
+  <% notification_banner.with_heading do %>
+    There is a problem with the connection between Publish and Apply for teacher training (Apply), preventing open and
+    closed courses from updating correctly.
+    <br><br>
+    Find postgraduate teacher training (Find) is still working as intended.
+    <br><br>
+    We’re urgently working to fix the problem with Apply.
+    If you need to make a change, contact <%= link_to Settings.support_email, "mailto:#{Settings.support_email}" %>
+  <% end %>
+<% end %>
+
 <h1 class="govuk-heading-l <%= "govuk-!-margin-bottom-2" if (course.is_published? && course.is_running?) || course.is_withdrawn? %>">
   <%= course.name_and_code %> <span data-qa=“course__content-status”><%= course.status_tag %></span>
 </h1>

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -1,6 +1,18 @@
 <% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
 
+<%= govuk_notification_banner(title_text: t("notification_banner.info")) do |notification_banner| %>
+  <% notification_banner.with_heading do %>
+    There is a problem with the connection between Publish and Apply for teacher training (Apply), preventing open and
+    closed courses from updating correctly.
+    <br><br>
+    Find postgraduate teacher training (Find) is still working as intended.
+    <br><br>
+    We’re urgently working to fix the problem with Apply.
+    If you need to make a change, contact <%= link_to Settings.support_email, "mailto:#{Settings.support_email}" %>
+  <% end %>
+<% end %>
+
 <h1 class="govuk-heading-l">Courses</h1>
 
   <%= govuk_button_link_to(

--- a/app/views/publish/courses/show.html.erb
+++ b/app/views/publish/courses/show.html.erb
@@ -1,6 +1,18 @@
 <% content_for :page_title, title_with_error_prefix("#{course.name_and_code} - Courses", @errors.present?) %>
 <%= content_for :before_content, render_breadcrumbs(:course) %>
 
+<%= govuk_notification_banner(title_text: t("notification_banner.info")) do |notification_banner| %>
+  <% notification_banner.with_heading do %>
+    There is a problem with the connection between Publish and Apply for teacher training (Apply), preventing open and
+    closed courses from updating correctly.
+    <br><br>
+    Find postgraduate teacher training (Find) is still working as intended.
+    <br><br>
+    We’re urgently working to fix the problem with Apply.
+    If you need to make a change, contact <%= link_to Settings.support_email, "mailto:#{Settings.support_email}" %>
+  <% end %>
+<% end %>
+
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">


### PR DESCRIPTION
### Context

We have an issue where courses opened or closed on Publish wont be reflected on Apply.

### Changes proposed in this pull request

- Add a notfication banner to course index page
- Add a notfication banner to course show page

### Screenshot

<img width="921" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/7b5527fe-5c99-48bf-97f6-1e1b70f33b83">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
