### PR TITLE
1675 add 4 year default for tda courses

### DIFF
--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -39,6 +39,8 @@ module Courses
         course.can_sponsor_student_visa = false
         course.can_sponsor_skilled_worker_visa = false
         course.degree_grade = 'not_required'
+        course_enrichment = course.enrichments.find_or_initialize_draft
+        course_enrichment.course_length = '4 years'
       end
 
       AssignSubjectsService.call(course:, subject_ids:)

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -42,6 +42,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     when_i_click_on_the_course_description_tab
     then_i_do_not_see_the_degree_requirements_row
     and_i_do_not_see_the_change_link_for_course_length
+
+    given_i_fill_in_all_other_fields_for_the_course
+    when_i_publish_the_course
+    then_the_course_is_published
   end
 
   scenario 'creating a degree awarding course from scitt provider' do
@@ -78,6 +82,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     when_i_click_on_the_course_description_tab
     then_i_do_not_see_the_degree_requirements_row
     and_i_do_not_see_the_change_link_for_course_length
+
+    given_i_fill_in_all_other_fields_for_the_course
+    when_i_publish_the_course
+    then_the_course_is_published
   end
 
   scenario 'when choosing primary course' do
@@ -113,6 +121,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     when_i_click_on_the_course_description_tab
     then_i_do_not_see_the_degree_requirements_row
     and_i_do_not_see_the_change_link_for_course_length
+
+    given_i_fill_in_all_other_fields_for_the_course
+    when_i_publish_the_course
+    then_the_course_is_published
   end
 
   scenario 'do not show teacher degree apprenticeship for further education' do
@@ -368,6 +380,50 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def then_i_do_not_see_the_degree_requirements_row
     expect(publish_provider_courses_show_page).not_to have_degree
+  end
+
+  def given_i_fill_in_all_other_fields_for_the_course
+    and_i_add_course_details
+    and_i_add_salary_information
+    and_i_add_gcse_requirements
+  end
+
+  def and_i_add_course_details
+    publish_provider_courses_show_page.about_course.find_link(
+      text: 'Change details about this course'
+    ).click
+    publish_course_information_edit_page.about_course.set('Details about the course')
+    publish_course_information_edit_page.interview_process.set('Interview process details')
+    publish_course_information_edit_page.school_placements.set('School placements information')
+    publish_course_information_edit_page.submit.click
+  end
+
+  def and_i_add_salary_information
+    publish_provider_courses_show_page.salary_details.find_link(text: 'Change salary').click
+    publish_course_salary_edit_page.salary_details.set('Some salary details')
+    publish_course_salary_edit_page.submit.click
+  end
+
+  def and_i_add_gcse_requirements
+    publish_provider_courses_show_page.gcse.find_link(
+      text: 'Enter GCSE and equivalency test requirements'
+    ).click
+    publish_courses_gcse_requirements_page.pending_gcse_yes_radio.click
+    publish_courses_gcse_requirements_page.gcse_equivalency_yes_radio.click
+    publish_courses_gcse_requirements_page.english_equivalency.check
+    publish_courses_gcse_requirements_page.maths_equivalency.check
+    publish_courses_gcse_requirements_page.additional_requirements.set('Some Proficiency')
+    publish_courses_gcse_requirements_page.save.click
+  end
+
+  def when_i_publish_the_course
+    publish_provider_courses_show_page.course_button_panel.publish_button.click
+  end
+
+  def then_the_course_is_published
+    expect(publish_provider_courses_show_page.errors.map(&:text)).to eq([])
+    expect(page).to have_content('Your course has been published.')
+    expect(course.content_status).to be :published
   end
 
   def provider

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -141,7 +141,8 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     recruitment_cycle = create(:recruitment_cycle, year: 2025)
     @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
-    @accredited_provider = create(:provider, :accredited_provider, recruitment_cycle:)
+    create(:provider, :accredited_provider, provider_code: '1BJ')
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -311,6 +311,8 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     expect(course.additional_degree_subject_requirements).to be_nil
     expect(course.degree_subject_requirements).to be_nil
     expect(course.degree_grade).to eq('not_required')
+    expect(course.enrichments.last).to be_present
+    expect(course.enrichments.last.course_length).to eq('4 years')
   end
 
   def and_i_select_no_send

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -37,6 +37,8 @@ describe Courses::CreationService do
       expect(subject.additional_degree_subject_requirements).to be_nil
       expect(subject.degree_subject_requirements).to be_nil
       expect(subject.degree_grade).to eq('not_required')
+      expect(subject.enrichments.last).to be_present
+      expect(subject.enrichments.last.course_length).to eq('4 years')
     end
   end
 


### PR DESCRIPTION
### Context

We have defaulted all TDA courses to a length of 4 years. 

After this the course can be published. So we need to test the publishing mechanism for a TDA course.

## Observation

I am not sure why, but the course length has two patterns:

1. Enumerator: OneYear, TwoYears
2. Free text: 3 years, etc

I optin for a free text. Let me know if you disagree.

### Guidance to review

1. Does it save 4 years?
4. Does the API returns 4 years as free text?

### Trello card

https://trello.com/c/KRuhpAaL/1675-add-4-year-default-for-tda-courses