### PR TITLE
Revert "Bump sidekiq-cron from 1.10.1 to 1.11.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     formatador (1.1.0)
-    fugit (1.9.0)
+    fugit (1.8.1)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     geocoder (1.8.2)
@@ -650,7 +650,7 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
-    sidekiq-cron (1.11.0)
+    sidekiq-cron (1.10.1)
       fugit (~> 1.8)
       globalid (>= 1.0.1)
       sidekiq (>= 6)


### PR DESCRIPTION
Reverts DFE-Digital/publish-teacher-training#3917

Builds are falling – sidekiq is broken:
https://qa.publish-teacher-training-courses.service.gov.uk/healthcheck

<img width="754" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/d17041b8-e425-4616-a92d-b68f229a8e5a">

_Could_ be due to this bump?