### PR TITLE
Support getting resources from the current recruitment cycle

### DIFF
--- a/app/controllers/api/public/v1/application_controller.rb
+++ b/app/controllers/api/public/v1/application_controller.rb
@@ -5,6 +5,21 @@ module API
     module V1
       class ApplicationController < PublicAPIController
         include PagyPagination
+
+        private
+
+        def recruitment_cycle
+          @recruitment_cycle ||= begin
+            year = params.require(:recruitment_cycle_year)
+
+            case year
+            when 'current'
+              RecruitmentCycle.current_recruitment_cycle
+            else
+              RecruitmentCycle.find_by!(year:)
+            end
+          end
+        end
       end
     end
   end

--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -23,17 +23,6 @@ module API
           )
         end
 
-        def recruitment_cycle
-          year = params.require(:recruitment_cycle_year)
-
-          case year
-          when 'current'
-            RecruitmentCycle.current_recruitment_cycle
-          else
-            RecruitmentCycle.find_by!(year:)
-          end
-        end
-
         def include_param
           params.fetch(:include, '')
         end

--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -24,9 +24,14 @@ module API
         end
 
         def recruitment_cycle
-          @recruitment_cycle = RecruitmentCycle.find_by(
-            year: params[:recruitment_cycle_year]
-          ) || RecruitmentCycle.current_recruitment_cycle
+          year = params.require(:recruitment_cycle_year)
+
+          case year
+          when 'current'
+            RecruitmentCycle.current_recruitment_cycle
+          else
+            RecruitmentCycle.find_by!(year:)
+          end
         end
 
         def include_param

--- a/app/controllers/api/public/v1/providers/courses/locations_controller.rb
+++ b/app/controllers/api/public/v1/providers/courses/locations_controller.rb
@@ -31,10 +31,6 @@ module API
               @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
             end
 
-            def recruitment_cycle
-              @recruitment_cycle ||= RecruitmentCycle.find_by(year: params[:recruitment_cycle_year])
-            end
-
             def include_param
               params.fetch(:include, '')
             end

--- a/app/controllers/api/public/v1/providers/courses_controller.rb
+++ b/app/controllers/api/public/v1/providers/courses_controller.rb
@@ -33,10 +33,6 @@ module API
             @provider ||= recruitment_cycle.providers.find_by!(provider_code: params[:provider_code])
           end
 
-          def recruitment_cycle
-            @recruitment_cycle ||= RecruitmentCycle.find_by(year: params[:recruitment_cycle_year])
-          end
-
           def include_param
             params.fetch(:include, '')
           end

--- a/app/controllers/api/public/v1/providers/locations_controller.rb
+++ b/app/controllers/api/public/v1/providers/locations_controller.rb
@@ -22,10 +22,6 @@ module API
             @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
           end
 
-          def recruitment_cycle
-            @recruitment_cycle ||= RecruitmentCycle.find_by(year: params[:recruitment_cycle_year])
-          end
-
           def include_param
             params.fetch(:include, '')
           end

--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -84,9 +84,14 @@ module API
         end
 
         def recruitment_cycle
-          @recruitment_cycle = RecruitmentCycle.find_by(
-            year: params[:recruitment_cycle_year]
-          ) || RecruitmentCycle.current_recruitment_cycle
+          year = params.require(:recruitment_cycle_year)
+
+          case year
+          when 'current'
+            RecruitmentCycle.current_recruitment_cycle
+          else
+            RecruitmentCycle.find_by!(year:)
+          end
         end
 
         def fields

--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -83,17 +83,6 @@ module API
           @providers
         end
 
-        def recruitment_cycle
-          year = params.require(:recruitment_cycle_year)
-
-          case year
-          when 'current'
-            RecruitmentCycle.current_recruitment_cycle
-          else
-            RecruitmentCycle.find_by!(year:)
-          end
-        end
-
         def fields
           { providers: provider_fields } if provider_fields.present?
         end

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -24,13 +24,14 @@ RSpec.describe API::Public::V1::CoursesController do
         provider.courses << build_list(:course, 2, provider:)
       end
 
