### PR TITLE
Refactors Program Types and Funding Types

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -519,16 +519,12 @@ class Course < ApplicationRecord
     :not_running
   end
 
-  def funding_type
-    return if program_type.nil?
+  def program
+    Program.from_type(program_type) if program_type.present?
+  end
 
-    if school_direct_salaried_training_programme? || scitt_salaried_programme? || higher_education_salaried_programme?
-      'salary'
-    elsif pg_teaching_apprenticeship? || teacher_degree_apprenticeship?
-      'apprenticeship'
-    else
-      'fee'
-    end
+  def funding_type
+    program.funding_type if program.present?
   end
 
   def is_fee_based?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -288,21 +288,7 @@ class Course < ApplicationRecord
   }
 
   scope :with_funding_types, lambda { |funding_types|
-    program_types = []
-
-    program_types << :school_direct_salaried_training_programme if funding_types.include?('salary')
-
-    program_types << :pg_teaching_apprenticeship if funding_types.include?('apprenticeship')
-
-    if funding_types.include?('fee')
-      %i[
-        higher_education_programme
-        scitt_programme
-        school_direct_training_programme
-      ].each do |program_type|
-        program_types << program_type
-      end
-    end
+    program_types = Program.where_funding_types(funding_types)
 
     where(program_type: program_types)
   }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -491,8 +491,8 @@ class Course < ApplicationRecord
   end
 
   def program_type_description
