### PR TITLE
[892] Add course status to support view

### DIFF
--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -4,6 +4,7 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Course name and code</th>
+      <th scope="col" class="govuk-table__header">Status</th>
       <th scope="col" class="govuk-table__header"></th>
     </tr>
   </thead>
@@ -13,6 +14,9 @@
       <tr class="govuk-table__row course-row">
         <td class="govuk-table__cell name">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.name %> (<%= course.course_code %>)</span>
+        </td>
+           <td class="govuk-table__cell status">
+          <%= course.decorate.status_tag %>
         </td>
         <td class="govuk-table__cell change">
           <%= govuk_link_to "Change", edit_support_recruitment_cycle_provider_course_url(@provider.recruitment_cycle_year, @provider, course) %>


### PR DESCRIPTION
### Context

Adding course status to the course index page on support, so that the information is more visible.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
