### PR TITLE
Refactor references to provider codes in view templates

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="training-locations">Training locations</h2>
   <div data-qa="course__about_schools">
-    <% if course.program_type == "higher_education_programme" && course.provider.provider_code != "B31" %>
+    <% if show_higher_education_guidance? %>
       <%= render Find::Utility::AdviceComponent::View.new(title: "Where you will train") do %>
         <p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within
           commuting distance.</p>
@@ -10,7 +10,7 @@
         <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10
           miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
       <% end %>
-    <% elsif course.program_type == "scitt_programme" && course.provider.provider_code != "E65" %>
+    <% elsif show_scitt_guidance? %>
       <%= render Find::Utility::AdviceComponent::View.new(title: "Where you will train") do %>
         <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your training provider will place you in schools you can travel to.</p>
       <% end %>

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -29,13 +29,13 @@ module Find
         def show_higher_education_guidance?
           return false unless course.higher_education_programme?
 
-          course_information_config.show_placement_guidance?(:program_type, :higher_education)
+          course_information_config.show_placement_guidance?(:program_type)
         end
 
         def show_scitt_guidance?
           return false unless course.scitt_programme?
 
-          course_information_config.show_placement_guidance?(:program_type, :scitt_programmes)
+          course_information_config.show_placement_guidance?(:program_type)
         end
 
         private

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -29,21 +29,19 @@ module Find
         def show_higher_education_guidance?
           return false unless course.higher_education_programme?
 
-          course_information_config(:higher_education, :except_provider_codes).exclude?(course.provider.provider_code)
+          course_information_config.placement(:program_type, :higher_education)
         end
 
         def show_scitt_guidance?
           return false unless course.scitt_programme?
 
-          course_information_config(:scitt_programmes, :except_provider_codes).exclude?(course.provider_code)
+          course_information_config.placement(:program_type, :scitt_programmes)
         end
 
         private
 
-        def course_information_config(*path)
-          @course_information_config ||= Rails.application.config_for(:course_information)
-
-          @course_information_config.dig(:where_you_will_train, *path)
+        def course_information_config
+          @course_information_config ||= Configs::CourseInformation.new(course)
         end
       end
     end

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -29,13 +29,13 @@ module Find
         def show_higher_education_guidance?
           return false unless course.higher_education_programme?
 
-          course_information_config.placement(:program_type, :higher_education)
+          course_information_config.show_placement_guidance?(:program_type, :higher_education)
         end
 
         def show_scitt_guidance?
           return false unless course.scitt_programme?
 
-          course_information_config.placement(:program_type, :scitt_programmes)
+          course_information_config.show_placement_guidance?(:program_type, :scitt_programmes)
         end
 
         private

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -21,8 +21,7 @@ module Find
 
         def render?
           published_how_school_placements_work.present? ||
-            program_type == 'higher_education_programme' ||
-            program_type == 'scitt_programme' ||
+            program_type.in?(%w[higher_education_programme scitt_programme]) ||
             study_sites.any? ||
             site_statuses.map(&:site).uniq.many? || preview?(params)
         end

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -25,6 +25,26 @@ module Find
             study_sites.any? ||
             site_statuses.map(&:site).uniq.many? || preview?(params)
         end
+
+        def show_higher_education_guidance?
+          return false unless course.higher_education_programme?
+
+          course_information_config(:higher_education, :except_provider_codes).exclude?(course.provider.provider_code)
+        end
+
+        def show_scitt_guidance?
+          return false unless course.scitt_programme?
+
+          course_information_config(:scitt_programmes, :except_provider_codes).exclude?(course.provider_code)
+        end
+
+        private
+
+        def course_information_config(*path)
+          @course_information_config ||= Rails.application.config_for(:course_information)
+
+          @course_information_config.dig(:where_you_will_train, *path)
+        end
       end
     end
   end

--- a/app/components/find/courses/contact_details_component/view.html.erb
+++ b/app/components/find/courses/contact_details_component/view.html.erb
@@ -33,7 +33,7 @@
         </dd>
       <% end %>
 
-      <% if course.provider.provider_code == "28T" && course.course_code == "X104" %>
+      <% if show_address? %>
         <dt class="app-description-list__label">Address</dt>
         <dd data-qa="provider__address">
           LSJS

--- a/app/components/find/courses/contact_details_component/view.html.erb
+++ b/app/components/find/courses/contact_details_component/view.html.erb
@@ -3,12 +3,10 @@
 
   <div class="course-basicinfo">
     <dl class="app-description-list">
