### PR TITLE
Update width on provider index support page

### DIFF
--- a/app/views/support/providers/_list.html.erb
+++ b/app/views/support/providers/_list.html.erb
@@ -2,8 +2,8 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">UKPRN</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Provider code</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">UKPRN</th>
     </tr>
   </thead>
 


### PR DESCRIPTION
### Context

Update the width for a more balanced look, since the introduction of the UKPRN column.

#### Before

<img width="1076" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/22187398-9539-4898-bd41-5f03f1ccb4f7">


#### After

<img width="995" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/0467b2aa-3e2c-48f8-8e39-517975c2f6cd">
