### PR TITLE
Move Error summary for Study Site forms above the heading

### DIFF
--- a/app/views/publish/providers/school_search/new.html.erb
+++ b/app/views/publish/providers/school_search/new.html.erb
@@ -6,44 +6,46 @@
 <% end %>
 
 <div class="govuk-grid-row">
+
+  <%= form_with(
+    model: @school_search_form,
+    url: search_publish_provider_recruitment_cycle_schools_path(@provider.provider_code),
+    method: :post,
+    html: { data: { module: "app-schools-autocomplete" } }
+  ) do |f| %>
+
+  <div class="govuk-grid-column-full">
+  <%= f.govuk_error_summary %>
+  </div>
+
   <div class="govuk-grid-column-two-thirds">
-
-    <%= form_with(
-        model: @school_search_form,
-        url: search_publish_provider_recruitment_cycle_schools_path(@provider.provider_code),
-        method: :post,
-        html: { data: { module: "app-schools-autocomplete" } }
-      ) do |f| %>
-
-      <%= f.govuk_error_summary %>
-
-      <div class="govuk-form-group<% if f.object.errors.present? %> govuk-form-group--error<% end %>">
-        <%= f.label :query, { class: "govuk-label govuk-label--l", for: "publish-schools-search-form-query-field" } do %>
-          <span class="govuk-caption-l">Add school</span>
-          <%= I18n.t("publish.providers.school_search.new.title") %>
-          <% if f.object.errors.present? %>
-            <span class="govuk-error-message" id="publish-schools-search-form-query-field-error" data-qa="provider-error">
-              <%= f.object.errors.first.message %>
-            </span>
-          <% end %>
+    <div class="govuk-form-group<% if f.object.errors.present? %> govuk-form-group--error<% end %>">
+      <%= f.label :query, { class: "govuk-label govuk-label--l", for: "publish-schools-search-form-query-field" } do %>
+        <span class="govuk-caption-l">Add school</span>
+        <%= I18n.t("publish.providers.school_search.new.title") %>
+        <% if f.object.errors.present? %>
+          <span class="govuk-error-message" id="publish-schools-search-form-query-field-error" data-qa="provider-error">
+            <%= f.object.errors.first.message %>
+          </span>
         <% end %>
-        <%= f.text_field :query,
-                              id: "publish-schools-search-form-query-field",
-                              value: params[:query],
-                              class: "govuk-input",
-                              data: { qa: "schools-search" } %>
-        <div id="school-autocomplete"></div>
-      </div>
+      <% end %>
+      <%= f.text_field :query,
+        id: "publish-schools-search-form-query-field",
+        value: params[:query],
+        class: "govuk-input",
+        data: { qa: "schools-search" } %>
+      <div id="school-autocomplete"></div>
+    </div>
 
-      <p class="govuk-body govuk-!-margin-bottom-7">
-        <%= govuk_link_to(t(".cannot_find"), new_publish_provider_recruitment_cycle_school_path(@provider.provider_code)) %>
-      </p>
-
-      <%= f.govuk_submit t("continue") %>
-    <% end %>
-
-    <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_schools_path) %>
+    <p class="govuk-body govuk-!-margin-bottom-7">
+    <%= govuk_link_to(t(".cannot_find"), new_publish_provider_recruitment_cycle_school_path(@provider.provider_code)) %>
     </p>
+
+    <%= f.govuk_submit t("continue") %>
+  <% end %>
   </div>
 </div>
+
+<p class="govuk-body">
+  <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_schools_path) %>
+</p>

--- a/app/views/publish/providers/study_site_search/new.html.erb
+++ b/app/views/publish/providers/study_site_search/new.html.erb
@@ -5,44 +5,43 @@
 <% end %>
 
 <div class="govuk-grid-row">
+  <%= form_with(
+    model: @study_site_search_form,
+    url: search_publish_provider_recruitment_cycle_study_sites_path(@provider.provider_code),
+    method: :post,
+    html: { data: { module: "app-schools-autocomplete" } }
+  ) do |f| %>
+
+  <%= f.govuk_error_summary %>
+
   <div class="govuk-grid-column-two-thirds">
