### PR TITLE
[924] Revert withdrawals (support)

### DIFF
--- a/app/controllers/support/revert_withdrawal_controller.rb
+++ b/app/controllers/support/revert_withdrawal_controller.rb
@@ -8,7 +8,10 @@ module Support
     end
 
     def update
-      redirect_to edit_support_recruitment_cycle_provider_course_path(provider.recruitment_cycle_year, provider, course), flash: { success: t('support.flash.updated', resource: 'Course status') }
+      Support::Courses::RevertWithdrawalService.new(course).call
+
+      redirect_to edit_support_recruitment_cycle_provider_course_path(provider.recruitment_cycle_year, provider, course),
+                  flash: { success: t('support.flash.updated', resource: 'Course status') }
     end
 
     private

--- a/app/controllers/support/revert_withdrawal_controller.rb
+++ b/app/controllers/support/revert_withdrawal_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Support
+  class RevertWithdrawalController < SupportController
+    def edit
+      provider
+      course
+    end
+
+    def update
+      redirect_to edit_support_recruitment_cycle_provider_course_path(provider.recruitment_cycle_year, provider, course), flash: { success: t('support.flash.updated', resource: 'Course status') }
+    end
+
+    private
+
+    def provider
+      @provider ||= recruitment_cycle.providers.find(params[:provider_id])
+    end
+
+    def course
+      @course ||= provider.courses.find(params[:course_id])
+    end
+  end
+end

--- a/app/services/support/courses/revert_withdrawal_service.rb
+++ b/app/services/support/courses/revert_withdrawal_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Support
+  module Courses
+    class RevertWithdrawalService
+      def initialize(course)
+        @course = course
+      end
+
+      def call
+        return unless @course.is_withdrawn?
+
+        update_enrichments
+        update_site_status
+        close_course
+      end
+
+      private
+
+      def update_enrichments
+        @course.enrichments.max_by(&:created_at).update(status: 'published', last_published_timestamp_utc: Time.now.utc)
+      end
+
+      def update_site_status
+        @course.site_statuses.each do |site_status|
+          site_status.update(status: :running)
+        end
+      end
+
+      def close_course
+        @course.update(application_status: 'closed')
+      end
+    end
+  end
+end

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -11,6 +11,15 @@
 
       <%= f.govuk_text_field(:name, label: { text: "Course title", size: "m" }) %>
 
+      <div class="govuk-!-margin-bottom-6">
+        <h2 class="govuk-heading-m">Course status</h2>
+        <p><%= @course.decorate.status_tag %></p>
+
+        <% if @course.is_withdrawn? %>
+          <%= govuk_link_to("Revert withdrawal", edit_support_recruitment_cycle_provider_course_revert_withdrawal_path(@provider.recruitment_cycle_year, @provider.id, @course.id)) %>
+        <% end %>
+      </div>
+
       <%= f.govuk_date_field(:start_date, legend: { text: "Start date" }) %>
 
       <%= f.govuk_date_field(:applications_open_from, legend: { text: "Applications open from date" }) %>

--- a/app/views/support/revert_withdrawal/edit.html.erb
+++ b/app/views/support/revert_withdrawal/edit.html.erb
@@ -13,8 +13,8 @@
 
  <p class="govuk-body">Reverting this withdrawal will:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>Set the course to published</li>
-      <li>Mark the course as closed for applications</li>
+      <li>set the course to published</li>
+      <li>mark the course as closed for applications</li>
     </ul>
   </p>
 

--- a/app/views/support/revert_withdrawal/edit.html.erb
+++ b/app/views/support/revert_withdrawal/edit.html.erb
@@ -1,0 +1,30 @@
+<%= render PageTitle.new(title: "Revert withdrawal") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(edit_support_recruitment_cycle_provider_course_path(@provider.recruitment_cycle_year, @provider, @course)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @course.decorate.name_and_code %></span>
+        Are you sure you want to revert this withdrawal?
+    </h1>
+
+ <p class="govuk-body">Reverting this withdrawal will:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Set the course to published</li>
+      <li>Mark the course as closed for applications</li>
+    </ul>
+  </p>
+
+    <%= govuk_button_to "Revert withdrawal",
+                        support_recruitment_cycle_provider_course_revert_withdrawal_path(@provider.recruitment_cycle_year, @provider, @course),
+        method: :patch,
+        class: "govuk-button--warning" %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), edit_support_recruitment_cycle_provider_course_path(@provider.recruitment_cycle_year, @provider, @course)) %>
+    </p>
+  </div>
+</div>

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -20,7 +20,11 @@ namespace :support do
           delete :delete, to: 'providers/users#destroy'
         end
       end
-      resources :courses, only: %i[index edit update]
+
+      resources :courses do
+        resource :revert_withdrawal, only: %i[edit update], path: 'revert-withdrawal', controller: 'revert_withdrawal'
+      end
+
       resource :check_school, only: %i[show update], controller: 'providers/schools_check', path: 'schools/check'
       resources :schools do
         member do

