### PR TITLE
[1579] Remove personal qualities and other requirements from publish

### DIFF
--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -17,6 +17,9 @@ module Publish
       fetch_course
 
       authorize @course
+
+      @hide_other_requirements = provider.course_requirements_deprecated?
+
       @errors = flash[:error_summary]
       flash.delete(:error_summary)
     end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -381,6 +381,10 @@ class Provider < ApplicationRecord
     recruitment_cycle_year.to_i > 2024 && FeatureService.enabled?(:teacher_degree_apprenticeship)
   end
 
+  def course_requirements_deprecated?
+    recruitment_cycle_year.after_2024? && FeatureService.enabled?(:course_requirements_deprecated)
+  end
+
   private
 
   def accredited_provider_codes

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -382,7 +382,7 @@ class Provider < ApplicationRecord
   end
 
   def course_requirements_deprecated?
-    recruitment_cycle_year.after_2024? && FeatureService.enabled?(:course_requirements_deprecated)
+    recruitment_cycle.after_2024? || FeatureService.enabled?(:course_requirements_deprecated)
   end
 
   private

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -67,4 +67,8 @@ class RecruitmentCycle < ApplicationRecord
   def after_2021?
     year.to_i >= 2022
   end
+
+  def after_2024?
+    year.to_i > 2024
+  end
 end

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -146,23 +146,25 @@
       action_visually_hidden_text: "GCSEs"
     ) %>
 
-  <% enrichment_summary(
-    summary_list,
-    :course,
-    "Personal qualities",
-    value_provided?(course.personal_qualities),
-    %w[personal_qualities],
-    action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities",
-    action_visually_hidden_text: "personal qualities"
-  ) %>
+  <% unless @hide_other_requirements %>
+    <% enrichment_summary(
+      summary_list,
+      :course,
+      "Personal qualities",
+      value_provided?(course.personal_qualities),
+      %w[personal_qualities],
+      action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities",
+      action_visually_hidden_text: "personal qualities"
+    ) %>
 
-  <% enrichment_summary(
-    summary_list,
-    :course,
-    "Other requirements",
-    value_provided?(course.other_requirements),
-    %w[other_requirements],
-    action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements",
-    action_visually_hidden_text: "other requirements"
-  ) %>
+    <% enrichment_summary(
+      summary_list,
+      :course,
+      "Other requirements",
+      value_provided?(course.other_requirements),
+      %w[other_requirements],
+      action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements",
+      action_visually_hidden_text: "other requirements"
+    ) %>
+  <% end %>
 <% end %>

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -165,8 +165,14 @@ namespace :publish, as: :publish do
         patch '/interview-process', on: :member, to: 'courses/interview_process#update'
         get '/school-placements', on: :member, to: 'courses/school_placements#edit'
         patch '/school-placements', on: :member, to: 'courses/school_placements#update'
-        get '/requirements', on: :member, to: 'courses/requirements#edit'
-        patch '/requirements', on: :member, to: 'courses/requirements#update'
+
+        # This feature is deprecated and will be removed after the beginning of
+        # 2025 recruitment cycle.
+        scope constraints: { recruitment_cycle_year: /2024/ } do
+          get '/requirements', on: :member, to: 'courses/requirements#edit'
+          patch '/requirements', on: :member, to: 'courses/requirements#update'
+        end
+
         get '/length', on: :member, to: 'courses/length#edit'
         patch '/length', on: :member, to: 'courses/length#update'
         get '/fees-and-financial-support', on: :member, to: 'courses/fees_and_financial_support#edit'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,6 +92,7 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
+  course_requirements_deprecated: false
   teacher_degree_apprenticeship: false
   send_request_data_to_bigquery: false
   rollover:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -11,6 +11,7 @@ environment:
 
 features:
   teacher_degree_apprenticeship: true
+  course_requirements_deprecated: true
 
 find_valid_referers:
   - http://localhost:3001

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -31,6 +31,7 @@ basic_auth:
 features:
   send_request_data_to_bigquery: true
   teacher_degree_apprenticeship: true
