### PR TITLE
[1638] publish amends to course description tab

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -262,7 +262,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def placements_heading
-    CourseEnrichment.human_attribute_name("how_school_placements_work#{further_education? ? '/further_education' : nil}")
+    CourseEnrichment.human_attribute_name('how_school_placements_work')
   end
 
   def length_and_fees_or_salary_heading

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -265,6 +265,14 @@ class CourseDecorator < ApplicationDecorator
     CourseEnrichment.human_attribute_name("how_school_placements_work#{further_education? ? '/further_education' : nil}")
   end
 
+  def length_and_fees_or_salary_heading
+    if has_fees?
+      I18n.t('publish.providers.courses.description_content.course_length_and_fees_heading')
+    else
+      I18n.t('publish.providers.courses.description_content.course_length_and_salary_heading')
+    end
+  end
+
   def further_education?
     level == 'further_education' && subjects.any? { |s| s.subject_name == 'Further education' || s.subject_code = '41' }
   end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -266,11 +266,9 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def length_and_fees_or_salary_heading
-    if has_fees?
-      I18n.t('publish.providers.courses.description_content.course_length_and_fees_heading')
-    else
-      I18n.t('publish.providers.courses.description_content.course_length_and_salary_heading')
-    end
+    heading = has_fees? ? 'course_length_and_fees_heading' : 'course_length_and_salary_heading'
+
+    I18n.t("publish.providers.courses.description_content.#{heading}")
   end
 
   def further_education?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,7 @@ module ApplicationHelper
   end
 
   # TODO: refactor enrichment_summary method to not use an instance variable
-  def enrichment_summary(summary_list, model, key, value, fields, truncate_value: false, action_path: nil, action_visually_hidden_text: nil)
+  def enrichment_summary(summary_list, model, key, value, fields, action_path: nil, action_visually_hidden_text: nil)
     action = render_action(action_path, action_visually_hidden_text || key.downcase)
 
     if fields.any? { |field| @errors&.key? field.to_sym }
@@ -47,15 +47,13 @@ module ApplicationHelper
 
       value = raw(*errors)
       action = nil
-    elsif truncate_value
-      classes = 'app-summary-list__value--truncate'
     end
 
     value = raw('<span class="app-!-colour-muted">Empty</span>') if value.blank?
 
     summary_list.with_row(html_attributes: { data: { qa: "enrichment__#{fields.first}" } }) do |row|
       row.with_key { key.html_safe }
-      row.with_value(classes: classes || ['govuk-summary-list__value']) { value }
+      row.with_value(classes: ['govuk-summary-list__value']) { value }
       if action
         row.with_action(**action)
       else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,8 +37,8 @@ module ApplicationHelper
   end
 
   # TODO: refactor enrichment_summary method to not use an instance variable
-  def enrichment_summary(summary_list, model, key, value, fields, truncate_value: true, action_path: nil, action_visually_hidden_text: nil)
-    action = render_action(action_path, action_visually_hidden_text)
+  def enrichment_summary(summary_list, model, key, value, fields, truncate_value: false, action_path: nil, action_visually_hidden_text: nil)
+    action = render_action(action_path, action_visually_hidden_text || key.downcase)
 
     if fields.any? { |field| @errors&.key? field.to_sym }
       errors = fields.map do |field|

