### PR TITLE
Find visa status page

### DIFF
--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -66,6 +66,7 @@ module FilterParameters
       .require(form_name)
       .permit(
         *legacy_paramater_keys,
+        :visa_status,
         :age_group,
         :c,
         :can_sponsor_visa,

--- a/app/controllers/find/search/age_groups_controller.rb
+++ b/app/controllers/find/search/age_groups_controller.rb
@@ -18,7 +18,7 @@ module Find
 
         if @age_groups_form.valid?
           if form_params[:age_group] == 'further_education'
-            redirect_to find_results_path(further_education_params.merge(has_vacancies: default_vacancies, applications_open: default_applications_open))
+            redirect_to find_visa_status_path(further_education_params.merge(has_vacancies: default_vacancies, applications_open: default_applications_open))
           else
             redirect_to find_subjects_path(filter_params[:find_age_groups_form])
           end

--- a/app/controllers/find/search/subjects_controller.rb
+++ b/app/controllers/find/search/subjects_controller.rb
@@ -16,11 +16,7 @@ module Find
         @subjects_form = SubjectsForm.new(subjects: sanitised_subject_codes, age_group: form_params[:age_group])
 
         if @subjects_form.valid?
-          redirect_to find_results_path(form_params.merge(
-                                          subjects: sanitised_subject_codes,
-                                          has_vacancies: default_vacancies,
-                                          applications_open: default_applications_open
-                                        ))
+          redirect_to find_visa_status_path(filter_params[:find_subjects_form])
         else
           render :new
         end

--- a/app/controllers/find/search/visa_status_controller.rb
+++ b/app/controllers/find/search/visa_status_controller.rb
@@ -38,7 +38,7 @@ module Find
       def form_name = :find_visa_status_form
 
       def back_path(backlink_params)
-        if params[:age_group] == 'further_education'
+        if params[:age_group] == 'further_education' || (params[:find_visa_status_form] && params[:find_visa_status_form][:age_group] == 'further_education')
           find_age_groups_path(backlink_params)
         else
           find_subjects_path(backlink_params)
@@ -46,7 +46,7 @@ module Find
       end
 
       def build_backlink_query_parameters
-        @backlink_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+        @backlink_query_parameters = ResultsView.new(query_parameters: request.query_parameters[:find_visa_status_form].presence || request.query_parameters)
                                                 .query_parameters_with_defaults
                                                 .except(:find_visa_status_form)
       end

--- a/app/controllers/find/search/visa_status_controller.rb
+++ b/app/controllers/find/search/visa_status_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Find
+  module Search
+    class VisaStatusController < Find::ApplicationController
+      include FilterParameters
+      include DefaultVacancies
+      include DefaultApplicationsOpen
+
+      before_action :build_backlink_query_parameters
+      helper_method :back_path
+
+      def new
+        @visa_status_form = VisaStatusForm.new(visa_status: params[:visa_status])
+      end
+
+      def create
+        @visa_status_form = VisaStatusForm.new(visa_status: form_params[:visa_status])
+
+        if @visa_status_form.valid?
+          redirect_to find_results_path(form_params.merge(
+                                          subjects: sanitised_subject_codes,
+                                          has_vacancies: default_vacancies,
+                                          applications_open: default_applications_open,
+                                          can_sponsor_visa: form_params[:visa_status]
+                                        ))
+        else
+          render :new
+        end
+      end
+
+      private
+
+      def sanitised_subject_codes
+        form_params['subjects'].compact_blank!
+      end
+
+      def form_name = :find_visa_status_form
+
+      def back_path(backlink_params)
+        if params[:age_group] == 'further_education'
+          find_age_groups_path(backlink_params)
+        else
+          find_subjects_path(backlink_params)
+        end
+      end
+
+      def build_backlink_query_parameters
+        @backlink_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+                                                .query_parameters_with_defaults
+                                                .except(:find_visa_status_form)
+      end
+    end
+  end
+end

--- a/app/forms/find/visa_status_form.rb
+++ b/app/forms/find/visa_status_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Find
+  class VisaStatusForm
+    include ActiveModel::Model
+
+    attr_accessor :visa_status
+
+    validates :visa_status, presence: true
+    validates :visa_status, inclusion: { in: %w[true false] }
+  end
+end

--- a/app/views/find/result_filters/location/_form.html.erb
+++ b/app/views/find/result_filters/location/_form.html.erb
@@ -87,7 +87,7 @@
                 checked: params[:l] == "3"
               ) %>
               <%= form.label :l_3, class: "govuk-label govuk-radios__label" do %>
