### PR TITLE
[1573] publish cut down course information move interview process to its own page

### DIFF
--- a/app/controllers/publish/courses/interview_process_controller.rb
+++ b/app/controllers/publish/courses/interview_process_controller.rb
@@ -20,7 +20,7 @@ module Publish
         @interview_process_form = CourseInterviewProcessForm.new(course_enrichment, params: interview_process_params)
 
         if @interview_process_form.save!
-          course_updated_message I18n.t('publish.providers.interview_process.edit.interview_process')
+          course_updated_message I18n.t('publish.providers.interview_process.edit.interview_process_success')
 
           redirect_to redirect_path
         else

--- a/app/controllers/publish/courses/interview_process_controller.rb
+++ b/app/controllers/publish/courses/interview_process_controller.rb
@@ -31,15 +31,19 @@ module Publish
       private
 
       def authorise_with_pundit
-        authorize provider
+        authorize course_to_authorise
       end
 
       def interview_process_params
         params.require(:publish_course_interview_process_form).permit(*CourseInterviewProcessForm::FIELDS)
       end
 
+      def course_to_authorise
+        @course_to_authorise ||= provider.courses.find_by!(course_code: params[:code])
+      end
+
       def course
-        @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
+        @course ||= CourseDecorator.new(course_to_authorise)
       end
 
       def course_enrichment

--- a/app/controllers/publish/courses/interview_process_controller.rb
+++ b/app/controllers/publish/courses/interview_process_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    class InterviewProcessController < PublishController
+      include CopyCourseContent
+      before_action :authorise_with_pundit
+
+      def edit
+        @interview_process_form = CourseInterviewProcessForm.new(course_enrichment)
+        @copied_fields = copy_content_check(::Courses::Copy::INTERVIEW_PROCESS_FIELDS)
+
+        @copied_fields_values = copied_fields_values if @copied_fields.present?
+
+        @interview_process_form.valid? if show_errors_on_publish?
+      end
+
+      def update
+        @interview_process_form = CourseInterviewProcessForm.new(course_enrichment, params: interview_process_params)
+        @interview_process_form = CourseInterviewProcessForm.new(course_enrichment, params: interview_process_params)
+
+        if @interview_process_form.save!
+          course_updated_message I18n.t('publish.providers.interview_process.edit.interview_process')
+
+          redirect_to redirect_path
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def authorise_with_pundit
+        authorize provider
+      end
+
+      def interview_process_params
+        params.require(:publish_course_interview_process_form).permit(*CourseInterviewProcessForm::FIELDS)
+      end
+
+      def course
+        @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
+      end
+
+      def course_enrichment
+        @course_enrichment ||= course.enrichments.find_or_initialize_draft
+      end
+
+      def redirect_path
+        publish_provider_recruitment_cycle_course_path(
+          provider.provider_code,
+          recruitment_cycle.year,
+          course.course_code
+        )
+      end
+    end
+  end
+end

--- a/app/forms/publish/course_interview_process_form.rb
+++ b/app/forms/publish/course_interview_process_form.rb
@@ -1,18 +1,16 @@
 # frozen_string_literal: true
 
 module Publish
-  class CourseInformationForm < BaseProviderForm
+  class CourseInterviewProcessForm < BaseProviderForm
     alias course_enrichment model
 
-    FIELDS = %i[how_school_placements_work].freeze
+    FIELDS = %i[interview_process].freeze
 
     attr_accessor(*FIELDS)
 
     delegate :recruitment_cycle_year, :provider_code, :name, to: :course
 
-    validates :how_school_placements_work, presence: true
-    validates :how_school_placements_work, words_count: { maximum: 350, message: :too_long }
-
+    validates :interview_process, words_count: { maximum: 250, message: :too_long }
     def save!
       if valid?
         assign_attributes_to_model

--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -19,8 +19,11 @@ module Courses
       ['About this course', 'about_course']
     ].freeze
 
+    INTERVIEW_PROCESS_FIELDS = [
+      ['Interview process', 'interview_process']
+    ].freeze
+
     ABOUT_FIELDS = [
-      ['Interview process', 'interview_process'],
       ['How school placements work', 'how_school_placements_work']
     ].freeze
 

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -17,7 +17,7 @@
     "Interview process",
     value_provided?(course.interview_process),
     %w[interview_process],
