### PR TITLE
Do not expect attribute setter to save the record

### DIFF
--- a/app/services/courses/assign_program_type_service.rb
+++ b/app/services/courses/assign_program_type_service.rb
@@ -17,8 +17,6 @@ module Courses
       when 'fee'
         course.program_type = calculate_fee_program(course)
       end
-      # NOTE: This looks like unwarranted side effects
-      course.save
     end
 
     private

--- a/spec/services/courses/assign_program_type_service_spec.rb
+++ b/spec/services/courses/assign_program_type_service_spec.rb
@@ -58,7 +58,6 @@ describe Courses::AssignProgramTypeService do
       let(:course) { create(:course, :with_accrediting_provider) }
 
       it 'returns :school_direct_training_programme' do
-        course.reload
         expect(course.program_type).to eq('school_direct_training_programme')
       end
     end


### PR DESCRIPTION
### Context

In the past, developers decided it was a good idea to try to save a `Course` record when assigning an attribute.
This is a hang over from when Publish used an API to create `Course`s. [This API has been deleted](https://github.com/DFE-Digital/publish-teacher-training/pull/2677) and I can find no reason why this code should continue to exist.

The functionality behaves in a very unexpected way:

```ruby
# This will try to save the record and add errors to the object
c = Provider.last.courses.new
c.funding_type = 'fee'
```
```ruby
FactoryBot.build(:course, funding_type: 'fee').errors

=> #<ActiveModel::Errors [#<ActiveModel::Error attribute=subjects, type=course_creation, options={}>]>
```

If there are undesirable results from this change we know the area the change will affect and should learn about that quite quickly. The worst outcome I can expect is that courses program type are not saved correctly, but I think this has a low likelihood of happening and can be fixed relatively easily.

### Historical tickets
https://trello.com/c/CKtm7FGo/122-bug-incorrect-route-being-set

### Relevant Pull requests
[Save course after assigning program_type](https://github.com/DFE-Digital/publish-teacher-training/pull/2202)
[Rake task to correct program_type](https://github.com/DFE-Digital/publish-teacher-training/pull/2225)

### Changes proposed in this pull request

Stop calling save on `Course` in the `AssignProgramTypeService`.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
