### PR TITLE
Strip whitespace before adding new users to the database

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -22,8 +22,6 @@ module Support
 
     def create
       @user = User.new(user_params)
-      @user.email.strip!
-
       if @user.save
         redirect_to support_recruitment_cycle_users_path(params[:recruitment_cycle_year])
       else

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -22,6 +22,8 @@ module Support
 
     def create
       @user = User.new(user_params)
+      @user.email.strip!
+
       if @user.save
         redirect_to support_recruitment_cycle_users_path(params[:recruitment_cycle_year])
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   include PgSearch::Model
   include RecruitmentCycleHelper
 
-  before_save :downcase_email
+  before_save :downcase_email, :strip_email_whitespace
 
   has_many :organisation_users
 
@@ -104,5 +104,9 @@ class User < ApplicationRecord
 
   def downcase_email
     email&.downcase!
+  end
+
+  def strip_email_whitespace
+    email.strip!
   end
 end

--- a/spec/features/support/users/creating_a_new_user_spec.rb
+++ b/spec/features/support/users/creating_a_new_user_spec.rb
@@ -17,8 +17,9 @@ feature 'Creating a new user' do
       scenario 'Adding a new user record' do
         and_i_fill_in_first_name
         and_i_fill_in_last_name
-        and_i_fill_in_email
+        and_i_fill_in_email_with_some_whitespace
         when_i_save_the_form
+        and_the_users_email_is_saved_to_the_db_without_any_whitespace
         then_i_am_taken_to_the_user_index_page
       end
     end
@@ -51,8 +52,12 @@ feature 'Creating a new user' do
     support_user_new_page.last_name.set('Skywalker')
   end
 
-  def and_i_fill_in_email
-    support_user_new_page.email.set('lukeskywalker@jedi.com')
+  def and_i_fill_in_email_with_some_whitespace
+    support_user_new_page.email.set('    lukeskywalker@jedi.com     ')
+  end
+
+  def and_the_users_email_is_saved_to_the_db_without_any_whitespace
+    expect(User.find_by(email: 'lukeskywalker@jedi.com')).to be_present
   end
 
   def when_i_save_the_form


### PR DESCRIPTION
### Context

Users were being added with unintentional leading and proceeding white space, causing login issues.

### Changes proposed in this pull request

Strip the white space before and after the email address.

### Guidance to review

[Test it out here](https://publish-review-4112.test.teacherservices.cloud/support/2024/users/new)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
