### PR TITLE
Updated tta link to reflect the fact it's hosted on Get Into Teaching now

### DIFF
--- a/app/components/find/results/results_component.html.erb
+++ b/app/components/find/results/results_component.html.erb
@@ -13,8 +13,8 @@
   <div class="app-filter-layout__content">
 
     <div class="app-promoted-link">
-      <%= govuk_link_to "Talk to teacher training providers at an event near you",
-                        t("find.get_into_teaching.url_teacher_training_events") %>.
+      <%= govuk_link_to "Get free one-to-one support from a teacher training adviser",
+                        t("find.get_into_teaching.url_get_an_advisor") %>.
     </div>
 
     <%= render Find::Results::NoResultsComponent.new(results:) %>

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -120,16 +120,16 @@
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <h2 class="govuk-heading-m">Meet local teacher training providers</h2>
+    <h2 class="govuk-heading-m">Get free one-to-one support</h2>
 
-    <p class="govuk-body">Visit a Get Into Teaching event where you can:</p>
+    <p class="govuk-body">An experienced teacher training adviser can guide you through how to find your teacher training course and more. They can help you to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>get advice on your application</li>
-      <li>talk to existing teachers</li>
-      <li>connect with people like you who are interested in teaching</li>
+      <li>understand more about the different courses</li>
+      <li>answer questions about fees and funding</li>
+      <li>make an application for a course</li>
     </ul>
 
-    <%= govuk_link_to("Talk to teacher training providers at an event near you", t("find.get_into_teaching.url_events"), class: "govuk-body") %>.
+    <%= govuk_link_to("Find out about teacher training advisers", t("find.get_into_teaching.url_get_an_advisor"), class: "govuk-body") %>.
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1019,7 +1019,7 @@ en:
   get_into_teaching:
     tel: 0800 389 2500
     opening_times: "Monday to Friday, 8.30am to 5.30pm"
-    url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_course_support&utm_content=advisers
+    url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
     url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
     url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
     url: https://getintoteaching.education.gov.uk

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1019,8 +1019,8 @@ en:
   get_into_teaching:
     tel: 0800 389 2500
     opening_times: "Monday to Friday, 8.30am to 5.30pm"
-    url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
-    url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
+    url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_course_support&utm_content=advisers
+    url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
     url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
     url: https://getintoteaching.education.gov.uk
   google_privacy_policy_url: "https://policies.google.com/technologies/cookies?hl=en-US#types-of-cookies"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1019,7 +1019,7 @@ en:
   get_into_teaching:
     tel: 0800 389 2500
     opening_times: "Monday to Friday, 8.30am to 5.30pm"
-    url_get_an_advisor: https://adviser-getintoteaching.education.gov.uk
+    url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
     url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
     url: https://getintoteaching.education.gov.uk

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -121,8 +121,8 @@ en:
       tel: 0800 389 2500
       opening_times: "Monday to Friday, 8.30am to 5.30pm"
       url_engineers_teach_physics: https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics
-      url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
-      url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
+      url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_course_support&utm_content=advisers
+      url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
       url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
       url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training
       url_bursaries_and_scholarships: https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -121,7 +121,7 @@ en:
       tel: 0800 389 2500
       opening_times: "Monday to Friday, 8.30am to 5.30pm"
       url_engineers_teach_physics: https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics
-      url_get_an_advisor: https://adviser-getintoteaching.education.gov.uk
+      url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
       url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
       url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
       url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -121,7 +121,7 @@ en:
       tel: 0800 389 2500
       opening_times: "Monday to Friday, 8.30am to 5.30pm"
       url_engineers_teach_physics: https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics
-      url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_course_support&utm_content=advisers
+      url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
       url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
       url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
       url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training


### PR DESCRIPTION
### Context

- There are no events until September, so we can amend the CTA here.

### Changes proposed in this pull request

- Update the link to point to TTAs
- Update copy based on @gemmadallmandfe's suggestions

### Guidance to review

- Does this work?

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
