### PR TITLE
The degree apprenticeship ADR

### DIFF
--- a/guides/adr/0011-tda-courses.md
+++ b/guides/adr/0011-tda-courses.md
@@ -1,10 +1,14 @@
-# 11. Add PGTA/TDA Courses to Find/Publish
+# 11. Add TDA Courses to Find/Publish
 
 Date: 29/02/2024
 
 ## Status
 
 Proposed
+
+## Glossary
+
+TDA - The degree apprenticeship
 
 ## Context
 
@@ -21,18 +25,17 @@ trainees will achieve an undergraduate or master’s degree – just like someon
 who has got their degree through a traditional route.
 
 Our platform currently supports courses through API v1 in the Publish module.
-However, it lacks support for two additional values: pgta and pgta_with_qts,
-representing the degree apprenticeship program.
-Additionally, the course wizard in Publish needs improvement to accept PGTA/TDA
+However, it lacks support for the additional value: 'tda' representing the degree apprenticeship program.
+Additionally, the course wizard in Publish needs improvement to accept TDA
 courses seamlessly. Furthermore, the details course tab requires enhancements to
 automatically set degrees as not required for TDA courses.
 Lastly, there's a need for a filtering mechanism in the Find module to streamline course discovery.
 
 ## Decision
 
-API v1 Enhancement: We will extend API v1 in the Publish module to accommodate the two additional values: pgta and pgta_with_qts, representing the degree apprenticeship program. This will involve updating the API attributes and documentation accordingly.
+API v1 Enhancement: We will extend API v1 in the Publish module to accommodate the additional value: tda, representing the degree apprenticeship program. This will involve updating the API attributes and documentation accordingly.
 
-Course Wizard Enhancement: The add course wizard in Publish will be improved to seamlessly accept PGTA/TDA courses. This enhancement aims to streamline the course addition process for users and ensure compatibility with the new course types.
+Course Wizard Enhancement: The add course wizard in Publish will be improved to seamlessly accept TDA courses. This enhancement aims to streamline the course addition process for users and ensure compatibility with the new course types.
 
 Description Course Tab Enhancement: The description course tab functionality will be enhanced to automatically configure degrees as not required when adding TDA courses. This automation will simplify course management for users and ensure accurate representation of TDA course requirements.
 

--- a/guides/adr/0011-tda-courses.md
+++ b/guides/adr/0011-tda-courses.md
@@ -11,13 +11,13 @@ Proposed
 Trainee teachers will soon be able to gain a degree through an apprenticeship,
 instead of through the traditional university route into the profession.
 
-A degree apprenticeship allows candidates to study towards an undergraduate or
+A degree apprenticeship allows trainees to study towards an undergraduate or
 master’s degree while they work, getting invaluable industry experience and
-earning a salary. Candidate's off-the-job training takes place in your working hours,
-and candidates won’t have to pay for their tuition.
+earning a salary. Trainees off-the-job training takes place in working hours,
+and trainees won’t have to pay for their tuition.
 
 Degree apprenticeships are jobs with training. On completion of the apprenticeship,
-candidates will achieve an undergraduate or master’s degree – just like someone
+trainees will achieve an undergraduate or master’s degree – just like someone
 who has got their degree through a traditional route.
 
 Our platform currently supports courses through API v1 in the Publish module.

--- a/guides/adr/0011-tda-courses.md
+++ b/guides/adr/0011-tda-courses.md
@@ -6,7 +6,7 @@ Date: 29/02/2024
 
 Proposed
 
-## Context
+## Context
 
 Trainee teachers will soon be able to gain a degree through an apprenticeship,
 instead of through the traditional university route into the profession.

--- a/guides/adr/0011-tda-courses.md
+++ b/guides/adr/0011-tda-courses.md
@@ -1,10 +1,12 @@
-Title: Add PGTA/TDA Courses to Find/Publish
+# 11. Add PGTA/TDA Courses to Find/Publish
 
 Date: 29/02/2024
 
-Status: Proposed
+## Status
 
-Context:
+Proposed
+
+## Context
 
 Trainee teachers will soon be able to gain a degree through an apprenticeship,
 instead of through the traditional university route into the profession.
@@ -26,17 +28,17 @@ courses seamlessly. Furthermore, the details course tab requires enhancements to
 automatically set degrees as not required for TDA courses.
 Lastly, there's a need for a filtering mechanism in the Find module to streamline course discovery.
 
-Decision:
+## Decision
 
 API v1 Enhancement: We will extend API v1 in the Publish module to accommodate the two additional values: pgta and pgta_with_qts, representing the degree apprenticeship program. This will involve updating the API attributes and documentation accordingly.
 
 Course Wizard Enhancement: The add course wizard in Publish will be improved to seamlessly accept PGTA/TDA courses. This enhancement aims to streamline the course addition process for users and ensure compatibility with the new course types.
 
