### PR TITLE
Migrate QA env to AKS

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -371,7 +371,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa,staging]
+        environment: [staging]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa, staging]
+        environment: [staging]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ on:
         required: true
         type: choice
         options:
-        - qa
         - staging
         - production
         - sandbox

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,13 +3,12 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'The environment to run tests against (qa, staging, production, sandbox or review)'
-        default: qa
+        description: 'The environment to run tests against (staging, production, sandbox or review)'
+        default: staging
         required: true
         type: choice
         options:
         - review
-        - qa
         - staging
         - production
         - sandbox

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -1,14 +1,14 @@
 gcp_api_key: please_change_me
-publish_api_url: https://qa2.api.publish-teacher-training-courses.service.gov.uk
-publish_url: https://qa2.publish-teacher-training-courses.service.gov.uk
-find_url: https://qa2.find-postgraduate-teacher-training.service.gov.uk
+publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
+publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
+find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:
-  base_url: https://qa2.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 
 # URL of this app for the callback after sigining in
-base_url: https://qa2.publish-teacher-training-courses.service.gov.uk
+base_url: https://qa.publish-teacher-training-courses.service.gov.uk
 
 bg_jobs:
   save_statistic:
@@ -16,7 +16,7 @@ bg_jobs:
     class: "SaveStatisticJob"
     queue: save_statistic
 skylight:
-  enable: false
+  enable: true
 environment:
   label: "QA"
   name: "qa"
@@ -29,7 +29,7 @@ basic_auth:
   enabled: true
 
 features:
-  send_request_data_to_bigquery: false
+  send_request_data_to_bigquery: true
 
 find_valid_referers:
-  - https://qa2.find-postgraduate-teacher-training.service.gov.uk
+  - https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/terraform/aks/workspace_variables/qa_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/qa_aks.tfvars.json
@@ -18,9 +18,9 @@
   },
   "enable_find": true,
   "additional_hostnames": [
-    "qa2.publish-teacher-training-courses.service.gov.uk",
-    "qa2.find-postgraduate-teacher-training.service.gov.uk",
-    "qa2.api.publish-teacher-training-courses.service.gov.uk"
+    "qa.publish-teacher-training-courses.service.gov.uk",
+    "qa.find-postgraduate-teacher-training.service.gov.uk",
+    "qa.api.publish-teacher-training-courses.service.gov.uk"
   ],
   "enable_monitoring": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_qa.tfvars.json
@@ -3,12 +3,8 @@
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
-      "exclude_cnames": [
-        "qa"
-      ],
       "domains": [
-        "qa",
-        "qa2"
+        "qa"
       ],
       "cached_paths": [
         "/assets/*"
@@ -24,10 +20,6 @@
         "_726e3e7a4fe7f031753f263a79752196.qa-assets": {
           "target": "_4c48ed2d6f1c52b816b4ceab6e4944c6.tjxrvlrcqj.acm-validations.aws",
           "ttl": 86400
-        },
-        "qa": {
-          "target": "d1g6p51l52so6s.cloudfront.net",
-          "ttl": 300
         },
         "_05cc28b6a8575651297b1f9200e98539.qa": {
           "target": "_8c4a2c29360023c1279ad79c710a5961.bsgbmzkfwj.acm-validations.aws",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_qa.tfvars.json
@@ -3,15 +3,9 @@
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",
       "resource_group_name": "s189p01-pttdomains-rg",
-      "exclude_cnames": [
-        "qa",
-        "qa.api"
-      ],
       "domains": [
         "qa",
-        "qa.api",
-        "qa2",
-        "qa2.api"
+        "qa.api"
       ],
       "cached_paths": [
         "/assets/*"
@@ -21,17 +15,9 @@
       "origin_hostname": "publish-qa.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
-        "qa.api": {
-          "target": "d1g6p51l52so6s.cloudfront.net",
-          "ttl": 300
-        },
         "_209733afc8cf49ed3e82a5c52d1c46ad.qa.api": {
           "target": "_f9d5ee89910d9d01037eec263b4952e3.wggjkglgrm.acm-validations.aws",
           "ttl": 86400
-        },
-        "qa": {
-          "target": "d1g6p51l52so6s.cloudfront.net",
-          "ttl": 300
         },
         "_43a66adc4c27b7a24afa517c03dce100.qa": {
           "target": "_44663673f49fbe9fc1103e9bb5e9a315.wggjkglgrm.acm-validations.aws",


### PR DESCRIPTION
### Context
Change required to migrate QA from GOV.UK PaaS to the Teacher Services Cloud AKS platform.

This builds an image where the QA AKS environment uses the proper QA domains and includes the DNS changes to point QA (for find and publish) and QA API (for publish) to the new AKS environment.

### Changes proposed in this pull request

- Update the qa_aks environment configuration to use the qa domain. Previously qa2.
- Remove the existing CNAME records that are used by the GOV.UK PaaS environment
- Remove the qa2 and qa2.api front door configuration currently used by the QA AKS environment
- Add the CNAME record for QA, QA API to point to the previously provisioned front door endpoint

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
