### PR TITLE
[1697] TDA edge cases

### DIFF
--- a/app/controllers/publish/courses/funding_type_controller.rb
+++ b/app/controllers/publish/courses/funding_type_controller.rb
@@ -122,7 +122,7 @@ module Publish
         if goto_visa_path?
           redirect_to visa_sponsorship_path
         elsif previous_tda_course_path?
-          redirect_to previously_defaulted_attributes
+          redirect_to new_publish_provider_recruitment_cycle_courses_study_mode_path(previously_defaulted_attributes)
         else
           redirect_to next_step
         end
@@ -137,7 +137,7 @@ module Publish
       end
 
       def previously_defaulted_attributes
-        new_publish_provider_recruitment_cycle_courses_study_mode_path(path_params.merge(previous_tda_course: 'true'))
+        path_params.merge(previous_tda_course: 'true')
       end
     end
   end

--- a/app/controllers/publish/courses/funding_type_controller.rb
+++ b/app/controllers/publish/courses/funding_type_controller.rb
@@ -10,10 +10,8 @@ module Publish
         @errors = errors
         if @errors.any?
           render :new
-        elsif params[:goto_visa]
-          redirect_to visa_sponsorship_path
         else
-          redirect_to next_step
+          handle_redirect
         end
       end
 
@@ -118,6 +116,28 @@ module Publish
 
       def section_key
         'Funding type'
+      end
+
+      def handle_redirect
+        if goto_visa_path?
+          redirect_to visa_sponsorship_path
+        elsif previous_tda_course_path?
+          redirect_to previously_defaulted_attributes
+        else
+          redirect_to next_step
+        end
+      end
+
+      def goto_visa_path?
+        params[:goto_visa] == 'true' && params[:course][:previous_tda_course] != 'true'
+      end
+
+      def previous_tda_course_path?
+        params[:course][:previous_tda_course] == 'true'
+      end
+
+      def previously_defaulted_attributes
+        new_publish_provider_recruitment_cycle_courses_study_mode_path(path_params.merge(previous_tda_course: 'true'))
       end
     end
   end

--- a/app/controllers/publish/courses/funding_type_controller.rb
+++ b/app/controllers/publish/courses/funding_type_controller.rb
@@ -129,11 +129,11 @@ module Publish
       end
 
       def goto_visa_path?
-        params[:goto_visa] == 'true' && params[:course][:previous_tda_course] != 'true'
+        params[:goto_visa] == 'true' && params.dig(:course, :previous_tda_course) != 'true'
       end
 
       def previous_tda_course_path?
-        params[:course][:previous_tda_course] == 'true'
+        params.dig(:course, :previous_tda_course) == 'true'
       end
 
       def previously_defaulted_attributes

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -51,22 +51,17 @@ module Publish
       end
 
       def handle_qualification_update
-        if undergraduate_degree_with_qts?
-          Publish::Courses::AssignTdaAttributesService.new(@course).call
-
-          course_updated_message('Qualification')
-
-          redirect_to course_details_path
-        elsif undergraduate_to_other_qualification?
+        if undergraduate_to_other_qualification?
           redirect_to funding_type_with_previous_course_path
         else
-          redirect_to(
-            details_publish_provider_recruitment_cycle_course_path(
-              @course.provider_code,
-              @course.recruitment_cycle_year,
-              @course.course_code
-            )
+          Publish::Courses::AssignTdaAttributesService.new(@course).call if undergraduate_degree_with_qts?
+
+          redirect_to details_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code
           )
+
           course_updated_message('Qualification')
         end
       end
