### PR TITLE
[366] Fix editing AP in next cycle

### DIFF
--- a/app/forms/accredited_provider_form.rb
+++ b/app/forms/accredited_provider_form.rb
@@ -15,7 +15,7 @@ class AccreditedProviderForm < Form
   alias compute_fields new_attributes
 
   def accredited_provider
-    @accredited_provider ||= RecruitmentCycle.current.providers.find(accredited_provider_id)
+    @accredited_provider ||= model.recruitment_cycle.providers.find(accredited_provider_id)
   end
 
   private

--- a/spec/forms/accredited_provider_form_spec.rb
+++ b/spec/forms/accredited_provider_form_spec.rb
@@ -39,6 +39,22 @@ describe AccreditedProviderForm, type: :model do
     it { is_expected.to be_truthy }
   end
 
+  describe '#accredited_provider' do
+    subject { described_class.new(user, model, params:).accredited_provider }
+
+    let(:accredited_provider) { create(:provider, :accredited_provider) }
+    let(:params) do
+      {
+        accredited_provider_id: accredited_provider.id,
+        description: 'Foo'
+      }
+    end
+
+    it 'returns the accredited provider' do
+      expect(subject).to eq(accredited_provider)
+    end
+  end
+
   describe '#save!' do
     subject { described_class.new(user, model, params:) }
 


### PR DESCRIPTION
### Context

We are unable to edit accredited providers in the next cycle, this is the fix.

### Changes proposed in this pull request

Make the recruitment cycle dynamic.

### Guidance to review

:shipit: 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
