### PR TITLE
[579] Update financial incentives for 2024 cycle

### DIFF
--- a/app/services/subjects/financial_incentive_creator_service.rb
+++ b/app/services/subjects/financial_incentive_creator_service.rb
@@ -10,6 +10,26 @@ module Subjects
 
     def subject_and_financial_incentives
       subject_and_financial_incentives = {
+        2024 => {
+          %w[Mathematics Physics Chemistry Computing] => {
+            bursary_amount: '28000',
+            scholarship: '31000'
+          },
+          %w[
+            French
+            German
+            Spanish
+          ] => {
+            bursary_amount: '25000',
+            scholarship: '29000'
+          },
+          ['Biology', 'Design and technology'] => {
+            bursary_amount: '25000'
+          },
+          ['English', 'Art and design', 'Citizenship', 'Music', 'Religious education'] => {
+            bursary_amount: '10000'
+          }
+        },
         2023 => {
           %w[Mathematics Physics Chemistry Computing] => {
             bursary_amount: '27000',

--- a/app/services/subjects/financial_incentive_creator_service.rb
+++ b/app/services/subjects/financial_incentive_creator_service.rb
@@ -133,7 +133,8 @@ module Subjects
     def execute
       subject_and_financial_incentives.each do |subject_name, financial_incentive_attributes|
         @subject.where(subject_name:).each do |subject|
-          @financial_incentive.find_or_create_by(subject:, **financial_incentive_attributes)
+          financial_incentive_record = @financial_incentive.find_or_initialize_by(subject:)
+          financial_incentive_record.update(financial_incentive_attributes)
         end
       end
     end

--- a/spec/services/subjects/financial_incentive_creator_service_spec.rb
+++ b/spec/services/subjects/financial_incentive_creator_service_spec.rb
@@ -21,6 +21,6 @@ describe Subjects::FinancialIncentiveCreatorService do
   it 'creates subject financial incentive data unless subject financial incentive already exists' do
     service.execute
     expect(subject_spy).to have_received(:where).exactly(10).times
-    expect(financial_incentive_spy).to have_received(:find_or_create_by).exactly(30).times
+    expect(financial_incentive_spy).to have_received(:find_or_initialize_by).exactly(30).times
   end
 end


### PR DESCRIPTION
### Context

Updates to financial incentives for the 2024 cycle.

**Note:** This PR doesn't seed the values. We will do that in a data migration in a follow up PR after rollover has ended and the new cycle has started. 

### Changes proposed in this pull request

- Update the figures and subjects in line with the new list provided (see Trello ticket)

### Guidance to review

Compare the figures in the PR with the figures attached to the Trello card.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
