### PR TITLE
Fix incomplete accredited provider preview link

### DIFF
--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -25,6 +25,10 @@ module CoursePreview
       FeatureService.enabled?(:course_preview_missing_information) && is_preview
     end
 
+    def accrediting_provider_present?(course)
+      course.provider.accredited_providers.include?(course.accrediting_provider)
+    end
+
     private
 
     def about_course_link = about_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
@@ -36,9 +40,14 @@ module CoursePreview
     def train_with_us_link = "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)}#train-with-us"
 
     def about_accrediting_provider_link
-      return "#{edit_publish_provider_recruitment_cycle_accredited_provider_path(provider_code, recruitment_cycle_year, accredited_provider_code: @course.accredited_provider_code, goto_preview: true)}#accredited-provider-form-description-field" if FeatureService.enabled?(:accredited_provider_search)
-
-      "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)}#accrediting-provider-#{accrediting_provider.provider_code}"
+      if FeatureService.enabled?(:accredited_provider_search) && accrediting_provider_present?(course)
+        "#{edit_publish_provider_recruitment_cycle_accredited_provider_path(provider_code, recruitment_cycle_year, accredited_provider_code: @course.accredited_provider_code, goto_preview: true)}#accredited-provider-form-description-field"
+      elsif FeatureService.enabled?(:accredited_provider_search) && !accrediting_provider_present?(course)
+        publish_provider_recruitment_cycle_accredited_providers_path(provider_code,
+                                                                     recruitment_cycle_year)
+      else
+        "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)}#accrediting-provider-#{accrediting_provider.provider_code}"
+      end
     end
   end
 end

--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -35,18 +35,18 @@ module CoursePreview
     def degree_link = degrees_start_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
     def fee_uk_eu_link = fees_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
     def gcse_link = gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
-    def how_school_placements_work_link = "#{about_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)}#how-school-placements-work"
-    def train_with_disability_link = "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)}#train-with-disability"
-    def train_with_us_link = "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)}#train-with-us"
+    def how_school_placements_work_link = about_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true, anchor: 'how-school-placements-work')
+    def train_with_disability_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true, anchor: 'train-with-disability')
+    def train_with_us_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true, anchor: 'train-with-us')
 
     def about_accrediting_provider_link
       if FeatureService.enabled?(:accredited_provider_search) && accrediting_provider_present?(course)
-        "#{edit_publish_provider_recruitment_cycle_accredited_provider_path(provider_code, recruitment_cycle_year, accredited_provider_code: @course.accredited_provider_code, goto_preview: true)}#accredited-provider-form-description-field"
+        edit_publish_provider_recruitment_cycle_accredited_provider_path(provider_code, recruitment_cycle_year, accredited_provider_code: @course.accredited_provider_code, goto_preview: true, anchor: 'accredited-provider-form-description-field')
       elsif FeatureService.enabled?(:accredited_provider_search) && !accrediting_provider_present?(course)
         publish_provider_recruitment_cycle_accredited_providers_path(provider_code,
                                                                      recruitment_cycle_year)
       else
-        "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)}#accrediting-provider-#{accrediting_provider.provider_code}"
+        about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true, anchor: "accrediting-provider-#{accrediting_provider.provider_code}")
       end
     end
   end

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -31,7 +31,8 @@ module CoursePreview
           train_with_us:
         "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)}#train-with-us",
           about_accrediting_provider:
-        "#{edit_publish_provider_recruitment_cycle_accredited_provider_path(provider_code, recruitment_cycle_year, accredited_provider_code: course.accredited_provider_code, goto_preview: true)}#accredited-provider-form-description-field"
+          publish_provider_recruitment_cycle_accredited_providers_path(provider_code,
+                                                                       recruitment_cycle_year)
         }
       end
 


### PR DESCRIPTION
### Context

The incomplete accredited provider preview link was trying to take the user to the edit page of a non existing accredited provider. If the accredited provider does not exist under the AP tab, we should redirect them to add an AP.

<img width="519" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/4c11d44d-baae-4518-b141-2081e0caba4e">


This is a temporary fix until we resolve our data rot.

### Changes proposed in this pull request

Redirect the user to the add accredited provider journey if the accredited provider doesn't exist under the accredited provider tab.

### Guidance to review

- Click the link (as seen in the screenshot above): https://publish-review-3746.test.teacherservices.cloud/publish/organisations/2BY/2024/courses/2XNN/preview

- Should the content of the link be updated to reflect that we are now taking them on an "Add accredited provider" journey?
