### PR TITLE
[1671] Add course flow TDA changes

### DIFF
--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -4,7 +4,6 @@ module Publish
   module Courses
     class OutcomeController < PublishController
       include CourseBasicDetailConcern
-      before_action :order_edit_options, only: %i[edit new]
 
       def new
         super
@@ -38,33 +37,8 @@ module Publish
 
       private
 
-      def order_edit_options
-        qualification_options = @course.edit_course_options[:qualifications]
-        @course.edit_course_options[:qualifications] = if @course.level == 'further_education'
-                                                         non_qts_qualifications(qualification_options)
-                                                       else
-                                                         qts_qualifications(qualification_options)
-                                                       end
-      end
-
       def current_step
         :outcome
-      end
-
-      def qts_qualifications(edit_options)
-        options = %w[pgce_with_qts qts pgde_with_qts]
-
-        raise 'Non QTS qualification options do not match' if edit_options.sort != options.sort
-
-        options
-      end
-
-      def non_qts_qualifications(edit_options)
-        options = %w[pgce pgde]
-
-        raise 'QTS qualification options do not match' if edit_options.sort != options.sort
-
-        options
       end
 
       def errors

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -412,6 +412,24 @@ class CourseDecorator < ApplicationDecorator
     subjects.map(&:subject_name).include?('Physical education')
   end
 
+  def cannot_change_funding_type?
+    is_published? || is_withdrawn? || teacher_degree_apprenticeship?
+  end
+
+  def cannot_change_study_mode?
+    is_withdrawn? || teacher_degree_apprenticeship?
+  end
+
+  def cannot_change_skilled_worker_visa?
+    is_withdrawn? || teacher_degree_apprenticeship?
+  end
+
+  def show_skilled_worker_visa_row?
+    school_direct_salaried_training_programme? ||
+      pg_teaching_apprenticeship? ||
+      teacher_degree_apprenticeship?
+  end
+
   private
 
   def not_on_find

--- a/app/models/concerns/courses/edit_options/qualification_concern.rb
+++ b/app/models/concerns/courses/edit_options/qualification_concern.rb
@@ -15,7 +15,21 @@ module Courses
 
         def qualifications_with_qts
           Course.qualifications.keys.select do |qualification|
-            qualification.include?('qts')
+            if tda_active?
+              qualification.include?('qts')
+            else
+              qualification.include?('qts') && qualification != 'undergraduate_degree_with_qts'
+            end
+          end
+        end
+
+        def qualifications_with_qts
+          Course.qualifications.keys.select do |qualification|
+            if tda_active?
+              qualification.include?('qts')
+            else
+              qualification.include?('qts') && qualification != 'undergraduate_degree_with_qts'
+            end
           end
         end
 

--- a/app/models/concerns/courses/edit_options/qualification_concern.rb
+++ b/app/models/concerns/courses/edit_options/qualification_concern.rb
@@ -14,23 +14,11 @@ module Courses
         end
 
         def qualifications_with_qts
-          Course.qualifications.keys.select do |qualification|
-            if tda_active?
-              qualification.include?('qts')
-            else
-              qualification.include?('qts') && qualification != 'undergraduate_degree_with_qts'
-            end
-          end
-        end
+          qts_list = Course.qualifications.keys.grep(/qts/)
 
-        def qualifications_with_qts
-          Course.qualifications.keys.select do |qualification|
-            if tda_active?
-              qualification.include?('qts')
-            else
-              qualification.include?('qts') && qualification != 'undergraduate_degree_with_qts'
-            end
-          end
+          return qts_list if tda_active?
+
+          qts_list - %w[undergraduate_degree_with_qts]
         end
 
         def qualifications_without_qts

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -203,7 +203,11 @@ module Publish
       when :can_sponsor_student_visa
         new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
       when :can_sponsor_skilled_worker_visa
-        new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
+        if course.undergraduate_degree_with_qts?
+          new_publish_provider_recruitment_cycle_courses_applications_open_path(path_params)
+        else
+          new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
+        end
       when :start_date
         new_publish_provider_recruitment_cycle_courses_start_date_path(path_params)
       when :age_range
@@ -223,7 +227,7 @@ module Publish
 
     def tda_path_params
       path_params.merge(
-        course: { funding_type: 'apprenticeship', study_mode: 'full_time' }
+        course: path_params[:course].merge({ funding_type: 'apprenticeship', study_mode: 'full_time' })
       )
     end
 

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -203,11 +203,7 @@ module Publish
       when :can_sponsor_student_visa
         new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
       when :can_sponsor_skilled_worker_visa
-        if course.undergraduate_degree_with_qts?
-          new_publish_provider_recruitment_cycle_courses_applications_open_path(path_params)
-        else
-          new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
-        end
+        new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
       when :start_date
         new_publish_provider_recruitment_cycle_courses_start_date_path(path_params)
       when :age_range
@@ -215,11 +211,7 @@ module Publish
       when :subjects
         new_publish_provider_recruitment_cycle_courses_subjects_path(path_params)
       when :funding_type
-        if course.undergraduate_degree_with_qts?
-          new_publish_provider_recruitment_cycle_courses_schools_path(tda_path_params)
-        else
-          new_publish_provider_recruitment_cycle_courses_funding_type_path(path_params)
-        end
+        new_publish_provider_recruitment_cycle_courses_funding_type_path(path_params)
       when :confirmation
         confirmation_publish_provider_recruitment_cycle_courses_path(path_params)
       end

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -217,12 +217,6 @@ module Publish
       end
     end
 
-    def tda_path_params
-      path_params.merge(
-        course: path_params[:course].merge({ funding_type: 'apprenticeship', study_mode: 'full_time' })
-      )
-    end
-
     def go_to_confirmation_params
       params[:goto_confirmation] || params.dig(:course, :goto_confirmation)
     end

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -211,10 +211,20 @@ module Publish
       when :subjects
         new_publish_provider_recruitment_cycle_courses_subjects_path(path_params)
       when :funding_type
-        new_publish_provider_recruitment_cycle_courses_funding_type_path(path_params)
+        if course.undergraduate_degree_with_qts?
+          new_publish_provider_recruitment_cycle_courses_schools_path(tda_path_params)
+        else
+          new_publish_provider_recruitment_cycle_courses_funding_type_path(path_params)
+        end
       when :confirmation
         confirmation_publish_provider_recruitment_cycle_courses_path(path_params)
       end