-      context 'with no recruitment cycle provided' do
+      context 'when "current" is specified as the recruitment cycle' do
         let(:next_cycle) { create(:recruitment_cycle, :next) }
 
         before do
           next_cycle
 
           get :index, params: {
+            recruitment_cycle_year: 'current',
             include: 'recruitment_cycle'
           }
         end
@@ -51,6 +52,18 @@ RSpec.describe API::Public::V1::CoursesController do
 
         it 'returns correct number of courses' do
           expect(json_response['data'].size).to be(2)
+        end
+      end
+
+      context 'when a non-existent recruitment cycle is specified' do
+        before do
+          get :index, params: {
+            recruitment_cycle_year: '1066'
+          }
+        end
+
+        it 'returns a 404 error' do
+          expect(response).to have_http_status(:not_found)
         end
       end
 

--- a/spec/controllers/api/public/v1/providers/courses/locations_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses/locations_controller_spec.rb
@@ -65,5 +65,37 @@ RSpec.describe API::Public::V1::Providers::Courses::LocationsController do
         end
       end
     end
+
+    describe 'recruitment cycle' do
+      context 'when "current" is specified as the recruitment cycle' do
+        before do
+          course.sites << build_list(:site, 2, provider:)
+
+          get :index, params: {
+            recruitment_cycle_year: 'current',
+            provider_code: provider.provider_code,
+            course_code: course.course_code
+          }
+        end
+
+        it 'returns the correct number of locations' do
+          expect(json_response['data'].size).to be(2)
+        end
+      end
+
+      context 'when a non-existent recruitment cycle is specified' do
+        before do
+          get :index, params: {
+            recruitment_cycle_year: '1066',
+            provider_code: provider.provider_code,
+            course_code: course.course_code
+          }
+        end
+
+        it 'returns a 404 error' do
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -182,6 +182,36 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
         end
       end
     end
+
+    describe 'recruitment cycle' do
+      context 'when "current" is specified as the recruitment cycle' do
+        before do
+          create_list(:course, 3, provider:)
+
+          get :index, params: {
+            recruitment_cycle_year: 'current',
+            provider_code: provider.provider_code
+          }
+        end
+
+        it 'returns correct number of courses' do
+          expect(json_response['data'].size).to be(3)
+        end
+      end
+
+      context 'when a non-existent recruitment cycle is specified' do
+        before do
+          get :index, params: {
+            recruitment_cycle_year: '1066',
+            provider_code: provider.provider_code
+          }
+        end
+
+        it 'returns a 404 error' do
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
   end
 
   describe '#show' do
@@ -256,6 +286,39 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
 
       it 'returns 404' do
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe 'recruitment cycle' do
+      let!(:course) { create(:course, provider:) }
+
+      context 'when "current" is specified as the recruitment cycle' do
+        before do
+          get :show, params: {
+            recruitment_cycle_year: 'current',
+            provider_code: provider.provider_code,
+            code: course.course_code
+          }
+        end
+
+        it 'returns the course' do
+          expect(response).to be_successful
+          expect(json_response['data']['id']).to eql(course.id.to_s)
+        end
+      end
+
+      context 'when a non-existent recruitment cycle is specified' do
+        before do
+          get :index, params: {
+            recruitment_cycle_year: '1066',
+            provider_code: provider.provider_code,
+            code: course.course_code
+          }
+        end
+
+        it 'returns a 404 error' do
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
   end

--- a/spec/controllers/api/public/v1/providers/locations_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/locations_controller_spec.rb
@@ -65,5 +65,35 @@ RSpec.describe API::Public::V1::Providers::LocationsController do
         end
       end
     end
+
+    describe 'recruitment cycle' do
+      context 'when "current" is specified as the recruitment cycle' do
+        before do
+          provider.sites << build_list(:site, 5, provider:)
+
+          get :index, params: {
+            recruitment_cycle_year: 'current',
+            provider_code: provider.provider_code
+          }
+        end
+
+        it 'returns the correct number of locations' do
+          expect(json_response['data'].size).to be(5)
+        end
+      end
+
+      context 'when a non-existent recruitment cycle is specified' do
+        before do
+          get :index, params: {
+            recruitment_cycle_year: '1066',
+            provider_code: provider.provider_code
+          }
+        end
+
+        it 'returns a 404 error' do
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -72,6 +72,35 @@ RSpec.describe API::Public::V1::ProvidersController do
             expect(parsed_provider_id).to eq(next_provider.id)
           end
         end
