### PR TITLE
[1567] full-time part-time study change from radio buttons to checkboxes

### DIFF
--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -41,7 +41,7 @@ module Publish
       end
 
       def errors
-        params.dig(:course, :study_mode) ? {} : { study_mode: ['Select full time or part time'] }
+        params.dig(:course, :study_mode) ? {} : { study_mode: [I18n.t('activemodel.errors.models.publish/course_study_mode_form.attributes.study_mode.blank')] }
       end
     end
   end

--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -16,7 +16,7 @@ module Publish
 
         @course_study_mode_form = CourseStudyModeForm.new(@course, params: study_mode_params)
         if @course_study_mode_form.save!
-          course_updated_message('Full time or part time')
+          course_updated_message I18n.t('publish.providers.study_mode.form.study_pattern')
 
           redirect_to details_publish_provider_recruitment_cycle_course_path(
             provider.provider_code,
@@ -33,7 +33,7 @@ module Publish
       def study_mode_params
         return { study_mode: nil } if params[:publish_course_study_mode_form].blank?
 
-        params.require(:publish_course_study_mode_form).permit(*CourseStudyModeForm::FIELDS)
+        params.require(:publish_course_study_mode_form).permit(study_mode: [])
       end
 
       def current_step

--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -95,6 +95,7 @@ module Publish
         params.require(:course)
               .permit(
                 policy(Course.new).permitted_new_course_attributes,
+                study_mode: [],
                 sites_ids: [],
                 subjects_ids: [],
                 study_sites_ids: []

--- a/app/forms/publish/course_study_mode_form.rb
+++ b/app/forms/publish/course_study_mode_form.rb
@@ -12,6 +12,12 @@ module Publish
               presence: true,
               inclusion: { in: Course.study_modes.keys }
 
+    def study_mode_checked?(value)
+      mode = study_mode.nil? ? model.study_mode : study_mode
+
+      mode == value || mode == 'full_time_or_part_time'
+    end
+
     private
 
     def valid_before_save
@@ -19,7 +25,7 @@ module Publish
     end
 
     def compute_fields
-      course.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+      { study_mode: new_attributes[:study_mode]&.compact_blank&.sort&.join('_or_') }
     end
   end
 end

--- a/app/models/concerns/courses/edit_options/study_mode_concern.rb
+++ b/app/models/concerns/courses/edit_options/study_mode_concern.rb
@@ -6,7 +6,7 @@ module Courses
       extend ActiveSupport::Concern
       included do
         def study_mode_options
-          Course.study_modes.keys
+          %w[full_time part_time]
         end
       end
     end

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -95,6 +95,7 @@ module Publish
                 :language_ids
               ).permit(
                 policy(Course.new).permitted_new_course_attributes,
+                study_mode: [],
                 sites_ids: [],
                 subjects_ids: [],
                 study_sites_ids: []

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -87,7 +87,7 @@
      end
 
      summary_list.with_row(html_attributes: { data: { qa: "course__study_mode" } }) do |row|
-       row.with_key { "Full time or part time" }
+       row.with_key { t("publish.providers.study_mode.form.study_pattern") }
        row.with_value { course.study_mode&.humanize }
 
        if course.cannot_change_study_mode?

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -91,7 +91,7 @@
         <% end %>
 
         <% summary_list.with_row(html_attributes: { data: { qa: "course__study_mode" } }) do |row| %>
-          <% row.with_key { "Full time or part time" } %>
+          <% row.with_key { t("publish.providers.study_mode.form.study_pattern") } %>
           <% row.with_value { course.study_mode&.humanize } %>
           <% unless course.teacher_degree_apprenticeship?
                row.with_action(

--- a/app/views/publish/courses/study_mode/_form_fields.html.erb
+++ b/app/views/publish/courses/study_mode/_form_fields.html.erb
@@ -12,13 +12,12 @@
 
     <%= render "publish/shared/error_messages", error_keys: [:study_mode] %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-      <% @course.edit_course_options["study_modes"].each_with_index do |value, index| %>
+      <% @course.edit_course_options["study_modes"].each do |value| %>
         <div class="govuk-checkboxes__item">
           <%= form.govuk_check_box :study_mode,
                                    value,
                                    label: { text: t("edit_options.study_modes.#{value}.label") },
-                                   checked: course.study_mode.in?([value, "full_time_or_part_time"]),
-                                   link_errors: index.zero? %>
+                                   checked: course.study_mode.in?([value, "full_time_or_part_time"]) %>
         </div>
       <% end %>
     </div>

--- a/app/views/publish/courses/study_mode/_form_fields.html.erb
+++ b/app/views/publish/courses/study_mode/_form_fields.html.erb
@@ -3,21 +3,22 @@
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
         <%= render CaptionText.new(text: t("course.add_course")) %>
-        Full time or part time
+        <%= t("publish.providers.study_mode.form.study_pattern") %>
       </h1>
     </legend>
+    <div class="govuk-hint" id="study-pattern-hint">
+      <%= t("publish.providers.study_mode.form.select_all_that_apply") %>
+    </div>
 
     <%= render "publish/shared/error_messages", error_keys: [:study_mode] %>
-    <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios">
-      <% @course.edit_course_options["study_modes"].each do |value| %>
-        <div class="govuk-radios__item">
-          <%= form.radio_button :study_mode,
-                  value,
-                  class: "govuk-radios__input" %>
-          <%= form.label :study_mode,
-                  t("edit_options.study_modes.#{value}.label"),
-                  value:,
-                  class: "govuk-label govuk-radios__label" %>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <% @course.edit_course_options["study_modes"].each_with_index do |value, index| %>
+        <div class="govuk-checkboxes__item">
+          <%= form.govuk_check_box :study_mode,
+                                   value,
+                                   label: { text: t("edit_options.study_modes.#{value}.label") },
+                                   checked: course.study_mode.in?([value, "full_time_or_part_time"]),
+                                   link_errors: index.zero? %>
         </div>
       <% end %>
     </div>

--- a/app/views/publish/courses/study_mode/edit.html.erb
+++ b/app/views/publish/courses/study_mode/edit.html.erb
@@ -26,14 +26,18 @@
 
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:study_mode, legend: { text: "#{render CaptionText.new(text: course.name_and_code)} Full time or part time?".html_safe, tag: "h1", size: "l" }) do %>
-        <% course.edit_course_options["study_modes"].each_with_index do |study_mode, index| %>
-          <%= f.govuk_radio_button(
-            :study_mode,
-            study_mode,
-            label: { text: t("edit_options.study_modes.#{study_mode}.label") },
-            link_errors: index.zero?
-          ) %>
+      <%= f.govuk_check_boxes_fieldset :study_mode,
+                                       hint: { text: t("publish.providers.study_mode.form.select_all_that_apply") },
+                                       legend: { text: "#{render CaptionText.new(text: course.name_and_code)} #{t('publish.providers.study_mode.form.study_pattern')}".html_safe,
+                                                 tag: "h1",
+                                                 size: "l" } do %>
+        <% course.edit_course_options[:study_modes].each_with_index do |value, index| %>
+          <%= f.govuk_check_box :study_mode,
+                                value,
+                                label: { text: t("edit_options.study_modes.#{value}.label") },
+                                checked: @course_study_mode_form.study_mode_checked?(value),
+                                link_errors: index.zero? %>
+
         <% end %>
       <% end %>
 

--- a/app/views/publish/courses/study_mode/edit.html.erb
+++ b/app/views/publish/courses/study_mode/edit.html.erb
@@ -1,4 +1,4 @@
-<% page_title = "Full time or part time" %>
+<% page_title = t("page_titles.study_mode.edit") %>
 <% content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", @course_study_mode_form.errors.any?) %>
 
 <% content_for :before_content do %>

--- a/app/views/publish/courses/study_mode/new.html.erb
+++ b/app/views/publish/courses/study_mode/new.html.erb
@@ -4,7 +4,7 @@
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
-<%= render "publish/shared/errors", error_id: "#course-study-mode-field-error" %>
+<%= render "publish/shared/errors" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/courses/study_mode/new.html.erb
+++ b/app/views/publish/courses/study_mode/new.html.erb
@@ -1,10 +1,10 @@
-<% content_for :page_title, title_with_error_prefix("Full time or part time", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(t("page_titles.study_mode.new"), @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
 
-<%= render "publish/shared/errors" %>
+<%= render "publish/shared/errors", error_id: "#course-study-mode-field-error" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/shared/_errors.html.erb
+++ b/app/views/publish/shared/_errors.html.erb
@@ -7,7 +7,7 @@
       <ul class="govuk-list govuk-error-summary__list">
         <% @errors.each do |id, messages| %>
           <% messages.each do |message| %>
-            <li data-error-message="<%= message %>"><%= link_to message, "##{id}-error" %></li>
+            <li data-error-message="<%= message %>"><%= link_to message, error_id.presence || "##{id}-error" %></li>
           <% end %>
         <% end %>
       </ul>

--- a/app/views/publish/shared/_errors.html.erb
+++ b/app/views/publish/shared/_errors.html.erb
@@ -1,5 +1,3 @@
-<%# locals: (error_id: nil) -%>
-
 <% if @errors && @errors.any? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
@@ -9,7 +7,7 @@
       <ul class="govuk-list govuk-error-summary__list">
         <% @errors.each do |id, messages| %>
           <% messages.each do |message| %>
-            <li data-error-message="<%= message %>"><%= link_to message, error_id.presence || "##{id}-error" %></li>
+            <li data-error-message="<%= message %>"><%= link_to message, "##{id}-error" %></li>
           <% end %>
         <% end %>
       </ul>

--- a/app/views/publish/shared/_errors.html.erb
+++ b/app/views/publish/shared/_errors.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (error_id: nil) -%>
+
 <% if @errors && @errors.any? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,9 @@ en:
       apprenticeship_and_visa: "Teaching apprenticeship and %{visa_type} visas updated"
       visa: "%{visa_type} visas updated"
   page_titles:
+    study_mode:
+      edit: Study pattern
+      new: Study pattern
     funding_type:
       edit: "Funding type"
     skilled_worker_visas:
@@ -292,6 +295,10 @@ en:
     update: "Update user"
   publish:
     providers:
+      study_mode:
+        form:
+          select_all_that_apply: Select all that apply
+          study_pattern: Study pattern
       study_sites:
         index:
           add_study_site: &add_study_site "Add study site"
@@ -832,7 +839,7 @@ en:
         publish/course_study_mode_form:
           attributes:
             study_mode:
-              blank: "Select full time or part time"
+              blank: You must choose a study pattern. Select all that apply.
         publish/course_withdrawal_form:
           attributes:
             confirm_course_code:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,8 +130,6 @@ en:
         label: "Part time"
       full_time:
         label: "Full time"
-      full_time_or_part_time:
-        label: "Full time or part time"
     apprenticeship:
       pg_teaching_apprenticeship:
         label: "Yes"
@@ -839,7 +837,7 @@ en:
         publish/course_study_mode_form:
           attributes:
             study_mode:
-              blank: You must choose a study pattern. Select all that apply.
+              blank: Select a study pattern
         publish/course_withdrawal_form:
           attributes:
             confirm_course_code:
@@ -982,8 +980,6 @@ en:
         label: "Part time"
       full_time:
         label: "Full time"
-      full_time_or_part_time:
-        label: "Full time or part time"
     can_sponsor_skilled_worker_visas:
       true:
         label: "Yes"

--- a/spec/features/publish/courses/editing_course_study_mode_spec.rb
+++ b/spec/features/publish/courses/editing_course_study_mode_spec.rb
@@ -7,20 +7,40 @@ feature 'Editing course study mode', { can_edit_current_and_next_cycles: false }
     given_i_am_authenticated_as_a_provider_user
   end
 
-  scenario 'i can update the course study mode' do
+  scenario 'I can update the course study mode to both full time and part time' do
     and_there_is_a_part_time_course_i_want_to_edit
     when_i_visit_the_course_study_mode_page
+    then_i_see_part_time_selected
+
     and_i_choose_a_full_time_study_mode
     and_i_submit
     then_i_should_see_a_success_message
-    and_the_course_study_mode_is_updated
+    and_the_course_study_mode_is_updated_to_full_or_part_time
+
+    when_i_visit_the_course_study_mode_page
+    then_i_see_both_part_time_and_full_time_selected
+  end
+
+  scenario 'I can change the course study mode from part time to full time' do
+    and_there_is_a_part_time_course_i_want_to_edit
+    when_i_visit_the_course_study_mode_page
+    and_i_choose_a_full_time_study_mode
+    and_i_uncheck_part_time_study_mode
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_the_course_study_mode_is_updated_to_full_time
+
+    when_i_visit_the_course_study_mode_page
+    then_i_see_full_time_selected
   end
 
   scenario 'updating with invalid data' do
-    and_there_is_a_course_with_no_study_mode
+    and_there_is_a_part_time_course_i_want_to_edit
     when_i_visit_the_course_study_mode_page
+    and_i_uncheck_part_time_study_mode
     and_i_submit
     then_i_should_see_an_error_message
+    and_nothing_is_selected
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -43,7 +63,11 @@ feature 'Editing course study mode', { can_edit_current_and_next_cycles: false }
   end
 
   def and_i_choose_a_full_time_study_mode
-    publish_course_study_mode_edit_page.full_time.choose
+    publish_course_study_mode_edit_page.full_time.click
+  end
+
+  def and_i_uncheck_part_time_study_mode
+    publish_course_study_mode_edit_page.part_time.click
   end
 
   def and_i_submit
@@ -51,16 +75,40 @@ feature 'Editing course study mode', { can_edit_current_and_next_cycles: false }
   end
 
   def then_i_should_see_a_success_message
-    expect(page).to have_content(I18n.t('success.saved', value: 'Full time or part time'))
+    expect(page).to have_content(I18n.t('success.saved', value: 'Study pattern'))
   end
 
-  def and_the_course_study_mode_is_updated
+  def then_i_see_part_time_selected
+    expect(publish_course_study_mode_edit_page.part_time.checked?).to be true
+    expect(publish_course_study_mode_edit_page.full_time.checked?).to be false
+  end
+
+  def then_i_see_both_part_time_and_full_time_selected
+    expect(publish_course_study_mode_edit_page.part_time.checked?).to be true
+    expect(publish_course_study_mode_edit_page.full_time.checked?).to be true
+  end
+
+  def and_the_course_study_mode_is_updated_to_full_or_part_time
+    expect(course.reload).to be_full_time_or_part_time
+  end
+
+  def and_the_course_study_mode_is_updated_to_full_time
     expect(course.reload).to be_full_time
+  end
+
+  def then_i_see_full_time_selected
+    expect(publish_course_study_mode_edit_page.full_time.checked?).to be true
+    expect(publish_course_study_mode_edit_page.part_time.checked?).to be false
+  end
+
+  def and_nothing_is_selected
+    expect(publish_course_study_mode_edit_page.part_time.checked?).to be false
+    expect(publish_course_study_mode_edit_page.full_time.checked?).to be false
   end
 
   def then_i_should_see_an_error_message
     expect(publish_course_study_mode_edit_page.error_messages)
-      .to include('You must choose a study pattern. Select all that apply.')
+      .to include('Select a study pattern')
   end
 
   def provider

--- a/spec/features/publish/courses/editing_course_study_mode_spec.rb
+++ b/spec/features/publish/courses/editing_course_study_mode_spec.rb
@@ -59,9 +59,8 @@ feature 'Editing course study mode', { can_edit_current_and_next_cycles: false }
   end
 
   def then_i_should_see_an_error_message
-    expect(publish_course_study_mode_edit_page.error_messages).to include(
-      I18n.t('activemodel.errors.models.publish/course_study_mode_form.attributes.study_mode.blank')
-    )
+    expect(publish_course_study_mode_edit_page.error_messages)
+      .to include('You must choose a study pattern. Select all that apply.')
   end
 
   def provider

--- a/spec/features/publish/courses/new_funding_type_spec.rb
+++ b/spec/features/publish/courses/new_funding_type_spec.rb
@@ -56,7 +56,7 @@ feature 'selecting funding type', { can_edit_current_and_next_cycles: false } do
 
   def then_i_am_met_with_the_full_or_part_time_page(funding_type)
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/full-part-time/new#{selected_params(funding_type)}")
-    expect(page).to have_content('Full time or part time')
+    expect(page).to have_content('Study pattern')
   end
 
   def then_i_am_met_with_errors

--- a/spec/features/publish/courses/new_study_mode_spec.rb
+++ b/spec/features/publish/courses/new_study_mode_spec.rb
@@ -12,18 +12,28 @@ feature 'selecting full time or part time or full or part time', { can_edit_curr
     when_i_select_a_study_mode(:full_time)
     and_i_click_continue
     then_i_am_met_with_the_schools_page(:full_time)
+
+    when_i_click_back
+    then_full_time_is_selected
   end
 
   scenario 'selecting part time' do
     when_i_select_a_study_mode(:part_time)
     and_i_click_continue
     then_i_am_met_with_the_schools_page(:part_time)
+
+    when_i_click_back
+    then_part_time_is_selected
   end
 
   scenario 'selecting full or part time' do
-    when_i_select_a_study_mode(:full_time_or_part_time)
+    when_i_select_a_study_mode(:full_time)
+    and_i_select_a_study_mode(:part_time)
     and_i_click_continue
     then_i_am_met_with_the_schools_page(:full_time_or_part_time)
+
+    when_i_click_back
+    then_full_time_and_part_time_are_selected
   end
 
   scenario 'invalid entries' do
@@ -45,6 +55,7 @@ feature 'selecting full time or part time or full or part time', { can_edit_curr
   def when_i_select_a_study_mode(study_mode)
     publish_courses_new_study_mode_page.study_mode_fields.send(study_mode).click
   end
+  alias_method :and_i_select_a_study_mode, :when_i_select_a_study_mode
 
   def and_i_click_continue
     publish_courses_new_study_mode_page.continue.click
@@ -61,10 +72,41 @@ feature 'selecting full time or part time or full or part time', { can_edit_curr
 
   def then_i_am_met_with_errors
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content('Select full time or part time')
+    expect(page).to have_content('You must choose a study pattern. Select all that apply.').twice
   end
 
   def selected_params(study_mode)
-    "?course%5Bage_range_in_years%5D=3_to_7&course%5Bis_send%5D=0&course%5Blevel%5D=primary&course%5Bstudy_mode%5D=#{study_mode}&course%5Bsubjects_ids%5D%5B%5D=2"
+    if study_mode == :full_time_or_part_time
+      '?course%5Bage_range_in_years%5D=3_to_7&course%5Bis_send%5D=0&course%5Blevel%5D=primary&course%5Bstudy_mode%5D%5B%5D=full_time&course%5Bstudy_mode%5D%5B%5D=part_time&course%5Bsubjects_ids%5D%5B%5D=2'
+    else
+      "?course%5Bage_range_in_years%5D=3_to_7&course%5Bis_send%5D=0&course%5Blevel%5D=primary&course%5Bstudy_mode%5D%5B%5D=#{study_mode}&course%5Bsubjects_ids%5D%5B%5D=2"
+    end
+  end
+
+  def when_i_click_back
+    click_on 'Back'
+  end
+
+  def then_full_time_is_selected
+    then_the_study_mode_is_selected(:full_time)
+    then_the_study_mode_is_not_selected(:part_time)
+  end
+
+  def then_part_time_is_selected
+    then_the_study_mode_is_selected(:part_time)
+    then_the_study_mode_is_not_selected(:full_time)
+  end
+
+  def then_full_time_and_part_time_are_selected
+    then_the_study_mode_is_selected(:full_time)
+    then_the_study_mode_is_selected(:part_time)
+  end
+
+  def then_the_study_mode_is_selected(study_mode)
+    expect(publish_courses_new_study_mode_page.study_mode_fields.send(study_mode).checked?).to be true
+  end
+
+  def then_the_study_mode_is_not_selected(study_mode)
+    expect(publish_courses_new_study_mode_page.study_mode_fields.send(study_mode).checked?).to be false
   end
 end

--- a/spec/features/publish/courses/new_study_mode_spec.rb
+++ b/spec/features/publish/courses/new_study_mode_spec.rb
@@ -72,7 +72,7 @@ feature 'selecting full time or part time or full or part time', { can_edit_curr
 
   def then_i_am_met_with_errors
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content('You must choose a study pattern. Select all that apply.').twice
+    expect(page).to have_content('Select a study pattern').twice
   end
 
   def selected_params(study_mode)

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -166,7 +166,7 @@ feature 'new course', { can_edit_current_and_next_cycles: false } do
   end
 
   def select_study_mode(course_creation_params, next_page:)
-    course_creation_params[:study_mode] = 'full_time'
+    course_creation_params[:study_mode] = ['full_time']
 
     publish_courses_new_study_mode_page.study_mode_fields.full_time.click
     publish_courses_new_study_mode_page.continue.click

--- a/spec/forms/publish/course_study_mode_form_spec.rb
+++ b/spec/forms/publish/course_study_mode_form_spec.rb
@@ -12,23 +12,59 @@ module Publish
       let(:params) { {} }
 
       describe '#save!' do
-        it 'does not call the course.ensure_site_statuses_match_study_mode' do
-          expect(course).to receive(:changed?)
-          expect(course).not_to receive(:ensure_site_statuses_match_study_mode)
-          subject.save!
+        it 'does not save any changes' do
+          expect(subject.save!).to be false
         end
       end
     end
 
     context 'when params are study mode is part_time' do
-      let(:params) { { study_mode: 'part_time' } }
+      let(:params) { { study_mode: ['part_time'] } }
 
       describe '#save!' do
         it 'does calls the course.ensure_site_statuses_match_study_mode' do
-          expect(course).to receive(:changed?)
-          expect(course).not_to receive(:ensure_site_statuses_match_study_mode)
+          allow(course).to receive(:changed?).and_return true
+          expect(course).to receive(:ensure_site_statuses_match_study_mode)
           subject.save!
         end
+
+        it 'saves the study mode as part time' do
+          subject.save!
+
+          expect(course.study_mode).to eq 'part_time'
+        end
+      end
+    end
+
+    context 'when params are study mode is both part time and full time' do
+      let(:params) { { study_mode: %w[full_time part_time] } }
+
+      it 'does calls the course.ensure_site_statuses_match_study_mode' do
+        allow(course).to receive(:changed?).and_return true
+        expect(course).to receive(:ensure_site_statuses_match_study_mode)
+        subject.save!
+      end
+
+      it 'saves the study mode as full_time_or_part_time' do
+        subject.save!
+
+        expect(course.study_mode).to eq 'full_time_or_part_time'
+      end
+    end
+
+    context 'when params are study mode is full time' do
+      let(:params) { { study_mode: ['full_time'] } }
+
+      it 'does calls the course.ensure_site_statuses_match_study_mode' do
+        allow(course).to receive(:changed?).and_return true
+        expect(course).to receive(:ensure_site_statuses_match_study_mode)
+        subject.save!
+      end
+
+      it 'saves the study mode as full time' do
+        subject.save!
+
+        expect(course.study_mode).to eq 'full_time'
       end
     end
   end

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -52,7 +52,7 @@ describe Courses::CreationService do
         'level' => 'primary',
         'qualification' => 'qts',
         'start_date' => "September #{recruitment_cycle.year}",
-        'study_mode' => 'full_time',
+        'study_mode' => ['full_time'],
         'sites_ids' => [site.id],
         'study_sites_ids' => [study_site.id],
         'subjects_ids' => [primary_subject.id],
@@ -61,7 +61,7 @@ describe Courses::CreationService do
     end
 
     it 'create the primary course' do
-      valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'subjects_ids', 'course_code').each do |key, value|
+      valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'subjects_ids', 'course_code', 'study_mode').each do |key, value|
         expect(subject.public_send(key)).to eq(value)
       end
 
@@ -71,6 +71,7 @@ describe Courses::CreationService do
       expect(subject.subjects.map(&:id)).to eq([primary_subject.id])
       expect(subject.course_code).to be_nil
       expect(subject.name).to eq('Primary (SEND)')
+      expect(subject.study_mode).to eq 'full_time'
       expect(subject.errors).to be_empty
     end
 
@@ -80,7 +81,7 @@ describe Courses::CreationService do
       end
 
       it 'create the primary course' do
-        valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'subjects_ids', 'course_code').each do |key, value|
+        valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'subjects_ids', 'course_code', 'study_mode').each do |key, value|
           expect(subject.public_send(key)).to eq(value)
         end
 
@@ -91,6 +92,7 @@ describe Courses::CreationService do
         expect(subject.course_code).not_to be_nil
         expect(subject.course_code).not_to eq('D0CK')
         expect(subject.name).to eq('Primary (SEND)')
+        expect(subject.study_mode).to eq 'full_time'
         expect(subject.errors).to be_empty
       end
     end
@@ -108,7 +110,7 @@ describe Courses::CreationService do
         'level' => 'secondary',
         'qualification' => 'pgce_with_qts',
         'start_date' => "September #{recruitment_cycle.year}",
-        'study_mode' => 'part_time',
+        'study_mode' => ['part_time'],
         'sites_ids' => [site.id],
         'study_sites_ids' => [study_site.id],
         'subjects_ids' => [secondary_subject.id],
@@ -117,7 +119,7 @@ describe Courses::CreationService do
     end
 
     it 'create the secondary course' do
-      valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'subjects_ids', 'course_code').each do |key, value|
+      valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'subjects_ids', 'course_code', 'study_mode').each do |key, value|
         expect(subject.send(key)).to eq(value)
       end
 
@@ -127,6 +129,7 @@ describe Courses::CreationService do
       expect(subject.subjects.map(&:id)).to eq([secondary_subject.id])
       expect(subject.course_code).to be_nil
       expect(subject.name).to eq('Biology')
+      expect(subject.study_mode).to eq 'part_time'
       expect(subject.errors).to be_empty
     end
 
@@ -136,7 +139,7 @@ describe Courses::CreationService do
       end
 
       it 'create the secondary course' do
-        valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'subjects_ids', 'course_code').each do |key, value|
+        valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'subjects_ids', 'course_code', 'study_mode').each do |key, value|
           expect(subject.public_send(key)).to eq(value)
         end
 
