### PR TITLE
Invalidate incomplete course on publish

### DIFF
--- a/app/components/accredited_provider.html.erb
+++ b/app/components/accredited_provider.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_summary_card(title: provider_name) do |card|
-      card.with_action { govuk_link_to("Remove", remove_path, class: "app-link--destructive govuk-!-font-weight-regular") }
+      card.with_action { govuk_link_to("Remove", remove_path, class: "app-link--destructive govuk-!-font-weight-regular", data: { qa: "remove-link" }) }
       card.with_summary_list(rows: [{ key: { text: "About the accredited provider" },
                                       value: { text: about_accredited_provider },
                                       actions: [{ href: change_about_accredited_provider_path }] }])

--- a/app/controllers/publish/courses/accredited_provider_controller.rb
+++ b/app/controllers/publish/courses/accredited_provider_controller.rb
@@ -50,11 +50,13 @@ module Publish
 
       def update
         build_provider
-        code = update_course_params[:accredited_provider_code]
-        query = update_course_params[:accredited_provider]
-
-        @errors = errors_for_search_query(code, query)
-        return render :edit if @errors.present?
+        begin
+          code = update_course_params[:accredited_provider_code]
+          query = update_course_params[:accredited_provider]
+        rescue ActionController::ParameterMissing
+          @errors = errors_for_search_query(code, query)
+          return render :edit if @errors.present?
+        end
 
         if update_params[:accredited_provider_code] == 'other'
           redirect_to_provider_search

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -61,7 +61,8 @@ module ViewHelper
         required_qualifications: "#{base}/requirements?display_errors=true#required_qualifications_wrapper",
         age_range_in_years: "#{base}/age-range?display_errors=true",
         sites: "#{base}/schools?display_errors=true",
-        study_sites: (course.provider&.study_sites&.none? ? "#{provider_base}/study-sites" : "#{base}/study-sites").to_s
+        study_sites: (course.provider&.study_sites&.none? ? "#{provider_base}/study-sites" : "#{base}/study-sites").to_s,
+        accrediting_provider: accredited_provider_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)
       }.with_indifferent_access[field]
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -322,6 +322,7 @@ class Course < ApplicationRecord
   validates :sites, presence: true, on: %i[publish new]
   validates :study_sites, presence: true, on: %i[publish new], if: -> { recruitment_cycle_after_2023? }
   validates :subjects, presence: true, on: :publish
+  validates :accrediting_provider, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish
   validate :validate_provider_visa_sponsorship_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -327,6 +327,7 @@ class Course < ApplicationRecord
   validate :validate_site_statuses_publishable, on: :publish
   validate :validate_provider_visa_sponsorship_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }
   validate :validate_provider_urn_ukprn_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }
+  validate :validate_accredited_provider_is_accredited, on: :publish
   validate :validate_degree_requirements_publishable, on: :publish
   validate :validate_gcse_requirements_publishable, on: :publish
   validate :validate_enrichment
@@ -902,6 +903,12 @@ class Course < ApplicationRecord
 
     latest_enrichment.valid?
     add_enrichment_errors(latest_enrichment)
+  end
+
+  def validate_accredited_provider_is_accredited
+    return if accrediting_provider.blank?
+
+    accrediting_provider.accredited? || errors.add(:accrediting_provider, :is_not_accredited)
   end
 
   def validate_enrichment_publishable

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -69,6 +69,7 @@ class Provider < ApplicationRecord
   end
 
   alias accrediting_providers accredited_providers
+  alias accredited? accredited_provider?
 
   delegate :year, to: :recruitment_cycle, prefix: true
 

--- a/app/views/publish/courses/accredited_provider/edit.html.erb
+++ b/app/views/publish/courses/accredited_provider/edit.html.erb
@@ -25,6 +25,11 @@
         </div>
 
         <%= form.submit "Update accredited provider", class: "govuk-button govuk-!-margin-top-5", data: { qa: "course__save" } %>
+        <%= govuk_button_link_to(
+          "Add accredited provider",
+          publish_provider_recruitment_cycle_accredited_providers_path(course.provider_code, course.recruitment_cycle_year),
+          class: "govuk-!-margin-bottom-6 govuk-!-margin-top-5 govuk-button--secondary"
+        ) %>
       <% end %>
 
       <p class="govuk-body">

