### PR TITLE
[890] Add visa sponsorship edit functionality to support

### DIFF
--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -40,7 +40,9 @@ module Support
         *EditCourseForm::FIELDS,
         :'start_date(3i)', :'start_date(2i)', :'start_date(1i)',
         :'applications_open_from(3i)', :'applications_open_from(2i)', :'applications_open_from(1i)',
-        :is_send
+        :is_send,
+        :can_sponsor_student_visa,
+        :can_sponsor_skilled_worker_visa
       ).transform_keys { |key| date_field_to_attribute(key) }
     end
 

--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -9,7 +9,7 @@ module Support
       course_code name
     ].freeze
 
-    attr_accessor(*FIELDS, :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_day, :applications_open_from_month, :applications_open_from_year, :is_send)
+    attr_accessor(*FIELDS, :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_day, :applications_open_from_month, :applications_open_from_year, :is_send, :can_sponsor_student_visa, :can_sponsor_skilled_worker_visa)
 
     validate :validate_start_date_format
     validate :validate_applications_open_from_format
@@ -27,6 +27,8 @@ module Support
         applications_open_from_month: @course.applications_open_from&.month,
         applications_open_from_year: @course.applications_open_from&.year,
         is_send: @course.is_send,
+        can_sponsor_student_visa: @course.can_sponsor_student_visa,
+        can_sponsor_skilled_worker_visa: @course.can_sponsor_skilled_worker_visa
       )
     end
 
@@ -80,7 +82,9 @@ module Support
         name:,
         start_date:,
         applications_open_from:,
-        is_send: send?
+        is_send: send?,
+        can_sponsor_student_visa:,
+        can_sponsor_skilled_worker_visa:
       }
 
       course.assign_attributes(attributes)

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -19,6 +19,20 @@
         <% f.govuk_check_box :is_send, true, false, label: { text: "This course has an additional SEND specialism" }, multiple: false %>
       <% end %>
 
+      <% if @course.decorate.salaried? %>
+
+           <%= f.govuk_check_boxes_fieldset :can_sponsor_skilled_worker_visa, legend: { text: "Visa sponsorship" }, multiple: false do %>
+          <% f.govuk_check_box :can_sponsor_skilled_worker_visa, true, false, label: { text: "This course can sponsor a skilled worker visa" }, multiple: false %>
+        <% end %>
+
+      <% else %>
+
+     <%= f.govuk_check_boxes_fieldset :can_sponsor_student_visa, legend: { text: "Visa sponsorship" }, multiple: false do %>
+          <% f.govuk_check_box :can_sponsor_student_visa, true, false, label: { text: "This course can sponsor a student visa" }, multiple: false %>
+        <% end %>
+
+      <% end %>
+
       <%= f.govuk_submit t("support.update_record") %>
     <% end %>
 

