### PR TITLE
Remove staging 2 front door configuration

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
@@ -4,8 +4,7 @@
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
       "domains": [
-        "staging",
-        "staging2"
+        "staging"
       ],
       "cached_paths": [
         "/assets/*"

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
@@ -5,9 +5,7 @@
       "resource_group_name": "s189p01-pttdomains-rg",
       "domains": [
         "staging",
-        "staging.api",
-        "staging2",
-        "staging2.api"
+        "staging.api"
       ],
       "cached_paths": [
         "/assets/*"


### PR DESCRIPTION
### Context

We need to tidy-up the staging2 environment configuration now we have migrated from GOV.UK PaaS to AKS.

### Changes proposed in this pull request

Remove the staging2 front door and associated DNS configurations.

### Guidance to review

Already applied as we had reached our limit of front door endpoint configurations for the publish profile.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