+    end
+
+    def tda_path_params
+      path_params.merge(
+        course: { funding_type: 'apprenticeship', study_mode: 'full_time' }
+      )
     end
 
     def go_to_confirmation_params

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -55,6 +55,7 @@ module WithQualifications
     def qualifications
       case qualification
       when 'qts' then [:qts]
+      when 'undergraduate_degree_with_qts' then %i[qts undergraduate_degree]
       when 'pgce_with_qts' then %i[qts pgce]
       when 'pgde_with_qts' then %i[qts pgde]
       when 'pgce' then [:pgce]
@@ -75,7 +76,7 @@ module WithQualifications
     def qualifications_description
       return '' unless qualifications
 
-      qualifications.map(&:upcase).sort.join(' with ')
+      I18n.t("qualifications.description.#{qualification}")
     end
 
     def full_qualification_descriptions

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -41,7 +41,7 @@ module WithQualifications
     # subjects this course was tagged to.
     #
     # Defined here: https://github.com/DFE-Digital/manage-courses-api/blob/master/src/ManageCourses.Domain/Models/CourseQualification.cs
-    enum qualification: { qts: 0, pgce_with_qts: 1, pgde_with_qts: 2, pgce: 3, pgde: 4 }
+    enum qualification: { qts: 0, pgce_with_qts: 1, pgde_with_qts: 2, pgce: 3, pgde: 4, undergraduate_degree_with_qts: 5 }
 
     # This field may seem like an unnecessary overhead when there is already a
     # database-backed `qualification` field. However it's misleading, from the

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -511,7 +511,7 @@ class Course < ApplicationRecord
 
     if school_direct_salaried_training_programme? || scitt_salaried_programme? || higher_education_salaried_programme?
       'salary'
-    elsif pg_teaching_apprenticeship?
+    elsif pg_teaching_apprenticeship? || teacher_degree_apprenticeship?
       'apprenticeship'
     else
       'fee'

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -85,7 +85,7 @@ class Course < ApplicationRecord
 
   belongs_to :provider
 
-  delegate :tda_active?, to: :provider
+  delegate :tda_active?, to: :provider, allow_nil: true
 
   belongs_to :accrediting_provider,
              ->(c) { where(recruitment_cycle: c.recruitment_cycle) },

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -35,7 +35,8 @@ class Course < ApplicationRecord
     school_direct_salaried_training_programme: 'SS',
     scitt_programme: 'SC',
     scitt_salaried_programme: 'SSC',