--- a/app/views/publish/providers/accredited_providers/index.html.erb
+++ b/app/views/publish/providers/accredited_providers/index.html.erb
@@ -9,7 +9,7 @@
     <%= govuk_button_link_to("Add accredited provider", search_publish_provider_recruitment_cycle_accredited_providers_path(
       provider_code: @provider.provider_code,
       recruitment_cycle_year: @provider.recruitment_cycle_year
-    )) %>
+    ), data: { qa: "add-accredited-provider-link" }) %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -499,6 +499,7 @@ en:
               blank: "^Select an applications open date"
             accrediting_provider:
               blank: "Select an accrediting provider"
+              is_not_accredited: "The assigned accrediting provider is not accredited"
             base:
               duplicate: "This course already exists. You should add further schools for this course to the existing profile in Publish"
               visa_sponsorship_not_publishable: "Select if visas can be sponsored"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -499,7 +499,7 @@ en:
               blank: "^Select an applications open date"
             accrediting_provider:
               blank: "Select an accrediting provider"
-              is_not_accredited: "The assigned accrediting provider is not accredited"
+              is_not_accredited: "Update the accredited provider (it's no longer accredited)"
             base:
               duplicate: "This course already exists. You should add further schools for this course to the existing profile in Publish"
               visa_sponsorship_not_publishable: "Select if visas can be sponsored"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -497,6 +497,8 @@ en:
               blank: "^Select a study mode"
             applications_open_from:
               blank: "^Select an applications open date"
+            accrediting_provider:
+              blank: "Select an accrediting provider"
             base:
               duplicate: "This course already exists. You should add further schools for this course to the existing profile in Publish"
               visa_sponsorship_not_publishable: "Select if visas can be sponsored"