@@ -95,14 +90,6 @@ module Publish
 
       def funding_type_path
         funding_type_publish_provider_recruitment_cycle_course_path(
-          @course.provider_code,
-          @course.recruitment_cycle_year,
-          @course.course_code
-        )
-      end
-
-      def course_details_path
-        details_publish_provider_recruitment_cycle_course_path(
           @course.provider_code,
           @course.recruitment_cycle_year,
           @course.course_code

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -56,7 +56,13 @@ module Publish
         elsif undergraduate_to_other_qualification?
           redirect_to funding_type_with_previous_course_path
         else
-          redirect_to funding_type_path
+          redirect_to(
+            details_publish_provider_recruitment_cycle_course_path(
+              @course.provider_code,
+              @course.recruitment_cycle_year,
+              @course.course_code
+            )
+          )
           course_updated_message('Qualification')
         end
       end

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -52,7 +52,11 @@ module Publish
 
       def handle_qualification_update
         if undergraduate_degree_with_qts?
-          update_undergraduate_course
+          Publish::Courses::AssignTdaAttributesService.new(@course).call
+
+          course_updated_message('Qualification')
+
+          redirect_to course_details_path
         elsif undergraduate_to_other_qualification?
           redirect_to funding_type_with_previous_course_path
         else
@@ -78,19 +82,6 @@ module Publish
 
       def undergraduate_to_other_qualification?
         @current_qualification == 'undergraduate_degree_with_qts' && @updated_qualification != 'undergraduate_degree_with_qts'
-      end
-
-      def update_undergraduate_course
-        @course.update(
-          study_mode: 'full_time',
-          funding_type: 'apprenticeship',
-          can_sponsor_skilled_worker_visa: false,
-          can_sponsor_student_visa: false
-        )
-
-        course_updated_message('Qualification')
-
-        redirect_to course_details_path
       end
 
       def funding_type_with_previous_course_path

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -19,21 +19,13 @@ module Publish
         @errors = errors
         return render :edit if @errors.present?
 
+        @current_qualification = @course.qualification
+        @updated_qualification = params[:course][:qualification]
+
         if @course.update(course_params)
-          @course.update_default_attributes_for_undergraduate_degree_with_qts
-
-          course_updated_message('Qualification')
-
-          redirect_to(
-            details_publish_provider_recruitment_cycle_course_path(
-              @course.provider_code,
-              @course.recruitment_cycle_year,
-              @course.course_code
-            )
-          )
+          handle_qualification_update
         else
-          @errors = @course.errors.messages
-          render :edit
+          handle_update_failure
         end
       end
 
@@ -45,6 +37,68 @@ module Publish
 
       def errors
         params.dig(:course, :qualification) ? {} : { qualification: ['Select a qualification'] }
+      end
+
+      def handle_qualification_update
+        if undergraduate_degree_with_qts?
+          update_undergraduate_course
+        elsif undergraduate_to_other_qualification?
+          redirect_to funding_type_with_previous_course_path
+        else
+          redirect_to funding_type_path
+          course_updated_message('Qualification')
+        end
+      end
+
+      def handle_update_failure
+        @errors = @course.errors.messages
+        render :edit
+      end
+
+      def undergraduate_degree_with_qts?
+        @updated_qualification == 'undergraduate_degree_with_qts'
+      end
+
+      def undergraduate_to_other_qualification?
+        @current_qualification == 'undergraduate_degree_with_qts' && @updated_qualification != 'undergraduate_degree_with_qts'
+      end
+
+      def update_undergraduate_course
+        @course.update(
+          study_mode: 'full_time',
+          funding_type: 'apprenticeship',
+          can_sponsor_skilled_worker_visa: false,
+          can_sponsor_student_visa: false
+        )
+
+        course_updated_message('Qualification')
+
+        redirect_to course_details_path
+      end
+
+      def funding_type_with_previous_course_path
+        funding_type_publish_provider_recruitment_cycle_course_path(
+          @course.provider_code,
+          @course.recruitment_cycle_year,
+          @course.course_code,
+          previous_tda_course: true
+        )
+      end
+
+      def funding_type_path
+        funding_type_publish_provider_recruitment_cycle_course_path(
+          @course.provider_code,
+          @course.recruitment_cycle_year,
+          @course.course_code
+        )
+      end
+
+      def course_details_path
+        details_publish_provider_recruitment_cycle_course_path(
+          @course.provider_code,
+          @course.recruitment_cycle_year,
+          @course.course_code
+        )
       end
     end
   end

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -52,7 +52,12 @@ module Publish
 
       def handle_qualification_update
         if undergraduate_to_other_qualification?
-          redirect_to funding_type_with_previous_course_path
+          redirect_to funding_type_publish_provider_recruitment_cycle_course_path(
+            @course.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code,
+            previous_tda_course: true
+          )
         else
           Publish::Courses::AssignTdaAttributesService.new(@course).call if undergraduate_degree_with_qts?
 
@@ -77,23 +82,6 @@ module Publish
 
       def undergraduate_to_other_qualification?
         @current_qualification == 'undergraduate_degree_with_qts' && @updated_qualification != 'undergraduate_degree_with_qts'
-      end
-
-      def funding_type_with_previous_course_path
-        funding_type_publish_provider_recruitment_cycle_course_path(
-          @course.provider_code,
-          @course.recruitment_cycle_year,
-          @course.course_code,
-          previous_tda_course: true
-        )
-      end
-
-      def funding_type_path
-        funding_type_publish_provider_recruitment_cycle_course_path(
-          @course.provider_code,
-          @course.recruitment_cycle_year,
-          @course.course_code
-        )
       end
 
       def handle_redirect

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -31,7 +31,7 @@ module Publish
         return render :edit if @errors.present?
 
         @current_qualification = @course.qualification
-        @updated_qualification = params[:course][:qualification]
+        @updated_qualification = params.dig(:course, :qualification)
 
         if @course.update(course_params)
           handle_qualification_update

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -5,6 +5,17 @@ module Publish
     class OutcomeController < PublishController
       include CourseBasicDetailConcern
 
+      def continue
+        authorize(@provider, :can_create_course?)
+        @errors = errors
+
+        if @errors.any?
+          render :new
+        else
+          handle_redirect
+        end
+      end
+
       def new
         super
       end
@@ -99,6 +110,18 @@ module Publish
           @course.recruitment_cycle_year,
           @course.course_code
         )
+      end
+
+      def handle_redirect
+        if previously_chosen_tda?
+          redirect_to new_publish_provider_recruitment_cycle_courses_funding_type_path(path_params.merge(previous_tda_course: true))
+        else
+          redirect_to next_step
+        end
+      end
+
+      def previously_chosen_tda?
+        params[:current_qualification] == 'undergraduate_degree_with_qts' && params[:goto_confirmation] == 'true'
       end
     end
   end

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -20,6 +20,8 @@ module Publish
         return render :edit if @errors.present?
 
         if @course.update(course_params)
+          @course.update_default_attributes_for_undergraduate_degree_with_qts
+
           course_updated_message('Qualification')
 
           redirect_to(

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -59,7 +59,10 @@ module Publish
             previous_tda_course: true
           )
         else