-    action_path: course.is_withdrawn? ? nil : about_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+    action_path: course.is_withdrawn? ? nil : interview_process_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
     action_visually_hidden_text: "details about the interview process"
   ) %>
 

--- a/app/views/publish/courses/about_this_course/edit.html.erb
+++ b/app/views/publish/courses/about_this_course/edit.html.erb
@@ -63,7 +63,6 @@
         ) %>
   </aside>
       <%= f.govuk_submit t("publish.providers.about_course.edit.submit_button") %>
-    <% end %>
   </div>
   <aside class="govuk-grid-column-one-third" data-qa="course__related_sidebar">
     <%= render(

--- a/app/views/publish/courses/about_this_course/edit.html.erb
+++ b/app/views/publish/courses/about_this_course/edit.html.erb
@@ -62,6 +62,9 @@
           }
         ) %>
   </aside>
+      <%= f.govuk_submit t("publish.providers.about_course.edit.submit_button") %>
+    <% end %>
+  </div>
 </div>
 
 <p class="govuk-body">

--- a/app/views/publish/courses/about_this_course/edit.html.erb
+++ b/app/views/publish/courses/about_this_course/edit.html.erb
@@ -65,6 +65,19 @@
       <%= f.govuk_submit t("publish.providers.about_course.edit.submit_button") %>
     <% end %>
   </div>
+  <aside class="govuk-grid-column-one-third" data-qa="course__related_sidebar">
+    <%= render(
+          partial: "publish/courses/related_sidebar",
+          locals: {
+            course: @course,
+            page_path: about_this_course_publish_provider_recruitment_cycle_course_path(
+              @provider.provider_code,
+              @course.recruitment_cycle_year,
+              @course.course_code
+            )
+          }
+        ) %>
+  </aside>
 </div>
 
 <p class="govuk-body">

--- a/app/views/publish/courses/course_information/edit.html.erb
+++ b/app/views/publish/courses/course_information/edit.html.erb
@@ -28,24 +28,6 @@
         <%= page_title %>
       </h1>
 
-      <h3 class="govuk-heading-m" id="interview-process">Interview process</h3>
-
-      <p class="govuk-body">
-        Include information about:
-      </p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>how many interviews candidates will have</li>
-        <li>who will be interviewing them</li>
-        <li>any tests needed - if so, how they can prepare</li>
-      </ul>
-
-      <%= f.govuk_text_area(:interview_process,
-        value: @copied_fields_values&.dig("interview_process") || @course.interview_process,
-        label: { text: "Interview process (optional)", size: "s" },
-        max_words: 250,
-        rows: 15) %>
-
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
       <h3 class="govuk-heading-m" id="how-school-placements-work"><%= @course.placements_heading %></h3>

--- a/app/views/publish/courses/interview_process/_copy_interview_process_content_warning.html.erb
+++ b/app/views/publish/courses/interview_process/_copy_interview_process_content_warning.html.erb
@@ -1,0 +1,30 @@
+<%= govuk_notification_banner(
+      title_text: t("notification_banner.warning"),
+      classes: "govuk-notification-banner--warning",
+      html_attributes: {
+        data: { qa: "copy-course-warning" },
+        role: "alert"
+      }
+    ) do |notification_banner| %>
+  <% notification_banner.with_heading(text: t("publish.providers.interview_process.edit.changes_not_saved")) %>
+  <p class="govuk-body">
+    <%= t(
+          "publish.providers.interview_process.edit.copied_fields_from",
+          name_and_code: "#{@source_course.name} (#{@source_course.course_code})"
+        ) %>
+  </p>
+  <ul class="govuk-list">
+    <% @copied_fields.each do |name, field| %>
+      <li>
+        <%= govuk_link_to(
+              name,
+              "#publish-course-interview-process-form-#{field.gsub('_', '-')}-field",
+              class: "govuk-notification-banner__link"
+            ) %>
+      </li>
+    <% end %>
+  </ul>
+  <p class="govuk-body">
+    <%= t("publish.providers.interview_process.edit.please_check_changes") %>
+  </p>
+<% end %>

