### PR TITLE
[549] Update deadline banners/pages and fix cycle switcher

### DIFF
--- a/app/components/find/deadline_banner_component.html.erb
+++ b/app/components/find/deadline_banner_component.html.erb
@@ -19,7 +19,7 @@
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
     <% notification_banner.with_heading(text: "Courses are currently closed but you can get your application ready") %>
     <p class="govuk-body">Courses starting in the <%= cycle_timetable.cycle_year_range %> academic year are closed.</p>
-    <p class="govuk-body">You can <%= govuk_link_to("start or continue your application", Settings.apply_base_url) %> to get it ready for courses starting in the <%= cycle_timetable.next_cycle_year_range %> academic year.</p>
-    <p class="govuk-body">You’ll be able to find courses from <%= cycle_timetable.find_reopens.to_fs(:govuk_date_and_time) %> and submit your application from <%= cycle_timetable.apply_reopens.to_fs(:govuk_date_and_time) %>.</p>
+    <p class="govuk-body">You can <%= govuk_link_to("start or continue applying", Settings.apply_base_url) %> for courses starting in the <%= cycle_timetable.next_cycle_year_range %> academic year.</p>
+    <p class="govuk-body">You’ll be able to find courses from <%= cycle_timetable.find_reopens.to_fs(:govuk_date_and_time) %> and submit your applications from <%= cycle_timetable.apply_reopens.to_fs(:govuk_date_and_time) %>.</p>
   <% end %>
 <% end %>

--- a/app/controllers/find/pages_controller.rb
+++ b/app/controllers/find/pages_controller.rb
@@ -6,7 +6,9 @@ module Find
     skip_before_action :redirect_to_maintenance_page_if_flag_is_active, only: :maintenance
     before_action :redirect_to_homepage_unless_in_maintenance_mode, only: :maintenance
 
-    def cycle_has_ended; end
+    def cycle_has_ended
+      redirect_to root_path unless CycleTimetable.find_down?
+    end
 
     def accessibility; end
 

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -106,24 +106,32 @@ module Find
       Time.zone.now.between?(apply_2_deadline, find_closes)
     end
 
-    def self.find_down?
-      current_cycle_schedule == :today_is_after_find_closes || Time.zone.now.between?(find_closes, find_reopens)
+    def self.find_down? = phase_in_time?(:today_is_after_find_closes)
+
+    def self.mid_cycle? = phase_in_time?(:today_is_after_find_opens)
+
+    def self.show_apply_1_deadline_banner? = phase_in_time?(:today_is_mid_cycle)
+
+    def self.show_apply_2_deadline_banner? = phase_in_time?(:today_is_after_apply_1_deadline_passed)
+
+    def self.show_cycle_closed_banner? = phase_in_time?(:today_is_after_apply_2_deadline_passed)
+
+    def self.phases_in_time
+      {
+        today_is_after_find_closes: Time.zone.now.between?(find_closes, find_reopens),
+        today_is_after_find_opens: Time.zone.now.between?(find_opens, apply_2_deadline),
+        today_is_mid_cycle: Time.zone.now.between?(first_deadline_banner, apply_1_deadline),
+        today_is_after_apply_1_deadline_passed: Time.zone.now.between?(apply_1_deadline, apply_2_deadline),
+        today_is_after_apply_2_deadline_passed: Time.zone.now.between?(apply_2_deadline, find_closes)
+      }
     end
 
-    def self.mid_cycle?
-      current_cycle_schedule == :today_is_after_find_opens || Time.zone.now.between?(find_opens, apply_2_deadline)
-    end
-
-    def self.show_apply_1_deadline_banner?
-      current_cycle_schedule == :today_is_mid_cycle || Time.zone.now.between?(first_deadline_banner, apply_1_deadline)
-    end
-
-    def self.show_apply_2_deadline_banner?
-      current_cycle_schedule == :today_is_after_apply_1_deadline_passed || Time.zone.now.between?(apply_1_deadline, apply_2_deadline)
-    end
-
-    def self.show_cycle_closed_banner?
-      current_cycle_schedule == :today_is_after_apply_2_deadline_passed || Time.zone.now.between?(apply_2_deadline, find_closes)
+    def self.phase_in_time?(time_period)
+      if current_cycle_schedule == :real
+        phases_in_time[time_period]
+      else
+        current_cycle_schedule == time_period
+      end
     end
 
     def self.date(name, year = current_year)

--- a/app/views/find/pages/cycle_has_ended.html.erb
+++ b/app/views/find/pages/cycle_has_ended.html.erb
@@ -8,7 +8,7 @@
       <p class="govuk-body">Applications for courses starting in the <%= Find::CycleTimetable.cycle_year_range %> academic year are closed.</p>
 
       <p class="govuk-body">
-        You can <%= govuk_link_to("start or continue an application", Settings.apply_base_url) %>
+        You can <%= govuk_link_to("start or continue applying", Settings.apply_base_url) %>
         for courses starting in the <%= Find::CycleTimetable.next_cycle_year_range %>
         academic year.
       </p>
@@ -16,7 +16,7 @@
       <p class="govuk-body">You’ll be able to:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>find courses from <%= Find::CycleTimetable.find_reopens.to_fs(:govuk_date_and_time) %></li>
-        <li>submit your application from <%= Find::CycleTimetable.apply_reopens.to_fs(:govuk_date_and_time) %></li>
+        <li>submit your applications from <%= Find::CycleTimetable.apply_reopens.to_fs(:govuk_date_and_time) %></li>
       </ul>
     </div>
   </div>

--- a/spec/features/find/view_pages_spec.rb
+++ b/spec/features/find/view_pages_spec.rb
@@ -23,4 +23,9 @@ feature 'View pages' do
     expect(page).to have_selector('h1', text: 'Accessibility statement')
     expect(page).to have_text('This statement applies to the Find postgraduate teacher training service (Find)')
   end
+
+  scenario 'Redirect to /cycle-has-ended when cycle open' do
+    visit '/cycle-has-ended'
+    expect(page).to have_current_path(root_path)
+  end
 end


### PR DESCRIPTION
### Context

Fixing the cycle switcher and updating our content on the banners and pages in line with multiple applications.

The cycle switcher was not working once we were in one of the "between" periods. The if statement would always return true for the first conditional because the second part of this "or" statement would always be true.

`current_cycle_schedule == :today_is_after_find_opens || Time.zone.now.between?(find_opens, apply_2_deadline)`

### Changes proposed in this pull request

- Fix cycle switcher
- Update content on Find banners
- Update content on "Applications closed" page

### Guidance to review

<img width="1012" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/a6cd6a52-5bdc-4cac-ac9d-c18481758e2d">

<img width="999" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/a3fab76d-ed75-430e-b825-646419c5f25f">

<img width="992" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/6adc46e8-69d2-4665-aa9e-781c9d26ba14">

<img width="735" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/b0e5baa5-6db4-43b8-92f4-5db1c427c1a7">




### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
