### PR TITLE
[379] Ensure accredited provider tab appears

### DIFF
--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -14,7 +14,7 @@ module NavigationBarHelper
       *([name: t('navigation_bar.study_sites'), url: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year)] if FeatureService.enabled?(:study_sites) && recruitment_cycle_after_2023?(provider)),
       { name: t('navigation_bar.users'), url: publish_provider_users_path(provider_code: provider.provider_code), additional_url: request_access_publish_provider_path(provider.provider_code) },
       *([name: t('navigation_bar.training_partners'), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.accredited_provider?),
-      *([name: t('navigation_bar.accredited_provider'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.lead_school? && FeatureService.enabled?(:accredited_provider_search)),
+      *([name: t('navigation_bar.accredited_provider'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)] unless provider.accredited_provider? && FeatureService.enabled?(:accredited_provider_search)),
       { name: t('navigation_bar.organisation_details'), url: details_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year) }
     ]
   end

--- a/spec/helpers/navigation_bar_helper_spec.rb
+++ b/spec/helpers/navigation_bar_helper_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NavigationBarHelper do
+  describe '#navigation_items' do
+    subject do
+      helper.navigation_items(provider)
+    end
+
+    let(:accredited_provider_item) { subject.find { |item| item[:name] == 'Accredited providers' } }
+
+    context 'when provider is an accredited provider' do
+      let(:provider) { create(:provider, :accredited_provider) }
+
+      it 'does not include accredited_provider in items' do
+        expect(accredited_provider_item).to be_nil
+      end
+    end
+
+    context 'when provider is not an accredited provider' do
+      let(:provider) { create(:provider) }
+
+      it 'includes accredited_provider in items' do
+        expect(accredited_provider_item).not_to be_nil
+      end
+
+      it 'includes the correct link to accredited providers' do
+        expect(accredited_provider_item[:url]).to eq publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle.year)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ensure accredited provider tab appears unless the provider is an accredited provider.

### Guidance to review

Check a HEI and ensure that it does not have the AP tab. Downgrade that org on support and check that AP tab now appears. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
