### PR TITLE
[692] Add financial support banner

### DIFF
--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -20,6 +20,14 @@ module Find
           elsif financial_incentive.bursary_amount.present?
             financial_info = "Bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} available"
           end
+        elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
+          if financial_incentive.scholarship.present? && financial_incentive.bursary_amount.present?
+            financial_info = 'Scholarships and bursaries are available'
+          elsif financial_incentive.scholarship.present?
+            financial_info = 'Scholarships available'
+          elsif financial_incentive.bursary_amount.present?
+            financial_info = 'Bursaries available'
+          end
         end
 
         SecondarySubjectInput.new(subject.subject_code, subject.subject_name, financial_info)

--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -14,7 +14,7 @@ module Find
         financial_info = nil
         if FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
           if financial_incentive.scholarship.present? && financial_incentive.bursary_amount.present?
-            financial_info = "Scholarships of £#{number_with_delimiter(financial_incentive.scholarship, delimiter: ',')} and bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} are available"
+            financial_info = "Scholarships of £#{number_with_delimiter(financial_incentive.scholarship, delimiter: ',')} or bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} are available"
           elsif financial_incentive.scholarship.present?
             financial_info = "Scholarships of £#{number_with_delimiter(financial_incentive.scholarship, delimiter: ',')} are available"
           elsif financial_incentive.bursary_amount.present?
@@ -22,7 +22,7 @@ module Find
           end
         elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
           if financial_incentive.scholarship.present? && financial_incentive.bursary_amount.present?
-            financial_info = 'Scholarships and bursaries are available'
+            financial_info = 'Scholarships or bursaries are available'
           elsif financial_incentive.scholarship.present?
             financial_info = 'Scholarships available'
           elsif financial_incentive.bursary_amount.present?

--- a/app/views/find/search/subjects/_secondary_subjects.html.erb
+++ b/app/views/find/search/subjects/_secondary_subjects.html.erb
@@ -1,3 +1,15 @@
+<% unless FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
+
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.with_heading(text: "Financial support") %>
+    <p class="govuk-body">Details of financial support for courses starting in the <%= Find::CycleTimetable.next_cycle_year_range %> academic year will be released soon.</p>
+    <p class="govuk-body">In the meantime, you can <%= govuk_link_to("view the bursaries and scholarships", t("get_into_teaching.url_bursaries_and_scholarships"), target: "_blank", rel: "noopener noreferrer") %>
+ for courses starting between September <%= Find::CycleTimetable.current_year %> and July <%= Find::CycleTimetable.next_year %>.</p>
+
+  <% end %>
+
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= f.govuk_collection_check_boxes :subjects, secondary_subject_options,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1023,6 +1023,7 @@ en:
   get_into_teaching:
     tel: 0800 389 2500
     opening_times: "Monday to Friday, 8.30am to 5.30pm"
+    url_bursaries_and_scholarships: https://getintoteaching.education.gov.uk/funding-and-support/scholarships-and-bursaries
     url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
     url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
     url_ways_to_train_no_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree

--- a/spec/features/find/search/across_england/secondary_spec.rb
+++ b/spec/features/find/search/across_england/secondary_spec.rb
@@ -39,7 +39,51 @@ feature 'Searching across England' do
     and_i_should_see_the_correct_courses
   end
 
+  context 'Given the bursaries and scholarships announced feature flag' do
+    context 'when deactivated' do
+      before do
+        given_the_bursaries_and_scholarships_feature_flag_is_deactivated
+      end
+
+      scenario 'displays the financial support banner' do
+        when_i_visit_the_secondary_subjects_page
+        then_i_should_see_the_financial_support_banner
+      end
+    end
+
+    context 'when activated' do
+      before do
+        given_the_bursaries_and_scholarships_feature_flag_is_activated
+      end
+
+      scenario 'does not display the financial support banner' do
+        when_i_visit_the_secondary_subjects_page
+        then_i_should_not_see_the_financial_support_banner
+      end
+    end
+  end
+
   private