+  course_requirements_deprecated: true
 
 find_valid_referers:
   - https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -13,6 +13,7 @@ search_ui:
 
 features:
   teacher_degree_apprenticeship: true
+  course_requirements_deprecated: true
 
 authentication:
   secret: secret

--- a/spec/features/publish/courses/editing_course_requirements_2024_spec.rb
+++ b/spec/features/publish/courses/editing_course_requirements_2024_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 feature 'Editing course requirements', { can_edit_current_and_next_cycles: false } do
   before do
+    allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2024)
+    disable_features(:course_requirements_deprecated)
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_requirements_page
@@ -18,7 +20,7 @@ feature 'Editing course requirements', { can_edit_current_and_next_cycles: false
   end
 
   context 'copying content from another course' do
-    let!(:course2) do
+    let!(:course_two) do
       create(
         :course,
         provider:,
@@ -48,7 +50,7 @@ feature 'Editing course requirements', { can_edit_current_and_next_cycles: false
 
     scenario 'all fields get copied if all are present' do
       when_i_visit_the_course_requirements_page
-      publish_course_requirement_edit_page.copy_content.copy(course2)
+      publish_course_requirement_edit_page.copy_content.copy(course_two)
 
       [
         'Your changes are not yet saved',
@@ -64,7 +66,7 @@ feature 'Editing course requirements', { can_edit_current_and_next_cycles: false
 
     scenario 'missing fields do not get copied' do
       publish_course_requirement_edit_page.load(
-        provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course2.course_code
+        provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course_two.course_code
       )
       publish_course_requirement_edit_page.copy_content.copy(course3)
 

--- a/spec/features/publish/courses/editing_course_requirements_2025_spec.rb
+++ b/spec/features/publish/courses/editing_course_requirements_2025_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Editing course deprecated requirements in 2025', { can_edit_current_and_next_cycles: false } do
+  before do
+    allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
+    enable_features(:course_requirements_deprecated)
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_course_i_want_to_edit
+    provider
+  end
+
+  scenario 'there are no links to the course requirements page' do
+    when_i_visit_the_course_details_page
+    then_there_is_no_link_to_course_requirements
+  end
+
+  scenario 'I can not visit the other requirements page' do
+    expect do
+      visit requirements_publish_provider_recruitment_cycle_course_path(@course.provider.provider_code, 2025, @course.course_code)
+    end.to raise_error(ActionController::UrlGenerationError)
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_course_i_want_to_edit
+    given_a_course_exists(enrichments: [build(:course_enrichment, :published)])
+  end
+
+  def then_there_is_no_link_to_course_requirements
+    expect(page).to have_no_content('Other requirements')
+  end
+
+  def when_i_visit_the_course_details_page
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
+  end
+
+  def when_i_visit_the_course_requirements_page
+    publish_course_requirement_edit_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content(I18n.t('success.saved', value: 'Personal qualities and other requirements'))
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/features/publish/viewing_a_course_2024_spec.rb
+++ b/spec/features/publish/viewing_a_course_2024_spec.rb
@@ -1,0 +1,444 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Course show', { can_edit_current_and_next_cycles: false } do
+  include ActiveSupport::NumberHelper
+
+  scenario 'i can view the course basic details' do
+    allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2024)
+    enable_features(:course_requirements_deprecated)
+
+    given_i_am_authenticated_as_a_provider_user(course: build(:course))
+    when_i_visit_the_course_page
+    and_i_click_on_basic_details
+    then_i_see_the_course_basic_details
+  end
+
+  describe 'with a fee paying course' do
+    context 'bursaries and scholarships is announced' do
+      before do
+        FeatureFlag.activate(:bursaries_and_scholarships_announced)
+      end
+
+      scenario 'i can view a fee course' do
+        given_i_am_authenticated_as_a_provider_user(course: course_with_financial_incentive)
+        when_i_visit_the_course_page
+        then_i_should_see_the_description_of_the_fee_course
+        and_i_should_see_the_course_financial_incentives
+        and_i_should_see_the_course_button_panel
+      end
+    end
+
+    context 'bursaries and scholarships is not announced' do
+      scenario 'i can view a fee course' do
+        given_i_am_authenticated_as_a_provider_user(course: course_with_financial_incentive)
+        when_i_visit_the_course_page
+        then_i_should_see_the_description_of_the_fee_course
+        and_i_should_see_the_course_has_no_financial_incentives_information
+        and_i_should_see_the_course_button_panel
+      end
+    end
+  end
+
+  describe 'with a salary paying course' do
+    scenario 'i can view a salary course' do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], funding_type: 'salary'))
+      when_i_visit_the_course_page
+      then_i_should_see_the_description_of_the_salary_course
+      and_i_should_see_the_course_as('Closed')
+      and_i_should_see_the_course_button_panel
+    end
+  end
+
+  describe 'with a published and running course' do
+    scenario 'i can view the published partial' do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], application_status: 'open', funding_type: 'salary', site_statuses: [build(:site_status, :findable)]))
+      when_i_visit_the_course_page
+      then_i_should_see_the_description_of_the_salary_course
+      and_i_should_see_the_course_as('Open')
+      and_i_should_see_the_course_button_panel
+      and_i_should_see_the_published_partial
+      and_i_should_not_see_the_rollover_button
+    end
+  end
+
+  describe 'in the next cycle' do
+    scenario "published courses have a 'Scheduled' status" do
+      given_there_is_a_next_recruitment_cycle
+      given_i_am_authenticated_as_a_provider_user(course: build(:course))
+      when_i_visit_the_next_cycle_courses_page
+      then_i_should_see_the_status_scheduled
+    end
+  end
+
+  describe 'with a published with unpublished changes course' do
+    scenario 'i can view the unpublished partial' do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_unpublished_changes], funding_type: 'salary'))
+      when_i_visit_the_course_page
+      then_i_should_see_the_description_of_the_unpublished_changes_course
+      and_i_should_see_the_course_button_panel
+      and_i_should_see_the_unpublished_with_changes_partial
+      and_i_should_not_see_the_rollover_button
+    end
+  end
+
+  describe 'with an initial draft course' do
+    scenario 'i can view the unpublished partial and rollover' do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_initial_draft], funding_type: 'salary'))
+      given_there_is_a_next_recruitment_cycle
+      when_i_visit_the_course_page
+      then_i_should_see_the_description_of_the_initial_draft_course
+      and_i_should_see_the_course_button_panel
+      and_i_should_see_the_unpublished_partial
+      and_i_should_see_the_rollover_button
+      and_there_are_change_links
+      when_i_click_the_rollover_button
+      then_i_should_see_the_rollover_form_page
+      when_i_click_the_rollover_course_button
+      then_i_should_see_the_course_show_page_with_success_message
+      when_i_click_the_view_rollover_link
+      then_i_should_see_the_rolled_over_course_show_page
+    end
+  end
+
+  describe 'rollover with an empty course' do
+    scenario 'i can see the success message and link' do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [], funding_type: 'salary'))
+      given_there_is_a_next_recruitment_cycle
+      when_i_visit_the_rollover_form_page
+      when_i_click_the_rollover_course_button
+      then_i_should_see_the_course_show_page_with_success_message
+      when_i_click_the_view_rollover_link
+      then_i_should_see_the_draft_course_on_the_show_page
+    end
+  end
+
+  describe 'rollover with an rolled over course' do
+    scenario 'i can see the success message, link and preview' do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_rolled_over], funding_type: 'salary'))
+      given_there_is_a_next_recruitment_cycle
+      when_i_visit_the_rollover_form_page
+      when_i_click_the_rollover_course_button
+      then_i_should_see_the_course_show_page_with_success_message
+      when_i_click_the_view_rollover_link
+      and_i_should_see_the_rolled_over_course_show_page
+      then_i_should_see_the_link_to_preview
+    end
+  end
+
+  describe 'with a withdrawn course' do
+    scenario 'i can view the withdrawn course' do
+      given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_withdrawn]))
+      when_i_visit_the_course_page
+      then_i_should_see_the_course_button_panel
+      and_i_should_see_the_course_withdrawn_date_and_preview_link
+      and_there_is_no_change_links
+    end
+  end
+
+  private
+
+  def then_i_should_see_the_link_to_preview
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).to have_preview_link
+    end
+  end
+
+  def and_there_are_change_links
+    expect(page.find_all('.govuk-summary-list__actions a').all? { |actions| actions.text.include?('Change ') }).to be(true)
+  end
+
+  def and_there_is_no_change_links
+    expect(page.find_all('.govuk-summary-list__actions a').any?).to be(false)
+  end
+
+  def then_i_should_see_the_rolled_over_course_show_page
+    expect(page).to have_content 'Rolled over'
+  end
+
+  alias_method :and_i_should_see_the_rolled_over_course_show_page, :then_i_should_see_the_rolled_over_course_show_page
+
+  def then_i_should_see_the_draft_course_on_the_show_page
+    expect(page).to have_content 'Draft'
+  end
+
+  def then_i_should_see_the_course_show_page_with_success_message
+    expect(page).to have_content 'Course rolled over'
+  end
+
+  def when_i_click_the_view_rollover_link
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
+    publish_provider_courses_show_page.rolled_over_course_link.click
+  end
+
+  def given_there_is_a_next_recruitment_cycle
+    next_year = RecruitmentCycle.current.year.to_i + 1
+    RecruitmentCycle.create(year: next_year, application_start_date: Date.new(next_year - 1, 10, 1), application_end_date: Date.new(next_year, 9, 30))
+  end
+
+  def when_i_click_the_rollover_course_button
+    rollover_form_page.rollover_course_button.click
+  end
+
+  def then_i_should_see_the_rollover_form_page
+    rollover_form_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{course.course_code}/rollover?")
+    expect(page).to have_content 'Are you sure you want to roll over the course into the next recruitment cycle?'
+  end
+
+  alias_method :when_i_visit_the_rollover_form_page, :then_i_should_see_the_rollover_form_page
+
+  def rollover_form_page
+    @rollover_form_page ||= PageObjects::Publish::DraftRollover.new
+  end
+
+  def and_i_should_see_the_course_button_panel
+    expect(publish_provider_courses_show_page).to have_course_button_panel
+  end
+
+  def and_i_should_see_the_rollover_button
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).to have_rollover_button
+    end
+  end
+
+  def and_i_should_not_see_the_rollover_button
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).not_to have_rollover_button
+    end
+  end
+
+  alias_method :then_i_should_see_the_course_button_panel, :and_i_should_see_the_course_button_panel
+
+  def and_i_should_see_the_unpublished_with_changes_partial
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).to have_publish_button
+      expect(course_button_panel).to have_withdraw_link
+      expect(course_button_panel).to have_last_publish_date
+    end
+  end
+
+  def and_i_should_see_the_unpublished_partial
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).to have_publish_button
+      expect(course_button_panel).to have_preview_link
+      expect(course_button_panel).to have_delete_link
+    end
+  end
+
+  def and_i_should_see_the_published_partial
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).to have_view_on_find
+      expect(course_button_panel).to have_withdraw_link
+      expect(course_button_panel).to have_last_publish_date
+      expect(course_button_panel).not_to have_delete_link
+    end
+  end
+
+  def and_i_click_on_basic_details
+    publish_provider_courses_show_page.basic_details_link.click
+  end
+
+  def when_i_click_the_rollover_button
+    publish_provider_courses_show_page.course_button_panel.rollover_button.click
+  end
+
+  def then_i_see_the_course_basic_details
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{course.course_code}/details")
+  end
+
+  def and_i_should_see_the_course_withdrawn_date_and_preview_link
+    publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
+      expect(course_button_panel).to have_withdrawn_date
+      expect(course_button_panel).to have_preview_link
+    end
+  end
+
+  def course_enrichment
+    @course_enrichment ||= build(:course_enrichment, :published, course_length: :TwoYears, fee_uk_eu: 9250, fee_international: 14_000)
+  end
+
+  def financial_incentive
+    @financial_incentive ||= build(:financial_incentive, bursary_amount: 10_000)
+  end
+
+  def course_enrichment_unpublished_changes
+    @course_enrichment_unpublished_changes ||= build(:course_enrichment, :subsequent_draft, course_length: :TwoYears, fee_uk_eu: 9250, fee_international: 14_000)
+  end
+
+  def course_enrichment_initial_draft
+    @course_enrichment_initial_draft ||= build(:course_enrichment, :initial_draft)
+  end
+
+  def course_enrichment_rolled_over
+    @course_enrichment_rolled_over ||= build(:course_enrichment, :rolled_over)
+  end
+
+  def course_enrichment_withdrawn
+    @course_enrichment_withdrawn ||= build(:course_enrichment, :withdrawn)
+  end
+
+  def given_i_am_authenticated_as_a_provider_user(course:)
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          create(:provider, sites: [build(:site)], courses: [course])
+        ]
+      )
+    )
+  end
+
+  def when_i_visit_the_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
+  end
+
+  def then_i_should_see_the_description_of_the_unpublished_changes_course
+    expect(publish_provider_courses_show_page.about_course).to have_content(
+      course_enrichment_unpublished_changes.about_course
+    )
+  end
+
+  def then_i_should_see_the_description_of_the_initial_draft_course
+    expect(publish_provider_courses_show_page.about_course).to have_content(
+      course_enrichment_initial_draft.about_course
+    )
+
+    expect(publish_provider_courses_show_page.content_status).to have_content(
+      'Draft'
+    )
+  end
+
+  def and_i_should_see_the_course_financial_incentives
+    expect(publish_provider_courses_show_page.financial_incentives).to have_content(number_to_currency(10_000))
+  end
+
+  def and_i_should_see_the_course_has_no_financial_incentives_information
+    expect(publish_provider_courses_show_page.financial_incentives).to have_content('Information not yet available')
+  end
+
+  def then_i_should_see_the_description_of_the_fee_course
+    expect(publish_provider_courses_show_page.title).to have_content(
+      "#{course.name} (#{course.course_code})"
+    )
+    expect(publish_provider_courses_show_page.about_course).to have_content(
+      course_enrichment.about_course
+    )
+    expect(publish_provider_courses_show_page.interview_process).to have_content(
+      course_enrichment.interview_process
+    )
+    expect(publish_provider_courses_show_page.how_school_placements_work).to have_content(
+      course_enrichment.how_school_placements_work
+    )
+    expect(publish_provider_courses_show_page.course_length).to have_content(
+      'Up to 2 years'
+    )
+    expect(publish_provider_courses_show_page.fee_uk_eu).to have_content(
+      '£9,250'
+    )
+    expect(publish_provider_courses_show_page.fee_international).to have_content(
+      '£14,000'
+    )
+    expect(publish_provider_courses_show_page.fee_details).to have_content(
+      course_enrichment.fee_details
+    )
+
+    expect(publish_provider_courses_show_page).not_to have_salary_details
+
+    expect(publish_provider_courses_show_page).to have_degree
+    expect(publish_provider_courses_show_page).to have_gcse
+
+    expect(publish_provider_courses_show_page.personal_qualities).to have_content(
+      course_enrichment.personal_qualities
+    )
+    expect(publish_provider_courses_show_page.other_requirements).to have_content(
+      course_enrichment.other_requirements
+    )
+  end
+
+  def then_i_should_see_the_description_of_the_salary_course
+    expect(publish_provider_courses_show_page.title).to have_content(
+      "#{course.name} (#{course.course_code})"
+    )
+
+    expect(publish_provider_courses_show_page.about_course).to have_content(
+      course_enrichment.about_course
+    )
+    expect(publish_provider_courses_show_page.interview_process).to have_content(
+      course_enrichment.interview_process
+    )
+    expect(publish_provider_courses_show_page.how_school_placements_work).to have_content(
+      course_enrichment.how_school_placements_work
+    )
+    expect(publish_provider_courses_show_page.course_length).to have_content(
+      'Up to 2 years'
+    )
+    expect(publish_provider_courses_show_page).not_to have_fee_uk_eu
+
+    expect(publish_provider_courses_show_page).not_to have_fee_international
+
+    expect(publish_provider_courses_show_page).not_to have_fee_details
+    expect(publish_provider_courses_show_page.salary_details).to have_content(
+      course_enrichment.salary_details
+    )
+    expect(publish_provider_courses_show_page).to have_degree
+    expect(publish_provider_courses_show_page).to have_gcse
+    expect(publish_provider_courses_show_page.personal_qualities).to have_content(
+      course_enrichment.personal_qualities
+    )
+    expect(publish_provider_courses_show_page.other_requirements).to have_content(
+      course_enrichment.other_requirements
+    )
+  end
+
+  def and_i_should_see_the_course_as(status_tag)
+    expect(publish_provider_courses_show_page.content_status).to have_content(status_tag)
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def course
+    provider.courses.first
+  end
+
+  def course_with_financial_incentive
+    build(
+      :course,
+      :secondary,
+      enrichments: [course_enrichment],
+      funding_type: 'fee',
+      subjects: [build(:secondary_subject, bursary_amount: 10_000)]
+    )
+  end
+
+  def course_enrichments_published
+    build(:course_enrichment, :published)
+  end
+
+  def next_recruitment_cycle_year
+    Settings.current_recruitment_cycle_year + 1
+  end
+
+  def when_i_visit_the_next_cycle_courses_page
+    publish_provider_courses_index_page.load(
+      provider_code: next_cycle_provider.provider_code, recruitment_cycle_year: next_recruitment_cycle_year
+    )
+  end
+
+  def next_cycle_provider
+    create(:provider, :next_recruitment_cycle, courses: [build(:course, enrichments: [course_enrichments_published])])
+  end
+
+  def then_i_should_see_the_status_scheduled
+    expect(publish_provider_courses_index_page).to have_scheduled_tag
+  end
+end

