### PR TITLE
[434] Add production to the daily paas to aks db restore

### DIFF
--- a/.github/workflows/scheduled-aks-db-restore.yml
+++ b/.github/workflows/scheduled-aks-db-restore.yml
@@ -19,13 +19,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [sandbox]
+        environment: [sandbox,production]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Backup and Restore action for ${{ matrix.environment }} to AKS prod cluster
-        if: matrix.environment == 'sandbox' || matrix.environment == 'production'
         id: backup_and_restore_env_prod
         uses: ./.github/actions/backup_and_restore/
         with:


### PR DESCRIPTION
### Context
We already restore GOV.UK PaaS sandbox data to AKS nightly. We also need to restore the production database too.

### Changes proposed in this pull request
Add production to the matrix of environments we create the restore job for.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
