### PR TITLE
Replace 'PGCE with QTS' with 'QTS with PGCE'

### DIFF
--- a/app/components/find/courses/qualifications_summary_component/view.html.erb
+++ b/app/components/find/courses/qualifications_summary_component/view.html.erb
@@ -9,8 +9,8 @@
         It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.
       </p>
     <% end %>
-<% when "PGCE with QTS" %>
-    <%= govuk_details(summary_text: "PGCE with QTS") do %>
+<% when "QTS with PGCE" %>
+    <%= govuk_details(summary_text: "QTS with PGCE") do %>
       <p class="govuk-body">
         A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
       </p>

--- a/app/components/find/courses/qualifications_summary_component/view.html.erb
+++ b/app/components/find/courses/qualifications_summary_component/view.html.erb
@@ -12,13 +12,10 @@
 <% when "QTS with PGCE" %>
     <%= govuk_details(summary_text: "QTS with PGCE") do %>
       <p class="govuk-body">
-        A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
+       You need qualified teacher status (QTS) to teach in state schools in England. QTS may also allow you to teach in other parts of the UK.
       </p>
       <p class="govuk-body">
-        It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.
-      </p>
-      <p class="govuk-body">
-        Many PGCE courses include credits that count toward a Master’s degree.
+        This course also offers a postgraduate certificate in education (PGCE). PGCE courses can include credits that count towards a master’s degree.
       </p>
     <% end %>
   <% when "PGDE with QTS" %>

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -27,6 +27,10 @@ class CourseDecorator < ApplicationDecorator
     h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
   end
 
+  def description
+    object.description.to_s.gsub('PGCE with QTS', 'QTS with PGCE')
+  end
+
   def on_find(provider = object.provider)
     if object.findable?
       if current_cycle_and_open?

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -28,7 +28,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def description
-    object.description.to_s.gsub('PGCE with QTS', 'QTS with PGCE')
+    object.description.to_s.sub('PGCE with QTS', 'QTS with PGCE')
   end
 
   def on_find(provider = object.provider)

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -65,7 +65,7 @@ module WithQualifications
     def full_qualifications
       case qualification
       when 'qts' then 'Qualified teacher status (QTS)'
-      when 'pgce_with_qts' then 'Postgraduate certificate in education (PGCE) with qualified teacher status (QTS)'
+      when 'pgce_with_qts' then 'Qualified teacher status (QTS) with a postgraduate certificate in education (PGCE)'
       when 'pgde_with_qts' then 'Postgraduate diploma in education (PGDE) with qualified teacher status (QTS)'
       when 'pgce' then 'Postgraduate certificate in education (PGCE) without qualified teacher status (QTS)'
       when 'pgde' then 'Postgraduate diploma in education (PGDE) without qualified teacher status (QTS)'

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -45,7 +45,7 @@ module WithQualifications
 
     # This field may seem like an unnecessary overhead when there is already a
     # database-backed `qualification` field. However it's misleading, from the
-    # point of view of the teacher training domain, to think of 'PGCE with QTS'
+    # point of view of the teacher training domain, to think of 'QTS with PGCE'
     # as a single qualification, since the QTS and PGCE aspects are completely
     # separate and may even be delivered in different places by different providers.
     # e.g. the QTS might come from a SCITT but the PGCE would come from a university.

--- a/app/views/find/result_filters/_qualifications_filter.html.erb
+++ b/app/views/find/result_filters/_qualifications_filter.html.erb
@@ -34,7 +34,7 @@
         false
       ) %>
       <%= form.label :qualification, { for: "qualification_pgce_with_qts" }, value: "PgdePgceWithQts", class: "govuk-label govuk-checkboxes__label" do %>
-        PGCE (or PGDE) with QTS
+        QTS with PGCE (or PGDE)
       <% end %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,7 @@ en:
         help: "Postgraduate certificate in education"
       pgce_with_qts:
         label: "QTS with PGCE"
-        help: "Postgraduate certificate in education with qualified teacher status"
+        help: "Qualified teacher status with a postgraduate certificate in education"
       pgde:
         label: "PGDE only (without QTS)"
         help: "Postgraduate diploma in education"
@@ -929,7 +929,7 @@ en:
         help: "Postgraduate certificate in education"
       pgce_with_qts:
         label: "QTS with PGCE"
