### PR TITLE
[504] Migrate sandbox to AKS

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -431,37 +431,14 @@ jobs:
           sha: ${{ github.sha }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
-  deploy-sandbox:
-    name: Sandbox deployment
-    environment:
-      name: sandbox
-      url: ${{ steps.deploy_sandbox.outputs.deploy-url }}
-    if: ${{ success() && github.ref == 'refs/heads/main' }}
-    needs: [deploy-production]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Deploy App to sandbox
-        id: deploy_sandbox
-        uses: ./.github/actions/deploy/
-        with:
-          arm-access-key: ${{ secrets.ARM_ACCESS_KEY_SANDBOX }}
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS_SANDBOX }}
-          environment: sandbox
-          sha: ${{ github.sha }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-
   deploy-aks-sandbox:
     name: Sandbox deployment v2
     environment:
       name: sandbox_aks
       url: ${{ steps.deploy_sandbox_v2.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/main' }}
-    needs: [deploy-aks-production]
+    needs: [deploy-aks-production,deploy-production]
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,6 @@ on:
         type: choice
         options:
         - production
-        - sandbox
         - loadtest
         - rollover
       sha:

--- a/.github/workflows/scheduled-aks-db-restore.yml
+++ b/.github/workflows/scheduled-aks-db-restore.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [sandbox,production]
+        environment: [production]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,14 +3,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'The environment to run tests against (production, sandbox or review)'
-        default: sandbox
+        description: 'The environment to run tests against (production or review)'
+        default: production
         required: true
         type: choice
         options:
         - review
         - production
-        - sandbox
       pr:
         description: 'The PR number if the environment is review'
         required: false

--- a/config/settings/sandbox_aks.yml
+++ b/config/settings/sandbox_aks.yml
@@ -1,7 +1,7 @@
 gcp_api_key: please_change_me
-publish_api_url: https://sandbox2.api.publish-teacher-training-courses.service.gov.uk
-publish_url: https://sandbox2.publish-teacher-training-courses.service.gov.uk
-find_url: https://sandbox2.find-postgraduate-teacher-training.service.gov.uk
+publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
+publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
+find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
 environment:
@@ -9,9 +9,9 @@ environment:
   name: "sandbox"
 
 search_ui:
-  base_url: https://sandbox2.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 
-base_url: https://sandbox2.publish-teacher-training-courses.service.gov.uk
+base_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://oidc.signin.education.gov.uk
@@ -20,4 +20,4 @@ dfe_signin:
   user_search_url: https://support.signin.education.gov.uk/users
 
 find_valid_referers:
-  - https://sandbox2.find-postgraduate-teacher-training.service.gov.uk
+  - https://sandbox.find-postgraduate-teacher-training.service.gov.uk

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -18,9 +18,9 @@
   },
   "enable_find": true,
   "additional_hostnames": [
-    "sandbox2.publish-teacher-training-courses.service.gov.uk",
-    "sandbox2.find-postgraduate-teacher-training.service.gov.uk",
-    "sandbox2.api.publish-teacher-training-courses.service.gov.uk"
+    "sandbox.publish-teacher-training-courses.service.gov.uk",
+    "sandbox.find-postgraduate-teacher-training.service.gov.uk",
+    "sandbox.api.publish-teacher-training-courses.service.gov.uk"
   ],
   "enable_monitoring": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
@@ -3,9 +3,6 @@
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
-      "exclude_cnames": [
-        "sandbox"
-      ],
       "domains": [
         "sandbox",
         "sandbox2"
@@ -24,10 +21,6 @@
         "_22a0e2097a2b837d2ef2ce075b5942c9.sandbox-assets": {
           "target": "_26726e941fc8a9ae7eba93d7351c0a15.tjxrvlrcqj.acm-validations.aws",
           "ttl": 86400
-        },
-        "sandbox": {
-          "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 60
         },
         "_09cba63498801fac38cb744aeba235f0.sandbox": {
           "target": "_7158ce184053826b11bad77bddba8327.vtqfhvjlcp.acm-validations.aws",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
@@ -3,10 +3,6 @@
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",
       "resource_group_name": "s189p01-pttdomains-rg",
-      "exclude_cnames": [
-        "sandbox",
-        "sandbox.api"
-      ],
       "domains": [
         "sandbox",
         "sandbox.api",
@@ -21,17 +17,9 @@
       "origin_hostname": "publish-sandbox.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
-        "sandbox.api": {
-          "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 60
-        },
         "_25e39480c6c7a3d6c2777b12e18c43fe.sandbox.api": {
           "target": "_d4ca59408d3adc72a29610041ec348ed.vtqfhvjlcp.acm-validations.aws",
           "ttl": 86400
-        },
-        "sandbox": {
-          "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 60
         },
         "_4bd923eed7432e9fc1e6e05bcc7a29ec.sandbox": {
           "target": "_05fee2160f7973c172583369506577f3.vtqfhvjlcp.acm-validations.aws",


### PR DESCRIPTION
### Context
Change required to migrate sandbox from GOV.UK PaaS to the Teacher Services Cloud AKS platform.

This builds an image where the sandbox AKS environment uses the proper sandbox domains and includes the DNS changes to point sandbox (for find and publish) and sandbox API (for publish) to the new AKS environment.

### Changes proposed in this pull request

- Removal of sandbox input and jobs from various GitHub action workflows and actions.
- Update the sandbox_aks environment configuration to use the sandbox domain. Previously sandbox2.
- Remove the existing CNAME records that are used by the GOV.UK PaaS environment
- Add the CNAME record for sandbox, sandbox API to point to the previously provisioned front door endpoint. This may fail first time unless the existing CNAME deletion happens quickly enough

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
