### PR TITLE
[1316] Fix flakey test

### DIFF
--- a/spec/forms/support/provider_contact_form_spec.rb
+++ b/spec/forms/support/provider_contact_form_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'cgi'
 
 require_relative '../shared_examples/blank_validation'
 
@@ -27,12 +28,12 @@ module Support
     describe '#full_address' do
       subject { provider_contact_form.full_address }
       let(:expected_full_address) do
-        params.slice(:address1,
-                     :address2,
-                     :address3,
-                     :town,
-                     :address4,
-                     :postcode).values.join('<br> ')
+        CGI.unescapeHTML(params.slice(:address1,
+                                      :address2,
+                                      :address3,
+                                      :town,
+                                      :address4,
+                                      :postcode).values.join('<br> '))
       end
 
       it 'matches the expected full address' do

--- a/spec/forms/support/provider_contact_form_spec.rb
+++ b/spec/forms/support/provider_contact_form_spec.rb
@@ -28,6 +28,7 @@ module Support
     describe '#full_address' do
       subject { provider_contact_form.full_address }
       let(:expected_full_address) do
+        # Decode html entities before comparison to prevent a flaky test from apostrophes
         CGI.unescapeHTML(params.slice(:address1,
                                       :address2,
                                       :address3,


### PR DESCRIPTION
### Context

Fix flaky test by normalising HTML before comparison, avoiding a mismatch in the encoding of apostrophes.

### Guidance to review

- Run the test as many times as you can: `spec/forms/support/provider_contact_form_spec.rb:38`
- Ensure it never unexpectedly fails