-        help: "Postgraduate certificate in education with qualified teacher status"
+        help: "Qualified teacher status with a postgraduate certificate in education"
       pgde:
         label: "PGDE only (without QTS)"
         help: "Postgraduate diploma in education"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,7 +89,7 @@ en:
         label: "PGCE only (without QTS)"
         help: "Postgraduate certificate in education"
       pgce_with_qts:
-        label: "PGCE with QTS"
+        label: "QTS with PGCE"
         help: "Postgraduate certificate in education with qualified teacher status"
       pgde:
         label: "PGDE only (without QTS)"
@@ -254,7 +254,7 @@ en:
         maths: "at least grade B in maths A-level (or an equivalent)"
       qualification:
         qts: "QTS"
-        pgce_with_qts: "PGCE with QTS"
+        pgce_with_qts: "QTS with PGCE"
         pgce: "PGCE"
         pgde_with_qts: "PGDE with QTS"
         pgde: "PGDE"
@@ -928,7 +928,7 @@ en:
         label: "PGCE only (without QTS)"
         help: "Postgraduate certificate in education"
       pgce_with_qts:
-        label: "PGCE with QTS"
+        label: "QTS with PGCE"
         help: "Postgraduate certificate in education with qualified teacher status"
       pgde:
         label: "PGDE only (without QTS)"

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -22,7 +22,7 @@ en:
     qualifications:
       qts: "QTS"
       pgce: "PGCE"
-      pgce_with_qts: "PGCE with QTS"
+      pgce_with_qts: "QTS with PGCE"
       pgde: "PGDE"
       pgde_with_qts: "PGDE with QTS"
     location_filter:
@@ -140,7 +140,7 @@ en:
         qts:
           html: <abbr title='Qualified teacher status'>QTS</abbr> only
         pgce_with_qts:
-          html: <abbr title='Postgraduate certificate in education'>PGCE</abbr> with <abbr title='Qualified teacher status'>QTS</abbr>
+          html: <abbr title='Qualified teacher status'>QTS</abbr> with <abbr title='Postgraduate certificate in education'>PGCE</abbr>
         pgde_with_qts:
           html: <abbr title='Postgraduate diploma in education'>PGDE</abbr> with <abbr title='Qualified teacher status'>QTS</abbr>
         pgce:

--- a/spec/components/find/courses/qualifications_summary_component/view_spec.rb
+++ b/spec/components/find/courses/qualifications_summary_component/view_spec.rb
@@ -13,7 +13,7 @@ describe Find::Courses::QualificationsSummaryComponent::View, type: :component d
 
   context 'PGCE with QTS qualification' do
     it 'renders correct text' do
-      result = render_inline(described_class.new('PGCE with QTS'))
+      result = render_inline(described_class.new('QTS with PGCE'))
 
       expect(result.text).to include('A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England')
     end

--- a/spec/components/find/courses/qualifications_summary_component/view_spec.rb
+++ b/spec/components/find/courses/qualifications_summary_component/view_spec.rb
@@ -15,7 +15,8 @@ describe Find::Courses::QualificationsSummaryComponent::View, type: :component d
     it 'renders correct text' do
       result = render_inline(described_class.new('QTS with PGCE'))
 
-      expect(result.text).to include('A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England')
+      expect(result.text).to include('You need qualified teacher status (QTS) to teach in state schools in England. QTS may also allow you to teach in other parts of the UK.')
+      expect(result.text).to include('This course also offers a postgraduate certificate in education (PGCE)')
     end
   end
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -766,6 +766,26 @@ describe CourseDecorator do
     end
   end
 
+  describe '#description' do
+    subject(:description) { course.decorate.description }
+
+    context 'when PGCE with QTS' do
+      let(:course) { build_stubbed(:course, qualification: 'pgce_with_qts') }
+
+      it 'returns the correct page title' do
+        expect(description).to eq('QTS with PGCE full time teaching apprenticeship')
+      end
+    end
+
+    context 'when PGDE with QTS' do
+      let(:course) { build_stubbed(:course, qualification: 'pgde_with_qts') }
+
+      it 'returns the correct page title' do
+        expect(description).to eq(course.description)
+      end
+    end
+  end
+
   describe '#cycle_range' do
     subject { course.decorate.cycle_range }
 

--- a/spec/features/find/result_page_filters/qualifications_spec.rb
+++ b/spec/features/find/result_page_filters/qualifications_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Qualifications filter' do
   end
 
   def when_i_unselect_the_pgce_and_further_education_qualification_checkboxes