@@ -147,6 +150,7 @@ describe Courses::CreationService do
         expect(subject.course_code).not_to be_nil
         expect(subject.course_code).not_to eq('D0CK')
         expect(subject.name).to eq('Biology')
+        expect(subject.study_mode).to eq 'part_time'
         expect(subject.errors).to be_empty
       end
     end
@@ -162,7 +166,7 @@ describe Courses::CreationService do
         'level' => 'further_education',
         'qualification' => 'pgde',
         'start_date' => "September #{recruitment_cycle.year}",
-        'study_mode' => 'full_time_or_part_time',
+        'study_mode' => %w[full_time part_time],
         'sites_ids' => [site.id],
         'study_sites_ids' => [study_site.id]
       }
@@ -180,6 +184,7 @@ describe Courses::CreationService do
       expect(subject.english).to eq('not_required')
       expect(subject.maths).to eq('not_required')
       expect(subject.science).to eq('not_required')
+      expect(subject.study_mode).to eq 'full_time_or_part_time'
     end
 
     context 'next_available_course_code is true' do
@@ -188,7 +193,7 @@ describe Courses::CreationService do
       end
 
       it 'create the further_education course' do
-        valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'course_code').each do |key, value|
+        valid_course_params.except('is_send', 'sites_ids', 'study_sites_ids', 'course_code', 'study_mode').each do |key, value|
           expect(subject.send(key)).to eq(value)
         end
 
