### PR TITLE
Pin hasicorp-azurerm version to 3.104.2

### DIFF
--- a/terraform/aks/providers.tf
+++ b/terraform/aks/providers.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.52"
+      version = "3.104.2"
     }
     statuscake = {
       source  = "StatusCakeDev/statuscake"

--- a/terraform/custom_domains/environment_domains/terraform.tf
+++ b/terraform/custom_domains/environment_domains/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.43.0"
+      version = "3.104.2"
     }
   }
   backend "azurerm" {

--- a/terraform/custom_domains/infrastructure/terraform.tf
+++ b/terraform/custom_domains/infrastructure/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.43.0"
+      version = "3.104.2"
     }
   }
   backend "azurerm" {


### PR DESCRIPTION
### Context
Our builds are failing because this version was automatically upgraded and there is a breaking change. See https://github.com/hashicorp/terraform-provider-azurerm/issues/26098

### Changes proposed in this pull request
Pin the version to the latest working version, on the advice of @saliceti 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