-          Publish::Courses::AssignTdaAttributesService.new(@course).call if undergraduate_degree_with_qts?
+          if undergraduate_degree_with_qts?
+            Publish::Courses::AssignTdaAttributesService.new(@course).call
+            @course.save
+          end
 
           redirect_to details_publish_provider_recruitment_cycle_course_path(
             @course.provider_code,

--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -5,6 +5,16 @@ module Publish
     class StudyModeController < PublishController
       include CourseBasicDetailConcern
 
+      def continue
+        authorize(@provider, :can_create_course?)
+
+        if previous_tda_course_path?
+          redirect_to appropriate_visa_new_path
+        else
+          super
+        end
+      end
+
       def edit
         authorize(provider)
 
@@ -60,12 +70,24 @@ module Publish
         end
       end
 
+      def appropriate_visa_new_path
+        if @course.student_visa?
+          new_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(path_params)
+        else
+          new_publish_provider_recruitment_cycle_courses_skilled_worker_visa_sponsorship_path(path_params)
+        end
+      end
+
       def current_step
         :full_or_part_time
       end
 
       def errors
         params.dig(:course, :study_mode) ? {} : { study_mode: [I18n.t('activemodel.errors.models.publish/course_study_mode_form.attributes.study_mode.blank')] }
+      end
+
+      def previous_tda_course_path?
+        params[:previous_tda_course] == 'true'
       end
     end
   end

--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -55,7 +55,7 @@ module Publish
       end
 
       def previous_tda_course?
-        params[:publish_course_study_mode_form][:previous_tda_course] == 'true'
+        params.dig(:publish_course_study_mode_form, :previous_tda_course) == 'true'
       end
 
       def appropriate_visa_path

--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -15,14 +15,9 @@ module Publish
         authorize(provider)
 
         @course_study_mode_form = CourseStudyModeForm.new(@course, params: study_mode_params)
-        if @course_study_mode_form.save!
-          course_updated_message I18n.t('publish.providers.study_mode.form.study_pattern')
 
-          redirect_to details_publish_provider_recruitment_cycle_course_path(
-            provider.provider_code,
-            recruitment_cycle.year,
-            course.course_code
-          )
+        if @course_study_mode_form.save!
+          handle_redirect
         else
           render :edit
         end
@@ -33,7 +28,36 @@ module Publish
       def study_mode_params
         return { study_mode: nil } if params[:publish_course_study_mode_form].blank?
 
-        params.require(:publish_course_study_mode_form).permit(study_mode: [])
+        params.require(:publish_course_study_mode_form).permit(:previous_tda_course, study_mode: [])
+      end
+
+      def handle_redirect
+        if previous_tda_course?
+          redirect_to appropriate_visa_path
+        else
+          course_updated_message I18n.t('publish.providers.study_mode.form.study_pattern')
+          redirect_to details_publish_provider_recruitment_cycle_course_path(
+            provider.provider_code,
+            recruitment_cycle.year,
+            course.course_code
+          )
+        end
+      end
+
+      def previous_tda_course?
+        params[:publish_course_study_mode_form][:previous_tda_course] == 'true'
+      end
+
+      def appropriate_visa_path
+        if @course.student_visa?
+          student_visa_sponsorship_publish_provider_recruitment_cycle_course_path(provider_code: course.provider_code,
+                                                                                  recruitment_cycle_year: course.recruitment_cycle_year,
+                                                                                  course_code: course.course_code)
+        else
+          skilled_worker_visa_sponsorship_publish_provider_recruitment_cycle_course_path(provider_code: course.provider_code,
+                                                                                         recruitment_cycle_year: course.recruitment_cycle_year,
+                                                                                         course_code: course.course_code)
+        end
       end
 
       def current_step

--- a/app/forms/publish/course_funding_form.rb
+++ b/app/forms/publish/course_funding_form.rb
@@ -8,6 +8,7 @@ module Publish
       funding_type
       can_sponsor_skilled_worker_visa
       can_sponsor_student_visa
+      previous_tda_course
     ].freeze
 
     attr_accessor(*FIELDS)
@@ -50,6 +51,10 @@ module Publish
 
     def skilled_worker_visa?
       visa_type == :skilled_worker
+    end
+
+    def fields_to_ignore_before_save
+      super + [:previous_tda_course]
     end
 
     private

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -92,7 +92,8 @@ module Publish
                 :goto_confirmation,
                 :skip_languages_goto_confirmation,
                 :goto_visa,
-                :language_ids
+                :language_ids,
+                :previous_tda_course
               ).permit(
                 policy(Course.new).permitted_new_course_attributes,
                 study_mode: [],

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -827,6 +827,17 @@ class Course < ApplicationRecord
     enrichments.where(status: 'published').order(last_published_timestamp_utc: :desc).first
   end
 
+  def update_default_attributes_for_undergraduate_degree_with_qts
+    return unless undergraduate_degree_with_qts?
+
+    update(
+      study_mode: 'full_time',
+      funding_type: 'apprenticeship',
+      can_sponsor_skilled_worker_visa: false,
+      can_sponsor_student_visa: false
+    )
+  end
+
   private
 
   def add_site!(site:)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -535,6 +535,14 @@ class Course < ApplicationRecord
     funding_type == 'fee'
   end
 
+  def visa_type
+    is_fee_based? ? :student : :skilled_worker
+  end
+
+  def student_visa?
+    visa_type == :student
+  end
+
   # https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c11-gcse-standard-equivalent
   def gcse_subjects_required
     case level

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -835,17 +835,6 @@ class Course < ApplicationRecord
     enrichments.where(status: 'published').order(last_published_timestamp_utc: :desc).first
   end
 
-  def update_default_attributes_for_undergraduate_degree_with_qts
-    return unless undergraduate_degree_with_qts?
-
-    update(
-      study_mode: 'full_time',
-      funding_type: 'apprenticeship',
-      can_sponsor_skilled_worker_visa: false,
-      can_sponsor_student_visa: false
-    )
-  end
-
   private
 
   def add_site!(site:)

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -38,16 +38,7 @@ module Courses
       course.accrediting_provider = course.provider.accrediting_providers.first if course.provider.accredited_bodies.length == 1
       course.course_code = provider.next_available_course_code if next_available_course_code
 
-      if course.undergraduate_degree_with_qts?
-        course.funding_type = 'apprenticeship'
-        course.study_mode = 'full_time'
-        course.program_type = 'teacher_degree_apprenticeship'
-        course.can_sponsor_student_visa = false
-        course.can_sponsor_skilled_worker_visa = false
-        course.degree_grade = 'not_required'
-        course_enrichment = course.enrichments.find_or_initialize_draft
-        course_enrichment.course_length = '4 years'
-      end
+      Publish::Courses::AssignTdaAttributesService.new(course).call if course.undergraduate_degree_with_qts?
 
       course.valid?(:new) if course.errors.blank?
 

--- a/app/services/publish/courses/assign_tda_attributes_service.rb
+++ b/app/services/publish/courses/assign_tda_attributes_service.rb
@@ -19,8 +19,12 @@ module Publish
           degree_subject_requirements: false
         )
 
