### PR TITLE
Add dotenv-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -202,6 +202,8 @@ group :development, :test do
   gem 'factory_bot_rails', '~> 6.2'
   gem 'fakefs', require: 'fakefs/safe'
   gem 'faker'
+
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,10 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -770,6 +774,7 @@ DEPENDENCIES
   database_cleaner
   dfe-analytics!
   discard
+  dotenv-rails
   draper
   dry-container
   erb_lint


### PR DESCRIPTION
Some of us need to change the database user and password in the `database.yml` file. We can use dotenv-rails to store the user and password in a `.env` file that is gitignored.

Didn't add a `.env.example` as it seems it doesn't use other envs locally