### PR TITLE
[1340] Improve the visibility of fees

### DIFF
--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -13,6 +13,9 @@
   <dt class="app-description-list__label">Visa sponsorship</dt>
   <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_row %></dd>
 
+   <dt class="app-description-list__label">Course fee</dt>
+  <dd data-qa="course__visa_sponsorship"><%= course_fee_value %></dd>
+
   <dt class="app-description-list__label">Qualification</dt>
   <%= render Find::Courses::QualificationsSummaryComponent::View.new(find_outcome) %>
   <% if age_range_in_years.present? %>

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -13,8 +13,8 @@
   <dt class="app-description-list__label">Visa sponsorship</dt>
   <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_row %></dd>
 
-   <dt class="app-description-list__label">Course fee</dt>
-  <dd data-qa="course__visa_sponsorship"><%= course_fee_value %></dd>
+  <dt class="app-description-list__label">Course fee</dt>
+  <dd data-qa="course__fee"><%= course_fee_value %></dd>
 
   <dt class="app-description-list__label">Qualification</dt>
   <%= render Find::Courses::QualificationsSummaryComponent::View.new(find_outcome) %>

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -13,8 +13,10 @@
   <dt class="app-description-list__label">Visa sponsorship</dt>
   <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_row %></dd>
 
-  <dt class="app-description-list__label">Course fee</dt>
-  <dd data-qa="course__fee"><%= course_fee_value %></dd>
+  <% unless no_fee? %>
+    <dt class="app-description-list__label">Course fee</dt>
+    <dd data-qa="course__fee"><%= course_fee_value %></dd>
+  <% end %>
 
   <dt class="app-description-list__label">Qualification</dt>
   <%= render Find::Courses::QualificationsSummaryComponent::View.new(find_outcome) %>

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -50,6 +50,22 @@ module Find
             'Visas cannot be sponsored'
           end
         end
+
+        def course_fee_value
+          safe_join([formatted_uk_eu_fee_label, tag.br, formatted_international_fee_label])
+        end
+
+        def formatted_uk_eu_fee_label
+          return if course.fee_uk_eu.blank?
+
+          "UK students: #{number_to_currency(course.fee_uk_eu)}"
+        end
+
+        def formatted_international_fee_label
+          return if course.fee_international.blank?
+
+          "International students: #{number_to_currency(course.fee_international)}"
+        end
       end
     end
   end

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -66,6 +66,10 @@ module Find
 
           "International students: #{number_to_currency(course.fee_international)}"
         end
+
+        def no_fee?
+          course.fee_international.blank? && course.fee_uk_eu.blank?
+        end
       end
     end
   end

--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -6,8 +6,19 @@
     <% end %>
   </h2>
   <dl class="app-description-list app-description-list--search-result">
-    <dt class="app-description-list__label">Study type</dt>
-    <dd data-qa="course__study_mode"><%= course.study_mode.humanize %></dd>
+
+    <dt class="app-description-list__label">Fee or salary</dt>
+    <dd data-qa="course__funding_options"><%= course.funding %>
+      <br>
+      <p class="govuk-hint"><%= course.funding_option %>
+    </dd>
+
+    <dt class="app-description-list__label">Course fee</dt>
+    <dd data-qa="course__visa_sponsorship"><%= course_fee_value %></dd>
+
+    <dt class="app-description-list__label">Visa sponsorship</dt>
+    <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_status %></dd>
+
     <dt class="app-description-list__label">Qualification</dt>
     <dd data-qa="course__qualification">
       <% if accredited_provider %>
@@ -18,6 +29,9 @@
       <% end %>
     </dd>
 
+    <dt class="app-description-list__label">Study type</dt>
+    <dd data-qa="course__study_mode"><%= course.study_mode.humanize %></dd>
+
     <% if filtered_by_location? && has_sites? %>
       <% if course.university_based? %>
         <%= render partial: "find/results/university", locals: { course: } %>
