### PR TITLE
[xxxx] Remove validation from study_sites

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -317,7 +317,6 @@ class Course < ApplicationRecord
 
   validates :is_send, inclusion: { in: [true, false] }
   validates :sites, presence: true, on: %i[publish new]
-  validates :study_sites, presence: true, on: %i[publish new]
   validates :subjects, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish


### PR DESCRIPTION
### Context

Removing the validation from study sites as providers are unable to publish courses. 

We will need to add this back but only enforce from the next cycle (when the study sites feature will also be launched)

### Guidance to review

:shipit: 
