### PR TITLE
Fix the editing of visa sponsorship and SEND in support

### DIFF
--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -16,19 +16,19 @@
       <%= f.govuk_date_field(:applications_open_from, legend: { text: "Applications open from date" }) %>
 
       <%= f.govuk_check_boxes_fieldset :is_send, legend: { text: "Special Education Needs and Disability (SEND)" }, multiple: false do %>
-        <% f.govuk_check_box :is_send, true, false, label: { text: "This course has an additional SEND specialism" }, multiple: false %>
+        <% f.govuk_check_box :is_send, "true", "false", label: { text: "This course has an additional SEND specialism" }, multiple: false %>
       <% end %>
 
       <% if @course.decorate.salaried? %>
 
            <%= f.govuk_check_boxes_fieldset :can_sponsor_skilled_worker_visa, legend: { text: "Visa sponsorship" }, multiple: false do %>
-          <% f.govuk_check_box :can_sponsor_skilled_worker_visa, true, false, label: { text: "This course can sponsor a skilled worker visa" }, multiple: false %>
+          <% f.govuk_check_box :can_sponsor_skilled_worker_visa, "true", "false", label: { text: "This course can sponsor a skilled worker visa" }, multiple: false %>
         <% end %>
 
       <% else %>
 
      <%= f.govuk_check_boxes_fieldset :can_sponsor_student_visa, legend: { text: "Visa sponsorship" }, multiple: false do %>
-          <% f.govuk_check_box :can_sponsor_student_visa, true, false, label: { text: "This course can sponsor a student visa" }, multiple: false %>
+          <% f.govuk_check_box :can_sponsor_student_visa, "true", "false", label: { text: "This course can sponsor a student visa" }, multiple: false %>
         <% end %>
 
       <% end %>


### PR DESCRIPTION
### Context

Currently you can't change the SEND or visa sponsorship fields to false using the support console. This is the fix.

### Changes proposed in this pull request

See commit