-        course_enrichment = @course.enrichments.find_or_initialize_draft
-        course_enrichment.course_length = '4 years'
+        if @course.enrichments.blank?
+          course_enrichment = @course.enrichments.find_or_initialize_draft
+          course_enrichment.course_length = '4 years'
+        else
+          @course.enrichments.max_by(&:created_at).update(course_length: '4 years')
+        end
       end
     end
   end

--- a/app/services/publish/courses/assign_tda_attributes_service.rb
+++ b/app/services/publish/courses/assign_tda_attributes_service.rb
@@ -16,7 +16,7 @@ module Publish
           can_sponsor_skilled_worker_visa: false,
           degree_grade: 'not_required',
           additional_degree_subject_requirements: false,
-          degree_subject_requirements: false
+          degree_subject_requirements: nil
         )
 
         if @course.enrichments.blank?

--- a/app/services/publish/courses/assign_tda_attributes_service.rb
+++ b/app/services/publish/courses/assign_tda_attributes_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    class AssignTdaAttributesService
+      def initialize(course)
+        @course = course
+      end
+
+      def call
+        @course.update(
+          funding_type: 'apprenticeship',
+          study_mode: 'full_time',
+          program_type: 'teacher_degree_apprenticeship',
+          can_sponsor_student_visa: false,
+          can_sponsor_skilled_worker_visa: false,
+          degree_grade: 'not_required',
+          additional_degree_subject_requirements: false,
+          degree_subject_requirements: false
+        )
+
+        course_enrichment = @course.enrichments.find_or_initialize_draft
+        course_enrichment.course_length = '4 years'
+      end
+    end
+  end
+end

--- a/app/services/publish/courses/assign_tda_attributes_service.rb
+++ b/app/services/publish/courses/assign_tda_attributes_service.rb
@@ -8,16 +8,14 @@ module Publish
       end
 
       def call
-        @course.update(
-          funding_type: 'apprenticeship',
-          study_mode: 'full_time',
-          program_type: 'teacher_degree_apprenticeship',
-          can_sponsor_student_visa: false,
-          can_sponsor_skilled_worker_visa: false,
-          degree_grade: 'not_required',
-          additional_degree_subject_requirements: false,
-          degree_subject_requirements: nil
-        )
+        @course.assign_attributes(funding_type: 'apprenticeship',
+                                  study_mode: 'full_time',
+                                  program_type: 'teacher_degree_apprenticeship',
+                                  can_sponsor_student_visa: false,
+                                  can_sponsor_skilled_worker_visa: false,
+                                  degree_grade: 'not_required',
+                                  additional_degree_subject_requirements: false,
+                                  degree_subject_requirements: nil)
 
         if @course.enrichments.blank?
           course_enrichment = @course.enrichments.find_or_initialize_draft

--- a/app/views/publish/courses/funding_type/_form_fields.html.erb
+++ b/app/views/publish/courses/funding_type/_form_fields.html.erb
@@ -46,5 +46,7 @@
                 data: { qa: "course__funding_type_apprenticeship" } %>
       </div>
     </div>
+
+         <%= form.hidden_field :previous_tda_course, value: params[:previous_tda_course] %>
   </fieldset>
 <% end %>

--- a/app/views/publish/courses/outcome/new.html.erb
+++ b/app/views/publish/courses/outcome/new.html.erb
@@ -16,6 +16,8 @@
 
       <%= render "publish/courses/new_fields_holder", form:, except_keys: [:qualification] do |fields| %>
         <%= render "form_fields", form: fields, course_name_and_code: nil %>
+
+        <%= form.hidden_field :current_qualification, value: params[:course][:qualification] %>
       <% end %>
     <% end %>
 

--- a/app/views/publish/courses/study_mode/edit.html.erb
+++ b/app/views/publish/courses/study_mode/edit.html.erb
@@ -41,6 +41,8 @@
         <% end %>
       <% end %>
 
+      <%= f.hidden_field :previous_tda_course, value: params[:previous_tda_course] %>
+
       <%= f.govuk_submit "Update #{page_title.downcase}" %>
     <% end %>
 

