### PR TITLE
Return 404 not found for locations API when provider not found

### DIFF
--- a/app/controllers/api/public/v1/providers/locations_controller.rb
+++ b/app/controllers/api/public/v1/providers/locations_controller.rb
@@ -15,11 +15,11 @@ module API
           private
 
           def locations
-            @locations ||= provider&.sites
+            @locations ||= provider.sites
           end
 
           def provider
-            @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
+            @provider ||= recruitment_cycle.providers.find_by!(provider_code: params[:provider_code])
           end
 
           def include_param

--- a/spec/controllers/api/public/v1/providers/locations_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/locations_controller_spec.rb
@@ -65,6 +65,21 @@ RSpec.describe API::Public::V1::Providers::LocationsController do
         end
       end
     end
+
+    context 'when the provider does not exist' do
+      before do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: 'asdf'
+        }
+      end
+
+      it 'returns errors not found' do
+        expect(response).to be_not_found
+
+        expect(json_response['errors']).to eql([{ 'status' => 404, 'title' => 'NOT_FOUND', 'detail' => 'The requested resource could not be found' }])
+      end
+    end
   end
 
   describe 'recruitment cycle' do


### PR DESCRIPTION
### Context

API request for locations belonging to a provider that does not exist triggers exception in the application.

We should be returning a 404 as a response.


### Changes proposed in this pull request
Return 404 with errors when provider is not found in Locations API endpoint


```ruby
      [
        {
          'status' => 404,
          'title' => 'NOT_FOUND',
          'detail' => 'The requested resource could not be found'
        }
      ]
```

### Guidance to review
Is this consistent with the API documentations?

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
