### PR TITLE
Fix the Publish course information bug

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -18,6 +18,8 @@
 
     <% if course.published_how_school_placements_work.present? %>
       <%= markdown(course.published_how_school_placements_work) %>
+    <% elsif course.how_school_placements_work.present? %>
+      <%= markdown(course.how_school_placements_work) %>
     <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :how_school_placements_work, is_preview: preview?(params)) %>
     <% end %>

--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -16,8 +16,8 @@
       <% end %>
     <% end %>
 
-    <% if course.how_school_placements_work.present? %>
-      <%= markdown(course.how_school_placements_work) %>
+    <% if course.published_how_school_placements_work.present? %>
+      <%= markdown(course.published_how_school_placements_work) %>
     <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :how_school_placements_work, is_preview: preview?(params)) %>
     <% end %>

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -9,7 +9,7 @@ module Find
 
         attr_reader :course
 
-        delegate :how_school_placements_work,
+        delegate :published_how_school_placements_work,
                  :program_type,
                  :study_sites,
                  :site_statuses, to: :course
@@ -20,7 +20,7 @@ module Find
         end
 
         def render?
-          how_school_placements_work.present? ||
+          published_how_school_placements_work.present? ||
             program_type == 'higher_education_programme' ||
             program_type == 'scitt_programme' ||
             study_sites.any? ||

--- a/app/controllers/concerns/copy_course_content.rb
+++ b/app/controllers/concerns/copy_course_content.rb
@@ -3,6 +3,12 @@
 module CopyCourseContent
   extend ActiveSupport::Concern
 
+  def copied_fields_values
+    @copied_fields.each_with_object({}) do |(_, field, enrichment_to_update), values_to_write|
+      values_to_write[field] = enrichment_to_update.send(field)
+    end
+  end
+
   private
 
   def copy_content_check(fields)

--- a/app/controllers/publish/courses/course_information_controller.rb
+++ b/app/controllers/publish/courses/course_information_controller.rb
@@ -10,7 +10,9 @@ module Publish
         authorize(provider)
 
         @course_information_form = CourseInformationForm.new(course_enrichment)
-        copy_content_check(::Courses::Copy::ABOUT_FIELDS)
+        @copied_fields = copy_content_check(::Courses::Copy::ABOUT_FIELDS)
+
+        @copied_fields_values = copied_fields_values if @copied_fields.present?
 
         @course_information_form.valid? if show_errors_on_publish?
       end

--- a/app/controllers/publish/courses/fees_controller.rb
+++ b/app/controllers/publish/courses/fees_controller.rb
@@ -10,7 +10,10 @@ module Publish
         authorize(provider)
 
         @course_fee_form = CourseFeeForm.new(course_enrichment)
-        copy_content_check(::Courses::Copy::FEES_FIELDS)
+        @copied_fields = copy_content_check(::Courses::Copy::FEES_FIELDS)
+
+        @copied_fields_values = copied_fields_values if @copied_fields.present?
+
         @course_fee_form.valid? if show_errors_on_publish?
       end
 

--- a/app/controllers/publish/courses/requirements_controller.rb
+++ b/app/controllers/publish/courses/requirements_controller.rb
@@ -10,11 +10,12 @@ module Publish
         authorize(provider)
 
         @course_requirement_form = CourseRequirementForm.new(course_enrichment)
-        if @course.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE
-          copy_content_check(::Courses::Copy::POST_2022_CYCLE_REQUIREMENTS_FIELDS)
-        else
-          copy_content_check(::Courses::Copy::PRE_2022_CYCLE_REQUIREMENTS_FIELDS)
-        end
+        @copied_fields = if @course.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE
+                           copy_content_check(::Courses::Copy::POST_2022_CYCLE_REQUIREMENTS_FIELDS)
+                         else
+                           copy_content_check(::Courses::Copy::PRE_2022_CYCLE_REQUIREMENTS_FIELDS)
+                         end
+        @copied_fields_values = copied_fields_values if @copied_fields.present?
       end
 
       def update

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -344,7 +344,7 @@ class CourseDecorator < ApplicationDecorator
   def published_how_school_placements_work
     return nil if no_published_enrichment?
 
