### PR TITLE
[318] Hide add course button when organisation details are missing (next cycle only)

### DIFF
--- a/app/components/add_course_button.html.erb
+++ b/app/components/add_course_button.html.erb
@@ -10,17 +10,14 @@
 
 <% else %>
 
-<div class="govuk-inset-text">
+  <div class="govuk-inset-text">
     <p class="govuk-body">Before adding a course, you need to:</p>
-      <ul class="govuk-list govuk-list--bullet">
-
-        <% incomplete_sections_hash.each do |section, path| %>
-          <% if send(section) %>
-            <li>
-              <%= govuk_link_to("Add #{incomplete_section_article(section)} #{incomplete_section_label_suffix(section)}", path) %>
-            </li>
-          <% end %>
-        <% end %>
-      </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <% incomplete_sections.each do |section| %>
+        <li>
+          <%= govuk_link_to(section.name, section.path) %>
+        </li>
+      <% end %>
+    </ul>
   </div>
 <% end %>

--- a/app/components/add_course_button.html.erb
+++ b/app/components/add_course_button.html.erb
@@ -1,0 +1,26 @@
+<% if required_organisation_details_present? %>
+  <%= govuk_button_link_to(
+    "Add course",
+    new_publish_provider_recruitment_cycle_course_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year
+    ),
+    class: "govuk-!-margin-bottom-6"
+  ) %>
+
+<% else %>
+
+<div class="govuk-inset-text">
+    <p class="govuk-body">Before adding a course, you need to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+
+        <% incomplete_sections_hash.each do |section, path| %>
+          <% if send(section) %>
+            <li>
+              <%= govuk_link_to("Add #{incomplete_section_article(section)} #{incomplete_section_label_suffix(section)}", path) %>
+            </li>
+          <% end %>
+        <% end %>
+      </ul>
+  </div>
+<% end %>

--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -4,7 +4,7 @@ class AddCourseButton < ViewComponent::Base
   include RecruitmentCycleHelper
   attr_reader :provider
 
-  Section = Struct.new(:name, :path)
+  Section = Struct.new(:name, :path, keyword_init: true)
 
   def initialize(provider:)
     @provider = provider
@@ -15,7 +15,7 @@ class AddCourseButton < ViewComponent::Base
 
   def incomplete_sections
     incomplete_sections_hash.keys.select { |section| send(section) }.map do |section|
-      Section.new("Add #{incomplete_section_article(section)} #{incomplete_section_label_suffix(section)}", incomplete_sections_hash[section])
+      Section.new(name: "Add #{incomplete_section_article(section)} #{incomplete_section_label_suffix(section)}", path: incomplete_sections_hash[section])
     end
   end
 

--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -4,12 +4,20 @@ class AddCourseButton < ViewComponent::Base
   include RecruitmentCycleHelper
   attr_reader :provider
 
+  Section = Struct.new(:name, :path)
+
   def initialize(provider:)
     @provider = provider
     super
   end
 
   private
