### PR TITLE
Remove UCL from grade 5 requirements

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -74,7 +74,7 @@ class Course < ApplicationRecord
 
   # Most providers require GCSE grade 4 ("C"),
   # but some require grade 5 ("strong C")
-  PROVIDERS_REQUIRING_GCSE_GRADE_5 = %w[U80 I30].freeze
+  PROVIDERS_REQUIRING_GCSE_GRADE_5 = %w[I30].freeze
 
   enum maths: ENTRY_REQUIREMENT_OPTIONS, _suffix: :for_maths
   enum english: ENTRY_REQUIREMENT_OPTIONS, _suffix: :for_english

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -160,7 +160,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
         :course,
         accept_gcse_equivalency: false,
         accept_pending_gcse: false,
-        provider: build(:provider, provider_code: 'U80'),
+        provider: build(:provider, provider_code: 'I30'),
         level: 'secondary'
       )
 
@@ -193,7 +193,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     context 'when the accrediting provider requires grade 5 and the course is secondary' do
       it 'renders correct message' do
-        accrediting_provider = build(:provider, provider_code: 'U80')
+        accrediting_provider = build(:provider, provider_code: 'I30')
         course = build(
           :course,
           accept_gcse_equivalency: false,


### PR DESCRIPTION
### Context

https://becomingateacher.zendesk.com/agent/tickets/138675

UCL are changing their Grade requirements from Grade 5 to Grade 4. We previously had a special case for them in Publish to reflect this Grade 5 requirement. We have also confirmed that this change back to Grade 4 will apply to their training partners. The code ensures this flows down to UCL's training partners too.

This is a quick change to remove them from the code, but the other provider remaining in this array does not appear to exist, so we should look at removing this whole function around `course.gcse_grade_required` and perhaps move back to hardcoding this to 4.

### Changes proposed in this pull request

Remove `U80` from the code that renders Grade 5 as the GCSE requirements.
Amend tests that check for Grade 5 from UCL's provier code to the only outstanding provider code that we set this for (`I30`).

### Guidance to review

- Try and publish a course with UCL and examine what its GCSE grade requirements are.
- Try and publish a course accredited by UCL, and examine what its GCSE grade requirements are.

Both should say Grade 4/C

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
