### PR TITLE
[631] Remove `gias_search` feature flag

### DIFF
--- a/app/views/publish/providers/schools/index.html.erb
+++ b/app/views/publish/providers/schools/index.html.erb
@@ -9,11 +9,7 @@
       <%= page_title %>
     </h1>
 
-    <% if FeatureService.enabled?(:gias_search) %>
       <%= govuk_button_link_to t(".add_school"), search_publish_provider_recruitment_cycle_schools_path(@provider.provider_code) %>
-    <% else %>
-      <%= govuk_button_link_to t(".add_school"), new_publish_provider_recruitment_cycle_school_path(@provider.provider_code) %>
-    <% end %>
 
     <p class="govuk-body">A school placement is a school where the candidate might be placed in to do classroom experience, for example. Add placement schools then attach them to any of your courses from the ‘Basic details’ tab on the course page.</p>
 

--- a/app/views/publish/providers/study_sites/index.html.erb
+++ b/app/views/publish/providers/study_sites/index.html.erb
@@ -9,11 +9,7 @@
       <%= page_title %>
     </h1>
 
-    <% if FeatureService.enabled?(:gias_search) %>
-      <%= govuk_button_link_to t(".add_study_site"), search_publish_provider_recruitment_cycle_study_sites_path(@provider.provider_code) %>
-    <% else %>
-      <%= govuk_button_link_to t(".add_study_site"), new_publish_provider_recruitment_cycle_study_site_path(@provider.provider_code) %>
-    <% end %>
+    <%= govuk_button_link_to t(".add_study_site"), search_publish_provider_recruitment_cycle_study_sites_path(@provider.provider_code) %>
 
     <p class="govuk-body">A study site, such as a university campus, is where trainees do theoretical training. Add study sites for your organisation and then attach one or more to a course from the ‘Basic details’ tab on the course page.</p>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,7 +104,6 @@ features:
     # During rollover providers should be able to edit current & next recruitment cycle courses
     can_edit_current_and_next_cycles: true
   user_management: true
-  gias_search: true
   accredited_provider_search: true
 
 cookies:


### PR DESCRIPTION
### Context

Removing the `gias_search` feature flag, because it's been active for a few months now and adds unnecessary complexity.

### Changes proposed in this pull request

- Remove the feature flag
- Remove the usages

### Guidance to review

- Did I miss anything?
- Does the functionality still work as expected?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
