### PR TITLE
[504] Sandbox AKS migration prep

### DIFF
--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -22,5 +22,5 @@
     "sandbox2.find-postgraduate-teacher-training.service.gov.uk",
     "sandbox2.api.publish-teacher-training-courses.service.gov.uk"
   ],
-  "enable_monitoring": false
+  "enable_monitoring": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
@@ -3,7 +3,11 @@
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
+      "exclude_cnames": [
+        "sandbox"
+      ],
       "domains": [
+        "sandbox",
         "sandbox2"
       ],
       "cached_paths": [
@@ -23,7 +27,7 @@
         },
         "sandbox": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_09cba63498801fac38cb744aeba235f0.sandbox": {
           "target": "_7158ce184053826b11bad77bddba8327.vtqfhvjlcp.acm-validations.aws",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
@@ -3,7 +3,13 @@
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",
       "resource_group_name": "s189p01-pttdomains-rg",
+      "exclude_cnames": [
+        "sandbox",
+        "sandbox.api"
+      ],
       "domains": [
+        "sandbox",
+        "sandbox.api",
         "sandbox2",
         "sandbox2.api"
       ],
@@ -17,7 +23,7 @@
       "cnames": {
         "sandbox.api": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_25e39480c6c7a3d6c2777b12e18c43fe.sandbox.api": {
           "target": "_d4ca59408d3adc72a29610041ec348ed.vtqfhvjlcp.acm-validations.aws",
@@ -25,7 +31,7 @@
         },
         "sandbox": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_4bd923eed7432e9fc1e6e05bcc7a29ec.sandbox": {
           "target": "_05fee2160f7973c172583369506577f3.vtqfhvjlcp.acm-validations.aws",


### PR DESCRIPTION
### Context

Add monitoring resources to the AKS sandbox environment and configures front door for the sandbox environment but crucially does not update the CNAME record.

### Changes proposed in this pull request

- Enable alerting for the `sandbox_aks` environment
- Add front door and certificate configuration of sandbox to find and publish domains, and sandbox.api to the publish domain
- Exclude the CNAME records to ensure the live service is not impacted
- Lower the TTL of the CNAME records for sandbox and sandbox.api across the two DNS zones

### Guidance to review

- `make sandbox_aks action-group-resources ACTION_GROUP_EMAIL=firstname.lastname@domain.com` to deploy the resource group and action group resources to support the monitoring resources
- `make sandbox_aks deploy IMAGE_TAG=current_image_tag` to see the plan of the monitoring resources that will be deployed
- `make find sandbox domains-plan`
- `make publish sandbox domains-plan`

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