--- a/guides/support_playbook.md
+++ b/guides/support_playbook.md
@@ -10,21 +10,6 @@ RecruitmentCycle.current.providers.find_by(provider_code: "1JJ").discard
 
 If the organisation has running courses, you will get a validation error. In this scenario you just need to make sure there aren't any users attached to it.
 
-## Republishing a withdrawn course
-
-To republish a course which has been withdrawn:
-
-```ruby
-# Find the course by code or urn
-course = RecruitmentCycle.current.providers.find_by(provider_code: "138459").courses.find_by(course_code: "3C2F")
-
-course.enrichments.max_by(&:created_at).update(status: "published", last_published_timestamp_utc: Time.now.utc)
-
-course.site_statuses.each do |site_status|
-  site_status.update(vac_status: :no_vacancies, status: :running)
-end
-```
-
 ## Unpublishing a published course
 
 Sometimes providers will accidentally publish a course and would like to unpublish it.

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -217,6 +217,10 @@ FactoryBot.define do
       enrichments { [build(:course_enrichment, :published)] }
     end
 
+    trait :withdrawn do
+      enrichments { [build(:course_enrichment, :withdrawn)] }
+    end
+
     trait :can_sponsor_skilled_worker_visa do
       can_sponsor_skilled_worker_visa { true }
     end

--- a/spec/features/support/providers/courses/reverting_a_withdrawal_spec.rb
+++ b/spec/features/support/providers/courses/reverting_a_withdrawal_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Reverting a withdrawal' do
+  before do
+    given_i_am_authenticated_as_an_admin_user
+    and_there_is_a_provider_with_a_withdrawn_course
+  end
+
+  scenario 'Reverting a withdrawn course' do
+    when_i_navigate_to_the_withdrawn_course
+    and_i_click_revert_withdrawal
+    and_i_confirm
+    and_i_see_the_success_message
+    then_i_should_see_the_published_and_closed_course
+    and_i_should_no_longer_see_the_revert_withdrawal_link
+  end
+
+  def and_i_should_no_longer_see_the_revert_withdrawal_link
+    expect(page).not_to have_link('Revert withdrawal')
+  end
+
+  def then_i_should_see_the_published_and_closed_course
+    expect(page).to have_css('.govuk-tag.govuk-tag--purple', text: 'Closed')
+  end
+
+  def and_i_see_the_success_message
+    expect(page).to have_css('.govuk-notification-banner__heading', text: 'Course status successfully updated')
+  end
+
+  def and_i_confirm
+    click_button 'Revert withdrawal'
+  end
+
+  def when_i_navigate_to_the_withdrawn_course
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: @provider.id, id: @course.id, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+  end
+
+  def and_i_click_revert_withdrawal
+    click_link 'Revert withdrawal'
+  end
+
+  def given_i_am_authenticated_as_an_admin_user
+    given_i_am_authenticated(user: create(:user, :admin))
+  end
+
+  def and_there_is_a_provider_with_a_withdrawn_course
+    @provider ||= create(:provider, courses: [build(:course, :withdrawn)])
+    @course ||= @provider.courses.first
+  end
+end

--- a/spec/services/support/courses/revert_withdrawal_service_spec.rb
+++ b/spec/services/support/courses/revert_withdrawal_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Support::Courses::RevertWithdrawalService do
+  describe '#call' do
+    let(:service) { described_class.new(course) }
+    let(:course) { create(:course, :withdrawn, :open) }
+
+    before do
+      service.call
+    end
+
+    it 'publishes the latest enrichment' do
+      expect(course.enrichments.max_by(&:created_at).status).to eq('published')
+    end
+
+    it 'sets the time stamp to the current time' do
+      expect(course.enrichments.max_by(&:created_at).last_published_timestamp_utc).to be_within(1.minute).of(Time.now.utc)
+    end
+
+    it 'closes the course for applications' do
+      expect(course.reload.application_status).to eq('closed')
+    end
+
+    it 'updates the course to published' do
+      expect(course.reload.is_withdrawn?).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
### Context

We often see providers unintentionally withdrawing courses, so we are building the ability to revert withdrawn courses as a feature into our support UI.

### Changes proposed in this pull request

- Show course status on all courses within support

- Show a `Revert withdrawal` link below the course status if the course status is `Withdrawn`

- When the course is reverted, the `course_status` is set to `published` and the `last_published_timestamp_utc` is set to the current time.

### Screenshots

<img width="1081" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/4780118b-d601-47d0-9a5d-5e5fa59df5d7">
<img width="1075" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/4b78674a-b931-4206-9412-06947e085c9c">
<img width="1157" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/255e465f-4091-41ea-9946-e5b4f2377d64">


### Guidance to review

- Go to Publish, withdraw a course.
- Navigate to the same course on support.
- Revert the withdrawal.
- Go back to Publish and ensure the course is back how it was.
- Try to revert the withdrawal of a course that isn't withdrawn (there should be no link).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
