### PR TITLE
Use Rails default logger in development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,9 +93,6 @@ gem 'govuk_notify_rails'
 gem 'sidekiq'
 gem 'sidekiq-cron'
 
-# Semantic Logger makes logs pretty
-gem 'rails_semantic_logger'
-
 # Render nice markdown
 gem 'redcarpet'
 gem 'rubypants'
@@ -154,6 +151,9 @@ gem 'rack-cors'
 
 group :production, :qa, :sandbox, :staging do
   gem 'cloudfront-rails'
+
+  # Semantic Logger makes logs pretty
+  gem 'rails_semantic_logger'
 end
 
 group :development, :test do

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,7 @@ module ManageCoursesBackend
     config.session_store :cookie_store, key: Settings.cookies.session.name, httponly: true
 
     config.skylight.environments = Settings.skylight.enable ? [Rails.env] : []
-    config.skylight.logger = SemanticLogger[Skylight]
+    config.skylight.logger = SemanticLogger[Skylight] if defined? SemanticLogger
     config.skylight.log_level = :fatal
     config.skylight.native_log_level = :fatal
 

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -19,15 +19,16 @@ module Find
 
     describe '#apply' do
       it 'redirects' do
-        expect(Rails.logger).to receive(:info).with("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}").once
-        expect(Rails.logger).to receive(:info)
+        with_logger_double do
+          expect(Rails.logger).to receive(:info).with("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}").once
 
-        get :apply, params: {
-          provider_code: provider.provider_code,
-          course_code: course.course_code
-        }
+          get :apply, params: {
+            provider_code: provider.provider_code,
+            course_code: course.course_code
+          }
 
-        expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{provider.provider_code}&courseCode=#{course.course_code}")
+          expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{provider.provider_code}&courseCode=#{course.course_code}")
+        end
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,7 @@ RSpec.configure do |config|
   config.include RequestHelpers, type: :controller
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include MockLogger
 
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
   config.before(:suite) do

--- a/spec/support/mock_logger.rb
+++ b/spec/support/mock_logger.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module MockLogger
+  def with_logger_double
+    logger = Rails.logger
+    logger_double = instance_double(Logger)
+    Rails.logger = logger_double
+
+    yield
+  ensure
+    Rails.logger = logger
+  end
+end


### PR DESCRIPTION
### Context

  Rails Semantic Logger appears to less useful in development.
  Much of the output is dedicated to printing the timestamp and the
  server details on each line. This is not particularly useful in
  development.

  Also, the default logger conveys the seapartion of requests more
  distinctly by separating each new http request with a new line.
  This is particularly useful when the application triggers over three
  consecutive redirects.


### Changes proposed in this pull request

Use Rails ActiveSupport::Logger in development environment.
This is achieved by moving the gem declaration into only the production, qa, sandbox groups in the Gemfile

### Guidance to review
Ensure that the changes only affect the development environment.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
