### PR TITLE
Require factory_bot in `rubocop.yml`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-capybara
+  - rubocop-factory_bot
 
 inherit_from:
   - ./config/rubocop/layout.yml


### PR DESCRIPTION
Avoid:

```shell
The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-factory_bot
```