-    if school_direct_salaried_training_programme? then ' with salary'
-    elsif pg_teaching_apprenticeship? || teacher_degree_apprenticeship? then ' teaching apprenticeship'
+    if program.funding_type.salary? then ' with salary'
+    elsif program.funding_type.apprenticeship? then ' teaching apprenticeship'
     else
       ''
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -248,9 +248,8 @@ class Course < ApplicationRecord
   scope :findable, -> { joins(:site_statuses).merge(SiteStatus.findable) }
   scope :with_vacancies, -> { joins(:site_statuses).merge(SiteStatus.with_vacancies) }
   scope :with_salary, lambda {
-    where(
-      program_type: %i[school_direct_salaried_training_programme pg_teaching_apprenticeship scitt_salaried_programme higher_education_salaried_programme]
-    )
+    program_types = Program.where_salaried
+    where(program_type: program_types)
   }
   scope :with_study_modes, lambda { |study_modes|
     if study_modes.include? 'full_time_or_part_time'
@@ -509,9 +508,7 @@ class Course < ApplicationRecord
     Program.from_type(program_type)
   end
 
-  def funding_type
-    program.funding_type
-  end
+  delegate :funding_type, to: :program
 
   def is_fee_based?
     program.fee_based?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -520,15 +520,15 @@ class Course < ApplicationRecord
   end
 
   def program
-    Program.from_type(program_type) if program_type.present?
+    Program.from_type(program_type)
   end
 
   def funding_type
-    program.funding_type if program.present?
+    program.funding_type
   end
 
   def is_fee_based?
-    funding_type == 'fee'
+    program.fee_based?
   end
 
   def visa_type

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -298,12 +298,12 @@ class Course < ApplicationRecord
 
   scope :can_sponsor_visa, lambda {
     where(
-      program_type: %w[school_direct_training_programme higher_education_programme scitt_programme],
+      program_type: Program.where_sponsor_student_visa,
       can_sponsor_student_visa: true
     )
       .or(
         where(
-          program_type: %w[school_direct_salaried_training_programme pg_teaching_apprenticeship],
+          program_type: Program.where_sponsor_skilled_worker_visa,
           can_sponsor_skilled_worker_visa: true
         )
       )

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -1,34 +1,23 @@
 # frozen_string_literal: true
 
 class Program
+  def self.all
+    {
+      higher_education_programme: HigherEducationProgramme,
+      higher_education_salaried_programme: HigherEducationSalariedProgramme,
+      school_direct_training_programme: SchoolDirectTrainingProgramme,
+      school_direct_salaried_training_programme: SchoolDirectSalariedTrainingProgramme,
+      scitt_programme: SCITTProgramme,
+      scitt_salaried_programme: SCITTSalariedProgramme,
+      pg_teaching_apprenticeship: PostgraduateTeachingApprenticeship,
+      teacher_degree_apprenticeship: TeacherDegreeApprenticeship
+    }
+  end
+
   def self.from_type(program_type)
     return UnknownProgramme unless program_type
 
-    {
-      higher_education_programme: HigherEducationProgramme,
-      higher_education_salaried_programme: HigherEducationSalariedProgramme,
-      school_direct_training_programme: SchoolDirectTrainingProgramme,
-      school_direct_salaried_training_programme: SchoolDirectSalariedTrainingProgramme,
-      scitt_programme: SCITTProgramme,
-      scitt_salaried_programme: SCITTSalariedProgramme,
-      pg_teaching_apprenticeship: PostgraduateTeachingApprenticeship,
-      teacher_degree_apprenticeship: TeacherDegreeApprenticeship
-    }.fetch(program_type.to_sym, UnknownProgramme)
-  end
-
-  def self.where_funding_types(funding_types = [])
-    funding_types = Array(funding_types)
-    {
-      higher_education_programme: HigherEducationProgramme,
-      higher_education_salaried_programme: HigherEducationSalariedProgramme,
-      school_direct_training_programme: SchoolDirectTrainingProgramme,
-      school_direct_salaried_training_programme: SchoolDirectSalariedTrainingProgramme,
-      scitt_programme: SCITTProgramme,
-      scitt_salaried_programme: SCITTSalariedProgramme,
-      pg_teaching_apprenticeship: PostgraduateTeachingApprenticeship,
-      teacher_degree_apprenticeship: TeacherDegreeApprenticeship
-    }.select { |_key, value| funding_types.include?(value.funding_type) }
-      .keys
+    all.fetch(program_type.to_sym, UnknownProgramme)
   end
 
   def self.funding_type
@@ -39,8 +28,24 @@ class Program
     funding_type.fee?
   end
 
+  def self.sponsors_student_visa? = false
+  def self.sponsors_skilled_worker_visa? = false
+
   def self.where_salaried
-    where_funding_types(['salary', 'apprenticeship'])
+    where_funding_types(%w[salary apprenticeship])
+  end
+
+  def self.where_funding_types(funding_types = [])
+    funding_types = Array(funding_types)
+    all.select { |_key, value| funding_types.include?(value.funding_type) }.keys
+  end
+
+  def self.where_sponsor_student_visa
+    all.select { |_key, value| value.sponsors_student_visa? }.keys
+  end
+
+  def self.where_sponsor_skilled_worker_visa
+    all.select { |_key, value| value.sponsors_skilled_worker_visa? }.keys
   end
 end
 
@@ -54,6 +59,8 @@ class HigherEducationProgramme < Program
   def self.funding_type
     ActiveSupport::StringInquirer.new('fee')
   end
+
+  def self.sponsors_student_visa? = true
 end
 
 class HigherEducationSalariedProgramme < Program
@@ -66,18 +73,24 @@ class SchoolDirectTrainingProgramme < Program
   def self.funding_type
     ActiveSupport::StringInquirer.new('fee')
   end
+
+  def self.sponsors_student_visa? = true
 end
 
 class SchoolDirectSalariedTrainingProgramme < Program
   def self.funding_type
     ActiveSupport::StringInquirer.new('salary')
   end
+
+  def self.sponsors_skilled_worker_visa? = true
 end
 
 class SCITTProgramme < Program
   def self.funding_type
     ActiveSupport::StringInquirer.new('fee')
   end
+
+  def self.sponsors_student_visa? = true
 end
 
 class SCITTSalariedProgramme < Program
@@ -90,6 +103,8 @@ class PostgraduateTeachingApprenticeship < Program
   def self.funding_type
     ActiveSupport::StringInquirer.new('apprenticeship')
   end
+
+  def self.sponsors_skilled_worker_visa? = true
 end
 
 class TeacherDegreeApprenticeship < Program

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -38,6 +38,10 @@ class Program
   def self.fee_based?
     funding_type.fee?
   end
+
+  def self.where_salaried
+    where_funding_types(['salary', 'apprenticeship'])
+  end
 end
 
 class UnknownProgramme < Program

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -2,6 +2,8 @@
 
 class Program
   def self.from_type(program_type)
+    return UnknownProgramme unless program_type
+
     {
       higher_education_programme: HigherEducationProgramme,
       higher_education_salaried_programme: HigherEducationSalariedProgramme,
@@ -11,11 +13,21 @@ class Program
       scitt_salaried_programme: SCITTSalariedProgramme,
       pg_teaching_apprenticeship: PostgraduateTeachingApprenticeship,
       teacher_degree_apprenticeship: TeacherDegreeApprenticeship,
-    }.fetch(program_type.to_sym, nil)
+    }.fetch(program_type.to_sym, UnknownProgramme)
   end
 
-  def self.funding_type(funding_type)
-    ActiveSupport::StringInquirer.new(funding_type)
+  def self.funding_type
+    NotImplementedError
+  end
+
+  def self.fee_based?
+    funding_type.fee?
+  end
+end
+
+class UnknownProgramme < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('unknown')
   end
 end
 

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Program
+  def self.from_type(program_type)
+    {
+      higher_education_programme: HigherEducationProgramme,
+      higher_education_salaried_programme: HigherEducationSalariedProgramme,
+      school_direct_training_programme: SchoolDirectTrainingProgramme,
+      school_direct_salaried_training_programme: SchoolDirectSalariedTrainingProgramme,
+      scitt_programme: SCITTProgramme,
+      scitt_salaried_programme: SCITTSalariedProgramme,
+      pg_teaching_apprenticeship: PostgraduateTeachingApprenticeship,
+      teacher_degree_apprenticeship: TeacherDegreeApprenticeship,
+    }.fetch(program_type.to_sym, nil)
+  end
+
+  def self.funding_type(funding_type)
+    ActiveSupport::StringInquirer.new(funding_type)
+  end
+end
+
+class HigherEducationProgramme < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('fee')
+  end
+end
+
+class HigherEducationSalariedProgramme < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('salary')
+  end
+end
+
+class SchoolDirectTrainingProgramme < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('fee')
+  end
+end
+
+class SchoolDirectSalariedTrainingProgramme < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('salary')
+  end
+end
+
+class SCITTProgramme < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('fee')
+  end
+end
+
+class SCITTSalariedProgramme < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('salary')
+  end
+end
+
+class PostgraduateTeachingApprenticeship < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('apprenticeship')
+  end
+end
+
+class TeacherDegreeApprenticeship < Program
+  def self.funding_type
+    ActiveSupport::StringInquirer.new('apprenticeship')
+  end
+end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -12,8 +12,23 @@ class Program
       scitt_programme: SCITTProgramme,
       scitt_salaried_programme: SCITTSalariedProgramme,
       pg_teaching_apprenticeship: PostgraduateTeachingApprenticeship,
-      teacher_degree_apprenticeship: TeacherDegreeApprenticeship,
+      teacher_degree_apprenticeship: TeacherDegreeApprenticeship
     }.fetch(program_type.to_sym, UnknownProgramme)