--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -24,7 +24,7 @@ module Courses
     ].freeze
 
     SCHOOL_PLACEMENTS_FIELDS = [
-      ['How school placements work', 'how_school_placements_work']
+      ['How placements work', 'how_school_placements_work']
     ].freeze
 
     FEES_FIELDS = [

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -1,170 +1,165 @@
-<h2 class="govuk-heading-m">Course information</h2>
+<h2 class="govuk-heading-m">
+  <%= t("publish.providers.courses.description_content.course_information_heading") %>
+</h2>
 
 <%= govuk_summary_list do |summary_list| %>
   <% enrichment_summary(
     summary_list,
     :course,
-    "About this course",
+    t("publish.providers.courses.description_content.about_course_label"),
     value_provided?(course.about_course),
     %w[about_course],
     action_path: course.is_withdrawn? ? nil : about_this_course_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-    action_visually_hidden_text: "details about this course"
+    action_visually_hidden_text: t("publish.providers.courses.description_content.about_course_hidden_text")
   ) %>
+
+  <% enrichment_summary(
+       summary_list,
+       :course,
+       course.placements_heading,
+       value_provided?(course.how_school_placements_work),
+       %w[how_school_placements_work],
+       action_path: course.is_withdrawn? ? nil : school_placements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+       action_visually_hidden_text: t("publish.providers.courses.description_content.how_school_placements_work_hidden_text")
+     ) %>
 
   <% enrichment_summary(
     summary_list,
     :course,
-    "Interview process",
+    t("publish.providers.courses.description_content.interview_process_label"),
     value_provided?(course.interview_process),
     %w[interview_process],
     action_path: course.is_withdrawn? ? nil : interview_process_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-    action_visually_hidden_text: "details about the interview process"
+    action_visually_hidden_text: t("publish.providers.courses.description_content.interview_process_hidden_text")
   ) %>
 
-  <% enrichment_summary(
-    summary_list,
-    :course,
-    course.placements_heading,
-    value_provided?(course.how_school_placements_work),
-    %w[how_school_placements_work],
-    action_path: course.is_withdrawn? ? nil : school_placements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-    action_visually_hidden_text: "details about how school placements work"
-  ) %>
 <% end %>
 
-<h2 class="govuk-heading-m">
-  <% if course.has_fees? %>
-    Course length and fees
-  <% else %>
-    Course length and salary
-  <% end %>
-</h2>
+<h2 class="govuk-heading-m"><%= course.length_and_fees_or_salary_heading %></h2>
+
 <%= govuk_summary_list do |summary_list| %>
   <% if course.has_fees? %>
     <% enrichment_summary(
       summary_list,
       :course,
-      "Course length",
+      t("publish.providers.courses.description_content.course_length_label"),
       value_provided?(course.length),
       %w[course_length],
-      action_path: course.cannot_change_course_length? ? nil : length_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      action_visually_hidden_text: "course length"
+      action_path: course.cannot_change_course_length? ? nil : length_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)
     ) %>
 
     <% enrichment_summary(
       summary_list,
       :course,
-      "Fee for UK students",
+      t("publish.providers.courses.description_content.fee_for_uk_students_label"),
       value_provided?(number_to_currency(course.fee_uk_eu)),
       %w[fee_uk_eu],
       action_path: course.is_withdrawn? ? nil : fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      action_visually_hidden_text: "fee for UK students"
+      action_visually_hidden_text: t("publish.providers.courses.description_content.fee_for_uk_students_hidden_text")
     ) %>
 
     <% enrichment_summary(
       summary_list,
       :course,
-      "Fee for international students",
+      t("publish.providers.courses.description_content.fee_for_international_students_label"),
       value_provided?(number_to_currency(course.fee_international)),
       %w[fee_international],
-      action_path: course.is_withdrawn? ? nil : fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      action_visually_hidden_text: "fee for international students"
+      action_path: course.is_withdrawn? ? nil : fees_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)
     ) %>
 
     <% enrichment_summary(
       summary_list,
       :course,
-      CourseEnrichment.human_attribute_name("fee_details"),
+      t("publish.providers.courses.description_content.fee_details_label"),
       value_provided?(course.fee_details),
       %w[fee_details],
       action_path: course.is_withdrawn? ? nil : fees_and_financial_support_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      action_visually_hidden_text: CourseEnrichment.human_attribute_name("fee_details")
+      action_visually_hidden_text: t("publish.providers.courses.description_content.fee_details_hidden_text")
     ) %>
 
     <% if course.financial_support.present? %>
       <% enrichment_summary(
         summary_list,
         :course,
-        "Financial support you offer",
+        t("publish.providers.courses.description_content.financial_support_you_offer_label"),
         value_provided?(course.financial_support),
         %w[financial_support]
       ) %>
     <% end %>
 
     <% summary_list.with_row(html_attributes: { data: { qa: "course__financial_incentives" } }) do |row| %>
