### PR TITLE
[433] Enable editing of applications open date for draft courses

### DIFF
--- a/app/controllers/publish/courses/applications_open_controller.rb
+++ b/app/controllers/publish/courses/applications_open_controller.rb
@@ -81,6 +81,10 @@ module Publish
       def error_keys
         [:applications_open_from]
       end
+
+      def section_key
+        'Applications open date'
+      end
     end
   end
 end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -219,7 +219,7 @@
     summary_list.with_row(html_attributes: { data: { qa: "course__applications_open" } }) do |row|
       row.with_key { "Applications open date" }
       row.with_value { l(course.applications_open_from&.to_date) }
-      if course.edit_course_options[:show_applications_open]
+      if course.changeable?
         row.with_action(href: applications_open_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                         visually_hidden_text: "date applications open")
       else

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -220,10 +220,8 @@
       row.with_key { "Applications open date" }
       row.with_value { l(course.applications_open_from&.to_date) }
       if course.edit_course_options[:show_applications_open]
-        row.with_action(**{
-                      # href: applications_open_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                      # visually_hidden_text: "date applications open",
-                    })
+        row.with_action(href: applications_open_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                        visually_hidden_text: "date applications open")
       else
         row.with_action
       end

--- a/app/views/publish/courses/applications_open/_form_fields.html.erb
+++ b/app/views/publish/courses/applications_open/_form_fields.html.erb
@@ -1,34 +1,34 @@
 <div class="govuk-form-group">
   <div class="govuk-radios govuk-!-margin-top-2 govuk-radios--conditional" data-module="govuk-radios">
   <%= render "publish/shared/error_wrapper", error_keys: [:applications_open_from], data_qa: "course__applications_open_from" do %>
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading" id="applications_open_from-error">
-          <%= render CaptionText.new(text: t("course.add_course")) %>
-          Applications open date
-        </h1>
-      </legend>
-      <%= render "publish/shared/error_messages", error_keys: [:applications_open_from] %>
-      <div class="govuk-radios__item govuk-!-margin-top-4">
-        <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
-              class: "govuk-radios__input", data: { qa: "applications_open_from" } %>
-        <%= form.label :applications_open_from, course.applications_open_first_label(@recruitment_cycle),
-              for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
-              class: "govuk-label govuk-radios__label" %>
-      </div>
-      <div class="govuk-radios__divider">or</div>
-      <div class="govuk-radios__item">
-        <%= form.radio_button :applications_open_from, "other",
-              class: "govuk-radios__input",
-              checked: @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date,
-              aria: { controls: "other-container" }, data: { qa: "applications_open_from_other" } %>
-        <%= form.label :applications_open_from,
-              for: "course_applications_open_from_other",
-              value: "Another date",
-              class: "govuk-label govuk-radios__label",
-              data: { qa: "applications_open_field_from_other_label" } %>
-      </div>
-    </fieldset>
+
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading" id="applications_open_from-error">
+        <%= render caption_text %>
+        Applications open date
+      </h1>
+    </legend>
+    <%= render "publish/shared/error_messages", error_keys: [:applications_open_from] %>
+    <div class="govuk-radios__item govuk-!-margin-top-4">
+      <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
+            class: "govuk-radios__input", data: { qa: "applications_open_from" } %>
+      <%= form.label :applications_open_from, course.applications_open_first_label(@recruitment_cycle),
+            for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
+            class: "govuk-label govuk-radios__label" %>
+    </div>
+    <div class="govuk-radios__divider">or</div>
+    <div class="govuk-radios__item">
+      <%= form.radio_button :applications_open_from, "other",
+            class: "govuk-radios__input",
+            checked: @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date,
+            aria: { controls: "other-container" }, data: { qa: "applications_open_from_other" } %>
+      <%= form.label :applications_open_from,
+            for: "course_applications_open_from_other",
+            value: "Another date",
+            class: "govuk-label govuk-radios__label",
+            data: { qa: "applications_open_field_from_other_label" } %>
+    </div>
+
     <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date %>" id="other-container">
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
@@ -36,7 +36,7 @@
             When will applications open?
           </legend>
           <span class="govuk-hint">
-            For example, 30 9 <%= @recruitment_cycle.year %>
+            For example <%= @recruitment_cycle.application_start_date.to_fs(:day_month_year) %>
           </span>
           <div class="govuk-date-input">
             <div class="govuk-date-input__item">

