### PR TITLE
Activate study sites in all environments

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -110,7 +110,7 @@ features:
   gias_search: true
   support_new_provider_creation_flow: true
   accredited_provider_search: true
-  study_sites: false
+  study_sites: true
 
 cookies:
   session:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -15,6 +15,3 @@ find_valid_referers:
 base_url: https://publish.localhost
 find_url: https://find.localhost
 use_ssl: true
-
-features:
-  study_sites: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -15,5 +15,3 @@ authentication:
   secret: secret
   mode: persona
 
-features:
-  study_sites: true

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -15,5 +15,3 @@ authentication:
   secret: secret
   mode: persona
 
-features:
-  study_sites: true

--- a/spec/features/publish/add_course_button_spec.rb
+++ b/spec/features/publish/add_course_button_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'Add course button', { can_edit_current_and_next_cycles: true } do
   scenario 'with no study sites on the provider in the next cycle' do
     given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
-    and_the_study_sites_feature_flag_is_active
     when_i_visit_the_courses_page
     then_i_should_see_the_add_study_site_link
     and_i_should_not_see_the_add_course_button
@@ -13,20 +12,19 @@ feature 'Add course button', { can_edit_current_and_next_cycles: true } do
 
   scenario 'with no study sites on the provider in the next cycle and feature flag off' do
     given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+    and_the_study_sites_feature_flag_is_not_active
     when_i_visit_the_courses_page
     then_i_should_see_the_add_course_button
   end
 
   scenario 'with study sites on the provider in the next cycle' do
     given_i_am_authenticated_as_a_provider_user_with_study_sites_in_the_next_cycle
-    and_the_study_sites_feature_flag_is_active
     when_i_visit_the_courses_page
     then_i_should_see_the_add_course_button
   end
 
   scenario 'with no study sites on the provider in the current cycle' do  # This scenario can be deleted when the 2023 cycle becomes 2024
     given_i_am_authenticated_as_a_provider_user_in_the_current_cycle
-    and_the_study_sites_feature_flag_is_active
     when_i_visit_the_courses_page
     then_i_should_see_the_add_course_button
   end
@@ -76,8 +74,8 @@ feature 'Add course button', { can_edit_current_and_next_cycles: true } do
     )
   end
 
-  def and_the_study_sites_feature_flag_is_active
-    allow(Settings.features).to receive(:study_sites).and_return(true)
+  def and_the_study_sites_feature_flag_is_not_active
+    allow(Settings.features).to receive(:study_sites).and_return(false)
   end
 
   def when_i_visit_the_courses_page


### PR DESCRIPTION
### Context

Activating the study sites feature in all environments. 

Note that study sites have a after 2023 cycle check so it will only be active in the next cycle.

### Guidance to review

🚢 
