### PR TITLE
Filter for discarded providers in public API

### DIFF
--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -59,6 +59,10 @@ module API
           params.dig(:filter, :is_accredited_body)&.to_s&.downcase == 'true'
         end
 
+        def discarded?
+          params.dig(:filter, :discarded)&.to_s&.downcase == 'true'
+        end
+
         def providers
           @providers = recruitment_cycle.providers
 
@@ -69,6 +73,7 @@ module API
           @providers = @providers.with_can_sponsor_skilled_worker_visa(true) if can_sponsor_skilled_worker_visa?
           @providers = @providers.with_can_sponsor_student_visa(true) if can_sponsor_student_visa?
           @providers = @providers.accredited_provider if is_accredited_body?
+          @providers = @providers.unscope(where: :discarded_at).discarded if discarded?
           @providers = if sort_by_provider_ascending?
                          @providers.by_name_ascending
                        else

--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -4,6 +4,8 @@ module API
   module Public
     module V1
       class SerializableProvider < JSONAPI::Serializable::Resource
+        extend JSONAPI::Serializable::Resource::ConditionalFields
+
         type 'providers'
 
         belongs_to :recruitment_cycle
@@ -62,6 +64,8 @@ module API
         attribute :street_address_3 do
           @object.address3
         end
+
+        attribute :discarded_at, if: -> { @object.discarded? }
       end
     end
   end

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -5,6 +5,11 @@ weight: 2
 
 # Release Notes
 
+
+## 19 July 2023
+
+- Add `discard` filter to `ProviderFilter`. This boolean field returns only decomissioned providers. `discarded_at` is returned in the `ProviderAttributes`.
+
 ## 31 May 2023
 
 - Add `application_status` field to `CourseAttributes`. This is a string, corresponding to whether applications are open or closed.

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -334,6 +334,15 @@ RSpec.describe API::Public::V1::ProvidersController do
           end
         end
 
+        let(:discarded_provider) do
+          create(:provider,
+                 provider_code: '3wc',
+                 provider_name: 'Discarded',
+                 discarded_at: 1.minute.ago,
+                 organisations: [organisation],
+                 contacts: [contact])
+        end
+
         let(:provider_names_in_response) do
           json_response['data'].map do |provider|
             provider['attributes']['name']
@@ -342,6 +351,7 @@ RSpec.describe API::Public::V1::ProvidersController do
 
         before do
           provider2
+          discarded_provider
 
           get :index, params: {
             recruitment_cycle_year: recruitment_cycle.year,
@@ -402,6 +412,14 @@ RSpec.describe API::Public::V1::ProvidersController do
 
           it "returns 'Second' provider only" do
             expect(provider_names_in_response).to eq([provider2.provider_name])
+          end
+        end
+
+        context 'passing in discarded param' do
+          let(:filter) { { discarded: 'true' } }
+
+          it "returns 'discarded' provider only" do
+            expect(provider_names_in_response).to eq([discarded_provider.provider_name])
           end
         end
       end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -420,6 +420,15 @@ RSpec.describe API::Public::V1::ProvidersController do
 
           it "returns 'discarded' provider only" do
             expect(provider_names_in_response).to eq([discarded_provider.provider_name])
+            expect(Time.zone.parse(response.parsed_body.dig('data', 0, 'attributes', 'discarded_at'))).to be_within(1.second).of(discarded_provider.discarded_at)
+          end
+        end
+
+        context 'not passing in discarded param' do
+          let(:filter) { {} }
+
+          it 'returns provider attributes without discarded_at' do
+            expect(response.parsed_body.dig('data', 0, 'attributes')).not_to have_attribute('discarded_at')
           end
         end
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,11 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+# Allows response.parsed_body to parse JSONAPI responses
+# Doesn't work by default with RSpec.
+# https://github.com/jsonapi-rb/jsonapi-rails/blob/master/lib/jsonapi/rails/railtie.rb#L47
+ActionDispatch::RequestEncoder.register_encoder :jsonapi, response_parser: ->(body) { JSON.parse(body) }
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1260,6 +1260,13 @@
             "type": "boolean",
             "description": "Can this provider sponsor Student visas?",
             "example": "true"
+          },
+          "discarded_at": {
+            "type": "string",
+            "description": "Timestamp of when this provider was decomissioned",
+            "example": "2023-07-18T15:23:15Z",
+            "format": "date-time",
+            "nullable": true
           }
         }
       },
@@ -1321,6 +1328,11 @@
             "description": "Return providers that have been updated since the date (ISO 8601 date format)",
             "type": "string",
             "example": "2020-11-13T11:21:55Z"
+          },
+          "discarded": {
+            "description": "Return only providers that have been decommissioned. Using this filter will add the `discarded_at` property to the attributes of the returned providers.",
+            "type": "boolean",
+            "example": "true"
           }
         }
       },

--- a/swagger/public_v1/component_schemas/ProviderAttributes.yml
+++ b/swagger/public_v1/component_schemas/ProviderAttributes.yml
@@ -144,3 +144,9 @@ properties:
     type: boolean
     description: "Can this provider sponsor Student visas?"
     example: "true"
+  discarded_at:
+    type: string
+    description: "Timestamp of when this provider was decomissioned"
+    example: "2023-07-18T15:23:15Z"
+    format: date-time
+    nullable: true

--- a/swagger/public_v1/component_schemas/ProviderFilter.yml
+++ b/swagger/public_v1/component_schemas/ProviderFilter.yml
@@ -47,3 +47,7 @@ properties:
     description: "Return providers that have been updated since the date (ISO 8601 date format)"
     type: string
     example: "2020-11-13T11:21:55Z"
+  discarded:
+    description: "Return only providers that have been decommissioned. Using this filter will add the `discarded_at` property to the attributes of the returned providers."
+    type: boolean
+    example: 'true'


### PR DESCRIPTION
### Trello
https://trello.com/c/nR0xM6aq/266-delete-providers-that-have-no-region-code-on-manage-and-dont-exist-on-publish

### Context
Apply/Manage needs a way to identify `Provider`s that have been discarded. The current API filters out discarded providers at the definition of the association between `RecruitmentCycle` and `Provider`. We can `unscope` this exclusion in the API for the purposes of returning discarded providers.

This is a non-breaking change to the API. API consumers do not need to be made aware of this change. It can be an undocumented feature if that is preferred.  There is probably no reason a consumer of the API would need to access discarded `Provider`s

### Changes proposed in this pull request

Provider API accepts `filter[discarded]=true` which returns discarded Providers.
When the `filter[discarded]=true` is passed, only providers that are discarded are returned. The attributes include `discarded_at`
Without the filter, `discarded_at` is not returned, keeping the current response consistent.

### Guidance to review
Is this desirable to be added to the Public API?
Could this be made available via another way?
Should this new filter be explicitly documented in public schema?
How should this filter be documented internally?


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
