### PR TITLE
Fix OS check on MacOS

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -19,7 +19,7 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
 
   puts "\n== Copying development settings file =="
-  if OS.windows?
+  if Gem.win_platform?
     puts "ATTENTION WINDOWS USER!".red
     puts
     puts "Copy #{"config/settings/development.yml".yellow} to #{"config/settings/development.local.yml".yellow} and edit it:",


### PR DESCRIPTION
`OS.windows?` throws an error when running the setup on MacOS `uninitialized constant OS (NameError)`.

I'm assuming this was tested on Linux. CC @inulty-dfe