--- a/app/views/publish/courses/study_mode/new.html.erb
+++ b/app/views/publish/courses/study_mode/new.html.erb
@@ -16,6 +16,8 @@
 
       <%= render "publish/courses/new_fields_holder", form:, except_keys: [:study_mode] do |fields| %>
         <%= render "form_fields", form: fields %>
+
+        <%= form.hidden_field :previous_tda_course, value: params[:previous_tda_course] %>
       <% end %>
     <% end %>
 

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -13,6 +13,13 @@ search_ui:
 
 features:
   teacher_degree_apprenticeship: true
+  rollover:
+    # Normally a short period of time between rollover and the next cycle
+    # actually starting when it would be set to false
+    has_current_cycle_started?: true
+    # During rollover providers should be able to edit current & next recruitment cycle courses
+    can_edit_current_and_next_cycles: true
+
 
 authentication:
   secret: secret

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -3,11 +3,8 @@
 require 'rails_helper'
 
 feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
-  before do
-    given_i_am_authenticated_as_a_provider_user
-  end
-
   scenario 'i can update the course outcome' do
+    given_i_am_authenticated_as_a_provider_user
     and_there_is_a_qts_course_i_want_to_edit
     when_i_visit_the_course_outcome_page
     and_i_update_the_course_outcome
@@ -18,6 +15,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
   context 'a course offering QTS' do
     scenario 'shows the correct outcome options to choose from' do
+      given_i_am_authenticated_as_a_provider_user
       and_there_is_a_qts_course_i_want_to_edit
       when_i_visit_the_course_outcome_page
       then_i_am_shown_the_correct_qts_options
@@ -26,10 +24,32 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
   context 'a further education course not offering QTS' do
     scenario 'shows the correct outcome options to choose from' do
+      given_i_am_authenticated_as_a_provider_user
       and_there_is_a_non_qts_course_i_want_to_edit
       when_i_visit_the_course_outcome_page
       then_i_am_shown_the_correct_non_qts_options
     end
+  end
+
+  context 'TDA course' do
+    scenario 'changing the outcome from non TDA to TDA' do
+      given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+      and_the_tda_feature_flag_is_active
+      and_there_is_a_qts_course_i_want_to_edit
+      when_i_visit_the_course_outcome_page_in_the_next_cycle
+      and_i_choose_undergraduate_degree_with_qts
+      and_i_submit
+      then_the_default_options_for_a_tda_course_should_be_applied
+    end
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+    next_cycle_providers = [build(:provider, :next_recruitment_cycle, :accredited_provider,
+                                  courses: [create(:course, :with_accrediting_provider)],
+                                  sites: [build(:site), build(:site)],
+                                  study_sites: [build(:site, :study_site)])]
+    @next_cycle_user = create(:user, providers: next_cycle_providers)
+    given_i_am_authenticated(user: @next_cycle_user)
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -54,6 +74,10 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     publish_courses_outcome_edit_page.pgce_with_qts.choose
   end
 
+  def and_i_update_the_course_outcome_to_tda
+    publish_courses_outcome_edit_page.pgce_with_qts.choose
+  end
+
   def and_i_submit
     publish_courses_outcome_edit_page.submit.click
   end
@@ -74,7 +98,48 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('PGCE only (without QTS)', 'PGDE only (without QTS)')
   end
 
+  def and_i_choose_undergraduate_degree_with_qts
+    publish_courses_outcome_edit_page.undergraduate_degree_with_qts.choose
+  end
+
+  def and_the_tda_feature_flag_is_active
+    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
+  end
+
   def provider
     @current_user.providers.first
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+    next_cycle_providers = [build(:provider, :accredited_provider, :next_recruitment_cycle,
+                                  courses: [create(:course, :with_accrediting_provider, study_mode: 'part_time', funding_type: 'fee', can_sponsor_skilled_worker_visa: true)])]
+    @next_cycle_user = create(:user, providers: next_cycle_providers)
+    given_i_am_authenticated(user: @next_cycle_user)
+  end
+
+  def next_cycle_provider
+    @provider ||= @current_user.providers.first
+  end
+
+  def and_the_tda_feature_flag_is_active
+    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
+  end
+
+  def and_there_is_a_qts_course_i_want_to_edit
+    given_a_course_exists(:resulting_in_qts, study_mode: 'part_time', funding_type: 'fee', can_sponsor_skilled_worker_visa: true)
+  end
+
+  def when_i_visit_the_course_outcome_page_in_the_next_cycle
+    publish_courses_outcome_edit_page.load(
+      provider_code: next_cycle_provider.provider_code, recruitment_cycle_year: next_cycle_provider.recruitment_cycle_year, course_code: next_cycle_provider.courses.first.course_code
+    )
+  end
+
+  def then_the_default_options_for_a_tda_course_should_be_applied
+    course.reload
+    expect(course.study_mode == 'full_time').to be(true)
+    expect(course.funding_type == 'apprenticeship').to be(true)
+    expect(course.can_sponsor_skilled_worker_visa == false).to be(true)
+    expect(course.can_sponsor_student_visa == false).to be(true)
   end
 end

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -195,18 +195,18 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
   def then_the_default_options_for_a_tda_course_should_be_applied
     course.reload
-    expect(course.study_mode == 'full_time').to be(true)
+    expect(course.full_time?).to be(true)
     expect(course.funding_type == 'apprenticeship').to be(true)
-    expect(course.can_sponsor_skilled_worker_visa == false).to be(true)
-    expect(course.can_sponsor_student_visa == false).to be(true)
+    expect(course.can_sponsor_skilled_worker_visa).to be false
+    expect(course.can_sponsor_student_visa).to be false
   end
 
   def then_i_see_the_correct_attributes_in_the_database_for_fee_paying
     course.reload
