### PR TITLE
[374] Destroy StudySitePlacements with Course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -123,7 +123,7 @@ class Course < ApplicationRecord
   has_many :subjects, through: :course_subjects
   has_many :financial_incentives, through: :subjects
   has_many :site_statuses
-  has_many :study_site_placements
+  has_many :study_site_placements, dependent: :destroy
   accepts_nested_attributes_for :site_statuses
 
   has_many :sites,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -65,7 +65,7 @@ describe Course do
 
     it { is_expected.to have_many(:subjects).through(:course_subjects) }
     it { is_expected.to have_many(:site_statuses) }
-    it { is_expected.to have_many(:study_site_placements) }
+    it { is_expected.to have_many(:study_site_placements).dependent(:destroy) }
     it { is_expected.to have_many(:study_sites).through(:study_site_placements).source(:site) }
     it { is_expected.to have_many(:sites) }
     it { is_expected.to have_many(:enrichments) }


### PR DESCRIPTION
### Context

There is a bug in the next cycle which prevents users from being able to delete draft courses with study sites attached.

### Changes proposed in this pull request

Destroy all the associated StudySitePlacement records when a Course is destroyed.

### Guidance to review

Try to delete a course with a study site attached, preferably in the next cycle. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
