### PR TITLE
Freeze cycle switcher specs

### DIFF
--- a/spec/features/find/switcher_cycles_spec.rb
+++ b/spec/features/find/switcher_cycles_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 feature 'switcher cycle' do
+  before do
+    Timecop.freeze(2022, 10, 12)
+  end
+
   scenario 'Navigate to /cycle' do
     when_i_visit_switcher_cycle_page
     then_i_should_see_the_page_title
@@ -94,6 +98,6 @@ feature 'switcher cycle' do
   end
 
   def and_i_should_see_the_correct_previous_recruitment_cycle_year
-    expect(page).to have_text("Previous cycle year#{RecruitmentCycle.current.year}") # After find reopens, the previous cycle year for the fake cycle becomes the current cycle year for the real cycle
+    expect(page).to have_text('Previous cycle year2023') # After find reopens, the previous cycle year for the fake cycle becomes the current cycle year for the real cycle
   end
 end


### PR DESCRIPTION
### Context

Builds are failing:
<img width="883" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/558ae6be-5acb-4e65-9bcf-05e0b5032770">
This is because these tests are not frozen in time. The Apply 1 deadline banner has just gone live on production so these tests are failing because we never render the Apply 2 deadline banner due to the first branch of the `if` statement returning `true`.

### Changes proposed in this pull request

Freeze the test at the start of the 2022 cycle.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
