### PR TITLE
[392] Enable reclassified providers to add AP's

### DIFF
--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -173,9 +173,17 @@
         row.with_value { course.accrediting_provider&.provider_name }
         if course.is_published? || course.is_withdrawn?
           row.with_action
-        elsif FeatureService.enabled?(:accredited_provider_search) && @provider.accredited_providers.size > 1
+        elsif !course.accrediting_provider.nil?
           row.with_action(href: accredited_provider_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                           visually_hidden_text: "accredited provider")
+        elsif @provider.accredited_providers.any?
+          row.with_value do
+            "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Select an accredited provider', accredited_provider_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code))}</div>".html_safe
+          end
+        else
+          row.with_value do
+            "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Add at least one accredited provider', publish_provider_recruitment_cycle_accredited_providers_path(@course.provider_code, @course.recruitment_cycle_year))}</div>".html_safe
+          end
         end
       end
     end

--- a/spec/features/publish/courses/adding_an_accredited_provider_to_an_existing_course_spec.rb
+++ b/spec/features/publish/courses/adding_an_accredited_provider_to_an_existing_course_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'adding an accredited provider to a an existing course', { can_edit_current_and_next_cycles: false } do
+  scenario 'adding and changing an accredited provider for an existing course without one' do
+    given_i_am_authenticated_as_a_provider_user
+    and_i_visit_the_course_details_page_of_a_course_without_an_accredited_provider
+    and_i_click_the_add_accredited_provider_link
+    and_i_create_a_new_accredited_provider
+    and_i_revisit_the_course_details_page
+    when_i_click_select_an_accredited_provider
+    and_i_choose_the_new_accredited_provider
+    then_i_should_see_the_success_message
+
+    given_i_click_change_accredited_provider
+    and_i_click_update_accredited_provider
+    then_i_should_see_the_success_message
+  end
+
+  def given_i_click_change_accredited_provider
+    click_link 'Change accredited provider'
+  end
+
+  def then_i_should_see_the_success_message
+    expect(page).to have_text('Accredited provider updated')
+  end
+
+  def and_i_click_update_accredited_provider
+    click_button 'Update accredited provider'
+  end
+
+  def and_i_choose_the_new_accredited_provider
+    choose @accredited_provider.provider_name
+    and_i_click_update_accredited_provider
+  end
+
+  def when_i_click_select_an_accredited_provider
+    click_link 'Select an accredited provider'
+  end
+
+  def and_i_create_a_new_accredited_provider
+    and_there_is_an_accredited_provider_in_the_database
+    and_i_click_add_accredited_provider
+    and_i_search_for_an_accredited_provider_with_a_valid_query
+    and_i_select_the_provider
+    and_i_input_some_information
+    and_i_click_add_accredited_provider
+  end
+
+  def and_i_select_the_provider
+    choose @accredited_provider.provider_name
+    click_continue
+  end
+
+  def and_i_input_some_information
+    fill_in 'About the accredited provider', with: 'This is a description'
+    click_continue
+  end
+
+  def and_there_is_an_accredited_provider_in_the_database
+    @accredited_provider = create(:provider, :accredited_provider, provider_name: 'UCL')
+  end
+
+  def and_i_search_for_an_accredited_provider_with_a_valid_query
+    fill_in form_title, with: @accredited_provider.provider_name
+    click_continue
+  end
+
+  def click_continue
+    click_on 'Continue'
+  end
+
+  def form_title
+    'Enter a provider name, UKPRN or postcode'
+  end
+
+  def and_i_click_the_add_accredited_provider_link
+    click_link 'Add at least one accredited provider'
+  end
+
+  def and_i_click_add_accredited_provider
+    click_on 'Add accredited provider'
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          create(:provider, sites: [build(:site)], courses: [build(:course)])
+        ]
+      )
+    )
+  end
+
+  def and_i_visit_the_course_details_page_of_a_course_without_an_accredited_provider
+    publish_provider_courses_details_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
+  end
+
+  alias_method :and_i_revisit_the_course_details_page, :and_i_visit_the_course_details_page_of_a_course_without_an_accredited_provider
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def course
+    provider.courses.first
+  end
+end

--- a/spec/features/publish/courses/adding_an_accredited_provider_to_an_unpublished_course_spec.rb
+++ b/spec/features/publish/courses/adding_an_accredited_provider_to_an_unpublished_course_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-feature 'adding an accredited provider to a an existing course', { can_edit_current_and_next_cycles: false } do
-  scenario 'adding and changing an accredited provider for an existing course without one' do
+feature 'unpublished course without accredited provider', { can_edit_current_and_next_cycles: false } do
+  scenario 'adding and changing an accredited provider' do
     given_i_am_authenticated_as_a_provider_user
     and_i_visit_the_course_details_page_of_a_course_without_an_accredited_provider
     and_i_click_the_add_accredited_provider_link


### PR DESCRIPTION
### Context

Providers which have been reclassified from an accredited provider to a non accredited provider in the new cycle have rolled over courses which do not have an accredited provider. We need to create a journey for them to add these.

### Changes proposed in this pull request

Enable reclassified providers to add accredited providers

### Screenshots

<img width="634" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/12d26102-89d8-45e0-ab85-6b7e7f4ccb7b">

<img width="631" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/3d4cd87e-34e7-482a-a7aa-65234e75992d">

<img width="644" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/47a3bd13-2ef1-4715-8a36-bdb33a853a41">


### Guidance to review

Reclassify an accredited provider to a non accredited provider using support, then navigate to that provider and try to assign an accredited provider to a course.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