-    expect(course.study_mode == 'part_time').to be(true)
+    expect(course.part_time?).to be(true)
     expect(course.funding_type == 'fee').to be(true)
-    expect(course.can_sponsor_skilled_worker_visa == false).to be(true)
-    expect(course.can_sponsor_student_visa == true).to be(true)
+    expect(course.can_sponsor_skilled_worker_visa).to be(false)
+    expect(course.can_sponsor_student_visa).to be(true)
   end
 
   def and_i_choose_salaried
@@ -218,8 +218,8 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     course.reload
     expect(course.study_mode == 'part_time').to be(true)
     expect(course.funding_type == 'salary').to be(true)
-    expect(course.can_sponsor_skilled_worker_visa == true).to be(true)
-    expect(course.can_sponsor_student_visa == false).to be(true)
+    expect(course.can_sponsor_skilled_worker_visa).to be(true)
+    expect(course.can_sponsor_student_visa).to be(false)
   end
 
   def and_i_should_be_on_the_course_details_page

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -41,6 +41,34 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
       and_i_submit
       then_the_default_options_for_a_tda_course_should_be_applied
     end
+
+    context 'fee course' do
+      scenario 'changing the outcome from TDA to non TDA' do
+        given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+        and_the_tda_feature_flag_is_active
+        and_there_is_a_tda_course_i_want_to_edit
+        when_i_visit_the_course_outcome_page_in_the_next_cycle
+        and_i_choose_qts
+        and_i_choose_the_fee_paying
+        and_i_choose_part_time
+        and_i_choose_to_sponsor_a_student_visa
+        then_i_see_the_correct_attributes_in_the_database_for_fee_paying
+      end
+    end
+
+    context 'salaried course' do
+      scenario 'changing the outcome from TDA to non TDA' do
+        given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+        and_the_tda_feature_flag_is_active
+        and_there_is_a_tda_course_i_want_to_edit
+        when_i_visit_the_course_outcome_page_in_the_next_cycle
+        and_i_choose_qts
+        and_i_choose_salaried
+        and_i_choose_part_time
+        and_i_choose_to_sponsor_a_skilled_worker_visa
+        then_i_see_the_correct_attributes_in_the_database_for_salaried
+      end
+    end
   end
 
   def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
@@ -58,6 +86,10 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
   def and_there_is_a_qts_course_i_want_to_edit
     given_a_course_exists(:resulting_in_qts)
+  end
+
+  def and_there_is_a_tda_course_i_want_to_edit
+    given_a_course_exists(:undergraduate_degree_with_qts)
   end
 
   def and_there_is_a_non_qts_course_i_want_to_edit
@@ -82,6 +114,10 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     publish_courses_outcome_edit_page.submit.click
   end
 
+  def and_i_update
+    click_on 'Update'
+  end
+
   def then_i_should_see_a_success_message
     expect(page).to have_content(I18n.t('success.saved', value: 'Qualification'))
   end
@@ -100,6 +136,27 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
   def and_i_choose_undergraduate_degree_with_qts
     publish_courses_outcome_edit_page.undergraduate_degree_with_qts.choose
+  end
+
+  def and_i_choose_qts
+    publish_courses_outcome_edit_page.qts.choose
+    and_i_submit
+  end
+
+  def and_i_choose_the_fee_paying
+    choose 'Fee - no salary'
+    and_i_update
+  end
+
+  def and_i_choose_to_sponsor_a_student_visa
+    choose 'Yes'
+    and_i_update
+  end
+
+  def and_i_choose_part_time
+    uncheck 'Full time'
+    check 'Part time'
+    and_i_update
   end
 
   def and_the_tda_feature_flag_is_active
@@ -142,4 +199,27 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     expect(course.can_sponsor_skilled_worker_visa == false).to be(true)
     expect(course.can_sponsor_student_visa == false).to be(true)
   end
+
+  def then_i_see_the_correct_attributes_in_the_database_for_fee_paying
+    course.reload
+    expect(course.study_mode == 'part_time').to be(true)
+    expect(course.funding_type == 'fee').to be(true)
+    expect(course.can_sponsor_skilled_worker_visa == false).to be(true)
+    expect(course.can_sponsor_student_visa == true).to be(true)
+  end
+
+  def and_i_choose_salaried
+    choose 'Salary'
+    and_i_update
+  end
+
+  def then_i_see_the_correct_attributes_in_the_database_for_salaried
+    course.reload
+    expect(course.study_mode == 'part_time').to be(true)
+    expect(course.funding_type == 'salary').to be(true)
+    expect(course.can_sponsor_skilled_worker_visa == true).to be(true)
+    expect(course.can_sponsor_student_visa == false).to be(true)
+  end
+
+  alias_method :and_i_choose_to_sponsor_a_skilled_worker_visa, :and_i_choose_to_sponsor_a_student_visa
 end

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -11,6 +11,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     and_i_submit
     then_i_should_see_a_success_message
     and_the_course_outcome_is_updated
+    and_i_should_be_on_the_course_details_page
   end
 
   context 'a course offering QTS' do
@@ -219,6 +220,10 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     expect(course.funding_type == 'salary').to be(true)
     expect(course.can_sponsor_skilled_worker_visa == true).to be(true)
     expect(course.can_sponsor_student_visa == false).to be(true)
