### PR TITLE
Update FI banner now we've moved recruitment cycle

### DIFF
--- a/app/views/find/search/subjects/_secondary_subjects.html.erb
+++ b/app/views/find/search/subjects/_secondary_subjects.html.erb
@@ -2,9 +2,9 @@
 
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
     <% notification_banner.with_heading(text: "Financial support") %>
-    <p class="govuk-body">Details of financial support for courses starting in the <%= Find::CycleTimetable.next_cycle_year_range %> academic year will be released soon.</p>
+    <p class="govuk-body">Details of financial support for courses starting in the 2024 to 2025 academic year will be released soon.</p>
     <p class="govuk-body">In the meantime, you can <%= govuk_link_to("view the bursaries and scholarships", t("get_into_teaching.url_bursaries_and_scholarships"), target: "_blank", rel: "noopener noreferrer") %>
- for courses starting between September <%= Find::CycleTimetable.current_year %> and July <%= Find::CycleTimetable.next_year %>.</p>
+ for courses starting between September September 2023 and July 2024.</p>
 
   <% end %>
 


### PR DESCRIPTION
### Context

Now we've bumped the recruitment cycle year, these values are wrong.

### Changes proposed in this pull request

Amending the incorrect values in this image:
![image](https://github.com/DFE-Digital/publish-teacher-training/assets/35870975/8fc4fd87-57ef-4cf9-976c-e412da6977ca)

Hardcoding these values to:
- 2024 to 2025 academic year
- September 2023 and July 2024


 It shou;d look like this:

![image](https://github.com/DFE-Digital/publish-teacher-training/assets/35870975/9087c03c-4540-4ead-bbc1-2335c5e5ff32)

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
