### PR TITLE
Update libpq to fix CVE-2023-39417

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
 # Remove once the base image ruby:3.1-alpine3.15 has been updated with the below pkgs
-RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.2.1-r0 libcrypto1.1=1.1.1v-r0 pkgconf=1.8.1-r0 nghttp2=1.46.0-r1 nghttp2-libs=1.46.0-r1 pcre2=10.42-r0 libpq=14.9-r0
+RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.2.1-r0 libcrypto1.1=1.1.1v-r0 pkgconf=1.8.1-r0 nghttp2=1.46.0-r1 nghttp2-libs=1.46.0-r1 pcre2=10.42-r0 libpq=14.9-r0 postgresql14-dev=14.9-r0
 
 ENV APP_HOME /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
 # Remove once the base image ruby:3.1-alpine3.15 has been updated with the below pkgs
-RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.2.1-r0 libcrypto1.1=1.1.1u-r2 pkgconf=1.8.1-r0 nghttp2=1.46.0-r1 nghttp2-libs=1.46.0-r1 pcre2=10.42-r0
+RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.2.1-r0 libcrypto1.1=1.1.1v-r0 pkgconf=1.8.1-r0 nghttp2=1.46.0-r1 nghttp2-libs=1.46.0-r1 pcre2=10.42-r0 libpq=14.9-r0
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
### Context
Fix for occasional Snyk step failures. In [this](https://github.com/DFE-Digital/publish-teacher-training/actions/runs/5952813434/job/16145642690) case libpq and libcrypto1.1.

We can search for the available packages in the [Alpine Linux package site](https://pkgs.alpinelinux.org/packages?name=&branch=v3.15&repo=&arch=&maintainer=).

We can check when the Ruby image we use was last updated to see if the packages will be part of the base image by default. Even if the alpine3.15 base image has been updated with the fixed packages, we use the [ruby:3.1-alpine3.15](https://hub.docker.com/_/ruby/tags?page=1&name=3.1-alpine3.15) image so we have to wait for that to be updated, or manually add the fixed packages as we are doing in this PR.

Currently the latest version of:

- libpq is 14.9-r0
- libcrypto1.1 is 1.1.1v-r0

### Changes proposed in this pull request

Fix for CVE-2023-39417
Also update libcrypto and postgresql14-dev versions

### Guidance to review
[Check Snyk passes](https://github.com/DFE-Digital/publish-teacher-training/actions/runs/5954050635/job/16149703062)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
