### PR TITLE
[504] Migrate staging env to AKS

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -360,32 +360,6 @@ jobs:
           env_url: ${{ steps.deploy_v2_review.outputs.deploy-url }}
           ref: ${{ github.head_ref }}
 
-  deploy-before-production:
-    name: Parallel deployment before production
-    environment:
-      name: ${{ matrix.environment }}
-      url: ${{ steps.deploy_app_before_production.outputs.deploy-url }}
-    if: ${{ success() && github.ref == 'refs/heads/main' }}
-    needs: [test]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        environment: [staging]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Deploy App to ${{ matrix.environment }}
-        id: deploy_app_before_production
-        uses: ./.github/actions/deploy/
-        with:
-          arm-access-key: ${{ secrets[format('ARM_ACCESS_KEY_{0}', matrix.environment)] }}
-          azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
-          environment: ${{ matrix.environment }}
-          sha: ${{ github.sha }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-
   deploy-aks-before-production:
     name: Parallel deployment before production v2
     environment:
@@ -419,7 +393,7 @@ jobs:
       name: production
       url: ${{ steps.deploy_app.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/main' }}
-    needs: [deploy-before-production,deploy-aks-before-production]
+    needs: [deploy-aks-before-production]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -110,53 +110,6 @@ jobs:
           path: backup_sanitised.sql
           retention-days: 7
 
-  restore:
-    needs: [backup]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        environment: [staging]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set KV environment variables
-        run: |
-          tf_vars_file=terraform/paas/workspace_variables/${{ matrix.environment }}.tfvars.json
-          echo "key_vault_name=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
-          echo "key_vault_infra_secret_name=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
-          echo "paas_space_name=$(jq -r '.cf_space' ${tf_vars_file})" >> $GITHUB_ENV
-
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
-
-      - uses: DFE-Digital/keyvault-yaml-secret@v1
-        id: get-secrets
-        with:
-          keyvault: ${{ env.key_vault_name }}
-          secret: ${{ env.key_vault_infra_secret_name }}
-          key: CF_USER,CF_PASSWORD
-
-      - uses: DFE-Digital/github-actions/setup-cf-cli@master
-        name: Setup cf cli
-        with:
-          CF_USERNAME: ${{ steps.get-secrets.outputs.CF_USER }}
-          CF_PASSWORD: ${{ steps.get-secrets.outputs.CF_PASSWORD  }}
-          CF_SPACE_NAME: ${{ env.paas_space_name }}
-          INSTALL_CONDUIT: true
-
-      - name: Download Sanitised Backup
-        uses: actions/download-artifact@v3
-        with:
-          name: backup_sanitised
-
-      - name: Restore backup to ${{ matrix.environment }}
-        run: cf conduit ${POSTGRES_SERVICE_INSTANCE} -- psql < backup_sanitised.sql
-        env:
-          POSTGRES_SERVICE_INSTANCE: publish-teacher-training-postgres-${{ matrix.environment }}
-
   restore-aks:
     needs: [backup]
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ on:
         required: true
         type: choice
         options:
-        - staging
         - production
         - sandbox
         - loadtest

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,13 +3,12 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'The environment to run tests against (staging, production, sandbox or review)'
-        default: staging
+        description: 'The environment to run tests against (production, sandbox or review)'
+        default: sandbox
         required: true
         type: choice
         options:
         - review
-        - staging
         - production
         - sandbox
       pr:

--- a/config/settings/staging_aks.yml
+++ b/config/settings/staging_aks.yml
@@ -1,14 +1,14 @@
 gcp_api_key: please_change_me
-publish_api_url: https://staging2.api.publish-teacher-training-courses.service.gov.uk
-publish_url: https://staging2.publish-teacher-training-courses.service.gov.uk
-find_url: https://staging2.find-postgraduate-teacher-training.service.gov.uk
+publish_api_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
+publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
+find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:
-  base_url: https://staging2.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 
 # URL of this app for the callback after sigining in
-base_url: https://staging2.publish-teacher-training-courses.service.gov.uk
+base_url: https://staging.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://pp-oidc.signin.education.gov.uk
@@ -26,7 +26,7 @@ environment:
   name: "staging"
 
 features:
-  send_request_data_to_bigquery: false
+  send_request_data_to_bigquery: true
 
 find_valid_referers:
-  - https://staging2.find-postgraduate-teacher-training.service.gov.uk
+  - https://staging.find-postgraduate-teacher-training.service.gov.uk

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -19,9 +19,9 @@
   },
   "enable_find": true,
   "additional_hostnames": [
-    "staging2.publish-teacher-training-courses.service.gov.uk",
-    "staging2.find-postgraduate-teacher-training.service.gov.uk",
-    "staging2.api.publish-teacher-training-courses.service.gov.uk"
+    "staging.publish-teacher-training-courses.service.gov.uk",
+    "staging.find-postgraduate-teacher-training.service.gov.uk",
+    "staging.api.publish-teacher-training-courses.service.gov.uk"
   ],
   "enable_monitoring": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
@@ -3,9 +3,6 @@
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
-      "exclude_cnames": [
-        "staging"
-      ],
       "domains": [
         "staging",
         "staging2"
@@ -24,10 +21,6 @@
         "_cdbda462948c3cb8ed45d63692a7ed85.staging-assets": {
           "target": "_178a0720a90428ab7b6a1cdd99c9d80c.tjxrvlrcqj.acm-validations.aws",
           "ttl": 86400
-        },
-        "staging": {
-          "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 60
         },
         "_48d5780dfc0f00802dbda96478d1f21a.staging": {
           "target": "_3393a8bc155665a9a5351baf2ef27ea5.bsgbmzkfwj.acm-validations.aws",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
@@ -3,10 +3,6 @@
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",
       "resource_group_name": "s189p01-pttdomains-rg",
-      "exclude_cnames": [
-        "staging",
-        "staging.api"
-      ],
       "domains": [
         "staging",
         "staging.api",
@@ -21,17 +17,9 @@
       "origin_hostname": "publish-staging.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
-        "staging.api": {
-          "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 60
-        },
         "_b49b689ce7f256324c817b829ea761a7.staging.api": {
           "target": "_5817e045d9461e363452fce3a7900dff.wggjkglgrm.acm-validations.aws",
           "ttl": 86400
-        },
-        "staging": {
-          "target": "d192luriw5sv7r.cloudfront.net",
-          "ttl": 60
         },
         "_95f70c03f017e96f692e2c424f30e1b3.staging": {
           "target": "_45adb437563b27844ca2750b0979284e.wggjkglgrm.acm-validations.aws",


### PR DESCRIPTION
### Context
Change required to migrate staging from GOV.UK PaaS to the Teacher Services Cloud AKS platform.

This builds an image where the staging AKS environment uses the proper staging domains and includes the DNS changes to point staging (for find and publish) and staging API (for publish) to the new AKS environment.

### Changes proposed in this pull request

- Removal of staging input and jobs from various GitHub action workflows and actions.
- Update the staging_aks environment configuration to use the staging domain. Previously staging2.
- Remove the existing CNAME records that are used by the GOV.UK PaaS environment
- Add the CNAME record for staging, staging API to point to the previously provisioned front door endpoint. This may fail first time unless the existing CNAME deletion happens quickly enough

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
