### PR TITLE
[412] Populate accredited provider list based on recruitment cycle

### DIFF
--- a/app/controllers/api/accredited_provider_suggestions_controller.rb
+++ b/app/controllers/api/accredited_provider_suggestions_controller.rb
@@ -5,7 +5,7 @@ module API
     def index
       return render_json_error(status: 400, message: I18n.t('accredited_provider_suggestion.errors.bad_request')) if invalid_query?
 
-      accredited_providers = AccreditedProviders::SearchService.call(query: params[:query]).providers
+      accredited_providers = AccreditedProviders::SearchService.call(query: params[:query], recruitment_cycle_year: params[:recruitment_cycle_year]).providers
       render json: accredited_providers
     end
 

--- a/app/controllers/publish/providers/accredited_provider_search_controller.rb
+++ b/app/controllers/publish/providers/accredited_provider_search_controller.rb
@@ -25,7 +25,7 @@ module Publish
 
           if @accredited_provider_search_form.valid?
             @accredited_provider_select_form = AccreditedProviderSelectForm.new
-            @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:)
+            @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:, recruitment_cycle_year: params[:recruitment_cycle_year])
             render :results
           else
             provider
@@ -46,7 +46,7 @@ module Publish
             accredited_provider_id: accredited_provider_select_params[:provider_id]
           )
         else
-          @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:)
+          @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:, recruitment_cycle_year: params[:recruitment_cycle_year])
           render :results
         end
       end

--- a/app/controllers/support/providers/accredited_provider_search_controller.rb
+++ b/app/controllers/support/providers/accredited_provider_search_controller.rb
@@ -17,7 +17,7 @@ module Support
 
         if @accredited_provider_search_form.valid?
           @accredited_provider_select_form = AccreditedProviderSelectForm.new
-          @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:)
+          @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:, recruitment_cycle_year: params[:recruitment_cycle_year])
 
           render :results
         else
@@ -32,7 +32,7 @@ module Support
         if @accredited_provider_select_form.valid?
           redirect_to new_support_recruitment_cycle_provider_accredited_provider_path(accredited_provider_id: accredited_provider_select_params[:provider_id])
         else
-          @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:)
+          @accredited_provider_search = ::AccreditedProviders::SearchService.call(query:, recruitment_cycle_year: params[:recruitment_cycle_year])
           render :results
         end
       end

--- a/app/forms/accredited_provider_search_form.rb
+++ b/app/forms/accredited_provider_search_form.rb
@@ -5,6 +5,7 @@ class AccreditedProviderSearchForm
 
   FIELDS = %i[
     query
+    recruitment_cycle_year
   ].freeze
 
   attr_accessor(*FIELDS)

--- a/app/javascript/publish/autocomplete/__snapshots__/accredited_provider.spec.js.snap
+++ b/app/javascript/publish/autocomplete/__snapshots__/accredited_provider.spec.js.snap
@@ -13,6 +13,13 @@ exports[`Accredited provider init should instantiate an autocomplete 1`] = `
   />
   
            
+  <input
+    id="accredited_provider_search_form_recruitment_cycle_year"
+    type="text"
+    value="2023"
+  />
+  
+           
   <div
     id="accredited-provider-autocomplete"
   >

--- a/app/javascript/publish/autocomplete/accredited_provider.js
+++ b/app/javascript/publish/autocomplete/accredited_provider.js
@@ -3,19 +3,20 @@ import initAutocomplete from './autocomplete'
 const providerTemplate = (result) => result && result.provider_name
 const providerSuggestionTemplate = (result) => result && `${result.provider_name} (${result.provider_code})`
 const onConfirm = (input) => (option) => (input.value = option ? option.id : '')
-const recruitment_cycle_year = document.getElementById('accredited_provider_search_form_recruitment_cycle_year').value
-const options = {
-  path: `/api/${recruitment_cycle_year}/accredited_provider_suggestions`,
-  template: {
-    inputValue: providerTemplate,
-    suggestion: providerSuggestionTemplate
-  },
-  minLength: 2,
-  inputName: 'accredited_provider_id',
-  onConfirm
-}
 
 function init () {
+  const recruitmentCycleYear = document.getElementById('accredited_provider_search_form_recruitment_cycle_year').value
+  const options = {
+    path: `/api/${recruitmentCycleYear}/accredited_provider_suggestions`,
+    template: {
+      inputValue: providerTemplate,
+      suggestion: providerSuggestionTemplate
+    },
+    minLength: 2,
+    inputName: 'accredited_provider_id',
+    onConfirm
+  }
+
   initAutocomplete('accredited-provider-autocomplete', 'accredited-provider-search-form-query-field', options)
 }
 

--- a/app/javascript/publish/autocomplete/accredited_provider.js
+++ b/app/javascript/publish/autocomplete/accredited_provider.js
@@ -3,8 +3,9 @@ import initAutocomplete from './autocomplete'
 const providerTemplate = (result) => result && result.provider_name
 const providerSuggestionTemplate = (result) => result && `${result.provider_name} (${result.provider_code})`
 const onConfirm = (input) => (option) => (input.value = option ? option.id : '')
+const recruitment_cycle_year = document.getElementById('accredited_provider_search_form_recruitment_cycle_year').value
 const options = {
-  path: '/api/accredited_provider_suggestions',
+  path: `/api/${recruitment_cycle_year}/accredited_provider_suggestions`,
   template: {
     inputValue: providerTemplate,
     suggestion: providerSuggestionTemplate

--- a/app/javascript/publish/autocomplete/accredited_provider.spec.js
+++ b/app/javascript/publish/autocomplete/accredited_provider.spec.js
@@ -10,6 +10,7 @@ describe('Accredited provider', () => {
       document.body.innerHTML = `
          <div id="outer-container">
            <input type="text" id="accredited-provider-search-form-query-field">
