### PR TITLE
Update Azure CLI to 2.53.1 to avoid Python incompatibility issues

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,7 +5,7 @@ nodejs 16.14.0
 terraform 1.2.3
 adr-tools 3.0.0
 cf 7.4.0
-azure-cli 2.36.0
+azure-cli 2.53.1
 jq 1.6
 make 4.2.1
 redis 7.0.0


### PR DESCRIPTION
Was getting the following error:
<img width="1198" alt="Screenshot 2023-11-06 at 14 02 30" src="https://github.com/DFE-Digital/publish-teacher-training/assets/1636476/b1f7596d-c60c-4dd4-80c0-e370e4749cc7">
