### PR TITLE
[1423] Show schools on Find even if there is only one attached to the course on Publish

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -44,7 +44,7 @@
       </ul>
     <% end %>
 
-    <% if course.site_statuses.map(&:site).uniq.many? %>
+    <% if course.site_statuses.map(&:site).uniq.any? %>
       <h3 class="govuk-heading-m">
         School placements
       </h3>

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -29,19 +29,31 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
     end
   end
 
-  context 'course with multiple sites' do
-    it 'renders the component' do
+  context 'course with site' do
+    it 'renders the school placement heading' do
       provider = build(:provider)
       course = build(:course,
                      provider:,
                      site_statuses: [
-                       build(:site_status, site: build(:site)),
                        build(:site_status, site: build(:site))
                      ]).decorate
 
       result = render_inline(described_class.new(course))
 
       expect(result.text).to include(course.placements_heading)
+    end
+  end
+
+  context 'course with no site' do
+    it 'does not render the school placement heading' do
+      provider = build(:provider)
+      course = build(:course,
+                     site_statuses: [],
+                     provider:).decorate
+
+      result = render_inline(described_class.new(course))
+
+      expect(result.text).not_to include(course.placements_heading)
     end
   end
 


### PR DESCRIPTION
### Context

We currently only show schools on Find if there is more than one attached the the course on Publish.

I think the reasoning behind this might be because previously if the provider only had one school that would always be called main site, which didn't mean a lot. This might still be the case for some providers who haven't changed it.

We have decided to remove this restriction as it’s confusing providers who are expecting to see their school listed on Find.

### Before/After

<img width="1231" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/006e074f-1c00-4f58-89e2-3dde72c57df8">


### Changes proposed in this pull request

- Show schools on Find even if there is only one. 

### Guidance to review

- Course on QA: https://qa.find-postgraduate-teacher-training.service.gov.uk/course/1KV/G149#training-locations 
- Course on the review app: https://find-review-4109.test.teacherservices.cloud/course/1KV/G149#training-locations 

**Note: You may need to refresh the review app link after you click it**

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
