### PR TITLE
Remove rollover activation from review app

### DIFF
--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -13,13 +13,6 @@ search_ui:
 
 features:
   teacher_degree_apprenticeship: true
-  rollover:
-    # Normally a short period of time between rollover and the next cycle
-    # actually starting when it would be set to false
-    has_current_cycle_started?: true
-    # During rollover providers should be able to edit current & next recruitment cycle courses
-    can_edit_current_and_next_cycles: true
-
 
 authentication:
   secret: secret


### PR DESCRIPTION
### Context

Remove the rollover activation in the review app.

This was used in this commit: https://github.com/DFE-Digital/publish-teacher-training/pull/4223/commits/d8d32025e8a95087af672a685a75d6a1b7fbf841

It should have been removed before merging, so it doesn't confuse people testing on other review apps.