-       <!-- Temporary stop gap for https://trello.com/c/vJRKI35V/614-stop-gap-ucl-is-moving-away-from-using-email. BIN it as soon as we have a better solution. -->
-      <% if course.provider.provider_code == "U80" %>
-        <% link = "https://www.ucl.ac.uk/prospective-students/graduate/admissions-enquiries" %>
+      <% if show_contact_form_instead_of_email? %>
         <dt class="app-description-list__label">Contact form</dt>
         <dd data-qa="provider__email">
-          <%= govuk_link_to link, link %>
+          <%= govuk_link_to contact_form, contact_form %>
         </dd>
       <% else %>
         <% if course.provider.email.present? %>

--- a/app/components/find/courses/contact_details_component/view.rb
+++ b/app/components/find/courses/contact_details_component/view.rb
@@ -12,6 +12,14 @@ module Find
           super
           @course = course
         end
+
+        def show_address?
+          course.provider_code.in?(course_information_config(:only_provider_codes)) && course.course_code.in?(course_information_config(:only_course_codes))
+        end
+
+        def course_information_config(*path)
+          Rails.application.config_for(:course_information).dig(:show_address, *path)
+        end
       end
     end
   end

--- a/app/components/find/courses/contact_details_component/view.rb
+++ b/app/components/find/courses/contact_details_component/view.rb
@@ -7,6 +7,7 @@ module Find
         attr_reader :course
 
         delegate :provider, to: :course
+        delegate :contact_form?, :contact_form, :show_address?, to: :course_information_config
 
         def initialize(course)
           super
@@ -14,27 +15,13 @@ module Find
         end
 
         def show_contact_form_instead_of_email?
-          course.provider.provider_code.in?(course_information_config(:contact_forms).keys.map(&:to_s))
-        end
-
-        def show_address?
-          course.provider_code.in?(course_information_config(:show_address, :only_provider_codes)) && course.course_code.in?(course_information_config(:show_address, :only_course_codes))
-        end
-
-        def contact_form
-          contact_forms[course.provider.provider_code]
+          contact_form?
         end
 
         private
 
-        def contact_forms
-          course_information_config(:contact_forms).stringify_keys
-        end
-
-        def course_information_config(*path)
-          @course_information_config ||= Rails.application.config_for(:course_information)
-
-          @course_information_config.dig(*path)
+        def course_information_config
+          @course_information_config ||= Configs::CourseInformation.new(course)
         end
       end
     end

--- a/app/components/find/courses/contact_details_component/view.rb
+++ b/app/components/find/courses/contact_details_component/view.rb
@@ -13,12 +13,28 @@ module Find
           @course = course
         end
 
+        def show_contact_form_instead_of_email?
+          course.provider.provider_code.in?(course_information_config(:contact_forms).keys.map(&:to_s))
+        end
+
         def show_address?
-          course.provider_code.in?(course_information_config(:only_provider_codes)) && course.course_code.in?(course_information_config(:only_course_codes))
+          course.provider_code.in?(course_information_config(:show_address, :only_provider_codes)) && course.course_code.in?(course_information_config(:show_address, :only_course_codes))
+        end
+
+        def contact_form
+          contact_forms[course.provider.provider_code]
+        end
+
+        private
+
+        def contact_forms
+          course_information_config(:contact_forms).stringify_keys
         end
 
         def course_information_config(*path)
-          Rails.application.config_for(:course_information).dig(:show_address, *path)
+          @course_information_config ||= Rails.application.config_for(:course_information)
+
+          @course_information_config.dig(*path)
         end
       end
     end

--- a/app/controllers/publish/courses/course_information_controller.rb
+++ b/app/controllers/publish/courses/course_information_controller.rb
@@ -61,21 +61,19 @@ module Publish
       def param_form_key = :publish_course_information_form
 
       def course_information
-        @course_information ||= Rails.application.config_for('course_information').fetch(:where_you_will_train)
+        @course_information ||= Configs::CourseInformation.new(@course)
       end
 
       def show_scitt_guidance?
         return false unless @course.scitt_programme?
 
-        codes = course_information.dig(:scitt_programmes, :except_provider_codes)
-        codes.exclude?(@course.provider.provider_code)
+        course_information.placement(:program_type, :scitt_programmes)
       end
 
       def show_universities_guidance?
         return false unless @provider.university?
 