-                By school, university or other training provider
+                By University or other training provider
               <% end %>
             </div>
             <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless params[:l] == "3" %>"

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -90,7 +90,7 @@
                 checked: params[:l] == "3"
               ) %>
               <%= form.label :l_3, class: "govuk-label govuk-radios__label" do %>
-                By school, university or other training provider
+                By University or other training provider
               <% end %>
             </div>
             <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless params[:l] == "3" %>"

--- a/app/views/find/search/subjects/_primary_subjects.html.erb
+++ b/app/views/find/search/subjects/_primary_subjects.html.erb
@@ -17,6 +17,6 @@
     <%= f.govuk_collection_check_boxes :subjects, primary_subject_options,
        :code, :name, legend: { text: "Which courses would you like to find?" } %>
 
-    <%= f.govuk_submit "Find courses" %>
+     <%= f.govuk_submit "Continue" %>
   </div>
 </div>

--- a/app/views/find/search/subjects/_secondary_subjects.html.erb
+++ b/app/views/find/search/subjects/_secondary_subjects.html.erb
@@ -3,6 +3,6 @@
     <%= f.govuk_collection_check_boxes :subjects, secondary_subject_options,
                                           :code, :name, :financial_info, legend: { text: t("find.subjects_page.secondary_title"), size: "l", tag: "h1" } %>
 
-    <%= f.govuk_submit "Find courses" %>
+    <%= f.govuk_submit "Continue" %>
   </div>
 </div>

--- a/app/views/find/search/visa_status/new.html.erb
+++ b/app/views/find/search/visa_status/new.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :page_title, title_with_error_prefix(I18n.t("find.visa_status.title"), @visa_status_form.errors.any?) %>
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    text: "Back",
+    href: back_path(@backlink_query_parameters),
+    html_attributes: {
+      data: { qa: "page-back" }
+    }
+  ) %>
+<% end %>
+
+    <%= form_with(model: @visa_status_form, url: find_visa_status_create_path, method: :get) do |f| %>
+      <%= f.govuk_error_summary %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      <%= render Find::HiddenFieldsComponent.new(
+        query_params: request.query_parameters,
+        form: f,
+        form_name: :find_visa_status_form,
+        exclude_keys: ["visa_status"]
+      ) %>
+
+    <%= f.govuk_radio_buttons_fieldset :visa_status, legend: { text: I18n.t("find.visa_status.title"), size: "l", tag: "h1" } do %>
+        <%= f.govuk_radio_button :visa_status, "false", label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :visa_status, "true", label: { text: "Not yet" } %>
+      <% end %>
+
+      <%= f.govuk_submit "Find courses" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -59,6 +59,8 @@ en:
         further_education:
           radio: Further education
           hint_text: For example, teaching A levels or vocational courses
+    visa_status:
+      title: Do you already have the right to work or study in the UK?
     subjects:
       primary_title: Primary courses with subject specialisms
       secondary_title: Which secondary subjects do you want to teach?

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -153,6 +153,10 @@ en:
           attributes:
             age_group:
               blank: "Select which age group you want to teach"
+        find/visa_status_form:
+          attributes:
+            visa_status:
+              blank: "Select if you have the right to work or study in the UK"
         find/subjects_form:
           blank: "Select at least one subject you want to teach"
           attributes:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -44,8 +44,8 @@ en:
         across_england:
           radio: Across England
         by_school_uni_or_provider:
