### PR TITLE
[414] Update rollover script to handle the correct `application_open_from` date

### DIFF
--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -55,7 +55,7 @@ module Courses
       return course.applications_open_from if next_cycle.blank?
 
       if course_start_is_same_as_current_cycle_start?(course)
-        next_cycle.application_start_date
+        Find::CycleTimetable.apply_reopens.to_date
       else
         [course.applications_open_from + year_differential.year, next_cycle.application_start_date].max
       end

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -54,7 +54,11 @@ module Courses
 
       return course.applications_open_from if next_cycle.blank?
 
-      [course.applications_open_from + year_differential.year, next_cycle.application_start_date].max
+      if course_start_is_same_as_current_cycle_start?(course)
+        next_cycle.application_start_date
+      else
+        [course.applications_open_from + year_differential.year, next_cycle.application_start_date].max
+      end
     end
 
     def copy_schools(course:, new_provider:, new_course:)
@@ -63,6 +67,10 @@ module Courses
 
         @sites_copy_to_course.call(new_site:, new_course:) if new_site.present?
       end
+    end
+
+    def course_start_is_same_as_current_cycle_start?(course)
+      course.applications_open_from == current_cycle.application_start_date
     end
 
     def copy_study_sites(course:, new_provider:, new_course:)

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Courses::CopyToProviderService do
       it "sets the new course's applications open from date correctly" do
         service.execute(course:, new_provider:)
 
-        expect(new_course.applications_open_from).to eq(new_recruitment_cycle.application_start_date)
+        expect(new_course.applications_open_from).to eq(Find::CycleTimetable.apply_reopens.to_date)
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Courses::CopyToProviderService do
       it "sets the new course's applications open from date correctly" do
         service.execute(course:, new_provider:)
 
-        expect(new_course.applications_open_from).to eq(new_recruitment_cycle.application_start_date)
+        expect(new_course.applications_open_from).to eq(Find::CycleTimetable.apply_reopens.to_date)
       end
     end
   end


### PR DESCRIPTION
### Context

Update rollover script to handle the correct `application_start_date`.

### Changes proposed in this pull request

If the course `applications_open_from` date is the same as the current cycle `application_start_date` set the next recruitment cycle `application_start_date` as the course `applications_open_from` date 🤯 🤯 🤯 

### Guidance to review

You can try it with manual rollover in the review app. It should be easy to find a course with a `applications_open_from` date as the 11th of October. Currently this would be rolled over to the 11th of October the following year. With this change it be the 10th of October when rolled over.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
