### PR TITLE
Update open-api-rswag to v0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,9 +108,9 @@ gem 'geokit-rails'
 # Geocoding
 gem 'geocoder'
 
-gem 'open_api-rswag-api', '0.1.0', github: 'DFE-Digital/open-api-rswag', tag: 'v0.1.0'
-gem 'open_api-rswag-specs', '0.1.0', github: 'DFE-Digital/open-api-rswag', tag: 'v0.1.0'
-gem 'open_api-rswag-ui', '0.1.0', github: 'DFE-Digital/open-api-rswag', tag: 'v0.1.0'
+gem 'open_api-rswag-api', '0.2.0', github: 'DFE-Digital/open-api-rswag', tag: 'v0.2.0'
+gem 'open_api-rswag-specs', '0.2.0', github: 'DFE-Digital/open-api-rswag', tag: 'v0.2.0'
+gem 'open_api-rswag-ui', '0.2.0', github: 'DFE-Digital/open-api-rswag', tag: 'v0.2.0'
 
 gem 'pg_search'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,17 +24,17 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/open-api-rswag.git
-  revision: efdf5532077f9b0927ad05bfd2bbeec2a91d5488
-  tag: v0.1.0
+  revision: b39fb1bdc9fef1c3beca52b0d0c61072c2597bae
+  tag: v0.2.0
   specs:
-    open_api-rswag-api (0.1.0)
+    open_api-rswag-api (0.2.0)
       railties
-    open_api-rswag-specs (0.1.0)
+    open_api-rswag-specs (0.2.0)
       activesupport
       hashie
       json-schema (~> 2.2)
       railties
-    open_api-rswag-ui (0.1.0)
+    open_api-rswag-ui (0.2.0)
       actionpack
       railties
 
@@ -789,9 +789,9 @@ DEPENDENCIES
   omniauth (~> 2.1)
   omniauth-rails_csrf_protection (~> 1.0)
   omniauth_openid_connect (~> 0.7)
-  open_api-rswag-api (= 0.1.0)!
-  open_api-rswag-specs (= 0.1.0)!
-  open_api-rswag-ui (= 0.1.0)!
+  open_api-rswag-api (= 0.2.0)!
+  open_api-rswag-specs (= 0.2.0)!
+  open_api-rswag-ui (= 0.2.0)!
   pagy (~> 7.0)
   parallel_tests
   pg


### PR DESCRIPTION
### Context
This library renders our api documentation but it is erroring now. We need to update the version so it starts to work again.


### Changes proposed in this pull request

Update `open-api-rswag` version to one compatible with ruby 3.2

### Guidance to review

[Docs render in Review App](https://publish-review-4130.test.teacherservices.cloud/docs/#about)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