+
+        context 'when "current" is specified as the recruitment cycle' do
+          before do
+            get :index, params: {
+              recruitment_cycle_year: 'current',
+              include: 'recruitment_cycle'
+            }
+          end
+
+          it 'returns correct number of providers for the current cycle' do
+            parsed_recruitment_cycle_id = json_response['data'][0].dig('relationships', 'recruitment_cycle', 'data', 'id').to_i
+            parsed_provider_id = json_response['data'][0]['id'].to_i
+            expect(parsed_recruitment_cycle_id).to eq(recruitment_cycle.id)
+            expect(json_response['data'].size).to be(1)
+            expect(parsed_provider_id).to eq(provider.id)
+          end
+        end
+
+        context 'when a non-existent recruitment cycle is specified' do
+          before do
+            get :index, params: {
+              recruitment_cycle_year: '1066'
+            }
+          end
+
+          it 'returns a 404 error' do
+            expect(response).to have_http_status(:not_found)
+          end
+        end
       end
 
       context 'with pagination' do

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -67,7 +67,8 @@ describe 'API', :with_publish_constraint do
                    command: 'curl -X GET "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/courses?page\[per_page\]=10&filter\[latitude\]=51.8975918&filter\[longitude\]=-0.4910925&filter\[radius\]=10&sort=distance"'
 
       response '200', 'The collection of courses.' do
-        let(:year) { '2020' }
+        let(:recruitment_cycle) { create(:recruitment_cycle) }
+        let(:year) { recruitment_cycle.year }
         let(:include) { 'provider' }
 
         before do

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -13,7 +13,7 @@ describe 'API', :with_publish_constraint do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
-                example: '2020'
+                example: Settings.current_recruitment_cycle_year
       parameter name: :filter,
                 in: :query,
                 schema: { '$ref' => '#/components/schemas/CourseFilter' },

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -12,7 +12,7 @@ describe 'API', :with_publish_constraint do
                 in: :path,
                 type: :string,
                 required: true,
-                description: 'The starting year of the recruitment cycle.',
+                description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
                 example: '2020'
       parameter name: :filter,
                 in: :query,

--- a/spec/docs/providers/courses/locations_spec.rb
+++ b/spec/docs/providers/courses/locations_spec.rb
@@ -12,7 +12,7 @@ describe 'API', :with_publish_constraint do
                 in: :path,
                 type: :string,
                 required: true,
-                description: 'The starting year of the recruitment cycle.',
+                description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
                 example: Settings.current_recruitment_cycle_year
       parameter name: :provider_code,
                 in: :path,

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -12,7 +12,7 @@ describe 'API', :with_publish_constraint do
                 in: :path,
                 type: :string,
                 required: true,
-                description: 'The starting year of the recruitment cycle.',
+                description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
                 example: '2020'
       parameter name: :provider_code,
                 in: :path,
@@ -96,7 +96,7 @@ describe 'API', :with_publish_constraint do
                 in: :path,
                 type: :string,
                 required: true,
-                description: 'The starting year of the recruitment cycle.',
+                description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
                 example: '2020'
       parameter name: :provider_code,
                 in: :path,

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -13,7 +13,7 @@ describe 'API', :with_publish_constraint do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
-                example: '2020'
+                example: Settings.current_recruitment_cycle_year
       parameter name: :provider_code,
                 in: :path,
                 type: :string,
@@ -97,7 +97,7 @@ describe 'API', :with_publish_constraint do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
-                example: '2020'
+                example: Settings.current_recruitment_cycle_year
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/locations_spec.rb
+++ b/spec/docs/providers/locations_spec.rb
@@ -12,7 +12,7 @@ describe 'API', :with_publish_constraint do
                 in: :path,
                 type: :string,
                 required: true,
-                description: 'The starting year of the recruitment cycle.',
+                description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
                 example: Settings.current_recruitment_cycle_year
       parameter name: :provider_code,
                 in: :path,

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -16,7 +16,7 @@ describe 'API', :with_publish_constraint do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
-                example: '2020'
+                example: Settings.current_recruitment_cycle_year
       parameter name: :sort,
                 in: :query,
                 schema: { '$ref' => '#/components/schemas/Sort' },
