### PR TITLE
[14] Enforce study sites post rollover

### DIFF
--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -41,7 +41,7 @@ module Publish
       private
 
       def update_course_study_sites
-        study_site_ids = params[:course][:study_sites_ids]
+        study_site_ids = params[:course][:study_sites]
         @study_sites ||= provider.study_sites.find(study_site_ids.compact_blank!)
 
         course.study_sites = @study_sites.select { |site| study_site_ids.include?(site.id.to_s) }

--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -38,6 +38,15 @@ module Publish
         end
       end
 
+      def back
+        authorize(@provider, :edit?)
+        if @provider.study_sites.count > 1
+          redirect_to new_publish_provider_recruitment_cycle_courses_study_sites_path(path_params)
+        else
+          redirect_to @back_link_path
+        end
+      end
+
       private
 
       def update_course_study_sites

--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -40,11 +40,7 @@ module Publish
 
       def back
         authorize(@provider, :edit?)
-        if @provider.study_sites.count > 1
-          redirect_to new_publish_provider_recruitment_cycle_courses_study_sites_path(path_params)
-        else
-          redirect_to @back_link_path
-        end
+        redirect_to @provider.study_sites.many? ? new_publish_provider_recruitment_cycle_courses_study_sites_path(path_params) : @back_link_path
       end
 
       private

--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -11,7 +11,7 @@ module NavigationBarHelper
     [
       { name: t('navigation_bar.courses'), url: publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year) },
       { name: t('navigation_bar.schools'), url: publish_provider_recruitment_cycle_schools_path(provider.provider_code, provider.recruitment_cycle_year) },
-      *([name: t('navigation_bar.study_sites'), url: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year)] if FeatureService.enabled?(:study_sites)),
+      *([name: t('navigation_bar.study_sites'), url: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year)] if FeatureService.enabled?(:study_sites) && recruitment_cycle_after_2023?(provider)),
       { name: t('navigation_bar.users'), url: publish_provider_users_path(provider_code: provider.provider_code), additional_url: request_access_publish_provider_path(provider.provider_code) },
       *([name: t('navigation_bar.training_partners'), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.accredited_provider?),
       *([name: t('navigation_bar.accredited_provider'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.lead_school? && FeatureService.enabled?(:accredited_provider_search)),

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -36,4 +36,8 @@ module RecruitmentCycleHelper
   def current_recruitment_cycle?(provider)
     provider.recruitment_cycle_year.to_i == Settings.current_recruitment_cycle_year
   end
+
+  def recruitment_cycle_after_2023?(provider_or_course)
+    provider_or_course.recruitment_cycle_year.to_i > 2023
+  end
 end

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -32,4 +32,8 @@ module RecruitmentCycleHelper
   def hint_text_for_today_is_after_find_opens
     "#{I18n.t('find.cycles.today_is_after_find_opens.description')} (#{Find::CycleTimetable.find_reopens.to_fs(:govuk_date)})"
   end
+
+  def current_recruitment_cycle?(provider)
+    provider.recruitment_cycle_year.to_i == Settings.current_recruitment_cycle_year
+  end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -81,7 +81,6 @@ module ViewHelper
     }[field]
   end
 
-
   # def environment_colour
   #  return "purple" if sandbox_mode?
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -58,7 +58,8 @@ module ViewHelper
         salary_details: "#{base}/salary?display_errors=true#salary_details-error",
         required_qualifications: "#{base}/requirements?display_errors=true#required_qualifications_wrapper",
         age_range_in_years: "#{base}/age-range?display_errors=true",
-        sites: "#{base}/schools?display_errors=true"
+        sites: "#{base}/schools?display_errors=true",
+        study_sites: "#{base}/study-sites"
       }.with_indifferent_access[field]
     end
   end
@@ -79,6 +80,7 @@ module ViewHelper
       'postcode' => "#{base}/contact?display_errors=true#provider_postcode"
     }[field]
   end
