### PR TITLE
Make sure environments are not excluded in Skylight

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module ManageCoursesBackend
 
     config.session_store :cookie_store, key: Settings.cookies.session.name, httponly: true
 
-    config.skylight.environments = Settings.skylight.enable ? [Rails.env] : []
+    config.skylight.environments += Settings.skylight.enable ? [Rails.env] : []
     config.skylight.logger = SemanticLogger[Skylight]
     config.skylight.log_level = :fatal
     config.skylight.native_log_level = :fatal


### PR DESCRIPTION
### Context

We are not sending any data to Skylight in Publish.

After investigation nothing tell me what is wrong:

First the env var:

```
kubectl exec ... -n ... -- env | grep SETTINGS__SKYLIGHT__AUTHENTICATION

SETTINGS__SKYLIGHT__AUTHENTICATION=THE ENV VAR IS HERE WITH THE VALUE YAY
```

So env var is good, then I tried to run the doctor command:

```
kubectl exec -it ... -n ... -- bundle exec skylight doctor
```

The results is that everything was as expected:

```
Checking SSL
  OK

Checking for Rails
  Rails application detected

Checking for native agent
  Native agent installed

Checking for valid configuration
  Configuration is valid

Checking Skylight startup
  Successfully started
  Waiting for daemon...   Success
All checks passed!
```

So then I read the documentation and it says:

<img width="659" alt="Screenshot 2024-04-12 at 16 18 06" src="https://github.com/DFE-Digital/publish-teacher-training/assets/27509/d299e44d-e161-48f0-9036-9445788299fb">

So trying this and see if works.

### Changes proposed in this pull request

On the doc https://www.skylight.io/support/environments Skylight suggests to use << (or +), so verifying if that's the cause of issue.

### Guidance to review

1. Does it work sending the data to skylight?
