### PR TITLE
Allow all Providers to add StudySites

### DIFF
--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -12,9 +12,6 @@ module Publish
 
       def new
         authorize(@provider, :edit?)
-
-        set_default_study_site
-        redirect_to next_step
       end
 
       def edit

--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -12,7 +12,6 @@ module Publish
 
       def new
         authorize(@provider, :edit?)
-        return unless @provider.study_sites.one?
 
         set_default_study_site
         redirect_to next_step

--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -55,11 +55,6 @@ module Publish
       def error_keys
         [:study_sites]
       end
-
-      def set_default_study_site
-        params['course'] ||= {}
-        params['course']['study_sites_ids'] = [@provider.study_sites.first.id]
-      end
     end
   end
 end


### PR DESCRIPTION
### Context
  Require all Course creations to explicitly specify StudySites for the new course.
### Changes proposed in this pull request
  The previous flow was to automatically assign the study site if only one existed.
  Now, the form is required to be completed by the admin even in only one study site exists.

### Guidance to
![Screenshot from 2023-07-06 12-48-22](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/78154b30-24d6-44e7-9b0e-089f1f2df30f)
 review
## Trello ticket
https://trello.com/c/zkJ8XYko/317-dont-skip-the-study-site-step
### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