+  end
+
+  def and_i_should_be_on_the_course_details_page
+    expect(page).to have_current_path(details_publish_provider_recruitment_cycle_course_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, code: course.course_code), ignore_query: true)
   end
 
   alias_method :and_i_choose_to_sponsor_a_skilled_worker_visa, :and_i_choose_to_sponsor_a_student_visa

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -391,8 +391,8 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     expect(course.funding_type).to eq('apprenticeship')
     expect(course.can_sponsor_student_visa?).to be false
     expect(course.can_sponsor_skilled_worker_visa?).to be false
-    expect(course.additional_degree_subject_requirements).to be(false)
-    expect(course.degree_subject_requirements).to eq('f')
+    expect(course.additional_degree_subject_requirements).to be false
+    expect(course.degree_subject_requirements).to be_nil
     expect(course.degree_grade).to eq('not_required')
     expect(course.enrichments.last).to be_present
     expect(course.enrichments.last.course_length).to eq('4 years')

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -165,6 +165,28 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     then_i_am_on_the_check_your_answers_page
   end
 
+  scenario 'creating a tda course then changing it to a non tda fee paying course' do
+    given_i_am_on_the_check_answers_page_of_a_new_tda_course
+    when_i_visit_the_course_outcome_page
+    and_i_choose_qts
+    and_i_choose_fee
+    and_i_choose_part_time
+    and_i_choose_to_sponsor_a_student_visa
+    when_i_click_on_add_a_course
+    then_i_see_the_correct_attributes_in_the_database_for_fee_paying
+  end
+
+  scenario 'creating a tda course then changing it to a non tda salaried course' do
+    given_i_am_on_the_check_answers_page_of_a_new_tda_course
+    when_i_visit_the_course_outcome_page
+    and_i_choose_qts
+    and_i_choose_salaried
+    and_i_choose_part_time
+    and_i_choose_to_sponsor_a_skilled_worker_visa
+    when_i_click_on_add_a_course
+    then_i_see_the_correct_attributes_in_the_database_for_salaried
+  end
+
   def given_i_am_authenticated_as_a_school_direct_provider_user
     recruitment_cycle = create(:recruitment_cycle, year: 2025)
     @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
@@ -493,5 +515,77 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     course.decorate.name_and_code
   end
 
+  def given_i_am_on_the_check_answers_page_of_a_new_tda_course
+    given_i_am_authenticated_as_a_school_direct_provider_user
+    and_the_tda_feature_flag_is_active
+    and_i_visit_the_courses_page
+    and_i_click_on_add_course
+    and_i_choose_a_secondary_course
+    and_i_select_a_subject
+    and_i_choose_an_age_range
+    and_i_choose_a_degree_awarding_qualification
+    and_i_choose_the_school
+    and_i_choose_the_study_site
+    and_i_choose_the_applications_open_date
+    and_i_choose_the_first_start_date
+    then_i_am_on_the_check_your_answers_page
+  end
+
+  def when_i_visit_the_course_outcome_page
+    publish_course_confirmation_page.details.outcome.change_link.click
+  end
+
+  def and_i_choose_qts
+    publish_courses_outcome_edit_page.qts.choose
+    and_i_click_continue
+  end
+
+  def and_i_choose_fee
+    choose 'Fee - no salary'
+    and_i_click_continue
+  end
+
+  def and_i_choose_salaried
+    choose 'Salary'
+    and_i_click_continue
+  end
+
+  def and_i_choose_part_time
+    uncheck 'Full time'
+    check 'Part time'
+    and_i_click_continue
+  end
+
+  def and_i_choose_to_sponsor_a_student_visa
+    choose 'Yes'
+    and_i_click_continue
+  end
+
+  def and_i_choose_to_sponsor_a_skilled_worker_visa
+    choose('course_can_sponsor_skilled_worker_visa_true')
+    and_i_click_continue
+  end
+
+  def then_i_see_the_correct_attributes_in_the_database_for_fee_paying
+    course.reload
+    expect(course.study_mode == 'part_time').to be(true)
+    expect(course.funding_type == 'fee').to be(true)
+    expect(course.can_sponsor_skilled_worker_visa == false).to be(true)
+    expect(course.can_sponsor_student_visa == true).to be(true)
+  end
+
+  def then_i_see_the_correct_attributes_in_the_database_for_salaried
+    course.reload
+    expect(course.study_mode == 'part_time').to be(true)
+    expect(course.funding_type == 'salary').to be(true)
+    expect(course.can_sponsor_skilled_worker_visa == true).to be(true)
+    expect(course.can_sponsor_student_visa == false).to be(true)
+  end
+
   alias_method :and_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship, :then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship
+  alias_method :and_i_visit_the_courses_page, :when_i_visit_the_courses_page
+  alias_method :and_i_choose_a_degree_awarding_qualification, :when_i_choose_a_degree_awarding_qualification
+  alias_method :and_i_choose_the_school, :when_i_choose_the_school
+  alias_method :and_i_choose_the_applications_open_date, :when_i_choose_the_applications_open_date
+  alias_method :and_i_am_on_the_check_your_answers_page, :then_i_am_on_the_check_your_answers_page
 end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -391,8 +391,8 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     expect(course.funding_type).to eq('apprenticeship')
     expect(course.can_sponsor_student_visa?).to be false
     expect(course.can_sponsor_skilled_worker_visa?).to be false
-    expect(course.additional_degree_subject_requirements).to be_nil
-    expect(course.degree_subject_requirements).to be_nil
+    expect(course.additional_degree_subject_requirements).to be(false)
+    expect(course.degree_subject_requirements).to eq('f')
     expect(course.degree_grade).to eq('not_required')
     expect(course.enrichments.last).to be_present
     expect(course.enrichments.last.course_length).to eq('4 years')

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -568,18 +568,18 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def then_i_see_the_correct_attributes_in_the_database_for_fee_paying
     course.reload
