### PR TITLE
Fix adding user in next cycle

### DIFF
--- a/app/services/user_associations_service/create.rb
+++ b/app/services/user_associations_service/create.rb
@@ -2,6 +2,8 @@
 
 module UserAssociationsService
   class Create
+    include RecruitmentCycleHelper
+
     attr_reader :provider, :user, :all_providers
 
     class << self
@@ -34,12 +36,16 @@ module UserAssociationsService
       end
     end
 
-    def add_user_to_a_single_provider
-      add_user_to_provider_in_current_cycle
+    def add_user_to_provider_in_next_cycle
+      RecruitmentCycle.next.providers.find_by(provider_code: provider.provider_code).users << user
     end
 
-    def add_user_to_provider_in_current_cycle
+    def add_user_to_a_single_provider
       provider.users << user
+
+      return unless rollover_active?
+
+      add_user_to_provider_in_next_cycle
     end
 
     def send_user_added_to_provider_email

--- a/spec/services/user_associations_service/create_spec.rb
+++ b/spec/services/user_associations_service/create_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe UserAssociationsService::Create, { can_edit_current_and_next_cycl
         expect(action_mailer).to have_received(:deliver_later)
       end
 
+      context 'during rollover', { can_edit_current_and_next_cycles: true } do
+        let!(:next_new_accredited_provider) { create(:provider, :accredited_provider, :next_recruitment_cycle, provider_code: 'AAA') }
+
+        it 'creates user_permissions association in both cycles' do
+          subject
+          expect(new_accredited_provider.users).to eq([user])
+          expect(next_new_accredited_provider.users).to eq([user])
+          expect(user.providers).to include(accredited_provider, new_accredited_provider, next_new_accredited_provider)
+        end
+      end
+
       context 'when user have saved notification preferences' do
         let(:user_notification) do
           create(


### PR DESCRIPTION
### Context

Allow users to be added in the next cycle

### Changes proposed in this pull request

If the next recruitment cycle is active, add the user to the next recruitment cycle provider in addition to the current recruitment cycle provider.

### Guidance to review

Try it on the review app.
