### PR TITLE
Add colorize gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,6 +149,9 @@ gem 'http'
 # For configuring domains and assets
 gem 'rack-cors'
 
+# Rails console colours
+gem 'colorize'
+
 group :production, :qa, :sandbox, :staging do
   gem 'cloudfront-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
     cloudfront-rails (0.4.0)
       railties (> 4.0)
     coderay (1.1.3)
+    colorize (1.1.0)
     concurrent-ruby (1.2.3)
     config (5.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -771,6 +772,7 @@ DEPENDENCIES
   canonical-rails
   capybara (>= 2.15)
   cloudfront-rails
+  colorize
   config
   cssbundling-rails (~> 1.4)
   custom_error_message!


### PR DESCRIPTION
### Context

This should fix an issue which currently prevents access to the production console due to: 

```undefined method `red' for "**************************************************":String```

in: `config/initializers/console.rb`

### Guidance to review

:shipit: 