--- a/spec/features/publish/viewing_a_course_2025_spec.rb
+++ b/spec/features/publish/viewing_a_course_2025_spec.rb
@@ -35,9 +35,9 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
       scenario 'i can view a fee course' do
         given_i_am_authenticated_as_a_provider_user(course: course_with_financial_incentive)
         when_i_visit_the_course_page
-        then_i_should_see_the_description_of_the_fee_course
-        and_i_should_see_the_course_financial_incentives
-        and_i_should_see_the_course_button_panel
+        then_i_see_the_description_of_the_fee_course
+        and_i_see_the_course_financial_incentives
+        and_i_see_the_course_button_panel
       end
     end
 
@@ -45,9 +45,9 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
       scenario 'i can view a fee course' do
         given_i_am_authenticated_as_a_provider_user(course: course_with_financial_incentive)
         when_i_visit_the_course_page
-        then_i_should_see_the_description_of_the_fee_course
-        and_i_should_see_the_course_has_no_financial_incentives_information
-        and_i_should_see_the_course_button_panel
+        then_i_see_the_description_of_the_fee_course
+        and_i_see_the_course_has_no_financial_incentives_information
+        and_i_see_the_course_button_panel
       end
     end
   end
@@ -56,9 +56,9 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     scenario 'i can view a salary course' do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], funding_type: 'salary'))
       when_i_visit_the_course_page
