### PR TITLE
Update non uk guidance link to not link to withdrawn guidance

### DIFF
--- a/app/components/find/courses/financial_support/bursary_component/view.html.erb
+++ b/app/components/find/courses/financial_support/bursary_component/view.html.erb
@@ -20,6 +20,6 @@
   <p class="govuk-body">
     Depending on your immigration status, financial support may not be available.
     Find out about
-    <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen") %>.
+    <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers") %>.
   </p>
 </div>

--- a/app/components/find/courses/financial_support/bursary_component/view.html.erb
+++ b/app/components/find/courses/financial_support/bursary_component/view.html.erb
@@ -20,6 +20,6 @@
   <p class="govuk-body">
     Depending on your immigration status, financial support may not be available.
     Find out about
-    <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers") %>.
+    <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student") %>.
   </p>
 </div>

--- a/app/components/find/courses/financial_support/scholarship_and_bursary_component/view.html.erb
+++ b/app/components/find/courses/financial_support/scholarship_and_bursary_component/view.html.erb
@@ -31,6 +31,6 @@
   </p>
 
   <p class="govuk-body">
-    Depending on your immigration status, financial support may not be available. Find out about <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen") %>, including financial support.
+    Depending on your immigration status, financial support may not be available. Find out about <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers") %>, including financial support.
   </p>
 </div>

--- a/app/components/find/courses/financial_support/scholarship_and_bursary_component/view.html.erb
+++ b/app/components/find/courses/financial_support/scholarship_and_bursary_component/view.html.erb
@@ -31,6 +31,6 @@
   </p>
 
   <p class="govuk-body">
-    Depending on your immigration status, financial support may not be available. Find out about <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers") %>, including financial support.
+    Depending on your immigration status, financial support may not be available. Find out about <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student") %>, including financial support.
   </p>
 </div>

--- a/app/views/find/courses/financial_support/_loan.html.erb
+++ b/app/views/find/courses/financial_support/_loan.html.erb
@@ -7,6 +7,6 @@
   <p class="govuk-body">
     Depending on your immigration status, financial support may not be available.
     Find out about
-    <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers") %>, including financial support.
+    <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student") %>, including financial support.
   </p>
 </div>

--- a/app/views/find/courses/financial_support/_loan.html.erb
+++ b/app/views/find/courses/financial_support/_loan.html.erb
@@ -7,6 +7,6 @@
   <p class="govuk-body">
     Depending on your immigration status, financial support may not be available.
     Find out about
-    <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen") %>, including financial support.
+    <%= govuk_link_to("training to teach if you’re a non-UK citizen", "https://getintoteaching.education.gov.uk/non-uk-teachers") %>, including financial support.
   </p>
 </div>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -96,7 +96,7 @@ en:
             <p class="govuk-body">If you do not already have the right to work in the UK, you may need to apply for a visa. The main visa for salaried courses is the <a class="govuk-link" href="https://www.gov.uk/skilled-worker-visa">Skilled Worker visa.</a></p>
             <p class="govuk-body">Sponsorship for a Skilled Worker visa is not available for this course.</p>
             <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
-            <p class="govuk-body">You can also <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#studying-and-working-as-a-teacher-in-the-uk-without-a-skilled-worker-visa-or-a-student-visa">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
+            <p class="govuk-body">You can also <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-teachers">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
         available:
           html:
             <p class="govuk-body">If you do not already have the right to work in the UK for the duration of this course, you may need to apply for a Skilled Worker visa.</p>
@@ -108,7 +108,7 @@ en:
             <p class="govuk-body">If you do not already have the right to study in the UK, you may need to apply for a visa.</p>
             <p class="govuk-body">Sponsorship for a student visa is not available for this course.</p>
             <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
-            <p class="govuk-body">You can also <a class="govuk-link" href="https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#studying-and-working-as-a-teacher-in-the-uk-without-a-skilled-worker-visa-or-a-student-visa">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
+            <p class="govuk-body">You can also <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-teachers">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
         available:
           html:
             <p class="govuk-body">If you do not already have the right to study in the UK for the duration of this course, you may need to apply for a Student visa.</p>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -96,7 +96,7 @@ en:
             <p class="govuk-body">If you do not already have the right to work in the UK, you may need to apply for a visa. The main visa for salaried courses is the <a class="govuk-link" href="https://www.gov.uk/skilled-worker-visa">Skilled Worker visa.</a></p>
             <p class="govuk-body">Sponsorship for a Skilled Worker visa is not available for this course.</p>
             <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
-            <p class="govuk-body">You can also <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-teachers">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
+            <p class="govuk-body">You can also <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
         available:
           html:
             <p class="govuk-body">If you do not already have the right to work in the UK for the duration of this course, you may need to apply for a Skilled Worker visa.</p>
@@ -108,7 +108,7 @@ en:
             <p class="govuk-body">If you do not already have the right to study in the UK, you may need to apply for a visa.</p>
             <p class="govuk-body">Sponsorship for a student visa is not available for this course.</p>
             <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
-            <p class="govuk-body">You can also <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-teachers">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
+            <p class="govuk-body">You can also <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
         available:
           html:
             <p class="govuk-body">If you do not already have the right to study in the UK for the duration of this course, you may need to apply for a Student visa.</p>


### PR DESCRIPTION
### Context

We wrongly link to this gov uk page that has now been withdrawn. We should point to where this withdrawn guidance points.

### Changes proposed in this pull request

https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen -> https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student

Old link destination: 
<img width="1003" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/35870975/1999e85d-1377-48b1-ac78-cd67bfdd7534">

New link destination: 
<img width="822" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/35870975/fea880a8-4c34-4085-9392-c490da093437">

Also updated visa pages. Visa destination:
<img width="761" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/35870975/047d4ebc-d4b6-4a4c-b62e-b03d50c64d91">


### Guidance to review

Does this look right?

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