+
+  def incomplete_sections
+    incomplete_sections_hash.keys.select { |section| send(section) }.map do |section|
+      Section.new("Add #{incomplete_section_article(section)} #{incomplete_section_label_suffix(section)}", incomplete_sections_hash[section])
+    end
+  end
 
   def incomplete_sections_hash
     {

--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class AddCourseButton < ViewComponent::Base
+  include RecruitmentCycleHelper
+  attr_reader :provider
+
+  def initialize(provider:)
+    @provider = provider
+    super
+  end
+
+  private
+
+  def incomplete_sections_hash
+    {
+      study_site_not_present_and_feature_active?: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year),
+      accredited_provider_not_present?: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year),
+      site_not_present?: publish_provider_recruitment_cycle_schools_path(provider.provider_code, provider.recruitment_cycle_year)
+    }
+  end
+
+  def incomplete_section_label_suffix(section)
+    labels = {
+      study_site_not_present_and_feature_active?: 'study site',
+      accredited_provider_not_present?: 'accredited provider',
+      site_not_present?: 'school'
+    }
+
+    labels[section]
+  end
+
+  def required_organisation_details_present?
+    if study_sites_active?
+      study_site_present? &&
+        accredited_provider_present? &&
+        site_present?
+    else
+      accredited_provider_present? &&
+        site_present?
+    end
+  end
+
+  def study_site_present?
+    provider.study_sites.any?
+  end
+
+  def accredited_provider_present?
+    provider.accredited_providers.any?
+  end
+
+  def site_present?
+    provider.sites.any?
+  end
+
+  def study_site_not_present_and_feature_active?
+    !study_site_present? && study_sites_active?
+  end
+
+  def accredited_provider_not_present?
+    return if provider.accredited_provider?
+
+    !accredited_provider_present?
+  end
+
+  def site_not_present?
+    !site_present?
+  end
+
+  def not_accredited_provider?
+    !provider.accredited_provider?
+  end
+
+  def study_sites_active?
+    FeatureService.enabled?(:study_sites)
+  end
+
+  def incomplete_section_article(section)
+    incomplete_section_label_suffix(section) == 'accredited provider' ? 'an' : 'a'
+  end
+end

--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -45,6 +45,8 @@ class AddCourseButton < ViewComponent::Base
   end
 
   def accredited_provider_present?
+    return true if accredited_provider?
+
     provider.accredited_providers.any?
   end
 
@@ -66,8 +68,8 @@ class AddCourseButton < ViewComponent::Base
     !site_present?
   end
 
-  def not_accredited_provider?
-    !provider.accredited_provider?
+  def accredited_provider?
+    provider.accredited_provider?
   end
 
   def study_sites_active?

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -3,27 +3,21 @@
 
 <h1 class="govuk-heading-l">Courses</h1>
 
-<% if (current_recruitment_cycle?(@provider) || @provider.study_sites.any? || !FeatureService.enabled?(:study_sites)) %>
+<% if recruitment_cycle_after_2023?(@provider) %>
 
-  <%= govuk_button_link_to(
-    "Add course",
-    new_publish_provider_recruitment_cycle_course_path(
-      provider_code: @provider.provider_code,
-      recruitment_cycle_year: @provider.recruitment_cycle_year
-    ),
-    class: "govuk-!-margin-bottom-6"
-  ) %>
+  <%= render AddCourseButton.new(provider: @provider) %>
 
 <% else %>
 
