### PR TITLE
[623] Remove `add_multiple_schools` feature flag

### DIFF
--- a/app/views/support/schools/index.html.erb
+++ b/app/views/support/schools/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= govuk_link_to("Add school", new_support_recruitment_cycle_provider_school_path, class: "govuk-button govuk-!-margin-bottom-3") %>
 
-<%= govuk_link_to("Add multiple schools", new_support_recruitment_cycle_provider_schools_multiple_path, class: "govuk-button govuk-button--secondary govuk") if FeatureService.enabled?(:add_multiple_schools) %>
+<%= govuk_link_to("Add multiple schools", new_support_recruitment_cycle_provider_schools_multiple_path, class: "govuk-button govuk-button--secondary govuk") %>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,7 +104,6 @@ features:
     # During rollover providers should be able to edit current & next recruitment cycle courses
     can_edit_current_and_next_cycles: true
   user_management: true
-  add_multiple_schools: true
   course_preview_missing_information: true
   gias_search: true
   support_new_provider_creation_flow: true

--- a/spec/features/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/features/support/providers/schools/creating_multiple_schools_spec.rb
@@ -8,7 +8,6 @@ feature 'Multiple schools' do
   end
 
   scenario 'submitting an empty form' do
-    and_the_multiple_schools_feature_flag_is_active
     when_i_visit_a_provider_schools_page
     then_i_click_add_multiple_schools
 
@@ -17,7 +16,6 @@ feature 'Multiple schools' do
   end
 
   scenario 'submitting a form with two schools' do
-    and_the_multiple_schools_feature_flag_is_active
     when_i_visit_the_multiple_schools_new_page
     and_i_submit_the_form_with_two_schools
     and_i_see_the_text_one_of_two
@@ -37,8 +35,7 @@ feature 'Multiple schools' do
   end
 
   scenario 'clicking back' do
-    given_the_multiple_schools_feature_flag_is_active
-    and_i_visit_the_multiple_schools_new_page
+    when_i_visit_the_multiple_schools_new_page
     and_i_submit_the_form_with_two_schools
     and_i_see_the_text_one_of_two
     and_i_should_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham')
@@ -73,16 +70,14 @@ feature 'Multiple schools' do
   end
 
   scenario 'cancel from multiple schools new page' do
-    given_the_multiple_schools_feature_flag_is_active
-    and_i_visit_the_multiple_schools_new_page
+    when_i_visit_the_multiple_schools_new_page
 
     when_i_click_cancel
     then_i_should_be_on_the_provider_schools_page
   end
 
   scenario 'cancel from multiple schools new page for a school' do
-    given_the_multiple_schools_feature_flag_is_active
-    and_i_visit_the_multiple_schools_new_page
+    when_i_visit_the_multiple_schools_new_page
     and_i_submit_the_form_with_two_schools
     and_i_see_the_text_one_of_two
     and_i_should_see_that_the_text_field_has_been_prepopulated('Name', 'Tottenham')
@@ -92,8 +87,7 @@ feature 'Multiple schools' do
   end
 
   scenario 'cancel from multiple school confirm page' do
-    given_the_multiple_schools_feature_flag_is_active
-    and_i_visit_the_multiple_schools_new_page
+    when_i_visit_the_multiple_schools_new_page
     and_i_submit_the_form_with_two_schools
     and_i_submit_a_valid_form
     and_i_see_the_text_two_of_two
@@ -168,10 +162,6 @@ feature 'Multiple schools' do
     @provider ||= create(:provider, sites: [build(:site)])
   end
 
-  def and_the_multiple_schools_feature_flag_is_active
-    allow(Settings.features).to receive(:add_multiple_schools).and_return(true)
-  end
-
   def then_i_click_add_multiple_schools
     click_link 'Add multiple schools'
   end
@@ -208,9 +198,7 @@ feature 'Multiple schools' do
 
   alias_method :then_i_see_the_text_two_of_two, :and_i_see_the_text_two_of_two
   alias_method :and_i_should_see_that_the_text_field_has_been_prepopulated, :then_i_should_see_that_the_text_field_has_been_prepopulated
-  alias_method :and_i_visit_the_multiple_schools_new_page, :when_i_visit_the_multiple_schools_new_page
   alias_method :and_the_database_should_not_have_updated_with_the_new_school, :then_the_database_should_not_have_updated_with_the_new_school
-  alias_method :given_the_multiple_schools_feature_flag_is_active, :and_the_multiple_schools_feature_flag_is_active
 
   alias_method :then_i_should_be_on_the_provider_schools_page, :when_i_am_redirected_to_the_schools_page
   alias_method :and_i_should_be_on_the_provider_schools_page, :when_i_am_redirected_to_the_schools_page


### PR DESCRIPTION
### Context

Removing the `add_multiple_schools` feature flag, because it's been active for a few months now and adds unnecessary complexity.

### Changes proposed in this pull request

- Remove the feature flag
- Remove the usages

### Guidance to review

- Did I miss anything?
- Does the functionality still work as expected?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