+
 
   # def environment_colour
   #  return "purple" if sandbox_mode?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -317,6 +317,7 @@ class Course < ApplicationRecord
 
   validates :is_send, inclusion: { in: [true, false] }
   validates :sites, presence: true, on: %i[publish new]
+  validates :study_sites, presence: true, on: %i[publish new update], if: -> { recruitment_cycle_after_2023? }
   validates :subjects, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish
@@ -343,6 +344,10 @@ class Course < ApplicationRecord
 
   def is_engineers_teach_physics?
     master_subject_id == SecondarySubject.physics.id && engineers_teach_physics?
+  end
+
+  def recruitment_cycle_after_2023?
+    provider.recruitment_cycle_year.to_i > 2023
   end
 
   def university_based?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -347,7 +347,7 @@ class Course < ApplicationRecord
   end
 
   def recruitment_cycle_after_2023?
-    provider.recruitment_cycle_year.to_i > 2023
+    recruitment_cycle_year.to_i > 2023
   end
 
   def university_based?

--- a/app/services/workflow_step_service.rb
+++ b/app/services/workflow_step_service.rb
@@ -16,7 +16,7 @@ class WorkflowStepService
       if course.provider.accredited_bodies.length == 1
         school_direct_workflow_steps - (visas_to_remove(course) + [:accredited_provider]) - remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
       else
-        school_direct_workflow_steps - remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
+        school_direct_workflow_steps - remove_study_site_if_feature_flag_disabled_or_current_cycle(course) - visas_to_remove(course)
       end
     end
   end

--- a/app/services/workflow_step_service.rb
+++ b/app/services/workflow_step_service.rb
@@ -9,14 +9,14 @@ class WorkflowStepService
 
   def call
     if course.is_further_education?
-      further_education_workflow_steps - remove_study_site_if_feature_flag_disabled
+      further_education_workflow_steps - remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
     elsif course.is_uni_or_scitt?
-      uni_or_scitt_workflow_steps - visas_to_remove(course) - remove_study_site_if_feature_flag_disabled
+      uni_or_scitt_workflow_steps - visas_to_remove(course) - remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
     elsif course.is_school_direct?
       if course.provider.accredited_bodies.length == 1
-        school_direct_workflow_steps - (visas_to_remove(course) + [:accredited_provider]) - remove_study_site_if_feature_flag_disabled
+        school_direct_workflow_steps - (visas_to_remove(course) + [:accredited_provider]) - remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
       else
-        school_direct_workflow_steps - visas_to_remove(course) - remove_study_site_if_feature_flag_disabled
+        school_direct_workflow_steps - remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
       end
     end
   end
@@ -94,7 +94,7 @@ class WorkflowStepService
     end
   end
 
-  def remove_study_site_if_feature_flag_disabled
-    FeatureService.enabled?(:study_sites) ? [] : [:study_site]
+  def remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
+    course.in_current_cycle? || !FeatureService.enabled?(:study_sites) ? [:study_site] : []
   end
 end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -138,7 +138,7 @@
       end
     end
 
-    if FeatureService.enabled?(:study_sites)
+    if FeatureService.enabled?(:study_sites) && recruitment_cycle_after_2023?(course)
       summary_list.with_row(html_attributes: { data: { qa: "course__study_sites" } }) do |row|
         row.with_key { "Study site" }
 

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -133,7 +133,7 @@
           <% end %>
         <% end %>
 
-        <% if FeatureService.enabled?(:study_sites) %>
+        <% if FeatureService.enabled?(:study_sites) && recruitment_cycle_after_2023?(course) %>
           <% summary_list.with_row(html_attributes: { data: { qa: "course__study_sites" } }) do |row| %>
             <% row.with_key { "Study site".pluralize(course.study_sites.length) } %>
             <% row.with_value do %>

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -3,6 +3,8 @@
 
 <h1 class="govuk-heading-l">Courses</h1>
 
