### PR TITLE
[362] A few rollover snags

### DIFF
--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -15,7 +15,7 @@ class AddCourseButton < ViewComponent::Base
 
   def incomplete_sections
     incomplete_sections_hash.keys.select { |section| send(section) }.map do |section|
-      Section.new(name: "Add #{incomplete_section_article(section)} #{incomplete_section_label_suffix(section)}", path: incomplete_sections_hash[section])
+      Section.new(name: "add #{incomplete_section_article(section)} #{incomplete_section_label_suffix(section)}", path: incomplete_sections_hash[section])
     end
   end
 

--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -21,9 +21,9 @@ class AddCourseButton < ViewComponent::Base
 
   def incomplete_sections_hash
     {
+      site_not_present?: publish_provider_recruitment_cycle_schools_path(provider.provider_code, provider.recruitment_cycle_year),
       study_site_not_present_and_feature_active?: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year),
-      accredited_provider_not_present?: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year),
-      site_not_present?: publish_provider_recruitment_cycle_schools_path(provider.provider_code, provider.recruitment_cycle_year)
+      accredited_provider_not_present?: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)
     }
   end
 

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -11,8 +11,10 @@
                         data: { qa: "course__publish" }) %>
   <% end %>
 
-  <% unless course.has_unpublished_changes? %>
-    <%= govuk_link_to search_ui_course_page_url(provider_code: course.provider.provider_code, course_code: course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
+  <% if !course.has_unpublished_changes? && course.scheduled? %>
+    <%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
+  <% elsif !course.has_unpublished_changes? && !course.scheduled? %>
+     <%= govuk_link_to search_ui_course_page_url(provider_code: course.provider.provider_code, course_code: course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
       View on Find <span class="govuk-visually-hidden">postgraduate teacher training</span>
     <% end %>
   <% end %>

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -11,11 +11,13 @@
                         data: { qa: "course__publish" }) %>
   <% end %>
 
-  <% if !course.has_unpublished_changes? && course.scheduled? %>
-    <%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
-  <% elsif !course.has_unpublished_changes? && !course.scheduled? %>
-     <%= govuk_link_to search_ui_course_page_url(provider_code: course.provider.provider_code, course_code: course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
+  <% unless course.has_unpublished_changes? %>
+    <% if course.scheduled? %>
+     <%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
+    <% else %>
+      <%= govuk_link_to search_ui_course_page_url(provider_code: course.provider.provider_code, course_code: course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
       View on Find <span class="govuk-visually-hidden">postgraduate teacher training</span>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/spec/components/add_course_button_spec.rb
+++ b/spec/components/add_course_button_spec.rb
@@ -16,7 +16,7 @@ describe AddCourseButton do
   context 'when the provider has not filled out any required sections' do
     it 'renders a study sites link' do
       expect(rendered_content).to have_link(
-        'Add a study site',
+        'add a study site',
         href: publish_provider_recruitment_cycle_study_sites_path(
           provider.provider_code,
           provider.recruitment_cycle_year
@@ -26,7 +26,7 @@ describe AddCourseButton do
 
     it 'renders an accredited provider link' do
       expect(rendered_content).to have_link(
-        'Add an accredited provider',
+        'add an accredited provider',
         href: publish_provider_recruitment_cycle_accredited_providers_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -36,7 +36,7 @@ describe AddCourseButton do
 
     it 'renders a schools link' do
       expect(rendered_content).to have_link(
-        'Add a school',
+        'add a school',
         href: publish_provider_recruitment_cycle_schools_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -50,7 +50,7 @@ describe AddCourseButton do
 
     it 'renders a study sites link' do
       expect(rendered_content).not_to have_link(
-        'Add a study site',
+        'add a study site',
         href: publish_provider_recruitment_cycle_study_sites_path(
           provider.provider_code,
           provider.recruitment_cycle_year
@@ -60,7 +60,7 @@ describe AddCourseButton do
 
     it 'renders an accredited provider link' do
       expect(rendered_content).to have_link(
-        'Add an accredited provider',
+        'add an accredited provider',
         href: publish_provider_recruitment_cycle_accredited_providers_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -70,7 +70,7 @@ describe AddCourseButton do
 
     it 'renders a schools link' do
       expect(rendered_content).to have_link(
-        'Add a school',
+        'add a school',
         href: publish_provider_recruitment_cycle_schools_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -84,7 +84,7 @@ describe AddCourseButton do
 
     it 'renders a study sites link' do
       expect(rendered_content).to have_link(
-        'Add a study site',
+        'add a study site',
         href: publish_provider_recruitment_cycle_study_sites_path(
           provider.provider_code,
           provider.recruitment_cycle_year
@@ -94,7 +94,7 @@ describe AddCourseButton do
 
     it 'renders an accredited provider link' do
       expect(rendered_content).not_to have_link(
-        'Add an accredited provider',
+        'add an accredited provider',
         href: publish_provider_recruitment_cycle_accredited_providers_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -104,7 +104,7 @@ describe AddCourseButton do
 
     it 'renders a schools link' do
       expect(rendered_content).to have_link(
-        'Add a school',
+        'add a school',
         href: publish_provider_recruitment_cycle_schools_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -118,7 +118,7 @@ describe AddCourseButton do
 
     it 'renders a study sites link' do
       expect(rendered_content).to have_link(
-        'Add a study site',
+        'add a study site',
         href: publish_provider_recruitment_cycle_study_sites_path(
           provider.provider_code,
           provider.recruitment_cycle_year
@@ -128,7 +128,7 @@ describe AddCourseButton do
 
     it 'renders an accredited provider link' do
       expect(rendered_content).to have_link(
-        'Add an accredited provider',
+        'add an accredited provider',
         href: publish_provider_recruitment_cycle_accredited_providers_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -138,7 +138,7 @@ describe AddCourseButton do
 
     it 'renders a schools link' do
       expect(rendered_content).not_to have_link(
-        'Add a school',
+        'add a school',
         href: publish_provider_recruitment_cycle_schools_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -152,7 +152,7 @@ describe AddCourseButton do
 
     it 'renders a study sites link' do
       expect(rendered_content).not_to have_link(
-        'Add a study site',
+        'add a study site',
         href: publish_provider_recruitment_cycle_study_sites_path(
           provider.provider_code,
           provider.recruitment_cycle_year
@@ -162,7 +162,7 @@ describe AddCourseButton do
 
     it 'renders an accredited provider link' do
       expect(rendered_content).to have_link(
-        'Add an accredited provider',
+        'add an accredited provider',
         href: publish_provider_recruitment_cycle_accredited_providers_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -172,7 +172,7 @@ describe AddCourseButton do
 
     it 'renders a schools link' do
       expect(rendered_content).not_to have_link(
-        'Add a school',
+        'add a school',
         href: publish_provider_recruitment_cycle_schools_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -186,7 +186,7 @@ describe AddCourseButton do
 
     it 'renders a study sites link' do
       expect(rendered_content).not_to have_link(
-        'Add a study site',
+        'add a study site',
         href: publish_provider_recruitment_cycle_study_sites_path(
           provider.provider_code,
           provider.recruitment_cycle_year
@@ -196,7 +196,7 @@ describe AddCourseButton do
 
     it 'renders an accredited provider link' do
       expect(rendered_content).not_to have_link(
-        'Add an accredited provider',
+        'add an accredited provider',
         href: publish_provider_recruitment_cycle_accredited_providers_path(
           provider.provider_code,
           provider.recruitment_cycle.year
@@ -206,7 +206,7 @@ describe AddCourseButton do
 
     it 'renders a schools link' do
       expect(rendered_content).not_to have_link(
-        'Add a school',
+        'add a school',
         href: publish_provider_recruitment_cycle_schools_path(
           provider.provider_code,
           provider.recruitment_cycle.year

--- a/spec/features/publish/add_course_button_spec.rb
+++ b/spec/features/publish/add_course_button_spec.rb
@@ -30,7 +30,7 @@ feature 'Add course button', { can_edit_current_and_next_cycles: true } do
   end
 
   def then_i_should_see_the_add_study_site_link
-    expect(page).to have_link('Add a study site', href: "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/study-sites")
+    expect(page).to have_link('add a study site', href: "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/study-sites")
   end
 
   def and_i_should_not_see_the_add_course_button

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -112,14 +112,15 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   describe 'rollover with an rolled over course' do
-    scenario 'i can see the success message and link' do
+    scenario 'i can see the success message, link and preview' do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_rolled_over], funding_type: 'salary'))
       given_there_is_a_next_recruitment_cycle
       when_i_visit_the_rollover_form_page
       when_i_click_the_rollover_course_button
       then_i_should_see_the_course_show_page_with_success_message
       when_i_click_the_view_rollover_link
-      then_i_should_see_the_rolled_over_course_show_page
+      and_i_should_see_the_rolled_over_course_show_page
+      then_i_should_see_the_link_to_preview
     end
   end
 
@@ -135,6 +136,12 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   private
 
+  def then_i_should_see_the_link_to_preview
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).to have_preview_link
+    end
+  end
+
   def and_there_are_change_links
     expect(page.find_all('.govuk-summary-list__actions a').all? { |actions| actions.text.include?('Change ') }).to be(true)
   end
@@ -146,6 +153,8 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   def then_i_should_see_the_rolled_over_course_show_page
     expect(page).to have_content 'Rolled over'
   end
+
+  alias_method :and_i_should_see_the_rolled_over_course_show_page, :then_i_should_see_the_rolled_over_course_show_page
 
   def then_i_should_see_the_draft_course_on_the_show_page
     expect(page).to have_content 'Draft'


### PR DESCRIPTION
### Context

Following a review of the rollover environment there a a few small snags that we should address.

### Changes proposed in this pull request

- The links that show before you can create a course e.g “Add a study site” etc should have lowercase “a”

- The order of the links above should follow the same order as the nav bar items

- For scheduled courses it should have a preview link, not a view on Find link

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
