### PR TITLE
Remove SASSC gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,6 @@ gem 'rails', '7.0.6'
 # Use PostgreSQL as the database for Active Record
 gem 'pg'
 
-# This library utilizes libsass to allow you to compile SCSS or SASS syntax to CSS
-
-gem 'sassc'
-
 # Authorisation
 gem 'pundit'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -630,8 +630,6 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubypants (0.7.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     schema_to_scaffold (0.8.2)
       activesupport (~> 7)
     semantic_logger (4.13.0)
@@ -829,7 +827,6 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   rubypants
-  sassc
   schema_to_scaffold
   sentry-rails
   sentry-ruby


### PR DESCRIPTION
### Context

  The gem was added because the 2.10.0 release of `better_errors` broke
  the build. A new release 2.10.1 fixed the issue and SASSC is no longer
  needed in the application.

  The css is compiled and included in the built gem.

  Breaking Change: https://github.com/BetterErrors/better_errors/pull/498
  Fix: https://github.com/BetterErrors/better_errors/pull/520

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