-    object.current_published_enrichment[:interview_process]
+    object.current_published_enrichment[:how_school_placements_work]
   end
 
   def published_fee_uk_eu

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -329,6 +329,52 @@ class CourseDecorator < ApplicationDecorator
     object.enrichment_attribute(:financial_support)
   end
 
+  def published_about_course
+    return nil if no_published_enrichment?
+
+    object.current_published_enrichment[:about_course]
+  end
+
+  def published_interview_process
+    return nil if no_published_enrichment?
+
+    object.current_published_enrichment[:interview_process]
+  end
+
+  def published_how_school_placements_work
+    return nil if no_published_enrichment?
+
+    object.current_published_enrichment[:interview_process]
+  end
+
+  def published_fee_uk_eu
+    return nil if no_published_enrichment?
+
+    object.current_published_enrichment[:fee_uk_eu]
+  end
+
+  def published_fee_international
+    return nil if no_published_enrichment?
+
+    object.current_published_enrichment[:fee_international]
+  end
+
+  def published_fee_details
+    return nil if no_published_enrichment?
+
+    object.current_published_enrichment[:fee_details]
+  end
+
+  def published_financial_support
+    return nil if no_published_enrichment?
+
+    object.current_published_enrichment[:financial_support]
+  end
+
+  def no_published_enrichment?
+    object.current_published_enrichment.nil?
+  end
+
   def financial_incentive_details
     financial_incentive = object.financial_incentives.first
     bursary_amount = number_to_currency(financial_incentive&.bursary_amount)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -330,49 +330,45 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def published_about_course
-    return nil if no_published_enrichment?
+    return unless current_published_enrichment
 
-    object.current_published_enrichment[:about_course]
+    current_published_enrichment[:about_course]
   end
 
   def published_interview_process
-    return nil if no_published_enrichment?
+    return unless current_published_enrichment
 
-    object.current_published_enrichment[:interview_process]
+    current_published_enrichment[:interview_process]
   end
 
   def published_how_school_placements_work
-    return nil if no_published_enrichment?
+    return unless current_published_enrichment
 
-    object.current_published_enrichment[:how_school_placements_work]
+    current_published_enrichment[:how_school_placements_work]
   end
 
   def published_fee_uk_eu
-    return nil if no_published_enrichment?
+    return unless current_published_enrichment
 
-    object.current_published_enrichment[:fee_uk_eu]
+    current_published_enrichment[:fee_uk_eu]
   end
 
   def published_fee_international
-    return nil if no_published_enrichment?
+    return unless current_published_enrichment
 
-    object.current_published_enrichment[:fee_international]
+    current_published_enrichment[:fee_international]
   end
 
   def published_fee_details
-    return nil if no_published_enrichment?
+    return unless current_published_enrichment
 
-    object.current_published_enrichment[:fee_details]
+    current_published_enrichment[:fee_details]
   end
 
   def published_financial_support
-    return nil if no_published_enrichment?
+    return unless current_published_enrichment
 
-    object.current_published_enrichment[:financial_support]
-  end
-
-  def no_published_enrichment?
-    object.current_published_enrichment.nil?
+    current_published_enrichment[:financial_support]
   end
 
   def financial_incentive_details

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -543,7 +543,7 @@ class Course < ApplicationRecord
   end
 
   def last_published_at
-    current_published_enrichment&.last_published_timestamp_utc || enrichment_attribute(:last_published_timestamp_utc)
+    enrichments.maximum(:last_published_timestamp_utc)
   end
 
   def withdrawn_at
@@ -850,7 +850,7 @@ class Course < ApplicationRecord
   end
 
   def all_enrichments_are_published?
-    (enrichments.one? && published?) || enrichments.flat_map(&:status).none?('draft')
+    (enrichments.one? && published?) || enrichments.none? { |enrichment| %w[draft withdrawn].include?(enrichment.status) }
   end
 
   def assignable_after_publish(course_params, is_admin)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -673,7 +673,7 @@ class Course < ApplicationRecord
   end
 
   def has_unpublished_changes?
-    return false if enrichments.one? && published?
+    return false if all_enrichments_are_published?
 
     (published? && draft_enrichment.present?) || (last_published_at.present? && enrichment_not_withdrawn?)
   end
