### PR TITLE
Just to make ruby version manager adaptable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '~> 3.2.3'
+ruby '3.2.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '7.0.8'


### PR DESCRIPTION
### Context

On RVM  I am getting:

```
 Unknown ruby interpreter version (do not know how to handle): ~>3.2.3
```

Removing the `~>` works.