-      then_i_should_see_the_description_of_the_salary_course
-      and_i_should_see_the_course_as('Closed')
-      and_i_should_see_the_course_button_panel
+      then_i_see_the_description_of_the_salary_course
+      and_i_see_the_course_as('Closed')
+      and_i_see_the_course_button_panel
     end
   end
 
@@ -66,11 +66,11 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     scenario 'i can view the published partial' do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment], application_status: 'open', funding_type: 'salary', site_statuses: [build(:site_status, :findable)]))
       when_i_visit_the_course_page
-      then_i_should_see_the_description_of_the_salary_course
-      and_i_should_see_the_course_as('Open')
-      and_i_should_see_the_course_button_panel
-      and_i_should_see_the_published_partial
-      and_i_should_not_see_the_rollover_button
+      then_i_see_the_description_of_the_salary_course
+      and_i_see_the_course_as('Open')
+      and_i_see_the_course_button_panel
+      and_i_see_the_published_partial
+      and_i_do_not_see_the_rollover_button
     end
   end
 
@@ -78,10 +78,10 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     scenario 'i can view the unpublished partial' do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_unpublished_changes], funding_type: 'salary'))
       when_i_visit_the_course_page
-      then_i_should_see_the_description_of_the_unpublished_changes_course
-      and_i_should_see_the_course_button_panel
-      and_i_should_see_the_unpublished_with_changes_partial
-      and_i_should_not_see_the_rollover_button
+      then_i_see_the_description_of_the_unpublished_changes_course
+      and_i_see_the_course_button_panel
+      and_i_see_the_unpublished_with_changes_partial
+      and_i_do_not_see_the_rollover_button
     end
   end
 
