### PR TITLE
[504] Production AKS migration prep

### DIFF
--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -23,7 +23,7 @@
     "www3.find-postgraduate-teacher-training.service.gov.uk",
     "api3.publish-teacher-training-courses.service.gov.uk"
   ],
-  "enable_monitoring": false,
+  "enable_monitoring": true,
   "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
   "postgres_enable_high_availability": true,
   "postgres_azure_maintenance_window": {

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
@@ -3,7 +3,11 @@
     "find-postgraduate-teacher-training.service.gov.uk": {
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
+      "exclude_cnames": [
+        "www"
+      ],
       "domains": [
+        "www",
         "www3"
       ],
       "cached_paths": [
@@ -15,7 +19,7 @@
       "cnames": {
         "www": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_9357f29512431b51b0be15b92f4492ab.www": {
           "target": "_46045336ca9b4525aa640b14d88627f1.bsgbmzkfwj.acm-validations.aws",

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
@@ -3,7 +3,13 @@
     "publish-teacher-training-courses.service.gov.uk": {
       "front_door_name": "s189p01-ptt-svc-domains-fd",
       "resource_group_name": "s189p01-pttdomains-rg",
+      "exclude_cnames": [
+        "www",
+        "api"
+      ],
       "domains": [
+        "www",
+        "api",
         "www3",
         "api3"
       ],
@@ -17,7 +23,7 @@
       "cnames": {
         "api": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_a98442e9708055734d485fc16391b111.api": {
           "target": "_3ffb9473360637566c1d2e8f6b6b7bcf.hkmpvcwbzw.acm-validations.aws",
@@ -25,7 +31,7 @@
         },
         "www": {
           "target": "d3kffbwt0ldx12.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_0e49c6a807a0c6e3d46d75754d00b9ef.www": {
           "target": "_57be959e2468f1f7bc90cdd8ea3182a8.hkmpvcwbzw.acm-validations.aws",


### PR DESCRIPTION
### Context

Add monitoring resources to the AKS production environment and configure front door for the production environment but crucially does not update the CNAME record.

### Changes proposed in this pull request

- Enable alerting for the `production_aks` environment
- Add front door and certificate configuration of `www` to find and publish domains, and `api` to the publish domain
- Exclude the CNAME records to ensure the live service is not impacted
- Lower the TTL of the CNAME records for `www` and `api` across the two DNS zones

### Guidance to review

- `make production_aks action-group-resources ACTION_GROUP_EMAIL=firstname.lastname@domain.com` to deploy the resource group and action group resources to support the monitoring resources
- `make production_aks deploy IMAGE_TAG=current_image_tag` to see the plan of the monitoring resources that will be deployed
- `make find production domains-plan`
- `make publish production domains-plan`

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