+<% if (current_recruitment_cycle?(@provider) || @provider.study_sites.any? || !FeatureService.enabled?(:study_sites)) %>
+
   <%= govuk_button_link_to(
     "Add course",
     new_publish_provider_recruitment_cycle_course_path(
@@ -11,6 +13,18 @@
     ),
     class: "govuk-!-margin-bottom-6"
   ) %>
+
+<% else %>
+
+  <div class="govuk-inset-text">
+    <p class="govuk-body">Before adding a course, you need to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <%= govuk_link_to("Add a study site", publish_provider_recruitment_cycle_study_sites_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+        </li>
+    </ul>
+  </div>
+<% end %>
 
 <% if @self_accredited_courses %>
   <section data-qa="courses__table-section">

--- a/app/views/publish/courses/study_sites/edit.html.erb
+++ b/app/views/publish/courses/study_sites/edit.html.erb
@@ -6,31 +6,36 @@
 
 <%= render "publish/shared/errors" %>
 
-    <%= form_with(
-      model: course,
-      url: study_sites_publish_provider_recruitment_cycle_course_path(
-        course.provider_code,
-        course.recruitment_cycle_year,
-        course.course_code
-      ),
-      method: :put,
-      local: true
-    ) do |f| %>
+<%= form_with(
+  model: course,
+  url: study_sites_publish_provider_recruitment_cycle_course_path(
+    course.provider_code,
+    course.recruitment_cycle_year,
+    course.course_code
+  ),
+  method: :put,
+  local: true
+) do |f| %>
 
-      <%= f.govuk_error_summary %>
+  <%= f.govuk_error_summary %>
 
-      <%= f.govuk_check_boxes_fieldset :study_sites_ids, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Study sites".html_safe, tag: "h1", size: "l" } do %>
-         <div class="govuk-hint">Select all that apply</div>
-        <% @provider.study_sites.sort_by(&:location_name).each_with_index do |site, index| %>
-                  <%= f.govuk_check_box :study_sites_ids,
-                      site.id,
-                      label: { text: site.location_name },
-                      hint: { text: site.full_address } %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <%= f.govuk_check_boxes_fieldset :study_sites_ids, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Study sites".html_safe, tag: "h1", size: "l" } do %>
+          <div class="govuk-hint">Select all that apply</div>
+          <% @provider.study_sites.sort_by(&:location_name).each_with_index do |site, index| %>
+                    <%= f.govuk_check_box :study_sites_ids,
+                        site.id,
+                        label: { text: site.location_name },
+                        hint: { text: site.full_address } %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <%= f.govuk_submit "Update study sites" %>
-    <% end %>
+        <%= f.govuk_submit "Update study sites" %>
+      <% end %>
+      </div>
+    </div>
 
 <p class="govuk-body">
   <%= govuk_link_to(t("cancel"), details_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>

--- a/app/views/publish/courses/study_sites/edit.html.erb
+++ b/app/views/publish/courses/study_sites/edit.html.erb
@@ -22,13 +22,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <%= f.govuk_check_boxes_fieldset :study_sites_ids, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Study sites".html_safe, tag: "h1", size: "l" } do %>
+        <%= f.govuk_check_boxes_fieldset :study_sites, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Study sites".html_safe, tag: "h1", size: "l" } do %>
           <div class="govuk-hint">Select all that apply</div>
           <% @provider.study_sites.sort_by(&:location_name).each_with_index do |site, index| %>
-                    <%= f.govuk_check_box :study_sites_ids,
+                    <%= f.govuk_check_box :study_sites,
                         site.id,
                         label: { text: site.location_name },
-                        hint: { text: site.full_address } %>
+                        hint: { text: site.full_address },
+                        checked: f.object.study_sites.include?(site) %>
           <% end %>
         <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -479,7 +479,7 @@ en:
             sites:
               blank: "^Select at least one school"
             study_sites:
-              blank: "^Select at least one study site"
+              blank: "Select at least one study site"
             age_range_in_years:
               blank: "^Select an age range"
             program_type:

--- a/spec/features/publish/add_course_button_spec.rb
+++ b/spec/features/publish/add_course_button_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Add course button', { can_edit_current_and_next_cycles: true } do
+  scenario 'with no study sites on the provider in the next cycle' do
+    given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+    and_the_study_sites_feature_flag_is_active
+    when_i_visit_the_courses_page
+    then_i_should_see_the_add_study_site_link
+    and_i_should_not_see_the_add_course_button
+  end
+
+  scenario 'with no study sites on the provider in the next cycle and feature flag off' do
+    given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+    when_i_visit_the_courses_page
+    then_i_should_see_the_add_course_button
+  end
+
+  scenario 'with study sites on the provider in the next cycle' do
+    given_i_am_authenticated_as_a_provider_user_with_study_sites_in_the_next_cycle
+    and_the_study_sites_feature_flag_is_active
+    when_i_visit_the_courses_page
+    then_i_should_see_the_add_course_button
+  end
+
+  scenario 'with no study sites on the provider in the current cycle' do  # This scenario can be deleted when the 2023 cycle becomes 2024
+    given_i_am_authenticated_as_a_provider_user_in_the_current_cycle
+    and_the_study_sites_feature_flag_is_active
+    when_i_visit_the_courses_page
+    then_i_should_see_the_add_course_button
+  end
+
+  def then_i_should_see_the_add_study_site_link
+    expect(page).to have_link('Add a study site', href: "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/study-sites")
+  end
+
+  def and_i_should_not_see_the_add_course_button
+    expect(page).not_to have_link('Add course')
+  end
+
+  def then_i_should_see_the_add_course_button
+    expect(page).to have_link('Add course')
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          create(:provider, :next_recruitment_cycle, sites: [build(:site)], courses: [build(:course)])
+        ]
+      )
+    )
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_in_the_current_cycle
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          create(:provider, sites: [build(:site)], courses: [build(:course)])
+        ]
+      )
+    )
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_study_sites_in_the_next_cycle
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          create(:provider, :next_recruitment_cycle, sites: [build(:site, :study_site)], courses: [build(:course)])
+        ]
+      )
+    )
+  end
+
+  def and_the_study_sites_feature_flag_is_active
+    allow(Settings.features).to receive(:study_sites).and_return(true)
+  end
+
+  def when_i_visit_the_courses_page
+    publish_provider_courses_index_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -189,7 +189,7 @@ feature 'course confirmation', { can_edit_current_and_next_cycles: false } do
     expect(publish_course_confirmation_page.details.age_range.value.text).to eq('14 to 19')
     expect(publish_course_confirmation_page.details.study_mode.value.text).to eq('Full time or part time')
     expect(publish_course_confirmation_page.details.schools.value.text).to have_content(site.location_name)