--- a/app/views/publish/courses/applications_open/edit.html.erb
+++ b/app/views/publish/courses/applications_open/edit.html.erb
@@ -12,7 +12,72 @@
                   url: applications_open_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                   method: :put do |form| %>
 
-      <%= render "form_fields", form: %>
+  <div class="govuk-form-group">
+  <div class="govuk-radios govuk-!-margin-top-2 govuk-radios--conditional" data-module="govuk-radios">
+  <%= render "publish/shared/error_wrapper", error_keys: [:applications_open_from], data_qa: "course__applications_open_from" do %>
+
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading" id="applications_open_from-error">
+        <%= render CaptionText.new(text: course.name_and_code) %>
+        Applications open date
+      </h1>
+    </legend>
+    <%= render "publish/shared/error_messages", error_keys: [:applications_open_from] %>
+    <div class="govuk-radios__item govuk-!-margin-top-4">
+      <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
+            class: "govuk-radios__input" %>
+      <%= form.label :applications_open_from, course.applications_open_first_label(@recruitment_cycle),
+            for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
+            class: "govuk-label govuk-radios__label" %>
+    </div>
+    <div class="govuk-radios__divider">or</div>
+    <div class="govuk-radios__item">
+      <%= form.radio_button :applications_open_from, "other",
+            class: "govuk-radios__input",
+            checked: @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date,
+            aria: { controls: "other-container" }, data: { qa: "applications_open_from_other" } %>
+      <%= form.label :applications_open_from,
+            for: "course_applications_open_from_other",
+            value: "Another date",
+            class: "govuk-label govuk-radios__label",
+            data: { qa: "applications_open_field_from_other_label" } %>
+    </div>
+
+    <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date %>" id="other-container">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            When will applications open?
+          </legend>
+          <span class="govuk-hint">
+            For example <%= @recruitment_cycle.application_start_date.to_s(:day_month_year) %>
+          </span>
+          <div class="govuk-date-input">
+            <div class="govuk-date-input__item">
+              <%= render "publish/shared/form_field",
+                form:, field: :day do |field, options| %>
+                <%= form.text_field field, options.merge(autocomplete: "off", class: "govuk-input govuk-input--width-2") %>
+              <% end %>
+            </div>
+            <div class="govuk-date-input__item">
+              <%= render "publish/shared/form_field",
+                form:, field: :month do |field, options| %>
+                <%= form.text_field field, options.merge(autocomplete: "off", class: "govuk-input govuk-input--width-2") %>
+              <% end %>
+            </div>
+            <div class="govuk-date-input__item">
+              <%= render "publish/shared/form_field",
+                form:, field: :year do |field, options| %>
+                <%= form.text_field field, options.merge(autocomplete: "off", class: "govuk-input govuk-input--width-4") %>
+              <% end %>
+            </div>
+          </div>
+        </fieldset>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
 
       <%= form.submit "Update applications open date", class: "govuk-button" %>
     <% end %>

--- a/app/views/publish/courses/applications_open/edit.html.erb
+++ b/app/views/publish/courses/applications_open/edit.html.erb
@@ -12,74 +12,13 @@
                   url: applications_open_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                   method: :put do |form| %>
 