+  end
+
+  def self.where_funding_types(funding_types = [])
+    funding_types = Array(funding_types)
+    {
+      higher_education_programme: HigherEducationProgramme,
+      higher_education_salaried_programme: HigherEducationSalariedProgramme,
+      school_direct_training_programme: SchoolDirectTrainingProgramme,
+      school_direct_salaried_training_programme: SchoolDirectSalariedTrainingProgramme,
+      scitt_programme: SCITTProgramme,
+      scitt_salaried_programme: SCITTSalariedProgramme,
+      pg_teaching_apprenticeship: PostgraduateTeachingApprenticeship,
+      teacher_degree_apprenticeship: TeacherDegreeApprenticeship
+    }.select { |_key, value| funding_types.include?(value.funding_type) }
+      .keys
   end
 
   def self.funding_type

--- a/app/services/courses/assign_program_type_service.rb
+++ b/app/services/courses/assign_program_type_service.rb
@@ -3,32 +3,29 @@
 module Courses
   class AssignProgramTypeService
     def execute(funding_type, course)
-      case funding_type
-      when 'salary'
-        course.program_type = if course.provider.scitt?
-                                :scitt_salaried_programme
-                              elsif course.provider.university?
-                                :higher_education_salaried_programme
-                              else
-                                :school_direct_salaried_training_programme
-                              end
-      when 'apprenticeship'
-        course.program_type = :pg_teaching_apprenticeship
-      when 'fee'
-        course.program_type = calculate_fee_program(course)
-      end
+      program_type = {
+        'salary' => calculate_salary_program(course),
+        'apprenticeship' => :pg_teaching_apprenticeship,
+        'fee' => calculate_fee_program(course),
+      }.fetch(funding_type, course.program_type)
+
+      course.program_type = program_type
     end
 
     private
 