-    expect(publish_course_confirmation_page.details.study_sites.value.text).to have_content(study_site.location_name)
+    # expect(publish_course_confirmation_page.details.study_sites.value.text).to have_content(study_site.location_name) # this can be uncommented when the 2023 cycle is over
     expect(publish_course_confirmation_page.details.applications_open.value.text).to eq("12 October #{Settings.current_recruitment_cycle_year.to_i - 1}")
     expect(publish_course_confirmation_page.details.start_date.value.text).to eq("October #{Settings.current_recruitment_cycle_year.to_i - 1}")
   end

--- a/spec/features/publish/courses/editing_study_sites_spec.rb
+++ b/spec/features/publish/courses/editing_study_sites_spec.rb
@@ -97,11 +97,11 @@ feature 'updating study sites on a course', { can_edit_current_and_next_cycles: 
   end
 
   def and_the_previously_selected_study_site_is_still_checked
-    expect(page).to have_checked_field('course-study-sites-ids-3-field')
+    expect(page).to have_field(checked: true)
   end
 
   def and_the_study_site_checkbox_is_not_checked
-    expect(page).not_to have_checked_field('course-study-sites-ids-3-field')
+    expect(page).not_to have_field(checked: true)
   end
 
   alias_method :and_there_is_a_course_i_want_to_edit, :given_a_course_exists

--- a/spec/features/publish/courses/editing_study_sites_spec.rb
+++ b/spec/features/publish/courses/editing_study_sites_spec.rb
@@ -79,12 +79,12 @@ feature 'updating study sites on a course', { can_edit_current_and_next_cycles: 
   end
 
   def and_i_check_the_first_study_site_and_submit
-    check('course-study-sites-ids-3-field')
+    check('course-study-sites-ids-3-field', allow_label_click: true)
     click_button 'Update study sites'
   end
 
   def and_i_uncheck_the_first_study_site_and_submit
-    uncheck('course-study-sites-ids-3-field')
+    uncheck('course-study-sites-ids-3-field', allow_label_click: true)
     click_button 'Update study sites'
   end
 

--- a/spec/features/publish/courses/editing_study_sites_spec.rb
+++ b/spec/features/publish/courses/editing_study_sites_spec.rb
@@ -79,12 +79,12 @@ feature 'updating study sites on a course', { can_edit_current_and_next_cycles: 
   end
 
   def and_i_check_the_first_study_site_and_submit
-    check('course-study-sites-ids-3-field', allow_label_click: true)
+    check(provider.study_sites.first.location_name)
     click_button 'Update study sites'
   end
 
   def and_i_uncheck_the_first_study_site_and_submit
-    uncheck('course-study-sites-ids-3-field', allow_label_click: true)
+    uncheck(provider.study_sites.first.location_name)
     click_button 'Update study sites'
   end
 
@@ -97,11 +97,11 @@ feature 'updating study sites on a course', { can_edit_current_and_next_cycles: 
   end
 
   def and_the_previously_selected_study_site_is_still_checked
-    expect(page).to have_selector('#course-study-sites-ids-3-field[checked="checked"]')
+    expect(page).to have_checked_field('course-study-sites-ids-3-field')
   end
 
   def and_the_study_site_checkbox_is_not_checked
-    expect(page).not_to have_selector('#course-study-sites-ids-3-field[checked="checked"]')
+    expect(page).not_to have_checked_field('course-study-sites-ids-3-field')
   end
 
   alias_method :and_there_is_a_course_i_want_to_edit, :given_a_course_exists

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -3,15 +3,24 @@
 require 'rails_helper'
 
 feature 'new course', { can_edit_current_and_next_cycles: false } do
-  scenario 'creates the correct course' do
+  scenario 'creates the correct course in the 2023 cycle' do
     # This is intended to be a test which will go through the entire flow
     # and ensure that the correct page gets displayed at the end
     # with the correct course being created
-    given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
     when_i_visit_the_courses_page
     and_the_study_sites_feature_flag_is_active
     and_i_click_on_add_course
     then_i_can_create_the_course
+  end
+
+  scenario 'creates the correct course in the 2022 cycle' do
+    # this test is a duplicate of above and can be deleted when the
+    # 2022 cycle has finished and the study sites feature is active
+    given_i_am_authenticated_as_a_provider_user_in_the_current_cycle
+    when_i_visit_the_courses_page
+    and_i_click_on_add_course
+    then_i_can_create_the_course_in_the_current_cycle
   end
 
   private
@@ -40,12 +49,42 @@ feature 'new course', { can_edit_current_and_next_cycles: false } do
     save_course
   end
 
-  def given_i_am_authenticated_as_a_provider_user
+  def then_i_can_create_the_course_in_the_current_cycle
+    expect(publish_courses_new_level_page).to be_displayed
+    course_creation_params = select_level({}, level: 'primary', level_selection: publish_courses_new_level_page.level_fields.primary, next_page: publish_courses_new_subjects_page)
+
+    course_creation_params = select_subjects(course_creation_params, level: 'primary', next_page: publish_courses_new_age_range_page)
+
+    course_creation_params = select_age_range(course_creation_params, next_page: publish_courses_new_outcome_page)
+
+    course_creation_params = select_outcome(course_creation_params, qualification: 'qts', qualification_selection: publish_courses_new_outcome_page.qualification_fields.qts, next_page: publish_courses_new_apprenticeship_page)
+    course_creation_params = select_apprenticeship(course_creation_params, next_page: publish_courses_new_study_mode_page)
+    course_creation_params = select_study_mode(course_creation_params, next_page: publish_courses_new_schools_page)
+    course_creation_params = select_school(course_creation_params, next_page: publish_courses_new_study_sites_page)
+    course_creation_params = select_visa_settings(course_creation_params, next_page: publish_courses_new_applications_open_page)
+    course_creation_params = select_applications_open_from(course_creation_params, next_page: publish_courses_new_start_date_page)
+    select_start_date(course_creation_params)
+
+    save_course
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_in_the_current_cycle
     given_i_am_authenticated(
       user: create(
         :user,
         providers: [
           create(:provider, :accredited_provider, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
+        ]
+      )
+    )
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          create(:provider, :next_recruitment_cycle, :accredited_provider, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
         ]
       )
     )

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -14,15 +14,6 @@ feature 'new course', { can_edit_current_and_next_cycles: false } do
     then_i_can_create_the_course
   end
 
-  scenario 'creates the correct course in the 2022 cycle' do
-    # this test is a duplicate of above and can be deleted when the
-    # 2022 cycle has finished and the study sites feature is active
-    given_i_am_authenticated_as_a_provider_user_in_the_current_cycle
-    when_i_visit_the_courses_page
-    and_i_click_on_add_course
-    then_i_can_create_the_course_in_the_current_cycle
-  end
-
   private
 
   def and_the_study_sites_feature_flag_is_active
@@ -66,17 +57,6 @@ feature 'new course', { can_edit_current_and_next_cycles: false } do
     select_start_date(course_creation_params)
 
     save_course
-  end
-
-  def given_i_am_authenticated_as_a_provider_user_in_the_current_cycle
-    given_i_am_authenticated(
-      user: create(
-        :user,
-        providers: [
-          create(:provider, :accredited_provider, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
-        ]
-      )
-    )
   end
 
   def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle

--- a/spec/models/course/update_valid_spec.rb
+++ b/spec/models/course/update_valid_spec.rb
@@ -39,7 +39,8 @@ describe Course do
           let(:course) do
             create(:course,
                    provider:,
-                   applications_open_from: next_cycle.application_start_date)
+                   applications_open_from: next_cycle.application_start_date,
+                   study_sites: [build(:site, :study_site)])
           end
 
           its(:update_valid?) { is_expected.to be true }
@@ -82,6 +83,7 @@ describe Course do
           let(:course) do
             create(:course,
                    provider:,
+                   study_sites: [build(:site, :study_site)],
                    start_date: DateTime.new(next_year, 9, 1))
           end
 


### PR DESCRIPTION
### Context

We are enforcing providers to attach study sites to courses after rollover. This will mean before a provider can see the add course button, they will need to have created at least one study site. 

When the "Add course" button appears, it will be a requirement for providers to attach at least one study site when creating a course. 

### Changes proposed in this pull request


Show Add course button under the following conditions:
- If it's the current cycle
- if the provider has any study sites attached
- if the `study_sites` feature flag is off


Enforce validation of at least one study site on courses for the next cycle

Remove the study sites flow from the current cycle

### Guidance to review

May be easier to screenshare, as rollover hasn't been done on the review app.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