@@ -26,16 +40,7 @@
       <% end %>
     <% end %>
 
-    <dt class="app-description-list__label">Fee or salary</dt>
-    <dd data-qa="course__funding_options"><%= course.funding %>
-      <br>
-      <p class="govuk-hint"><%= course.funding_option %>
-    </dd>
-
     <dt class="app-description-list__label">Degree required</dt>
     <dd data-qa="course__degree_required"><%= degree_required_status %></dd>
-
-    <dt class="app-description-list__label">Visa sponsorship</dt>
-    <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_status %></dd>
   </dl>
 </li>

--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -14,7 +14,7 @@
     </dd>
 
     <dt class="app-description-list__label">Course fee</dt>
-    <dd data-qa="course__visa_sponsorship"><%= course_fee_value %></dd>
+    <dd data-qa="course__fee"><%= course_fee_value %></dd>
 
     <dt class="app-description-list__label">Visa sponsorship</dt>
     <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_status %></dd>

--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -13,8 +13,10 @@
       <p class="govuk-hint"><%= course.funding_option %>
     </dd>
 
-    <dt class="app-description-list__label">Course fee</dt>
-    <dd data-qa="course__fee"><%= course_fee_value %></dd>
+    <% unless no_fee? %>
+      <dt class="app-description-list__label">Course fee</dt>
+      <dd data-qa="course__fee"><%= course_fee_value %></dd>
+    <% end %>
 
     <dt class="app-description-list__label">Visa sponsorship</dt>
     <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_status %></dd>

--- a/app/components/find/results/search_result_component.rb
+++ b/app/components/find/results/search_result_component.rb
@@ -51,6 +51,22 @@ module Find
         end
       end
 
+      def course_fee_value
+        safe_join([formatted_uk_eu_fee_label, tag.br, formatted_international_fee_label])
+      end
+
+      def formatted_uk_eu_fee_label
+        return if course.fee_uk_eu.blank?
+
+        "UK students: #{number_to_currency(course.fee_uk_eu)}"
+      end
+
+      def formatted_international_fee_label
+        return if course.fee_international.blank?
+
+        "International students: #{number_to_currency(course.fee_international)}"
+      end
+
       def accredited_provider
         return nil if course.accrediting_provider.blank?
 

--- a/app/components/find/results/search_result_component.rb
+++ b/app/components/find/results/search_result_component.rb
@@ -67,6 +67,10 @@ module Find
         "International students: #{number_to_currency(course.fee_international)}"
       end
 
+      def no_fee?
+        course.fee_international.blank? && course.fee_uk_eu.blank?
+      end
+
       def accredited_provider
         return nil if course.accrediting_provider.blank?
 

--- a/spec/components/find/courses/sumary_component/view_preview.rb
+++ b/spec/components/find/courses/sumary_component/view_preview.rb
@@ -57,7 +57,7 @@ module Find
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:provider, :accrediting_provider, :has_bursary, :age_range_in_years, :course_length, :applications_open_from, :start_date, :qualification, :funding_type, :subjects, :level, :can_sponsor_student_visa)
+          attr_accessor(:provider, :accrediting_provider, :has_bursary, :age_range_in_years, :course_length, :applications_open_from, :start_date, :qualification, :funding_type, :subjects, :level, :can_sponsor_student_visa, :fee_uk_eu, :fee_international)
 
           def has_bursary?
             has_bursary

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -128,6 +128,46 @@ module Find
             expect(result.text).to include('Visas cannot be sponsored')
           end
         end
