### PR TITLE
Move scheduling of job to correct folder

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -22,10 +22,6 @@ bg_jobs:
     cron: "0 0 * * *" # daily at midnight
     class: "SaveStatisticJob"
     queue: save_statistic
-  send_entity_table_checks_to_bigquery:
-    cron: "30 0 * * *"  # daily at 00:30
-    class: "DfE::Analytics::EntityTableCheckJob"
-    queue: low_priority
 skylight:
   enable: true
 environment:

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -21,6 +21,10 @@ bg_jobs:
     cron: "0 0 * * *" # daily at midnight
     class: "SaveStatisticJob"
     queue: save_statistic
+  send_entity_table_checks_to_bigquery:
+  cron: "30 0 * * *"  # daily at 00:30
+  class: "DfE::Analytics::EntityTableCheckJob"
+  queue: low_priority
 skylight:
   enable: true
 environment:


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review
Data from the EntityTableCheckJob hasn't been sending to BigQuery - I enabled the job in the wrong folder (production.yml rather than production_aks.yml)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