-        codes = course_information.dig(:universities, :except_provider_codes)
-        codes.exclude?(@course.provider.provider_code)
+        course_information.placement(:provider_type, :universities)
       end
       helper_method :show_scitt_guidance?, :show_universities_guidance?
     end

--- a/app/controllers/publish/courses/course_information_controller.rb
+++ b/app/controllers/publish/courses/course_information_controller.rb
@@ -65,15 +65,11 @@ module Publish
       end
 
       def show_scitt_guidance?
-        return false unless @course.scitt_programme?
-
-        course_information.show_placement_guidance?(:program_type, :scitt_programmes)
+        course_information.show_placement_guidance?(:program_type)
       end
 
       def show_universities_guidance?
-        return false unless @provider.university?
-
-        course_information.show_placement_guidance?(:provider_type, :universities)
+        course_information.show_placement_guidance?(:provider_type)
       end
       helper_method :show_scitt_guidance?, :show_universities_guidance?
     end

--- a/app/controllers/publish/courses/course_information_controller.rb
+++ b/app/controllers/publish/courses/course_information_controller.rb
@@ -59,6 +59,25 @@ module Publish
       end
 
       def param_form_key = :publish_course_information_form
+
+      def course_information
+        @course_information ||= Rails.application.config_for('course_information').fetch(:where_you_will_train)
+      end
+
+      def show_scitt_guidance?
+        return false unless @course.scitt_programme?
+
+        codes = course_information.dig(:scitt_programmes, :except_provider_codes)
+        codes.exclude?(@course.provider.provider_code)
+      end
+
+      def show_universities_guidance?
+        return false unless @provider.university?
+
+        codes = course_information.dig(:universities, :except_provider_codes)
+        codes.exclude?(@course.provider.provider_code)
+      end
+      helper_method :show_scitt_guidance?, :show_universities_guidance?
     end
   end
 end

--- a/app/controllers/publish/courses/course_information_controller.rb
+++ b/app/controllers/publish/courses/course_information_controller.rb
@@ -67,13 +67,13 @@ module Publish
       def show_scitt_guidance?
         return false unless @course.scitt_programme?
 
-        course_information.placement(:program_type, :scitt_programmes)
+        course_information.show_placement_guidance?(:program_type, :scitt_programmes)
       end
 
       def show_universities_guidance?
         return false unless @provider.university?
 
-        course_information.placement(:provider_type, :universities)
+        course_information.show_placement_guidance?(:provider_type, :universities)
       end
       helper_method :show_scitt_guidance?, :show_universities_guidance?
     end

--- a/app/services/configs/course_information.rb
+++ b/app/services/configs/course_information.rb
@@ -7,7 +7,7 @@ module Configs
       @course = course
     end
 
-    def placement(type, subtype)
+    def show_placement_guidance?(type, subtype)
       @db.dig(:placements, type, subtype, :except_provider_codes).exclude?(@course.provider.provider_code)
     end
 

--- a/app/services/configs/course_information.rb
+++ b/app/services/configs/course_information.rb
@@ -7,8 +7,8 @@ module Configs
       @course = course
     end
 
-    def placement(*path)
-      @db.dig(*path)
+    def placement(type, subtype)
+      @db.dig(:placements, type, subtype, :except_provider_codes).exclude?(@course.provider.provider_code)
     end
 
     def contact_form

--- a/app/services/configs/course_information.rb
+++ b/app/services/configs/course_information.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Configs
+  class CourseInformation
+    def initialize(course)
+      @db = Rails.application.config_for(:course_information)
+      @course = course
+    end
+
+    def placement(*path)
+      @db.dig(*path)
+    end
+
+    def contact_form
+      @db.fetch(:contact_forms).stringify_keys[@course.provider.provider_code]
+    end
+
+    def contact_form?
+      @db.fetch(:contact_forms).stringify_keys.include?(@course.provider.provider_code)
+    end
+
+    def show_address?
+      @db.dig(:show_address, :only_provider_codes).include?(@course.provider.provider_code) &&
+        @db.dig(:show_address, :only_course_codes).include?(@course.course_code)
+    end
+  end
+end

--- a/app/services/configs/course_information.rb
+++ b/app/services/configs/course_information.rb
@@ -7,8 +7,15 @@ module Configs
       @course = course
     end
 
