### PR TITLE
Add guard to handle no users

### DIFF
--- a/app/services/user_associations_service/create.rb
+++ b/app/services/user_associations_service/create.rb
@@ -37,8 +37,14 @@ module UserAssociationsService
     end
 
     def add_user_to_provider_in_both_cycles
-      current_cycle_provider(provider).users << user unless current_cycle_provider(provider).users.include?(user)
-      next_cycle_provider(provider).users << user unless next_cycle_provider(provider).users.include?(user)
+      add_user_to_provider_if_provider_exists(current_cycle_provider(provider))
+      add_user_to_provider_if_provider_exists(next_cycle_provider(provider))
+    end
+
+    def add_user_to_provider_if_provider_exists(provider)
+      return if provider.blank?
+
+      provider.users << user unless provider.users.include?(user)
     end
 
     def add_user_to_a_single_provider

--- a/spec/services/user_associations_service/create_spec.rb
+++ b/spec/services/user_associations_service/create_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe UserAssociationsService::Create, { can_edit_current_and_next_cycl
             expect(user.providers).to include(accredited_provider, new_accredited_provider, next_cycle_new_accredited_provider)
           end
         end
+
+        context 'when provider does not exist in the next cycle' do
+          subject do
+            described_class.call(
+              provider: current_cycle_provider,
+              user:
+            )
+          end
+
+          let!(:current_cycle_provider) { create(:provider, :accredited_provider, users: [user]) }
+
+          it 'adds user to provider in current cycle without error' do
+            expect { subject }.not_to raise_error
+            expect(current_cycle_provider.users).to eq([user])
+          end
+        end
       end
 
       context 'when only one recruitment cycle is active' do


### PR DESCRIPTION
### Context

Support encountered an error when creating a new organisation and adding a user before creating the organisation in the next cycle.

Although this wasn't blocking the users from being added, we should add a guard so we don't get an error.

https://dfe-teacher-services.sentry.io/issues/4377371108/?alert_rule_id=11137790&alert_type=issue&project=1377944&referrer=slack

### Changes proposed in this pull request

- Add a guard to protect against `provider.users.nil?`

### Guidance to review

- Create a brand new org in one cycle using support without adding the org to the next cycle.

- Attempt to add a user to it, and it should work.

- If you try the same thing in QA you should get an error (although it will still work).
