### PR TITLE
Revert "Update events links in Find as there are no events currently"

### DIFF
--- a/app/components/find/results/results_component.html.erb
+++ b/app/components/find/results/results_component.html.erb
@@ -13,8 +13,8 @@
   <div class="app-filter-layout__content">
 
     <div class="app-promoted-link">
-      <%= govuk_link_to "Get free support from a teacher training adviser",
-                        t("find.get_into_teaching.url_get_an_advisor") %>.
+      <%= govuk_link_to "Talk to teacher training providers at an event near you",
+                        t("find.get_into_teaching.url_teacher_training_events") %>.
     </div>
 
     <%= render Find::Results::NoResultsComponent.new(results:) %>

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -120,16 +120,16 @@
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <h2 class="govuk-heading-m">Get free one-to-one support</h2>
+    <h2 class="govuk-heading-m">Meet local teacher training providers</h2>
 
-    <p class="govuk-body">An experienced teacher training adviser can guide you through how to find your teacher training course and more. They can:</p>
+    <p class="govuk-body">Visit a Get Into Teaching event where you can:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>help you to understand more about different courses</li>
-      <li>answer questions about fees and funding</li>
-      <li>support you to make an application for a course</li>
+      <li>get advice on your application</li>
+      <li>talk to existing teachers</li>
+      <li>connect with people like you who are interested in teaching</li>
     </ul>
 
-    <%= govuk_link_to("Find out about teacher training advisers", t("find.get_into_teaching.url_get_an_advisor"), class: "govuk-body") %>.
+    <%= govuk_link_to("Talk to teacher training providers at an event near you", t("find.get_into_teaching.url_events"), class: "govuk-body") %>.
   </div>
 </div>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -130,7 +130,7 @@ en:
       url_improve_your_subject_knowledge: https://getintoteaching.education.gov.uk/improve-your-subject-knowledge
       url_teacher_training_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_banner&utm_content=Autumn23events
       url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
-      url_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_start&utm_content=Autumnevents
+      url_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_start&utm_content=Autumn23events
       url_train_to_teach_as_international_candidate: https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student
       url_fund_your_training: https://getintoteaching.education.gov.uk/funding-and-support
     qualification:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -128,9 +128,9 @@ en:
       url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training
       url_bursaries_and_scholarships: https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships
       url_improve_your_subject_knowledge: https://getintoteaching.education.gov.uk/improve-your-subject-knowledge
-      url_teacher_training_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_banner&utm_content=Spring23events
+      url_teacher_training_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_banner&utm_content=Autumn23events
       url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
-      url_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_start&utm_content=Spring23events
+      url_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_start&utm_content=Autumnevents
       url_train_to_teach_as_international_candidate: https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student
       url_fund_your_training: https://getintoteaching.education.gov.uk/funding-and-support
     qualification:

--- a/spec/components/find/results/results_component_spec.rb
+++ b/spec/components/find/results/results_component_spec.rb
@@ -38,7 +38,7 @@ module Find
         component = render_inline(
           described_class.new(results: results_view, courses:)
         )
-        expect(component.text).to include('teacher training adviser')
+        expect(component.text).to include('event near you')
       end
     end
 
@@ -93,7 +93,7 @@ module Find
             filtered_by_location: false
           )
         end
-        expect(component.text).to include('teacher training adviser')
+        expect(component.text).to include('event near you')
       end
     end
   end


### PR DESCRIPTION
Reverts DFE-Digital/publish-teacher-training#3755

Events are now back live on the GIT Website, so we can cleanly revert this PR to go back to promoting events.