+
+  def given_the_bursaries_and_scholarships_feature_flag_is_deactivated
+    FeatureFlag.deactivate(:bursaries_and_scholarships_announced)
+  end
+
+  def given_the_bursaries_and_scholarships_feature_flag_is_activated
+    FeatureFlag.activate(:bursaries_and_scholarships_announced)
+  end
+
+  def then_i_should_see_the_financial_support_banner
+    expect(page).to have_css('.govuk-notification-banner__heading', text: 'Financial support')
+  end
+
+  def then_i_should_not_see_the_financial_support_banner
+    expect(page).not_to have_css('.govuk-notification-banner__heading', text: 'Financial support')
+  end
+
+  def when_i_visit_the_secondary_subjects_page
+    find_secondary_subjects_page.load
+  end
 
   def given_there_are_secondary_courses_in_england
     create(:course, :published, :with_salary, application_status: 'open', site_statuses: [build(:site_status, :findable)])

--- a/spec/helpers/find/subject_helper_spec.rb
+++ b/spec/helpers/find/subject_helper_spec.rb
@@ -58,7 +58,7 @@ describe Find::SubjectHelper do
           let(:subjects) { [find_or_create(:secondary_subject, :biology)] }
 
           it 'returns the correct financial information' do
-            expect(subject.first.financial_info).to be_nil
+            expect(subject.first.financial_info).to eq('Bursaries available')
           end
         end
 
@@ -66,7 +66,7 @@ describe Find::SubjectHelper do
           let(:subjects) { [find_or_create(:secondary_subject, subject_name: 'made up subject', scholarship: 1_000_000_000)] }
 
           it 'returns the correct financial information' do
-            expect(subject.first.financial_info).to be_nil
+            expect(subject.first.financial_info).to eq('Scholarships available')
           end
         end
 
@@ -74,7 +74,7 @@ describe Find::SubjectHelper do
           let(:subjects) { [find_or_create(:secondary_subject, :chemistry)] }
 
           it 'returns the correct financial information' do
-            expect(subject.first.financial_info).to be_nil
+            expect(subject.first.financial_info).to eq('Scholarships and bursaries are available')
           end
         end
       end

--- a/spec/helpers/find/subject_helper_spec.rb
+++ b/spec/helpers/find/subject_helper_spec.rb
@@ -45,7 +45,7 @@ describe Find::SubjectHelper do
         let(:subjects) { [find_or_create(:secondary_subject, :chemistry)] }
 
         it 'returns the correct financial information' do
-          expect(subject.first.financial_info).to eq('Scholarships of £26,000 and bursaries of £24,000 are available')
+          expect(subject.first.financial_info).to eq('Scholarships of £26,000 or bursaries of £24,000 are available')
         end
       end
 
@@ -74,7 +74,7 @@ describe Find::SubjectHelper do
           let(:subjects) { [find_or_create(:secondary_subject, :chemistry)] }
 
           it 'returns the correct financial information' do
-            expect(subject.first.financial_info).to eq('Scholarships and bursaries are available')
+            expect(subject.first.financial_info).to eq('Scholarships or bursaries are available')
           end
         end
       end


### PR DESCRIPTION
### Context

Adding a banner to Find which will be displayed at the start of the new cycle before scholarships and bursaries have been announced.

### Changes proposed in this pull request

- Add a banner to be displayed when bursaries and scholarships have not been announced.

- Put this behind the existing `bursaries_and_scholarships_announced` feature flag. This means when the `bursaries_and_scholarships_announced` flag is deactivated the figures will disappear and the banner will **appear**. 

- Add a holding line if feature flag is inactive.

### Guidance to review

- This change will only be applied on the "Secondary subjects" page. Do we not want this on any other page?

- Currently the end of cycle banner is there, this banner is due to disappear after Find closes which is the 3rd of October. 

- [This is the page on the review app](https://find-review-3857.test.teacherservices.cloud/subjects?age_group=secondary&l=2).

### Screenshot

<img width="1784" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/5412dfc6-1ec9-47b5-b2eb-1f19b9669c8d">

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
