### PR TITLE
[358] Add degree subject requirement validation

### DIFF
--- a/app/forms/publish/subject_requirement_form.rb
+++ b/app/forms/publish/subject_requirement_form.rb
@@ -11,7 +11,7 @@ module Publish
     before_validation :cast_additional_degree_subject_requirements
 
     validates :additional_degree_subject_requirements, inclusion: { in: [true, false], message: 'Select if you have degree subject requirements' }
-    validates :degree_subject_requirements, presence: { message: 'Enter details of degree subject requirements' }, if: -> { additional_degree_subject_requirements }
+    validates :degree_subject_requirements, presence: { message: 'Enter details of degree subject requirements' }, words_count: { maximum: 250, message: :too_long }, if: -> { additional_degree_subject_requirements }
 
     def save(course)
       return false unless valid?

--- a/app/views/publish/courses/degrees/_additional_degree_subject_requirements.html.erb
+++ b/app/views/publish/courses/degrees/_additional_degree_subject_requirements.html.erb
@@ -11,6 +11,7 @@
       value: course_object.additional_degree_subject_requirements ? course_object.degree_subject_requirements : "",
       form_group: { id: "degree-subject-requirements" },
       label: { text: "Degree subject requirements" },
-      data: { qa: "degree_subject_requirements__requirements" } %>
+      data: { qa: "degree_subject_requirements__requirements" },
+      max_words: 250  %>
   <% end %>
 <% end %>

--- a/app/views/publish/courses/degrees/_additional_degree_subject_requirements.html.erb
+++ b/app/views/publish/courses/degrees/_additional_degree_subject_requirements.html.erb
@@ -12,6 +12,6 @@
       form_group: { id: "degree-subject-requirements" },
       label: { text: "Degree subject requirements" },
       data: { qa: "degree_subject_requirements__requirements" },
-      max_words: 250  %>
+      max_words: 250 %>
   <% end %>
 <% end %>

--- a/app/views/publish/courses/degrees/subject_requirements/edit.html.erb
+++ b/app/views/publish/courses/degrees/subject_requirements/edit.html.erb
@@ -29,7 +29,7 @@
 
       <p class="govuk-body">Candidates will be advised that their degree subject should match or be closely related to <%= @course.name %>.</p>
 
-      <%= render partial: "publish/courses/degrees/additional_degree_subject_requirements", locals: { f:, course_object: @source_course ? source_course : @course } %>
+      <%= render partial: "publish/courses/degrees/additional_degree_subject_requirements", locals: { f:, course_object: @source_course ? source_course : @subject_requirements_form } %>
 
       <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -602,6 +602,10 @@ en:
           attributes:
             campaign_name:
               inclusion: "Select if this course is part of the Engineers teach physics programme"
+        publish/subject_requirement_form:
+          attributes:
+            degree_subject_requirements:
+              too_long: "Reduce the word count for degree subject requirements"
         publish/course_rollover_form:
           attributes:
             course_is_rollable:

--- a/spec/forms/publish/subject_requirement_form_spec.rb
+++ b/spec/forms/publish/subject_requirement_form_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Publish
+  describe SubjectRequirementForm, type: :model do
+    let(:params) { { additional_degree_subject_requirements: true, degree_subject_requirements: "#{(%w[word] * 250).join(' ')} popped" } }
+
+    subject { described_class.new(params) }
+
+    describe 'validations' do
+      before { subject.valid? }
+
+      it 'validates :degree_subject_requirements does not exceed 250 words' do
+        expect(subject.errors[:degree_subject_requirements]).to include('Reduce the word count for degree subject requirements')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Restrict degree subject requirement to 250 words

### Guidance to review

Attempt to submit the degree subject requirement form with over 250 words

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
