### PR TITLE
Add audited to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
+  - dependency-name: audited
   - dependency-name: simplecov
     versions:
     - ">= 0.18.a, < 0.19"


### PR DESCRIPTION
### Context
See for fuller explanation: https://github.com/DFE-Digital/apply-for-teacher-training/pull/9258

### Changes proposed in this pull request
- Add the audited gem to dependabot ignore so it won't accidentally get merged in later

### Trello card
https://trello.com/c/pepJCZgL

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