@@ -89,8 +89,8 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     scenario 'i can view the withdrawn course' do
       given_i_am_authenticated_as_a_provider_user(course: build(:course, enrichments: [course_enrichment_withdrawn]))
       when_i_visit_the_course_page
-      then_i_should_see_the_course_button_panel
-      and_i_should_see_the_course_withdrawn_date_and_preview_link
+      then_i_see_the_course_button_panel
+      and_i_see_the_course_withdrawn_date_and_preview_link
       and_there_is_no_change_links
     end
   end
@@ -101,19 +101,19 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     expect(page.find_all('.govuk-summary-list__actions a').any?).to be(false)
   end
 
-  def and_i_should_see_the_course_button_panel
+  def and_i_see_the_course_button_panel
     expect(publish_provider_courses_show_page).to have_course_button_panel
   end
 
-  def and_i_should_not_see_the_rollover_button
+  def and_i_do_not_see_the_rollover_button
     publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
       expect(course_button_panel).not_to have_rollover_button
     end
   end
 
-  alias_method :then_i_should_see_the_course_button_panel, :and_i_should_see_the_course_button_panel
+  alias_method :then_i_see_the_course_button_panel, :and_i_see_the_course_button_panel
 
-  def and_i_should_see_the_unpublished_with_changes_partial
+  def and_i_see_the_unpublished_with_changes_partial
     publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
       expect(course_button_panel).to have_publish_button
       expect(course_button_panel).to have_withdraw_link