--- a/spec/controllers/publish/courses_controller_spec.rb
+++ b/spec/controllers/publish/courses_controller_spec.rb
@@ -11,6 +11,7 @@ module Publish
       create(
         :course,
         :with_gcse_equivalency,
+        :with_accrediting_provider,
         enrichments: [build(:course_enrichment, :initial_draft)],
         sites: [create(:site, location_name: 'location 1')],
         study_sites: [create(:site, :study_site)],

--- a/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Publishing a course when course accrediting provider is invalid', { can_edit_current_and_next_cycles: false } do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario 'Add accrediting provider to provider and provider has no accrediting providers, change accrediting provider of course then publish' do
+    and_the_provider_has_no_accredited_provider
+    and_there_is_a_draft_course_with_an_unaccredited_provider
+
+    # Publising is invalid
+    when_i_visit_the_course_page
+    and_i_click_the_publish_button
+    then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
+
+    # Add accrediting provider to provider
+    when_i_click_the_error_message_link
+    then_it_takes_me_to_the_accredited_providers_page
+    when_i_click_add_an_accredited_provider
+    and_i_click_to_add_new_accredited_provider
+    and_i_search_for_an_accredited_provider
+    and_i_fill_in_the_accredited_provider_form
+    and_i_confirm_creation_of_the_accredited_provider
+    then_i_see_that_the_accredited_provider_has_been_added
+
+    # Publishing is invalid
+    when_i_visit_the_course_page
+    and_i_click_the_publish_button
+    then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
+
+    # Clicking error message allows user to select accrediting provider
+    when_i_click_the_error_message_link
+    and_i_choose_the_new_accredited_provider
+    and_i_click_the_publish_button
+    then_i_should_see_a_success_message
+  end
+
+  scenario 'Select valid accrediting provider to course and publish' do
+    and_the_provider_has_a_valid_accrediting_provider
+    and_there_is_a_draft_course_without_accrediting_provider
+    and_an_accredited_provider_exists
+
+    # Publising is invalid
+    when_i_visit_the_course_page
+    and_i_click_the_publish_button
+    then_i_should_see_an_error_message_for_the_accrediting_provider
+
+    # Clicking error message allows user to select accrediting provider
+    when_i_click_the_select_accredited_provider_error_message_link
+    and_i_choose_the_new_accredited_provider
+    and_i_click_the_publish_button
+    then_i_should_see_a_success_message
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    @user = create(:user, :with_provider)
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_the_provider_has_a_valid_accrediting_provider
+    enrichment = AccreditingProviderEnrichment.new(
+      UcasProviderCode: accredited_provider.provider_code,
+      Description: ''
+    )
+    provider = @user.providers.first
+    provider.update!(accrediting_provider_enrichments: [enrichment])
+  end
+
+  def and_the_provider_has_no_accredited_provider
+    expect(provider.accredited_providers).to be_empty
+  end
+
+  def and_there_is_a_draft_course_without_accrediting_provider
+    given_a_course_exists(
+      :with_gcse_equivalency,
+      enrichments: [create(:course_enrichment, :initial_draft)],
+      sites: [create(:site, location_name: 'location 1')],
+      study_sites: [create(:site, :study_site)]
+    )
+  end
+
+  def and_there_is_a_draft_course_with_an_unaccredited_provider
+    given_a_course_exists(
+      :with_gcse_equivalency,
+      accrediting_provider: provider,
+      enrichments: [create(:course_enrichment, :initial_draft)],
+      sites: [create(:site, location_name: 'location 1')],
+      study_sites: [create(:site, :study_site)]
+    )
+  end
+
+  def when_i_visit_the_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      course_code: course.course_code
+    )
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content('Your course has been published.')
+  end
+
+  def then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
+    expect(publish_provider_courses_show_page.error_messages).to include("Update the accredited provider (it's no longer accredited)")
+  end
+
+  def then_i_should_see_an_error_message_for_the_accrediting_provider
+    expect(publish_provider_courses_show_page.error_messages).to include('Select an accrediting provider')
+  end
+
+  def when_i_click_the_error_message_link
+    publish_provider_courses_show_page.errors.first.link.click
+  end
+
+  def then_it_takes_me_to_the_accredited_providers_page
+    expect(publish_courses_accredited_providers_page).to be_displayed
+  end
+
+  def when_i_click_add_an_accredited_provider
+    publish_courses_accredited_providers_page.add_new_button.click
+    expect(publish_provider_accredited_providers_index_page).to be_displayed
+  end
+
+  def and_i_click_to_add_new_accredited_provider
+    publish_provider_accredited_providers_index_page.add_new_link.click
+    expect(publish_provider_accredited_providers_search_page).to be_displayed
+    # expect(page).to have_current_path(%r{accredited-providers/search})
+  end
+
+  def and_i_search_for_an_accredited_provider
+    publish_provider_accredited_providers_search_page.search_input.set(accredited_provider.provider_name)
+    publish_provider_accredited_providers_search_page.continue_button.click
+    choose accredited_provider.name_and_code
+    publish_provider_accredited_providers_search_page.continue_button.click
+  end
+
+  def and_i_fill_in_the_accredited_provider_form
+    publish_courses_new_accredited_provider_page.about_section_input.set('About course')
+
+    publish_courses_new_accredited_provider_page.submit.click
+  end
+
+  def and_i_confirm_creation_of_the_accredited_provider
+    publish_courses_new_accredited_provider_page.submit.click
+  end
+
+  def then_i_see_that_the_accredited_provider_has_been_added
+    expect(page).to have_content('Accredited provider added')
+  end
+
+  def and_i_click_the_publish_button
+    publish_provider_courses_show_page.publish_button.click
+  end
+
+  def when_i_click_the_select_accredited_provider_error_message_link
+    page.click_on('Select an accrediting provider')
+  end
+
+  def and_i_choose_the_new_accredited_provider
+    choose accredited_provider.provider_name
+    page.click_on('Update accredited provider')
+    expect(page).to have_content('Accredited provider updated')
+  end
+
+  def and_an_accredited_provider_exists
+    accredited_provider
+  end
+
+  def accredited_provider
+    @accredited_provider ||= create(:provider, :accredited_provider)
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -56,6 +56,7 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
   def and_there_is_a_course_i_want_to_publish
     given_a_course_exists(
       :with_gcse_equivalency,
+      :with_accrediting_provider,
       enrichments: [create(:course_enrichment, :initial_draft)],
       sites: [create(:site, location_name: 'location 1')],
       study_sites: [create(:site, :study_site)]
@@ -64,6 +65,7 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
 
   def and_there_is_a_draft_course
     given_a_course_exists(
+      :with_accrediting_provider,
       enrichments: [create(:course_enrichment, :initial_draft)],
       sites: [create(:site, location_name: 'location 1')],
       study_sites: [create(:site, :study_site)]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,8 +10,8 @@ describe ApplicationHelper do
   describe '#enrichment_error_link' do
     context 'with a course' do
       before do
-        @provider = Provider.new(build(:provider).attributes)
-        @course = Course.new(build(:course).attributes)
+        @provider = build(:provider)
+        @course = build(:course, provider: @provider)
       end
 
       it 'returns correct content' do
@@ -42,8 +42,8 @@ describe ApplicationHelper do
       let(:error_message) { 'Enter something about the course' }
 
       before do
-        @provider = Provider.new(build(:provider).attributes)
-        @course = Course.new(build(:course).attributes)
+        @provider = build_stubbed(:provider)
+        @course = build_stubbed(:course, provider: @provider)
         @errors = { about_course: [error_message] }
 
         enrichment_summary(summary_list, :course, 'About course', '', [:about_course])

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -11,7 +11,32 @@ describe Course do
     let(:study_site) { create(:site, :study_site) }
     let(:site_status) { create(:site_status, :new_status, site:) }
 
-    its(:publishable?) { is_expected.to be_falsey }
+    # TODO: Individual scenarios should test all possible errors
+    it 'adds all unpublishable error messages' do
+      expect(course).not_to be_publishable
+      expect(course.errors.messages).to eq(
+        { sites: ['^Select at least one school'],
+          accrediting_provider: ['Select an accrediting provider'],
+          about_course: ['^Enter details about this course'],
+          how_school_placements_work: ['^Enter details about school placements'],
+          course_length: ['^Enter a course length'],
+          salary_details: ['^Enter details about the salary for this course'],
+          base: ['Enter GCSE requirements'] }
+      )
+    end
+
+    context 'when associated accredited provider is no longer accredited' do
+      let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
+      let(:primary_with_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
+      let(:course) do
+        create(:course, :with_gcse_equivalency, :with_accrediting_provider, :self_accredited, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status], study_sites: [study_site])
+      end
+
+      it 'is not publishable' do
+        course.accrediting_provider.not_an_accredited_provider!
+        expect(course).not_to be_publishable
+      end
+    end
 
     context 'with enrichment' do
       let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -17,7 +17,7 @@ describe Course do
       let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
       let(:primary_with_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
       let(:course) do
-        create(:course, :with_gcse_equivalency, :self_accredited, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status], study_sites: [study_site])
+        create(:course, :with_gcse_equivalency, :with_accrediting_provider, :self_accredited, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status], study_sites: [study_site])
       end
 
       its(:publishable?) { is_expected.to be_truthy }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -942,4 +942,22 @@ describe Provider do
       expect(provider.study_sites).to match([study_site])
     end
   end
+
+  describe '#accredited?' do
+    context 'for an accredited provider' do
+      let(:provider) { create(:provider, :accredited_provider) }
+
+      it 'returns true' do
+        expect(provider).to be_accredited
+      end
+    end
+
+    context 'for an unaccredited provider' do
+      let(:provider) { create(:provider) }
+
+      it 'returns false' do
+        expect(provider).not_to be_accredited
+      end
+    end
+  end
 end

--- a/spec/support/page_objects/publish/courses/accredited_providers.rb
+++ b/spec/support/page_objects/publish/courses/accredited_providers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    module Courses
+      class AccreditedProviders < PageObjects::Base
+        set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/accredited-provider'
+
+        elements :suggested_accredited_bodies, '[data-qa="course__accredited_provider_option"]'
+        element :add_new_button, '.govuk-button--secondary'
+
+        element :update_button, 'input[type=submit]'
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/courses/new_accredited_provider.rb
+++ b/spec/support/page_objects/publish/courses/new_accredited_provider.rb
@@ -9,6 +9,8 @@ module PageObjects
         elements :suggested_accredited_bodies, '[data-qa="course__accredited_provider_option"]'
 
         element :continue, '[data-qa="course__save"]'
+        element :about_section_input, 'textarea'
+        element :submit, 'button[type="submit"]'
       end
     end
   end

--- a/spec/support/page_objects/publish/provider_accredited_providers_index.rb
+++ b/spec/support/page_objects/publish/provider_accredited_providers_index.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class ProviderAccreditedProvidersIndex < PageObjects::Base
+      set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/accredited-providers'
+
+      element :add_new_link, '[data-qa="add-accredited-provider-link"]'
+      elements :remove, '[data-qa="remove-link"]'
+    end
+  end
+end

--- a/spec/support/page_objects/publish/provider_accredited_providers_search.rb
+++ b/spec/support/page_objects/publish/provider_accredited_providers_search.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class ProviderAccreditedProvidersSearch < PageObjects::Base
+      set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/accredited-providers/search'
+
+      element :search_input, '#accredited-provider-search-form-query-field'
+      element :submit, 'input[type=submit]'
+      element :continue_button, 'button[type=submit]'
+      elements :choices, 'input[type=radio]'
+    end
+  end
+end

--- a/spec/support/page_objects/publish/provider_courses_show.rb
+++ b/spec/support/page_objects/publish/provider_courses_show.rb
@@ -30,6 +30,7 @@ module PageObjects
       element :basic_details_link, 'a.govuk-link.govuk-tabs__tab', text: 'Basic details'
       element :content_status, '[data-qa="course__content-status"]'
       element :rolled_over_course_link, '[data-qa="course__rolled-over-link"]'
+      element :publish_button, 'button[type=submit]'
 
       def error_messages
         errors.map(&:text)


### PR DESCRIPTION
### Trello
[Validate a course has an accrediting provider](https://trello.com/c/Ox93dbSJ/393-itt-reform-prevent-publication-of-an-incomplete-course)
[Users can add accredited provider to their account when selecting an accredited provider for a course](https://trello.com/c/YsMU17Nu/404-when-publish-users-click-change-links-for-study-site-or-accredited-provider-in-course-description-and-they-only-have-1-surface-a)

### Review App

**Course's accredited provider is no longer accredited.**
https://publish-review-3747.test.teacherservices.cloud/publish/organisations/1JE/2024/courses/3FNB
**Course has no accredited provider associated**
https://publish-review-3747.test.teacherservices.cloud/publish/organisations/1JE/2024/courses/2B76 (edited) 

### Context

When a course is published, the course must:
 - have an accrediting provider associated. 
 - the accrediting provider must be validated as accredited

1. When the accrediting provider doesn't exist, we direct the user to choose an accredited provider from the providers that are associated with the courses training provider.
2. When the associated accrediting provider is not in fact accredited, we direct the user to add a new accredited provider to
their provider account. This is based on the assumption that a provider will likely need to do this.

### Changes proposed in this pull request
Add validations to the Course model to ensure that the Accrediting Provider is in a valid state for :publish

### Guidance to review

The PR only focuses on publishing a course. Some of the dependent data states offer problems. This PR does not address the fact that a training provider may be associated with accredited providers that are no longer accredited. Publishing a course assumes the accredited providers associated with the training provider are valid and correct. The course will not publish with an invalid accredited provider but the user **_can_** assign an unaccredited provider as the courses accredited provider.

I believe the `enrichment_error_url` method needs refactoring, along with many of the `ViewHelper` methods.


### UPDATE

Added [Users can add accredited provider to their account when selecting an accredited provider for a course](https://trello.com/c/YsMU17Nu/404-when-publish-users-click-change-links-for-study-site-or-accredited-provider-in-course-description-and-they-only-have-1-surface-a) ticket into this PR out of necesity.

1. When publishing a course, and the course has no accrediting provider
2. And the training provider has no accredited providers
3. Then we need to fix both these issues.

We cannot assign an accrediting provider to the course until we add an accredited provider to the training provider.

Error messages that appear:

-   if the course has an accredited provider but it is not accredited, we prompt the user to "**Update the accredited provider (it's no longer accredited)**"
-   if the course has no accredited provider we "**Select an accredited provider**"

Both these errors link to the same page. The Choose an accredited provider from the list of accredited providers associated with the training provider.

This list could be empty.

In any case, there is a link that allows the training provider to add a new accredited provider to their account. After doing this they will be able to choose a valid accredited provider.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
