### PR TITLE
[2282] Fix provider name mapping for autocomplete

### DIFF
--- a/app/helpers/find/provider_helper.rb
+++ b/app/helpers/find/provider_helper.rb
@@ -9,7 +9,7 @@ module Find
           'data-boost' => 1.5
         }
 
-        value = provider.provider_name
+        value = provider.provider_name.strip
         name = "#{value} (#{provider.provider_code})"
 
         [name, value, data]

--- a/spec/helpers/find/provider_helper_spec.rb
+++ b/spec/helpers/find/provider_helper_spec.rb
@@ -27,6 +27,18 @@ module Find
         expect(subject[2]).to eql(expected_provider_options[1])
         expect(subject[3]).to eql(expected_provider_options[2])
       end
+
+      context 'provider names have leading or trailing whitespace' do
+        let(:providers) do
+          [
+            build(:provider, provider_name: ' Provider 1 ')
+          ]
+        end
+
+        it 'strips the whitespace from the provider names' do
+          expect(subject[1][0]).to eq("Provider 1 (#{providers[0].provider_code})")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/ACtolcvq/2282-mulberry-college-of-teaching-does-not-show-on-find

Some providers could have leading/trailing whitespace in their names which breaks the autocomplete from setting them correctly. Here is an example of how the option is received by the js logic. 

<img width="431" alt="Screenshot 2023-10-06 at 16 31 58" src="https://github.com/DFE-Digital/publish-teacher-training/assets/616080/78e478cd-96b7-420a-8006-962a6dda0093">

It fails the comparison check here https://github.com/DFE-Digital/publish-teacher-training/blob/422241cf81c6d2ff6eb3fe57d2efa3c5f3ecc9c9/app/javascript/find/dfe-autocomplete/dfe-autocomplete.js#L48

### Changes proposed in this pull request

- Strip from source 

### Guidance to review

You can re-produce the issue by searching `5V5` in the Find provider lookup. If you try to go to the next step it'll trigger an error. Try this in the review app and it should be fixed. 