--- a/app/views/publish/courses/interview_process/edit.html.erb
+++ b/app/views/publish/courses/interview_process/edit.html.erb
@@ -35,18 +35,23 @@
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= @course.name_and_code %></span>
-        <%= t("publish.providers.interview_process.edit.interview_process") %>
+        <%= t("publish.providers.interview_process.edit.interview_process_heading") %>
       </h1>
 
       <%= t("publish.providers.interview_process.edit.include_information_about_html") %>
 
       <%= f.govuk_text_area(:interview_process,
                             value: @copied_fields_values&.dig("interview_process") || @interview_process_form.interview_process,
-                            label: { text: t("publish.providers.interview_process.edit.interview_process"), size: "s" },
-                            max_words: 400,
+                            label: { text: t("publish.providers.interview_process.edit.interview_process_label"), size: "s" },
+                            max_words: 250,
                             rows: 20) %>
       <%= f.govuk_submit t("publish.providers.interview_process.edit.submit_button") %>
     <% end %>
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_course_path(@provider.provider_code,
+                                                                                    @provider.recruitment_cycle.year,
+                                                                                    @course.course_code)) %>
+    </p>
   </div>
   <aside class="govuk-grid-column-one-third" data-qa="course__related_sidebar">
     <%= render(
@@ -62,9 +67,3 @@
         ) %>
   </aside>
 </div>
-
-<p class="govuk-body">
-  <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_course_path(@provider.provider_code,
-                                                                                @provider.recruitment_cycle.year,
-                                                                                @course.course_code)) %>
-</p>

--- a/app/views/publish/courses/interview_process/edit.html.erb
+++ b/app/views/publish/courses/interview_process/edit.html.erb
@@ -1,17 +1,17 @@
 <% content_for :page_title, title_with_error_prefix(
-  t("publish.providers.about_course.edit.page_title", course_name_and_code: @course.name_and_code),
-  @about_this_course_form.errors.any?
+  t("publish.providers.interview_process.edit.page_title", course_name_and_code: @course.name_and_code),
+  @interview_process_form.errors.any?
 ) %>
 
 <% if params[:copy_from].present? && @copied_fields.any? %>