-      <% row.with_key { "Financial support from the government" } %>
+      <% row.with_key { t("publish.providers.courses.description_content.financial_incentive_details_label") } %>
       <% row.with_value { course.financial_incentive_details } %>
       <% row.with_action %>
     <% end %>
   <% else %>
     <% enrichment_summary(
-      summary_list,
-      :course,
-      "Course length",
-      value_provided?(course.length),
-      %w[course_length],
-      action_path: course.cannot_change_course_length? ? nil : length_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      action_visually_hidden_text: "course length"
-    ) %>
+         summary_list,
+         :course,
+         t("publish.providers.courses.description_content.course_length_label"),
+         value_provided?(course.length),
+         %w[course_length],
+         action_path: course.cannot_change_course_length? ? nil : length_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+         action_visually_hidden_text: t("publish.providers.courses.description_content.course_length_hidden_text")
+       ) %>
 
     <% enrichment_summary(
       summary_list,
       :course,
-      "Salary",
+      t("publish.providers.courses.description_content.salary_label"),
       value_provided?(course.salary_details),
       %w[salary_details],
       action_path: course.is_withdrawn? ? nil : salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      action_visually_hidden_text: "salary"
+      action_visually_hidden_text: t("publish.providers.courses.description_content.salary_hidden_text")
     ) %>
   <% end %>
 <% end %>
 
-<h2 class="govuk-heading-m">Requirements and eligibility</h2>
+<h2 class="govuk-heading-m">
+  <%= t("publish.providers.courses.description_content.requirements_heading") %>
+</h2>
 
   <%= govuk_summary_list do |summary_list| %>
     <% if course.show_degree_requirements_row? %>
       <% enrichment_summary(
         summary_list,
         :course,
-        "Degree",
+        t("publish.providers.courses.description_content.degree_label"),
         (render DegreeRowContent.new(course:, errors: @errors)),
         %w[degree_grade degree_subject_requirements],
         truncate_value: false,
         action_path: !course.is_withdrawn? && course.degree_section_complete? ? degrees_start_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
-        action_visually_hidden_text: "degree"
+        action_visually_hidden_text: t("publish.providers.courses.description_content.degree_hidden_text")
       ) %>
     <% end %>
 
     <% enrichment_summary(
       summary_list,
       :course,
-      "GCSEs",
+      t("publish.providers.courses.description_content.gcse_label"),
       (render GcseRowContent.new(course:, errors: @errors)),
       %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
       truncate_value: false,
-      action_path: !course.is_withdrawn? && course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
-      action_visually_hidden_text: "GCSEs"
+      action_path: !course.is_withdrawn? && course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil
     ) %>
 
   <% unless @hide_other_requirements %>
     <% enrichment_summary(
       summary_list,
       :course,
-      "Personal qualities",
+      t("publish.providers.courses.description_content.personal_qualities_label"),
       value_provided?(course.personal_qualities),
       %w[personal_qualities],
-      action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities",
-      action_visually_hidden_text: "personal qualities"
+      action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities"
     ) %>
 
     <% enrichment_summary(
       summary_list,
       :course,
-      "Other requirements",
+      t("publish.providers.courses.description_content.other_requirements_label"),
       value_provided?(course.other_requirements),
       %w[other_requirements],
-      action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements",
-      action_visually_hidden_text: "other requirements"
+      action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements"
     ) %>
   <% end %>
 <% end %>

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -109,8 +109,7 @@
       t("publish.providers.courses.description_content.salary_label"),
       value_provided?(course.salary_details),
       %w[salary_details],
-      action_path: course.is_withdrawn? ? nil : salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-      action_visually_hidden_text: t("publish.providers.courses.description_content.salary_hidden_text")
+      action_path: course.is_withdrawn? ? nil : salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)
     ) %>
   <% end %>
 <% end %>
@@ -127,9 +126,7 @@
         t("publish.providers.courses.description_content.degree_label"),
         (render DegreeRowContent.new(course:, errors: @errors)),
         %w[degree_grade degree_subject_requirements],
-        truncate_value: false,
-        action_path: !course.is_withdrawn? && course.degree_section_complete? ? degrees_start_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
-        action_visually_hidden_text: t("publish.providers.courses.description_content.degree_hidden_text")
+        action_path: !course.is_withdrawn? && course.degree_section_complete? ? degrees_start_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil
       ) %>
     <% end %>
 
@@ -139,7 +136,6 @@
       t("publish.providers.courses.description_content.gcse_label"),
       (render GcseRowContent.new(course:, errors: @errors)),
       %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
