### PR TITLE
[891] Enable support to search by UKPRN

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -172,7 +172,7 @@ class Provider < ApplicationRecord
   end
 
   pg_search_scope :provider_search,
-                  against: %i[provider_code provider_name],
+                  against: %i[provider_code provider_name ukprn],
                   using: { tsearch: { prefix: true } }
 
   pg_search_scope :course_search,

--- a/app/views/support/providers/_list.html.erb
+++ b/app/views/support/providers/_list.html.erb
@@ -3,6 +3,7 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">UKPRN</th>
     </tr>
   </thead>
 
@@ -18,6 +19,12 @@
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <%= provider.provider_code %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.ukprn %>
           </span>
         </td>
       </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en:
           index: "Data exports"
     filter:
       providers:
-        provider_search: "Provider name or code"
+        provider_search: "Provider name, code or UKPRN"
         course_search: "Course code"
       users:
         text_search: "Name or email"

--- a/spec/components/filter/provider_attributes/view_spec.rb
+++ b/spec/components/filter/provider_attributes/view_spec.rb
@@ -14,7 +14,7 @@ module Filters
       end
 
       it 'renders all the correct details' do
-        expect(component).to have_text('Provider name or code')
+        expect(component).to have_text('Provider name, code or UKPRN')
         expect(component).to have_text('Course code')
       end
     end

--- a/spec/features/support/providers/providers_filter_spec.rb
+++ b/spec/features/support/providers/providers_filter_spec.rb
@@ -20,6 +20,9 @@ feature 'View filtered providers' do
     when_i_remove_the_provider_filter
     then_i_see_the_unfiltered_providers
 
+    when_filter_by_ukprn
+    then_i_see_providers_filtered_by_ukprn
+
     when_i_filter_by_course_code
     then_i_see_the_providers_filtered_by_course_code
 
@@ -33,9 +36,22 @@ feature 'View filtered providers' do
     then_i_see_the_unfiltered_providers
   end
 
+  def then_i_see_providers_filtered_by_ukprn
+    expect(page).to have_css('.qa-provider_row', count: 1)
+
+    within first('.qa-provider_row') { expect(page).to have_text('12345678') }
+
+    expect(page).to have_field('provider_search', with: '12345678')
+  end
+
+  def when_filter_by_ukprn
+    fill_in 'Provider name, code or UKPRN', with: '12345678'
+    click_button 'Apply filters'
+  end
+
   def and_there_are_providers
     create(:provider, provider_name: 'Really big school', provider_code: 'A01', courses: [build(:course, course_code: '2VVZ')])
-    create(:provider, provider_name: 'Slightly smaller school', provider_code: 'A02', courses: [build(:course, course_code: '2VVZ')])
+    create(:provider, provider_name: 'Slightly smaller school', provider_code: 'A02', ukprn: '12345678', courses: [build(:course, course_code: '2VVZ')])
   end
 
   def when_i_visit_the_support_provider_index_page
@@ -49,18 +65,18 @@ feature 'View filtered providers' do
   alias_method :then_i_see_the_unfiltered_providers, :then_i_see_the_providers
 
   def when_i_filter_by_provider
-    fill_in 'Provider name or code', with: 'Really big school'
+    fill_in 'Provider name, code or UKPRN', with: 'Really big school'
     click_button 'Apply filters'
   end
 
   def when_i_filter_by_course_code
-    fill_in 'Provider name or code', with: ''
+    fill_in 'Provider name, code or UKPRN', with: ''
     fill_in 'Course code', with: '2VVZ'
     click_button 'Apply filters'
   end
 
   def when_i_filter_by_provider_code_and_course_code
-    fill_in 'Provider name or code', with: 'A01'
+    fill_in 'Provider name, code or UKPRN', with: 'A01'
     fill_in 'Course code', with: '2vvZ'
     click_button 'Apply filters'
   end


### PR DESCRIPTION
### Context

Occasionally when the support team receive requests from providers they will provide their UKPRN number. Adding this as an additional search field will help reduce back-and-forth with the provider

### Changes proposed in this pull request

- Add a new UKPRN column on the provider index page
- Add the ability to be able to search by UKPRN

### Screenshot

<img width="1201" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/b6031869-0f9b-4201-8e4f-15db0362a8c3">


### Guidance to review

Search for a provider using a UKRPN [here](https://publish-review-3912.test.teacherservices.cloud/support/2024/providers).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
