### PR TITLE
Add kubelogin and kubectl to tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,7 @@
 ruby      3.2.3
 bundler   2.3.20
+kubelogin 0.1.0
+kubectl   1
 yarn      1.22.4
 nodejs    20.10.0
 terraform 1.4.5


### PR DESCRIPTION
### Context

These tools are necesary to connect to the remote pods, so why not have them available in the tool-versions?

### Changes proposed in this pull request

Add kubelogin and kubectl to tool-versions

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
