### PR TITLE
Add a BigQuery maintenance window

### DIFF
--- a/terraform/aks/workspace_variables/app_config.yml
+++ b/terraform/aks/workspace_variables/app_config.yml
@@ -27,3 +27,4 @@ production:
   <<: *default
   RAILS_ENV: production_aks
   RACK_ENV: production_aks
+  BIGQUERY_MAINTENANCE_WINDOW: "04-06-2024 18:15..04-06-2024 18:30"


### PR DESCRIPTION
### Context

This allows the Data Insights team to perform some maintenance on live streamed tables in BigQuery.

Any events to be sent to BigQuery are queued up in Redis and sent after the maintenance window is over.

Requires dfe_analytics GEM Versions >= 1.12.7

### Changes proposed in this pull request

Proposed time: 04-06-2024 18:15 - 18:30 UTC

Please note that UTC is 1 hour behind of BST.

Link to trello card: https://trello.com/c/OLgfjgl9

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
