### PR TITLE
Update events links in Find as there are no events currently

### DIFF
--- a/app/components/find/results/results_component.html.erb
+++ b/app/components/find/results/results_component.html.erb
@@ -13,8 +13,8 @@
   <div class="app-filter-layout__content">
 
     <div class="app-promoted-link">
-      <%= govuk_link_to "Talk to teacher training providers at an event near you",
-                        t("find.get_into_teaching.url_teacher_training_events") %>.
+      <%= govuk_link_to "Get free support from a teacher training adviser",
+                        t("find.get_into_teaching.url_get_an_advisor") %>.
     </div>
 
     <%= render Find::Results::NoResultsComponent.new(results:) %>

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -120,16 +120,16 @@
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <h2 class="govuk-heading-m">Meet local teacher training providers</h2>
+    <h2 class="govuk-heading-m">Get free one-to-one support</h2>
 
-    <p class="govuk-body">Visit a Get Into Teaching event where you can:</p>
+    <p class="govuk-body">An experienced teacher training adviser can guide you through how to find your teacher training course and more. They can help you to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>get advice on your application</li>
-      <li>talk to existing teachers</li>
-      <li>connect with people like you who are interested in teaching</li>
+      <li>understand more about the different courses</li>
+      <li>answer questions about fees and funding</li>
+      <li>make an application for a course</li>
     </ul>
 
-    <%= govuk_link_to("Talk to teacher training providers at an event near you", t("find.get_into_teaching.url_events"), class: "govuk-body") %>.
+    <%= govuk_link_to("Find out about teacher training advisers", t("find.get_into_teaching.url_get_an_advisor"), class: "govuk-body") %>.
   </div>
 </div>

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -125,7 +125,7 @@
     <p class="govuk-body">An experienced teacher training adviser can guide you through how to find your teacher training course and more. They can:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>understand more about the different courses</li>
+      <li>help you to understand more about different courses</li>
       <li>answer questions about fees and funding</li>
       <li>support you to make an application for a course</li>
     </ul>

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -122,7 +122,7 @@
 
     <h2 class="govuk-heading-m">Get free one-to-one support</h2>
 
-    <p class="govuk-body">An experienced teacher training adviser can guide you through how to find your teacher training course and more. They can help you to:</p>
+    <p class="govuk-body">An experienced teacher training adviser can guide you through how to find your teacher training course and more. They can:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>understand more about the different courses</li>

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -127,7 +127,7 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>understand more about the different courses</li>
       <li>answer questions about fees and funding</li>
-      <li>make an application for a course</li>
+      <li>support you to make an application for a course</li>
     </ul>
 
     <%= govuk_link_to("Find out about teacher training advisers", t("find.get_into_teaching.url_get_an_advisor"), class: "govuk-body") %>.

--- a/spec/components/find/results/results_component_spec.rb
+++ b/spec/components/find/results/results_component_spec.rb
@@ -38,7 +38,7 @@ module Find
         component = render_inline(
           described_class.new(results: results_view, courses:)
         )
-        expect(component.text).to include('event near you')
+        expect(component.text).to include('teacher training adviser')
       end
     end
 
@@ -93,7 +93,7 @@ module Find
             filtered_by_location: false
           )
         end
-        expect(component.text).to include('event near you')
+        expect(component.text).to include('teacher training adviser')
       end
     end
   end


### PR DESCRIPTION
### Context

- Requests from Gemma in GIT, the links we use here currently serve no purpose

### Changes proposed in this pull request

- Updated copy
- I've made this PR such that we can revert in September

### Guidance to review

- Does this work?

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
