### PR TITLE
[504] Remove sandbox2 front door configuration

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
@@ -4,8 +4,7 @@
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
       "domains": [
-        "sandbox",
-        "sandbox2"
+        "sandbox"
       ],
       "cached_paths": [
         "/assets/*"

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
@@ -5,9 +5,7 @@
       "resource_group_name": "s189p01-pttdomains-rg",
       "domains": [
         "sandbox",
-        "sandbox.api",
-        "sandbox2",
-        "sandbox2.api"
+        "sandbox.api"
       ],
       "cached_paths": [
         "/assets/*"


### PR DESCRIPTION
### Context

Ensure we have enough quota on the publish front door to prepare the production endpoints by removing the now redundant sandbox2 entries.

### Changes proposed in this pull request

Remove the sandbox2 front door configuration.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
