### PR TITLE
StudySite back link points to referrer

### DIFF
--- a/app/views/publish/providers/study_sites/new.html.erb
+++ b/app/views/publish/providers/study_sites/new.html.erb
@@ -1,7 +1,7 @@
 <% page_title = "Study site details - Add study site" %>
 <% content_for :page_title, title_with_error_prefix(page_title, @study_site_form.errors.any?) %>
 <%= content_for :before_content do %>
-  <%= govuk_back_link_to(search_publish_provider_recruitment_cycle_study_sites_path) %>
+  <%= govuk_back_link_to %>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/qRmmYmIt/331-study-site-back-links-from-check-page

Back link produces correct contextual URL.

The `site-studies/new` template can be accessed from two places. The `search` page and from the `check` page.
Currently the back link only points at the search. This PR updates the back link to point to the http referer.

The link will now point to the check page if that's where the user navigated from or the search page if they came from there.

### Changes proposed in this pull request
The back links URL target is `:back`

### Guidance to review
Q: Assumption that using the default `govuk_back_link_to` method with `:back` should suffice.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
