### PR TITLE
[620] Remove `study_sites` feature flag

### DIFF
--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -11,7 +11,7 @@ module NavigationBarHelper
     [
       { name: t('navigation_bar.courses'), url: publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year) },
       { name: t('navigation_bar.schools'), url: publish_provider_recruitment_cycle_schools_path(provider.provider_code, provider.recruitment_cycle_year) },
-      *([name: t('navigation_bar.study_sites'), url: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year)] if FeatureService.enabled?(:study_sites) && recruitment_cycle_after_2023?(provider)),
+      *([name: t('navigation_bar.study_sites'), url: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year)] if recruitment_cycle_after_2023?(provider)),
       { name: t('navigation_bar.users'), url: publish_provider_users_path(provider_code: provider.provider_code), additional_url: request_access_publish_provider_path(provider.provider_code) },
       *([name: t('navigation_bar.training_partners'), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.accredited_provider?),
       *([name: t('navigation_bar.accredited_provider'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)] unless provider.accredited_provider? && FeatureService.enabled?(:accredited_provider_search)),

--- a/app/services/workflow_step_service.rb
+++ b/app/services/workflow_step_service.rb
@@ -12,7 +12,7 @@ class WorkflowStepService
       workflow_for_recruitment_cycle_after2023
     else
       workflow_for_recruitment_cycle_before2023
-    end - remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
+    end - remove_study_site_if_current_cycle(course)
   end
 
   private
@@ -160,7 +160,7 @@ class WorkflowStepService
     end
   end
 
-  def remove_study_site_if_feature_flag_disabled_or_current_cycle(course)
-    course.in_current_cycle? || !FeatureService.enabled?(:study_sites) ? [:study_site] : []
+  def remove_study_site_if_current_cycle(course)
+    course.in_current_cycle? ? [:study_site] : []
   end
 end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -138,7 +138,7 @@
       end
     end
 
-    if FeatureService.enabled?(:study_sites) && recruitment_cycle_after_2023?(course)
+    if recruitment_cycle_after_2023?(course)
       summary_list.with_row(html_attributes: { data: { qa: "course__study_sites" } }) do |row|
         row.with_key { "Study site" }
 

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -133,7 +133,7 @@
           <% end %>
         <% end %>
 
-        <% if FeatureService.enabled?(:study_sites) && recruitment_cycle_after_2023?(course) %>
+        <% if recruitment_cycle_after_2023?(course) %>
           <% summary_list.with_row(html_attributes: { data: { qa: "course__study_sites" } }) do |row| %>
             <% row.with_key { "Study site".pluralize(course.study_sites.length) } %>
             <% row.with_value do %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -109,7 +109,6 @@ features:
   gias_search: true
   support_new_provider_creation_flow: true
   accredited_provider_search: true
-  study_sites: true
 
 cookies:
   session:

--- a/spec/components/add_course_button_spec.rb
+++ b/spec/components/add_course_button_spec.rb
@@ -9,7 +9,6 @@ describe AddCourseButton do
   let(:provider) { build(:provider, recruitment_cycle:) }
 
   before do
-    allow(Settings.features).to receive(:study_sites).and_return(true)
     render_inline(described_class.new(provider:))
   end
 

--- a/spec/features/publish/add_course_button_spec.rb
+++ b/spec/features/publish/add_course_button_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'Add course button', { can_edit_current_and_next_cycles: true } do
   scenario 'with no study sites on the provider in the next cycle and feature flag off' do
     given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
-    and_the_study_sites_feature_flag_is_not_active
     when_i_visit_the_courses_page
     then_i_should_see_the_add_course_button
   end
@@ -65,10 +64,6 @@ feature 'Add course button', { can_edit_current_and_next_cycles: true } do
         ]
       )
     )
-  end
-
-  def and_the_study_sites_feature_flag_is_not_active
-    allow(Settings.features).to receive(:study_sites).and_return(false)
   end
 
   def when_i_visit_the_courses_page

--- a/spec/features/publish/add_course_button_spec.rb
+++ b/spec/features/publish/add_course_button_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 feature 'Add course button', { can_edit_current_and_next_cycles: true } do
-  scenario 'with no study sites on the provider in the next cycle and feature flag off' do
+  scenario 'with no study sites on the provider in the next cycle' do
     given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
     when_i_visit_the_courses_page
     then_i_should_see_the_add_course_button

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -133,7 +133,7 @@ feature 'course confirmation', { can_edit_current_and_next_cycles: false } do
       query: confirmation_params(next_cycle_provider)
     )
   end
