### PR TITLE
Make sandbox AKS depend on prod AKS

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -486,7 +486,7 @@ jobs:
       name: sandbox_aks
       url: ${{ steps.deploy_sandbox_v2.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/main' }}
-    needs: [deploy-production]
+    needs: [deploy-aks-production]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:


### PR DESCRIPTION
### Context
Make sandbox AKS depend on prod AKS. Currently it depends on GOV.UK PaaS prod.

### Changes proposed in this pull request
Make sandbox AKS depend on prod AKS

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