@@ -80,7 +80,7 @@ describe 'API', :with_publish_constraint do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
-                example: '2020'
+                example: Settings.current_recruitment_cycle_year
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -15,7 +15,7 @@ describe 'API', :with_publish_constraint do
                 in: :path,
                 type: :string,
                 required: true,
-                description: 'The starting year of the recruitment cycle.',
+                description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
                 example: '2020'
       parameter name: :sort,
                 in: :query,
@@ -79,7 +79,7 @@ describe 'API', :with_publish_constraint do
                 in: :path,
                 type: :string,
                 required: true,
-                description: 'The starting year of the recruitment cycle.',
+                description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle.',
                 example: '2020'
       parameter name: :provider_code,
                 in: :path,
@@ -111,7 +111,7 @@ describe 'API', :with_publish_constraint do
         run_test!
       end
 
-      response '404', 'The non existant provider.' do
+      response '404', 'The non-existent provider.' do
         let(:provider_code) { '999' }
         let(:include) { nil }
 

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -3,6 +3,9 @@
 require 'swagger_helper'
 
 describe 'API', :with_publish_constraint do
+  let(:recruitment_cycle) { create(:recruitment_cycle) }
+  let(:year) { recruitment_cycle.year }
+
   path '/recruitment_cycles/{year}/providers' do
     get 'Returns providers for the specified recruitment cycle.' do
       operationId :public_api_v1_provider_index
@@ -58,7 +61,6 @@ describe 'API', :with_publish_constraint do
                    command: 'curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers?page[page]=2'
 
       response '200', 'Collection of providers.' do
-        let(:year) { '2020' }
         let(:include) { 'recruitment_cycle' }
 
         schema({ '$ref' => '#/components/schemas/ProviderListResponse' })
@@ -100,8 +102,8 @@ describe 'API', :with_publish_constraint do
 
       response '200', 'The provider.' do
         let(:provider) { create(:provider, provider_code: '1AT') }
-        let(:year) { provider.recruitment_cycle.year }
         let(:provider_code) { provider.provider_code }
+        let(:recruitment_cycle) { provider.recruitment_cycle }
         let(:include) { nil }
 
         schema({ '$ref' => '#/components/schemas/ProviderSingleResponse' })
@@ -110,7 +112,6 @@ describe 'API', :with_publish_constraint do
       end
 
       response '404', 'The non existant provider.' do
-        let(:year) { '2020' }
         let(:provider_code) { '999' }
         let(:include) { nil }
 

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1926,7 +1926,7 @@
             "name": "year",
             "in": "path",
             "required": true,