-
-    <%= form_with(
-        model: @study_site_search_form,
-        url: search_publish_provider_recruitment_cycle_study_sites_path(@provider.provider_code),
-        method: :post,
-        html: { data: { module: "app-schools-autocomplete" } }
-      ) do |f| %>
-
-      <%= f.govuk_error_summary %>
-
-      <div class="govuk-form-group<% if f.object.errors.present? %> govuk-form-group--error<% end %>">
-        <%= f.label :query, { class: "govuk-label govuk-label--l", for: "publish-schools-search-form-query-field" } do %>
-          <span class="govuk-caption-l">Add study site</span>
-          <%= I18n.t("publish.providers.study_site_search.new.title") %>
-          <% if f.object.errors.present? %>
-            <span class="govuk-error-message" id="publish-study_sites-search-form-query-field-error" data-qa="provider-error">
-              <%= f.object.errors.first.message %>
-            </span>
-          <% end %>
+    <div class="govuk-form-group<% if f.object.errors.present? %> govuk-form-group--error<% end %>">
+      <%= f.label :query, { class: "govuk-label govuk-label--l", for: "publish-schools-search-form-query-field" } do %>
+        <span class="govuk-caption-l">Add study site</span>
+        <%= I18n.t("publish.providers.study_site_search.new.title") %>
+        <% if f.object.errors.present? %>
+          <span class="govuk-error-message" id="publish-study_sites-search-form-query-field-error" data-qa="provider-error">
+            <%= f.object.errors.first.message %>
+          </span>
         <% end %>
-        <%= f.text_field :query,
-                              id: "publish-schools-search-form-query-field",
-                              value: params[:query],
-                              class: "govuk-input",
-                              data: { qa: "study_sites-search" } %>
-        <div id="school-autocomplete"></div>
-      </div>
+      <% end %>
+      <%= f.text_field :query,
+        id: "publish-schools-search-form-query-field",
+        value: params[:query],
+        class: "govuk-input",
+        data: { qa: "study_sites-search" } %>
+      <div id="school-autocomplete"></div>
+    </div>
 
-      <p class="govuk-body govuk-!-margin-bottom-7">
-        <%= govuk_link_to(t(".cannot_find"), new_publish_provider_recruitment_cycle_study_site_path(@provider.provider_code)) %>
-      </p>
-
-      <%= f.govuk_submit t("continue") %>
-    <% end %>
-
-    <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
+    <p class="govuk-body govuk-!-margin-bottom-7">
+    <%= govuk_link_to(t(".cannot_find"), new_publish_provider_recruitment_cycle_study_site_path(@provider.provider_code)) %>
     </p>
+
+    <%= f.govuk_submit t("continue") %>
+  <% end %>
+
+  <p class="govuk-body">
+  <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
+  </p>
   </div>
 </div>

--- a/app/views/publish/providers/study_sites/_form.html.erb
+++ b/app/views/publish/providers/study_sites/_form.html.erb
@@ -1,5 +1,11 @@
 <%= form_with model:, local: true, url: form_url, method: form_method, class: "school-form" do |f| %>
+
+  <div class="govuk-grid-column-full">
   <%= f.govuk_error_summary %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+  <%= content_for :form_heading %>
 
   <%= f.govuk_text_field :location_name, label: { text: "Study site name", size: "s" } %>
 
@@ -27,4 +33,5 @@
   <% end %>
 
   <%= f.govuk_submit(site.persisted? ? t("publish.providers.study_sites.update") : t("continue")) %>
+  </div>
 <% end %>

--- a/app/views/publish/providers/study_sites/edit.html.erb
+++ b/app/views/publish/providers/study_sites/edit.html.erb
@@ -5,15 +5,16 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <% content_for :form_heading do %>
     <h1 class="govuk-heading-l">
       <%= @site.location_name_was %>
     </h1>
+  <% end %>
 
-    <%= render partial: "form", locals: { model: @study_site_form, site: @site, form_url: publish_provider_recruitment_cycle_study_site_path, form_method: :patch } %>
+  <%= render partial: "form", locals: { model: @study_site_form, site: @site, form_url: publish_provider_recruitment_cycle_study_site_path, form_method: :patch } %>
 
-    <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
-    </p>
-  </div>
 </div>
+
+<p class="govuk-body">
+  <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
+</p>

--- a/app/views/publish/providers/study_sites/new.html.erb
+++ b/app/views/publish/providers/study_sites/new.html.erb
@@ -5,17 +5,16 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <% content_for :form_heading do %>
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">Add study site</span>
+      Study site details
+    </h1>
+  <% end %>
 
-      <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Add study site</span>
-        Study site details
-      </h1>
-
-    <%= render partial: "publish/providers/study_sites/form", locals: { model: @study_site_form, site: @site, form_url: publish_provider_recruitment_cycle_study_sites_path, form_method: :post } %>
-
-    <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
-    </p>
-  </div>
+  <%= render partial: "publish/providers/study_sites/form", locals: { model: @study_site_form, site: @site, form_url: publish_provider_recruitment_cycle_study_sites_path, form_method: :post } %>
 </div>
+
+<p class="govuk-body">
+  <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
+</p>


### PR DESCRIPTION
### Context

Fix a snag from implementing the Study Site form.

### Changes proposed in this pull request

Wrap each of the headings in the `new` and `edit` templates in a `content_for` block. This block can be evaluated within the form and the content placed above below the error message.

### Guidance to review

This important documentation was consulted when deciding how to create the layout for the PR.
https://design-system.service.gov.uk/styles/layout/

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