+
+        context 'when there are UK fees' do
+          it 'renders the uk fees' do
+            course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
+
+            result = render_inline(described_class.new(course))
+            expect(result.text).to include('UK students: £9,250')
+          end
+        end
+
+        context 'when there are international fees' do
+          it 'renders the international fees' do
+            course = create(:course, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
+
+            result = render_inline(described_class.new(course))
+            expect(result.text).to include('International students: £14,000')
+          end
+        end
+
+        context 'when there are uk fees but no international fees' do
+          it 'renders the uk fees and not the internation fee label' do
+            course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250, fee_international: nil)]).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).to include('UK students: £9,250')
+            expect(result.text).not_to include('International students')
+          end
+        end
+
+        context 'when there are international fees but no uk fees' do
+          it 'renders the international fees but not the uk fee label' do
+            course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: 14_000)]).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).not_to include('UK students')
+            expect(result.text).to include('International students: £14,000')
+          end
+        end
       end
     end
   end

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -135,6 +135,7 @@ module Find
 
             result = render_inline(described_class.new(course))
             expect(result.text).to include('UK students: £9,250')
+            expect(result.text).to include('Course fee')
           end
         end
 
@@ -166,6 +167,18 @@ module Find
 
             expect(result.text).not_to include('UK students')
             expect(result.text).to include('International students: £14,000')
+          end
+        end
+
+        context 'when there are no fees' do
+          it 'does not render the row' do
+            course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).not_to include('UK students')
+            expect(result.text).not_to include('International students: £14,000')
+            expect(result.text).not_to include('Course fee')
           end
         end
       end

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -104,6 +104,7 @@ module Find
 
         result = render_inline(described_class.new(course:))
         expect(result.text).to include('UK students: £9,250')
+        expect(result.text).to include('Course fee')
       end
     end
 
@@ -135,6 +136,18 @@ module Find
 
         expect(result.text).not_to include('UK students')
         expect(result.text).to include('International students: £14,000')
+      end
+    end
+
+    context 'when there are no fees' do
+      it 'does not render the row' do
+        course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]).decorate
+
+        result = render_inline(described_class.new(course:))
+
+        expect(result.text).not_to include('UK students')
+        expect(result.text).not_to include('International students: £14,000')
+        expect(result.text).not_to include('Course fee')
       end
     end
   end

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -97,5 +97,45 @@ module Find
         expect(result.text).not_to include('QTS ratified by')
       end
     end
+
+    context 'when there are UK fees' do
+      it 'renders the uk fees' do
+        course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
+
+        result = render_inline(described_class.new(course:))
+        expect(result.text).to include('UK students: £9,250')
+      end
+    end
+
+    context 'when there are international fees' do
+      it 'renders the international fees' do
+        course = create(:course, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
+
+        result = render_inline(described_class.new(course:))
+        expect(result.text).to include('International students: £14,000')
+      end
+    end
+
+    context 'when there are uk fees but no international fees' do
+      it 'renders the uk fees and not the internation fee label' do
+        course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250, fee_international: nil)]).decorate
+
+        result = render_inline(described_class.new(course:))
+
+        expect(result.text).to include('UK students: £9,250')
+        expect(result.text).not_to include('International students')
+      end
+    end
+
+    context 'when there are international fees but no uk fees' do
+      it 'renders the international fees but not the uk fee label' do
+        course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: 14_000)]).decorate
+
+        result = render_inline(described_class.new(course:))
+
+        expect(result.text).not_to include('UK students')
+        expect(result.text).to include('International students: £14,000')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Small changes to the Find results and show page in an attempt to improve the visibilities of fees. This is an attempt to reduce the number of candidates withdrawing due to financial constraints. 

[Review app](https://find-review-4093.test.teacherservices.cloud/)


### Changes proposed in this pull request

- Add new labels to the results page and show page
- Add logic to generate the value for the new labels
- Re-order existing labels on the results page


### Screenshots

##### With UK and international fees

<img width="601" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/7f9bc5bf-bae3-4da5-9657-ee047476d27d">

<img width="786" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/f125e10c-9863-4296-b727-a933a976c233">

##### With only UK fees

<img width="600" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/95fc36f0-1461-489c-8e09-3b9915185a0c">

<img width="891" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/c937e7ea-4545-4453-8dad-e10cf61c1920">




### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
