### PR TITLE
[1403] Remove date you can apply from on Find if it has passed

### DIFF
--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -30,7 +30,7 @@
     <dd data-qa="course__length"><%= course_length_with_study_mode_row %></dd>
   <% end %>
 
-  <% if applications_open_from.present? %>
+  <% if applications_open_from.present? && !applications_open_from_date_has_passed? %>
     <dt class="app-description-list__label">Date you can apply from</dt>
     <dd data-qa="course__applications_open"><%= l(applications_open_from&.to_date) %></dd>
   <% end %>

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -30,7 +30,7 @@
     <dd data-qa="course__length"><%= course_length_with_study_mode_row %></dd>
   <% end %>
 
-  <% if applications_open_from.present? && !applications_open_from_date_has_passed? %>
+  <% if show_apply_from_row? %>
     <dt class="app-description-list__label">Date you can apply from</dt>
     <dd data-qa="course__applications_open"><%= l(applications_open_from&.to_date) %></dd>
   <% end %>

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -71,8 +71,8 @@ module Find
           course.fee_international.blank? && course.fee_uk_eu.blank?
         end
 
-        def applications_open_from_date_has_passed?
-          course.applications_open_from <= Time.zone.today
+        def show_apply_from_row?
+          course.applications_open_from&.future?
         end
       end
     end

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -70,6 +70,10 @@ module Find
         def no_fee?
           course.fee_international.blank? && course.fee_uk_eu.blank?
         end
+
+        def applications_open_from_date_has_passed?
+          course.applications_open_from <= Time.zone.today
+        end
       end
     end
   end

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -8,8 +8,7 @@ module Find
       describe View do
         it 'renders sub sections' do
           provider = build(:provider).decorate
-          course = create(:course, :draft_enrichment,
-                          provider:).decorate
+          course = create(:course, :draft_enrichment, applications_open_from: Time.zone.tomorrow, provider:).decorate
 
           result = render_inline(described_class.new(course))
           expect(result.text).to include(

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -23,6 +23,48 @@ module Find
           )
         end
 
+        context 'applications open date has not passed' do
+          it "renders the 'Date you can apply from'" do
+            course = build(
+              :course,
+              applications_open_from: Time.zone.tomorrow,
+              provider: build(:provider)
+            ).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).to include('Date you can apply from')
+          end
+        end
+
+        context 'applications open date has passed' do
+          it "does not render the 'Date you can apply from'" do
+            course = build(
+              :course,
+              applications_open_from: Time.zone.yesterday,
+              provider: build(:provider)
+            ).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).not_to include('Date you can apply from')
+          end
+        end
+
+        context 'applications open date is today' do
+          it "does not render the 'Date you can apply from'" do
+            course = build(
+              :course,
+              applications_open_from: Time.zone.today,
+              provider: build(:provider)
+            ).decorate
+
+            result = render_inline(described_class.new(course))
+
+            expect(result.text).not_to include('Date you can apply from')
+          end
+        end
+
         context 'a course has an accrediting provider that is not the provider' do
           it 'renders the accredited provider' do
             course = build(

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -76,7 +76,6 @@ feature 'Viewing a findable course' do
       :secondary,
       :with_scitt,
       funding_type: 'fee',
-      applications_open_from: '2022-01-01T00:00:00Z',
       start_date: '2022-09-01T00:00:00Z',
       degree_grade: 'two_one',
       additional_degree_subject_requirements: true,
@@ -178,10 +177,6 @@ feature 'Viewing a findable course' do
 
     expect(find_course_show_page.length).to have_content(
       '1 year - full time'
-    )
-
-    expect(find_course_show_page.applications_open_from).to have_content(
-      '1 January 2022'
     )
 
     expect(find_course_show_page.start_date).to have_content(

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -319,6 +319,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       :open,
       :secondary,
       :fee_type_based,
+      applications_open_from: Time.zone.tomorrow,
       accrediting_provider:,
       site_statuses:, enrichments: [course_enrichment],
       study_sites: [study_site],


### PR DESCRIPTION
### Context

Removing the date you can apply from on Find if it has passed.

<img width="1165" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/8debb24a-5ca8-412d-8665-3523f26aadbc">


### Changes proposed in this pull request

- Show the row if the date has not passed.
- Don't show the date if the date is the same.
- Don't show the date if the date has passed.

### Guidance to review

Update the date [here](https://publish-review-4110.test.teacherservices.cloud/publish/organisations/1Z1/2024/courses/A853/details) to be before/after today, then check the row is rendered or not rendered [here](https://publish-review-4110.test.teacherservices.cloud/publish/organisations/1Z1/2024/courses/A853/preview). 


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