-    def show_placement_guidance?(type, subtype)
-      @db.dig(:placements, type, subtype, :except_provider_codes).exclude?(@course.provider.provider_code)
+    def show_placement_guidance?(type)
+      case type
+      when :provider_type
+        subtype = @course.provider.provider_type
+      when :program_type
+        subtype = @course.program_type
+      end
+
+      @db.dig(:placements, type, subtype.to_sym, :except_provider_codes)&.exclude?(@course.provider.provider_code)
     end
 
     def contact_form

--- a/app/views/publish/courses/course_information/edit.html.erb
+++ b/app/views/publish/courses/course_information/edit.html.erb
@@ -98,14 +98,14 @@
         <li>how placement schools are selected</li>
       </ul>
 
-      <% if @provider.provider_type == 'university' && @provider.provider_code != 'B31' %>
+      <% if show_universities_guidance? %>
         <%= govuk_details(summary_text: "See the guidance we show in this section") do %>
           <h3 class="govuk-heading-m">Where you will train</h3>
           <p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within commuting distance.</p>
           <p class="govuk-body">You cannot pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
           <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
         <% end %>
-      <% elsif @course.program_type == 'scitt_programme' && @provider.provider_code != 'E65' %>
+      <% elsif show_scitt_guidance? %>
         <%= govuk_details(summary_text: "See the guidance we show in this section") do %>
           <h3 class="govuk-heading-m">Where you will train</h3>
           <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your training provider will place you in schools you can travel to.</p>

--- a/config/course_information.yml
+++ b/config/course_information.yml
@@ -1,0 +1,8 @@
+shared:
+  where_you_will_train:
+    universities:
+      except_provider_codes:
+        - B31
+    scitt_programmes:
+      except_provider_codes:
+        - E65

--- a/config/course_information.yml
+++ b/config/course_information.yml
@@ -14,3 +14,5 @@ shared:
       - 28T
     only_course_codes:
       - X104
+  contact_forms:
+    U80: https://www.ucl.ac.uk/prospective-students/graduate/admissions-enquiries

--- a/config/course_information.yml
+++ b/config/course_information.yml
@@ -1,14 +1,14 @@
 shared:
   placements:
     provider_type:
-      universities:
+      university:
         except_provider_codes:
           - B31
     program_type:
-      scitt_programmes:
+      scitt_programme:
         except_provider_codes:
           - E65
-      higher_education:
+      higher_education_programme:
         except_provider_codes:
           - B31
   show_address:

--- a/config/course_information.yml
+++ b/config/course_information.yml
@@ -9,3 +9,8 @@ shared:
     higher_education:
       except_provider_codes:
         - B31
+  show_address:
+    only_provider_codes:
+      - 28T
+    only_course_codes:
+      - X104

--- a/config/course_information.yml
+++ b/config/course_information.yml
@@ -1,14 +1,16 @@
 shared:
-  where_you_will_train:
-    universities:
-      except_provider_codes:
-        - B31
-    scitt_programmes:
-      except_provider_codes:
-        - E65
-    higher_education:
-      except_provider_codes:
-        - B31
+  placements:
+    provider_type:
+      universities:
+        except_provider_codes:
+          - B31
+    program_type:
+      scitt_programmes:
+        except_provider_codes:
+          - E65
+      higher_education:
+        except_provider_codes:
+          - B31
   show_address:
     only_provider_codes:
       - 28T

--- a/config/course_information.yml
+++ b/config/course_information.yml
@@ -6,3 +6,6 @@ shared:
     scitt_programmes:
       except_provider_codes:
         - E65
+    higher_education:
+      except_provider_codes:
+        - B31

--- a/spec/components/find/courses/about_schools_component/view_preview.rb
+++ b/spec/components/find/courses/about_schools_component/view_preview.rb
@@ -56,6 +56,10 @@ module Find
           include ActiveModel::Model
           attr_accessor(:provider, :published_how_school_placements_work, :placements_heading, :program_type, :study_sites, :site_statuses)
 
+          def higher_education_programme?
+            true
+          end
+
           def preview_site_statuses
             site_statuses.sort_by { |status| status.site.location_name }
           end

--- a/spec/components/find/courses/contact_details_component/view_spec.rb
+++ b/spec/components/find/courses/contact_details_component/view_spec.rb
@@ -76,4 +76,16 @@ describe Find::Courses::ContactDetailsComponent::View, type: :component do
       expect(result.text).to include('LSJS', '44A Albert Road', 'London', 'NW4 2SJ')
     end
   end
