### PR TITLE
Fix accrediting provider error text on Course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1059,6 +1059,6 @@ class Course < ApplicationRecord
   def accredited_provider_exists_in_current_cycle
     return unless accredited_provider_code
 
-    errors.add(:base, "The Accredited provider #{accredited_provider_code} does not exist in this cycle") unless RecruitmentCycle.current.providers.find_by(provider_code: accredited_provider_code)
+    errors.add(:accrediting_provider, :does_not_exist_in_cycle, accredited_provider_code:) unless RecruitmentCycle.current.providers.find_by(provider_code: accredited_provider_code)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1059,6 +1059,6 @@ class Course < ApplicationRecord
   def accredited_provider_exists_in_current_cycle
     return unless accredited_provider_code
 
-    errors.add(:accrediting_provider, :does_not_exist_in_cycle, accredited_provider_code:) unless RecruitmentCycle.current.providers.find_by(provider_code: accredited_provider_code)
+    errors.add(:accrediting_provider, :does_not_exist_in_cycle, accredited_provider_code:) unless RecruitmentCycle.current.providers.exists?(provider_code: accredited_provider_code)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -498,8 +498,8 @@ en:
             applications_open_from:
               blank: "^Select an applications open date"
             accrediting_provider:
-              blank: "Select an accrediting provider"
-              is_not_accredited: "Update the accredited provider (it's no longer accredited)"
+              blank: "Select an accredited provider"
+              is_not_accredited: "Update the accredited provider"
             base:
               duplicate: "This course already exists. You should add further schools for this course to the existing profile in Publish"
               visa_sponsorship_not_publishable: "Select if visas can be sponsored"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -500,6 +500,7 @@ en:
             accrediting_provider:
               blank: "Select an accredited provider"
               is_not_accredited: "Update the accredited provider"
+              does_not_exist_in_cycle: "The accredited provider %{accredited_provider_code} does not exist in this cycle"
             base:
               duplicate: "This course already exists. You should add further schools for this course to the existing profile in Publish"
               visa_sponsorship_not_publishable: "Select if visas can be sponsored"

--- a/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
@@ -105,11 +105,11 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
-    expect(publish_provider_courses_show_page.error_messages).to include("Update the accredited provider (it's no longer accredited)")
+    expect(publish_provider_courses_show_page.error_messages).to include('Update the accredited provider')
   end
 
   def then_i_should_see_an_error_message_for_the_accrediting_provider
-    expect(publish_provider_courses_show_page.error_messages).to include('Select an accrediting provider')
+    expect(publish_provider_courses_show_page.error_messages).to include('Select an accredited provider')
   end
 
   def when_i_click_the_error_message_link
@@ -157,7 +157,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def when_i_click_the_select_accredited_provider_error_message_link
-    page.click_on('Select an accrediting provider')
+    page.click_on('Select an accredited provider')
   end
 
   def and_i_choose_the_new_accredited_provider

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -16,7 +16,7 @@ describe Course do
       expect(course).not_to be_publishable
       expect(course.errors.messages).to eq(
         { sites: ['^Select at least one school'],
-          accrediting_provider: ['Select an accrediting provider'],
+          accrediting_provider: ['Select an accredited provider'],
           about_course: ['^Enter details about this course'],
           how_school_placements_work: ['^Enter details about school placements'],
           course_length: ['^Enter a course length'],


### PR DESCRIPTION
### Context
Courses belong to an accredited provider. In the code, this association is labeled `accrediting_provider`. 

All references to a courses `accrediting_provider` must be phrased as `accredited` rather than accrediting in the UI.
![accrediting](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/a29ab299-caa5-494a-b8bf-6734bac92b4e)



### Changes proposed in this pull request
Rails generates error messages based on the association name. Here we alias the association attribute to `accredited` and update the key in the locale file.

Any errors related to the courses accredited provider will describe use the correct terminology by default in the error messages.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
