### PR TITLE
Add a navbar to the support UI

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,14 +50,15 @@
         <% else %>
           <%= render PhaseBanner.new %>
         <% end %>
-        <%= yield :navigation_bar %>
         <% if params[:controller].start_with?("support") %>
           <%= render SupportTitleBar.new %>
         <% end %>
-        <%= yield :breadcrumbs %>
       </div>
 
+      <%= yield :navigation_bar %>
+
       <div class="govuk-width-container">
+        <%= yield :breadcrumbs %>
         <% if current_user && @provider && !params[:controller].start_with?("support") %>
           <% if render_title_bar?(current_user: current_user, provider: @provider) && !request.path.end_with?(@provider.provider_code.to_s) %>
            <%= render TitleBar.new(title: @provider.provider_name, provider: @provider.provider_code, current_user:) %>

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -6,17 +6,16 @@
     ) %>
   <% end %>
 
-<!-- Uncomment this when more items are needed on the navigation bar.
-  <%# <%= content_for(:navigation_bar) do %> %>
-    <%# <%= render NavigationBar.new( %>
-      <%# items: [ %>
-        <%# { name: "Providers", url: support_providers_path, current: true }, %>
-      <%# ], %>
-      <%# current_path: request.path, %>
-      <%# current_user: @current_user, %>
-    <%# ) %> %>
-  <%# <% end %> %>
--->
+  <%= content_for(:navigation_bar) do %>
+    <%= render NavigationBar.new(
+      items: [
+        { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
+        { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) }
+      ],
+      current_path: request.path,
+      current_user: @current_user
+    ) %>
+  <% end %>
 
   <%= yield %>
 <% end %>

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,4 +1,0 @@
-<%= render TabNavigation.new(items: [
-{ name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
-{ name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) }
-]) %>

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -2,8 +2,6 @@
 
 <h1 class="govuk-heading-l">Providers</h1>
 
-<%= render "support/menu" %>
-
 <%= govuk_link_to("Add provider",
       new_support_recruitment_cycle_providers_onboarding_path,
       class: "govuk-button govuk-!-margin-bottom-6") %>

--- a/app/views/support/users/index.html.erb
+++ b/app/views/support/users/index.html.erb
@@ -2,8 +2,6 @@
 
 <h1 class="govuk-heading-l">Users</h1>
 
-<%= render "support/menu" %>
-
 <div class="govuk-button-group">
   <%= link_to "Add a user", new_support_recruitment_cycle_user_path, class: "govuk-button govuk-button--primary" %>
   <%= link_to "Download users (CSV)", support_recruitment_cycle_data_exports_path(anchor: "users"), class: "govuk-button govuk-button--secondary" %>

--- a/spec/features/support/switching_between_recruitment_cycles_spec.rb
+++ b/spec/features/support/switching_between_recruitment_cycles_spec.rb
@@ -54,7 +54,7 @@ feature 'Support index' do
 
   def then_i_should_be_on_the_recruitment_cycle_switcher_page
     expect(support_recruitment_cycle_index_page).to have_link "#{Settings.current_recruitment_cycle_year} - current"
-    expect(support_recruitment_cycle_index_page).to have_link Settings.current_recruitment_cycle_year + 1
+    expect(support_recruitment_cycle_index_page).to have_link (Settings.current_recruitment_cycle_year + 1).to_s
   end
 
   def and_should_not_see_the_switch_cycle_link
@@ -66,7 +66,7 @@ feature 'Support index' do
   end
 
   def and_click_on_the_next_cycle
-    click_link_or_button Settings.current_recruitment_cycle_year + 1
+    click_link_or_button (Settings.current_recruitment_cycle_year + 1).to_s
   end
 
   def i_should_see_the_current_cycle_page


### PR DESCRIPTION
### Context

Continuing to improve the Publish support interface. Adding a navbar that will persist throughout pages on the support console, allowing for easier navigation. This can be built out to include additional sections in the future.

### Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="1043" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/2817e78a-bb0b-4328-8eb4-f1644f821c19">|<img width="1023" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/47917431/7081f4b4-2188-457e-9782-4d75592edf13">|