### PR TITLE
Set default degree requirements for TDA courses

### DIFF
--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -37,6 +37,9 @@ module Courses
         course.program_type = 'teacher_degree_apprenticeship'
         course.can_sponsor_student_visa = false
         course.can_sponsor_skilled_worker_visa = false
+        course.additional_degree_subject_requirements = nil
+        course.degree_subject_requirements = nil
+        course.degree_grade = 'not_required'
       end
 
       AssignSubjectsService.call(course:, subject_ids:)

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -37,8 +37,6 @@ module Courses
         course.program_type = 'teacher_degree_apprenticeship'
         course.can_sponsor_student_visa = false
         course.can_sponsor_skilled_worker_visa = false
-        course.additional_degree_subject_requirements = nil
-        course.degree_subject_requirements = nil
         course.degree_grade = 'not_required'
       end
 

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -270,6 +270,9 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     expect(course.funding_type).to eq('apprenticeship')
     expect(course.can_sponsor_student_visa?).to be false
     expect(course.can_sponsor_skilled_worker_visa?).to be false
+    expect(course.additional_degree_subject_requirements).to be_nil
+    expect(course.degree_subject_requirements).to be_nil
+    expect(course.degree_grade).to eq('not_required')
   end
 
   def and_i_select_no_send

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -19,6 +19,27 @@ describe Courses::CreationService do
 
   let(:next_available_course_code) { false }
 
+  context 'when teacher degree apprenticeship course' do
+    let(:valid_course_params) do
+      {
+        'level' => 'primary',
+        'is_send' => '1',
+        'age_range_in_years' => '3_to_7',
+        'qualification' => 'undergraduate_degree_with_qts'
+      }
+    end
+
+    it 'creates the teacher degree apprenticeship course' do
+      expect(subject.program_type).to eq('teacher_degree_apprenticeship')
+      expect(subject.funding_type).to eq('apprenticeship')
+      expect(subject.can_sponsor_student_visa?).to be false
+      expect(subject.can_sponsor_skilled_worker_visa?).to be false
+      expect(subject.additional_degree_subject_requirements).to be_nil
+      expect(subject.degree_subject_requirements).to be_nil
+      expect(subject.degree_grade).to eq('not_required')
+    end
+  end
+
   context 'primary course' do
     let(:primary_subject) { find_or_create(:primary_subject, :primary) }
 


### PR DESCRIPTION
### Context

Because the degree apprenticeship will awards a degree then these fields needs to be the default when provider is adding the course

### Trello card

https://trello.com/c/5MJ3HpDI/1674-default-additional-degree-info-to-false-for-tda-courses

