### PR TITLE
[1265] Fix opt-in and opt-out of notifications

### DIFF
--- a/app/view_objects/notifications_view.rb
+++ b/app/view_objects/notifications_view.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class NotificationsView
-  ORGANISATION_URL_PATTERN = %r{/organisations/(\S+)/?}
+  ORGANISATION_URL_PATTERN = %r{/publish/organisations/([^/]+)/}
 
   def initialize(
     request:,

--- a/spec/features/publish/editing_notification_preference_spec.rb
+++ b/spec/features/publish/editing_notification_preference_spec.rb
@@ -16,11 +16,16 @@ feature 'Opting into notifications' do
     and_i_select_yes
     then_i_should_see_my_preferences_have_been_saved
     and_the_users_preference_is_set
+    then_i_should_be_redirected_to_the_courses_index_path
   end
 
   scenario 'user is shown an error if they submit without selection' do
     and_i_submit
     then_i_should_see_an_error_message
+  end
+
+  def then_i_should_be_redirected_to_the_courses_index_path
+    expect(publish_provider_courses_index_page).to be_displayed
   end
 
   def given_i_am_authenticated_as_an_accredited_provider_user

--- a/spec/view_objects/notifications_view_spec.rb
+++ b/spec/view_objects/notifications_view_spec.rb
@@ -15,7 +15,7 @@ describe NotificationsView do
   let(:user_id) { '123' }
   let(:user_email) { 'dave@example.com' }
   let(:referer_url) { "https://www.example.com#{referer_path}" }
-  let(:referer_path) { '/organisations/B20' }
+  let(:referer_path) { '/publish/organisations/B20/' }
 
   describe '#user_id' do
     it "returns the current_user['user_id']" do


### PR DESCRIPTION
### Context

Fixing the "opt-in and opt-out of notifications" feature. 

### Changes proposed in this pull request

- Updating the regex pattern to specifically use `[^/]+` to match characters up to but not including the next `/` . This change fixes an encoding issue encountered in the previous version where `%2F` (the URL-encoded version of `/`) was being incorrectly included in the matched sections of the URL. 

- Also prefixing the match with `publish`, which is the correct URL.

### Before

<img width="338" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/61e11cd1-8d1e-47bb-abb8-80f28c94f610">


<img width="876" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/f498d1f0-3804-4518-a68f-777653236e9b">

### After

<img width="290" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/02acd9b3-1509-4560-bde2-df4c1accbff5">

<img width="912" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/9743d30b-1c21-49cd-9fdf-3d5fdb855c91">



### Guidance to review

- Try to switch notifications on and off.
- Ensure the back link on that page works as expected. 
- It appears this is cycle independent. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
