### PR TITLE
[319] Update financial support row in Find search results

### DIFF
--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -3,8 +3,13 @@
     <dt class="app-description-list__label">Accredited provider</dt>
     <dd data-qa="course__accredited_provider"><%= accrediting_provider.provider_name %></dd>
   <% end %>
-  <dt class="app-description-list__label">Financial support</dt>
-  <dd data-qa="course__funding_option"><%= funding_option %></dd>
+  <dt class="app-description-list__label">Fee or salary</dt>
+    <dd data-qa="course__funding_option"><%= course.funding %>
+      <br>
+      <p class="govuk-hint"><%= course.funding_option %>
+    </dd>
+  </dt>
+
   <dt class="app-description-list__label">Qualification</dt>
   <%= render Find::Courses::QualificationsSummaryComponent::View.new(find_outcome) %>
   <% if age_range_in_years.present? %>

--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -26,8 +26,11 @@
       <% end %>
     <% end %>
 
-    <dt class="app-description-list__label">Financial support</dt>
-    <dd data-qa="course__funding_options"><%= course.funding_option %></dd>
+    <dt class="app-description-list__label">Fee or salary</dt>
+    <dd data-qa="course__funding_options"><%= course.funding %>
+      <br>
+      <p class="govuk-hint"><%= course.funding_option %>
+    </dd>
 
     <dt class="app-description-list__label">Degree required</dt>
     <dd data-qa="course__degree_required"><%= degree_required_status %></dd>

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -190,10 +190,9 @@ class CourseDecorator < ApplicationDecorator
     !course.sites.nil? && object.sites.any? { |s| s.id == site.id }
   end
 
-  # rubocop:disable Lint/DuplicateBranch: Duplicate branch body detected
   def funding_option
     if salaried?
-      'Salary'
+      nil
     elsif excluded_from_bursary?
       # Duplicate branch body detected
       'Student finance if you’re eligible'
@@ -203,10 +202,9 @@ class CourseDecorator < ApplicationDecorator
       'Bursaries and student finance are available if you’re eligible'
     else
       # Duplicate branch body detected
-      'Student finance if you’re eligible'
+      'Student finance is available if you’re eligible'
     end
   end
-  # rubocop:enable Lint/DuplicateBranch: Duplicate branch body detected
 
   def current_cycle?
     course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -191,9 +191,9 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def funding_option
-    if salaried?
-      nil
-    elsif excluded_from_bursary?
+    return if salaried?
+
+    if excluded_from_bursary?
       # Duplicate branch body detected
       'Student finance if you’re eligible'
     elsif has_scholarship_and_bursary? && bursary_and_scholarship_flag_active_or_preview?

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -13,7 +13,7 @@ module Find
 
           result = render_inline(described_class.new(course))
           expect(result.text).to include(
-            'Financial support',
+            'Fee or salary',
             'Qualification',
             'Course length',
             'Qualification',

--- a/spec/features/find/search/course_results_spec.rb
+++ b/spec/features/find/search/course_results_spec.rb
@@ -39,7 +39,7 @@ feature 'results' do
       expect(first_course.provider_name.text).to be_present
       expect(first_course.qualification.text).to include('PGCE with QTS')
       expect(first_course.study_mode.text).to eq('Full time')
-      expect(first_course.funding_options.text).to eq('Salary')
+      expect(first_course.funding_options.text).to eq('Teaching apprenticeship - with salary')
     end
   end
 end


### PR DESCRIPTION
### Context

One of the priorities for the initial teacher training (ITT) reforms is to make ITT less complex for providers, candidates and trainees.

We are improving how we show course funding information to make it easier for candidates to understand.

### Changes proposed in this pull request

Replace the ‘Financial support’ section with ‘Fee or salary’ on the courses list and course details pages.

If the course is funded through fees, we show additional information:

- Bursaries and student finance are available if you’re eligible
- Scholarships or bursaries, as well as student finance, are available if you’re eligible
- Student finance is available if you’re eligible

### Guidance to review

Navigate to various courses on the review app, and check that the funding information is displayed correctly for each course.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [x] Inform data insights team due to database changes