-  
+
   def when_i_click_change_subject
     publish_course_confirmation_page.details.subjects.change_link.click
   end

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -6,7 +6,6 @@ feature 'course confirmation', { can_edit_current_and_next_cycles: false } do
   context 'lead school' do
     before do
       given_i_am_authenticated_as_a_provider_user
-      and_the_study_sites_feature_flag_is_active
       when_i_visit_the_publish_course_confirmation_page
     end
 
@@ -134,11 +133,7 @@ feature 'course confirmation', { can_edit_current_and_next_cycles: false } do
       query: confirmation_params(next_cycle_provider)
     )
   end
-
-  def and_the_study_sites_feature_flag_is_active
-    allow(Settings.features).to receive(:study_sites).and_return(true)
-  end
-
+  
   def when_i_click_change_subject
     publish_course_confirmation_page.details.subjects.change_link.click
   end

--- a/spec/features/publish/courses/editing_study_sites_spec.rb
+++ b/spec/features/publish/courses/editing_study_sites_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 feature 'updating study sites on a course', { can_edit_current_and_next_cycles: false } do
-
   scenario 'provider has no study sites' do
     and_i_am_authenticated_as_a_provider_user_in_the_next_cycle
     and_there_is_a_course_i_want_to_edit

--- a/spec/features/publish/courses/editing_study_sites_spec.rb
+++ b/spec/features/publish/courses/editing_study_sites_spec.rb
@@ -3,9 +3,6 @@
 require 'rails_helper'
 
 feature 'updating study sites on a course', { can_edit_current_and_next_cycles: false } do
-  before do
-    given_the_study_sites_feature_flag_is_active
-  end
 
   scenario 'provider has no study sites' do
     and_i_am_authenticated_as_a_provider_user_in_the_next_cycle
@@ -38,10 +35,6 @@ feature 'updating study sites on a course', { can_edit_current_and_next_cycles: 
 
   def then_i_see_the_error_message_add_one_study_site
     expect(page).to have_link('Add at least one study site')
-  end
-
-  def given_the_study_sites_feature_flag_is_active
-    allow(Settings.features).to receive(:study_sites).and_return(true)
   end
 
   def and_i_am_authenticated_as_a_provider_user_in_the_next_cycle

--- a/spec/features/publish/courses/new_schools_spec.rb
+++ b/spec/features/publish/courses/new_schools_spec.rb
@@ -22,10 +22,6 @@ feature 'selection schools', { can_edit_current_and_next_cycles: false } do
 
   private
 
-  def and_the_study_sites_feature_flag_is_active
-    allow(Settings.features).to receive(:study_sites).and_return(true)
-  end
-
   def given_i_am_authenticated_as_a_provider_user
     @user = create(:user, :with_provider)
     given_i_am_authenticated(user: @user)

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -9,16 +9,11 @@ feature 'new course', { can_edit_current_and_next_cycles: false } do
     # with the correct course being created
     given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
     when_i_visit_the_courses_page
-    and_the_study_sites_feature_flag_is_active
     and_i_click_on_add_course
     then_i_can_create_the_course
   end
 
   private
-
-  def and_the_study_sites_feature_flag_is_active
-    allow(Settings.features).to receive(:study_sites).and_return(true)
-  end
 
   def then_i_can_create_the_course
     expect(publish_courses_new_level_page).to be_displayed

--- a/spec/features/publish/managing_study_sites_spec.rb
+++ b/spec/features/publish/managing_study_sites_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 feature "Managing a provider's study_sites", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_study_sites_feature_is_active
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_study_sites_page
     then_i_should_see_a_list_of_study_sites
@@ -114,10 +113,6 @@ feature "Managing a provider's study_sites", { can_edit_current_and_next_cycles:
     and_i_click_add_study_site
     then_i_am_on_the_index_page
     and_the_study_site_is_added
-  end
-
-  def given_the_study_sites_feature_is_active
-    allow(Settings.features).to receive(:study_sites).and_return(true)
   end
 
   def and_the_study_site_is_not_added


### PR DESCRIPTION
### Context

Removing the study sites feature flag. The feature has been live for a good few months now. 

### Changes proposed in this pull request

See commits

### Guidance to review

Check the functionality still works as expected.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
