### PR TITLE
Makefile environment names to be equal to Apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,5 +268,5 @@ shell: aks-ssh
 .PHONY: worker-shell
 worker-shell: aks-worker-ssh
 
-.PHONY: aks-console
+.PHONY: console
 console: aks-console

--- a/Makefile
+++ b/Makefile
@@ -246,3 +246,27 @@ action-group-resources: set-azure-account # make env_aks action-group-resources 
 	echo ${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-mn-rg
 	az group create -l uksouth -g ${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-mn-rg --tags "Product=Find postgraduate teacher training" "Environment=Test" "Service Offering=Teacher services cloud"
 	az monitor action-group create -n ${RESOURCE_NAME_PREFIX}-${SERVICE_NAME} -g ${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-mn-rg --action email ${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-email ${ACTION_GROUP_EMAIL}
+
+.PHONY: qa
+qa: qa_aks
+
+.PHONY: staging
+staging: staging_aks
+
+.PHONY: sandbox
+sandbox: sandbox_aks
+
+.PHONY: production
+production: production_aks
+
+.PHONY: logs
+logs: aks-logs
+
+.PHONY: shell
+shell: aks-ssh
+
+.PHONY: worker-shell
+worker-shell: aks-worker-ssh
+
+.PHONY: aks-console
+console: aks-console


### PR DESCRIPTION
### Context

The Publish and Apply repos are managed by the same team and there are features that exist in one and not the other.

One such feature is convenient commands to login to console environments such as production and sandbox.

### Changes proposed in this pull request

Login to any environment exactly like Apply:

```
 make qa get-cluster-credentials
 make staging get-cluster-credentials
 make sandbox get-cluster-credentials
 make production get-cluster-credentials
```