@@ -847,6 +847,10 @@ class Course < ApplicationRecord
 
   def enrichment_not_withdrawn?
     !enrichments.most_recent.first.withdrawn?
+  end
+
+  def all_enrichments_are_published?
+    (enrichments.one? && published?) || enrichments.flat_map(&:status).none?('draft')
   end
 
   def assignable_after_publish(course_params, is_admin)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -673,6 +673,8 @@ class Course < ApplicationRecord
   end
 
   def has_unpublished_changes?
+    return false if enrichments.one? && published?
+
     (published? && draft_enrichment.present?) || (last_published_at.present? && enrichment_not_withdrawn?)
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -673,7 +673,7 @@ class Course < ApplicationRecord
   end
 
   def has_unpublished_changes?
-    (published? && draft_enrichment.present?) || last_published_at.present?
+    (published? && draft_enrichment.present?) || (last_published_at.present? && enrichment_not_withdrawn?)
   end
 
   def draft_enrichment
@@ -841,6 +841,10 @@ class Course < ApplicationRecord
 
   def published?
     current_published_enrichment.present?
+  end
+
+  def enrichment_not_withdrawn?
+    !enrichments.most_recent.first.withdrawn?
   end
 
   def assignable_after_publish(course_params, is_admin)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -543,7 +543,7 @@ class Course < ApplicationRecord
   end
 
   def last_published_at
-    current_published_enrichment&.last_published_timestamp_utc
+    current_published_enrichment&.last_published_timestamp_utc || enrichment_attribute(:last_published_timestamp_utc)
   end
 
   def withdrawn_at
@@ -673,7 +673,7 @@ class Course < ApplicationRecord
   end
 
   def has_unpublished_changes?
-    published? && draft_enrichment.present?
+    (published? && draft_enrichment.present?) || last_published_at.present?
   end
 
   def draft_enrichment

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -151,19 +151,19 @@ class Course < ApplicationRecord
     def new_draft_attributes
       latest_published_enrichment = most_recent.published.first
 
-      if latest_published_enrichment.present?
-        latest_published_enrichment_attributes = latest_published_enrichment
-                                                 .dup
-                                                 .attributes
-                                                 .with_indifferent_access
-                                                 .except(:json_data)
+      new_enrichment_attributes = if latest_published_enrichment.present?
+                                    latest_published_enrichment
+                                      .dup
+                                      .attributes
+                                      .with_indifferent_access
+                                      .except(:json_data)
+                                  else
+                                    {}
+                                  end
 
-        latest_published_enrichment_attributes[:status] = :draft
-        latest_published_enrichment_attributes[:last_published_timestamp_utc] = nil
-        latest_published_enrichment_attributes
-      else
-        { status: :draft, last_published_timestamp_utc: nil }.with_indifferent_access
-      end
+      new_enrichment_attributes.merge(
+        { status: :draft, last_published_timestamp_utc: nil }
+      )
     end
   end
 

--- a/app/services/courses/content_status_service.rb
+++ b/app/services/courses/content_status_service.rb
@@ -6,7 +6,7 @@ module Courses
       return :rolled_over if enrichment&.rolled_over?
       return :published if enrichment&.published?
       return :withdrawn if enrichment&.withdrawn?
-      return :published_with_unpublished_changes if enrichment&.has_been_published_before?
+      return :published_with_unpublished_changes if enrichment&.has_been_published_before? || (enrichment&.course&.enrichments&.most_recent && enrichment&.course&.enrichments&.many?)
 
       :draft
     end

--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -56,11 +56,10 @@ module Courses
         source_value = source_course.enrichment_attribute(field)
         next if source_value.blank?
 
-        enrichment_to_update = course.enrichments.most_recent&.first
+        enrichment_to_update = course.enrichments.most_recent&.first || course.course.enrichments.find_or_initialize_draft
         enrichment_to_update.assign_attributes(field => source_value)
-        enrichment_to_update.save
 
-        [name, field]
+        [name, field, enrichment_to_update]
       end
     end
 

--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -56,9 +56,9 @@ module Courses
         source_value = source_course.enrichment_attribute(field)
         next if source_value.blank?
 
