### PR TITLE
Make sure apply button on Find searches for case insensitive codes

### DIFF
--- a/app/controllers/concerns/apply_redirect.rb
+++ b/app/controllers/concerns/apply_redirect.rb
@@ -5,9 +5,8 @@ module ApplyRedirect
 
   def apply
     course = RecruitmentCycle.current
-                             .providers.find_by(provider_code: params[:provider_code])
-                             .courses.find_by(course_code: params[:"#{'course_' if find?}code"])
-
+                             .providers.case_insensitive_search(params[:provider_code])
+                             .courses.case_insensitive_search(course_code_param).first!
     if find?
       Rails.logger.info("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
     else
@@ -18,6 +17,14 @@ module ApplyRedirect
   end
 
   private
+
+  def course_code_param
+    if find?
+      params[:course_code]
+    else
+      params[:code]
+    end
+  end
 
   def find?
     self.class.module_parent == Find

--- a/app/controllers/concerns/apply_redirect.rb
+++ b/app/controllers/concerns/apply_redirect.rb
@@ -5,8 +5,9 @@ module ApplyRedirect
 
   def apply
     course = RecruitmentCycle.current
-                             .providers.case_insensitive_search(params[:provider_code])
+                             .providers.by_provider_code(params[:provider_code])
                              .courses.case_insensitive_search(course_code_param).first!
+
     if find?
       Rails.logger.info("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
     else

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -98,7 +98,7 @@ class Provider < ApplicationRecord
     accredited_courses.includes(:provider).where(provider: { recruitment_cycle: })
   end
 
-  scope :case_insensitive_search, lambda { |provider_code|
+  scope :by_provider_code, lambda { |provider_code|
     where('lower(provider_code) = ?', provider_code.to_s.downcase).first!
   }
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -98,6 +98,10 @@ class Provider < ApplicationRecord
     accredited_courses.includes(:provider).where(provider: { recruitment_cycle: })
   end
 
+  scope :case_insensitive_search, lambda { |provider_code|
+    where('lower(provider_code) = ?', provider_code.to_s.downcase).first!
+  }
+
   scope :changed_since, lambda { |timestamp|
     if timestamp.present?
       where('provider.changed_at > ?', timestamp)

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -33,6 +33,33 @@ module Find
 
         expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{provider.provider_code}&courseCode=#{course.course_code}")
       end
+
+      it 'redirects when downcase provider and course code' do
+        get :apply, params: {
+          provider_code: provider.provider_code.downcase,
+          course_code: course.course_code.downcase
+        }
+
+        expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{provider.provider_code}&courseCode=#{course.course_code}")
+      end
+
+      it 'when provider does not exist' do
+        get :apply, params: {
+          provider_code: 'ABCD',
+          course_code: course.course_code.downcase
+        }
+
+        expect(response).to be_not_found
+      end
+
+      it 'when course does not exist' do
+        get :apply, params: {
+          provider_code: provider.provider_code,
+          course_code: 'ABCD'
+        }
+
+        expect(response).to be_not_found
+      end
     end
 
     describe '#show' do

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -52,7 +52,7 @@ module Find
         expect(response).to be_not_found
       end
 
-      it 'when course does not exist' do
+      it 'raises a not found error when the course does not exist' do
         get :apply, params: {
           provider_code: provider.provider_code,
           course_code: 'ABCD'

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -43,7 +43,7 @@ module Find
         expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{provider.provider_code}&courseCode=#{course.course_code}")
       end
 
-      it 'when provider does not exist' do
+      it 'raises a not found error when the provider does not exist' do
         get :apply, params: {
           provider_code: 'ABCD',
           course_code: course.course_code.downcase


### PR DESCRIPTION
### Context

A candidate is clicking the Apply button on a course listed on Find and it’s raising an exception.

https://dfe-teacher-services.sentry.io/issues/5254968455/?alert_rule_id=11137790&alert_type=issue&notification_uuid=edb746ad-0dad-4c7a-a414-4f5e6d9abbe5&project=1377944&referrer=slack

### Changes proposed in this pull request

Make searching of provider and course, case insensitive.

### Guidance to review

1. Does it work?
2. Does it affect somewhere else?

