### PR TITLE
[434] Add dependency on backup for AKS QA and staging

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -158,6 +158,7 @@ jobs:
           POSTGRES_SERVICE_INSTANCE: publish-teacher-training-postgres-${{ matrix.environment }}
 
   restore-aks:
+    needs: [backup]
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Context
The restore-aks job runs alongside the backup job so it will restore the previous days sanitised backup not the current day.

Making the restore-aks job depend on the backup ensures the current days backup is used.

### Changes proposed in this pull request

Make the restore-aks job depend on the backup job

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
