### PR TITLE
[504] Make PaaS prod depend on AKS

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -419,7 +419,7 @@ jobs:
       name: production
       url: ${{ steps.deploy_app.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/main' }}
-    needs: [deploy-before-production]
+    needs: [deploy-before-production,deploy-aks-before-production]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Context
Now that AKS QA is the main QA environment, production should also depend on it in the deployment jobs.

### Changes proposed in this pull request
Make the production environment depend on the AKS deployment jobs.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
