### PR TITLE
[823] Add visa sponsorship row on Find

### DIFF
--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -10,6 +10,9 @@
     </dd>
   </dt>
 
+  <dt class="app-description-list__label">Visa sponsorship</dt>
+  <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_row %></dd>
+
   <dt class="app-description-list__label">Qualification</dt>
   <%= render Find::Courses::QualificationsSummaryComponent::View.new(find_outcome) %>
   <% if age_range_in_years.present? %>

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -19,7 +19,10 @@ module Find
                  :start_date,
                  :secondary_course?,
                  :level,
-                 :study_mode, to: :course
+                 :study_mode,
+                 :salaried?,
+                 :can_sponsor_student_visa,
+                 :can_sponsor_skilled_worker_visa, to: :course
 
         def initialize(course)
           super
@@ -36,6 +39,16 @@ module Find
 
         def course_length_with_study_mode_row
           "#{length} - #{study_mode.humanize.downcase}"
+        end
+
+        def visa_sponsorship_row
+          if !salaried? && can_sponsor_student_visa
+            'Student visas can be sponsored'
+          elsif salaried? && can_sponsor_skilled_worker_visa
+            'Skilled Worker visas can be sponsored'
+          else
+            'Visas cannot be sponsored'
+          end
         end
       end
     end

--- a/spec/components/find/courses/sumary_component/view_preview.rb
+++ b/spec/components/find/courses/sumary_component/view_preview.rb
@@ -51,12 +51,13 @@ module Find
                          qualification: 'pgce',
                          funding_type: 'salaried',
                          subjects: nil,
-                         level: :primary)
+                         level: :primary,
+                         can_sponsor_student_visa: true)
         end
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:provider, :accrediting_provider, :has_bursary, :age_range_in_years, :course_length, :applications_open_from, :start_date, :qualification, :funding_type, :subjects, :level)
+          attr_accessor(:provider, :accrediting_provider, :has_bursary, :age_range_in_years, :course_length, :applications_open_from, :start_date, :qualification, :funding_type, :subjects, :level, :can_sponsor_student_visa)
 
           def has_bursary?
             has_bursary

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -83,6 +83,51 @@ module Find
             expect(result.css('[data-qa="course__age_range"]').text).to eq('3 to 7')
           end
         end
+
+        context 'when course is fee paying and can sponsor student visas' do
+          it 'displays that student visas can be sponsored' do
+            course = build(
+              :course,
+              :fee_type_based,
+              can_sponsor_student_visa: true,
+              provider: build(:provider)
+            ).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).to include('Student visas can be sponsored')
+          end
+        end
+
+        context 'when course is salaried and can sponsor skilled worker visas' do
+          it 'displays that skilled worker visas can be sponsored' do
+            course = build(
+              :course,
+              :with_salary,
+              can_sponsor_skilled_worker_visa: true,
+              provider: build(:provider)
+            ).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).to include('Skilled Worker visas can be sponsored')
+          end
+        end
+
+        context 'when course cannot sponsor visas' do
+          it 'displays that visas cannot be sponsored' do
+            course = build(
+              :course,
+              can_sponsor_student_visa: false,
+              can_sponsor_skilled_worker_visa: false,
+              provider: build(:provider)
+            ).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).to include('Visas cannot be sponsored')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Adding the ‘Visa sponsorship’ row to the course page to make it easier to see if the course has visa sponsorship available or not.

### Changes proposed in this pull request

- Add visa sponsorship status to find course show page
- Add visa sponsorship status to find course results page

### Guidance to review

Visit a few courses, salaried, non salaried, can sponsor visas and cannot sponsor visas. Feel free to use [this link](
https://find-review-3909.test.teacherservices.cloud/results?can_sponsor_visa=true&study_type%5B%5D=full_time&study_type%5B%5D=part_time&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&degree_required=show_all_courses&applications_open=false&applications_open=true&l=2&subjects%5B%5D=09) to go to the review app.

### Screenshots

<img width="733" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/934c6800-baa0-4128-9f90-e630e566a188">

<img width="879" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/b892385f-4b73-4b91-a4e0-3317724e75e0">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