-      truncate_value: false,
       action_path: !course.is_withdrawn? && course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil
     ) %>
 

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -16,7 +16,7 @@
   <% enrichment_summary(
        summary_list,
        :course,
-       course.placements_heading,
+       t("publish.providers.courses.description_content.how_school_placements_work_label"),
        value_provided?(course.how_school_placements_work),
        %w[how_school_placements_work],
        action_path: course.is_withdrawn? ? nil : school_placements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),

--- a/app/views/publish/courses/details.html.erb
+++ b/app/views/publish/courses/details.html.erb
@@ -10,7 +10,7 @@
 
 <%= render partial: "publish/courses/course_navigation" %>
 
-<section class="app-section" id="basic_details" role="tabpanel" aria-labelledby="basic_details_tab">
+<section class="app-section" id="basic_details">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: "basic_details_tab" %>

--- a/app/views/publish/courses/show.html.erb
+++ b/app/views/publish/courses/show.html.erb
@@ -37,7 +37,7 @@
 
 <section class="app-section" id="description">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
       <%= render partial: "description_content" %>
     </div>
   </div>

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -59,7 +59,6 @@
              "Student visas",
              student_visa_sponsorship_status(@provider),
              %w[can_sponsor_student_visa],
-             truncate_value: false,
              action_path: @provider.university? ? student_visa_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) : nil,
              action_visually_hidden_text: "if candidates can get Student visa sponsorship"
            ) %>
@@ -70,7 +69,6 @@
              "Skilled Worker visas",
              skilled_worker_visa_sponsorship_status(@provider),
              %w[can_sponsor_skilled_worker_visa],
-             truncate_value: false,
              action_path: skilled_worker_visa_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
              action_visually_hidden_text: "if candidates can get Skilled Worker visa sponsorship"
            ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,7 +239,7 @@ en:
         gcse:
           text: "Enter GCSE and equivalency test requirements"
         how_school_placements_work:
-          text: "Enter details about how school placements work"
+          text: "Enter details about how placements work"
         train_with_disability:
           text: "Enter details about training with disabilities and other needs"
         train_with_us:
@@ -303,7 +303,8 @@ en:
           about_course_hidden_text: details about this course
           interview_process_label: Interview process (optional)
           interview_process_hidden_text: details about the interview process
-          how_school_placements_work_hidden_text: details about how school placements work
+          how_school_placements_work_label: How placements work
+          how_school_placements_work_hidden_text: details about how placements work
           course_length_and_fees_heading: Course length and fees
           course_length_and_salary_heading: Course length and salary
           course_length_label: Course length
@@ -377,8 +378,8 @@ en:
             </ul>
       school_placements:
         edit:
-          page_title: How school placements work - %{course_name_and_code}
-          submit_button: Update how school placements work
+          page_title: How placements work - %{course_name_and_code}
+          submit_button: Update how placements work
           guidance_text_html:
             <p class="govuk-body">Give candidates information about the schools they will be training in</p>
             <p class="govuk-body">Tell them:</p>
@@ -590,7 +591,7 @@ en:
       course_enrichment:
         fee_uk_eu: "Course fees for UK and EU students"
         fee_international: "Course fees for international students"
-        how_school_placements_work/further_education: Teaching placements
+        how_school_placements_work: How placements work
         fee_details: Fees and financial support
         about_course: About this course
       site:
@@ -692,7 +693,7 @@ en:
             about_course:
               blank: "^Enter information about this course"
             how_school_placements_work:
-              blank: "^Enter details about how school placements work"
+              blank: "^Enter details about how placements work"
             required_qualifications:
               blank: "^Enter details about the qualifications needed"
             course_length:
@@ -940,8 +941,8 @@ en:
         publish/course_school_placements_form:
           attributes:
             how_school_placements_work:
-              blank: Enter details about how school placements work
-              too_long: Reduce the word count for how school placements work
+              blank: Enter details about how placements work
+              too_long: Reduce the word count for how placements work
         publish/course_fees_and_financial_support_form:
           attributes:
             fee_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,10 +316,8 @@ en:
           financial_support_you_offer_label: Financial support you offer
           financial_incentive_details_label: Financial support from the government
           salary_label: Salary
-          salary_hidden_text: salary
           requirements_heading: Requirements and eligibility
           degree_label: Degree
-          degree_hidden_text: degree
           gcse_label: GCSEs
           personal_qualities_label: Personal qualities
           other_requirements_label: Other requirements

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,6 +296,32 @@ en:
     update: "Update user"
   publish:
     providers:
