### PR TITLE
[268] Downgrade data_migrate to version 9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,7 +144,7 @@ gem 'sprockets-rails', require: 'sprockets/railtie'
 gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.9.0'
 
 # For running data migrations
-gem 'data_migrate'
+gem 'data_migrate', '~> 9.0.0'
 
 # For outgoing http requests
 gem 'http'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.2.0)
       railties (>= 6.0.0)
-    data_migrate (10.0.2)
+    data_migrate (9.0.0)
       activerecord (>= 6.0)
       railties (>= 6.0)
     database_cleaner (2.0.2)
@@ -764,7 +764,7 @@ DEPENDENCIES
   config
   cssbundling-rails (~> 1.2)
   custom_error_message!
-  data_migrate
+  data_migrate (~> 9.0.0)
   database_cleaner
   dfe-analytics!
   discard


### PR DESCRIPTION
### Context

We are getting build failures on Publish due to this: https://github.com/ilyakatz/data-migrate/issues/267

We need to downgrade so that we can continue deploying.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