+
+  context 'when the provider has a contact form in the config' do
+    it 'renders the Contact Form instead of Email' do
+      provider = build(:provider, provider_code: 'U80')
+      course = build(:course, course_code: 'X104', provider:).decorate
+
+      result = render_inline(described_class.new(course))
+
+      expect(result.text).to include('Contact form')
+      expect(result.text).not_to include('Email')
+    end
+  end
 end

--- a/spec/features/publish/courses/editing_course_information_guidance_spec.rb
+++ b/spec/features/publish/courses/editing_course_information_guidance_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Guidance components on course edit page', { can_edit_current_and_next_cycles: false } do
+  describe 'university providers' do
+    context 'when provider is excluded via config' do
+      scenario 'Guidance is not shown' do
+        given_a_provider_which_does_not_show_guidance
+        and_the_provider_has_a_course
+        and_i_am_authenticated_as_a_provider_user
+        when_i_go_to_edit_a_course
+        i_do_not_see_the_guidance_text
+      end
+
+      def given_a_provider_which_does_not_show_guidance
+        @provider = create(:provider, :university, provider_code: 'B31')
+      end
+    end
+
+    context 'when provider is not excluded via config' do
+      scenario 'Guidance is shown' do
+        given_a_provider_which_does_show_guidance
+        and_the_provider_has_a_course
+        and_i_am_authenticated_as_a_provider_user
+        when_i_go_to_edit_a_course
+        i_do_see_the_guidance_text
+      end
+
+      def given_a_provider_which_does_show_guidance
+        @provider = create(:provider, :university, provider_code: 'XXX')
+      end
+    end
+  end
+
+  describe 'scitt courses' do
+    context 'when provider is excluded via config' do
+      scenario 'Guidance is not shown' do
+        given_a_provider_which_does_not_show_guidance
+        and_the_provider_has_a_course
+        and_i_am_authenticated_as_a_provider_user
+        when_i_go_to_edit_a_course
+        i_do_not_see_the_guidance_text
+      end
+
+      def given_a_provider_which_does_not_show_guidance
+        @provider = create(:provider, :scitt, provider_code: 'E65')
+      end
+    end
+
+    context 'when provider is not excluded via config' do
+      scenario 'Guidance is shown' do
+        given_a_provider_which_does_show_guidance
+        and_the_provider_has_a_course
+        and_i_am_authenticated_as_a_provider_user
+        when_i_go_to_edit_a_course
+        i_do_see_the_guidance_text
+      end
+
+      def and_the_provider_has_a_course
+        @course = create(:course, :with_scitt, provider: @provider)
+      end
+
+      def given_a_provider_which_does_show_guidance
+        @provider = create(:provider, :scitt, provider_code: 'T92')
+      end
+    end
+  end
+
+  def and_the_provider_has_a_course
+    @course = create(:course, provider: @provider)
+  end
+
+  def and_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated
+    @current_user.providers << @provider
+  end
+
+  def when_i_go_to_edit_a_course
+    publish_course_information_edit_page.load(
+      provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year, course_code: @course.course_code
+    )
+  end
+
+  def i_do_not_see_the_guidance_text
+    expect(page).to have_no_content('Where you will train')
+  end
+
+  def i_do_see_the_guidance_text
+    expect(page).to have_content('Where you will train')
+  end
+end

