### PR TITLE
Add test for teacher degree apprentice and further education

### DIFF
--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -103,6 +103,16 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
   end
 
+  scenario 'do not show teacher degree apprenticeship for further education' do
+    given_i_am_authenticated_as_a_school_direct_provider_user
+    and_the_tda_feature_flag_is_active
+    when_i_visit_the_courses_page
+    and_i_click_on_add_course
+    and_i_choose_a_further_education_course
+    then_i_am_on_the_qualifications_page
+    and_i_do_not_see_the_degree_awarding_option
+  end
+
   def given_i_am_authenticated_as_a_school_direct_provider_user
     recruitment_cycle = create(:recruitment_cycle, year: 2025)
     @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
@@ -154,6 +164,12 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_i_click_continue
   end
 
+  def and_i_choose_a_further_education_course
+    choose 'Further education'
+    and_i_select_no_send
+    and_i_click_continue
+  end
+
   def and_i_choose_a_primary_course
     choose 'Primary'
     and_i_select_no_send
@@ -188,6 +204,16 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     expect(publish_courses_new_outcome_page.qualification_fields.text).to include(
       'Teacher degree apprenticeship (TDA) with QTS'
     )
+  end
+
+  def then_i_am_on_the_qualifications_page
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_outcome_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+  end
+
+  def and_i_do_not_see_the_degree_awarding_option
+    expect(
+      publish_courses_new_outcome_page.qualification_fields.has_undergraduate_degree_with_qts?
+    ).to be false
   end
 
   def when_i_choose_a_degree_awarding_qualification


### PR DESCRIPTION
### Context

We should not show TDA option from add course - further education flow. 

The implementation does automatically under the file https://github.com/DFE-Digital/publish-teacher-training/blob/main/app/models/concerns/courses/edit_options/qualification_concern.rb#L8

But it is best to increase our coverage for that scenario so this PR only adds a spec to guarantee the functionality is tested and working.

## Trello card

https://trello.com/c/1GZDGD5K/1676-remove-tda-option-for-further-education