### PR TITLE
[353] Fix study sites validation bug

### DIFF
--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -16,14 +16,16 @@ module Publish
 
       def edit
         authorize(provider)
+
+        @course_study_site_form = CourseStudySiteForm.new(@course)
       end
 
       def update
         authorize(provider)
 
-        update_course_study_sites
+        @course_study_site_form = CourseStudySiteForm.new(@course, params: study_site_params)
 
-        if course.save
+        if @course_study_site_form.save!
           redirect_to details_publish_provider_recruitment_cycle_course_path(
             provider.provider_code,
             recruitment_cycle.year,
@@ -54,6 +56,12 @@ module Publish
 
       def error_keys
         [:study_sites]
+      end
+
+      def study_site_params
+        return { study_site_ids: nil } if params[:publish_course_study_site_form][:study_site_ids].all?(&:empty?)
+
+        params.require(:publish_course_study_site_form).permit(study_site_ids: [])
       end
     end
   end

--- a/app/forms/publish/course_study_site_form.rb
+++ b/app/forms/publish/course_study_site_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Publish
+  class CourseStudySiteForm < BaseCourseForm
+    FIELDS = %i[study_site_ids].freeze
+
+    attr_accessor(*FIELDS)
+
+    validate :no_study_sites_selected
+
+    private
+
+    def compute_fields
+      { study_site_ids: course.study_site_ids }.merge(new_attributes)
+    end
+
+    def no_study_sites_selected
+      return if params[:study_site_ids].present?
+
+      errors.add(:study_site_ids, :blank)
+    end
+  end
+end

--- a/app/forms/publish/course_study_site_form.rb
+++ b/app/forms/publish/course_study_site_form.rb
@@ -6,18 +6,12 @@ module Publish
 
     attr_accessor(*FIELDS)
 
-    validate :no_study_sites_selected
+    validates :study_site_ids, presence: true
 
     private
 
     def compute_fields
       { study_site_ids: course.study_site_ids }.merge(new_attributes)
-    end
-
-    def no_study_sites_selected
-      return if params[:study_site_ids].present?
-
-      errors.add(:study_site_ids, :blank)
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -319,7 +319,7 @@ class Course < ApplicationRecord
 
   validates :is_send, inclusion: { in: [true, false] }
   validates :sites, presence: true, on: %i[publish new]
-  validates :study_sites, presence: true, on: %i[publish new update], if: -> { recruitment_cycle_after_2023? }
+  validates :study_sites, presence: true, on: %i[publish new], if: -> { recruitment_cycle_after_2023? }
   validates :subjects, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish

--- a/app/views/publish/courses/study_sites/edit.html.erb
+++ b/app/views/publish/courses/study_sites/edit.html.erb
@@ -24,7 +24,7 @@
 
         <%= f.govuk_check_boxes_fieldset :study_site_ids, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Study sites".html_safe, tag: "h1", size: "l" } do %>
           <div class="govuk-hint">Select all that apply</div>
-          <% @provider.study_sites.sort_by(&:location_name).each_with_index do |study_site, index| %>
+          <% @provider.study_sites.sort_by(&:location_name).each do |study_site| %>
                     <%= f.govuk_check_box :study_site_ids,
                         study_site.id,
                         label: { text: study_site.location_name },

--- a/app/views/publish/courses/study_sites/edit.html.erb
+++ b/app/views/publish/courses/study_sites/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("Study sites – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Study sites – #{course.name_and_code}", @course_study_site_form.errors.present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -7,7 +7,7 @@
 <%= render "publish/shared/errors" %>
 
 <%= form_with(
-  model: course,
+  model: @course_study_site_form,
   url: study_sites_publish_provider_recruitment_cycle_course_path(
     course.provider_code,
     course.recruitment_cycle_year,
@@ -22,14 +22,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <%= f.govuk_check_boxes_fieldset :study_sites, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Study sites".html_safe, tag: "h1", size: "l" } do %>
+        <%= f.govuk_check_boxes_fieldset :study_site_ids, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Study sites".html_safe, tag: "h1", size: "l" } do %>
           <div class="govuk-hint">Select all that apply</div>
-          <% @provider.study_sites.sort_by(&:location_name).each_with_index do |site, index| %>
-                    <%= f.govuk_check_box :study_sites,
-                        site.id,
-                        label: { text: site.location_name },
-                        hint: { text: site.full_address },
-                        checked: f.object.study_sites.include?(site) %>
+          <% @provider.study_sites.sort_by(&:location_name).each_with_index do |study_site, index| %>
+                    <%= f.govuk_check_box :study_site_ids,
+                        study_site.id,
+                        label: { text: study_site.location_name },
+                        hint: { text: study_site.full_address } %>
           <% end %>
         <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -793,6 +793,10 @@ en:
           attributes:
             site_ids:
               no_schools: "Select at least one school"
+        publish/course_study_site_form:
+          attributes:
+            study_site_ids:
+              blank: "Select at least one study site"
         publish/course_requirement_form:
           attributes:
             required_qualifications:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -796,7 +796,7 @@ en:
         publish/course_study_site_form:
           attributes:
             study_site_ids:
-              blank: "Select at least one study site"
+              blank: "Add at least one study site"
         publish/course_requirement_form:
           attributes:
             required_qualifications:

--- a/spec/forms/publish/course_study_site_form_spec.rb
+++ b/spec/forms/publish/course_study_site_form_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Publish
+  describe CourseStudySiteForm, type: :model do
+    let(:course) { create(:course) }
+
+    subject { described_class.new(course) }
+
+    describe 'validations' do
+      before { subject.valid? }
+
+      it 'validates :study_site_ids' do
+        expect(subject.errors[:study_site_ids]).to include(I18n.t('activemodel.errors.models.publish/course_study_site_form.attributes.study_site_ids.blank'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

There is a bug which causes a study site validation to kick in when the course doesn’t have at least one study site attached and other attributes on the course basic details are updated.

### Changes proposed in this pull request

- Remove the presenece validation on update from the course.

- Use a form object to validate presence when updating the form. 

### Guidance to review

**Product:** Ask for a screenshare as study sites are only active in the next cycle

**Dev:** Ensure you are in the next cyclea and study sites are activated, then head to a courses basic details page and attempt to update the study site with no sites selected.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
