### PR TITLE
Remove front door config used for migration env

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
@@ -4,8 +4,7 @@
       "front_door_name": "s189p01-ftt-svc-domains-fd",
       "resource_group_name": "s189p01-fttdomains-rg",
       "domains": [
-        "www",
-        "www3"
+        "www"
       ],
       "cached_paths": [
         "/assets/*"

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
@@ -5,9 +5,7 @@
       "resource_group_name": "s189p01-pttdomains-rg",
       "domains": [
         "www",
-        "api",
-        "www3",
-        "api3"
+        "api"
       ],
       "cached_paths": [
         "/assets/*"


### PR DESCRIPTION
### Context

Tidy-up old environment front door and DNS configurations.

### Changes proposed in this pull request

Remove www3 and api3 records used for production AKS env.

### Guidance to review

- [ ] Run `make find production domains-apply CONFIRM_PRODUCTION=1` to remove the `www3` and `api3` front door and DNS configurations for the find application.
- [ ] Run `make publish production domains-apply CONFIRM_PRODUCTION=1` to remove the `www3` front door and DNS configurations for the publish application.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