-    uncheck('PGCE (or PGDE) with QTS')
+    uncheck('QTS with PGCE (or PGDE)')
     uncheck('Further education (PGCE or PGDE without QTS)')
   end
 
@@ -93,7 +93,7 @@ RSpec.feature 'Qualifications filter' do
   end
 
   def when_i_select_the_pgce_checkbox
-    check('PGCE (or PGDE) with QTS')
+    check('QTS with PGCE (or PGDE)')
   end
 
   def when_i_select_the_further_education_checkbox
@@ -105,7 +105,7 @@ RSpec.feature 'Qualifications filter' do
   end
 
   def and_i_deselect_the_pgce_checkbox
-    uncheck('PGCE (or PGDE) with QTS')
+    uncheck('QTS with PGCE (or PGDE)')
   end
 
   def then_i_see_that_the_qts_and_further_education_checkboxes_are_still_unselected

--- a/spec/features/find/search/course_results_spec.rb
+++ b/spec/features/find/search/course_results_spec.rb
@@ -41,7 +41,7 @@ feature 'results' do
       # list by provider?
       expect(first_course.course_name.text).to include('Hello there')
       expect(first_course.provider_name.text).to be_present
-      expect(first_course.qualification.text).to include('PGCE with QTS')
+      expect(first_course.qualification.text).to include('QTS with PGCE')
       expect(first_course.study_mode.text).to eq('Full time')
       expect(first_course.funding_options.text).to eq('Teaching apprenticeship - with salary')
     end

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -160,7 +160,7 @@ feature 'Viewing a findable course' do
     )
 
     expect(find_course_show_page.extended_qualification_descriptions).to have_content(
-      @course.extended_qualification_descriptions
+      'Qualified teacher status (QTS) with a postgraduate certificate in education (PGCE)'
     )
 
     expect(find_course_show_page.qualifications).to have_content(

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -164,7 +164,7 @@ feature 'Viewing a findable course' do
     )
 
     expect(find_course_show_page.qualifications).to have_content(
-      'PGCE with QTS'
+      'QTS with PGCE'
     )
 
     expect(find_course_show_page.age_range).to have_content(

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -67,7 +67,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   end
 
   def then_i_am_shown_the_correct_qts_options
-    expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('QTS', 'PGCE with QTS', 'PGDE with QTS')
+    expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('QTS', 'QTS with PGCE', 'PGDE with QTS')
   end
 
   def then_i_am_shown_the_correct_non_qts_options

--- a/spec/features/publish/viewing_a_course_details_spec.rb
+++ b/spec/features/publish/viewing_a_course_details_spec.rb
@@ -126,7 +126,7 @@ feature 'Course show' do
       course.subjects.sort.join
     )
     expect(publish_provider_courses_details_page.outcome).to have_content(
-      'PGCE with QTS'
+      'QTS with PGCE'
     )
     expect(publish_provider_courses_details_page.study_mode).to have_content(
       'Full time'

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -149,11 +149,11 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     )
 
     expect(publish_course_preview_page.description).to have_content(
-      course.description
+      course.decorate.description
     )
 
     expect(publish_course_preview_page.qualifications).to have_content(
-      'PGCE with QTS'
+      'QTS with PGCE'
     )
 
     expect(publish_course_preview_page.age_range_in_years).to have_content(

--- a/spec/services/course_attribute_formatter_service_spec.rb
+++ b/spec/services/course_attribute_formatter_service_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CourseAttributeFormatterService do
 
     context 'pgce_with_qts' do
       let(:value) { 'pgce_with_qts' }
-      let(:expected_value) { 'PGCE with QTS' }
+      let(:expected_value) { 'QTS with PGCE' }
 
       it { is_expected.to eq(expected_value) }
     end


### PR DESCRIPTION
## Context

There is inconsistency of terminology between GiT and Find. GiT use “QTS with PGCE” (which is more clear/intuitive) whereas Find uses “PGCE with QTS”.

## Changes proposed in this pull request

Replace "PGCE with QTS” with "QTS with PGCE".

## Gotcha

When it comes from qualifications is an easy change but because the terminology is inside of the course description from the TTAPI we need to replace part of the string.

## Guidance to review

1. All the places in Find/Publish being replaced?

## Link to Trello card

https://trello.com/c/eftEZsWL/1283-review-and-replace-existing-instances-of-pgce-with-qts-with-the-correct-terminology-of-qts-with-pgce-in-ui-only

