### PR TITLE
[504] Prepare front door, DNS for staging AKS migration

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
@@ -3,7 +3,11 @@
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
+      "exclude_cnames": [
+        "staging"
+      ],
       "domains": [
+        "staging",
         "staging2"
       ],
       "cached_paths": [
@@ -23,7 +27,7 @@
         },
         "staging": {
           "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_48d5780dfc0f00802dbda96478d1f21a.staging": {
           "target": "_3393a8bc155665a9a5351baf2ef27ea5.bsgbmzkfwj.acm-validations.aws",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
@@ -3,7 +3,13 @@
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",
       "resource_group_name": "s189p01-pttdomains-rg",
+      "exclude_cnames": [
+        "staging",
+        "staging.api"
+      ],
       "domains": [
+        "staging",
+        "staging.api",
         "staging2",
         "staging2.api"
       ],
@@ -17,7 +23,7 @@
       "cnames": {
         "staging.api": {
           "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_b49b689ce7f256324c817b829ea761a7.staging.api": {
           "target": "_5817e045d9461e363452fce3a7900dff.wggjkglgrm.acm-validations.aws",
@@ -25,7 +31,7 @@
         },
         "staging": {
           "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_95f70c03f017e96f692e2c424f30e1b3.staging": {
           "target": "_45adb437563b27844ca2750b0979284e.wggjkglgrm.acm-validations.aws",


### PR DESCRIPTION
### Context
This configures front door for the staging environment but crucially does not update the CNAME record.

### Changes proposed in this pull request

- Add staging to find and publish domains, and staging.api to the publish domain
- Exclude the CNAME records to ensure the live service is not impacted

### Guidance to review

- `make find staging domains-plan` 6 additions with no CNAME record
- `make publish staging domains-plan` 12 additions with no CNAME records