-        enrichments_to_update = course.enrichments.most_recent&.first
-        enrichments_to_update.assign_attributes(field => source_value)
-        enrichments_to_update.save
+        enrichment_to_update = course.enrichments.most_recent&.first
+        enrichment_to_update.assign_attributes(field => source_value)
+        enrichment_to_update.save
 
         [name, field]
       end

--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -53,11 +53,14 @@ module Courses
 
     def self.get_present_fields_in_source_course(fields, source_course, course)
       fields.filter_map do |name, field|
-        source_value = source_course.enrichments.last[field]
-        if source_value.present?
-          course.enrichments.last[field] = source_value
-          [name, field]
-        end
+        source_value = source_course.enrichment_attribute(field)
+        next if source_value.blank?
+
+        enrichments_to_update = course.enrichments.most_recent&.first
+        enrichments_to_update.assign_attributes(field => source_value)
+        enrichments_to_update.save
+
+        [name, field]
       end
     end
 

--- a/app/views/find/courses/_about_course.html.erb
+++ b/app/views/find/courses/_about_course.html.erb
@@ -3,6 +3,8 @@
   <div data-qa="course__about_course">
     <% if course.published_about_course.present? %>
       <%= markdown(course.published_about_course) %>
+    <% elsif course.about_course.present? %>
+      <%= markdown(course.about_course) %>
     <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :about_course, is_preview: preview?(params)) %>
     <% end %>

--- a/app/views/find/courses/_about_course.html.erb
+++ b/app/views/find/courses/_about_course.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-about">Course summary</h2>
   <div data-qa="course__about_course">
-    <% if course.about_course.present? %>
-      <%= markdown(course.about_course) %>
+    <% if course.published_about_course.present? %>
+      <%= markdown(course.published_about_course) %>
     <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :about_course, is_preview: preview?(params)) %>
     <% end %>

--- a/app/views/find/courses/_interview_process.html.erb
+++ b/app/views/find/courses/_interview_process.html.erb
@@ -1,6 +1,10 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-interviews">Interview process</h2>
   <div data-qa="course__interview_process">
-    <%= markdown(course.published_interview_process) %>
+    <% if course.published_interview_process %>
+      <%= markdown(course.published_interview_process) %>
+    <% else %>
+      <%= markdown(course.interview_process) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/find/courses/_interview_process.html.erb
+++ b/app/views/find/courses/_interview_process.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-interviews">Interview process</h2>
   <div data-qa="course__interview_process">
-    <%= markdown(course.interview_process) %>
+    <%= markdown(course.published_interview_process) %>
   </div>
 </div>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -34,7 +34,7 @@
 
     <%= render Find::Courses::ContentsComponent::View.new(@course) %>
 
-    <% if @course.about_course.present? %>
+    <% if @course.published_about_course.present? %>
       <%= render partial: "find/courses/about_course", locals: { course: @course } %>
     <% end %>
 
@@ -52,7 +52,7 @@
       <%= render partial: "find/courses/about_the_provider", locals: { course: @course } %>
     <% end %>
 
-    <% if @course.interview_process.present? %>
+    <% if @course.published_interview_process.present? %>
       <%= render partial: "find/courses/interview_process", locals: { course: @course } %>
     <% end %>
 

--- a/app/views/publish/courses/_course_length_field.html.erb
+++ b/app/views/publish/courses/_course_length_field.html.erb
@@ -4,13 +4,13 @@
     id: form_object.errors.key?(:course_length) ? "course_length-error" : "course-length"
   }) do %>
     <%= f.govuk_radio_button(:course_length, "OneYear",
-      checked: @course.course_length == "OneYear",
+      checked: @copied_fields_values&.value?("OneYear") || @course.course_length == "OneYear",
       data: { qa: "course_course_length_oneyear" },
       label: { text: "1 year" },
       link_errors: true) %>
 
     <%= f.govuk_radio_button(:course_length, "TwoYears",
-      checked: @course.course_length == "TwoYears",
+      checked: @copied_fields_values&.value?("TwoYears") || @course.course_length == "TwoYears",
       label: { text: "Up to 2 years" },
       data: { qa: "course_course_length_twoyears" }) %>
 

