### PR TITLE
Fix production check

### DIFF
--- a/app/controllers/find/feature_flags_controller.rb
+++ b/app/controllers/find/feature_flags_controller.rb
@@ -10,7 +10,7 @@ module Find
     def update
       FeatureFlag.send(action, feature_name)
 
-      if Rails.env.production?
+      if Rails.env.production? || Settings.environment.name == 'beta'
         SlackNotificationJob.perform_now(
           ":flags: Feature ‘#{feature_name}‘ was #{action}d",
           find_feature_flags_path

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -156,7 +156,7 @@ module Find
 
     def self.current_cycle_schedule
       # Make sure this setting only has effect on non-production environments
-      return :real if Rails.env.production?
+      return :real if Rails.env.production? || Settings.environment.name == 'beta'
 
       SiteSetting.cycle_schedule
     end

--- a/app/views/find/switcher/cycles.html.erb
+++ b/app/views/find/switcher/cycles.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_title, "Recruitment cycles" %>
-<% unless Rails.env.production? %>
+<% unless Rails.env.production? || Settings.environment.name == 'beta' %>
   <h1 class="govuk-heading-xl">Recruitment cycles</h1>
   <%= form_with model: Find::ChangeCycleForm.new, url: find_switch_cycle_schedule_path, method: :post do |f| %>
     <%= f.govuk_radio_buttons_fieldset :cycle_schedule_name,

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,7 @@ module ManageCoursesBackend
     config.view_component.preview_route = '/view_components'
     config.view_component.default_preview_layout = 'component_preview'
     config.view_component.preview_controller = 'ComponentPreviewsController'
-    config.view_component.show_previews = !Rails.env.production?
+    config.view_component.show_previews = Settings.environment.name != 'beta'
 
     config.analytics = config_for(:analytics)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Settings.environment.name == 'beta'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
### Context

Fix to the production check. Rails.env now returns `production_aks` instead of `production`.

This is a temporary fix until we address the route cause.
