### PR TITLE
[1558] Authenticate before displaying the terms and conditions

### DIFF
--- a/app/controllers/publish/terms_controller.rb
+++ b/app/controllers/publish/terms_controller.rb
@@ -2,8 +2,6 @@
 
 module Publish
   class TermsController < ApplicationController
-    skip_before_action :authenticate
-
     def edit
       @accept_terms_form = Interruption::AcceptTermsForm.new(current_user)
     end

--- a/spec/features/publish/accepting_terms_spec.rb
+++ b/spec/features/publish/accepting_terms_spec.rb
@@ -3,12 +3,9 @@
 require 'rails_helper'
 
 feature 'Accepting terms', { can_edit_current_and_next_cycles: false } do
-  before do
+  scenario 'i can accept the terms and conditions' do
     given_i_am_a_user_who_has_not_accepted_the_terms
     when_i_visit_the_publish_service
-  end
-
-  scenario 'i can accept the terms and conditions' do
     then_i_am_taken_to_the_publish_terms_page
     when_i_accept_the_terms_and_conditions
     then_i_should_be_redirected_to_the_courses_index_page
@@ -16,8 +13,23 @@ feature 'Accepting terms', { can_edit_current_and_next_cycles: false } do
   end
 
   scenario 'i am shown an error if i do not accept the terms' do
+    given_i_am_a_user_who_has_not_accepted_the_terms
+    when_i_visit_the_publish_service
     and_i_do_not_accept_the_terms_and_conditions
     then_i_should_see_an_error_message
+  end
+
+  scenario 'not logged in and navigate directly to the terms page' do
+    given_i_visit_the_terms_and_conditions_page
+    then_i_should_be_redirected_to_the_sign_in_page
+  end
+
+  def given_i_visit_the_terms_and_conditions_page
+    visit publish_accept_terms_path
+  end
+
+  def then_i_should_be_redirected_to_the_sign_in_page
+    expect(page).to have_current_path(sign_in_path)
   end
 
   def given_i_am_a_user_who_has_not_accepted_the_terms


### PR DESCRIPTION
### Context

We are skipping authentication on the terms and conditions page. This means if someone navigates to `https://qa.publish-teacher-training-courses.service.gov.uk/publish/accept-terms` without being authenticated they hit an internal server error. 

### Changes proposed in this pull request

Ensure the user is authenticated before allowing them to reach this page. 

### Guidance to review

Can you think of any reason to not authenticate on this page?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