@@ -204,6 +209,7 @@ describe Courses::CreationService do
         expect(subject.english).to eq('not_required')
         expect(subject.maths).to eq('not_required')
         expect(subject.science).to eq('not_required')
+        expect(subject.study_mode).to eq 'full_time_or_part_time'
       end
     end
   end

--- a/spec/support/feature_helpers/new_course_param_helper.rb
+++ b/spec/support/feature_helpers/new_course_param_helper.rb
@@ -8,7 +8,7 @@ module FeatureHelpers
         'course[funding_type]' => 'fee',
         'course[level]' => 'secondary',
         'course[is_send]' => '0',
-        'course[study_mode]' => 'full_time',
+        'course[study_mode][]' => 'full_time',
         'course[age_range_in_years]' => '11_to_16',
         'course[subjects_ids][]' => '2',
         'commit' => 'Continue'
@@ -29,7 +29,7 @@ module FeatureHelpers
         'course[funding_type]' => 'fee',
         'course[level]' => 'secondary',
         'course[is_send]' => '0',
-        'course[study_mode]' => 'full_time',
+        'course[study_mode][]' => 'full_time',
         'course[age_range_in_years]' => '11_to_16',
         'course[subjects_ids][]' => '2',
         'commit' => 'Continue'
@@ -61,7 +61,7 @@ module FeatureHelpers
         'course[is_send]' => '0',
         'course[level]' => 'primary',
         'course[qualification]' => 'qts',