-            "description": "The starting year of the recruitment cycle.",
+            "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle.",
             "example": "2020",
             "schema": {
               "type": "string"

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -2081,7 +2081,7 @@
             "name": "year",
             "in": "path",
             "required": true,
-            "description": "The starting year of the recruitment cycle.",
+            "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle.",
             "example": 2024,
             "schema": {
               "type": "string"
@@ -2155,7 +2155,7 @@
             "name": "year",
             "in": "path",
             "required": true,
-            "description": "The starting year of the recruitment cycle.",
+            "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle.",
             "example": "2020",
             "schema": {
               "type": "string"
@@ -2340,7 +2340,7 @@
             "name": "year",
             "in": "path",
             "required": true,
-            "description": "The starting year of the recruitment cycle.",
+            "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle.",
             "example": 2024,
             "schema": {
               "type": "string"

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1927,7 +1927,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle.",
-            "example": "2020",
+            "example": 2024,
             "schema": {
               "type": "string"
             }
@@ -2156,7 +2156,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle.",
-            "example": "2020",
+            "example": 2024,
             "schema": {
               "type": "string"
             }
@@ -2268,7 +2268,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle.",
-            "example": "2020",
+            "example": 2024,
             "schema": {
               "type": "string"
             }
@@ -2397,7 +2397,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle.",
-            "example": "2020",
+            "example": 2024,
             "schema": {
               "type": "string"
             }
@@ -2493,7 +2493,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle.",
-            "example": "2020",
+            "example": 2024,
             "schema": {
               "type": "string"
             }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -2082,7 +2082,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle.",
-            "example": 2023,
+            "example": 2024,
             "schema": {
               "type": "string"
             }
@@ -2341,7 +2341,7 @@
             "in": "path",
             "required": true,
             "description": "The starting year of the recruitment cycle.",
-            "example": 2023,
+            "example": 2024,
             "schema": {
               "type": "string"
             }
@@ -2396,7 +2396,7 @@
             "name": "year",
             "in": "path",
             "required": true,
-            "description": "The starting year of the recruitment cycle.",
+            "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle.",
             "example": "2020",
             "schema": {
               "type": "string"
@@ -2539,7 +2539,7 @@
             }
           },
           "404": {
-            "description": "The non existant provider.",
+            "description": "The non-existent provider.",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Context

The School Placements and Track & Pay services need to retrieve a list of providers from the [Teacher Training Courses API](https://api.publish-teacher-training-courses.service.gov.uk/docs/).

Within this app, providers belong to a recruitment cycle. The existing [GET /recruitment_cycles/{year}/providers](https://api.publish-teacher-training-courses.service.gov.uk/docs/api-reference.html#recruitment_cycles-year-providers-get) endpoint requires clients to specify which recruitment cycle they want to get providers for.

However in the case of School Placements and Track & Pay, we will always need to retrieve providers for the **current recruitment cycle**. Moreover, recruitment cycle years do not align with calendar years, meaning clients need to understand how to calculate the current recruitment cycle year is if that's what they need to retrieve.

Trello card: https://trello.com/c/0JIgI5Nj/127-use-the-current-recruitment-cycle-when-retrieving-providers-from-the-api

## Changes proposed in this pull request

I'm proposing changes that should make the API and its documentation more explicit and predictable in what it supports.

### Feature: retrieve providers for the current recruitment cycle

I've added support for `"current"` to be specified in place of a recruitment cycle year. This value serves as an alias for the currently active recruitment cycle.

API clients can now call:

```
GET /recruitment_cycles/current/courses
GET /recruitment_cycles/current/providers
GET /recruitment_cycles/current/providers/locations
GET /recruitment_cycles/current/providers/courses
GET /recruitment_cycles/current/providers/courses/{code}/locations
```

These will return providers and courses for the current recruitment cycle. I have updated the API documentation to explicitly point out that this is a supported use of these endpoints.

### ⚠️ Breaking change: remove fallback for non-existent recruitment cycles

I have also removed 'fallback' behaviour which meant that requests for non-existent recruitment years automatically returned the current recruitment cycle. This behaviour was unusual and slightly unexpected, because it returned a `200 OK` response with no indication that you'd requested data associated with a resource that doesn't exist.

While this is a breaking change, I note that there were no explicit tests for this behaviour, nor was it included in the API documentation. It could be considered an undocumented 'feature' or a bug, depending on your point of view. So I've made the assumption that it is safe to remove the behaviour in favour of explicit support for the `"current"` endpoint.

For example, it is **no longer possible** to call:

```
GET /recruitment_cycles/some-random-string/providers
GET /recruitment_cycles/some-random-string/courses
GET /recruitment_cycles/some-random-string/providers/locations
GET /recruitment_cycles/some-random-string/providers/courses
GET /recruitment_cycles/some-random-string/providers/courses/{code}/locations
```

These requests will now result in a `404 Not Found` error response.

## Guidance to review

To test this locally:

1. Pull this branch:
    ```
    git checkout add-api-endpoints-for-current-year
    ```
2. Run the app:
    ```
    bin/dev
    ```
3. Request the "current" endpoint. You should receive a valid response.
    ```
    $ curl -Is http://publish.localhost:3001/api/public/v1/recruitment_cycles/current/providers | head -n 1
    HTTP/1.1 200 OK
    ```
4. Request an invalid recruitment cycle. You should receive an error response.
    ```
    $ curl -Is http://publish.localhost:3001/api/public/v1/recruitment_cycles/non-existent/providers | head -n 1
    HTTP/1.1 404 Not Found
    ```

## Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [N/A] Inform data insights team due to database changes
