### PR TITLE
Remove unnecessary check from find

### DIFF
--- a/app/helpers/find/location_helper.rb
+++ b/app/helpers/find/location_helper.rb
@@ -5,8 +5,7 @@ module Find
     def provider_error?
       return false if flash[:error].nil?
 
-      flash[:error].include?(t('find.location_filter.fields.provider')) ||
-        flash[:error].include?(t('find.location_filter.errors.blank_provider')) ||
+      flash[:error].include?(t('find.location_filter.errors.blank_provider')) ||
         flash[:error].include?(t('find.location_filter.errors.missing_provider'))
     end
 


### PR DESCRIPTION
### Context

This blows up locally – we've just never hit it on prod:
<img width="1449" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/3ad759e6-828f-4f9e-aed3-e5e7b4b3a30d">

The translation should actually be `en.find.fields.provider`:
`config/locales/find.yml:37`
but it's not an error anyway.


### Changes proposed in this pull request
🚮 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
