### PR TITLE
Allow accredited providers to publish courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -322,7 +322,7 @@ class Course < ApplicationRecord
   validates :sites, presence: true, on: %i[publish new]
   validates :study_sites, presence: true, on: %i[publish new], if: -> { recruitment_cycle_after_2023? }
   validates :subjects, presence: true, on: :publish
-  validates :accrediting_provider, presence: true, on: :publish
+  validates :accrediting_provider, presence: true, on: :publish, unless: -> { self_accredited? }
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish
   validate :validate_provider_visa_sponsorship_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }

--- a/spec/features/publish/courses/2024_itt_provider_market_reform/publishing_a_course_as_an_accredited_provider_spec.rb
+++ b/spec/features/publish/courses/2024_itt_provider_market_reform/publishing_a_course_as_an_accredited_provider_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Publishing a course when course when accrediting_provider is nil', { can_edit_current_and_next_cycles: false } do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario 'Can publish the course if an accredited provider' do
+    and_the_provider_is_accredited
+    and_there_is_a_draft_course_without_accrediting_provider
+
+    when_i_visit_the_course_page
+    and_i_click_the_publish_button
+    then_i_should_see_a_success_message
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    @user = create(:user, :with_provider)
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_there_is_a_draft_course_without_accrediting_provider
+    given_a_course_exists(
+      :with_gcse_equivalency,
+      enrichments: [create(:course_enrichment, :initial_draft)],
+      sites: [create(:site, location_name: 'location 1')],
+      study_sites: [create(:site, :study_site)]
+    )
+  end
+
+  def when_i_visit_the_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      course_code: course.course_code
+    )
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content('Your course has been published.')
+  end
+
+  def and_i_click_the_publish_button
+    publish_provider_courses_show_page.publish_button.click
+  end
+
+  def and_the_provider_is_accredited
+    provider.update(accrediting_provider: 'accredited_provider')
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end


### PR DESCRIPTION
### Context

We need to tweak earlier validations as accredited providers who publish courses will have an accredited provider value as ‘nil’ on the course. 

We should not prevent publication when the value is nil - in fact this should be the only situation where this happens.

<img width="563" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/c3809a73-c101-49b8-8e0b-ccb6ecb5fbfe">


### Changes proposed in this pull request

Do not check for the presence of `accrediting_provider` on a `course` if the provider is accredited.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