-  <div class="govuk-inset-text">
-    <p class="govuk-body">Before adding a course, you need to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-        <li>
-          <%= govuk_link_to("Add at least one study site", publish_provider_recruitment_cycle_study_sites_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
-        </li>
-    </ul>
-  </div>
+  <%= govuk_button_link_to(
+      "Add course",
+      new_publish_provider_recruitment_cycle_course_path(
+        provider_code: @provider.provider_code,
+        recruitment_cycle_year: @provider.recruitment_cycle_year
+      ),
+      class: "govuk-!-margin-bottom-6"
+    ) %>
+
 <% end %>
 
 <% if @self_accredited_courses %>

--- a/spec/components/add_course_button_preview.rb
+++ b/spec/components/add_course_button_preview.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class AddCourseButtonPreview < ViewComponent::Preview
+  def with_all_incomplete_sections
+    render AddCourseButton.new(provider: FakeProvider.new(study_sites: [], accredited_providers: [], sites: []))
+  end
+
+  def with_only_study_site_completed
+    render AddCourseButton.new(provider: FakeProvider.new(study_sites: ['study site'], accredited_providers: [], sites: []))
+  end
+
+  def with_only_accredited_provider_completed
+    render AddCourseButton.new(provider: FakeProvider.new(accredited_providers: ['accredited provider'], study_sites: [], sites: []))
+  end
+
+  def with_only_sites_completed
+    render AddCourseButton.new(provider: FakeProvider.new(study_sites: [], accredited_providers: [], sites: ['site']))
+  end
+
+  def with_study_site_and_accredited_provider_completed
+    render AddCourseButton.new(provider: FakeProvider.new(study_sites: ['study site'], accredited_providers: ['accredited provider'], sites: []))
+  end
+
+  def with_accredited_provider_and_sites_completed
+    render AddCourseButton.new(provider: FakeProvider.new(study_sites: [], accredited_providers: ['accredited provider'], sites: []))
+  end
+
+  def with_sites_and_study_sites_completed
+    render AddCourseButton.new(provider: FakeProvider.new(study_sites: ['study site'], accredited_providers: [], sites: ['site']))
+  end
+
+  def with_all_completed_sections
+    render AddCourseButton.new(provider: FakeProvider.new(study_sites: ['study site'], accredited_providers: ['accredited provider'], sites: ['site']))
+  end
+
+  class FakeProvider
+    include ActiveModel::Model
+    attr_accessor(:study_sites, :accredited_providers, :sites)
+
+    def provider_code
+      'DFE'
+    end
+
+    def recruitment_cycle_year
+      2024
+    end
+
+    def accredited_provider?
+      false
+    end
+  end
+end

--- a/spec/components/add_course_button_spec.rb
+++ b/spec/components/add_course_button_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AddCourseButton do
+  include Rails.application.routes.url_helpers
+
+  let(:recruitment_cycle) { build(:recruitment_cycle, :next) }
+  let(:provider) { build(:provider, recruitment_cycle:) }
+
+  before do
+    allow(Settings.features).to receive(:study_sites).and_return(true)
+    render_inline(described_class.new(provider:))
+  end
+
+  context 'when the provider has not filled out any required sections' do
+    it 'renders a study sites link' do
+      expect(rendered_content).to have_link(
+        'Add a study site',
+        href: publish_provider_recruitment_cycle_study_sites_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year
+        )
+      )
+    end
+
+    it 'renders an accredited provider link' do
+      expect(rendered_content).to have_link(
+        'Add an accredited provider',
+        href: publish_provider_recruitment_cycle_accredited_providers_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+
+    it 'renders a schools link' do
+      expect(rendered_content).to have_link(
+        'Add a school',
+        href: publish_provider_recruitment_cycle_schools_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+  end
+
+  context 'when the provider has only added a study site' do
+    let(:provider) { build(:provider, study_sites: [build(:site, :study_site)], recruitment_cycle:) }
+
+    it 'renders a study sites link' do
+      expect(rendered_content).not_to have_link(
+        'Add a study site',
+        href: publish_provider_recruitment_cycle_study_sites_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year
+        )
+      )
+    end
+
+    it 'renders an accredited provider link' do
+      expect(rendered_content).to have_link(
+        'Add an accredited provider',
+        href: publish_provider_recruitment_cycle_accredited_providers_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+
+    it 'renders a schools link' do
+      expect(rendered_content).to have_link(
+        'Add a school',
+        href: publish_provider_recruitment_cycle_schools_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+  end
+
+  context 'when the provider is an accredited provider' do
+    let(:provider) { build(:provider, :accredited_provider, recruitment_cycle:) }
+
+    it 'renders a study sites link' do
+      expect(rendered_content).to have_link(
+        'Add a study site',
+        href: publish_provider_recruitment_cycle_study_sites_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year
+        )
+      )
+    end
+
+    it 'renders an accredited provider link' do
+      expect(rendered_content).not_to have_link(
+        'Add an accredited provider',
+        href: publish_provider_recruitment_cycle_accredited_providers_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+
+    it 'renders a schools link' do
+      expect(rendered_content).to have_link(
+        'Add a school',
+        href: publish_provider_recruitment_cycle_schools_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+  end
+
+  context 'when the provider has only added a site' do
+    let(:provider) { build(:provider, sites: [create(:site)], recruitment_cycle:) }
+
+    it 'renders a study sites link' do
+      expect(rendered_content).to have_link(
+        'Add a study site',
+        href: publish_provider_recruitment_cycle_study_sites_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year
+        )
+      )
+    end
+
+    it 'renders an accredited provider link' do
+      expect(rendered_content).to have_link(
+        'Add an accredited provider',
+        href: publish_provider_recruitment_cycle_accredited_providers_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+
+    it 'renders a schools link' do
+      expect(rendered_content).not_to have_link(
+        'Add a school',
+        href: publish_provider_recruitment_cycle_schools_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+  end
+
+  context 'when the provider has added a site and a study site' do
+    let(:provider) { build(:provider, study_sites: [build(:site, :study_site)], sites: [build(:site)], recruitment_cycle:) }
+
+    it 'renders a study sites link' do
+      expect(rendered_content).not_to have_link(
+        'Add a study site',
+        href: publish_provider_recruitment_cycle_study_sites_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year
+        )
+      )
+    end
+
+    it 'renders an accredited provider link' do
+      expect(rendered_content).to have_link(
+        'Add an accredited provider',
+        href: publish_provider_recruitment_cycle_accredited_providers_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+
+    it 'renders a schools link' do
+      expect(rendered_content).not_to have_link(
+        'Add a school',
+        href: publish_provider_recruitment_cycle_schools_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+  end
+
+  context 'when the provider has added all required organisation details' do
+    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], sites: [build(:site)], recruitment_cycle:) }
+
+    it 'renders a study sites link' do
+      expect(rendered_content).not_to have_link(
+        'Add a study site',
+        href: publish_provider_recruitment_cycle_study_sites_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year
+        )
+      )
+    end
+
+    it 'renders an accredited provider link' do
+      expect(rendered_content).not_to have_link(
+        'Add an accredited provider',
+        href: publish_provider_recruitment_cycle_accredited_providers_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+
+    it 'renders a schools link' do
+      expect(rendered_content).not_to have_link(
+        'Add a school',
+        href: publish_provider_recruitment_cycle_schools_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year
+        )
+      )
+    end
+  end
+end

--- a/spec/features/publish/add_course_button_spec.rb
+++ b/spec/features/publish/add_course_button_spec.rb
@@ -32,7 +32,7 @@ feature 'Add course button', { can_edit_current_and_next_cycles: true } do
   end
 
   def then_i_should_see_the_add_study_site_link
-    expect(page).to have_link('Add at least one study site', href: "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/study-sites")
+    expect(page).to have_link('Add a study site', href: "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/study-sites")
   end
 
   def and_i_should_not_see_the_add_course_button
@@ -48,7 +48,7 @@ feature 'Add course button', { can_edit_current_and_next_cycles: true } do
       user: create(
         :user,
         providers: [
-          create(:provider, :next_recruitment_cycle, sites: [build(:site)], courses: [build(:course)])
+          create(:provider, :accredited_provider, :next_recruitment_cycle, sites: [build(:site)], courses: [build(:course)])
         ]
       )
     )
@@ -70,7 +70,7 @@ feature 'Add course button', { can_edit_current_and_next_cycles: true } do
       user: create(
         :user,
         providers: [
-          create(:provider, :next_recruitment_cycle, sites: [build(:site, :study_site)], courses: [build(:course)])
+          create(:provider, :accredited_provider, :next_recruitment_cycle, sites: [build(:site)], study_sites: [build(:site, :study_site)], courses: [build(:course)])
         ]
       )
     )


### PR DESCRIPTION
### Context

Before adding a course in the next cycle, you will have to have filled in some of the organisation details. If the organisation details have not been filled in the "Add course" button will be hidden. 

### Changes proposed in this pull request

Hide the add course button under the following conditions:

- If the provider doesn't have any accredited providers attached and the provider is not an accredited provider
- If the provider doesn't have any schools
- If the provider doesn't have any study sites
- Link to these sections if the add course button is hidden

### Guidance to review

Product: As this is only enabled in the next cycle, it will be easiest to do a screenshare. 

Dev: As above or you can rollover your local environment and be sure to activate the `study_sites` feature flag.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
