### PR TITLE
Remove hardcoded pkg versions from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
 # Remove once the base image ruby:3.1-alpine3.15 has been updated with the below pkgs
-RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.2.1-r0 libcrypto1.1=1.1.1v-r0 pkgconf=1.8.1-r0 nghttp2=1.46.0-r1 nghttp2-libs=1.46.0-r1 pcre2=10.42-r0 libpq=14.9-r0 postgresql14-dev=14.9-r0
+RUN apk add --no-cache ncurses=6.3_p20211120-r2 ncurses-libs=6.3_p20211120-r2 libcurl=8.3.0-r0 pkgconf=1.8.1-r0 nghttp2=1.46.0-r1 nghttp2-libs=1.46.0-r1
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
### Context

Update libcurl to 8.3.0-r0
Remove hardcoded pkg versions from the Dockerfile, that are no longer required.
Old versions are breaking the build-no-cache workflow

### Changes proposed in this pull request

Update Dockerfile

### Guidance to review

Check build/build-no-cache workflow 

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