@@ -121,7 +121,7 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     end
   end
 
-  def and_i_should_see_the_published_partial
+  def and_i_see_the_published_partial
     publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
       expect(course_button_panel).to have_view_on_find
       expect(course_button_panel).to have_withdraw_link
@@ -138,7 +138,7 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{course.course_code}/details")
   end
 
-  def and_i_should_see_the_course_withdrawn_date_and_preview_link
+  def and_i_see_the_course_withdrawn_date_and_preview_link
     publish_provider_courses_show_page.course_button_panel.within do |course_button_panel|
       expect(course_button_panel).to have_withdrawn_date
       expect(course_button_panel).to have_preview_link
@@ -178,21 +178,21 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     )
   end
 
-  def then_i_should_see_the_description_of_the_unpublished_changes_course
+  def then_i_see_the_description_of_the_unpublished_changes_course
     expect(publish_provider_courses_show_page.about_course).to have_content(
       course_enrichment_unpublished_changes.about_course
     )
   end
 
-  def and_i_should_see_the_course_financial_incentives
+  def and_i_see_the_course_financial_incentives
     expect(publish_provider_courses_show_page.financial_incentives).to have_content(number_to_currency(10_000))
   end
 
-  def and_i_should_see_the_course_has_no_financial_incentives_information
+  def and_i_see_the_course_has_no_financial_incentives_information
     expect(publish_provider_courses_show_page.financial_incentives).to have_content('Information not yet available')
   end
 