-          radio: By school, university or other training provider
-          text_field: School, university or other training provider
+          radio: By university or other training provider
+          text_field: University or other training provider
           hint_text: Enter the name or provider code
     age_groups:
       title: Which age group do you want to teach?

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -60,7 +60,7 @@ en:
           radio: Further education
           hint_text: For example, teaching A levels or vocational courses
     visa_status:
-      title: Do you already have the right to work or study in the UK?
+      title: Do you have the right to work or study in the UK?
     subjects:
       primary_title: Primary courses with subject specialisms
       secondary_title: Which secondary subjects do you want to teach?

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -31,10 +31,12 @@ namespace :find, path: '/' do
 
   scope module: :search do
     root to: 'locations#start'
-    get '/age-groups' => 'age_groups#new'
+    get '/age-groups' => 'age_groups#new', as: :age_groups
     get '/age-groups-submit' => 'age_groups#create', as: :age_groups_create
-    get '/subjects' => 'subjects#new'
+    get '/subjects' => 'subjects#new', as: :subjects
     get '/subjects-submit' => 'subjects#create', as: :subjects_create
+    get '/visa-status' => 'visa_status#new', as: :visa_status
+    get '/visa-status-submit' => 'visa_status#create', as: :visa_status_create
     resources :locations, path: '/'
   end
 

--- a/spec/features/find/result_page_filters/engineers_teach_physics_spec.rb
+++ b/spec/features/find/result_page_filters/engineers_teach_physics_spec.rb
@@ -13,11 +13,13 @@ RSpec.feature 'Engineers teach physics' do
 
   scenario 'Candidate searches for physics subject' do
     given_i_choose_physics
+    and_i_provide_my_visa_status
     then_i_see_that_the_etp_checkbox_is_unchecked
   end
 
   scenario 'Candidate searches for any other subject' do
     given_i_choose_music
+    and_i_provide_my_visa_status
     then_i_dont_see_the_etp_checkbox
   end
 
@@ -43,6 +45,11 @@ RSpec.feature 'Engineers teach physics' do
   def given_i_choose_music
     check 'Chemistry'
     find_secondary_subjects_page.continue.click
+  end
+
+  def and_i_provide_my_visa_status
+    choose 'Yes'
+    click_button 'Find courses'
   end
 
   def then_i_see_that_the_etp_checkbox_is_unchecked

--- a/spec/features/find/search/across_england/further_education_spec.rb
+++ b/spec/features/find/search/across_england/further_education_spec.rb
@@ -59,7 +59,7 @@ feature 'Searching across England' do
   end
 
   def then_i_should_see_the_visa_status_page
-    expect(page).to have_content('Do you already have the right to work or study in the UK?')
+    expect(page).to have_content('Do you have the right to work or study in the UK?')
   end
 
   def when_i_select_my_visa_status

--- a/spec/features/find/search/across_england/further_education_spec.rb
+++ b/spec/features/find/search/across_england/further_education_spec.rb
@@ -16,6 +16,10 @@ feature 'Searching across England' do
 
     when_i_select_the_further_education_radio_button
     and_i_click_continue
+    then_i_should_see_the_visa_status_page
+
+    when_i_select_my_visa_status
+    and_i_click_find_courses
     then_i_should_see_the_find_results_page
   end
 
@@ -54,8 +58,20 @@ feature 'Searching across England' do
     choose 'Further education'
   end
 
+  def then_i_should_see_the_visa_status_page
+    expect(page).to have_content('Do you already have the right to work or study in the UK?')
+  end
+
+  def when_i_select_my_visa_status
+    choose 'Yes'
+  end
+
+  def and_i_click_find_courses
+    click_button 'Find courses'
+  end
+
   def then_i_should_see_the_find_results_page
