### PR TITLE
[629] Remove `course_preview` feature flag

### DIFF
--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -22,7 +22,7 @@ module CoursePreview
     end
 
     def render?
-      FeatureService.enabled?(:course_preview_missing_information) && is_preview
+      is_preview
     end
 
     def accrediting_provider_present?(course)

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -24,7 +24,7 @@ module Find
             program_type == 'higher_education_programme' ||
             program_type == 'scitt_programme' ||
             study_sites.any? ||
-            site_statuses.map(&:site).uniq.many?
+            site_statuses.map(&:site).uniq.many? || preview?(params)
         end
       end
     end

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -24,8 +24,7 @@ module Find
             program_type == 'higher_education_programme' ||
             program_type == 'scitt_programme' ||
             study_sites.any? ||
-            site_statuses.map(&:site).uniq.many? ||
-            FeatureService.enabled?(:course_preview_missing_information)
+            site_statuses.map(&:site).uniq.many?
         end
       end
     end

--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -1,13 +1,13 @@
 <h2 class="govuk-heading-m">Contents</h2>
 <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
-  <% if about_course.present? || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
+  <% if about_course.present? || preview? %>
     <li><%= govuk_link_to "Course summary", "#section-about" %></li>
   <% end %>
-  <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
+  <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" || preview? %>
     <li><%= govuk_link_to "Training locations", "#training-locations" %></li>
   <% end %>
   <li><%= govuk_link_to "Entry requirements", "#section-entry" %></li>
-  <% if provider.train_with_us.present? || about_accrediting_provider.present? || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
+  <% if provider.train_with_us.present? || about_accrediting_provider.present? || preview? %>
     <li><%= govuk_link_to "About the training provider", "#section-about-provider" %></li>
   <% end %>
   <% if salaried? %>
@@ -18,7 +18,7 @@
     <li><%= govuk_link_to "Interview process", "#section-interviews" %></li>
   <% end %>
   <li><%= govuk_link_to "International candidates", "#section-international-students" %></li>
-  <% if provider.train_with_disability.present? || (preview? && FeatureService.enabled?(:course_preview_missing_information)) %>
+  <% if provider.train_with_disability.present? || preview? %>
     <li><%= govuk_link_to "Training with disabilities and other needs", "#section-train-with-disabilities" %></li>
   <% end %>
   <li><%= govuk_link_to "Contact this training provider", "#section-contact" %></li>

--- a/app/views/find/courses/_train_with_disabilities.html.erb
+++ b/app/views/find/courses/_train_with_disabilities.html.erb
@@ -3,7 +3,7 @@
   <div data-qa="course__train_with_disabilities">
     <% if course.provider.train_with_disability.present? %>
       <%= markdown(course.provider.train_with_disability) %>
-    <% elsif FeatureService.enabled?(:course_preview_missing_information) %>
+    <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :train_with_disability, is_preview: preview?(params)) %>
     <% end %>
   </div>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -27,9 +27,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render Find::Courses::ContentsComponent::View.new(course) %>
 
-    <% if course.about_course.present? %>
-      <%= render partial: "find/courses/about_course", locals: { course: } %>
-    <% end %>
+    <%= render partial: "find/courses/about_course", locals: { course: } %>
 
     <%= render Find::Courses::AboutSchoolsComponent::View.new(course) %>
 

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -27,7 +27,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render Find::Courses::ContentsComponent::View.new(course) %>
 
-    <% if course.about_course.present? || FeatureService.enabled?(:course_preview_missing_information) %>
+    <% if course.about_course.present? %>
       <%= render partial: "find/courses/about_course", locals: { course: } %>
     <% end %>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,7 +104,6 @@ features:
     # During rollover providers should be able to edit current & next recruitment cycle courses
     can_edit_current_and_next_cycles: true
   user_management: true
-  course_preview_missing_information: true
   gias_search: true
   support_new_provider_creation_flow: true
   accredited_provider_search: true

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -38,7 +38,7 @@ module CoursePreview
 
       shared_examples 'course with missing information' do |information_type, text|
         before do
-          allow(Settings.features).to receive_messages(course_preview_missing_information: true, accredited_provider_search: true)
+          allow(Settings.features).to receive_messages(accredited_provider_search: true)
         end
 
         it "renders link for missing #{information_type}" do

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -17,10 +17,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   context 'with empty sections' do
-    before do
-      allow(Settings.features).to receive(:course_preview_missing_information).and_return(true)
-    end
-
     scenario 'blank about the training provider' do
       given_i_am_authenticated(user: user_with_no_course_enrichments)
       when_i_visit_the_publish_course_preview_page


### PR DESCRIPTION
### Context

Removing the `course_preview_missing_information` feature flag, because it's been active for a few months now and adds unnecessary complexity.

### Changes proposed in this pull request

- Remove the feature flag
- Remove the old logic

### Guidance to review

- Did I miss anything?
- Does the functionality still work as expected?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