-Details Course Tab Enhancement: The details course tab functionality will be enhanced to automatically configure degrees as not required when adding TDA courses. This automation will simplify course management for users and ensure accurate representation of TDA course requirements.
+Description Course Tab Enhancement: The description course tab functionality will be enhanced to automatically configure degrees as not required when adding TDA courses. This automation will simplify course management for users and ensure accurate representation of TDA course requirements.
 
 Filtering Mechanism Addition: A filtering mechanism will be added to the Find app to facilitate efficient course discovery. Users will be able to filter courses based on TDA parameters, enhancing the overall user experience and enabling quicker access to TDA courses.
 
-Consequences:
+## Consequences
 
 Efficiency Gains: The filtering mechanism in the Find module will improve efficiency by enabling users to quickly find TDA courses.
-Publish API consumers V1 changes: Ensuring that all teams, including Apply, Register, Vendors, Providers that uses Vendor API, and others, integrate TDA courses in their respective integrations to maintain consistency across the platform.
+Publish API consumers V1 changes: The V1 changes can potentially break their integrations, so we will ensure that all teams, including Apply, Register, Vendors, Providers that uses Vendor API, and others, integrate TDA courses in their respective integrations to maintain consistency across the platform.

--- a/guides/adr/0011-tda-courses.md
+++ b/guides/adr/0011-tda-courses.md
@@ -1,0 +1,42 @@
+Title: Add PGTA/TDA Courses to Find/Publish
+
+Date: 29/02/2024
+
+Status: Proposed
+
+Context:
+
+Trainee teachers will soon be able to gain a degree through an apprenticeship,
+instead of through the traditional university route into the profession.
+
+A degree apprenticeship allows candidates to study towards an undergraduate or
+master’s degree while they work, getting invaluable industry experience and
+earning a salary. Candidate's off-the-job training takes place in your working hours,
+and candidates won’t have to pay for their tuition.
+
+Degree apprenticeships are jobs with training. On completion of the apprenticeship,
+candidates will achieve an undergraduate or master’s degree – just like someone
+who has got their degree through a traditional route.
+
+Our platform currently supports courses through API v1 in the Publish module.
+However, it lacks support for two additional values: pgta and pgta_with_qts,
+representing the degree apprenticeship program.
+Additionally, the course wizard in Publish needs improvement to accept PGTA/TDA
+courses seamlessly. Furthermore, the details course tab requires enhancements to
+automatically set degrees as not required for TDA courses.
+Lastly, there's a need for a filtering mechanism in the Find module to streamline course discovery.
+
+Decision:
+
+API v1 Enhancement: We will extend API v1 in the Publish module to accommodate the two additional values: pgta and pgta_with_qts, representing the degree apprenticeship program. This will involve updating the API attributes and documentation accordingly.
+
+Course Wizard Enhancement: The add course wizard in Publish will be improved to seamlessly accept PGTA/TDA courses. This enhancement aims to streamline the course addition process for users and ensure compatibility with the new course types.
+
+Details Course Tab Enhancement: The details course tab functionality will be enhanced to automatically configure degrees as not required when adding TDA courses. This automation will simplify course management for users and ensure accurate representation of TDA course requirements.
+
+Filtering Mechanism Addition: A filtering mechanism will be added to the Find app to facilitate efficient course discovery. Users will be able to filter courses based on TDA parameters, enhancing the overall user experience and enabling quicker access to TDA courses.
+
+Consequences:
+
+Efficiency Gains: The filtering mechanism in the Find module will improve efficiency by enabling users to quickly find TDA courses.
+Publish API consumers V1 changes: Ensuring that all teams, including Apply, Register, Vendors, Providers that uses Vendor API, and others, integrate TDA courses in their respective integrations to maintain consistency across the platform.


### PR DESCRIPTION
### Context

This PR adds a ADR (and return of ADRs) about the Degree apprenticeship work.

Glossary:

TDA / PGTA: Course that awards a degree with QTS (qualified teacher status).

## Main challenges on this work

### Publish API integration: V1 or V2?

The problem: We need to include PGTA (with QTS) to courses but if we do, we need to decide what to do on Publish API

We separate into two columns the advantages and disavantages of changing v1 or creating a v2 to accomodate TDA courses:

<img width="672" alt="Screenshot 2024-02-29 at 18 12 52" src="https://github.com/DFE-Digital/publish-teacher-training/assets/27509/fd306958-7dee-4db1-bece-9ae925d1ff42">

## Proposal

On this ADR I proposed for changing V1 and talking with Vendors, Register, Providers and Apply (our team yay!).

But is all of us responsibility to accept and move forward with the proposal.

