### PR TITLE
Show all salaried program types in Find

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -231,7 +231,11 @@ class Course < ApplicationRecord
   scope :with_recruitment_cycle, ->(year) { joins(provider: :recruitment_cycle).where(recruitment_cycle: { year: }) }
   scope :findable, -> { joins(:site_statuses).merge(SiteStatus.findable) }
   scope :with_vacancies, -> { joins(:site_statuses).merge(SiteStatus.with_vacancies) }
-  scope :with_salary, -> { where(program_type: %i[school_direct_salaried_training_programme pg_teaching_apprenticeship]) }
+  scope :with_salary, lambda {
+    where(
+      program_type: %i[school_direct_salaried_training_programme pg_teaching_apprenticeship scitt_salaried_programme higher_education_salaried_programme]
+    )
+  }
   scope :with_study_modes, lambda { |study_modes|
     if study_modes.include? 'full_time_or_part_time'
       where(study_mode: study_modes)

--- a/spec/features/find/result_page_filters/salary_spec.rb
+++ b/spec/features/find/result_page_filters/salary_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'Funding filter' do
   end
 
   scenario 'Candidate applies salary filter' do
+    given_i_have_salaried_and_fee_courses
     when_i_visit_the_find_results_page
     then_i_see_that_the_salary_checkbox_is_not_selected
 
@@ -16,6 +17,71 @@ RSpec.feature 'Funding filter' do
     and_apply_the_filters
     then_i_see_that_the_salary_checkbox_is_selected
     and_the_salary_query_parameter_is_retained
+    and_i_should_see_the_salaried_courses
+  end
+
+  def given_i_have_salaried_and_fee_courses
+    @course_higher_education_programme = create(
+      :course,
+      :secondary,
+      :open,
+      site_statuses:,
+      program_type: :higher_education_programme
+    )
+    @course_scitt_salaried_programme = create(
+      :course,
+      :secondary,
+      :open,
+      site_statuses:,
+      program_type: :scitt_salaried_programme
+    )
+    @course_higher_education_salaried_programme = create(
+      :course,
+      :secondary,
+      :open,
+      site_statuses:,
+      program_type: :higher_education_salaried_programme
+    )
+    @course_school_direct_training_programme = create(
+      :course,
+      :secondary,
+      :open,
+      site_statuses:,
+      program_type: :school_direct_training_programme
+    )
+    @course_school_direct_salaried_training_programme = create(
+      :course,
+      :secondary,
+      :open,
+      site_statuses:,
+      program_type: :school_direct_salaried_training_programme
+    )
+    @course_scitt_programme = create(
+      :course,
+      :secondary,
+      :open,
+      site_statuses:,
+      program_type: :scitt_programme
+    )
+    @course_pg_teaching_apprenticeship = create(
+      :course,
+      :secondary,
+      :open,
+      site_statuses:,
+      program_type: :pg_teaching_apprenticeship
+    )
+  end
+
+  def and_i_should_see_the_salaried_courses
+    [
+      @course_scitt_salaried_programme,
+      @course_higher_education_salaried_programme,
+      @course_school_direct_salaried_training_programme,
+      @course_pg_teaching_apprenticeship
+    ].each do |course|
+      expect(find_results_page).to have_content(course.decorate.name_and_code)
+      expect(find_results_page).to have_content(course.provider.provider_name)
+    end
   end
 
   def then_i_see_that_the_salary_checkbox_is_not_selected
@@ -35,5 +101,9 @@ RSpec.feature 'Funding filter' do
       expect(uri.path).to eq('/results')
       expect(uri.query).to eq('study_type[]=full_time&study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=show_all_courses&funding=salary&applications_open=true')
     end
+  end
+
+  def site_statuses
+    [create(:site_status, :findable)]
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1129,33 +1129,38 @@ describe Course do
     describe '.with_salary' do
       subject { described_class.with_salary }
 
-      let(:course_higher_education_programme) do
+      let!(:course_higher_education_programme) do
         create(:course, program_type: :higher_education_programme)
       end
 
-      let(:course_school_direct_training_programme) do
+      let!(:course_scitt_salaried_programme) do
+        create(:course, program_type: :scitt_salaried_programme)
+      end
+
+      let!(:course_higher_education_salaried_programme) do
+        create(:course, program_type: :higher_education_salaried_programme)
+      end
+
+      let!(:course_school_direct_training_programme) do
         create(:course, program_type: :school_direct_training_programme)
       end
 
-      let(:course_school_direct_salaried_training_programme) do
+      let!(:course_school_direct_salaried_training_programme) do
         create(:course, program_type: :school_direct_salaried_training_programme)
       end
 
-      let(:course_scitt_programme) { create(:course, program_type: :scitt_programme) }
-      let(:course_pg_teaching_apprenticeship) do
+      let!(:course_scitt_programme) { create(:course, program_type: :scitt_programme) }
+      let!(:course_pg_teaching_apprenticeship) do
         create(:course, program_type: :pg_teaching_apprenticeship)
       end
 
-      before do
-        course_higher_education_programme
-        course_school_direct_training_programme
-        course_school_direct_salaried_training_programme
-        course_scitt_programme
-        course_pg_teaching_apprenticeship
-      end
-
       it 'only returns salaried training programme' do
-        expect(subject).to contain_exactly(course_school_direct_salaried_training_programme, course_pg_teaching_apprenticeship)
+        expect(subject).to contain_exactly(
+          course_scitt_salaried_programme,
+          course_higher_education_salaried_programme,
+          course_school_direct_salaried_training_programme,
+          course_pg_teaching_apprenticeship
+        )
       end
     end
 


### PR DESCRIPTION
### Context

Provider raised a ticket on support that the salaried courses are not appearing on Find.

For all salaried courses at some provider, when using the ‘Only show courses that come with a salary’ filter in Find, they do not show, despite being listed as salaried courses. They do show up before using this filter.

This PR fixes the issue.

### Guidance to review

1. Does it work the filter for each of salaried courses?

## Trello card

https://trello.com/c/9G0YRK3m/1043-fix-bug-on-find-for-salaried-courses