-    expect(page).to have_current_path('/results?age_group=further_education&applications_open=true&has_vacancies=true&l=2&subjects[]=41')
+    expect(page).to have_current_path('/results?age_group=further_education&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&subjects%5B%5D=41&visa_status=false')
   end
 
   def and_i_should_see_the_correct_courses

--- a/spec/features/find/search/across_england/primary_spec.rb
+++ b/spec/features/find/search/across_england/primary_spec.rb
@@ -44,6 +44,13 @@ feature 'Searching across England' do
     then_i_should_see_the_visa_status_page
 
 
+    when_i_click_find_courses
+    then_i_should_see_a_validation_error
+
+    when_i_click_back
+    then_i_should_see_the_subjects_form
+    and_i_click_continue
+
     when_i_select_my_visa_status
     and_i_click_find_courses
     then_i_should_see_the_find_results_page
@@ -138,6 +145,10 @@ feature 'Searching across England' do
 
   def when_i_select_my_visa_status
     choose 'Yes'
+  end
+
+  def then_i_should_see_a_validation_error
+    expect(page).to have_content('Select if you have the right to work or study in the UK')
   end
 
   def then_i_should_see_the_find_results_page

--- a/spec/features/find/search/across_england/primary_spec.rb
+++ b/spec/features/find/search/across_england/primary_spec.rb
@@ -36,10 +36,15 @@ feature 'Searching across England' do
     when_i_click_continue
     then_i_should_see_the_subjects_form
 
-    when_i_click_find_courses
+    when_i_click_continue
     then_i_should_see_a_subjects_validation_error
 
     when_i_select_the_primary_subject_textbox
+    and_i_click_continue
+    then_i_should_see_the_visa_status_page
+
+
+    when_i_select_my_visa_status
     and_i_click_find_courses
     then_i_should_see_the_find_results_page
     and_i_should_see_the_correct_courses
@@ -127,8 +132,16 @@ feature 'Searching across England' do
     check 'Primary'
   end
 
+  def then_i_should_see_the_visa_status_page
+    expect(page).to have_content('Do you already have the right to work or study in the UK?')
+  end
+
+  def when_i_select_my_visa_status
+    choose 'Yes'
+  end
+
   def then_i_should_see_the_find_results_page
-    expect(page).to have_current_path('/results?age_group=primary&applications_open=true&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00')
+    expect(page).to have_current_path('/results?age_group=primary&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00&visa_status=false')
   end
 
   def and_i_should_see_the_correct_courses

--- a/spec/features/find/search/across_england/primary_spec.rb
+++ b/spec/features/find/search/across_england/primary_spec.rb
@@ -133,7 +133,7 @@ feature 'Searching across England' do
   end
 
   def then_i_should_see_the_visa_status_page
-    expect(page).to have_content('Do you already have the right to work or study in the UK?')
+    expect(page).to have_content('Do you have the right to work or study in the UK?')
   end
 
   def when_i_select_my_visa_status

--- a/spec/features/find/search/across_england/primary_spec.rb
+++ b/spec/features/find/search/across_england/primary_spec.rb
@@ -43,7 +43,6 @@ feature 'Searching across England' do
     and_i_click_continue
     then_i_should_see_the_visa_status_page
 
-
     when_i_click_find_courses
     then_i_should_see_a_validation_error
 

--- a/spec/features/find/search/across_england/secondary_spec.rb
+++ b/spec/features/find/search/across_england/secondary_spec.rb
@@ -26,10 +26,14 @@ feature 'Searching across England' do
     when_i_click_continue
     then_i_should_see_the_subjects_form
 
-    when_i_click_find_courses
+    when_i_click_continue
     then_i_should_see_a_subjects_validation_error
 
     when_i_select_the_secondary_subject
+    and_i_click_continue
+    then_i_should_see_the_visa_status_page
+
+    when_i_select_my_visa_status
     and_i_click_find_courses
     then_i_should_see_the_find_results_page
     and_i_should_see_the_correct_courses
@@ -103,8 +107,16 @@ feature 'Searching across England' do
     check 'Biology'
   end
 
