### PR TITLE
Revert govuk_design_system_formbuilder-5.3.0 update as it is breaking the deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ gem 'skylight'
 
 # govuk styling
 gem 'govuk-components', '~> 5.2.1'
-gem 'govuk_design_system_formbuilder', '~> 5.3'
+gem 'govuk_design_system_formbuilder', '~> 5.2'
 
 # DfE Sign-In
 gem 'omniauth', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
       view_component (>= 3.9, < 3.11)
-    govuk_design_system_formbuilder (5.3.0)
+    govuk_design_system_formbuilder (5.2.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -765,7 +765,7 @@ DEPENDENCIES
   geokit-rails
   google-cloud-bigquery
   govuk-components (~> 5.2.1)
-  govuk_design_system_formbuilder (~> 5.3)
+  govuk_design_system_formbuilder (~> 5.2)
   govuk_notify_rails
   guard
   guard-rspec


### PR DESCRIPTION
…govuk_design_system_formbuilder-5.3.0"

This reverts commit 246da31a1338f6c9b842f6076e25f17fe4e02118, reversing changes made to 933276565d0eb2a307e9b33d20cfab11dd27e304.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