+      courses:
+        description_content:
+          course_information_heading: Course information
+          about_course_label: About this course
+          about_course_hidden_text: details about this course
+          interview_process_label: Interview process (optional)
+          interview_process_hidden_text: details about the interview process
+          how_school_placements_work_hidden_text: details about how school placements work
+          course_length_and_fees_heading: Course length and fees
+          course_length_and_salary_heading: Course length and salary
+          course_length_label: Course length
+          fee_for_uk_students_label: Fee for UK students
+          fee_for_uk_students_hidden_text: fee for UK students
+          fee_for_international_students_label: Fee for international students
+          fee_details_label: Fees and financial support (optional)
+          fee_details_hidden_text: fees and financial support
+          financial_support_you_offer_label: Financial support you offer
+          financial_incentive_details_label: Financial support from the government
+          salary_label: Salary
+          salary_hidden_text: salary
+          requirements_heading: Requirements and eligibility
+          degree_label: Degree
+          degree_hidden_text: degree
+          gcse_label: GCSEs
+          personal_qualities_label: Personal qualities
+          other_requirements_label: Other requirements
       course_length:
         edit:
           course_length: Course length
@@ -566,6 +592,7 @@ en:
         fee_international: "Course fees for international students"
         how_school_placements_work/further_education: Teaching placements
         fee_details: Fees and financial support
+        about_course: About this course
       site:
         location_name: "Name"
         address1: "Building and street"

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -48,7 +48,7 @@ module CoursePreview
       include_examples 'course with missing information', :degree, 'Enter degree requirements'
       include_examples 'course with missing information', :fee_uk_eu, 'Enter details about fees and financial support'
       include_examples 'course with missing information', :gcse, 'Enter GCSE and equivalency test requirements'
-      include_examples 'course with missing information', :how_school_placements_work, 'Enter details about how school placements work'
+      include_examples 'course with missing information', :how_school_placements_work, 'Enter details about how placements work'
       include_examples 'course with missing information', :train_with_disability, 'Enter details about training with disabilities and other needs'
       include_examples 'course with missing information', :train_with_us, 'Enter details about the training provider'
       include_examples 'course with missing information', :about_accrediting_provider, 'Enter details about the accredited provider'

--- a/spec/components/find/courses/about_schools_component/view_preview.rb
+++ b/spec/components/find/courses/about_schools_component/view_preview.rb
@@ -33,7 +33,7 @@ module Find
         def mock_scitt_course
           FakeCourse.new(provider: Provider.new(provider_code: 'DFE'),
                          published_how_school_placements_work: 'you will go on placement and learn more',
-                         placements_heading: 'Teaching placements',
+                         placements_heading: 'How placements work',
                          program_type: 'scitt_programme',
                          study_sites: [fake_study_site],
                          site_statuses: [SiteStatus.new(id: 2_245_455, course_id: 12_983_436, publish: 'published', site_id: 11_228_658, status: 'running', vac_status: 'part_time_vacancies'), SiteStatus.new(id: 22_454_556, course_id: 12_983_436, publish: 'published', site_id: 11_228_659, status: 'running', vac_status: 'part_time_vacancies')])
@@ -42,7 +42,7 @@ module Find
         def mock_hei_course
           FakeCourse.new(provider: Provider.new(provider_code: 'DFE'),
                          published_how_school_placements_work: 'you will go on placement and learn more',
-                         placements_heading: 'Teaching placements',
+                         placements_heading: 'How placements work',
                          program_type: 'higher_education_programme',
                          study_sites: [fake_study_site],
                          site_statuses: [SiteStatus.new(id: 2_245_455, course_id: 12_983_436, publish: 'published', site_id: 11_228_658, status: 'running', vac_status: 'part_time_vacancies'), SiteStatus.new(id: 22_454_556, course_id: 12_983_436, publish: 'published', site_id: 11_228_659, status: 'running', vac_status: 'part_time_vacancies')])

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -25,7 +25,7 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
                      provider:).decorate
 
       result = render_inline(described_class.new(course))
-      expect(result.text).to include('Enter details about how school placements work')
+      expect(result.text).to include('Enter details about how placements work')
     end
   end
 