+           <input type="text" id="accredited_provider_search_form_recruitment_cycle_year" value="2023">
            <div id="accredited-provider-autocomplete"></div>
          </div>
        `

--- a/app/services/accredited_providers/search_service.rb
+++ b/app/services/accredited_providers/search_service.rb
@@ -8,9 +8,10 @@ module AccreditedProviders
 
     Result = Struct.new(:providers, :limit, keyword_init: true)
 
-    def initialize(query: nil, limit: DEFAULT_LIMIT)
+    def initialize(query: nil, limit: DEFAULT_LIMIT, recruitment_cycle_year: nil)
       @query = StripPunctuationService.call(string: query)
       @limit = limit
+      @recruitment_cycle_year = recruitment_cycle_year
     end
 
     def call
@@ -19,10 +20,10 @@ module AccreditedProviders
 
     private
 
-    attr_reader :query, :limit
+    attr_reader :query, :limit, :recruitment_cycle_year
 
     def providers
-      providers = RecruitmentCycle.current.providers.accredited_provider
+      providers = RecruitmentCycle.find_by(year: recruitment_cycle_year).providers.accredited_provider
       providers = providers.accredited_provider_search(query) if query
       providers = providers.limit(limit) if limit
       providers.reorder(:provider_name)

--- a/app/views/publish/providers/accredited_provider_search/new.html.erb
+++ b/app/views/publish/providers/accredited_provider_search/new.html.erb
@@ -25,6 +25,9 @@
             </span>
           <% end %>
         <% end %>
+
+        <%= f.hidden_field :recruitment_cycle_year, value: @recruitment_cycle.year %>
+
         <%= f.text_field :query,
                               id: "accredited-provider-search-form-query-field",
                               value: params[:query],

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -27,7 +27,7 @@ namespace :api do
     end
   end
   get '/school_suggestions', to: 'school_suggestions#index'
-  get '/accredited_provider_suggestions', to: 'accredited_provider_suggestions#index'
+  get ':recruitment_cycle_year/accredited_provider_suggestions', to: 'accredited_provider_suggestions#index'
 end
 
 get 'error_500', to: 'api_error#error500'

--- a/spec/controllers/api/accredited_provider_suggestions_controller_spec.rb
+++ b/spec/controllers/api/accredited_provider_suggestions_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe API::AccreditedProviderSuggestionsController do
     context 'with invalid params' do
       before do
         get :index, params: {
-          query: 'cl'
+          query: 'cl',
+          recruitment_cycle_year: Settings.current_recruitment_cycle_year
         }
       end
 
@@ -25,7 +26,8 @@ RSpec.describe API::AccreditedProviderSuggestionsController do
     context 'with valid params' do
       before do
         get :index, params: {
-          query: 'cla'
+          query: 'cla',
+          recruitment_cycle_year: Settings.current_recruitment_cycle_year
         }
       end
 

--- a/spec/services/accredited_providers/search_service_spec.rb
+++ b/spec/services/accredited_providers/search_service_spec.rb
@@ -4,76 +4,78 @@ require 'rails_helper'
 
 module AccreditedProviders
   describe SearchService do
-    let(:accredited_provider) { create(:provider, :accredited_provider) }
+    let(:recruitment_cycle) { create(:recruitment_cycle, year: 2022) }
+    let(:accredited_provider) { create(:provider, :accredited_provider, recruitment_cycle:) }
+    let(:recruitment_cycle_year) { recruitment_cycle.year }
 
     describe '#call' do
       it 'can search by ukprn' do
-        expect(described_class.call(query: accredited_provider.ukprn).providers).to match([accredited_provider])
+        expect(described_class.call(query: accredited_provider.ukprn, recruitment_cycle_year:).providers).to match([accredited_provider])
       end
 
       it 'can search by name' do
-        expect(described_class.call(query: accredited_provider.provider_name).providers).to match([accredited_provider])
+        expect(described_class.call(query: accredited_provider.provider_name, recruitment_cycle_year:).providers).to match([accredited_provider])
       end
 
       it 'can search by postcode' do
-        expect(described_class.call(query: accredited_provider.postcode).providers).to match([accredited_provider])
+        expect(described_class.call(query: accredited_provider.postcode, recruitment_cycle_year:).providers).to match([accredited_provider])
       end
 
       context 'database has different providers' do
         before do
-          create(:provider)
+          create(:provider, recruitment_cycle:)
         end
 
         it 'only returns providers that are accredited' do
-          expect(described_class.call.providers).to match([accredited_provider])
+          expect(described_class.call(recruitment_cycle_year:).providers).to match([accredited_provider])
         end
       end
 
       context 'too many results' do
-        before { create_list(:provider, 2, :accredited_provider) }
+        before { create_list(:provider, 2, :accredited_provider, recruitment_cycle:) }
 
         it 'supports truncation' do
-          expect(described_class.call(limit: 1).providers.size).to eq(1)
+          expect(described_class.call(limit: 1, recruitment_cycle_year:).providers.size).to eq(1)
         end
       end
 
       context 'search order' do
-        let!(:provider_one) { create(:provider, :accredited_provider, provider_name: 'Acorn Park School', postcode: 'NW1 8TY') }
-        let!(:provider_two) { create(:provider, :accredited_provider, provider_name: 'Beaumont Parking School', postcode: 'NW1 9YU') }
-        let!(:provider_three) { create(:provider, :accredited_provider, provider_name: 'Parking School', postcode: 'NW1 5WS') }
+        let!(:provider_one) { create(:provider, :accredited_provider, provider_name: 'Acorn Park School', postcode: 'NW1 8TY', recruitment_cycle:) }
+        let!(:provider_two) { create(:provider, :accredited_provider, provider_name: 'Beaumont Parking School', postcode: 'NW1 9YU', recruitment_cycle:) }
+        let!(:provider_three) { create(:provider, :accredited_provider, provider_name: 'Parking School', postcode: 'NW1 5WS', recruitment_cycle:) }
 
         it 'orders the results alphabetically' do
-          expect(described_class.call.providers).to eq([provider_one, provider_two, provider_three])
+          expect(described_class.call(recruitment_cycle_year:).providers).to eq([provider_one, provider_two, provider_three])
         end
 
         context 'with a search query' do
           it 'orders the results alphabetically' do
-            expect(described_class.call(query: 'NW1').providers).to eq([provider_one, provider_two, provider_three])
+            expect(described_class.call(query: 'NW1', recruitment_cycle_year:).providers).to eq([provider_one, provider_two, provider_three])
           end
         end
       end
 
       context 'with special characters' do
-        let!(:provider_one) { create(:provider, :accredited_provider, provider_name: 'St Marys the Mount School') }
-        let!(:provider_two) { create(:provider, :accredited_provider, provider_name: "St Mary's Kilburn") }
-        let!(:provider_three) { create(:provider, :accredited_provider, provider_name: 'Beaumont College - A Salutem/Ambito College') }
+        let!(:provider_one) { create(:provider, :accredited_provider, provider_name: 'St Marys the Mount School', recruitment_cycle:) }
+        let!(:provider_two) { create(:provider, :accredited_provider, provider_name: "St Mary's Kilburn", recruitment_cycle:) }
+        let!(:provider_three) { create(:provider, :accredited_provider, provider_name: 'Beaumont College - A Salutem/Ambito College', recruitment_cycle:) }
 
         it 'matches all' do
-          expect(described_class.call(query: "mary's").providers).to contain_exactly(provider_one, provider_two)
+          expect(described_class.call(query: "mary's", recruitment_cycle_year:).providers).to contain_exactly(provider_one, provider_two)
         end
 
         it 'matches all without punctuations' do
-          expect(described_class.call(query: 'marys').providers).to contain_exactly(provider_one, provider_two)
+          expect(described_class.call(query: 'marys', recruitment_cycle_year:).providers).to contain_exactly(provider_one, provider_two)
         end
 
         it 'ignores non-punctuation characters' do
-          expect(described_class.call(query: 'Salutem Ambito').providers).to eq([provider_three])
+          expect(described_class.call(query: 'Salutem Ambito', recruitment_cycle_year:).providers).to eq([provider_three])
         end
       end
 
       context 'limit' do
         it 'can set a limit for the returned results' do
-          expect(described_class.call(query: accredited_provider.ukprn, limit: 10).limit).to eq(10)
+          expect(described_class.call(query: accredited_provider.ukprn, limit: 10, recruitment_cycle_year:).limit).to eq(10)
         end
       end
     end


### PR DESCRIPTION
### Context

The list of accredited providers is not recruitment cycle dependant. We need to make it dependant so that if an accredited provider in the current cycle is not an accredited provider in the next cycle, they are not seen in the list in the next cycle. 

More importantly, we need to ensure that providers who wern't accredited providers in the current cycle but are in the next cycle, are shown in this list - as this would prevent providers from adding and publishing courses. 

### Changes proposed in this pull request

Pass in the recruitment cycle and generate the list of accredited providers based on the recruitment cycle.

### Guidance to review

- Go to a provider which is not an accredited provider in both cycles
- Check that they are not in the list when adding an accredited provider
- Change them to an accredited provider in one cycle
- Check that they are now in the list but only for the cycle that you changed it. 

- Ensure the accredited provider flow still functions as expected. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
