### PR TITLE
Set the test to UTC time

### DIFF
--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe API::Public::V1::ProvidersController do
         end
 
         context 'passing in updated_since param' do
-          let(:filter) { { updated_since: (provider2.changed_at - 2.hours).iso8601 } }
+          let(:filter) { { updated_since: (provider2.changed_at.in_time_zone('UTC') - 1.second).iso8601 } }
 
           it "returns 'Second' provider only" do
             expect(provider_names_in_response).to eq([provider2.provider_name])


### PR DESCRIPTION
### Context
This test takes the providers changed at date, we're switched to BST now, but the API still expects a UTC timestamp. So convert the changed at time to UTC.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