@@ -82,7 +82,7 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
                      ]).decorate
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('Enter details about how school placements work')
+      expect(result.text).to include('Enter details about how placements work')
     end
   end
 

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -109,7 +109,7 @@ feature 'Viewing a findable course' do
           personal_qualities: 'We are looking for ambitious trainee teachers who are passionate.',
           other_requirements: 'You will need three years of prior work experience, but not necessarily in an educational context.',
           interview_process: 'Some helpful guidance about the interview process',
-          how_school_placements_work: 'Some info about how school placements work',
+          how_school_placements_work: 'Some info about how placements work',
           about_course: 'This is a course',
           required_qualifications: 'You need some qualifications for this course'
         )

--- a/spec/features/publish/courses/editing_course_school_placements_copy_content_spec.rb
+++ b/spec/features/publish/courses/editing_course_school_placements_copy_content_spec.rb
@@ -66,7 +66,7 @@ feature 'Editing school placements section, copying content from another course'
   def and_i_see_the_warning_that_changes_are_not_saved
     expect(page).to have_content 'Your changes are not yet saved'
     expect(page).to have_content "We have copied this field from #{copied_course_name_and_code}."
-    expect(page).to have_link 'How school placements work'
+    expect(page).to have_link 'How placements work'
     expect(page).to have_content 'Please check it and make your changes before saving'
   end
 
@@ -75,17 +75,17 @@ feature 'Editing school placements section, copying content from another course'
   end
 
   def and_the_warning_has_a_link_to_the_school_placements_input_field
-    href = find_link('How school placements work')[:href]
-    school_placements_id = (find_field 'How school placements work')[:id]
+    href = find_link('How placements work')[:href]
+    school_placements_id = (find_field 'How placements work')[:id]
     expect(school_placements_id).to eq(href.remove('#'))
   end
 
   def then_i_see_the_copied_course_data
-    expect(find_field('How school placements work').value).to eq @copied_course.enrichments.first.how_school_placements_work
+    expect(find_field('How placements work').value).to eq @copied_course.enrichments.first.how_school_placements_work
   end
 
   def then_i_do_not_see_copied_course_data
-    expect(find_field('How school placements work').value).to eq @course.enrichments.first.how_school_placements_work
+    expect(find_field('How placements work').value).to eq @course.enrichments.first.how_school_placements_work
   end
 
   def then_the_focus_is_on_the_input

--- a/spec/features/publish/courses/editing_course_school_placements_spec.rb
+++ b/spec/features/publish/courses/editing_course_school_placements_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-feature 'Editing how school placements work', { can_edit_current_and_next_cycles: false } do
+feature 'Editing how placements work', { can_edit_current_and_next_cycles: false } do
   scenario 'I can update some information about the course' do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
