### PR TITLE
Add accredited provider button changed to link

### DIFF
--- a/app/views/publish/courses/accredited_provider/edit.html.erb
+++ b/app/views/publish/courses/accredited_provider/edit.html.erb
@@ -24,12 +24,14 @@
           <%= render partial: "provider_suggestion", collection: @provider.accredited_bodies, locals: { form: } %>
         </div>
 
-        <%= form.submit "Update accredited provider", class: "govuk-button govuk-!-margin-top-5", data: { qa: "course__save" } %>
-        <%= govuk_button_link_to(
-          "Add accredited provider",
-          publish_provider_recruitment_cycle_accredited_providers_path(course.provider_code, course.recruitment_cycle_year),
-          class: "govuk-!-margin-bottom-6 govuk-!-margin-top-5 govuk-button--secondary"
-        ) %>
+        <div class="govuk-button-group">
+          <%= form.submit "Update accredited provider", class: "govuk-button govuk-!-margin-top-5", data: { qa: "course__save" } %>
+          <%= govuk_link_to(
+            "Add accredited provider",
+            search_publish_provider_recruitment_cycle_accredited_providers_path(course.provider_code, course.recruitment_cycle_year),
+            class: "govuk-!-margin-bottom-6 govuk-!-margin-top-5"
+          ) %>
+        </div>
       <% end %>
 
       <p class="govuk-body">

--- a/app/views/publish/courses/accredited_provider/edit.html.erb
+++ b/app/views/publish/courses/accredited_provider/edit.html.erb
@@ -29,7 +29,8 @@
           <%= govuk_link_to(
             "Add accredited provider",
             search_publish_provider_recruitment_cycle_accredited_providers_path(course.provider_code, course.recruitment_cycle_year),
-            class: "govuk-!-margin-bottom-6 govuk-!-margin-top-5"
+            class: "govuk-!-margin-bottom-6 govuk-!-margin-top-5",
+            data: { qa: "course__add" }
           ) %>
         </div>
       <% end %>

--- a/app/views/publish/providers/accredited_providers/index.html.erb
+++ b/app/views/publish/providers/accredited_providers/index.html.erb
@@ -9,7 +9,7 @@
     <%= govuk_button_link_to("Add accredited provider", search_publish_provider_recruitment_cycle_accredited_providers_path(
       provider_code: @provider.provider_code,
       recruitment_cycle_year: @provider.recruitment_cycle_year
-    ), data: { qa: "add-accredited-provider-link" }) %>
+    )) %>
   </div>
 </div>
 

--- a/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
@@ -20,7 +20,6 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
     when_i_click_the_error_message_link
     then_it_takes_me_to_the_accredited_providers_page
     when_i_click_add_an_accredited_provider
-    and_i_click_to_add_new_accredited_provider
     and_i_search_for_an_accredited_provider
     and_i_fill_in_the_accredited_provider_form
     and_i_confirm_creation_of_the_accredited_provider
@@ -121,14 +120,8 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def when_i_click_add_an_accredited_provider
-    publish_courses_accredited_providers_page.add_new_button.click
-    expect(publish_provider_accredited_providers_index_page).to be_displayed
-  end
-
-  def and_i_click_to_add_new_accredited_provider
-    publish_provider_accredited_providers_index_page.add_new_link.click
+    publish_courses_accredited_providers_page.add_new_link.click
     expect(publish_provider_accredited_providers_search_page).to be_displayed
-    # expect(page).to have_current_path(%r{accredited-providers/search})
   end
 
   def and_i_search_for_an_accredited_provider

--- a/spec/support/page_objects/publish/courses/accredited_providers.rb
+++ b/spec/support/page_objects/publish/courses/accredited_providers.rb
@@ -7,7 +7,7 @@ module PageObjects
         set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/accredited-provider'
 
         elements :suggested_accredited_bodies, '[data-qa="course__accredited_provider_option"]'
-        element :add_new_button, '.govuk-button--secondary'
+        element :add_new_link, '[data-qa="course__add"]'
 
         element :update_button, 'input[type=submit]'
       end


### PR DESCRIPTION
### Trello
https://trello.com/c/YsMU17Nu/404-when-publish-users-click-change-links-for-accredited-provider-in-course-description-and-they-only-have-1-surface-a-link-button-t

### Context
Update the user flow when adding accredited provider to their training provider account.

### Changes proposed in this pull request

Govuk design standards require we change use a link instead of a button where the user wants to go to a place they can add a new accredited provider to their provider account.

The button and the link are grouped.

The link targets the accredited provider search page instead of the accredited provider index.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