-        'course[study_mode]' => 'full_time',
+        'course[study_mode][]' => 'full_time',
         'course[subjects_ids][]' => '2'
       }
     end
@@ -76,7 +76,7 @@ module FeatureHelpers
         'course[level]' => 'secondary',
         'course[qualification]' => 'pgde_with_qts',
         'course[start_date]' => "October #{provider.recruitment_cycle_year.to_i - 1}",
-        'course[study_mode]' => 'full_time_or_part_time',
+        'course[study_mode][]' => 'full_time_or_part_time',
         'course[subjects_ids][]' => '30',
         'course[sites_ids][]' => provider.sites.first.id
       }
@@ -89,7 +89,7 @@ module FeatureHelpers
         'course[funding_type]' => 'fee',
         'course[level]' => 'secondary',
         'course[is_send]' => '0',
-        'course[study_mode]' => 'full_time',
+        'course[study_mode][]' => 'full_time',
         'course[age_range_in_years]' => '11_to_16',
         'course[subjects_ids][]' => '30',
         'course[applications_open_from]' => '2021-10-12'

--- a/spec/support/page_objects/publish/course_study_mode_edit.rb
+++ b/spec/support/page_objects/publish/course_study_mode_edit.rb
@@ -9,9 +9,8 @@ module PageObjects
 
       sections :errors, Sections::ErrorLink, '.govuk-error-summary__list li>a'
 
