### PR TITLE
Add spec for back links when TDA

### DIFF
--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -279,9 +279,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def and_the_back_link_points_to_outcome_page
-    and_i_click_back
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_outcome_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
-    and_i_click_continue
+    expect(publish_courses_new_outcome_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_outcome_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
   end
 
   def when_i_choose_the_school
@@ -290,9 +288,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def then_the_back_link_points_to_the_school_page
-    and_i_click_back
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
-    and_i_click_continue
+    expect(publish_courses_new_study_sites_page.back_link[:href]).to include(back_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
   end
 
   def and_i_choose_the_study_site
@@ -301,9 +297,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def and_the_back_link_points_to_the_study_site_page
-    and_i_click_back
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_study_sites_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
-    and_i_click_continue
+    expect(publish_courses_new_applications_open_page.back_link[:href]).to include(back_publish_provider_recruitment_cycle_courses_study_sites_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
   end
 
   def then_i_am_on_the_add_applications_open_date_page
@@ -311,9 +305,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def and_the_back_link_points_to_applications_open_date_page
-    and_i_click_back
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
-    and_i_click_continue
+    expect(publish_courses_new_start_date_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
   end
 
   def when_i_choose_the_applications_open_date
@@ -327,9 +319,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def and_the_back_link_points_to_start_date_page
-    and_i_click_back
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_start_date_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
-    and_i_click_continue
+    expect(publish_course_confirmation_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_start_date_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
   end
 
   def then_i_am_on_the_check_your_answers_page
@@ -495,10 +485,6 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def course_name_and_code
     course.decorate.name_and_code
-  end
-
-  def and_i_click_back
-    click_on 'Back'
   end
 
   alias_method :and_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship, :then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -137,6 +137,29 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_i_do_not_see_the_degree_awarding_option
   end
 
+  scenario 'back links when choosing a teacher degree apprenticeship' do
+    given_i_am_authenticated_as_a_school_direct_provider_user
+    and_the_tda_feature_flag_is_active
+    when_i_visit_the_courses_page
+    and_i_click_on_add_course
+    and_i_choose_a_primary_course
+    and_i_choose_a_primary_age_range
+    then_i_see_the_degree_awarding_option
+    when_i_choose_a_degree_awarding_qualification
+    then_i_am_on_the_choose_schools_page
+    and_the_back_link_points_to_outcome_page
+    when_i_choose_the_school
+    then_the_back_link_points_to_the_school_page
+    and_i_choose_the_study_site
+    then_i_am_on_the_add_applications_open_date_page
+    and_the_back_link_points_to_the_study_site_page
+    when_i_choose_the_applications_open_date
+    and_the_back_link_points_to_applications_open_date_page
+    and_i_choose_the_first_start_date
+    and_the_back_link_points_to_start_date_page
+    then_i_am_on_the_check_your_answers_page
+  end
+
   def given_i_am_authenticated_as_a_school_direct_provider_user
     recruitment_cycle = create(:recruitment_cycle, year: 2025)
     @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
@@ -250,8 +273,20 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
   end
 
+  def and_the_back_link_points_to_outcome_page
+    and_i_click_back
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_outcome_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    and_i_click_continue
+  end
+
   def when_i_choose_the_school
     check provider.sites.first.location_name
+    and_i_click_continue
+  end
+
+  def then_the_back_link_points_to_the_school_page
+    and_i_click_back
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
     and_i_click_continue
   end
 
@@ -260,8 +295,20 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_i_click_continue
   end
 
+  def and_the_back_link_points_to_the_study_site_page
+    and_i_click_back
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_study_sites_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    and_i_click_continue
+  end
+
   def then_i_am_on_the_add_applications_open_date_page
     expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+  end
+
+  def and_the_back_link_points_to_applications_open_date_page
+    and_i_click_back
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    and_i_click_continue
   end
 
   def when_i_choose_the_applications_open_date
@@ -271,6 +318,12 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def and_i_choose_the_first_start_date
     first('input.govuk-radios__input').set(true)
+    and_i_click_continue
+  end
+
+  def and_the_back_link_points_to_start_date_page
+    and_i_click_back
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_start_date_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
     and_i_click_continue
   end
 
@@ -437,6 +490,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def course_name_and_code
     course.decorate.name_and_code
+  end
+
+  def and_i_click_back
+    click_on 'Back'
   end
 
   alias_method :and_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship, :then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -145,14 +145,19 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_i_choose_a_primary_course
     and_i_choose_a_primary_age_range
     then_i_see_the_degree_awarding_option
+
     when_i_choose_a_degree_awarding_qualification
+    # We skip the pages for the TDA: funding type, part-time/full time
     then_i_am_on_the_choose_schools_page
     and_the_back_link_points_to_outcome_page
+
     when_i_choose_the_school
     then_the_back_link_points_to_the_school_page
     and_i_choose_the_study_site
+    # We skip the visa sponsorship question
     then_i_am_on_the_add_applications_open_date_page
     and_the_back_link_points_to_the_study_site_page
+
     when_i_choose_the_applications_open_date
     and_the_back_link_points_to_applications_open_date_page
     and_i_choose_the_first_start_date

--- a/spec/support/page_objects/base.rb
+++ b/spec/support/page_objects/base.rb
@@ -3,5 +3,7 @@
 require 'site_prism'
 
 module PageObjects
-  class Base < SitePrism::Page; end
+  class Base < SitePrism::Page
+    element :back_link, 'a', text: 'Back'
+  end
 end


### PR DESCRIPTION
### Context

Added the back links check when we choose a TDA course.

### Guidance to review

1. Does it need more specs?

### Trello card

https://trello.com/c/2aheIEsW/1677-fix-back-links-on-the-add-course-flow-and-basic-details-page?filter=label:Squad%20B,label:Squad%20Unassigned