+    def calculate_salary_program(course)
+      return :scitt_salaried_programme if course.provider.scitt?
+      return :higher_education_salaried_programme if course.provider.university?
+
+      :school_direct_salaried_training_programme
+    end
+
     def calculate_fee_program(course)
-      if !course.self_accredited?
-        :school_direct_training_programme
-      elsif course.provider.scitt?
-        :scitt_programme
-      else
-        :higher_education_programme
-      end
+      return :school_direct_training_programme unless course.self_accredited?
+      return :scitt_programme if course.provider.scitt?
+
+      :higher_education_programme
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2947,9 +2947,9 @@ describe Course do
 
   describe '#funding_type' do
     context 'when program_type is nil' do
-      it 'returns nil' do
+      it 'returns unknown' do
         course = described_class.new(program_type: nil)
-        expect(course.funding_type).to be_nil
+        expect(course.funding_type).to eq("unknown")
       end
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2975,6 +2975,24 @@ describe Course do
     end
   end
 
+  describe '#program' do
+    context 'when program_type is nil' do
+      it 'returns nil' do
+        course = build(:course, program_type: nil)
+
+        expect(course.program).to be_nil
+      end
+    end
+
+    context 'when program_type is higher_education_programme' do
+      it 'returns the HigherEducationProgramme' do
+        course = build(:course, program_type: :higher_education_programme)
+
+        expect(course.program).to be(HigherEducationProgramme)
+      end
+    end
+  end
+
   describe 'funding_type and program_type' do
     context 'setting the funding_type to apprenticeship' do
       it 'sets the funding_type to apprenticeship and program_type to pg_teaching_apprenticeship' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2980,7 +2980,7 @@ describe Course do
       it 'returns nil' do
         course = build(:course, program_type: nil)
 
-        expect(course.program).to be_nil
+        expect(course.program).to be(UnknownProgramme)
       end
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2974,4 +2974,79 @@ describe Course do
       end
     end
   end
