### PR TITLE
[1530] Update content on international qualifications section (Find)

### DIFF
--- a/app/components/find/courses/international_students_component/view.html.erb
+++ b/app/components/find/courses/international_students_component/view.html.erb
@@ -22,14 +22,22 @@
 
     <p class="govuk-body">Learn more about <%= govuk_link_to("training to teach in England as an international student", t("find.get_into_teaching.url_train_to_teach_as_international_candidate")) %>.</p>
 
-    <h3 class="govuk-heading-m">International qualifications</h3>
-    <p class="govuk-body">If your qualifications come from a non-UK institution, we may want to see a ‘statement of comparability’ from UK ENIC. This will show us how they compare to UK qualifications.</p>
+    <h3 class="govuk-heading-m">Qualifications gained outside the UK</h3>
+    <p class="govuk-body">If you studied for your qualifications outside of the UK you should apply for a statement of comparability from UK European Network of Information Centres (UK ENIC). This will show us how your qualifications compare to UK qualifications.</p>
 
-    <p class="govuk-body">You can call <%= govuk_link_to("Get Into Teaching", t("get_into_teaching.url")) %> on <%= t("get_into_teaching.tel") %> for:</p>
+    <p class="govuk-body">
+      <%= govuk_link_to("Apply for a statement of comparability (opens in new tab)",
+                        t("find.enic.statement_of_comparability.url"),
+                        target: "_blank",
+                        rel: "noopener") %>
+    </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>guidance on the UK equivalents of your qualifications</li>
-      <li>a free statement of comparability once you’ve submitted your application (if we ask you for this)</li>
-    </ul>
+    <p class="govuk-body">
+      <%= govuk_link_to("You can chat online (opens in new tab)",
+                        t("find.get_into_teaching.url_online_chat"),
+                        target: "_blank",
+                        rel: "noopener") %>
+        with the Get Into Teaching support team for guidance on the UK equivalents of your qualifications.
+    </p>
   </div>
 </div>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -19,6 +19,9 @@ en:
         name: Find has reopened
         description: Candidates can browse courses on Find. Courses returned are from the next recruitment cycle
       updated: Cycle schedule updated
+    enic:
+      statement_of_comparability: 
+        url: https://www.enic.org.uk/Qualifications/SOC/Default.aspx
     qualifications:
       qts: "QTS"
       pgce: "PGCE"

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -20,6 +20,18 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     it 'tells candidates sponsorship is not available' do
       expect(page).to have_text('Sponsorship for a student visa is not available for this course')
     end
+
+    it 'renders the h3 qualifications gained outside the UK' do
+      expect(page).to have_css('h3', text: 'Qualifications gained outside the UK')
+    end
+
+    it 'tells candidates about qualifications gained outside of the UK' do
+      expect(page).to have_text('If you studied for your qualifications outside of the UK you should apply for a statement of comparability from UK European Network of Information Centres (UK ENIC). This will show us how your qualifications compare to UK qualifications.')
+    end
+
+    it 'renders the enic link' do
+      expect(page).to have_link('Apply for a statement of comparability (opens in new tab)')
+    end
   end
 
   context 'when the course is fee-paying and does sponsor Student visas' do


### PR DESCRIPTION
### Context

Updates to the content around Qualifications gained outside the UK on Find.

### Before

<img width="781" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/7762ba1c-e5dd-44a2-bbca-d81be7f3e6b2">


### After

<img width="729" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/704405b6-fa7f-4294-bb63-7df9929c8574">


### Guidance to review

Navigate to the review app: https://find-review-4163.test.teacherservices.cloud/

Find a course and go to the "International candidates" section, checkout the new content in line with the screenshots above.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
