### PR TITLE
Add missing full stop

### DIFF
--- a/app/views/publish/courses/subjects/_secondary_form.html.erb
+++ b/app/views/publish/courses/subjects/_secondary_form.html.erb
@@ -12,7 +12,7 @@
     </legend>
     <%= render "publish/shared/error_messages", error_keys: [:subjects] %>
     <p class="govuk-body">For some subjects, candidates may be able to get a bursary or scholarship.</p>
-    <p class="govuk-body">If the course content is made up of at least 50% of an eligible subject, add this as the first subject so we can show the correct financial information to candidates</p>
+    <p class="govuk-body">If the course content is made up of at least 50% of an eligible subject, add this as the first subject so we can show the correct financial information to candidates.</p>
     <p class="govuk-body">
       <%= govuk_link_to "Learn more about the bursaries and scholarships", "https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-2023-to-2024#postgraduate-bursaries-and-scholarships" %>
     </p>


### PR DESCRIPTION
### Context

A full stop is missing, we need to add it. It surfaced in a Publish demo.

### Before

<img width="644" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/4ce6877c-1916-403c-b4e5-1ce0c1ea84d5">


### After

<img width="639" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/6ec5c355-9db9-48cf-81b1-c15fc983f376">


### Guidance to review

:shipit: 
