### PR TITLE
[1416] Prevent course fee values which are less than £1

### DIFF
--- a/app/forms/publish/course_fee_form.rb
+++ b/app/forms/publish/course_fee_form.rb
@@ -26,13 +26,13 @@ module Publish
     validates :fee_uk_eu,
               numericality: { allow_blank: true,
                               only_integer: true,
-                              greater_than_or_equal_to: 0,
+                              greater_than_or_equal_to: 1,
                               less_than_or_equal_to: 100_000 }
 
     validates :fee_international,
               numericality: { allow_blank: true,
                               only_integer: true,
-                              greater_than_or_equal_to: 0,
+                              greater_than_or_equal_to: 1,
                               less_than_or_equal_to: 100_000 }
 
     validates :fee_details, words_count: { maximum: 250, message: :too_long }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -778,13 +778,13 @@ en:
             fee_uk_eu:
               blank: "Enter fees for UK students"
               not_a_number: "Course fees for UK and EU students must be a valid number"
-              greater_than_or_equal_to: "Course fees for UK and EU students must be greater than or equal to £0"
+              greater_than_or_equal_to: "Course fees for UK and EU students must be greater than or equal to £1"
               less_than_or_equal_to: "Course fees for UK and EU students must be less than or equal to £100,000"
               not_an_integer: "Course fees for UK and EU students must not include pence, like 1000 or 1500"
             fee_international:
               blank: "Enter fees for international students"
               not_a_number: "Course fees for international students must be a valid number"
-              greater_than_or_equal_to: "Course fees for international students must be greater than or equal to £0"
+              greater_than_or_equal_to: "Course fees for international students must be greater than or equal to £1"
               less_than_or_equal_to: "Course fees for international students must be less than or equal to £100,000"
               not_an_integer: "Course fees for international students must not include pence, like 1000 or 1500"
             fee_details:

--- a/spec/forms/publish/course_fee_form_spec.rb
+++ b/spec/forms/publish/course_fee_form_spec.rb
@@ -17,7 +17,7 @@ module Publish
       it 'validates UK/EU Fee' do
         expect(subject).to validate_numericality_of(:fee_uk_eu)
           .only_integer
-          .is_greater_than_or_equal_to(0)
+          .is_greater_than_or_equal_to(1)
           .is_less_than_or_equal_to(100_000)
           .allow_nil
       end
@@ -25,7 +25,7 @@ module Publish
       it 'validates International Fee' do
         expect(subject).to validate_numericality_of(:fee_international)
           .only_integer
-          .is_greater_than_or_equal_to(0)
+          .is_greater_than_or_equal_to(1)
           .is_less_than_or_equal_to(100_000)
           .allow_nil
       end


### PR DESCRIPTION
### Context

 Prevent users adding course fee values which are less than £1. This aims to prevent candidates from thinking these courses are free.

### Changes proposed in this pull request

- Prevent users adding international fee values which are less that £1
- Prevent users adding UK fee values which are less that £1

### Guidance to review

Try and update either of the fees on the link below to be less than £1

https://publish-review-4116.test.teacherservices.cloud/publish/organisations/2AT/2024/courses/3CXG

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