--- a/spec/services/configs/course_information_spec.rb
+++ b/spec/services/configs/course_information_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Configs::CourseInformation do
+  let(:scitt_provider) { build(:provider, :scitt, provider_code:) }
+  let(:university_provider) { build(:provider, :university, provider_code:) }
+
+  let(:he_course) { build(:course, :with_higher_education, provider:, course_code:) }
+  let(:scitt_course) { build(:course, :with_scitt, provider:, course_code:) }
+
+  let(:type) { :provider_type }
+  let(:subtype) { :program_type }
+
+  let(:provider_code) { 'XXX' }
+  let(:course_code) { 'XXX' }
+
+  describe '#show_placement_guidance?' do
+    let(:course) { scitt_course }
+    let(:provider) { university_provider }
+    let(:type) { :provider_type }
+    let(:subtype) { :universities }
+
+    context 'when University providers provider code is present' do
+      let(:provider_code) { 'B31' }
+
+      it 'returns false' do
+        obj = described_class.new(course)
+
+        expect(obj.show_placement_guidance?(type, subtype)).to be(false)
+      end
+    end
+
+    context 'when University providers provider_code is absent' do
+      it 'returns true' do
+        obj = described_class.new(course)
+
+        expect(obj.show_placement_guidance?(type, subtype)).to be(true)
+      end
+    end
+
+    context 'when SCITT course with provider_code present' do
+      let(:provider) { scitt_provider }
+      let(:type) { :program_type }
+      let(:subtype) { :scitt_programmes }
+      let(:provider_code) { 'E65' }
+
+      it 'returns false' do
+        obj = described_class.new(course)
+
+        expect(obj.show_placement_guidance?(type, subtype)).to be(false)
+      end
+    end
+
+    context 'when SCITT course with provider_code absent' do
+      let(:provider) { scitt_provider }
+      let(:type) { :program_type }
+      let(:subtype) { :scitt_programmes }
+
+      it 'returns true' do
+        obj = described_class.new(course)
+
+        expect(obj.show_placement_guidance?(type, subtype)).to be(true)
+      end
+    end
+
+    context 'when Higher Education course with provider_code present' do
+      let(:course) { he_course }
+      let(:provider) { scitt_provider }
+      let(:type) { :program_type }
+      let(:subtype) { :higher_education }
+      let(:provider_code) { 'B31' }
+
+      it 'returns false' do
+        obj = described_class.new(course)
+
+        expect(obj.show_placement_guidance?(type, subtype)).to be(false)
+      end
+    end
+
+    context 'when Higher Education course with provider_code absent' do
+      let(:course) { he_course }
+      let(:provider) { scitt_provider }
+      let(:type) { :program_type }
+      let(:subtype) { :higher_education }
+
+      it 'returns true' do
+        obj = described_class.new(course)
+
+        expect(obj.show_placement_guidance?(type, subtype)).to be(true)
+      end
+    end
+  end
+
+  describe '#contact_form?' do
+    let(:provider) { scitt_provider }
+    let(:course) { scitt_course }
+
+    context 'when provider has a contact form' do
+      let(:provider_code) { 'U80' }
+
+      it 'returns true' do
+        obj = described_class.new(course)
+
+        expect(obj.contact_form?).to be(true)
+      end
+    end
+
+    context 'when provider does not have a contact form' do
+      it 'returns false' do
+        obj = described_class.new(course)
+
+        expect(obj.contact_form?).to be(false)
+      end
+    end
+  end
+
+  describe '#contact_form' do
+    let(:provider) { scitt_provider }
+    let(:course) { scitt_course }
+
+    context 'when provider has a contact form' do
+      let(:provider_code) { 'U80' }
+
+      it 'returns the contact form URL' do
+        obj = described_class.new(course)
+
+        expect(obj.contact_form).to eq('https://www.ucl.ac.uk/prospective-students/graduate/admissions-enquiries')
+      end
+    end
+
+    context 'when provider does not have a contact form' do
+      it 'returns false' do
+        obj = described_class.new(course)
+
+        expect(obj.contact_form).to be_nil
+      end
+    end
+  end
+
+  describe '#show_address?' do
+    subject { described_class.new(course).show_address? }
+
+    let(:provider) { scitt_provider }
+    let(:course) { scitt_course }
+
+    context 'when course and provider codes exist' do
+      let(:provider_code) { '28T' }
+      let(:course_code) { 'X104' }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when course and provider codes do not exist' do
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/services/configs/course_information_spec.rb
+++ b/spec/services/configs/course_information_spec.rb
@@ -9,9 +9,6 @@ describe Configs::CourseInformation do
   let(:he_course) { build(:course, :with_higher_education, provider:, course_code:) }
   let(:scitt_course) { build(:course, :with_scitt, provider:, course_code:) }
 
-  let(:type) { :provider_type }
-  let(:subtype) { :program_type }
-
   let(:provider_code) { 'XXX' }
   let(:course_code) { 'XXX' }
 
@@ -19,7 +16,6 @@ describe Configs::CourseInformation do
     let(:course) { scitt_course }
     let(:provider) { university_provider }
     let(:type) { :provider_type }
-    let(:subtype) { :universities }
 
     context 'when University providers provider code is present' do
       let(:provider_code) { 'B31' }
@@ -27,7 +23,7 @@ describe Configs::CourseInformation do
       it 'returns false' do
         obj = described_class.new(course)
 