-    pg_teaching_apprenticeship: 'TA'
+    pg_teaching_apprenticeship: 'TA',
+    teacher_degree_apprenticeship: 'TDA'
   }
 
   enum study_mode: {

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -479,7 +479,7 @@ class Course < ApplicationRecord
 
   def program_type_description
     if school_direct_salaried_training_programme? then ' with salary'
-    elsif pg_teaching_apprenticeship? then ' teaching apprenticeship'
+    elsif pg_teaching_apprenticeship? || teacher_degree_apprenticeship? then ' teaching apprenticeship'
     else
       ''
     end

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -31,6 +31,14 @@ module Courses
       course.accrediting_provider = course.provider.accrediting_providers.first if course.provider.accredited_bodies.length == 1
       course.course_code = provider.next_available_course_code if next_available_course_code
 
+      if course.undergraduate_degree_with_qts?
+        course.funding_type = 'apprenticeship'
+        course.study_mode = 'full_time'
+        course.program_type = 'teacher_degree_apprenticeship'
+        course.can_sponsor_student_visa = false
+        course.can_sponsor_skilled_worker_visa = false
+      end
+
       AssignSubjectsService.call(course:, subject_ids:)
 
       course.valid?(:new)

--- a/app/services/workflow_step_service.rb
+++ b/app/services/workflow_step_service.rb
@@ -8,6 +8,8 @@ class WorkflowStepService
   end
 
   def call
+    return teacher_degree_apprenticeship_workflow_steps if course.undergraduate_degree_with_qts?
+
     if course.is_further_education?
       further_education_workflow_steps
     elsif course.is_school_direct?
@@ -20,6 +22,41 @@ class WorkflowStepService
   private
 
   attr_reader :course
+
+  def teacher_degree_apprenticeship_workflow_steps
+    if course.is_school_direct?
+      %i[
+        courses_list
+        level
+        subjects
+        engineers_teach_physics
+        modern_languages
+        age_range
+        outcome
+        school
+        study_site
+        accredited_provider
+        applications_open
+        start_date
+        confirmation
+      ]
+    elsif course.is_uni_or_scitt?
+      %i[
+        courses_list
+        level
+        subjects
+        engineers_teach_physics
+        modern_languages
+        age_range
+        outcome
+        school
+        study_site
+        applications_open
+        start_date
+        confirmation
+      ]
+    end
+  end
 
   def further_education_workflow_steps
     %i[

--- a/app/services/workflow_step_service.rb
+++ b/app/services/workflow_step_service.rb
@@ -23,39 +23,53 @@ class WorkflowStepService
 
   attr_reader :course
 
+  def teacher_degree_apprenticeship_school_direct_workflow_steps
+    %i[
+      courses_list
+      level
+      subjects
+      engineers_teach_physics
+      modern_languages
+      age_range
+      outcome
+      school
+      study_site
+      accredited_provider
+      applications_open
+      start_date
+      confirmation
+    ]
+  end
+
+  def teacher_degree_apprenticeship_scitt_workflow_steps
+    %i[
+      courses_list
+      level
+      subjects
+      engineers_teach_physics
+      modern_languages
+      age_range
+      outcome
+      school
+      study_site
+      applications_open
+      start_date
+      confirmation
+    ]
+  end
+
   def teacher_degree_apprenticeship_workflow_steps
     if course.is_school_direct?
-      %i[
-        courses_list
-        level
-        subjects
-        engineers_teach_physics
-        modern_languages
-        age_range
-        outcome
-        school
-        study_site
-        accredited_provider
-        applications_open
-        start_date
-        confirmation
-      ]
+      teacher_degree_apprenticeship_school_direct_workflow_steps - workflow_removed_steps
     elsif course.is_uni_or_scitt?
-      %i[
-        courses_list
-        level
-        subjects
-        engineers_teach_physics
-        modern_languages
-        age_range
-        outcome
-        school
-        study_site
-        applications_open
-        start_date
-        confirmation
-      ]
+      teacher_degree_apprenticeship_scitt_workflow_steps - workflow_removed_steps
     end
+  end
+
+  def workflow_removed_steps
+    return [] unless course.provider.accredited_bodies.length == 1
+
+    %i[accredited_provider]
   end
 
   def further_education_workflow_steps

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -75,7 +75,7 @@
      summary_list.with_row(html_attributes: { data: { qa: "course__funding" } }) do |row|
        row.with_key { "Funding type" }
        row.with_value { course.funding }
-       if course.is_published? || course.is_withdrawn?
+       if course.is_published? || course.is_withdrawn? || course.teacher_degree_apprenticeship?
          row.with_action
        else
          row.with_action(
@@ -88,7 +88,7 @@
      summary_list.with_row(html_attributes: { data: { qa: "course__study_mode" } }) do |row|
        row.with_key { "Full time or part time" }
        row.with_value { course.study_mode&.humanize }
-       if course.is_withdrawn?
+       if course.is_withdrawn? || course.teacher_degree_apprenticeship?
          row.with_action
        else
          row.with_action(
@@ -188,7 +188,7 @@
        summary_list.with_row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row|
          row.with_key { "Skilled Worker visas" }
          row.with_value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" }
-         if course.is_withdrawn?
+         if course.is_withdrawn? || course.teacher_degree_apprenticeship?
            row.with_action
          else
            row.with_action(

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -75,7 +75,8 @@
      summary_list.with_row(html_attributes: { data: { qa: "course__funding" } }) do |row|
        row.with_key { "Funding type" }
        row.with_value { course.funding }
-       if course.is_published? || course.is_withdrawn? || course.teacher_degree_apprenticeship?
+
+       if course.cannot_change_funding_type?
          row.with_action
        else
          row.with_action(
@@ -88,7 +89,8 @@
      summary_list.with_row(html_attributes: { data: { qa: "course__study_mode" } }) do |row|
        row.with_key { "Full time or part time" }
        row.with_value { course.study_mode&.humanize }
-       if course.is_withdrawn? || course.teacher_degree_apprenticeship?
+
+       if course.cannot_change_study_mode?
          row.with_action
        else
          row.with_action(
@@ -188,7 +190,7 @@
        summary_list.with_row(html_attributes: { data: { qa: "course__can_sponsor_skilled_worker_visa" } }) do |row|
          row.with_key { "Skilled Worker visas" }
          row.with_value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" }
-         if course.is_withdrawn? || course.teacher_degree_apprenticeship?
+         if course.cannot_change_skilled_worker_visa?
            row.with_action
          else
            row.with_action(

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -82,19 +82,23 @@
         <% summary_list.with_row(html_attributes: { data: { qa: "course__funding_type" } }) do |row| %>
           <% row.with_key { "Funding type" } %>
           <% row.with_value { course.funding } %>
-          <% row.with_action(
+          <% unless course.teacher_degree_apprenticeship?
+               row.with_action(
             href: new_publish_provider_recruitment_cycle_courses_funding_type_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_visa: true, goto_confirmation: true)),
             visually_hidden_text: "if funding type"
-          ) %>
+          )
+             end %>
         <% end %>
 
         <% summary_list.with_row(html_attributes: { data: { qa: "course__study_mode" } }) do |row| %>
           <% row.with_key { "Full time or part time" } %>
           <% row.with_value { course.study_mode&.humanize } %>
-          <% row.with_action(
+          <% unless course.teacher_degree_apprenticeship?
+               row.with_action(
             href: new_publish_provider_recruitment_cycle_courses_study_mode_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
             visually_hidden_text: "if full or part time"
-          ) %>
+          )
+             end %>
         <% end %>
 
         <% summary_list.with_row(html_attributes: { data: { qa: "course__schools" } }) do |row| %>
@@ -173,14 +177,16 @@
           <% end %>
         <% end %>
 
-        <% if course.school_direct_salaried_training_programme? || course.pg_teaching_apprenticeship? %>
+        <% if course.school_direct_salaried_training_programme? || course.pg_teaching_apprenticeship? || course.teacher_degree_apprenticeship? %>
           <% summary_list.with_row(html_attributes: { data: { qa: "course__skilled_worker_visa_sponsorship" } }) do |row| %>
             <% row.with_key { "Skilled Worker visas" } %>
             <% row.with_value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>
-            <% row.with_action(
+            <% unless course.teacher_degree_apprenticeship?
+                 row.with_action(
               href: new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
               visually_hidden_text: "skilled worker visa sponsorship"
-            ) %>
+            )
+               end %>
           <% end %>
         <% end %>
 

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -177,7 +177,7 @@
           <% end %>
         <% end %>
 
-        <% if course.school_direct_salaried_training_programme? || course.pg_teaching_apprenticeship? || course.teacher_degree_apprenticeship? %>
+        <% if course.show_skilled_worker_visa_row? %>
           <% summary_list.with_row(html_attributes: { data: { qa: "course__skilled_worker_visa_sponsorship" } }) do |row| %>
             <% row.with_key { "Skilled Worker visas" } %>
             <% row.with_value { course.can_sponsor_skilled_worker_visa ? "Yes - can sponsor " : "No - cannot sponsor" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,14 @@ en:
     training_partners: "Training partners"
     organisation_details: "Organisation details"
     accredited_provider: "Accredited providers"
+  qualifications:
+    description:
+      qts: QTS
+      undergraduate_degree_with_qts: Teacher degree apprenticeship with QTS
+      pgce_with_qts: PGCE with QTS
+      pgde_with_qts: PGDE with QTS
+      pgce: PGCE
+      pgde: PGDE
   edit_options:
     entry_requirements:
       must_have_qualification_at_application_time:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -942,6 +942,9 @@ en:
       pgde_with_qts:
         label: "PGDE with QTS"
         help: "Postgraduate diploma in education with qualified teacher status"
+      undergraduate_degree_with_qts:
+        label: "Teacher degree apprenticeship (TDA) with QTS"
+        help: "Teacher degree apprenticeship with qualified teacher status"
     age_range_in_years:
       other:
         label: "Another age range"

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -831,6 +831,132 @@ describe CourseDecorator do
   #   end
   # end
 
+  describe '#cannot_change_funding_type?' do
+    context 'when course is published' do
+      before { allow(course).to receive(:is_published?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.cannot_change_funding_type?).to be true
+      end
+    end
+
+    context 'when course is withdrawn' do
+      before { allow(course).to receive(:is_withdrawn?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.cannot_change_funding_type?).to be true
+      end
+    end
+
+    context 'when teacher degree apprenticeship' do
+      before { allow(course).to receive(:teacher_degree_apprenticeship?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.cannot_change_funding_type?).to be true
+      end
+    end
+
+    context 'none of the conditions are met' do
+      before do
+        allow(course).to receive_messages(is_published?: false, is_withdrawn?: false, teacher_degree_apprenticeship?: false)
+      end
+
+      it 'returns false' do
+        expect(decorated_course.cannot_change_funding_type?).to be false
+      end
+    end
+  end
+
+  describe '#cannot_change_study_mode?' do
+    context 'when course is withdrawn' do
+      before { allow(course).to receive(:is_withdrawn?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.cannot_change_study_mode?).to be true
+      end
+    end
+
+    context 'when course is teacher degree apprenticeship' do
+      before { allow(course).to receive(:teacher_degree_apprenticeship?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.cannot_change_study_mode?).to be true
+      end
+    end
+
+    context 'when none of the conditions are met' do
+      before do
+        allow(course).to receive_messages(is_withdrawn?: false, teacher_degree_apprenticeship?: false)
+      end
+
+      it 'returns false' do
+        expect(decorated_course.cannot_change_study_mode?).to be false
+      end
+    end
+  end
+
+  describe '#cannot_change_skilled_worker_visa?' do
+    context 'when withdrawn' do
+      before { allow(course).to receive(:is_withdrawn?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.cannot_change_skilled_worker_visa?).to be true
+      end
+    end
+
+    context 'when course is teacher degree apprenticeship' do
+      before { allow(course).to receive(:teacher_degree_apprenticeship?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.cannot_change_skilled_worker_visa?).to be true
+      end
+    end
+
+    context 'when none of the conditions are met' do
+      before { allow(course).to receive(:teacher_degree_apprenticeship?).and_return(true) }
+
+      it 'returns false' do
+        expect(decorated_course.cannot_change_skilled_worker_visa?).to be true
+      end
+    end
+  end
+
+  describe '#show_skilled_worker_visa_row?' do
+    context 'when course is a school direct salaried training programme' do
+      before { allow(course).to receive(:school_direct_salaried_training_programme?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.show_skilled_worker_visa_row?).to be true
+      end
+    end
+
+    context 'when course is a pg teaching apprenticeship' do
+      before { allow(course).to receive(:pg_teaching_apprenticeship?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.show_skilled_worker_visa_row?).to be true
+      end
+    end
+
+    context 'when course is a teacher degree apprenticeship' do
+      before { allow(course).to receive(:teacher_degree_apprenticeship?).and_return(true) }
+
+      it 'returns true' do
+        expect(decorated_course.show_skilled_worker_visa_row?).to be true
+      end
+    end
+
+    context 'when none of the conditions are met' do
+      before do
+        allow(course).to receive_messages(school_direct_salaried_training_programme?: false, pg_teaching_apprenticeship?: false, teacher_degree_apprenticeship?: false)
+      end
+
+      it 'returns false' do
+        expect(decorated_course.show_skilled_worker_visa_row?).to be false
+      end
+    end
+  end
+
   describe '#financial_incentive_details' do
     subject { course.decorate.financial_incentive_details }
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -171,6 +171,10 @@ FactoryBot.define do
       program_type { :pg_teaching_apprenticeship }
     end
 
+    trait :with_teacher_degree_apprenticeship do
+      program_type { :teacher_degree_apprenticeship }
+    end
+
     trait :with_salary do
       program_type { :school_direct_salaried_training_programme }
     end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -143,6 +143,10 @@ FactoryBot.define do
       qualification { :pgde }
     end
 
+    trait :resulting_in_undergraduate_degree_with_qts do
+      qualification { :undergraduate_degree_with_qts }
+    end
+
     trait :self_accredited do
       association(:provider, factory: %i[provider accredited_provider])
     end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -26,7 +26,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     then_i_am_on_the_add_applications_open_date_page
 
     when_i_choose_the_applications_open_date
-    and_i_choose_the_course_start_date
+    and_i_choose_the_first_start_date
     then_i_am_on_the_check_your_answers_page
 
     when_i_click_on_add_a_course
@@ -34,17 +34,31 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_the_tda_defaults_are_saved
   end
 
-  # scenario 'changing from tda to non tda on check your answers page' do
-  # end
 
-  # scenario 'changing from non tda to tda on check your answers page' do
-  # end
+  scenario 'when choosing primary course' do
+    when_i_visit_the_courses_page
+    and_i_click_on_add_course
+    and_i_choose_a_primary_course
+    and_i_choose_a_primary_age_range
+    then_i_see_the_degree_awarding_option
 
-  # scenario 'when choosing a further education course' do
-  # end
+    when_i_choose_a_degree_awarding_qualification
+    # We skip the pages for the TDA: funding type, part-time/full time
+    then_i_am_on_the_choose_schools_page
 
-  # scenario 'when choosing primary course' do
-  # end
+    when_i_choose_the_school
+    and_i_choose_the_study_site
+    # We skip the visa sponsorship question
+    then_i_am_on_the_add_applications_open_date_page
+
+    when_i_choose_the_applications_open_date
+    and_i_choose_the_first_start_date
+    then_i_am_on_the_check_your_answers_page
+
+    when_i_click_on_add_a_course
+    then_the_tda_course_is_created
+    and_the_tda_defaults_are_saved
+  end
 
   def given_i_am_authenticated_as_a_provider_user
     @user = create(
@@ -79,6 +93,13 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_i_click_continue
   end
 
+  def and_i_choose_a_primary_course
+    choose 'Primary'
+    and_i_click_continue
+    choose 'Primary with English'
+    and_i_click_continue
+  end
+
   def and_i_select_a_subject
     select 'Dance', from: 'First subject'
     and_i_click_continue
@@ -86,6 +107,11 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def and_i_choose_an_age_range
     choose '14 to 19'
+    and_i_click_continue
+  end
+
+  def and_i_choose_a_primary_age_range
+    choose '3 to 7'
     and_i_click_continue
   end
 
@@ -126,17 +152,26 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def when_i_choose_the_applications_open_date
-    first('input[name="course[applications_open_from]"]').set(true)
+    first('input.govuk-radios__input').set(true)
     and_i_click_continue
   end
 
-  def and_i_choose_the_course_start_date; end
+  def and_i_choose_the_first_start_date
+    first('input.govuk-radios__input').set(true)
+    and_i_click_continue
+  end
 
-  def then_i_am_on_the_check_your_answers_page; end
+  def then_i_am_on_the_check_your_answers_page
+    expect(page).to have_current_path(confirmation_publish_provider_recruitment_cycle_courses_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+  end
 
-  def when_i_click_on_add_a_course; end
+  def when_i_click_on_add_a_course
+    click_on 'Add course'
+  end
 
-  def then_the_tda_course_is_created; end
+  def then_the_tda_course_is_created
+    expect(provider.courses.first.undergraduate_degree_with_qts?).to be(true)
+  end
 
   def and_the_tda_defaults_are_saved; end
 

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -126,7 +126,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def when_i_choose_the_applications_open_date
-    choose 'As soon as the course is on Find - recommended'
+    first('input[name="course[applications_open_from]"]').set(true)
     and_i_click_continue
   end
 

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -140,11 +140,13 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def and_i_choose_a_secondary_course
     choose 'Secondary'
+    and_i_select_no_send
     and_i_click_continue
   end
 
   def and_i_choose_a_primary_course
     choose 'Primary'
+    and_i_select_no_send
     and_i_click_continue
     choose 'Primary with English'
     and_i_click_continue
@@ -260,6 +262,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     expect(course.funding_type).to eq('apprenticeship')
     expect(course.can_sponsor_student_visa?).to be false
     expect(course.can_sponsor_skilled_worker_visa?).to be false
+  end
+
+  def and_i_select_no_send
+    publish_courses_new_level_page.send_fields.is_send_false.click
   end
 
   def provider

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -107,8 +107,32 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def then_i_am_on_the_choose_schools_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/2025/courses/funding-type/new?course%5Bage_range_in_years%5D=14_to_19&course%5Bcampaign_name%5D=&course%5Bis_send%5D=0&course%5Blevel%5D=secondary&course%5Bmaster_subject_id%5D=17&course%5Bqualification%5D=undergraduate_degree_with_qts&course%5Bsubjects_ids%5D%5B%5D=17")
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
   end
+
+  def when_i_choose_the_school
+    check provider.sites.first.location_name
+    and_i_click_continue
+  end
+
+  def then_i_am_on_the_add_applications_open_date_page
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+  end
+
+  def when_i_choose_the_applications_open_date
+    choose 'As soon as the course is on Find - recommended'
+    and_i_click_continue
+  end
+
+  def and_i_choose_the_course_start_date; end
+
+  def then_i_am_on_the_check_your_answers_page; end
+
+  def when_i_click_on_add_a_course; end
+
+  def then_the_tda_course_is_created; end
+
+  def and_the_tda_defaults_are_saved; end
 
   def provider
     @user.providers.first

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -101,6 +101,15 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     )
   end
 
+  def when_i_choose_a_degree_awarding_qualification
+    choose 'Teacher degree apprenticeship (TDA) with QTS'
+    and_i_click_continue
+  end
+
+  def then_i_am_on_the_choose_schools_page
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/2025/courses/funding-type/new?course%5Bage_range_in_years%5D=14_to_19&course%5Bcampaign_name%5D=&course%5Bis_send%5D=0&course%5Blevel%5D=secondary&course%5Bmaster_subject_id%5D=17&course%5Bqualification%5D=undergraduate_degree_with_qts&course%5Bsubjects_ids%5D%5B%5D=17")
+  end
+
   def provider
     @user.providers.first
   end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_next_cycles do
   before do
     given_i_am_authenticated_as_a_provider_user
+    and_the_tda_feature_flag_is_active
   end
 
   scenario 'creating a degree awarding course' do
@@ -32,17 +33,17 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_the_tda_defaults_are_saved
   end
 
-  scenario 'changing from tda to non tda on check your answers page' do
-  end
+  # scenario 'changing from tda to non tda on check your answers page' do
+  # end
 
-  scenario 'changing from non tda to tda on check your answers page' do
-  end
+  # scenario 'changing from non tda to tda on check your answers page' do
+  # end
 
-  scenario 'when choosing a further education course' do
-  end
+  # scenario 'when choosing a further education course' do
+  # end
 
-  scenario 'when choosing primary course' do
-  end
+  # scenario 'when choosing primary course' do
+  # end
 
   def given_i_am_authenticated_as_a_provider_user
     @user = create(
@@ -54,6 +55,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     given_i_am_authenticated(
       user: @user
     )
+  end
+
+  def and_the_tda_feature_flag_is_active
+    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   def when_i_visit_the_courses_page

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_next_cycles do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario 'creating a degree awarding course' do
+    when_i_visit_the_courses_page
+    and_i_click_on_add_course
+    and_i_choose_a_secondary_course
+    and_i_select_a_subject
+    and_i_choose_an_age_range
+    then_i_see_the_degree_awarding_option
+
+    when_i_choose_a_degree_awarding_qualification
+    # We skip the pages for the TDA: funding type, part-time/full time
+    then_i_am_on_the_choose_schools_page
+
+    when_i_choose_the_school
+    # We skip the visa sponsorship question
+    then_i_am_on_the_add_applications_open_date_page
+
+    when_i_choose_the_applications_open_date
+    and_i_choose_the_course_start_date
+    then_i_am_on_the_check_your_answers_page
+
+    when_i_click_on_add_a_course
+    then_the_tda_course_is_created
+    and_the_tda_defaults_are_saved
+  end
+
+  scenario 'changing from tda to non tda on check your answers page' do
+  end
+
+  scenario 'changing from non tda to tda on check your answers page' do
+  end
+
+  scenario 'when choosing a further education course' do
+  end
+
+  scenario 'when choosing primary course' do
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    @user = create(
+      :user,
+      providers: [
+        create(:provider, :accredited_provider, recruitment_cycle: build(:recruitment_cycle, year: 2025), sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
+      ]
+    )
+    given_i_am_authenticated(
+      user: @user
+    )
+  end
+
+  def when_i_visit_the_courses_page
+    publish_provider_courses_index_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year
+    )
+  end
+
+  def and_i_click_on_add_course
+    click_on 'Add course'
+    and_i_click_continue
+  end
+
+  def and_i_choose_a_secondary_course
+    choose 'Secondary'
+    and_i_click_continue
+  end
+
+  def and_i_select_a_subject
+    select 'Dance', from: 'First subject'
+    and_i_click_continue
+  end
+
+  def and_i_choose_an_age_range
+    choose '14 to 19'
+    and_i_click_continue
+  end
+
+  def and_i_click_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_degree_awarding_option
+    expect(
+      publish_courses_new_outcome_page.qualification_fields.has_undergraduate_degree_with_qts?
+    ).to be true
+    expect(publish_courses_new_outcome_page.qualification_fields.text).to include(
+      'Teacher degree apprenticeship (TDA) with QTS'
+    )
+  end
+
+  def provider
+    @user.providers.first
+  end
+end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -29,6 +29,9 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     when_i_choose_the_applications_open_date
     and_i_choose_the_first_start_date
     then_i_am_on_the_check_your_answers_page
+    and_i_can_not_change_funding_type
+    and_i_can_not_change_study_mode
+    and_i_can_not_change_visa_requirements
 
     when_i_click_on_add_a_course
     then_the_tda_course_is_created
@@ -212,6 +215,36 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def then_i_am_on_the_check_your_answers_page
     expect(page).to have_current_path(confirmation_publish_provider_recruitment_cycle_courses_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+  end
+
+  def and_i_can_not_change_funding_type
+    expect(
+      publish_course_confirmation_page.details.funding_type.value.text
+    ).to eq('Teaching apprenticeship - with salary')
+
+    expect(
+      publish_course_confirmation_page.details.funding_type.text
+    ).not_to include('Change')
+  end
+
+  def and_i_can_not_change_study_mode
+    expect(
+      publish_course_confirmation_page.details.study_mode.value.text
+    ).to eq('Full time')
+
+    expect(
+      publish_course_confirmation_page.details.study_mode.text
+    ).not_to include('Change')
+  end
+
+  def and_i_can_not_change_visa_requirements
+    expect(
+      publish_course_confirmation_page.details.skilled_visa_requirements.value.text
+    ).to eq('No - cannot sponsor')
+
+    expect(
+      publish_course_confirmation_page.details.skilled_visa_requirements.text
+    ).not_to include('Change')
   end
 
   def when_i_click_on_add_a_course

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -14,6 +14,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     then_i_see_the_degree_awarding_option
 
     when_i_choose_a_degree_awarding_qualification
+
     # We skip the pages for the TDA: funding type, part-time/full time
     then_i_am_on_the_choose_schools_page
 
@@ -91,7 +92,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def given_i_am_authenticated_as_a_school_direct_provider_user
     recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site)])])
+    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     @accredited_provider = create(:provider, :accredited_provider, recruitment_cycle:)
     @provider.accrediting_provider_enrichments = []

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -21,6 +21,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     then_i_am_on_the_choose_schools_page
 
     when_i_choose_the_school
+    and_i_choose_the_study_site
     # We skip the visa sponsorship question
     then_i_am_on_the_add_applications_open_date_page
 
@@ -112,6 +113,11 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def when_i_choose_the_school
     check provider.sites.first.location_name
+    and_i_click_continue
+  end
+
+  def and_i_choose_the_study_site
+    check provider.study_sites.first.location_name
     and_i_click_continue
   end
 

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -21,8 +21,6 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     when_i_choose_the_school
     and_i_choose_the_study_site
 
-    then_i_am_on_the_accreddited_provider_page
-
     # We skip the visa sponsorship question
     then_i_am_on_the_add_applications_open_date_page
 
@@ -32,10 +30,14 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_i_can_not_change_funding_type
     and_i_can_not_change_study_mode
     and_i_can_not_change_visa_requirements
+    then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship
 
     when_i_click_on_add_a_course
     then_the_tda_course_is_created
     and_the_tda_defaults_are_saved
+
+    when_i_click_on_the_course_i_created
+    then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
   end
 
   scenario 'creating a degree awarding course from scitt provider' do
@@ -60,10 +62,14 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     when_i_choose_the_applications_open_date
     and_i_choose_the_first_start_date
     then_i_am_on_the_check_your_answers_page
+    and_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship
 
     when_i_click_on_add_a_course
     then_the_tda_course_is_created
     and_the_tda_defaults_are_saved
+
+    when_i_click_on_the_course_i_created
+    then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
   end
 
   scenario 'when choosing primary course' do
@@ -87,10 +93,14 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     when_i_choose_the_applications_open_date
     and_i_choose_the_first_start_date
     then_i_am_on_the_check_your_answers_page
+    and_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship
 
     when_i_click_on_add_a_course
     then_the_tda_course_is_created
     and_the_tda_defaults_are_saved
+
+    when_i_click_on_the_course_i_created
+    then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
   end
 
   def given_i_am_authenticated_as_a_school_direct_provider_user
@@ -199,8 +209,6 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_i_click_continue
   end
 
-  def then_i_am_on_the_accreddited_provider_page; end
-
   def then_i_am_on_the_add_applications_open_date_page
     expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
   end
@@ -268,6 +276,39 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     publish_courses_new_level_page.send_fields.is_send_false.click
   end
 
+  def then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship
+    within('[data-qa="course__study_mode"]') do
+      expect(page).to have_no_link('Change')
+    end
+
+    within('[data-qa="course__funding_type"]') do
+      expect(page).to have_no_link('Change')
+    end
+
+    within('[data-qa="course__skilled_worker_visa_sponsorship"]') do
+      expect(page).to have_no_link('Change')
+    end
+  end
+
+  def then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
+    within('[data-qa="course__study_mode"]') do
+      expect(page).to have_no_link('Change')
+    end
+
+    within('[data-qa="course__funding"]') do
+      expect(page).to have_no_link('Change')
+    end
+
+    within('[data-qa="course__can_sponsor_skilled_worker_visa"]') do
+      expect(page).to have_no_link('Change')
+    end
+  end
+
+  def when_i_click_on_the_course_i_created
+    click_on course_name_and_code
+    click_on 'Basic details'
+  end
+
   def provider
     @user.providers.first
   end
@@ -275,4 +316,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   def course
     provider.courses.last
   end
+
+  def course_name_and_code
+    course.decorate.name_and_code
+  end
+
+  alias_method :and_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship, :then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship
 end

--- a/spec/features/publish/courses/new_tda_course_with_feature_flag_off_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_with_feature_flag_off_spec.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-# When we delete the TDA feature flag this file can also be deleted

--- a/spec/features/publish/courses/new_tda_course_with_feature_flag_off_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_with_feature_flag_off_spec.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# When we delete the TDA feature flag this file can also be deleted

--- a/spec/models/concerns/courses/edit_options/qualification_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/qualification_concern_spec.rb
@@ -7,6 +7,8 @@ describe Courses::EditOptions::QualificationConcern do
     klass = Class.new do
       include Courses::EditOptions::QualificationConcern
       attr_accessor :level
+
+      def tda_active?; end
     end
 
     klass.new
@@ -33,6 +35,18 @@ describe Courses::EditOptions::QualificationConcern do
       example_model.qualification_options.each do |q|
         expect(q).not_to include('qts')
       end
+    end
+  end
+
+  context 'for a teacher degree apprenticeship course' do
+    let(:level_value) { 'secondary' }
+
+    before do
+      allow(example_model).to receive(:tda_active?).and_return true
+    end
+
+    it 'returns a teacher degree apprenticeship' do
+      expect(example_model.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts undergraduate_degree_with_qts])
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1956,7 +1956,7 @@ describe Course do
         study_mode: :full_time,
         program_type: :teacher_degree_apprenticeship,
         qualification: :undergraduate_degree_with_qts
-      },
+      }
     }.freeze
 
     specs.each do |expected_description, course_attributes|
@@ -2923,14 +2923,14 @@ describe Course do
   describe '#funding_type' do
     context 'when program_type is nil' do
       it 'returns nil' do
-        course = Course.new(program_type: nil)
+        course = described_class.new(program_type: nil)
         expect(course.funding_type).to be_nil
       end
     end
 
     context 'when program_type is higher_education_salaried_programme' do
       it 'returns salary' do
-        course = Course.new(program_type: :higher_education_salaried_programme)
+        course = described_class.new(program_type: :higher_education_salaried_programme)
         expect(course.funding_type).to eq('salary')
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1951,7 +1951,12 @@ describe Course do
         study_mode: :full_time,
         program_type: :school_direct_salaried_training_programme,
         qualification: :pgce_with_qts
-      }
+      },
+      'Teacher degree apprenticeship with QTS full time teaching apprenticeship' => {
+        study_mode: :full_time,
+        program_type: :teacher_degree_apprenticeship,
+        qualification: :undergraduate_degree_with_qts
+      },
     }.freeze
 
     specs.each do |expected_description, course_attributes|

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2914,4 +2914,34 @@ describe Course do
       end
     end
   end
+
+  describe '#funding_type' do
+    context 'when program_type is nil' do
+      it 'returns nil' do
+        course = Course.new(program_type: nil)
+        expect(course.funding_type).to be_nil
+      end
+    end
+
+    context 'when program_type is higher_education_salaried_programme' do
+      it 'returns salary' do
+        course = Course.new(program_type: :higher_education_salaried_programme)
+        expect(course.funding_type).to eq('salary')
+      end
+    end
+
+    context 'when program_type is teacher_degree_apprenticeship' do
+      it 'returns apprenticeship' do
+        course = build(:course, :with_teacher_degree_apprenticeship)
+        expect(course.funding_type).to eq('apprenticeship')
+      end
+    end
+
+    context 'when program_type is pg_teaching_apprenticeship' do
+      it 'returns apprenticeship' do
+        course = build(:course, :with_apprenticeship)
+        expect(course.funding_type).to eq('apprenticeship')
+      end
+    end
+  end
 end

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -92,12 +92,12 @@ describe 'GET /reporting' do
           open: {
             higher_education_programme: 0, higher_education_salaried_programme: 0,
             school_direct_training_programme: 0, school_direct_salaried_training_programme: 0, scitt_programme: 0,
-            scitt_salaried_programme: 0, pg_teaching_apprenticeship: 0
+            scitt_salaried_programme: 0, pg_teaching_apprenticeship: 0, teacher_degree_apprenticeship: 0
           },
           closed: {
             higher_education_programme: 0, higher_education_salaried_programme: 0,
             school_direct_training_programme: 0, school_direct_salaried_training_programme: 0, scitt_programme: 0,
-            scitt_salaried_programme: 0, pg_teaching_apprenticeship: 0
+            scitt_salaried_programme: 0, pg_teaching_apprenticeship: 0, teacher_degree_apprenticeship: 0
           }
         },
         study_mode: {

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -106,10 +106,10 @@ describe 'GET /reporting' do
         },
         qualification: {
           open: {
-            qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+            qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0, undergraduate_degree_with_qts: 0
           },
           closed: {
-            qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+            qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0, undergraduate_degree_with_qts: 0
           }
         },
         is_send: {

--- a/spec/services/course_reporting_service_spec.rb
+++ b/spec/services/course_reporting_service_spec.rb
@@ -70,10 +70,10 @@ describe CourseReportingService do
       },
       qualification: {
         open: {
-          qts: 1, pgce_with_qts: 2, pgde_with_qts: 3, pgce: 4, pgde: 5
+          qts: 1, pgce_with_qts: 2, pgde_with_qts: 3, pgce: 4, pgde: 5, undergraduate_degree_with_qts: 6
         },
         closed: {
-          qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+          qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0, undergraduate_degree_with_qts: 0
         }
       },
       is_send: {
@@ -135,7 +135,7 @@ describe CourseReportingService do
         expect(open_courses_scope).to receive(:group).with(:qualification).and_return(open_courses_qualification_scope)
         expect(open_courses_qualification_scope).to receive(:count)
           .and_return(
-            { 'qts' => 1, 'pgce_with_qts' => 2, 'pgde_with_qts' => 3, 'pgce' => 4, 'pgde' => 5 }
+            { 'qts' => 1, 'pgce_with_qts' => 2, 'pgde_with_qts' => 3, 'pgce' => 4, 'pgde' => 5, 'undergraduate_degree_with_qts' => 6 }
           )
 
         expect(open_courses_scope).to receive(:group).with(:is_send).and_return(open_courses_is_send_scope)

--- a/spec/services/course_reporting_service_spec.rb
+++ b/spec/services/course_reporting_service_spec.rb
@@ -56,12 +56,14 @@ describe CourseReportingService do
           higher_education_salaried_programme: 0,
           school_direct_salaried_training_programme: 3, scitt_programme: 4,
           scitt_salaried_programme: 0,
-          pg_teaching_apprenticeship: 5
+          pg_teaching_apprenticeship: 5,
+          teacher_degree_apprenticeship: 0
         },
         closed: {
           higher_education_programme: 0, higher_education_salaried_programme: 0, school_direct_training_programme: 0,
           school_direct_salaried_training_programme: 0, scitt_programme: 0, scitt_salaried_programme: 0,
-          pg_teaching_apprenticeship: 0
+          pg_teaching_apprenticeship: 0,
+          teacher_degree_apprenticeship: 0
         }
       },
       study_mode: {

--- a/spec/services/workflow_step_service_spec.rb
+++ b/spec/services/workflow_step_service_spec.rb
@@ -78,6 +78,96 @@ describe WorkflowStepService do
     end
   end
 
+  context 'when school direct and teacher degree apprenticeship' do
+    context 'when more than one accredited provider' do
+      let(:provider) do
+        build(
+          :provider,
+          accrediting_provider_enrichments:
+        )
+      end
+      let(:course) { create(:course, :resulting_in_undergraduate_degree_with_qts, provider:) }
+      let(:accrediting_provider_enrichments) { [{ 'Description' => 'Something great about the accredited provider', 'UcasProviderCode' => accredited_provider.provider_code }, { 'Description' => 'some description', 'UcasProviderCode' => second_accredited_provider.provider_code }] }
+      let(:accredited_provider) { build(:provider, :accredited_provider) }
+      let(:second_accredited_provider) { build(:provider, :accredited_provider) }
+
+      it 'adds accredited provider step' do
+        expected_steps = %i[
+          courses_list
+          level
+          subjects
+          engineers_teach_physics
+          modern_languages
+          age_range
+          outcome
+          school
+          study_site
+          accredited_provider
+          applications_open
+          start_date
+          confirmation
+        ]
+
+        expect(subject).to eq(expected_steps)
+      end
+    end
+
+    context 'when only one accredited provider' do
+      let(:provider) do
+        build(
+          :provider,
+          accrediting_provider_enrichments:
+        )
+      end
+      let(:course) { create(:course, :resulting_in_undergraduate_degree_with_qts, accrediting_provider: accredited_provider, provider:) }
+      let(:accrediting_provider_enrichments) { [{ 'Description' => 'Something great about the accredited provider', 'UcasProviderCode' => accredited_provider.provider_code }] }
+      let(:accredited_provider) { build(:provider, :accredited_provider) }
+
+      it 'removes accredited provider step' do
+        expected_steps = %i[
+          courses_list
+          level
+          subjects
+          engineers_teach_physics
+          modern_languages
+          age_range
+          outcome
+          school
+          study_site
+          applications_open
+          start_date
+          confirmation
+        ]
+
+        expect(subject).to eq(expected_steps)
+      end
+    end
+  end
+
+  context 'when scitt and teacher degree apprenticeship' do
+    let(:provider) { create(:provider, :scitt, :accredited_provider) }
+    let(:course) { create(:course, :resulting_in_undergraduate_degree_with_qts, provider:) }
+
+    it 'returns workflow steps' do
+      expected_steps = %i[
+        courses_list
+        level
+        subjects
+        engineers_teach_physics
+        modern_languages
+        age_range
+        outcome
+        school
+        study_site
+        applications_open
+        start_date
+        confirmation
+      ]
+
+      expect(subject).to eq(expected_steps)
+    end
+  end
+
   context 'when course.is_further_education?' do
     let(:provider) { create(:provider, :accredited_provider) }
 

--- a/spec/support/page_objects/publish/course_confirmation.rb
+++ b/spec/support/page_objects/publish/course_confirmation.rb
@@ -29,6 +29,7 @@ module PageObjects
         section :start_date, SummaryList, '[data-qa=course__start_date]'
         section :name, SummaryList, '[data-qa=course__name]'
         section :entry_requirements, SummaryList, '[data-qa=course__entry_requirements]'
+        section :skilled_visa_requirements, SummaryList, '[data-qa=course__skilled_worker_visa_sponsorship]'
       end
 
       element :save_button, '[data-qa=course__save]'

--- a/spec/support/page_objects/publish/courses/new_outcome.rb
+++ b/spec/support/page_objects/publish/courses/new_outcome.rb
@@ -11,6 +11,7 @@ module PageObjects
           element :pgce, '#course_qualification_pgce'
           element :pgce_with_qts, '#course_qualification_pgce_with_qts'
           element :pgde_with_qts, '#course_qualification_pgde_with_qts'
+          element :undergraduate_degree_with_qts, '#course_qualification_undergraduate_degree_with_qts'
         end
 
         element :continue, '[data-qa="course__save"]'


### PR DESCRIPTION
### Context

We are now in a position to start building the TDA functionality for Publish. See the Trello card for what is in scope for this PR.

This PR deals with the add course logic changes to the add course multi step form.

<img width="908" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/5b3b4b6c-4a01-4e34-99e6-62fdca76146e">


### Changes proposed in this pull request

- Add a new qualification for TDA
- Incorporate the new qualification in the Add course flow
- Skip questions and set defaults if the course is TDA (study mode, visa sponsorship and funding type)
- Remove change links on the Add course flow summary page for the above questions if the course is TDA

### Guidance to review

If you want to pull this down locally and review it on the UI, you have two options. 

1) You can rollover your local machine

2) you can turn the `teacher_degree_apprenticeship` feature flag on locally in `development.local.yml` and change your `current_recruitment_cycle_year` to `2025`. 

After doing one of the two options above, you should then be able to create a new course and see the `Teacher degree apprenticeship (TDA) with QTS` option under qualifications.

## Trello card

https://trello.com/c/fFK6beK0/1671-add-course-flow-tda-changes?filter=label:Squad%20B,label:Squad%20Unassigned