### PR TITLE
489 add monitoring staging aks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,9 +225,11 @@ print-infra-secrets: read-keyvault-config install-fetch-config
 	bin/fetch_config.rb -s azure-key-vault-secret:${key_vault_name}/${key_vault_infra_secret_name} \
 		-f yaml
 
-console:
+console: # make qa console OR make qa console WORKER=1 to connect to the worker app
+	$(if $(WORKER),$(eval export WORKER_NAME=worker-), )
 	cf target -s ${space}
-	cf ssh publish-teacher-training-${paas_env} -t -c "cd /app && /usr/local/bin/bundle exec rails c"
+	echo "service name: publish-teacher-training-${WORKER_NAME}${paas_env}"
+	cf ssh publish-teacher-training-${WORKER_NAME}${paas_env} -t -c "cd /app && /usr/local/bin/bundle exec rails c"
 
 get-cluster-credentials: read-cluster-config set-azure-account ## make <config> get-cluster-credentials [ENVIRONMENT=<clusterX>]
 	az aks get-credentials --overwrite-existing -g ${RESOURCE_NAME_PREFIX}-tsc-${CLUSTER_SHORT}-rg -n ${RESOURCE_NAME_PREFIX}-tsc-${CLUSTER}-aks

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -23,5 +23,5 @@
     "staging2.find-postgraduate-teacher-training.service.gov.uk",
     "staging2.api.publish-teacher-training-courses.service.gov.uk"
   ],
-  "enable_monitoring": false
+  "enable_monitoring": true
 }


### PR DESCRIPTION
### Context

Add monitoring resources to the AKS staging environment

### Changes proposed in this pull request

- Enable alerting for the `staging_aks` environment
- Add a target to connect to the worker app console

### Guidance to review

`make staging_aks action-group-resources ACTION_GROUP_EMAIL=firstname.lastname@domain.com` to deploy the resource group and action group resources to support the monitoring resources
`make staging_aks deploy IMAGE_TAG=current_image_tag` to see the plan of the monitoring resources that will be deployed
`make staging console WORKER=1` to connect to the worker app and check queues even when the main web app is stopped

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
