### PR TITLE
Update schema to reflect rails version

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_02_071202) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_02_071202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"


### PR DESCRIPTION
### Context
We upgraded to rails 7.1, but the schema doesn't reflect that. As a result, every time someone runs `bin/setup`, the schema is updated. 

### Changes proposed in this pull request
Change the schema version to reflect rails version

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
