### PR TITLE
Rolled over courses are closed by default and automatically opened on publish

### DIFF
--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -133,9 +133,12 @@ module Publish
     end
 
     def publish_course
-      @course.publish_sites
-      @course.publish_enrichment(@current_user)
-      NotificationService::CoursePublished.call(course: @course)
+      Course.transaction do
+        @course.publish_sites
+        @course.publish_enrichment(@current_user)
+        @course.application_status_open!
+        NotificationService::CoursePublished.call(course: @course)
+      end
     end
 
     def format_publish_error_messages

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -15,15 +15,16 @@ module Courses
       new_course = nil
 
       Course.transaction do
-        new_course = course.dup
-        new_course.uuid = nil
-        new_course.provider = new_provider
-        year_differential = new_course.recruitment_cycle.year.to_i - course.recruitment_cycle.year.to_i
-        new_course.applications_open_from = adjusted_applications_open_from_date(course, year_differential)
-        new_course.start_date = course.start_date + year_differential.year
-        new_course.subjects = course.subjects
+        new_course                                 = course.dup
+        new_course.uuid                            = nil
+        new_course.application_status              = 'closed'
+        new_course.provider                        = new_provider
+        year_differential                          = new_course.recruitment_cycle.year.to_i - course.recruitment_cycle.year.to_i
+        new_course.applications_open_from          = adjusted_applications_open_from_date(course, year_differential)
+        new_course.start_date                      = course.start_date + year_differential.year
+        new_course.subjects                        = course.subjects
         new_course.can_sponsor_skilled_worker_visa = course.can_sponsor_skilled_worker_visa
-        new_course.can_sponsor_student_visa = course.can_sponsor_student_visa
+        new_course.can_sponsor_student_visa        = course.can_sponsor_student_visa
         new_course.save!(validate: false)
 
         copy_latest_enrichment_to_course(course, new_course)

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -9,11 +9,21 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
   end
 
   scenario 'i can publish a course' do
-    and_there_is_a_course_i_want_to_publish
+    and_there_is_a_draft_course_i_want_to_publish
     when_i_visit_the_course_page
     and_i_click_the_publish_link
     then_i_should_see_a_success_message
     and_the_course_is_published
+    and_the_course_is_open
+  end
+
+  scenario 'i can publish a rolled over course' do
+    and_there_is_a_rolled_over_course_i_want_to_publish
+    when_i_visit_the_course_page
+    and_i_click_the_publish_link
+    then_i_should_see_a_success_message
+    and_the_course_is_published
+    and_the_course_is_open
   end
 
   scenario 'i can re-publish a course' do
@@ -47,18 +57,30 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_have_previously_published_a_course
-    and_there_is_a_course_i_want_to_publish
+    and_there_is_a_draft_course_i_want_to_publish
     when_i_visit_the_course_page
     and_i_click_the_publish_link
     then_i_should_see_a_success_message
     and_the_course_is_published
   end
 
-  def and_there_is_a_course_i_want_to_publish
+  def and_there_is_a_draft_course_i_want_to_publish
     given_a_course_exists(
       :with_gcse_equivalency,
       :with_accrediting_provider,
+      :closed,
       enrichments: [create(:course_enrichment, :initial_draft)],
+      sites: [create(:site, location_name: 'location 1')],
+      study_sites: [create(:site, :study_site)]
+    )
+  end
+
+  def and_there_is_a_rolled_over_course_i_want_to_publish
+    given_a_course_exists(
+      :with_gcse_equivalency,
+      :with_accrediting_provider,
+      :closed,
+      enrichments: [create(:course_enrichment, :rolled_over)],
       sites: [create(:site, location_name: 'location 1')],
       study_sites: [create(:site, :study_site)]
     )
@@ -93,6 +115,10 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
 
   def and_the_course_is_published
     expect(course.reload.is_published?).to be(true)
+  end
+
+  def and_the_course_is_open
+    expect(course.reload).to be_application_status_open
   end
 
   def when_i_make_some_new_changes

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -88,8 +88,6 @@ RSpec.describe Courses::CopyToProviderService do
   end
 
   context 'when the original course is open' do
-    let(:new_recruitment_cycle) { create(:recruitment_cycle, :next) }
-
     before do
       course.update(application_status: 'open')
     end

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -87,6 +87,20 @@ RSpec.describe Courses::CopyToProviderService do
     end
   end
 
+  context 'when the original course is open' do
+    let(:new_recruitment_cycle) { create(:recruitment_cycle, :next) }
+
+    before do
+      course.update(application_status: 'open')
+    end
+
+    it "sets the new course's application_status to closed" do
+      service.execute(course:, new_provider:)
+
+      expect(new_course.application_status).to eq('closed')
+    end
+  end
+
   it 'leaves the existing course alone' do
     service.execute(course:, new_provider:)
 


### PR DESCRIPTION
### Context

When a course is rolled over, it is rolled over to the “rolled over” state.

It is currently rolled over with the same `application_status` it had in the previous cycle.

It doesn’t make sense from a data analysis point of view for the course to be `unpublished` and `open` at the beginning of the cycle.

Therefore we should roll over courses and set the course `application_status` to closed until it is `published`.

We automatically open a course during the publish step to avoid the multi-step process of 'publish', 'open', 'confirm'.

Now the provider needs only to publish a closed course and it will be open for applications pending it's scheduled open date.

### Changes proposed in this pull request

When a provider publishes a course, they must "Open" the course, even if the course was open in the previous cycle.
We've changed this to:

 - Rollover all courses closed
 - automatically open the course when it is published


### Guidance to review

## Before

|Rolled Over|Published|
|---|---|
|![1_unpublished](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/27c3d8cd-31e5-4d67-aa65-382164a55917)|![2_published](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/6fea1b76-dab7-47da-855a-dade3f7b580c)|

|Opening|Opened|
|---|---|
|![3_opening_course](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/5b853d1b-28ec-4a69-bf14-e58e25597b8d)|![4_opened](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/707c68da-57d9-4d66-a9e0-f7859af67d08)|


## After

[Screencast from 21-06-24 16:34:43.webm](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/98276119-3935-413b-bd66-a22c6d761b9f)


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
