### PR TITLE
[636] Remove `accredited_provider_search` feature flag

### DIFF
--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -40,13 +40,11 @@ module CoursePreview
     def train_with_us_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true, anchor: 'train-with-us')
 
     def about_accrediting_provider_link
-      if FeatureService.enabled?(:accredited_provider_search) && accrediting_provider_present?(course)
+      if accrediting_provider_present?(course)
         edit_publish_provider_recruitment_cycle_accredited_provider_path(provider_code, recruitment_cycle_year, accredited_provider_code: @course.accredited_provider_code, goto_preview: true, anchor: 'accredited-provider-form-description-field')
-      elsif FeatureService.enabled?(:accredited_provider_search) && !accrediting_provider_present?(course)
+      else
         publish_provider_recruitment_cycle_accredited_providers_path(provider_code,
                                                                      recruitment_cycle_year)
-      else
-        about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true, anchor: "accrediting-provider-#{accrediting_provider.provider_code}")
       end
     end
   end

--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -14,7 +14,7 @@ module NavigationBarHelper
       *([name: t('navigation_bar.study_sites'), url: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year)] if recruitment_cycle_after_2023?(provider)),
       { name: t('navigation_bar.users'), url: publish_provider_users_path(provider_code: provider.provider_code), additional_url: request_access_publish_provider_path(provider.provider_code) },
       *([name: t('navigation_bar.training_partners'), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.accredited_provider?),
-      *([name: t('navigation_bar.accredited_provider'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)] unless provider.accredited_provider? && FeatureService.enabled?(:accredited_provider_search)),
+      *([name: t('navigation_bar.accredited_provider'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)] unless provider.accredited_provider?),
       { name: t('navigation_bar.organisation_details'), url: details_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year) }
     ]
   end

--- a/app/views/layouts/provider_record.html.erb
+++ b/app/views/layouts/provider_record.html.erb
@@ -15,7 +15,7 @@
     { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
     { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
     { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-    *([{ name: "Accredited providers", url: support_recruitment_cycle_provider_accredited_providers_path(@provider.recruitment_cycle_year, @provider) }] if @provider.lead_school? && FeatureService.enabled?(:accredited_provider_search))
+    *([{ name: "Accredited providers", url: support_recruitment_cycle_provider_accredited_providers_path(@provider.recruitment_cycle_year, @provider) }] if @provider.lead_school?)
   ]) %>
 
   <%= yield %>

--- a/app/views/layouts/provider_record.html.erb
+++ b/app/views/layouts/provider_record.html.erb
@@ -15,7 +15,7 @@
     { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
     { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
     { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-    *([{ name: "Accredited providers", url: support_recruitment_cycle_provider_accredited_providers_path(@provider.recruitment_cycle_year, @provider) }] if @provider.lead_school?)
+    *([{ name: "Accredited providers", url: support_recruitment_cycle_provider_accredited_providers_path(@provider.recruitment_cycle_year, @provider) }] unless @provider.accredited_provider?)
   ]) %>
 
   <%= yield %>

--- a/app/views/publish/courses/accredited_provider/new.html.erb
+++ b/app/views/publish/courses/accredited_provider/new.html.erb
@@ -22,28 +22,6 @@
         <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_provider">
           <% if @provider.accredited_bodies.length > 0 %>
             <%= render partial: "provider_suggestion", collection: @provider.accredited_bodies.sort_by { |k| k[:provider_name] }, locals: { form: fields } %>
-
-            <!-- TODO: Remove this field once feature flag is removed -->
-            <% unless FeatureService.enabled?(:accredited_provider_search) %>
-              <div class="govuk-radios__divider">or</div>
-
-              <div class="govuk-radios__item">
-                <%= fields.radio_button :accredited_provider_code,
-                  "other",
-                  class: "govuk-radios__input",
-                  data: { "aria-controls" => "other-container" },
-                  checked: @errors && @errors[:accredited_provider]&.any? %>
-                <%= fields.label :accredited_provider_code,
-                  "Another accredited provider",
-                  for: "course_accredited_provider_code_other",
-                  value: false,
-                  class: "govuk-label govuk-radios__label" %>
-              </div>
-              <br>
-              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="other-container">
-                <%= render "provider_search_field", form: fields %>
-              </div>
-            <% end %>
           <% else %>
             <%= fields.hidden_field :accredited_provider_code, value: :other %>
             <%= render "provider_search_field", form: fields %>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -47,31 +47,6 @@
         max_words: 250,
         rows: 15) %>
 
-        <% unless FeatureService.enabled?(:accredited_provider_search) %>
-          <% if @about_form.accredited_bodies.present? %>
-            <% accredited_provider = "accredited provider".pluralize(@about_form.accredited_bodies.count) %>
-
-            <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
-
-            <h2 class="govuk-heading-m">About your <%= accredited_provider %></h2>
-
-            <p class="govuk-body">Tell candidates about your <%= accredited_provider %> – you could mention their academic specialities and achievements.</p>
-            <p class="govuk-body">Be specific with the claims you make, and support them with evidence.</p>
-
-            <% @about_form.accredited_bodies.each do |accredited_provider| %>
-              <%= f.fields_for :accredited_bodies, accredited_provider, index: nil do |abf| %>
-                <%= abf.hidden_field :provider_name %>
-                <%= abf.hidden_field :provider_code %>
-                <%= abf.govuk_text_area(:description,
-                  form_group: { id: "accrediting-provider-#{accredited_provider.provider_code}" },
-                  label: { text: "#{accredited_provider.provider_name} (optional)", size: "s" },
-                  max_words: 100,
-                  rows: 10) %>
-              <% end %>
-            <% end %>
-        <% end %>
-      <% end %>
-
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
       <h2 class="govuk-heading-m">Training with disabilities and other needs</h2>

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -39,19 +39,6 @@
         action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-us",
         action_visually_hidden_text: "details about training with your organisation"
       ) %>