--- a/app/views/publish/courses/course_information/edit.html.erb
+++ b/app/views/publish/courses/course_information/edit.html.erb
@@ -51,7 +51,7 @@
       </p>
 
       <%= f.govuk_text_area(:about_course,
-        value: @course.about_course,
+        value: @copied_fields_values&.dig("about_course") || @course.about_course,
         label: { text: "About this course", size: "s" },
         max_words: 400,
         rows: 20) %>
@@ -71,7 +71,7 @@
       </ul>
 
       <%= f.govuk_text_area(:interview_process,
-        value: @course.interview_process,
+        value: @copied_fields_values&.dig("interview_process") || @course.interview_process,
         label: { text: "Interview process (optional)", size: "s" },
         max_words: 250,
         rows: 15) %>
@@ -114,7 +114,7 @@
       <% end %>
 
       <%= f.govuk_text_area(:how_school_placements_work,
-        value: @course.how_school_placements_work,
+        value: @copied_fields_values&.dig("how_school_placements_work") || @course.how_school_placements_work,
         label: { text: @course.placements_heading, size: "s" },
         max_words: 350,
         rows: 15) %>

--- a/app/views/publish/courses/course_information/edit.html.erb
+++ b/app/views/publish/courses/course_information/edit.html.erb
@@ -51,7 +51,7 @@
       </p>
 
       <%= f.govuk_text_area(:about_course,
-        value: @course.enrichments.last[:about_course],
+        value: @course.about_course,
         label: { text: "About this course", size: "s" },
         max_words: 400,
         rows: 20) %>
@@ -71,7 +71,7 @@
       </ul>
 
       <%= f.govuk_text_area(:interview_process,
-        value: @course.enrichments.last[:interview_process],
+        value: @course.interview_process,
         label: { text: "Interview process (optional)", size: "s" },
         max_words: 250,
         rows: 15) %>
@@ -114,7 +114,7 @@
       <% end %>
 
       <%= f.govuk_text_area(:how_school_placements_work,
-        value: @course.enrichments.last[:how_school_placements_work],
+        value: @course.how_school_placements_work,
         label: { text: @course.placements_heading, size: "s" },
         max_words: 350,
         rows: 15) %>

--- a/app/views/publish/courses/fees/edit.html.erb
+++ b/app/views/publish/courses/fees/edit.html.erb
@@ -35,6 +35,7 @@
       <%= f.govuk_text_field(:fee_uk_eu,
         form_group: { id: @course_fee_form.errors.key?(:fee_uk_eu) ? "fee_uk_eu-error" : "fee-uk" },
         label: { text: "Fee for UK students", size: "s" },
+        value: @copied_fields_values&.dig("fee_uk_eu"),
         prefix_text: "£",
         width: 5,
         data: { qa: "course_fee_uk_eu" }) %>
@@ -42,6 +43,7 @@
       <%= f.govuk_text_field(:fee_international,
         form_group: { id: "fee-international" },
         label: { text: student_visa_and_after_2023_cycle(@course) ? "Fee for international students" : "Fee for international students (optional)", size: "s" },
+        value: @copied_fields_values&.dig("fee_international"),
         prefix_text: "£",
         width: 5,
         data: { qa: "course_fee_international" }) %>
@@ -56,6 +58,7 @@
 
       <%= f.govuk_text_area(:fee_details,
         label: { text: "Fee details (optional)", size: "s" },
+        value: @copied_fields_values&.dig("fee_details"),
         rows: 15,
         max_words: 250,
         data: { qa: "course_fee_details" }) %>
@@ -68,6 +71,7 @@
 
       <%= f.govuk_text_area(:financial_support,
         label: { text: "Financial support you offer (optional)", size: "s" },
+        value: @copied_fields_values&.dig("financial_support"),
         rows: 15,
         max_words: 250,
         data: { qa: "course_financial_support" }) %>

--- a/app/views/publish/courses/requirements/edit.html.erb
+++ b/app/views/publish/courses/requirements/edit.html.erb
@@ -29,7 +29,7 @@
 
       <%= f.govuk_text_area :personal_qualities,
         form_group: { id: "personal-qualities" },
-        value: @course.personal_qualities,
+        value: @copied_fields_values&.dig("personal_qualities") || @course.personal_qualities,
         label: { text: "Personal qualities (optional)", size: "m" },
         hint: { text: "Tell applicants about the skills, motivation and experience you’re looking for (for example, experience of working with children, a genuine passion for the subject or a talent for public speaking)." },
         max_words: 100,