+
+  describe 'funding_type and program_type' do
+    context 'setting the funding_type to apprenticeship' do
+      it 'sets the funding_type to apprenticeship and program_type to pg_teaching_apprenticeship' do
+        course = build(:course, funding_type: 'apprenticeship')
+
+        expect(course.funding_type).to eq('apprenticeship')
+        expect(course.program_type).to eq('pg_teaching_apprenticeship')
+      end
+    end
+
+    context 'setting the funding_type to salary' do
+      context 'when the provider is a SCITT' do
+        it 'sets the funding_type to salary and the program_type to scitt_salaried_programme' do
+          provider = build(:provider, provider_type: 'scitt')
+          course = build(:course, provider:, funding_type: 'salary')
+
+          expect(course.funding_type).to eq('salary')
+          expect(course.program_type).to eq('scitt_salaried_programme')
+        end
+      end
+
+      context 'when the provider is a University' do
+        it 'sets the funding_type to salary and the program_type to higher_education_salaried_programme' do
+          provider = build(:provider, provider_type: 'university')
+          course = build(:course, provider:, funding_type: 'salary')
+
+          expect(course.funding_type).to eq('salary')
+          expect(course.program_type).to eq('higher_education_salaried_programme')
+        end
+      end
+
+      context 'when the provider is a Lead School' do
+        it 'sets the funding_type to salary and the program_type to school_direct_salaried_training_programme' do
+          provider = build(:provider, provider_type: 'lead_school')
+          course = build(:course, provider:, funding_type: 'salary')
+
+          expect(course.funding_type).to eq('salary')
+          expect(course.program_type).to eq('school_direct_salaried_training_programme')
+        end
+      end
+    end
+
+    context 'setting the funding_type to fee' do
+      context 'when the provider is not self accredited' do
+        it 'sets the funding_type to salary and the program_type to school_direct_training_programme' do
+          provider = build(:provider, accrediting_provider: :not_an_accredited_provider)
+          course = build(:course, provider:, funding_type: 'fee')
+
+          expect(course.funding_type).to eq('fee')
+          expect(course.program_type).to eq('school_direct_training_programme')
+        end
+      end
+
+      context 'when the provider is self accredited and a SCITT' do
+        it 'sets the funding_type to salary and the program_type to scitt_programme' do
+          provider = build(:provider, accrediting_provider: :accredited_provider, provider_type: 'scitt')
+          course = build(:course, provider:, funding_type: 'fee')
+
+          expect(course.funding_type).to eq('fee')
+          expect(course.program_type).to eq('scitt_programme')
+        end
+      end
+
+      context 'when the provider is self accredited and not a SCITT' do
+        it 'sets the funding_type to salary and the program_type to higher_education_programme' do
+          provider = build(:provider, accrediting_provider: :accredited_provider, provider_type: nil)
+          course = build(:course, provider:, funding_type: 'fee')
+
+          expect(course.funding_type).to eq('fee')
+          expect(course.program_type).to eq('higher_education_programme')
+        end
+      end
+    end
+  end
 end

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Program do
     end
 
     it 'returns a PostgraduateTeachingApprenticeship instance when given :postgraduate_teaching_apprenticeship' do
-      expect(Program.from_type(:postgraduate_teaching_apprenticeship)).to be(PostgraduateTeachingApprenticeship)
+      expect(Program.from_type(:pg_teaching_apprenticeship)).to be(PostgraduateTeachingApprenticeship)
     end
 
     it 'returns a TeacherDegreeApprenticeship instance when given :teacher_degree_apprenticeship' do
@@ -37,7 +37,19 @@ RSpec.describe Program do
     end
 
     it 'returns nil when given an unknown type' do
-      expect(Program.from_type(:unknown)).to be_nil
+      expect(Program.from_type(:unknown)).to be(UnknownProgramme)
+    end
+  end
+
+  describe '.fee_funded?' do
+    it 'returns true when funding_type is "fee"' do
+      allow(Program).to receive(:funding_type).and_return(ActiveSupport::StringInquirer.new('fee'))
+      expect(Program).to be_fee_based
+    end
+
+    it 'returns false when funding_type is not "fee"' do
+      allow(Program).to receive(:funding_type).and_return(ActiveSupport::StringInquirer.new('salary'))
+      expect(Program).not_to be_fee_based
     end
   end
 end

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Program do
     end
   end
 
-  describe '.fee_funded?' do
+  describe '.fee_based?' do
     it 'returns true when funding_type is "fee"' do
       allow(Program).to receive(:funding_type).and_return(ActiveSupport::StringInquirer.new('fee'))
       expect(Program).to be_fee_based
@@ -57,6 +57,32 @@ RSpec.describe Program do
     it 'returns an array of program keys with the given funding types' do
       expect(Program.where_funding_types('fee')).to match_array(%i[higher_education_programme school_direct_training_programme scitt_programme])
       expect(Program.where_funding_types(%w[fee])).to match_array(%i[higher_education_programme school_direct_training_programme scitt_programme])