-    expect(course.study_mode == 'part_time').to be(true)
+    expect(course.part_time?).to be(true)
     expect(course.funding_type == 'fee').to be(true)
-    expect(course.can_sponsor_skilled_worker_visa == false).to be(true)
-    expect(course.can_sponsor_student_visa == true).to be(true)
+    expect(course.can_sponsor_skilled_worker_visa).to be(false)
+    expect(course.can_sponsor_student_visa).to be(true)
   end
 
   def then_i_see_the_correct_attributes_in_the_database_for_salaried
     course.reload
     expect(course.study_mode == 'part_time').to be(true)
     expect(course.funding_type == 'salary').to be(true)
-    expect(course.can_sponsor_skilled_worker_visa == true).to be(true)
-    expect(course.can_sponsor_student_visa == false).to be(true)
+    expect(course.can_sponsor_skilled_worker_visa).to be(true)
+    expect(course.can_sponsor_student_visa).to be(false)
   end
 
   alias_method :and_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship, :then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -34,8 +34,7 @@ describe Courses::CreationService do
       expect(subject.funding_type).to eq('apprenticeship')
       expect(subject.can_sponsor_student_visa?).to be false
       expect(subject.can_sponsor_skilled_worker_visa?).to be false
-      expect(subject.additional_degree_subject_requirements).to be_nil
-      expect(subject.degree_subject_requirements).to be_nil
+      expect(subject.additional_degree_subject_requirements).to be(false)
       expect(subject.degree_grade).to eq('not_required')
       expect(subject.enrichments.last).to be_present
       expect(subject.enrichments.last.course_length).to eq('4 years')

--- a/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
+++ b/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Publish::Courses::AssignTdaAttributesService do
   describe '#call' do
     it 'updates the course attributes and returns true' do
       expect(described_class.new(course).call).to be_truthy
-      expect(course.reload.study_mode).to eq('full_time')
+      expect(course.study_mode).to eq('full_time')
       expect(course.funding_type).to eq('apprenticeship')
       expect(course.can_sponsor_skilled_worker_visa).to be(false)
       expect(course.can_sponsor_student_visa).to be(false)

--- a/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
+++ b/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Publish::Courses::AssignTdaAttributesService do
       expect(course.can_sponsor_skilled_worker_visa).to be(false)
       expect(course.can_sponsor_student_visa).to be(false)
       expect(course.additional_degree_subject_requirements).to be(false)
-      expect(course.degree_subject_requirements).to eq('f')
+      expect(course.degree_subject_requirements).to be_nil
       expect(course.degree_grade).to eq('not_required')
     end
   end

--- a/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
+++ b/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Publish::Courses::AssignTdaAttributesService do
+  let(:course) { create(:course, study_mode: 'part_time', funding_type: 'fee', can_sponsor_skilled_worker_visa: true, can_sponsor_student_visa: true) }
+
+  describe '#call' do
+    it 'updates the course attributes and returns true' do
+      expect(described_class.new(course).call).to be_truthy
+      expect(course.reload.study_mode).to eq('full_time')
+      expect(course.funding_type).to eq('apprenticeship')
+      expect(course.can_sponsor_skilled_worker_visa).to be(false)
+      expect(course.can_sponsor_student_visa).to be(false)
+      expect(course.additional_degree_subject_requirements).to be(false)
+      expect(course.degree_subject_requirements).to eq('f')
+      expect(course.degree_grade).to eq('not_required')
+    end
+  end
+end

--- a/spec/support/page_objects/publish/courses/outcome_edit.rb
+++ b/spec/support/page_objects/publish/courses/outcome_edit.rb
@@ -16,6 +16,8 @@ module PageObjects
         element :qts, '#course_qualification_qts'
         element :pgce_with_qts, '#course_qualification_pgce_with_qts'
 
+        element :undergraduate_degree_with_qts, '#course_qualification_undergraduate_degree_with_qts'
+
         element :submit, 'input.govuk-button[type="submit"]'
 
         def error_messages

--- a/spec/support/test_data_cache.rb
+++ b/spec/support/test_data_cache.rb
@@ -62,6 +62,9 @@ class TestDataCache
         %i[resulting_in_pgce] => lambda do
                                    FactoryBot.create(:course, :resulting_in_pgce)
                                  end,
+        %i[undergraduate_degree_with_qts] => lambda do
+                                               FactoryBot.create(:course, :undergraduate_degree_with_qts)
+                                             end,
         %i[resulting_in_pgde] => lambda do
                                    FactoryBot.create(:course, :resulting_in_pgde)
                                  end


### PR DESCRIPTION
### Context

We need to ensure the attributes are correct for TDA courses and non TDA courses.


### Changes proposed in this pull request

There are certain attributes which are set by default on TDA courses, so when a user changes from a non TDA course to a TDA course we need to ensure these attributes are correctly set:

- `study_mode: 'full_time'`
- `funding_type: 'apprenticeship'`
- `can_sponsor_student_visa: false`
- `can_sponsor_skilled_worker_visa: false`

When a user changes from a TDA course to a non TDA course, we need to step the user back through the options which were previously defaulted.

The controllers are heavy, we will think of a good way to refactor in a following PR as there are a lot of changes in here already. 


### Guidance to review

Try and break it. Contact me if you'd like a demo.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