-  def then_i_should_see_the_description_of_the_fee_course
+  def then_i_see_the_description_of_the_fee_course
     expect(publish_provider_courses_show_page.title).to have_content(
       "#{course.name} (#{course.course_code})"
     )
@@ -231,7 +231,7 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     )
   end
 
-  def then_i_should_see_the_description_of_the_salary_course
+  def then_i_see_the_description_of_the_salary_course
     expect(publish_provider_courses_show_page.title).to have_content(
       "#{course.name} (#{course.course_code})"
     )
@@ -266,7 +266,7 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
     )
   end
 
-  def and_i_should_see_the_course_as(status_tag)
+  def and_i_see_the_course_as(status_tag)
     expect(publish_provider_courses_show_page.content_status).to have_content(status_tag)
   end
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 describe RecruitmentCycle do
   subject { current_cycle }
 
+  before { allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2023) }
+
   let(:current_cycle) { find_or_create(:recruitment_cycle) }
   let(:next_cycle) { find_or_create(:recruitment_cycle, :next) }
 
-  its(:to_s) { is_expected.to eq('2024/25') }
+  its(:to_s) { is_expected.to eq('2023/24') }
 
   it 'is valid with valid attributes' do
     expect(subject).to be_valid
@@ -49,6 +51,7 @@ describe RecruitmentCycle do
 
   context 'when there are multiple cycles' do
     let!(:third_cycle) do
