### PR TITLE
[378] Remove validation for code

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -37,10 +37,6 @@ class Site < ApplicationRecord
   validates :town, presence: true, on: %i[create]
 
   validates :postcode, postcode: true
-  # we don't validate code for study_sites
-  validates :code, uniqueness: { scope: :provider_id, case_sensitive: false, conditions: -> { where(discarded_at: nil) } },
-                   format: { with: /\A[A-Z0-9-]+\z/, message: 'Site code must contain only A-Z, 0-9 or -' },
-                   presence: true, if: -> { school? }
 
   validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: 'Site URN must be 5 or 6 numbers' }
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -19,28 +19,6 @@ describe Site do
   it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id, :site_type) }
 
-  describe '#code' do
-    context 'with school' do
-      before { subject.school! }
-
-      it { is_expected.to validate_uniqueness_of(:code).case_insensitive.scoped_to(:provider_id) }
-      it { is_expected.to validate_presence_of(:code) }
-    end
-
-    context 'with study_site' do
-      before { subject.study_site! }
-
-      it { is_expected.not_to validate_uniqueness_of(:code).case_insensitive.scoped_to(:provider_id) }
-      it { is_expected.not_to validate_presence_of(:code) }
-    end
-  end
-
-  it 'validates that code can only contain A-Z, 0-9 or -' do
-    subject.code = '22,A'
-    subject.valid?
-    expect(subject.errors[:code]).to include('Site code must contain only A-Z, 0-9 or -')
-  end
-
   it 'validates that URN cannot be letters' do
     subject.urn = 'XXXXXX'
     subject.valid?


### PR DESCRIPTION
### Context

Code is no longer in use and this is causing unecessary Sentry errors.

https://dfe-teacher-services.sentry.io/issues/4312626004/?alert_rule_id=11137790&alert_type=issue&project=1377944&referrer=slack
