### PR TITLE
Add helper method to check for next recruitment cycle and TDA

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -85,6 +85,8 @@ class Course < ApplicationRecord
 
   belongs_to :provider
 
+  delegate :tda_active?, to: :provider
+
   belongs_to :accrediting_provider,
              ->(c) { where(recruitment_cycle: c.recruitment_cycle) },
              class_name: 'Provider',

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -377,6 +377,10 @@ class Provider < ApplicationRecord
     Provider.joins(:recruitment_cycle).where(recruitment_cycle: { year: Settings.current_recruitment_cycle_year.succ.to_s }).find_by(provider_code:)
   end
 
+  def tda_active?
+    recruitment_cycle_year.to_i > 2024 && FeatureService.enabled?(:teacher_degree_apprenticeship)
+  end
+
   private
 
   def accredited_provider_codes

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -54,6 +54,62 @@ describe Provider do
     end
   end
 
+  describe '#tda_active?' do
+    let(:provider) { create(:provider) }
+
+    before do
+      allow(provider).to receive(:recruitment_cycle_year).and_return(recruitment_cycle_year)
+    end
+
+    context 'when recruitment cycle year is after 2024 and TDA is active' do
+      let(:recruitment_cycle_year) { 2025 }
+
+      before do
+        allow(FeatureService).to receive(:enabled?).with(:teacher_degree_apprenticeship).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(provider.tda_active?).to be true
+      end
+    end
+
+    context 'when recruitment cycle year is 2024 or before and TDA is active' do
+      let(:recruitment_cycle_year) { 2024 }
+
+      before do
+        allow(FeatureService).to receive(:enabled?).with(:teacher_degree_apprenticeship).and_return(true)
+      end
+
+      it 'returns false' do
+        expect(provider.tda_active?).to be false
+      end
+    end
+
+    context 'when recruitment cycle year is after 2024 and TDA is not active' do
+      let(:recruitment_cycle_year) { 2025 }
+
+      before do
+        allow(FeatureService).to receive(:enabled?).with(:teacher_degree_apprenticeship).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(provider.tda_active?).to be false
+      end
+    end
+
+    context 'when recruitment cycle year is 2024 or before and TDA is not active' do
+      let(:recruitment_cycle_year) { 2024 }
+
+      before do
+        allow(FeatureService).to receive(:enabled?).with(:teacher_degree_apprenticeship).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(provider.tda_active?).to be false
+      end
+    end
+  end
+
   describe 'validations' do
     describe 'urn validations' do
       context 'when provider_type is lead_school' do


### PR DESCRIPTION
### Context

This PR defines the check we will be using for most of the TDA work.

### Changes proposed in this pull request

Add a helper method:
- To check for the next recruitment cycle
- To check for an Active TDA feature flag


### Guidance to review

Does the check cover what we need it to?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
