### PR TITLE
Update gemfile.lock to extend apple silicon support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -752,6 +752,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21


### PR DESCRIPTION
### Context

Include `arm64-darwin-23` platform in `gemfile.lock` for enhanced compatibility with macOS on apple silicon macs.
