### PR TITLE
[633] Remove visa validation from provider level

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -324,7 +324,6 @@ class Course < ApplicationRecord
   validates :accrediting_provider, presence: true, on: :publish, unless: -> { self_accredited? }
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish
-  validate :validate_provider_visa_sponsorship_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }
   validate :validate_provider_urn_ukprn_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }
   validate :validate_accredited_provider_is_accredited, on: :publish
   validate :validate_degree_requirements_publishable, on: :publish
@@ -929,10 +928,6 @@ class Course < ApplicationRecord
     site_statuses.each do |site_status|
       raise "Site status invalid on course #{provider_code}/#{course_code}: #{site_status.errors.full_messages.first}" unless site_status.valid?
     end
-  end
-
-  def validate_provider_visa_sponsorship_publishable
-    errors.add(:base, :visa_sponsorship_not_publishable) if provider.can_sponsor_student_visa.nil? || provider.can_sponsor_skilled_worker_visa.nil?
   end
 
   def validate_provider_urn_ukprn_publishable


### PR DESCRIPTION
### Context

As part of an effort to increase the number of published courses, we are fixing a bug which prevents providers from publishing courses if `can_sponsor_student_visa` or `can_sponsor_skilled_worker_visa` is `nil` on the provider.

We have moved these to the course level and should validate on that level instead, as the provider has no way of updating on the provider level anymore.

### Changes proposed in this pull request

- Remove the validation from the provider level
- Remove the method as it's no longer used

### Guidance to review

Try publishing the course `1I2` `V655` `2023` on QA and compare with the review app. You'll only be able to do this once, so be careful! 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