--- a/spec/features/support/providers/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/features/support/providers/courses/editing_visa_sponsorship_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Editing visa sponsorship' do
+  before do
+    given_i_am_authenticated_as_an_admin_user
+    and_there_is_a_provider_with_courses
+  end
+
+  context 'Editing visa sponsorship' do
+    scenario 'fee-paying course' do
+      when_i_navigate_to_the_fee_paying_course
+      and_the_skilled_worker_visa_question_is_not_rendered
+      and_i_see_that_the_student_visa_checkbox_is_not_checked
+      and_i_check_the_student_visa_check_box
+      and_i_submit_the_form
+      and_i_navigate_to_the_same_fee_paying_course
+      then_the_student_visa_checkbox_should_be_checked
+    end
+
+    scenario 'salaried course' do
+      when_i_navigate_to_the_salaried_course
+      and_the_student_visa_question_is_not_rendered
+      and_i_see_that_the_skilled_worker_visa_checkbox_is_not_checked
+      and_i_check_the_skilled_worker_visa_check_box
+      and_i_submit_the_form
+      and_i_navigate_to_the_same_salaried_course
+      then_the_skilled_worker_visa_checkbox_should_be_checked
+    end
+
+    scenario 'apprenticeship course' do
+      when_i_navigate_to_the_apprenticeship_course
+      and_the_student_visa_question_is_not_rendered
+      and_i_see_that_the_skilled_worker_visa_checkbox_is_not_checked
+      and_i_check_the_skilled_worker_visa_check_box
+      and_i_submit_the_form
+      and_i_navigate_to_the_same_apprenticeship_course
+      then_the_skilled_worker_visa_checkbox_should_be_checked
+    end
+  end
+
+  def and_i_submit_the_form
+    click_button 'Update'
+  end
+
+  def and_i_check_the_student_visa_check_box
+    check('support-edit-course-form-can-sponsor-student-visa-true-field')
+  end
+
+  def and_i_check_the_skilled_worker_visa_check_box
+    check('support-edit-course-form-can-sponsor-skilled-worker-visa-true-field')
+  end
+
+  def and_i_see_that_the_student_visa_checkbox_is_not_checked
+    expect(page).to have_unchecked_field('support-edit-course-form-can-sponsor-student-visa-true-field')
+  end
+
+  def and_i_see_that_the_skilled_worker_visa_checkbox_is_not_checked
+    expect(page).to have_unchecked_field('support-edit-course-form-can-sponsor-skilled-worker-visa-true-field')
+  end
+
+  def then_the_student_visa_checkbox_should_be_checked
+    expect(page).to have_checked_field('support-edit-course-form-can-sponsor-student-visa-true-field')
+  end
+
+  def then_the_skilled_worker_visa_checkbox_should_be_checked
+    expect(page).to have_checked_field('support-edit-course-form-can-sponsor-skilled-worker-visa-true-field')
+  end
+
+  def and_the_skilled_worker_visa_question_is_not_rendered
+    expect(page).not_to have_css('#support-edit-course-form-can-sponsor-skilled-worker-visa-true-field')
+  end
+
+  def and_the_student_visa_question_is_not_rendered
+    expect(page).not_to have_css('#support-edit-course-form-can-sponsor-student-visa-true-field')
+  end
+
+  def given_i_am_authenticated_as_an_admin_user
+    given_i_am_authenticated(user: create(:user, :admin))
+  end
+
+  def provider
+    @provider ||= create(:provider, courses: [build(:course, :fee_type_based, id: 1, can_sponsor_student_visa: false), build(:course, :with_salary, id: 2), build(:course, :with_apprenticeship, id: 3)])
+  end
+
+  def and_there_is_a_provider_with_courses
+    provider
+  end
+
+  def when_i_navigate_to_the_apprenticeship_course
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 3, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+  end
+
+  def when_i_navigate_to_the_salaried_course
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 2, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+  end
+
+  def when_i_navigate_to_the_fee_paying_course
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 1, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+  end
+
+  alias_method :and_i_navigate_to_the_same_fee_paying_course, :when_i_navigate_to_the_fee_paying_course
+  alias_method :and_i_navigate_to_the_same_salaried_course, :when_i_navigate_to_the_salaried_course
+  alias_method :and_i_navigate_to_the_same_apprenticeship_course, :when_i_navigate_to_the_apprenticeship_course
+end


### PR DESCRIPTION
### Context

We receive a number of support requests from providers asking us to change the visa sponsorship status of a course. We want to introduce support functionality to enable the support team to do this.

### Changes proposed in this pull request

- Render student visa checkbox if the course if fee paying
- Render skilled checkbox if the course is salaried or apprenticeship

### Guidance to review

Test [here](https://publish-review-3910.test.teacherservices.cloud/support/2024/providers), with a fee paying course, a salaried course and an apprenticeship course. Ensure the value is updated and the corrected checkbox is rendered depending on the course.

### Screenshots

<img width="793" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/27efa68c-8721-4e85-9839-a2ac33b0eaac">

<img width="890" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/62c94dc8-3ef0-4927-896d-02db23a2e190">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