@@ -39,7 +39,7 @@
 
       <%= f.govuk_text_area :other_requirements,
         form_group: { id: "other-requirements" },
-        value: @course.other_requirements,
+        value: @copied_fields_values&.dig("other_requirements") || @course.other_requirements,
         label: { text: "Other requirements (optional)", size: "m" },
         hint: { text: "If applicants need any non-academic qualifications or documents, list them here (such as criminal record checks or relevant work experience)." },
         max_words: 100,

--- a/app/views/publish/courses/requirements/edit.html.erb
+++ b/app/views/publish/courses/requirements/edit.html.erb
@@ -29,7 +29,7 @@
 
       <%= f.govuk_text_area :personal_qualities,
         form_group: { id: "personal-qualities" },
-        value: @course.enrichments.last[:personal_qualities],
+        value: @course.personal_qualities,
         label: { text: "Personal qualities (optional)", size: "m" },
         hint: { text: "Tell applicants about the skills, motivation and experience you’re looking for (for example, experience of working with children, a genuine passion for the subject or a talent for public speaking)." },
         max_words: 100,
@@ -39,7 +39,7 @@
 
       <%= f.govuk_text_area :other_requirements,
         form_group: { id: "other-requirements" },
-        value: @course.enrichments.last[:other_requirements],
+        value: @course.other_requirements,
         label: { text: "Other requirements (optional)", size: "m" },
         hint: { text: "If applicants need any non-academic qualifications or documents, list them here (such as criminal record checks or relevant work experience)." },
         max_words: 100,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
   notification_banner:
     success: "Success"
     info: "Info"
+    warning: "Warning"
   cycles:
     updated: "Cycle schedule updated"
   service_name:

--- a/spec/components/find/courses/about_schools_component/view_preview.rb
+++ b/spec/components/find/courses/about_schools_component/view_preview.rb
@@ -32,7 +32,7 @@ module Find
 
         def mock_scitt_course
           FakeCourse.new(provider: Provider.new(provider_code: 'DFE'),
-                         how_school_placements_work: 'you will go on placement and learn more',
+                         published_how_school_placements_work: 'you will go on placement and learn more',
                          placements_heading: 'Teaching placements',
                          program_type: 'scitt_programme',
                          study_sites: [fake_study_site],
@@ -41,7 +41,7 @@ module Find
 
         def mock_hei_course
           FakeCourse.new(provider: Provider.new(provider_code: 'DFE'),
-                         how_school_placements_work: 'you will go on placement and learn more',
+                         published_how_school_placements_work: 'you will go on placement and learn more',
                          placements_heading: 'Teaching placements',
                          program_type: 'higher_education_programme',
                          study_sites: [fake_study_site],
@@ -54,7 +54,7 @@ module Find
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:provider, :how_school_placements_work, :placements_heading, :program_type, :study_sites, :site_statuses)
+          attr_accessor(:provider, :published_how_school_placements_work, :placements_heading, :program_type, :study_sites, :site_statuses)
 
           def preview_site_statuses
             site_statuses.sort_by { |status| status.site.location_name }

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -60,7 +60,7 @@ FactoryBot.define do
     # salaried or not. Maybe worth implementing this somehow at some point.
     salary_details do
       [
-        'Trainees should expcet to be paid as an Unqualified Teacher.',
+        'Trainees should expect to be paid as an Unqualified Teacher.',
         'For more information on salary please contact us',
         'Salary negotiable.',
         'Applicants will be paid as an unqualified teacher.',

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -37,7 +37,12 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    given_i_am_authenticated(user: create(:user, :with_provider))
+    @user = create(:user, :with_provider)
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_i_am_authed_again
+    given_i_am_authenticated(user: @user)
   end
 
   def and_i_have_previously_published_a_course
@@ -51,7 +56,7 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
   def and_there_is_a_course_i_want_to_publish
     given_a_course_exists(
       :with_gcse_equivalency,
-      enrichments: [build(:course_enrichment, :initial_draft)],
+      enrichments: [create(:course_enrichment, :initial_draft)],
       sites: [create(:site, location_name: 'location 1')],
       study_sites: [create(:site, :study_site)]
     )
@@ -59,14 +64,14 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
 
   def and_there_is_a_draft_course
     given_a_course_exists(
-      enrichments: [build(:course_enrichment, :initial_draft)],
+      enrichments: [create(:course_enrichment, :initial_draft)],
       sites: [create(:site, location_name: 'location 1')],
       study_sites: [create(:site, :study_site)]
     )
   end
 
   def and_there_is_a_published_course
-    given_a_course_exists(enrichments: [build(:course_enrichment, :published)])
+    given_a_course_exists(enrichments: [create(:course_enrichment, :published)])
   end
 
   def when_i_visit_the_course_page
@@ -111,6 +116,7 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
 
   def when_i_return_to_publish
     page.driver.header 'Host', 'publish'
+    and_i_am_authed_again
     publish_provider_courses_show_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
     )

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -19,7 +19,11 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
     and_i_have_previously_published_a_course
     when_i_make_some_new_changes
     then_i_should_see_the_unpublished_changes_message
+    and_i_do_not_see_the_unpublished_content_on_find
+    when_i_return_to_publish
     and_i_should_see_the_publish_button
+    and_i_click_the_publish_link
+    then_i_see_the_content_on_find
   end
 
   scenario 'attempting to publish with errors' do
@@ -91,6 +95,25 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
 
   def then_i_should_see_the_unpublished_changes_message
     expect(page).to have_content('* Unpublished changes')
+  end
+
+  def and_i_do_not_see_the_unpublished_content_on_find
+    page.driver.header 'Host', 'find'
+    visit "/course/#{provider.provider_code}/#{course.course_code}"
+    expect(page).not_to have_content('some new description')
+  end
+
+  def then_i_see_the_content_on_find
+    page.driver.header 'Host', 'find'
+    visit "/course/#{provider.provider_code}/#{course.course_code}"
+    expect(page).to have_content('some new description')
+  end
+
+  def when_i_return_to_publish
+    page.driver.header 'Host', 'publish'
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
   end
 
   def and_i_should_see_the_publish_button

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2328,7 +2328,7 @@ describe Course do
         end
 
         its(:id) { is_expected.to be_nil }
-        its(:last_published_timestamp_utc) { is_expected.to be_within(1.second).of published_enrichment.last_published_timestamp_utc }
+        its(:last_published_timestamp_utc) { is_expected.to be_nil }
         its(:status) { is_expected.to eq 'draft' }
       end
 

--- a/spec/services/courses/copy_spec.rb
+++ b/spec/services/courses/copy_spec.rb
@@ -19,10 +19,14 @@ RSpec.describe Courses::Copy do
       expect(new_course.enrichments.first.course_length).to be_nil
       expect(new_course.enrichments.first.about_course).to be_nil
 
-      described_class.get_present_fields_in_source_course(fields_to_copy, original_course, new_course)
+      updated_enrichments = described_class.get_present_fields_in_source_course(fields_to_copy, original_course, new_course)
 
-      expect(new_course.enrichments.first.reload.about_course).to eq original_course.enrichments.first.about_course
-      expect(new_course.enrichments.first.reload.salary_details).to eq original_course.enrichments.first.salary_details
+      expect(updated_enrichments.size).to eq(2)
+
+      updated_enrichments.each do |_name, field, enrichment_to_update|
+        expect(enrichment_to_update).to be_an_instance_of(CourseEnrichment)
+        expect(enrichment_to_update.send(field)).to eq(original_course.enrichments.first.send(field))
+      end
     end
 
     it 'skips attributes with blank source values' do

--- a/spec/services/courses/copy_spec.rb
+++ b/spec/services/courses/copy_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Courses::Copy do
 
       described_class.get_present_fields_in_source_course(fields_to_copy, original_course, new_course)
 
-      expect(new_course.enrichments.first.about_course).to eq original_course.enrichments.first.about_course
-      expect(new_course.enrichments.first.salary_details).to eq original_course.enrichments.first.salary_details
+      expect(new_course.enrichments.first.reload.about_course).to eq original_course.enrichments.first.about_course
+      expect(new_course.enrichments.first.reload.salary_details).to eq original_course.enrichments.first.salary_details
     end
 
     it 'skips attributes with blank source values' do


### PR DESCRIPTION
### Context

There are currently two bugs existing in Publish:

**Bug no1:**
The ordering of `course_enrichments` (_an enrichment stores additional information about a course for things like the interview process_) is not consistent across environments and there are currently two approaches to returning the latest `course_enrichment`:

- The **first approach** is to use `@course.enrichments.last[:about_course]`
- The **second approach** is to use `@course.about_course`

The first approach is what causes the inconsistency – locally this returns the expected result but in all envs up to prod it does not. The second is consistent because it utilises the `scope :most_recent, -> { order(created_at: :desc, id: :desc) }` scope on the `CourseEnrichment` model.

On this page we're using the second approach:
<img width="711" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/0f9c0cff-d554-4213-86d4-8e2d736b85de">

On this page (which you access when you go to update these values) we're using the first to pre-populate the text fields:
<img width="785" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/7b41e951-1cbb-4c6b-a231-6a0f81efb1fa">

This is the cause of the bug. By using the first approach to pre-populate these fields, we're unintentionally pre-populating them with old enrichment data, then when the user goes to update the information it writes the old data to the latest course enrichment object.
<img width="414" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/f949ffa8-eab5-4d10-bdba-5477a55b5e56">

**Bug no2:**
The second bug unfortunately creates a nasty combination with the first. Any changes to course enrichments is being instantly published on Find. Even if the user hasn't pressed 'Publish changes'.
<img width="554" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/496610aa-aab8-42b7-a692-b28b0624f718">

 



### Changes proposed in this pull request
- Ensured consistency in ordering approach by using the decorator methods where possible
- Introduced `published` decorator methods to distinguish between what enrichments have and haven't been published and to only display published enrichments on Find i.e.:
```
  def published_how_school_placements_work
    return nil if no_published_enrichment?

    object.current_published_enrichment[:interview_process]
  end
```
These utilise:
```
  def no_published_enrichment?
    object.current_published_enrichment.nil?
  end
```
`current_published_enrichment` is a new method on the `Course` model:
```
  def current_published_enrichment
    enrichments.where(status: 'published').order(last_published_timestamp_utc: :desc).first
  end
```
This required an update to the `new_draft_attributes` method to set the `last_published_timestamp_utc` to nil for new (draft) enrichments:
```
    def new_draft_attributes
      latest_published_enrichment = most_recent.published.first
      if latest_published_enrichment.present?
        latest_published_enrichment_attributes = latest_published_enrichment
                                                 .dup
                                                 .attributes
                                                 .with_indifferent_access
                                                 .except(:json_data)

        latest_published_enrichment_attributes[:status] = :draft
        latest_published_enrichment_attributes[:last_published_timestamp_utc] = nil
        latest_published_enrichment_attributes
      else
        { status: :draft, last_published_timestamp_utc: nil }.with_indifferent_access
      end
    end
```
- Updated `has_unpublished_changes?` to utilise this new concept and introduced a `draft_enrichment` method:
```
  def has_unpublished_changes?
    published? && draft_enrichment.present?
  end

  def draft_enrichment
    enrichments.draft.most_recent.first
  end
```
with `published?` being:
```
  def published?
    current_published_enrichment.present?
  end
```
- updated `last_published_at` to use the `current_published_enrichment` method:
```
  def last_published_at
    current_published_enrichment&.last_published_timestamp_utc
  end
```

-----
`has_unpublished_changes?` has now expanded to:
```
  def has_unpublished_changes?
    return false if all_enrichments_are_published?

    (published? && draft_enrichment.present?) || (last_published_at.present? && enrichment_not_withdrawn?)
  end
```

It needs to cover three scenarios from what I can understand:

1. Published course with no changes
2. Published course with unpublished changes
3. Withdrawn course

Which is in thanks to `app/views/publish/courses/_course_button_panel.html.erb`

### Guidance to review

This is probably in need of quite a refactor but this at least fixes the bug in the meantime. I've introduced a number of `published_[attribute]` methods on the `CourseDecorator` that are not being used. From manually testing it seems like we don't actually need to worry about the enrichment overwriting problem, that we're dealing with on course information. I'll 🪓  them if someone can confirm this.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
