### PR TITLE
Upgrade ruby patch version

### DIFF
--- a/.github/actions/smoke-test_v2/action.yml
+++ b/.github/actions/smoke-test_v2/action.yml
@@ -14,10 +14,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Ruby 3.2.3
+    - name: Set up Ruby 3.2.4
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.3
+        ruby-version: 3.2.4
 
     - name: install bundler and gems
       shell: bash

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby      3.2.3
+ruby      3.2.4
 bundler   2.3.20
 kubelogin 0.1.0
 kubectl   1

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN bundle exec middleman build --build-dir=../public
 
 ###
 
-FROM ruby:3.2.3-alpine3.19
+FROM ruby:3.2.4-alpine3.20
 
 RUN apk add --no-cache libxml2
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.2.3'
+ruby '3.2.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '7.1.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -874,7 +874,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.2.3p157
+   ruby 3.2.4p170
 
 BUNDLED WITH
    2.3.20


### PR DESCRIPTION
### Context

Github actions stopped working ([here](https://github.com/DFE-Digital/publish-teacher-training/actions/runs/9221004605/job/25369134547?pr=4227) and [here](https://github.com/DFE-Digital/publish-teacher-training/actions/runs/9218111748/job/25361139064?pr=4229) and [here](https://github.com/DFE-Digital/publish-teacher-training/actions/runs/9221603057/job/25371003676))

Security issue noted here: https://security.snyk.io/vuln/SNYK-ALPINE319-GIT-6854155

[Trello card](https://trello.com/c/R1W7ISKX/1727-bug-publish-github-actions-failing)

### Changes proposed in this pull request

Need to upgrade the image we use for the docker build. This requires upgrading a patch version of ruby (3.2.3. no longer supported, see [docker docs](https://hub.docker.com/_/ruby))

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