+  def then_i_should_see_the_visa_status_page
+    expect(page).to have_content('Do you already have the right to work or study in the UK?')
+  end
+
+  def when_i_select_my_visa_status
+    choose 'Yes'
+  end
+
   def then_i_should_see_the_find_results_page
-    expect(page).to have_current_path('/results?age_group=secondary&applications_open=true&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=C1')
+    expect(page).to have_current_path('/results?age_group=secondary&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=C1&visa_status=false')
   end
 
   def and_i_should_see_the_correct_courses

--- a/spec/features/find/search/across_england/secondary_spec.rb
+++ b/spec/features/find/search/across_england/secondary_spec.rb
@@ -108,7 +108,7 @@ feature 'Searching across England' do
   end
 
   def then_i_should_see_the_visa_status_page
-    expect(page).to have_content('Do you already have the right to work or study in the UK?')
+    expect(page).to have_content('Do you have the right to work or study in the UK?')
   end
 
   def when_i_select_my_visa_status

--- a/spec/features/find/search/editing_a_search_spec.rb
+++ b/spec/features/find/search/editing_a_search_spec.rb
@@ -27,6 +27,8 @@ feature 'Editing a search' do
     and_i_select_the_primary_radio_button
     and_i_click_continue
     and_i_select_the_primary_subject_checkbox
+    and_i_click_continue
+    and_i_select_the_not_yet_visa_status_radio_button
     and_i_click_find_courses
   end
 
@@ -61,9 +63,13 @@ feature 'Editing a search' do
     find_primary_subjects_page.primary.check
   end
 
+  def and_i_select_the_not_yet_visa_status_radio_button
+    choose 'Not yet'
+  end
+
   def then_i_should_see_the_find_results_page
     expect(find_results_page).to be_displayed
-    expect(find_results_page.current_url).to end_with('/results?age_group=primary&applications_open=true&has_vacancies=true&l=2&subjects%5B%5D=00')
+    expect(find_results_page.current_url).to end_with('/results?age_group=primary&applications_open=true&can_sponsor_visa=true&has_vacancies=true&l=2&subjects%5B%5D=00&visa_status=true')
   end
 
   def when_i_change_my_search_query
@@ -84,7 +90,7 @@ feature 'Editing a search' do
 
   def then_i_should_see_the_subjects_form
     expect(find_primary_subjects_page.current_url).to end_with(
-      '/subjects?age_group=primary&applications_open=true&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00'
+      '/subjects?age_group=primary&applications_open=true&can_sponsor_visa=true&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00&visa_status=true'
     )
   end
 

--- a/spec/features/find/search/location_options_spec.rb
+++ b/spec/features/find/search/location_options_spec.rb
@@ -28,6 +28,7 @@ feature 'Searching by location' do
 
   scenario 'searching for a location with no results' do
     when_i_enter_an_invalid_location_with_some_options
+    and_i_provide_my_visa_status
     then_should_see_the_no_results_text
   end
 
@@ -81,6 +82,11 @@ feature 'Searching by location' do
     find_courses_by_location_or_training_provider_page.continue.click
     choose 'Further education'
     click_button 'Continue'
+  end
+
+  def and_i_provide_my_visa_status
+    choose 'Yes'
+    click_button 'Find courses'
   end
 
   def then_should_see_the_no_results_text


### PR DESCRIPTION
### Context

We're seeing a high number of candidates that are applying for courses that won't sponsor their visa. Whilst we do have a visa sponsorship filter available on Find, it's appearing at the bottom of the page. 

We're going to make this more prominent by introducing a new page to the Find journey that will then pre filter the courses based on the candidates visa requirements.

### Changes proposed in this pull request

|New page | Hitting validation|
|---|---|
|<img width="674" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/ce70a641-6f51-4c19-8b5a-981631774368">|<img width="910" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/e2f1d4c4-6213-478a-b80c-7f1dad166e5c">|

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