+      current_cycle
       find_or_create :recruitment_cycle, year: next_cycle.year.to_i + 1
     end
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -49,6 +49,26 @@ describe RecruitmentCycle do
     end
   end
 
+  describe '#after_2024?', :aggregate_failures do
+    context 'when cycle year is 2024' do
+      before { allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2024) }
+
+      it 'returns false' do
+        expect(current_cycle).not_to be_after_2024
+        expect(next_cycle).to be_after_2024
+      end
+    end
+
+    context 'when cycle year is 2025' do
+      before { allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025) }
+
+      it 'returns true' do
+        expect(current_cycle).to be_after_2024
+        expect(next_cycle).to be_after_2024
+      end
+    end
+  end
+
   context 'when there are multiple cycles' do
     let!(:third_cycle) do
       current_cycle

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -8,6 +8,7 @@ def enable_features(*feature_keys)
 end
 
 def disable_features(*feature_keys)
+  allow(FeatureService).to receive(:enabled?).and_return(true)
   feature_keys.each do |feature_key|
     allow(FeatureService).to receive(:enabled?).with(feature_key).and_return(false)
   end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -334,15 +334,15 @@
             "type": "string",
             "nullable": true,
             "format": "markdown",
-            "description": "Any non-academic qualifications or documents the applicant may need.",
-            "example": "You'll need to provide confirmation you have the health and physical capacity to commence training, and a Disclosure and Barring Service (DBS) certificate."
+            "description": "This field is being deprecated after 2024 recruitment cycle.",
+            "example": ""
           },
           "personal_qualities": {
             "type": "string",
             "nullable": true,
             "format": "markdown",
-            "description": "Any skills, motivation and experience the provider is looking for in applicants.",
-            "example": "We are looking for applicants who have the potential to become outstanding teachers, and who are able to work independently on their studies while training in a school context."
+            "description": "This field is being deprecated after 2024 recruitment cycle.",
+            "example": ""
           },
           "program_type": {
             "type": "string",


### PR DESCRIPTION
### Context
Remove the opportunity for a provider to add Personal qualities or Other requirements to courses from after the 2024 RecruitmentCycle.

### Changes proposed in this pull request
 - make safe RecruitmentCycle specs so they don't fail after cycle changes
 - Add Settings feature `:course_requirements_deprecated`
 - Hide the links to the requirements page from the course show page if the the course is after the 2024 recruitment cycle or the feature `:course_requirements_deprecated` is enabled
 - Add tests for the requirements features for both 2024 and 2025. These need to be merged in the next cycle.


No work has been done on Find, I haven't looked into it and I'm not sure that's a requirement of this particular ticket. However, it looks like don't show anything in find for those attributes if they are not present. They won't be present in 2025 anyway.

### Guidance to review
I think there should be a separate module to test if a setting is enabled or not on a course / provider etc.

like: 

```ruby
  Features.enabled?(:some_thing, @provider)
```

rather than

```ruby
provider.some_thing_enabled?
````

### Trello
[Trello Ticket](https://trello.com/c/55x32DBr/1579-publish-remove-personal-qualities-and-other-requirements-from-publish-and-find)
### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
