### PR TITLE
Scrub content on search filters relating to FIs - mirroring what we did in 2021 and 2022

### DIFF
--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -20,10 +20,15 @@ module Find
           elsif financial_incentive.bursary_amount.present?
             financial_info = "Bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} available"
           end
-        elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced)
-          financial_info = nil
+        elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
+          if financial_incentive.scholarship.present? && financial_incentive.bursary_amount.present?
+            financial_info = nil
+          elsif financial_incentive.scholarship.present?
+            financial_info = nil
+          elsif financial_incentive.bursary_amount.present?
+            financial_info = nil
+          end
         end
-      end
 
         SecondarySubjectInput.new(subject.subject_code, subject.subject_name, financial_info)
       end

--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -20,15 +20,10 @@ module Find
           elsif financial_incentive.bursary_amount.present?
             financial_info = "Bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} available"
           end
-        elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
-          if financial_incentive.scholarship.present? && financial_incentive.bursary_amount.present?
-            financial_info = 'Scholarships or bursaries are available'
-          elsif financial_incentive.scholarship.present?
-            financial_info = 'Scholarships available'
-          elsif financial_incentive.bursary_amount.present?
-            financial_info = 'Bursaries available'
-          end
+        elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced)
+          financial_info = nil
         end
+      end
 
         SecondarySubjectInput.new(subject.subject_code, subject.subject_name, financial_info)
       end

--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -23,10 +23,6 @@ module Find
         elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
           if financial_incentive.scholarship.present? && financial_incentive.bursary_amount.present?
             financial_info = nil
-          elsif financial_incentive.scholarship.present?
-            financial_info = nil
-          elsif financial_incentive.bursary_amount.present?
-            financial_info = nil
           end
         end
 

--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -21,8 +21,7 @@ module Find
             financial_info = "Bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} available"
           end
         elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
-          if financial_incentive.scholarship.present? || financial_incentive.bursary_amount.present?
-            financial_info = nil
+             financial_info = nil
           end
         end
 

--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -20,9 +20,6 @@ module Find
           elsif financial_incentive.bursary_amount.present?
             financial_info = "Bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} available"
           end
-        elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
-             financial_info = nil
-          end
         end
 
         SecondarySubjectInput.new(subject.subject_code, subject.subject_name, financial_info)

--- a/app/helpers/find/subject_helper.rb
+++ b/app/helpers/find/subject_helper.rb
@@ -21,7 +21,7 @@ module Find
             financial_info = "Bursaries of £#{number_with_delimiter(financial_incentive.bursary_amount, delimiter: ',')} available"
           end
         elsif !FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
-          if financial_incentive.scholarship.present? && financial_incentive.bursary_amount.present?
+          if financial_incentive.scholarship.present? || financial_incentive.bursary_amount.present?
             financial_info = nil
           end
         end

--- a/spec/helpers/find/subject_helper_spec.rb
+++ b/spec/helpers/find/subject_helper_spec.rb
@@ -58,7 +58,7 @@ describe Find::SubjectHelper do
           let(:subjects) { [find_or_create(:secondary_subject, :biology)] }
 
           it 'returns the correct financial information' do
-            expect(subject.first.financial_info).to eq('Bursaries available')
+            expect(subject.first.financial_info).to be_nil
           end
         end
 
@@ -66,7 +66,7 @@ describe Find::SubjectHelper do
           let(:subjects) { [find_or_create(:secondary_subject, subject_name: 'made up subject', scholarship: 1_000_000_000)] }
 
           it 'returns the correct financial information' do
-            expect(subject.first.financial_info).to eq('Scholarships available')
+            expect(subject.first.financial_info).to be_nil
           end
         end
 
@@ -74,7 +74,7 @@ describe Find::SubjectHelper do
           let(:subjects) { [find_or_create(:secondary_subject, :chemistry)] }
 
           it 'returns the correct financial information' do
-            expect(subject.first.financial_info).to eq('Scholarships or bursaries are available')
+            expect(subject.first.financial_info).to be_nil
           end
         end
       end


### PR DESCRIPTION
### Context

- We recently shipped a PR to scrub bursary values ahead of the cycle opening
- This PR left in some content relating to scholarships and bursaries being available
- However, this announcement has not yet been made/confirmed, so we should not be presenting any information in relation to this.

### Changes proposed in this pull request

- reverting some of the changes in this PR to ensure policy compliance.

Bursaries and scholarships have not been announced yet, so we should scrub any reference to them until we have the approved values.

Before: 
![image](https://github.com/DFE-Digital/publish-teacher-training/assets/35870975/58b8137d-de84-4ee8-a787-5c78d2b59ece)

After:
![image](https://github.com/DFE-Digital/publish-teacher-training/assets/35870975/6fe6c49d-78a5-445b-b1c0-dcb26129ee26)

What have we done previously:
2021: https://github.com/DFE-Digital/find-teacher-training/pull/1014
2022: https://github.com/DFE-Digital/publish-teacher-training/pull/3050

In both, we showed no suggestion of bursaries and scholarships.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