+    end
+  end
+
+  describe '.sponsors_student_visa?' do
+    it { expect(Program.sponsors_student_visa?).to be_falsey }
+  end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(Program.sponsors_skilled_worker_visa?).to be_falsey }
+  end
+
+  describe '.where_salaried' do
+    it 'returns an array of program keys with funding types "salary" or "apprenticeship"' do
+      expect(Program.where_salaried).to match_array(%i[higher_education_salaried_programme school_direct_salaried_training_programme scitt_salaried_programme pg_teaching_apprenticeship teacher_degree_apprenticeship])
+    end
+  end
+
+  describe '.where_sponsor_student_visa' do
+    it 'returns an array of program keys that sponsor student visas' do
+      expect(Program.where_sponsor_student_visa).to match_array(%i[higher_education_programme school_direct_training_programme scitt_programme])
+    end
+  end
+
+  describe '.where_sponsor_skilled_worker_visa' do
+    it 'returns an array of program keys that sponsor skilled worker visas' do
+      expect(Program.where_sponsor_skilled_worker_visa).to match_array(%i[school_direct_salaried_training_programme pg_teaching_apprenticeship])
     end
   end
 end
@@ -75,6 +101,14 @@ RSpec.describe HigherEducationProgramme do
       expect(HigherEducationProgramme.funding_type).to be_fee
     end
   end
+
+  describe '.sponsors_student_visa?' do
+    it { expect(HigherEducationProgramme.sponsors_student_visa?).to be_truthy }
+  end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(HigherEducationProgramme.sponsors_skilled_worker_visa?).to be_falsey }
+  end
 end
 
 RSpec.describe HigherEducationSalariedProgramme do
@@ -90,6 +124,14 @@ RSpec.describe HigherEducationSalariedProgramme do
     it 'responds to salary?' do
       expect(HigherEducationSalariedProgramme.funding_type).to be_salary
     end
+  end
+
+  describe '.sponsors_student_visa?' do
+    it { expect(HigherEducationSalariedProgramme.sponsors_student_visa?).to be_falsey }
+  end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(HigherEducationSalariedProgramme.sponsors_skilled_worker_visa?).to be_falsey }
   end
 end
 
@@ -107,6 +149,14 @@ RSpec.describe SchoolDirectTrainingProgramme do
       expect(SchoolDirectTrainingProgramme.funding_type).to be_fee
     end
   end
+
+  describe '.sponsors_student_visa?' do
+    it { expect(SchoolDirectTrainingProgramme.sponsors_student_visa?).to be_truthy }
+  end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(SchoolDirectTrainingProgramme.sponsors_skilled_worker_visa?).to be_falsey }
+  end
 end
 
 RSpec.describe SchoolDirectSalariedTrainingProgramme do
@@ -122,6 +172,14 @@ RSpec.describe SchoolDirectSalariedTrainingProgramme do
     it 'responds to salary?' do
       expect(SchoolDirectSalariedTrainingProgramme.funding_type).to be_salary
     end
+  end
+
+  describe '.sponsors_student_visa?' do
+    it { expect(SchoolDirectSalariedTrainingProgramme.sponsors_student_visa?).to be_falsey }
+  end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(SchoolDirectSalariedTrainingProgramme.sponsors_skilled_worker_visa?).to be_truthy }
   end
 end
 
@@ -139,6 +197,14 @@ RSpec.describe SCITTProgramme do
       expect(SCITTProgramme.funding_type).to be_fee
     end
   end
+
+  describe '.sponsors_student_visa?' do
+    it { expect(SCITTProgramme.sponsors_student_visa?).to be_truthy }
+  end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(SCITTProgramme.sponsors_skilled_worker_visa?).to be_falsey }
+  end
 end
 
 RSpec.describe SCITTSalariedProgramme do
@@ -155,7 +221,14 @@ RSpec.describe SCITTSalariedProgramme do
       expect(SCITTSalariedProgramme.funding_type).to be_salary
     end
   end
+  describe '.sponsors_student_visa?' do
+    it { expect(SCITTSalariedProgramme.sponsors_student_visa?).to be_falsey }
   end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(SCITTSalariedProgramme.sponsors_skilled_worker_visa?).to be_falsey }
