### PR TITLE
Enable entity_table_check_job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ gem 'jsbundling-rails', '~> 1.2'
 gem 'sprockets-rails', require: 'sprockets/railtie'
 
 # for sending analytics data to the analytics platform
-gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.11.5'
+gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.11.6'
 
 # For running data migrations
 gem 'data_migrate', '~> 9.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: fdfd7f0bdbe5c6b6677d7502afb8691ae08bedeb
-  tag: v1.11.5
+  revision: 33251ca61e4806fc7eb86538c24de578bfea0007
+  tag: v1.11.6
   specs:
-    dfe-analytics (1.11.5)
+    dfe-analytics (1.11.6)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -30,6 +30,10 @@ DfE::Analytics.configure do |config|
   #
   config.bigquery_api_json_key = Settings.google.bigquery.api_json_key
 
+  # Enables the EntityTableCheckJob
+  #
+  config.entity_table_checks_enabled = true
+
   # Passed directly to the retries: option on the BigQuery client
   #
   # config.bigquery_retries = 3

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -22,6 +22,10 @@ bg_jobs:
     cron: "0 0 * * *" # daily at midnight
     class: "SaveStatisticJob"
     queue: save_statistic
+  send_entity_table_checks_to_bigquery:
+    cron: "30 0 * * *"  # daily at 00:30
+    class: "DfE::Analytics::EntityTableCheckJob"
+    queue: low_priority
 skylight:
   enable: true
 environment:


### PR DESCRIPTION
### Context
EntityTableCheck is a job which sends a row_count, a checksum and a timestamp for each entity table sent to Big Query and it’s purpose is to serve as a tool for confirming database tables match Big Query tables and then help to debug where they don’t match.

### Changes proposed in this pull request
This PR enables the job and schedules it to run daily at 00:30

### Guidance to review
Please check the scheduling looks correct and advise if there is a better time for the job to run. I went for low_priority as the queue and enabled it only in the production.yml.

N.B If it is possible, testing this PR prior to deployment would be ideal - I can help with that

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
