### PR TITLE
Remove bracketed statement in accredited provider error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -499,7 +499,7 @@ en:
               blank: "^Select an applications open date"
             accrediting_provider:
               blank: "Select an accrediting provider"
-              is_not_accredited: "Update the accredited provider (it's no longer accredited)"
+              is_not_accredited: "Update the accredited provider"
             base:
               duplicate: "This course already exists. You should add further schools for this course to the existing profile in Publish"
               visa_sponsorship_not_publishable: "Select if visas can be sponsored"

--- a/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
@@ -105,7 +105,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
-    expect(publish_provider_courses_show_page.error_messages).to include("Update the accredited provider (it's no longer accredited)")
+    expect(publish_provider_courses_show_page.error_messages).to include("Update the accredited provider")
   end
 
   def then_i_should_see_an_error_message_for_the_accrediting_provider


### PR DESCRIPTION
### Context

Small change to #3747 that I didn't want to stop merging once @JR-G had approved.

### Changes proposed in this pull request

Remove bracketed statement from a validation error.

### Guidance to review

I think I've caught the sole test for this copy.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
