### PR TITLE
Add "Add study site" button on provider study site index

### DIFF
--- a/app/views/publish/courses/study_sites/edit.html.erb
+++ b/app/views/publish/courses/study_sites/edit.html.erb
@@ -31,13 +31,15 @@
                         hint: { text: study_site.full_address } %>
           <% end %>
         <% end %>
-        <%= f.govuk_submit "Update study sites" %>
-        <%= govuk_button_link_to(
-          "Add study site",
-          publish_provider_recruitment_cycle_study_sites_path(course.provider_code, course.recruitment_cycle_year),
-          class: "govuk-!-margin-bottom-6 govuk-!-margin-top-0 govuk-button--secondary"
-        ) %>
 
+        <div class="govuk-button-group">
+          <%= f.govuk_submit "Update study sites" %>
+          <%= govuk_link_to(
+            "Add study site",
+            search_publish_provider_recruitment_cycle_study_sites_path(course.provider_code, course.recruitment_cycle_year),
+            class: "govuk-!-margin-bottom-6 govuk-!-margin-top-0"
+          ) %>
+        </div>
       <% end %>
       </div>
     </div>


### PR DESCRIPTION
### Trello
https://trello.com/c/fNfLmXTS/429-when-publish-users-click-change-links-for-study-site-in-course-description-and-they-only-have-1-surface-a-link-button-to-allow-t

### Context

At least one study site is required to be associated with a course before it can be published. Often a course will not have a  study site associated with it. 

On the screen where the provider can choose multiple study sites from the list of study sites associated with their provider account. It's likely that while choosing a study site for the course they are publishing, they will want to add a study site that does n't already associate with their provider.

### Changes proposed in this pull request
This PR adds a convenience "Add study site" button to the Course study site choice page.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
