### PR TITLE
Set the financial support banner to use cycle timetable

### DIFF
--- a/app/views/find/search/subjects/_secondary_subjects.html.erb
+++ b/app/views/find/search/subjects/_secondary_subjects.html.erb
@@ -2,9 +2,9 @@
 
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
     <% notification_banner.with_heading(text: "Financial support") %>
-    <p class="govuk-body">Details of financial support for courses starting in the 2024 to 2025 academic year will be released soon.</p>
+    <p class="govuk-body">Details of financial support for courses starting in the <%= Find::CycleTimetable.cycle_year_range %> academic year will be released soon.</p>
     <p class="govuk-body">In the meantime, you can <%= govuk_link_to("view the bursaries and scholarships", t("get_into_teaching.url_bursaries_and_scholarships"), target: "_blank", rel: "noopener noreferrer") %>
- for courses starting between September September 2023 and July 2024.</p>
+    for courses starting between September <%= Find::CycleTimetable.previous_year %> and July <%= Find::CycleTimetable.current_year %>.</p>
 
   <% end %>
 


### PR DESCRIPTION
### Context

Closing rollover jumped the year forward in Find – we've then hardcoded the values due to the comms we will start sending at 12. Now reverting these back to automated dates.

### Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="1043" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/1c5ce0e5-3e2c-44d3-83a0-7f2497d528e4">|<img width="1082" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/29b1bd6c-4992-4db2-ba8d-8a323bfe1d97">|

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
