### PR TITLE
Hide and show find on London timezone

### DIFF
--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -118,8 +118,8 @@ module Find
 
     def self.phases_in_time
       {
-        today_is_after_find_closes: Time.zone.now.between?(find_closes, find_reopens),
-        today_is_after_find_opens: Time.zone.now.between?(find_opens, apply_2_deadline),
+        today_is_after_find_closes: Time.zone.now.between?((find_closes.in_time_zone('London') - 1.hour), (find_reopens.in_time_zone('London') - 1.hour)),
+        today_is_after_find_opens: Time.zone.now.between?((find_opens.in_time_zone('London') - 1.hour), apply_2_deadline),
         today_is_mid_cycle: Time.zone.now.between?(first_deadline_banner, apply_1_deadline),
         today_is_after_apply_1_deadline_passed: Time.zone.now.between?(apply_1_deadline, apply_2_deadline),
         today_is_after_apply_2_deadline_passed: Time.zone.now.between?(apply_2_deadline, find_closes)

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -102,6 +102,10 @@ module Find
       date(:apply_opens, next_year)
     end
 
+    def self.mid_cycle
+      date(:find_opens, current_year) + 1.day
+    end
+
     def self.preview_mode?
       Time.zone.now.between?(apply_2_deadline, find_closes)
     end

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 module Find
   describe CoursesController do
+    before do
+      Timecop.travel(Find::CycleTimetable.mid_cycle)
+    end
+
     let(:user) { create(:user, :with_provider) }
     let(:provider) { user.providers.first }
 

--- a/spec/features/find/cookie_preferences_spec.rb
+++ b/spec/features/find/cookie_preferences_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 feature 'Updating cookie preferences' do
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
+
   scenario 'i can update my cookie preferences' do
     given_i_am_on_the_find_cookie_preferences_page
     and_i_can_see_the_heading

--- a/spec/features/find/maintainance_page_spec.rb
+++ b/spec/features/find/maintainance_page_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 feature 'Maintenance mode' do
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
+
   context 'given the maintenance_mode feature flag is active and i arrive at the site' do
     scenario 'sends me to the maintenance page' do
       FeatureFlag.activate(:maintenance_mode)

--- a/spec/features/find/result_page_filters/applications_open_spec.rb
+++ b/spec/features/find/result_page_filters/applications_open_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.feature 'Results page new application open filter' do
   include FiltersFeatureSpecsHelper
 
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
+
   scenario 'Candidate applies applications open filter on results page' do
     when_i_visit_the_find_results_page
     then_i_see_the_applications_open_checkbox_is_selected

--- a/spec/features/find/result_page_filters/degree_required_spec.rb
+++ b/spec/features/find/result_page_filters/degree_required_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.feature 'Degree required filter' do
   include FiltersFeatureSpecsHelper
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
 
   scenario 'Candidate applies required degree filters on results page' do
     when_i_visit_the_find_results_page

--- a/spec/features/find/result_page_filters/engineers_teach_physics_spec.rb
+++ b/spec/features/find/result_page_filters/engineers_teach_physics_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Engineers teach physics' do
   include FiltersFeatureSpecsHelper
 
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     given_i_visit_the_search_by_location_or_provider_page
     given_i_choose_across_england
     given_i_choose_secondary

--- a/spec/features/find/result_page_filters/qualifications_spec.rb
+++ b/spec/features/find/result_page_filters/qualifications_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.feature 'Qualifications filter' do
   include FiltersFeatureSpecsHelper
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
 
   scenario 'Candidate applies qualifications filters on results page' do
     when_i_visit_the_find_results_page

--- a/spec/features/find/result_page_filters/salary_spec.rb
+++ b/spec/features/find/result_page_filters/salary_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.feature 'Funding filter' do
   include FiltersFeatureSpecsHelper
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
 
   scenario 'Candidate applies salary filter' do
     when_i_visit_the_find_results_page

--- a/spec/features/find/result_page_filters/send_spec.rb
+++ b/spec/features/find/result_page_filters/send_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.feature 'SEND filter' do
   include FiltersFeatureSpecsHelper
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
 
   scenario 'Candidate applies the SEND filter' do
     when_i_visit_the_find_results_page

--- a/spec/features/find/result_page_filters/study_type_spec.rb
+++ b/spec/features/find/result_page_filters/study_type_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.feature 'Study type filter' do
   include FiltersFeatureSpecsHelper
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
 
   scenario 'Candidate applies study type filters on results page' do
     when_i_visit_the_find_results_page

--- a/spec/features/find/result_page_filters/visa_spec.rb
+++ b/spec/features/find/result_page_filters/visa_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 RSpec.feature 'Visa filter' do
   include FiltersFeatureSpecsHelper
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
 
   scenario 'Candidate applies visa filter' do
     when_i_visit_the_find_results_page

--- a/spec/features/find/search/across_england/further_education_spec.rb
+++ b/spec/features/find/search/across_england/further_education_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'Searching across England' do
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     given_there_are_further_education_courses_in_england
   end
 

--- a/spec/features/find/search/across_england/primary_spec.rb
+++ b/spec/features/find/search/across_england/primary_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'Searching across England' do
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     given_there_are_primary_courses_in_england
   end
 

--- a/spec/features/find/search/across_england/secondary_spec.rb
+++ b/spec/features/find/search/across_england/secondary_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'Searching across England' do
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     given_there_are_secondary_courses_in_england
   end
 

--- a/spec/features/find/search/course_results_spec.rb
+++ b/spec/features/find/search/course_results_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 feature 'results' do
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
+
   scenario 'when I visit the results page with no courses' do
     when_i_visit_the_find_results_page
     i_see_the_no_results_message

--- a/spec/features/find/search/editing_a_search_spec.rb
+++ b/spec/features/find/search/editing_a_search_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 feature 'Editing a search' do
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+  end
+
   scenario 'Candidate edits their search' do
     when_i_execute_a_valid_search
     then_i_should_see_the_find_results_page

--- a/spec/features/find/search/location_options_spec.rb
+++ b/spec/features/find/search/location_options_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'Searching by location' do
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     stub_geocoder_lookup
 
     given_i_visit_the_start_page

--- a/spec/features/find/search/provider_options_spec.rb
+++ b/spec/features/find/search/provider_options_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'Searching by provider' do
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     given_there_is_a_provider_with_courses
   end
 

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -6,6 +6,7 @@ feature 'Viewing a findable course' do
   include PublishHelper
 
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     FeatureFlag.activate(:bursaries_and_scholarships_announced)
   end
 

--- a/spec/features/find/sorted_by_filter_spec.rb
+++ b/spec/features/find/sorted_by_filter_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'sorted by' do
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     given_there_are_courses
     and_i_visit_the_find_results_page
   end

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
   before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/requests/find/locations_suggestions_spec.rb
+++ b/spec/requests/find/locations_suggestions_spec.rb
@@ -5,6 +5,9 @@ require 'rails_helper'
 module Find
   describe '/location-suggestions', :with_find_constraint do
     include StubbedRequests::LocationSuggestions
+    before do
+      Timecop.travel(Find::CycleTimetable.mid_cycle)
+    end
 
     context 'when provider suggestion is blank' do
       it 'returns bad request (400)' do

--- a/spec/requests/find/sitemaps_spec.rb
+++ b/spec/requests/find/sitemaps_spec.rb
@@ -24,6 +24,7 @@ module Find
     let(:site1) { build(:site, location_name: 'location 1') }
 
     before do
+      Timecop.travel(Find::CycleTimetable.mid_cycle)
       course
 
       get '/sitemap.xml'


### PR DESCRIPTION
### Context

The Find/Publish app is currently set to UTC. I did explore updating the config to use the London timezone (as we do on apply). This had knock on impact throughout the code base, so instead I've gone for more of a temporary fix until we have more time to review this.

### Changes proposed in this pull request

Within the CycleTimetable class we use the `.find_down?` method to determine rendering content and redirecting. Such as the redirect in the ApplicationsController:
```
    def redirect_to_cycle_has_ended_if_find_is_down
      redirect_to find_cycle_has_ended_path if CycleTimetable.find_down?
    end

```
For the workaround I'm setting 3 points in time to the expected London time – 2 of which are used within the `.find_down?` method. The other is used to determine if Find should open and then I haven't updated the apply 2 deadline, as we will look to have a permanent solution in place before then.

I've also fixed a bunch of tests that failed with Find closing – I've frozen them to the "mid cycle"

### Guidance to review

It's not pretty but this isn't a permanent fix – only to ensure that Find opens at 9am, instead of 10am.

The courses are ready for 2024 and Apply operates currently off BST so will (hopefully) correctly render the Find journey and will sync the courses at right time.

This is about enabling the pages to be viewable at the right time on Find.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
