### PR TITLE
Don't show the degree requirements section on TDA courses

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -430,6 +430,10 @@ class CourseDecorator < ApplicationDecorator
       teacher_degree_apprenticeship?
   end
 
+  def show_degree_requirements_row?
+    !teacher_degree_apprenticeship?
+  end
+
   private
 
   def not_on_find

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -121,17 +121,19 @@
 
 <h3 class="govuk-heading-m">Requirements and eligibility</h3>
 
-<%= govuk_summary_list do |summary_list| %>
-    <% enrichment_summary(
-      summary_list,
-      :course,
-      "Degree",
-      (render DegreeRowContent.new(course:, errors: @errors)),
-      %w[degree_grade degree_subject_requirements],
-      truncate_value: false,
-      action_path: !course.is_withdrawn? && course.degree_section_complete? ? degrees_start_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
-      action_visually_hidden_text: "degree"
-    ) %>
+  <%= govuk_summary_list do |summary_list| %>
+    <% if course.show_degree_requirements_row? %>
+      <% enrichment_summary(
+        summary_list,
+        :course,
+        "Degree",
+        (render DegreeRowContent.new(course:, errors: @errors)),
+        %w[degree_grade degree_subject_requirements],
+        truncate_value: false,
+        action_path: !course.is_withdrawn? && course.degree_section_complete? ? degrees_start_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+        action_visually_hidden_text: "degree"
+      ) %>
+    <% end %>
 
     <% enrichment_summary(
       summary_list,

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -38,7 +38,8 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
-    and_i_do_not_see_the_degree_requirements_row_on_description_tab
+    when_i_click_on_the_course_description_tab
+    then_i_do_not_see_the_degree_requirements_row
   end
 
   scenario 'creating a degree awarding course from scitt provider' do
@@ -71,7 +72,8 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
-    and_i_do_not_see_the_degree_requirements_row_on_description_tab
+    when_i_click_on_the_course_description_tab
+    then_i_do_not_see_the_degree_requirements_row
   end
 
   scenario 'when choosing primary course' do
@@ -103,7 +105,8 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
-    and_i_do_not_see_the_degree_requirements_row_on_description_tab
+    when_i_click_on_the_course_description_tab
+    then_i_do_not_see_the_degree_requirements_row
   end
 
   def given_i_am_authenticated_as_a_school_direct_provider_user
@@ -309,16 +312,14 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def when_i_click_on_the_course_i_created
     click_on course_name_and_code
-    click_on 'Basic details'
+    when_i_click_on_the_course_description_tab
   end
 
-  def and_i_do_not_see_the_degree_requirements_row_on_description_tab
-    publish_provider_courses_show_page.load(
-      provider_code: provider.provider_code,
-      recruitment_cycle_year: provider.recruitment_cycle_year,
-      course_code: course.course_code
-    )
+  def when_i_click_on_the_course_description_tab
+    publish_provider_courses_show_page.basic_details_link.click
+  end
 
+  def then_i_do_not_see_the_degree_requirements_row
     expect(publish_provider_courses_show_page).not_to have_degree
   end
 

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -38,6 +38,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
+    and_i_do_not_see_the_degree_requirements_row_on_description_tab
   end
 
   scenario 'creating a degree awarding course from scitt provider' do
@@ -70,6 +71,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
+    and_i_do_not_see_the_degree_requirements_row_on_description_tab
   end
 
   scenario 'when choosing primary course' do
@@ -101,6 +103,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
+    and_i_do_not_see_the_degree_requirements_row_on_description_tab
   end
 
   def given_i_am_authenticated_as_a_school_direct_provider_user
@@ -307,6 +310,16 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   def when_i_click_on_the_course_i_created
     click_on course_name_and_code
     click_on 'Basic details'
+  end
+
+  def and_i_do_not_see_the_degree_requirements_row_on_description_tab
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      course_code: course.course_code
+    )
+
+    expect(publish_provider_courses_show_page).not_to have_degree
   end
 
   def provider


### PR DESCRIPTION
### Context

Users don't need to enter and can't change the degree requirements for a course that offers undergraduate degree.

Therefore we're hiding the degree requirements row when the course is teacher degree aprenticeship.

## Trello card

https://trello.com/c/mQzGTkS9/1672-hide-degree-requirement-rows-for-tda-courses