### PR TITLE
[2664] Remove provider from their own training partner list (WIP)

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -91,7 +91,7 @@ class Provider < ApplicationRecord
 
   # the providers that this provider is an accredited_provider for
   def training_providers
-    Provider.where(id: current_accredited_courses.pluck(:provider_id))
+    Provider.where.not(provider_code:).where(id: current_accredited_courses.pluck(:provider_id))
   end
 
   def current_accredited_courses


### PR DESCRIPTION
### Context

**WIP**

Accredited providers shouldn’t appear on their own training partner list. Their courses should only show in the courses tab.

### Changes proposed in this pull request

Exclude the provider from the accredited provider list

### Guidance to review

#### Before 

<img width="1097" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/a9db20a0-3c68-4ee5-9f6e-55dff3d2fbc5">

#### After

<img width="1111" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/65315959-e12f-4142-920d-743d75e6cc5f">


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