-      <% if !FeatureService.enabled?(:accredited_provider_search) && @provider.accredited_bodies.present? %>
-        <% @provider.accredited_bodies.each do |accredited_provider| %>
-          <% enrichment_summary(
-            summary_list,
-            :provider,
-            "#{accredited_provider[:provider_name]} (optional)",
-            accredited_provider[:description],
-            ["accrediting_provider_#{accredited_provider[:provider_code]}"],
-            action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{accredited_provider[:provider_code]}",
-            action_visually_hidden_text: "details about #{accredited_provider[:provider_name]}"
-          ) %>
-        <% end %>
-      <% end %>
       <% enrichment_summary(
         summary_list,
         :provider,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -99,7 +99,6 @@ features:
     has_current_cycle_started?: true
     # During rollover providers should be able to edit current & next recruitment cycle courses
     can_edit_current_and_next_cycles: true
-  accredited_provider_search: true
 
 cookies:
   session:

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -37,10 +37,6 @@ module CoursePreview
       end
 
       shared_examples 'course with missing information' do |information_type, text|
-        before do
-          allow(Settings.features).to receive_messages(accredited_provider_search: true)
-        end
-
         it "renders link for missing #{information_type}" do
           render_inline(described_class.new(course:, information_type:, is_preview: true))
 

--- a/spec/features/publish/accredited_provider_spec.rb
+++ b/spec/features/publish/accredited_provider_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } do
   before do
     given_i_am_a_lead_school_provider_user
-    and_the_accredited_provider_search_feature_is_on
     and_i_visit_the_root_path
     when_i_click_on_the_accredited_provider_tab
   end
@@ -260,10 +259,6 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
 
   def and_i_visit_the_root_path
     visit root_path
-  end
-
-  def and_the_accredited_provider_search_feature_is_on
-    allow(Settings.features).to receive(:accredited_provider_search).and_return(true)
   end
 
   def given_i_am_a_lead_school_provider_user

--- a/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 feature 'Searching for an accredited provider' do
   before do
-    allow(Settings.features).to receive(:accredited_provider_search).and_return(true)
     given_i_am_authenticated_as_an_admin_user
     and_there_are_accredited_providers_in_the_database
   end

--- a/spec/features/support/providers/accredited_providers_spec.rb
+++ b/spec/features/support/providers/accredited_providers_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } do
   before do
-    allow(Settings.features).to receive(:accredited_provider_search).and_return(true)
     given_i_am_authenticated_as_an_admin_user
     and_there_are_accredited_providers_in_the_database
     and_i_visit_the_index_page


### PR DESCRIPTION
### Context

Removing the `accredited_provider_search` feature flag, because it's been active for a few months now and adds unnecessary complexity.

### Changes proposed in this pull request

- Remove the feature flag
- Remove the usages

### Guidance to review

- Did I miss anything?
- Does the functionality still work as expected?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
