### PR TITLE
[1673] Hide course length change link for TDA courses

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -420,6 +420,10 @@ class CourseDecorator < ApplicationDecorator
     is_withdrawn? || teacher_degree_apprenticeship?
   end
 
+  def cannot_change_course_length?
+    teacher_degree_apprenticeship? || is_withdrawn?
+  end
+
   def cannot_change_skilled_worker_visa?
     is_withdrawn? || teacher_degree_apprenticeship?
   end

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -47,7 +47,7 @@
       "Course length",
       value_provided?(course.length),
       %w[course_length],
-      action_path: course.is_withdrawn? ? nil : "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
+      action_path: course.cannot_change_course_length? ? nil : "#{fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
       action_visually_hidden_text: "course length"
     ) %>
 
@@ -103,7 +103,7 @@
       "Course length",
       value_provided?(course.length),
       %w[course_length],
-      action_path: course.is_withdrawn? ? nil : "#{salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
+      action_path: course.cannot_change_course_length? ? nil : "#{salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#course-length",
       action_visually_hidden_text: "course length"
     ) %>
 

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -38,8 +38,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
+
     when_i_click_on_the_course_description_tab
     then_i_do_not_see_the_degree_requirements_row
+    and_i_do_not_see_the_change_link_for_course_length
   end
 
   scenario 'creating a degree awarding course from scitt provider' do
@@ -72,8 +74,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
+
     when_i_click_on_the_course_description_tab
     then_i_do_not_see_the_degree_requirements_row
+    and_i_do_not_see_the_change_link_for_course_length
   end
 
   scenario 'when choosing primary course' do
@@ -105,8 +109,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
     when_i_click_on_the_course_i_created
     then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship_on_basic_details
+
     when_i_click_on_the_course_description_tab
     then_i_do_not_see_the_degree_requirements_row
+    and_i_do_not_see_the_change_link_for_course_length
   end
 
   scenario 'do not show teacher degree apprenticeship for further education' do
@@ -339,13 +345,23 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     end
   end
 
+  def and_i_do_not_see_the_change_link_for_course_length
+    within('[data-qa="enrichment__course_length"]') do
+      expect(page).to have_no_link('Change')
+    end
+  end
+
   def when_i_click_on_the_course_i_created
     click_on course_name_and_code
-    when_i_click_on_the_course_description_tab
+    when_i_click_on_the_course_basic_details_tab
+  end
+
+  def when_i_click_on_the_course_basic_details_tab
+    publish_provider_courses_show_page.basic_details_link.click
   end
 
   def when_i_click_on_the_course_description_tab
-    publish_provider_courses_show_page.basic_details_link.click
+    publish_provider_courses_show_page.description_link.click
   end
 
   def then_i_do_not_see_the_degree_requirements_row

--- a/spec/support/page_objects/publish/provider_courses_show.rb
+++ b/spec/support/page_objects/publish/provider_courses_show.rb
@@ -27,6 +27,7 @@ module PageObjects
       section :other_requirements, Sections::SummaryList, '[data-qa="enrichment__other_requirements"]'
       section :course_button_panel, Sections::CourseButtonPanel, '[data-qa="course__button_panel"]'
 
+      element :description_link, 'a.govuk-link.govuk-tabs__tab', text: 'Description'
       element :basic_details_link, 'a.govuk-link.govuk-tabs__tab', text: 'Basic details'
       element :content_status, '[data-qa="course__content-status"]'
       element :rolled_over_course_link, '[data-qa="course__rolled-over-link"]'


### PR DESCRIPTION
### Context

We are hiding the change links for the course length on TDA courses. The course length is fixed for these courses and this will be the default (the default part is being handled in another PR).

### Screenshot

<img width="627" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/a53c40ab-7fa3-4430-9ea9-22745ea1c152">


### Changes proposed in this pull request

- Hide change links for TDA courses

TDA courses can only be salaried teaching apprenticeships but i've added the logic to the fee paying page too as a precaution.

- Fix test

The method name is suggesting that you are clicking on description when the code is actually clicking on basic details

### Guidance to review

- Create a TDA course and check there is no change link for course length on the description section.
- Create a non TDA course and check there is a change link for course length on the description section.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
