### PR TITLE
Change Find domain in QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repo is home to three services:
 | ----------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------
 | Production  | [www](https://www.find-postgraduate-teacher-training.service.gov.uk)   | Public site
 | Staging     | [staging](https://staging.find-postgraduate-teacher-training.service.gov.uk)| For internal use by DfE to test deploys
-| QA          | [qa](https://qa.find-postgraduate-teacher-training.service.gov.uk)     | For internal use by DfE for testing. Automatically deployed from main
+| QA          | [qa](https://qa.find-teacher-training-courses.service.gov.uk)     | For internal use by DfE for testing. Automatically deployed from main
 
 ### Publish
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,12 +1,12 @@
 gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
-find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://qa.find-teacher-training-courses.service.gov.uk/
 find_assets_url: https://qa-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:
-  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://qa.find-teacher-training-courses.service.gov.uk
 
 # URL of this app for the callback after sigining in
 base_url: https://qa.publish-teacher-training-courses.service.gov.uk
@@ -34,3 +34,4 @@ features:
 
 find_valid_referers:
   - https://qa.find-postgraduate-teacher-training.service.gov.uk
+  - https://qa.find-teacher-training-courses.service.gov.uk

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -1,7 +1,7 @@
 gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
-find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+find_url: http://qa.find-teacher-training-courses.service.gov.uk/
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -1,11 +1,11 @@
 gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
-find_url: http://qa.find-teacher-training-courses.service.gov.uk/
+find_url: https://qa.find-teacher-training-courses.service.gov.uk/
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:
-  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://qa.find-teacher-training-courses.service.gov.uk
 
 # URL of this app for the callback after sigining in
 base_url: https://qa.publish-teacher-training-courses.service.gov.uk
@@ -35,3 +35,4 @@ features:
 
 find_valid_referers:
   - https://qa.find-postgraduate-teacher-training.service.gov.uk
+  - https://qa.find-teacher-training-courses.service.gov.uk


### PR DESCRIPTION
### Context

We have a card from [devops board](https://trello.com/c/H7vjsEwQ) to Create find-teacher-training-courses.service.gov.uk domain

Devops is changing the find domain but this also requires a code change on the implementation.

## Observation

This is only QA at the moment but in the future, we will do for the other environments.

## Trello card

https://trello.com/c/G5pV0hyX/1643-determine-and-implement-the-necessary-code-changes-to-switch-the-domain-of-find-service-in-qa
