### PR TITLE
[1240] validate `applications_open_from` when publishing a course

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -62,7 +62,8 @@ module ViewHelper
         age_range_in_years: "#{base}/age-range?display_errors=true",
         sites: "#{base}/schools?display_errors=true",
         study_sites: (course.provider&.study_sites&.none? ? "#{provider_base}/study-sites" : "#{base}/study-sites").to_s,
-        accrediting_provider: accredited_provider_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)
+        accrediting_provider: accredited_provider_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code),
+        applications_open_from: "#{base}/applications-open"
       }.with_indifferent_access[field]
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -336,7 +336,7 @@ class Course < ApplicationRecord
   validate :validate_enrichment
   validate :validate_qualification, on: %i[update new]
   validate :validate_start_date, on: :update, if: -> { provider.present? && start_date.present? }
-  validate :validate_applications_open_from, on: %i[update new], if: -> { provider.present? }
+  validate :validate_applications_open_from, on: %i[publish update new], if: -> { provider.present? }
   validate :validate_modern_languages
   validate :validate_has_languages, if: :has_the_modern_languages_secondary_subject_type?
   validate :validate_subject_count

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -14,6 +14,10 @@ describe ViewHelper do
     it 'returns enrichment error URL for base error' do
       expect(enrichment_error_url(provider_code: 'A1', course:, field: 'base', message: 'Select if student visas can be sponsored')).to eq("/publish/organisations/A1/#{Settings.current_recruitment_cycle_year}/student-visa")
     end
+
+    it 'returns the course applications open date url for the error' do
+      expect(enrichment_error_url(provider_code: provider.provider_code, course:, field: 'applications_open_from')).to eq("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/applications-open")
+    end
   end
 
   describe '#provider_enrichment_error_url' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -559,12 +559,21 @@ describe Course do
         let(:course) { create(:course, :without_validation, age_range_in_years: nil) }
         let(:errors) { course.errors.messages }
 
-        before { course.valid?(:publish) }
+        before do
+          course.applications_open_from = course.recruitment_cycle.application_start_date - 1
+          course.valid?(:publish)
+        end
 
         it 'requires age_range_in_years' do
           error = errors[:age_range_in_years]
           expect(error).not_to be_empty
           expect(error.first).to include('Select an age range')
+        end
+
+        it 'requires a applications_open_from date inside of the current recruitment cycle' do
+          error = course.errors.messages[:applications_open_from]
+          expect(error).not_to be_empty
+          expect(error.first).to include("is not valid for the #{Settings.current_recruitment_cycle_year} cycle. A valid date must be between")
         end
       end
 


### PR DESCRIPTION
### Context

There was a bug which allowed users to publish a course which has a `applications_open_from` date outside of the current recruitment cycle. 

[Sentry error](https://dfe-teacher-services.sentry.io/issues/4928616591/?alert_rule_id=11137790&alert_type=issue&notification_uuid=ee949ea3-81e2-4199-a47e-e2a66464f250&project=1377944&referrer=slack)

There is validation which prevents users being able to enter an `applications_open_from` date outside of the recruitment cycle, so I am not entirely sure how this happened. It only affected the one provider. 

![image](https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/d3dc1968-650a-4a80-96b2-10862a2311c3)


Support has reached out to the provider to find out if this was intentional or not. 

### Changes proposed in this pull request

- Add validation to prevent users publishing a course which has a `applications_open_from` date outside of the current recruitment cycle. 

- Update the error message link, to ensure it links to the correct place.


### Guidance to review

Change the `applications_open_date` to be outside of the current recruitment cycle range. See: https://www.apply-for-teacher-training.service.gov.uk/provider/service-guidance/dates-and-deadlines

Try and publish the course.

Or for an easier life, [this course](https://publish-review-4034.test.teacherservices.cloud/publish/organisations/2LF/2024/courses/T115) will do.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
