### PR TITLE
[433] Enable editing of start date for draft courses

### DIFF
--- a/app/controllers/publish/courses/start_date_controller.rb
+++ b/app/controllers/publish/courses/start_date_controller.rb
@@ -14,6 +14,10 @@ module Publish
       def error_keys
         [:start_date]
       end
+
+      def section_key
+        "Course start date"
+      end
     end
   end
 end

--- a/app/controllers/publish/courses/start_date_controller.rb
+++ b/app/controllers/publish/courses/start_date_controller.rb
@@ -16,7 +16,7 @@ module Publish
       end
 
       def section_key
-        "Course start date"
+        'Course start date'
       end
     end
   end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -234,10 +234,8 @@
               <p class=\"govuk-hint govuk-!-margin-top-0\">Academic year #{course.academic_year} </p>")
       end
       if course.edit_course_options[:show_start_date]
-        row.with_action(**{
-                      # href: start_date_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                      # visually_hidden_text: "date course starts",
-                    })
+        row.with_action(href: start_date_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+                        visually_hidden_text: "date course starts")
       else
         row.with_action
       end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -233,7 +233,7 @@
         raw("<p class=\"govuk-body\">#{l(course.start_date&.to_date, format: :short)} </p>
               <p class=\"govuk-hint govuk-!-margin-top-0\">Academic year #{course.academic_year} </p>")
       end
-      if course.edit_course_options[:show_start_date]
+      if course.changeable?
         row.with_action(href: start_date_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
                         visually_hidden_text: "date course starts")
       else

--- a/app/views/publish/courses/start_date/edit.html.erb
+++ b/app/views/publish/courses/start_date/edit.html.erb
@@ -14,8 +14,12 @@
 
       <%= render "form_fields", form: %>
 
-      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
+      <%= form.submit "Update course start date",
         class: "govuk-button", data: { qa: "course__save" } %>
     <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), details_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+    </p>
   </div>
 </div>

--- a/app/views/publish/courses/start_date/edit.html.erb
+++ b/app/views/publish/courses/start_date/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, title_with_error_prefix("Course start date – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
 <%= render "publish/shared/errors" %>
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course,
-                  url: start_date_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+                  url: start_date_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                   method: :put do |form| %>
 
       <%= render "form_fields", form: %>

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -237,6 +237,9 @@ namespace :publish, as: :publish do
 
         get '/applications-open', on: :member, to: 'courses/applications_open#edit'
         put '/applications-open', on: :member, to: 'courses/applications_open#update'
+
+        get '/start-date', on: :member, to: 'courses/start_date#edit'
+        put '/start-date', on: :member, to: 'courses/start_date#update'
       end
 
       scope module: :providers do

--- a/spec/features/publish/courses/editing_course_start_spec.rb
+++ b/spec/features/publish/courses/editing_course_start_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'editing course start date', { can_edit_current_and_next_cycles: false } do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_course_i_want_to_edit
+    then_i_visit_the_start_date_page
+  end
+
+  scenario 'choosing december' do
+    given_i_choose_december
+    when_i_click_update
+    then_i_should_see_the_december_start_date
+    and_i_should_see_the_success_flash_message
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def current_recruitment_cycle_year
+    Settings.current_recruitment_cycle_year
+  end
+
+  def and_there_is_a_course_i_want_to_edit
+    given_a_course_exists
+  end
+
+  def then_i_visit_the_start_date_page
+    visit start_date_publish_provider_recruitment_cycle_course_path(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, code: course.course_code
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def course
+    provider.courses.first
+  end
+
+  def given_i_choose_december
+    page.choose("December #{current_recruitment_cycle_year}")
+  end
+
+  def when_i_click_update
+    page.click_button('Update course start date')
+  end
+
+  def then_i_should_see_the_december_start_date
+    within("[data-qa='course__start_date']") do
+      expect(page).to have_text("December #{current_recruitment_cycle_year}")
+    end
+  end
+
+  def and_i_should_see_the_success_flash_message
+    expect(page).to have_selector('.govuk-notification-banner__heading', text: 'Course start date updated')
+  end
+end

--- a/spec/features/publish/viewing_a_course_details_spec.rb
+++ b/spec/features/publish/viewing_a_course_details_spec.rb
@@ -37,7 +37,7 @@ feature 'Course show' do
       scenario 'i can see the correct change links' do
         given_we_are_in_rollover
         and_i_am_authenticated_as_a_provider_user_for_next_cycle
-        and_there_is_a_published_course
+        and_there_is_a_scheduled_course
         when_i_visit_the_course_details_page
         then_i_see_the_correct_change_links_for_the_next_cycle
       end
@@ -96,6 +96,8 @@ feature 'Course show' do
     given_a_course_exists(:with_accrediting_provider, start_date: Date.parse('2022 January'), enrichments: [build(:course_enrichment, :published)])
     given_a_site_exists(:full_time_vacancies, :findable)
   end
+
+  alias_method :and_there_is_a_scheduled_course, :and_there_is_a_published_course
 
   def when_i_visit_the_course_details_page
     publish_provider_courses_details_page.load(
@@ -178,7 +180,7 @@ feature 'Course show' do
   end
 
   def then_i_see_the_correct_change_links_for_the_next_cycle
-    expect(publish_provider_courses_details_page.change_link_texts).to contain_exactly('subjects', 'age range', 'outcome', 'if full or part time', 'schools', 'can sponsor skilled_worker visa', 'date applications open')
+    expect(publish_provider_courses_details_page.change_link_texts).to contain_exactly('subjects', 'age range', 'outcome', 'if full or part time', 'schools', 'can sponsor skilled_worker visa', 'date applications open', 'date course starts')
   end
 
   def provider


### PR DESCRIPTION
### Context

We are enabling applications open date to be edited for courses in a `draft` or a `rolled_over` state.

### Changes proposed in this pull request

- Surface the change link
- Add routes
- Update text on submit button
- Add cancel link

### Screenshots

<img width="1455" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/7875b216-d762-488f-b662-97c5a3b2ac8a">

<img width="699" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/0f2aab47-b9e3-4052-8f80-42913a9e885f">


### Guidance to review

- Go to a `draft` course or a `rolled_over` course in any cycle and update the course start date within the basic details section. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