-        expect(obj.show_placement_guidance?(type, subtype)).to be(false)
+        expect(obj.show_placement_guidance?(type)).to be(false)
       end
     end
 
@@ -35,32 +31,30 @@ describe Configs::CourseInformation do
       it 'returns true' do
         obj = described_class.new(course)
 
-        expect(obj.show_placement_guidance?(type, subtype)).to be(true)
+        expect(obj.show_placement_guidance?(type)).to be(true)
       end
     end
 
     context 'when SCITT course with provider_code present' do
       let(:provider) { scitt_provider }
       let(:type) { :program_type }
-      let(:subtype) { :scitt_programmes }
       let(:provider_code) { 'E65' }
 
       it 'returns false' do
         obj = described_class.new(course)
 
-        expect(obj.show_placement_guidance?(type, subtype)).to be(false)
+        expect(obj.show_placement_guidance?(type)).to be(false)
       end
     end
 
     context 'when SCITT course with provider_code absent' do
       let(:provider) { scitt_provider }
       let(:type) { :program_type }
-      let(:subtype) { :scitt_programmes }
 
       it 'returns true' do
         obj = described_class.new(course)
 
-        expect(obj.show_placement_guidance?(type, subtype)).to be(true)
+        expect(obj.show_placement_guidance?(type)).to be(true)
       end
     end
 
@@ -68,13 +62,12 @@ describe Configs::CourseInformation do
       let(:course) { he_course }
       let(:provider) { scitt_provider }
       let(:type) { :program_type }
-      let(:subtype) { :higher_education }
       let(:provider_code) { 'B31' }
 
       it 'returns false' do
         obj = described_class.new(course)
 
-        expect(obj.show_placement_guidance?(type, subtype)).to be(false)
+        expect(obj.show_placement_guidance?(type)).to be(false)
       end
     end
 
@@ -82,12 +75,11 @@ describe Configs::CourseInformation do
       let(:course) { he_course }
       let(:provider) { scitt_provider }
       let(:type) { :program_type }
-      let(:subtype) { :higher_education }
 
       it 'returns true' do
         obj = described_class.new(course)
 
-        expect(obj.show_placement_guidance?(type, subtype)).to be(true)
+        expect(obj.show_placement_guidance?(type)).to be(true)
       end
     end
   end


### PR DESCRIPTION
### Context

Remove explicit references to Provider and Course codes in view templates.

We are extracting the logic for storing configuration related to conditionally showing aspects of the views based on the provider and course.

### Changes proposed in this pull request

Create a config file for what providers and courses should trigger the alternative view content.

`config/course_information.yml` holds the data mapping configurations for paricular `Provider`s, `provider_type`s `Course` `program_type`s

`Config::CourseInformation` is a class that encapsulates the loading and lookup behaviour providing an abstracted public interface for interacting with the config data. It is used throughout the application where provider / course specific checks need to happen.


### Question / Proposal
I would like to create a class that encapsulates the views config database. Something like `ViewConfig`.

What should we name it and where should it live in the directory structure?

### Trello 

[Trello Ticket](https://trello.com/c/HlLZsoz2/1141-find-remove-reference-to-provider-codes)


### Links Publish

#### Course Information Edit page



**Shows Guidance (SCITT programme but not E65)**
 - https://publish-review-4003.test.teacherservices.cloud/publish/organisations/24S/2024/courses/3D8V/about

**Doesn't show Guidance (SCITT programme E65)**
 - https://publish-review-4003.test.teacherservices.cloud/publish/organisations/E65/2024/courses/38NP/about

### Links - Find

**Shows Guidance (University Provider but not B31)**
- https://find-review-4003.test.teacherservices.cloud/course/U80/2P35

**Shows Guidance (SCITT programme but not E65)**
 - https://find-review-4003.test.teacherservices.cloud/course/24S/3D8V

**no show guidance (scitt programme E65)**
 - Doesn't show guidance : https://find-review-4003.test.teacherservices.cloud/course/E65/38np

### Links Address

**X104 course**
- https://find-review-4003.test.teacherservices.cloud/course/28T/X104

**non X104 course** 
- https://find-review-4003.test.teacherservices.cloud/course/28T/368R

### Links Contact Form

**Contact Form (U80 provider)**
- https://find-review-4003.test.teacherservices.cloud/course/U80/2P35

**Email (non U80 provider)**
- https://find-review-4003.test.teacherservices.cloud/course/2Z3/B275


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