@@ -92,25 +92,25 @@ feature 'Editing how school placements work', { can_edit_current_and_next_cycles
   def and_i_set_information_about_the_course
     @school_placements = 'This is a new school placements'
 
-    fill_in 'How school placements work', with: @school_placements
+    fill_in 'How placements work', with: @school_placements
   end
 
   def and_i_submit_with_too_many_words
-    fill_in 'How school placements work', with: Faker::Lorem.sentence(word_count: 351)
+    fill_in 'How placements work', with: Faker::Lorem.sentence(word_count: 351)
     and_i_submit
   end
 
   def and_i_submit_without_any_data
-    fill_in 'How school placements work', with: ''
+    fill_in 'How placements work', with: ''
     and_i_submit
   end
 
   def and_i_submit
-    click_on 'Update how school placements work'
+    click_on 'Update how placements work'
   end
 
   def then_i_see_a_success_message
-    expect(page).to have_content 'How school placements work updated'
+    expect(page).to have_content 'How placements work updated'
   end
 
   def and_the_course_information_is_updated
@@ -120,11 +120,11 @@ feature 'Editing how school placements work', { can_edit_current_and_next_cycles
   end
 
   def then_i_see_an_error_message_about_reducing_word_count
-    expect(page).to have_content('Reduce the word count for how school placements work').twice
+    expect(page).to have_content('Reduce the word count for how placements work').twice
   end
 
   def then_i_see_an_error_message_about_entering_data
-    expect(page).to have_content('Enter details about how school placements work').twice
+    expect(page).to have_content('Enter details about how placements work').twice
   end
 
   def provider

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -468,11 +468,11 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     click_on 'Update about this course'
 
     publish_provider_courses_show_page.how_school_placements_work.find_link(
-      text: 'Change details about how school placements work'
+      text: 'Change details about how placements work'
     ).click
 
-    fill_in 'How school placements work', with: 'School placements information'
-    click_on 'Update how school placements work'
+    fill_in 'How placements work', with: 'School placements information'
+    click_on 'Update how placements work'
   end
 
   def and_i_add_salary_information

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -101,8 +101,8 @@ feature 'Publishing courses', { can_edit_current_and_next_cycles: false } do
       course.recruitment_cycle_year,
       course.course_code
     )
-    fill_in 'How school placements work', with: 'some new information about school placements'
-    click_on 'Update how school placements work'
+    fill_in 'How placements work', with: 'some new information about school placements'
+    click_on 'Update how placements work'
   end
 
   def then_i_should_see_the_unpublished_changes_message

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -48,9 +48,9 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     scenario 'blank school placements section' do
       given_i_am_authenticated(user: user_with_no_course_enrichments)
       when_i_visit_the_publish_course_preview_page
-      and_i_click_link_or_button('Enter details about how school placements work')
+      and_i_click_link_or_button('Enter details about how placements work')
       and_i_click_link_or_button('Back')
-      and_i_click_link_or_button('Enter details about how school placements work')
+      and_i_click_link_or_button('Enter details about how placements work')
       and_i_submit_a_valid_form
       and_i_see_the_correct_banner
       and_i_see_the_new_course_text
@@ -84,9 +84,9 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     scenario 'blank school placements' do
       given_i_am_authenticated(user: user_with_no_course_enrichments)
       when_i_visit_the_publish_course_preview_page
-      and_i_click_link_or_button('Enter details about how school placements work')
+      and_i_click_link_or_button('Enter details about how placements work')
       and_i_click_link_or_button('Back')
-      and_i_click_link_or_button('Enter details about how school placements work')
+      and_i_click_link_or_button('Enter details about how placements work')
       and_i_submit_a_valid_form
       and_i_see_the_correct_banner
       then_i_should_be_back_on_the_preview_page
@@ -427,9 +427,9 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_submit_a_valid_form
-    fill_in 'How school placements work', with: 'great placement'
+    fill_in 'How placements work', with: 'great placement'
 
-    click_link_or_button 'Update how school placements work'
+    click_link_or_button 'Update how placements work'
   end
 
   def and_i_submit_a_valid_course_fees

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,7 +35,7 @@ describe ApplicationHelper do
       it 'injects the provided content into the provided summary list row' do
         expect(subject).to have_css(%(.govuk-summary-list__row[data-qa="enrichment__about"]))
         expect(subject).to have_css('.govuk-summary-list__key', text: 'About course')
-        expect(subject).to have_css('.govuk-summary-list__value.app-summary-list__value--truncate', text: 'Something about the course')
+        expect(subject).to have_css('.govuk-summary-list__value', text: 'Something about the course')
       end
     end
 

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -17,7 +17,7 @@ describe '#publishable?' do
       { sites: ['^Select at least one school'],
         accrediting_provider: ['Select an accredited provider'],
         about_course: ['^Enter information about this course'],
-        how_school_placements_work: ['^Enter details about how school placements work'],
+        how_school_placements_work: ['^Enter details about how placements work'],
         course_length: ['^Enter a course length'],
         salary_details: ['^Enter details about the salary for this course'],
         base: ['Enter GCSE requirements'] }


### PR DESCRIPTION
### Context
We have made lots of small changes to the content relevant to the course description. This [trello ticket](https://trello.com/c/wOOp6BHO) just does some final clean up of the content on that page. 

### Changes proposed in this pull request
- The main visual change is that we no longer truncate the information on the page. So the long text passages are all visible. To make the text more readable, we use the full width instead of the normal 2/3.
- There are a few small text changes to match the designs:
- How school placements work  => How placements work
- Course outline => About this course
- Fee details => Fees and financial support (optional)


| Before     | After        |
| --------- | --------- |
| <img width="902" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/44073106/c208ac3e-b4a0-42f8-b51d-b5c718467bb1"> | <img width="1120" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/44073106/d5012214-1f6c-48a1-bae4-4d1302e1e1e1"> |

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [NA] Inform data insights team due to database changes