+  end
+end
 
 RSpec.describe PostgraduateTeachingApprenticeship do
   describe '.funding_type' do
@@ -170,6 +243,14 @@ RSpec.describe PostgraduateTeachingApprenticeship do
     it 'responds to apprenticeship?' do
       expect(PostgraduateTeachingApprenticeship.funding_type).to be_apprenticeship
     end
+  end
+
+  describe '.sponsors_student_visa?' do
+    it { expect(PostgraduateTeachingApprenticeship.sponsors_student_visa?).to be_falsey }
+  end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(PostgraduateTeachingApprenticeship.sponsors_skilled_worker_visa?).to be_truthy}
   end
 end
 
@@ -186,5 +267,13 @@ RSpec.describe TeacherDegreeApprenticeship do
     it 'responds to apprenticeship?' do
       expect(TeacherDegreeApprenticeship.funding_type).to be_apprenticeship
     end
+  end
+
+  describe '.sponsors_student_visa?' do
+    it { expect(TeacherDegreeApprenticeship.sponsors_student_visa?).to be_falsey }
+  end
+
+  describe '.sponsors_skilled_worker_visa?' do
+    it { expect(TeacherDegreeApprenticeship.sponsors_skilled_worker_visa?).to be_falsey }
   end
 end

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Program do
+  describe '.from_type' do
+    it 'returns a HigherEducationProgramme instance when given :higher_education_programme' do
+      expect(Program.from_type(:higher_education_programme)).to be(HigherEducationProgramme)
+    end
+
+    it 'returns a HigherEducationSalariedProgramme instance when given :higher_education_salaried_programme' do
+      expect(Program.from_type(:higher_education_salaried_programme)).to be(HigherEducationSalariedProgramme)
+    end
+
+    it 'returns a SchoolDirectTrainingProgramme instance when given :school_direct_training_programme' do
+      expect(Program.from_type(:school_direct_training_programme)).to be(SchoolDirectTrainingProgramme)
+    end
+
+    it 'returns a SchoolDirectSalariedTrainingProgramme instance when given :school_direct_salaried_training_programme' do
+      expect(Program.from_type(:school_direct_salaried_training_programme)).to be(SchoolDirectSalariedTrainingProgramme)
+    end
+
+    it 'returns a SCITTProgramme instance when given :scitt_programme' do
+      expect(Program.from_type(:scitt_programme)).to be(SCITTProgramme)
+    end
+
+    it 'returns a SCITTSalariedProgramme instance when given :scitt_salaried_programme' do
+      expect(Program.from_type(:scitt_salaried_programme)).to be(SCITTSalariedProgramme)
+    end
+
+    it 'returns a PostgraduateTeachingApprenticeship instance when given :postgraduate_teaching_apprenticeship' do
+      expect(Program.from_type(:postgraduate_teaching_apprenticeship)).to be(PostgraduateTeachingApprenticeship)
+    end
+
+    it 'returns a TeacherDegreeApprenticeship instance when given :teacher_degree_apprenticeship' do
+      expect(Program.from_type(:teacher_degree_apprenticeship)).to be(TeacherDegreeApprenticeship)
+    end
+
+    it 'returns nil when given an unknown type' do
+      expect(Program.from_type(:unknown)).to be_nil
+    end
+  end
+end
+
+RSpec.describe HigherEducationProgramme do
+  describe '.funding_type' do
+    it 'returns an ActiveSupport::StringInquirer' do
+      expect(HigherEducationProgramme.funding_type).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'returns "fee"' do
+      expect(HigherEducationProgramme.funding_type).to eq('fee')
+    end
+
+    it 'responds to fee?' do
+      expect(HigherEducationProgramme.funding_type).to be_fee
+    end
+  end
+end
+
+RSpec.describe HigherEducationSalariedProgramme do
+  describe '.funding_type' do
+    it 'returns an ActiveSupport::StringInquirer' do
+      expect(HigherEducationSalariedProgramme.funding_type).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'returns "salary"' do
+      expect(HigherEducationSalariedProgramme.funding_type).to eq('salary')
+    end
+
+    it 'responds to salary?' do
+      expect(HigherEducationSalariedProgramme.funding_type).to be_salary
+    end
+  end
+end
+
+RSpec.describe SchoolDirectTrainingProgramme do
+  describe '.funding_type' do
+    it 'returns an ActiveSupport::StringInquirer' do
+      expect(SchoolDirectTrainingProgramme.funding_type).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'returns "fee"' do
+      expect(SchoolDirectTrainingProgramme.funding_type).to eq('fee')
+    end
+
+    it 'responds to fee?' do
+      expect(SchoolDirectTrainingProgramme.funding_type).to be_fee
+    end
+  end
+end
+
+RSpec.describe SchoolDirectSalariedTrainingProgramme do
+  describe '.funding_type' do
+    it 'returns an ActiveSupport::StringInquirer' do
+      expect(SchoolDirectSalariedTrainingProgramme.funding_type).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'returns "salary"' do
+      expect(SchoolDirectSalariedTrainingProgramme.funding_type).to eq('salary')
+    end
+
+    it 'responds to salary?' do
+      expect(SchoolDirectSalariedTrainingProgramme.funding_type).to be_salary
+    end
+  end
+end
+
+RSpec.describe SCITTProgramme do
+  describe '.funding_type' do
+    it 'returns an ActiveSupport::StringInquirer' do
+      expect(SCITTProgramme.funding_type).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'returns "fee"' do
+      expect(SCITTProgramme.funding_type).to eq('fee')
+    end
+
+    it 'responds to fee?' do
+      expect(SCITTProgramme.funding_type).to be_fee
+    end
+  end
+end
+
+RSpec.describe SCITTSalariedProgramme do
+  describe '.funding_type' do
+    it 'returns an ActiveSupport::StringInquirer' do
+      expect(SCITTSalariedProgramme.funding_type).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'returns "salary"' do
+      expect(SCITTSalariedProgramme.funding_type).to eq('salary')
+    end
+
+    it 'responds to salary?' do
+      expect(SCITTSalariedProgramme.funding_type).to be_salary
+    end
+  end
+  end
+
+RSpec.describe PostgraduateTeachingApprenticeship do
+  describe '.funding_type' do
+    it 'returns an ActiveSupport::StringInquirer' do
+      expect(PostgraduateTeachingApprenticeship.funding_type).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'returns "apprenticeship"' do
+      expect(PostgraduateTeachingApprenticeship.funding_type).to eq('apprenticeship')
+    end
+
+    it 'responds to apprenticeship?' do
+      expect(PostgraduateTeachingApprenticeship.funding_type).to be_apprenticeship
+    end
+  end
+end
+
+RSpec.describe TeacherDegreeApprenticeship do
+  describe '.funding_type' do
+    it 'returns an ActiveSupport::StringInquirer' do
+      expect(TeacherDegreeApprenticeship.funding_type).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'returns "apprenticeship"' do
+      expect(TeacherDegreeApprenticeship.funding_type).to eq('apprenticeship')
+    end
+
+    it 'responds to apprenticeship?' do
+      expect(TeacherDegreeApprenticeship.funding_type).to be_apprenticeship
+    end
+  end
+end

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe Program do
       expect(Program).not_to be_fee_based
     end
   end
+
+  describe '.where_funding_types' do
+    it 'returns an array of program keys with the given funding types' do
+      expect(Program.where_funding_types('fee')).to match_array(%i[higher_education_programme school_direct_training_programme scitt_programme])
+      expect(Program.where_funding_types(%w[fee])).to match_array(%i[higher_education_programme school_direct_training_programme scitt_programme])
+    end
+  end
 end
 
 RSpec.describe HigherEducationProgramme do


### PR DESCRIPTION
### Context

While investigating how the Funding and Program types, it was difficult to follow all the logic that relied on program_types.

### Changes proposed in this pull request

This PR introduces a Program model and models for each type of Program. These hold the information about their funding types, if they are salaried, and if the sponsor visas.

This keeps all the logic for each of these in the same place rather than peppered throughout the Course model

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