-      element :full_time, '#publish-course-study-mode-form-study-mode-full-time-field'
-      element :part_time, '#publish-course-study-mode-form-study-mode-part-time-field'
-      element :full_or_part_time, '#publish-course-study-mode-form-study-mode-full-time-or-part-time-field'
+      element :full_time, '[value="full_time"]'
+      element :part_time, '[value="part_time"]'
 
       element :submit, 'button.govuk-button[type="submit"]'
 

--- a/spec/support/page_objects/publish/courses/new_study_mode.rb
+++ b/spec/support/page_objects/publish/courses/new_study_mode.rb
@@ -7,8 +7,8 @@ module PageObjects
         set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/full-part-time/new{?query*}'
 
         section :study_mode_fields, '[data-qa="course__study_mode"]' do
-          element :full_time, '#course-study-mode-full-time-field'
-          element :part_time, '#course-study-mode-part-time-field'
+          element :full_time, '[value="full_time"]'
+          element :part_time, '[value="part_time"]'
         end
 
         element :continue, '[data-qa="course__save"]'

--- a/spec/support/page_objects/publish/courses/new_study_mode.rb
+++ b/spec/support/page_objects/publish/courses/new_study_mode.rb
@@ -7,9 +7,8 @@ module PageObjects
         set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/full-part-time/new{?query*}'
 
         section :study_mode_fields, '[data-qa="course__study_mode"]' do
-          element :full_time, '#course_study_mode_full_time'
-          element :part_time, '#course_study_mode_part_time'
-          element :full_time_or_part_time, '#course_study_mode_full_time_or_part_time'
+          element :full_time, '#course-study-mode-full-time-field'
+          element :part_time, '#course-study-mode-part-time-field'
         end
 
         element :continue, '[data-qa="course__save"]'


### PR DESCRIPTION
### Context

from the [Trello ticket](https://trello.com/c/zTDCLOFE):
Following a review of historic design/research findings:

1. Change from radio buttons to checkboxes
2. Removing the ‘Full time or Part time’ field
3. Amend wording to correlate to an either/or choice


### Changes proposed in this pull request
Replace radio buttons with checkboxes when selecting study pattern, for both editing a course and creating a new course.

https://github.com/DFE-Digital/publish-teacher-training/assets/44073106/8bcf5122-fbf5-47d6-8d02-60c0aa86b7ef

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [NA] Inform data insights team due to database changes
