### PR TITLE
bin/dev was accidentally deleted - recreate it

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v foreman &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
### Context

We accidentally deleted the bin/dev executable to start the application in development through the Procfile.dev

### Changes proposed in this pull request

Reintroduce the executable

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