-  <div class="govuk-form-group">
-  <div class="govuk-radios govuk-!-margin-top-2 govuk-radios--conditional" data-module="govuk-radios">
-  <%= render "publish/shared/error_wrapper", error_keys: [:applications_open_from], data_qa: "course__applications_open_from" do %>
-
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-      <h1 class="govuk-fieldset__heading" id="applications_open_from-error">
-        <%= render CaptionText.new(text: course.name_and_code) %>
-        Applications open date
-      </h1>
-    </legend>
-    <%= render "publish/shared/error_messages", error_keys: [:applications_open_from] %>
-    <div class="govuk-radios__item govuk-!-margin-top-4">
-      <%= form.radio_button :applications_open_from, @recruitment_cycle.application_start_date,
-            class: "govuk-radios__input" %>
-      <%= form.label :applications_open_from, course.applications_open_first_label(@recruitment_cycle),
-            for: "course_applications_open_from_#{@recruitment_cycle.application_start_date}",
-            class: "govuk-label govuk-radios__label" %>
-    </div>
-    <div class="govuk-radios__divider">or</div>
-    <div class="govuk-radios__item">
-      <%= form.radio_button :applications_open_from, "other",
-            class: "govuk-radios__input",
-            checked: @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date,
-            aria: { controls: "other-container" }, data: { qa: "applications_open_from_other" } %>
-      <%= form.label :applications_open_from,
-            for: "course_applications_open_from_other",
-            value: "Another date",
-            class: "govuk-label govuk-radios__label",
-            data: { qa: "applications_open_field_from_other_label" } %>
-    </div>
-
-    <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless @course.applications_open_from.present? && @course.applications_open_from != @recruitment_cycle.application_start_date %>" id="other-container">
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            When will applications open?
-          </legend>
-          <span class="govuk-hint">
-            For example <%= @recruitment_cycle.application_start_date.to_s(:day_month_year) %>
-          </span>
-          <div class="govuk-date-input">
-            <div class="govuk-date-input__item">
-              <%= render "publish/shared/form_field",
-                form:, field: :day do |field, options| %>
-                <%= form.text_field field, options.merge(autocomplete: "off", class: "govuk-input govuk-input--width-2") %>
-              <% end %>
-            </div>
-            <div class="govuk-date-input__item">
-              <%= render "publish/shared/form_field",
-                form:, field: :month do |field, options| %>
-                <%= form.text_field field, options.merge(autocomplete: "off", class: "govuk-input govuk-input--width-2") %>
-              <% end %>
-            </div>
-            <div class="govuk-date-input__item">
-              <%= render "publish/shared/form_field",
-                form:, field: :year do |field, options| %>
-                <%= form.text_field field, options.merge(autocomplete: "off", class: "govuk-input govuk-input--width-4") %>
-              <% end %>
-            </div>
-          </div>
-        </fieldset>
-        <% end %>
-      </div>
-    </div>
-  </div>
-</div>
+    <%= render "form_fields", form:, caption_text: CaptionText.new(text: course.name_and_code) %>
 
       <%= form.submit "Update applications open date", class: "govuk-button" %>
     <% end %>
