### PR TITLE
Simplify dev setup instructions

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -14,19 +14,25 @@ FileUtils.chdir APP_ROOT do
   # Add necessary setup steps to this file.
 
   puts "== Installing dependencies =="
+  system("yarn install")
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
-  # end
+  puts "\n== Copying development settings file =="
+  system! "sed 's/secret: secret/secret: persona/' config/settings/development.yml > config/settings/development.local.yml"
+
+  puts "\n== Install process manager foreman =="
+  system! "gem install foreman"
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
+
+  puts "\n== Restarting application server =="
+  system! "bin/rails restart"
+
 
   puts "\n== Restarting application server =="
   system! "bin/rails restart"

--- a/bin/setup
+++ b/bin/setup
@@ -19,7 +19,15 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
 
   puts "\n== Copying development settings file =="
-  system! "sed 's/secret: secret/secret: persona/' config/settings/development.yml > config/settings/development.local.yml"
+  if OS.windows?
+    puts "ATTENTION WINDOWS USER!".red
+    puts
+    puts "Copy #{"config/settings/development.yml".yellow} to #{"config/settings/development.local.yml".yellow} and edit it:",
+      "Replace #{"'secret: secret'".blue} with #{"'mode: persona'".blue}"
+    puts
+  else
+    system! "sed 's/secret: secret/mode: persona/' config/settings/development.yml > config/settings/development.local.yml"
+  end
 
   puts "\n== Install process manager foreman =="
   system! "gem install foreman"
@@ -29,10 +37,6 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
-
-  puts "\n== Restarting application server =="
-  system! "bin/rails restart"
-
 
   puts "\n== Restarting application server =="
   system! "bin/rails restart"

--- a/guides/setup-development.md
+++ b/guides/setup-development.md
@@ -4,37 +4,20 @@ Clone the repo:
 
     git clone git@github.com:DFE-Digital/publish-teacher-training.git
 
-## Setup the application
+## Setup the application libraries and dependencies
 
-Run the following commands:
+Run setup:
 
 ```bash
-yarn
-bundle
-bundle exec rails db:setup
+./bin/setup
 ```
 
 ## Start the server
 
-You can use [Foreman](https://github.com/ddollar/foreman) or [Overmind](https://github.com/DarthSim/overmind) to run all the processes needed for local dev. Once you have either of the two, you can run:
+To start all the processes run:
 
 ```bash
 ./bin/dev
-```
-
-Which will fire off the Rails server, watchers for JS/CSS changes and Sidekiq. You can also run them individually:
-
-```bash
-./bin/dev web
-```
-
-You don't have to use either of those tools. The script just wraps up the following commands:
-
-```bash
-yarn build --watch
-yarn build:css --watch
-bin/rails server -p 3001
-bundle exec sidekiq -t 25 -C config/sidekiq.yml
 ```
 
 ## Using Docker


### PR DESCRIPTION
### Context

Simplify developer setup instructions.

### Changes proposed in this pull request

Encourage developers to use `./bin/setup` in order to initialise the application locally

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