-  <%= render partial: "copy_about_course_content_warning" %>
+  <%= render partial: "copy_interview_process_content_warning" %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
-          model: @about_this_course_form,
-          url: about_this_course_publish_provider_recruitment_cycle_course_path(
+          model: @interview_process_form,
+          url: interview_process_publish_provider_recruitment_cycle_course_path(
             @provider.provider_code,
             @course.recruitment_cycle_year,
             @course.course_code
@@ -35,31 +35,27 @@
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= @course.name_and_code %></span>
-        <%= t("publish.providers.about_course.edit.about_this_course") %>
+        <%= t("publish.providers.interview_process.edit.interview_process") %>
       </h1>
 
-      <%= render partial: "guidance" %>
+      <p class="govuk-body"><%= t("publish.providers.interview_process.edit.include_information_about") %></p>
 
-      <%= f.govuk_text_area(:about_course,
-                            value: @copied_fields_values&.dig("about_course") || @about_this_course_form.about_course,
-                            label: { text: t("publish.providers.about_course.edit.about_this_course"), size: "s" },
+      <%= t("publish.providers.interview_process.edit.include_information_about_html") %>
+
+      <%= f.govuk_text_area(:interview_process,
+                            value: @copied_fields_values&.dig("interview_process") || @interview_process_form.interview_process,
+                            label: { text: t("publish.providers.interview_process.edit.interview_process"), size: "s" },
                             max_words: 400,
                             rows: 20) %>
-      <%= f.hidden_field(:goto_preview, value: params[:goto_preview]) %>
-      <%= f.govuk_submit t("publish.providers.about_course.edit.submit_button") %>
+      <%= f.govuk_submit t("publish.providers.interview_process.edit.submit_button") %>
     <% end %>
-    <p class="govuk-body">
-      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_course_path(@provider.provider_code,
-                                                                                    @provider.recruitment_cycle.year,
-                                                                                    @course.course_code)) %>
-    </p>
   </div>
   <aside class="govuk-grid-column-one-third" data-qa="course__related_sidebar">
     <%= render(
           partial: "publish/courses/related_sidebar",
           locals: {
             course: @course,
-            page_path: about_this_course_publish_provider_recruitment_cycle_course_path(
+            page_path: interview_process_publish_provider_recruitment_cycle_course_path(
               @provider.provider_code,
               @course.recruitment_cycle_year,
               @course.course_code
@@ -67,5 +63,10 @@
           }
         ) %>
   </aside>
-  </div>
 </div>
+
+<p class="govuk-body">
+  <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_course_path(@provider.provider_code,
+                                                                                @provider.recruitment_cycle.year,
+                                                                                @course.course_code)) %>
+</p>

--- a/app/views/publish/courses/interview_process/edit.html.erb
+++ b/app/views/publish/courses/interview_process/edit.html.erb
@@ -38,8 +38,6 @@
         <%= t("publish.providers.interview_process.edit.interview_process") %>
       </h1>
 
-      <p class="govuk-body"><%= t("publish.providers.interview_process.edit.include_information_about") %></p>
-
       <%= t("publish.providers.interview_process.edit.include_information_about_html") %>
 
       <%= f.govuk_text_area(:interview_process,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,8 +317,19 @@ en:
           course_fees: Course fees
       interview_process:
         edit:
-          interview_process: Interview process
-
+          interview_process: Interview process (optional)
+          page_title: Interview process - %{course_name_and_code}
+          submit_button: Update interview process
+          changes_not_saved: Your changes are not yet saved
+          copied_fields_from: We have copied this field from %{name_and_code}.
+          please_check_changes: Please check it and make your changes before saving.
+          include_information_about_html:
+            <ul class="govuk-list govuk-list--bullet">"Include information about:</ul>
+              <li>how many interview candidates will have</li>
+              <li>the format of interviews, for example could they interview online</li>
+              <li>who will be interviewing them</li>
+              <li>any tests needed - if so, how they can prepare</li>
+            </ul>
       about_course:
         edit:
           about_this_course: About this course
@@ -834,6 +845,10 @@ en:
               invalid: "Enter a real postcode"
             urn:
               format: "URN must be 5 or 6 numbers"
+        publish/course_interview_process_form:
+          attributes:
+            interview_process:
+              too_long: Reduce the word count for interview process
         publish/course_about_this_course_form:
           attributes:
             about_course:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,7 +324,8 @@ en:
           copied_fields_from: We have copied this field from %{name_and_code}.
           please_check_changes: Please check it and make your changes before saving.
           include_information_about_html:
-            <ul class="govuk-list govuk-list--bullet">"Include information about:</ul>
+            <p class="govuk-body">Include information about:</p>
+            <ul class="govuk-list govuk-list--bullet">
               <li>how many interview candidates will have</li>
               <li>the format of interviews, for example could they interview online</li>
               <li>who will be interviewing them</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,8 +317,10 @@ en:
           course_fees: Course fees
       interview_process:
         edit:
-          interview_process: Interview process (optional)
-          page_title: Interview process - %{course_name_and_code}
+          interview_process_heading: Interview process (optional)
+          interview_process_label: Interview process (optional)
+          interview_process_success: Interview process
+          page_title: Interview process (optional) - %{course_name_and_code}
           submit_button: Update interview process
           changes_not_saved: Your changes are not yet saved
           copied_fields_from: We have copied this field from %{name_and_code}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,7 +347,6 @@ en:
           changes_not_saved: Your changes are not yet saved
           copied_fields_from: We have copied this field from %{name_and_code}.
           please_check_changes: Please check it and make your changes before saving.
-
       study_mode:
         form:
           select_all_that_apply: Select all that apply

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -161,6 +161,8 @@ namespace :publish, as: :publish do
 
         get '/about-this-course', on: :member, to: 'courses/about_this_course#edit'
         patch '/about-this-course', on: :member, to: 'courses/about_this_course#update'
+        get '/interview-process', on: :member, to: 'courses/interview_process#edit'
+        patch '/interview-process', on: :member, to: 'courses/interview_process#update'
         get '/about', on: :member, to: 'courses/course_information#edit'
         patch '/about', on: :member, to: 'courses/course_information#update'
         get '/requirements', on: :member, to: 'courses/requirements#edit'

--- a/spec/features/publish/courses/copy_from_list_spec.rb
+++ b/spec/features/publish/courses/copy_from_list_spec.rb
@@ -63,7 +63,6 @@ feature 'Copying course information', { can_edit_current_and_next_cycles: false 
   end
 
   def then_i_see_the_current_course_information
-    expect(page).to have_content(course.enrichments.first.interview_process)
     expect(page).to have_content(course.enrichments.first.how_school_placements_work)
   end
 
@@ -93,7 +92,6 @@ feature 'Copying course information', { can_edit_current_and_next_cycles: false 
   def and_i_can_see_the_new_content
     copied_course_code = @course_to_copy.match(/\((.*?)\)/)[1]
     @copied_course = Course.find_by(course_code: copied_course_code)
-    expect(page).to have_content(@copied_course.enrichments.first.interview_process)
     expect(page).to have_content(@copied_course.enrichments.first.how_school_placements_work)
   end
 

--- a/spec/features/publish/courses/editing_course_information_spec.rb
+++ b/spec/features/publish/courses/editing_course_information_spec.rb
@@ -31,13 +31,11 @@ feature 'Editing course information', { can_edit_current_and_next_cycles: false 
 
       [
         'Your changes are not yet saved',
-        'Interview process',
         'How school placements work'
       ].each do |name|
         expect(publish_course_information_edit_page.copy_content_warning).to have_content(name)
       end
 
-      expect(publish_course_information_edit_page.interview_process.value).to eq(course2_enrichment.interview_process)
       expect(publish_course_information_edit_page.school_placements.value).to eq(course2_enrichment.how_school_placements_work)
     end
 
@@ -54,9 +52,6 @@ feature 'Editing course information', { can_edit_current_and_next_cycles: false 
         expect(publish_course_information_edit_page.copy_content_warning).to have_content(name)
       end
 
-      expect(publish_course_information_edit_page.copy_content_warning).to have_no_content('Interview process')
-
-      expect(publish_course_information_edit_page.interview_process.value).to eq(course2_enrichment.interview_process)
       expect(publish_course_information_edit_page.school_placements.value).to eq(course3_enrichment.how_school_placements_work)
     end
   end
@@ -85,10 +80,8 @@ feature 'Editing course information', { can_edit_current_and_next_cycles: false 
   end
 
   def and_i_set_information_about_the_course
-    @interview_process = 'This is a new interview process'
     @school_placements = 'This is a new school placements'
 
-    publish_course_information_edit_page.interview_process.set(@interview_process)
     publish_course_information_edit_page.school_placements.set(@school_placements)
   end
 
@@ -108,7 +101,6 @@ feature 'Editing course information', { can_edit_current_and_next_cycles: false 
   def and_the_course_information_is_updated
     enrichment = course.reload.enrichments.find_or_initialize_draft
 
-    expect(enrichment.interview_process).to eq(@interview_process)
     expect(enrichment.how_school_placements_work).to eq(@school_placements)
   end
 

--- a/spec/features/publish/courses/editing_course_interview_process_copy_content_spec.rb
+++ b/spec/features/publish/courses/editing_course_interview_process_copy_content_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Editing interview process section, copying content from another course' do
+  context 'source course has "interview process" data' do
+    scenario 'source course has "about course" data' do
+      given_i_am_authenticated_as_a_provider_user
+      and_there_is_a_course_i_want_to_edit
+      and_there_is_a_course_with_data_i_want_to_copy
+
+      when_i_visit_the_interview_process_edit_page
+      and_i_select_the_other_course_from_the_copy_content_dropdown
+
+      then_i_see_the_copied_course_data
+      and_i_see_the_warning_that_changes_are_not_saved
+      and_the_warning_has_a_link_to_the_interview_process_input_field
+    end
+  end
+
+  scenario 'source course does not "interview process" data' do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_course_i_want_to_edit
+    and_there_is_a_course_without_data_i_try_to_copy
+
+    when_i_visit_the_interview_process_edit_page
+    and_i_select_the_other_course_from_the_copy_content_dropdown
+    then_i_do_not_see_copied_course_data
+    then_i_do_not_see_the_warning_that_changes_are_not_saved
+  end
+
+  private
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_course_i_want_to_edit
+    given_a_course_exists(enrichments: [build(:course_enrichment, :published)])
+  end
+
+  def and_there_is_a_course_with_data_i_want_to_copy
+    course_to_copy('About this other course')
+  end
+
+  def and_there_is_a_course_without_data_i_try_to_copy
+    course_to_copy(nil)
+  end
+
+  def course_to_copy(interview_process)
+    @copied_course ||= create(
+      :course,
+      provider: current_user.providers.first,
+      enrichments: [build(:course_enrichment, :published, interview_process:)]
+    )
+  end
+
+  def copied_course_name_and_code
+    "#{@copied_course.name} (#{@copied_course.course_code})"
+  end
+
+  def and_i_select_the_other_course_from_the_copy_content_dropdown
+    select copied_course_name_and_code, from: 'Copy from'
+
+    click_on 'Copy content'
+  end
+
+  def and_i_see_the_warning_that_changes_are_not_saved
+    expect(page).to have_content 'Your changes are not yet saved'
+    expect(page).to have_content "We have copied this field from #{copied_course_name_and_code}."
+    expect(page).to have_link 'Interview process'
+    expect(page).to have_content 'Please check it and make your changes before saving'
+  end
+
+  def then_i_do_not_see_the_warning_that_changes_are_not_saved
+    expect(page).to have_no_content 'Your change are not yet saved'
+  end
+
+  def and_the_warning_has_a_link_to_the_interview_process_input_field
+    href = (find_link 'Interview process')[:href]
+    interview_process_id = (find_field 'Interview process')[:id]
+    expect(interview_process_id).to eq(href.remove('#'))
+  end
+
+  def then_i_see_the_copied_course_data
+    expect(find_field('Interview process').value).to eq @copied_course.enrichments.first.interview_process
+  end
+
+  def then_i_do_not_see_copied_course_data
+    expect(find_field('Interview process').value).to eq @course.enrichments.first.interview_process
+  end
+
+  def when_i_click_on_the_link_in_the_warning_box
+    click_on 'Interview process'
+  end
+
+  def then_the_focus_is_on_the_input
+    about = find_field 'Interview process'
+    expect(about.focus?).to be true
+  end
+
+  def when_i_visit_the_interview_process_edit_page
+    visit interview_process_publish_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code
+    )
+  end
+
+  def provider
+    @provider ||= @current_user.providers.first
+  end
+end

--- a/spec/features/publish/courses/editing_course_interview_process_copy_content_spec.rb
+++ b/spec/features/publish/courses/editing_course_interview_process_copy_content_spec.rb
@@ -18,7 +18,7 @@ feature 'Editing interview process section, copying content from another course'
     end
   end
 
-  scenario 'source course does not "interview process" data' do
+  scenario 'source course does not have "interview process" data' do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     and_there_is_a_course_without_data_i_try_to_copy
@@ -26,7 +26,7 @@ feature 'Editing interview process section, copying content from another course'
     when_i_visit_the_interview_process_edit_page
     and_i_select_the_other_course_from_the_copy_content_dropdown
     then_i_do_not_see_copied_course_data
-    then_i_do_not_see_the_warning_that_changes_are_not_saved
+    and_i_do_not_see_the_warning_that_changes_are_not_saved
   end
 
   private
@@ -72,7 +72,7 @@ feature 'Editing interview process section, copying content from another course'
     expect(page).to have_content 'Please check it and make your changes before saving'
   end
 
-  def then_i_do_not_see_the_warning_that_changes_are_not_saved
+  def and_i_do_not_see_the_warning_that_changes_are_not_saved
     expect(page).to have_no_content 'Your change are not yet saved'
   end
 
@@ -92,11 +92,6 @@ feature 'Editing interview process section, copying content from another course'
 
   def when_i_click_on_the_link_in_the_warning_box
     click_on 'Interview process'
-  end
-
-  def then_the_focus_is_on_the_input
-    about = find_field 'Interview process'
-    expect(about.focus?).to be true
   end
 
   def when_i_visit_the_interview_process_edit_page

--- a/spec/features/publish/courses/editing_course_interview_process_spec.rb
+++ b/spec/features/publish/courses/editing_course_interview_process_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Editing interview process section' do
+  scenario 'adding valid data' do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_course_i_want_to_edit
+    when_i_visit_the_interview_process_edit_page
+    and_i_enter_information_into_the_interview_process_field
+    and_i_submit_the_form
+    then_interview_process_data_has_changed
+
+    when_i_visit_the_interview_process_edit_page
+    then_i_see_the_new_interview_process_information
+  end
+
+  scenario 'entering invalid data' do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_course_i_want_to_edit
+    when_i_visit_the_interview_process_edit_page
+    and_i_enter_invalid_data
+    and_i_submit_the_form
+    then_i_see_an_error_message
+  end
+
+  private
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_course_i_want_to_edit
+    given_a_course_exists(enrichments: [build(:course_enrichment, :published)])
+  end
+
+  def when_i_visit_the_interview_process_edit_page
+    visit interview_process_publish_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code
+    )
+  end
+
+  def and_i_submit_the_form
+    click_on 'Update interview process'
+  end
+
+  def then_i_see_the_new_interview_process_information
+    expect(find_field('Interview process').value).to eq 'Here is very useful information interview process'
+  end
+
+  def then_interview_process_data_has_changed
+    enrichment = course.reload.enrichments.find_or_initialize_draft
+
+    expect(enrichment.interview_process).to eq('Here is very useful information interview process')
+    expect(page).to have_content 'Here is very useful information interview process'
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content('Reduce the word count for interview process').twice
+  end
+
+  def and_i_enter_invalid_data
+    fill_in 'Interview process', with: Faker::Lorem.sentence(word_count: 251)
+  end
+
+  def and_i_enter_information_into_the_interview_process_field
+    fill_in 'Interview process (optional)', with: 'Here is very useful information interview process'
+  end
+
+  def provider
+    @provider ||= @current_user.providers.first
+  end
+end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -445,11 +445,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     fill_in 'About this course', with: 'Details about this course'
     click_on 'Update about this course'
 
-    publish_provider_courses_show_page.interview_process.find_link(
-      text: 'Change details about the interview process'
+    publish_provider_courses_show_page.how_school_placements_work.find_link(
+      text: 'Change details about how school placements work'
     ).click
 
-    publish_course_information_edit_page.interview_process.set('Interview process details')
     publish_course_information_edit_page.school_placements.set('School placements information')
     publish_course_information_edit_page.submit.click
   end

--- a/spec/forms/publish/course_interview_process_form_spec.rb
+++ b/spec/forms/publish/course_interview_process_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Publish::CourseInterviewProcessForm, type: :model do
+  describe 'validations' do
+    it 'validates length' do
+      course = create(:course)
+      enrichment = course.enrichments.find_or_initialize_draft
+      valid_interview_process = Faker::Lorem.sentence(word_count: 249)
+      invalid_interview_process = Faker::Lorem.sentence(word_count: 251)
+
+      expect(described_class.new(enrichment, params: { interview_process: valid_interview_process }).valid?).to be true
+      expect(described_class.new(enrichment, params: { interview_process: nil }).valid?).to be true
+      expect(described_class.new(enrichment, params: { interview_process: invalid_interview_process }).valid?).to be false
+    end
+  end
+
+  describe '#save!' do
+    it 'saves valid interview_process values' do
+      course = create(:course)
+      enrichment = course.enrichments.find_or_initialize_draft
+
+      [nil, 'some value'].each do |value|
+        described_class.new(enrichment, params: { interview_process: value }).save!
+        expect(enrichment.reload.interview_process).to eq value
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/course_information_edit.rb
+++ b/spec/support/page_objects/publish/course_information_edit.rb
@@ -11,7 +11,6 @@ module PageObjects
       sections :errors, Sections::ErrorLink, '.govuk-error-summary__list li>a'
 
       element :copy_content_warning, '[data-qa="copy-course-warning"]'
-      element :interview_process, '#publish-course-information-form-interview-process-field'
       element :school_placements, '#publish-course-information-form-how-school-placements-work-field'
       element :use_content, '[data-qa="course__use_content"]'
       element :submit, 'button.govuk-button[type="submit"]'


### PR DESCRIPTION
### Context
We are moving the three sections of the 'course information' page into their own separate pages. 
'About this course' has already been merged
'How school placements work' is in the next PR

This PR moves the 'Interview process' section into it's own page.

[Trello ticket](https://trello.com/c/uICb3WCc)
### Changes proposed in this pull request
- Move Interview process onto its own page
- preserved the 'copy content' functionality


https://github.com/DFE-Digital/publish-teacher-training/assets/44073106/51ec9c23-460b-4939-825b-3e831ec78393



### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [NA] Inform data insights team due to database changes