+
+    <p class="govuk-body">
+        <%= govuk_link_to(t("cancel"), details_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+      </p>
   </div>
 </div>

--- a/app/views/publish/courses/applications_open/edit.html.erb
+++ b/app/views/publish/courses/applications_open/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, title_with_error_prefix("Applications open date – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
 <%= render "publish/shared/errors" %>
@@ -9,12 +9,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course,
-                  url: applications_open_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+                  url: applications_open_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                   method: :put do |form| %>
 
       <%= render "form_fields", form: %>
 
-      <%= form.submit course.is_running? ? "Save and publish changes" : "Save", class: "govuk-button", data: { qa: "course__save" } %>
+      <%= form.submit "Update applications open date", class: "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/publish/courses/applications_open/new.html.erb
+++ b/app/views/publish/courses/applications_open/new.html.erb
@@ -14,7 +14,7 @@
                   method: :get do |form| %>
 
       <%= render "publish/courses/new_fields_holder", form:, except_keys: %i[applications_open_from month day year] do |fields| %>
-        <%= render "form_fields", form: fields %>
+        <%= render "form_fields", form: fields, caption_text: CaptionText.new(text: t("course.add_course")) %>
       <% end %>
     <% end %>
 

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -4,6 +4,8 @@ Time::DATE_FORMATS[:govuk_date] = '%-d %B %Y'
 Time::DATE_FORMATS[:govuk_date_short_month] = '%-d %b %Y'
 Date::DATE_FORMATS[:govuk_date] = '%-d %B %Y'
 
+Date::DATE_FORMATS[:day_month_year] = '%-d %-m %Y'
+
 Time::DATE_FORMATS[:month_and_year] = '%B %Y'
 Date::DATE_FORMATS[:month_and_year] = '%B %Y'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -496,7 +496,7 @@ en:
             study_mode:
               blank: "^Select a study mode"
             applications_open_from:
-              blank: "^Select an applications open date"
+              blank: "Select an applications open date"
             accrediting_provider:
               blank: "Select an accredited provider"
               is_not_accredited: "Update the accredited provider"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -234,6 +234,9 @@ namespace :publish, as: :publish do
 
         get '/study-sites', on: :member, to: 'courses/study_sites#edit'
         put '/study-sites', on: :member, to: 'courses/study_sites#update'
+
+        get '/applications-open', on: :member, to: 'courses/applications_open#edit'
+        put '/applications-open', on: :member, to: 'courses/applications_open#update'
       end
 
       scope module: :providers do

--- a/spec/features/publish/courses/editing_applications_open_spec.rb
+++ b/spec/features/publish/courses/editing_applications_open_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'editing applications open date', { can_edit_current_and_next_cycles: false } do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_course_i_want_to_edit
+    then_i_visit_the_applications_open_page
+  end
+
+  scenario 'choosing the default' do
+    given_i_choose_as_soon_as_find_is_open
+    when_i_click_update
+    then_i_should_see_the_earliest_date_applications_can_open
+  end
+
+  scenario 'choosing a custom' do
+    given_i_enter_a_custom_date
+    when_i_click_update
+    then_i_should_see_the_custom_date
+  end
+
+  def given_i_enter_a_custom_date
+    find_field('Day').set('12')
+    find_field('Month').set('12')
+    find_field('Year').set(last_recruitment_cycle_year)
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def last_recruitment_cycle_year
+    Settings.current_recruitment_cycle_year - 1
+  end
+
+  def and_there_is_a_course_i_want_to_edit
+    given_a_course_exists
+  end
+
+  def then_i_visit_the_applications_open_page
+    visit applications_open_publish_provider_recruitment_cycle_course_path(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, code: course.course_code
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def course
+    provider.courses.first
+  end
+
+  def given_i_choose_as_soon_as_find_is_open
+    page.choose('As soon as the course is on Find - recommended')
+  end
+
+  def when_i_click_update
+    page.click_button('Update applications open date')
+  end
+
+  def then_i_should_see_the_earliest_date_applications_can_open
+    within("[data-qa='course__applications_open']") do
+      expect(page).to have_text(course.recruitment_cycle.application_start_date.to_fs(:govuk_date))
+    end
+  end
+
+  def then_i_should_see_the_custom_date
+    within("[data-qa='course__applications_open']") do
+      expect(page).to have_text("12 December #{last_recruitment_cycle_year}")
+    end
+  end
+end

--- a/spec/features/publish/viewing_a_course_details_spec.rb
+++ b/spec/features/publish/viewing_a_course_details_spec.rb
@@ -178,7 +178,7 @@ feature 'Course show' do
   end
 
   def then_i_see_the_correct_change_links_for_the_next_cycle
-    expect(publish_provider_courses_details_page.change_link_texts).to contain_exactly('subjects', 'age range', 'outcome', 'if full or part time', 'schools', 'can sponsor skilled_worker visa')
+    expect(publish_provider_courses_details_page.change_link_texts).to contain_exactly('subjects', 'age range', 'outcome', 'if full or part time', 'schools', 'can sponsor skilled_worker visa', 'date applications open')
   end
 
   def provider

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -81,7 +81,7 @@ module Support
           expect(subject.errors.messages[:course_code]).to include('Course code cannot be blank')
           expect(subject.errors.messages[:name]).to include('Course title cannot be blank')
           expect(subject.errors.messages[:start_date]).to include('Select a course start date')
-          expect(subject.errors.messages[:applications_open_from]).to include('^Select an applications open date')
+          expect(subject.errors.messages[:applications_open_from]).to include('Select an applications open date')
         end
       end
 


### PR DESCRIPTION
### Context

We are enabling applications open date to be edited for courses in a `draft` or a `rolled_over` state.

### Changes proposed in this pull request

- Surface the change link
- Add routes
- Fix validation error message
- Update text on submit button
- Disable change link on withdrawn courses
- Update the hint text so that the date is one that can actually be submitted (I've used the first date that applications are open)
- Add cancel link


### Before/After Screenshots

<img width="1412" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/96550e6d-a613-4806-b0e6-9cfd7e37a192">


<img width="834" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/80da9a1f-15b1-46f4-9fc6-b29065be251c">

<img width="654" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/62b5f8f7-44bc-4129-acbe-657cca091340">


<img width="1384" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/863341ae-6cfc-4975-8346-6ffad2f1f513">


### Guidance to review

- Go to a `draft` course or a `rolled_over` course in any cycle and update the applications open date within the basic details section. 

- Create a new course in any cycle and ensure the applications open question is still functioning the same.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
