### PR TITLE
[1695] publish: move and amend formatting panel also add to pages its missing from

### DIFF
--- a/app/components/accredited_provider.html.erb
+++ b/app/components/accredited_provider.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_summary_card(title: provider_name) do |card|
       card.with_action { govuk_link_to("Remove", remove_path, class: "app-link--destructive govuk-!-font-weight-regular", data: { qa: "remove-link" }) }
       card.with_summary_list(rows: [{ key: { text: "About the accredited provider" },
-                                      value: { text: about_accredited_provider },
+                                      value: { text: markdown(about_accredited_provider) },
                                       actions: [{ href: change_about_accredited_provider_path }] }])
     end %>

--- a/app/components/accredited_provider.rb
+++ b/app/components/accredited_provider.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccreditedProvider < ViewComponent::Base
+  include PublishHelper
+
   attr_reader :provider_name, :remove_path, :about_accredited_provider, :change_about_accredited_provider_path
 
   def initialize(provider_name:, remove_path:, about_accredited_provider:, change_about_accredited_provider_path:)

--- a/app/components/degree_row_content.html.erb
+++ b/app/components/degree_row_content.html.erb
@@ -5,7 +5,7 @@
 
   <% if course.degree_subject_requirements.present? %>
     <p class="govuk-summary-list-value">
-      <%= course.degree_subject_requirements %>
+      <%= markdown(course.degree_subject_requirements) %>
     </p>
   <% end %>
 <% else %>

--- a/app/components/degree_row_content.rb
+++ b/app/components/degree_row_content.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class DegreeRowContent < ViewComponent::Base
+  include PublishHelper
   attr_reader :course, :errors
 
   DEGREE_GRADE_MAPPING = {

--- a/app/components/gcse_row_content.html.erb
+++ b/app/components/gcse_row_content.html.erb
@@ -9,7 +9,7 @@
   </p>
 
   <% if course.additional_gcse_equivalencies %>
-    <%= simple_format(course.additional_gcse_equivalencies, class: "govuk-body") %>
+    <%= markdown(course.additional_gcse_equivalencies) %>
   <% end %>
 <% else %>
   <%= govuk_inset_text(classes: inset_text_css_classes) do %>

--- a/app/components/gcse_row_content.rb
+++ b/app/components/gcse_row_content.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class GcseRowContent < GcseRequirements
+  include PublishHelper
 end

--- a/app/helpers/publish_helper.rb
+++ b/app/helpers/publish_helper.rb
@@ -2,6 +2,8 @@
 
 module PublishHelper
   def markdown(source)
+    return '' if source.blank?
+
     render = Govuk::MarkdownRenderer
     # Options: https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
     # lax_spacing: HTML blocks do not require to be surrounded by an empty line as in the Markdown standard.

--- a/app/views/publish/courses/_additional_gcse_requirements_hint.html.erb
+++ b/app/views/publish/courses/_additional_gcse_requirements_hint.html.erb
@@ -1,0 +1,2 @@
+<p>For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay.</p>
+<%= render partial: "publish/courses/markdown_formatting" %>

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -7,7 +7,7 @@
     summary_list,
     :course,
     t("publish.providers.courses.description_content.about_course_label"),
-    value_provided?(course.about_course),
+    value_provided?(markdown(course.about_course)),
     %w[about_course],
     action_path: course.is_withdrawn? ? nil : about_this_course_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
     action_visually_hidden_text: t("publish.providers.courses.description_content.about_course_hidden_text")
@@ -17,7 +17,7 @@
        summary_list,
        :course,
        t("publish.providers.courses.description_content.how_school_placements_work_label"),
-       value_provided?(course.how_school_placements_work),
+       value_provided?(markdown(course.how_school_placements_work)),
        %w[how_school_placements_work],
        action_path: course.is_withdrawn? ? nil : school_placements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
        action_visually_hidden_text: t("publish.providers.courses.description_content.how_school_placements_work_hidden_text")
@@ -27,7 +27,7 @@
     summary_list,
     :course,
     t("publish.providers.courses.description_content.interview_process_label"),
-    value_provided?(course.interview_process),
+    value_provided?(markdown(course.interview_process)),
     %w[interview_process],
     action_path: course.is_withdrawn? ? nil : interview_process_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
     action_visually_hidden_text: t("publish.providers.courses.description_content.interview_process_hidden_text")
@@ -71,7 +71,7 @@
       summary_list,
       :course,
       t("publish.providers.courses.description_content.fee_details_label"),
-      value_provided?(course.fee_details),
+      value_provided?(markdown(course.fee_details)),
       %w[fee_details],
       action_path: course.is_withdrawn? ? nil : fees_and_financial_support_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
       action_visually_hidden_text: t("publish.providers.courses.description_content.fee_details_hidden_text")
@@ -82,7 +82,7 @@
         summary_list,
         :course,
         t("publish.providers.courses.description_content.financial_support_you_offer_label"),
-        value_provided?(course.financial_support),
+        value_provided?(markdown(course.financial_support)),
         %w[financial_support]
       ) %>
     <% end %>
@@ -107,7 +107,7 @@
       summary_list,
       :course,
       t("publish.providers.courses.description_content.salary_label"),
-      value_provided?(course.salary_details),
+      value_provided?(markdown(course.salary_details)),
       %w[salary_details],
       action_path: course.is_withdrawn? ? nil : salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)
     ) %>
@@ -144,7 +144,7 @@
       summary_list,
       :course,
       t("publish.providers.courses.description_content.personal_qualities_label"),
-      value_provided?(course.personal_qualities),
+      value_provided?(markdown(course.personal_qualities)),
       %w[personal_qualities],
       action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#personal-qualities"
     ) %>
@@ -153,7 +153,7 @@
       summary_list,
       :course,
       t("publish.providers.courses.description_content.other_requirements_label"),
-      value_provided?(course.other_requirements),
+      value_provided?(markdown(course.other_requirements)),
       %w[other_requirements],
       action_path: course.is_withdrawn? ? nil : "#{requirements_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)}#other-requirements"
     ) %>

--- a/app/views/publish/courses/_gcse_requirements.html.erb
+++ b/app/views/publish/courses/_gcse_requirements.html.erb
@@ -30,7 +30,10 @@
     <% end %>
     <%= f.govuk_text_area :additional_gcse_equivalencies,
       value: course_object.additional_gcse_equivalencies,
-      label: { text: "Details about equivalency tests you offer or accept", size: "s" }, hint: { text: "For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay." }, data: { qa: "gcse_requirements__additional_requirements" }, max_words: 200 %>
+      label: { text: "Details about equivalency tests you offer or accept", size: "s" },
+      hint: -> { render partial: "publish/courses/additional_gcse_requirements_hint" },
+      data: { qa: "gcse_requirements__additional_requirements" },
+      max_words: 200 %>
   <% end %>
   <%= f.govuk_radio_button :accept_gcse_equivalency, false,
     checked: course_object.accept_gcse_equivalency == false,

--- a/app/views/publish/courses/_markdown_formatting.html.erb
+++ b/app/views/publish/courses/_markdown_formatting.html.erb
@@ -1,18 +1,17 @@
-<div class="app-status-box">
-  <h3 class="govuk-heading-m">Formatting</h3>
-  <h4 class="govuk-heading-s">Links</h4>
-  <p class="govuk-body">Use square brackets [] around the link text and round brackets () around the link URL. Make sure there are no spaces between the brackets.</p>
-
-  <p class="govuk-body">For example:<br>[GOV.UK](https://gov.uk/)</p>
-
-  <h4 class="govuk-heading-s">Lists</h4>
-  <p class="govuk-body">To create a bulleted list:</p>
+<%= govuk_details(summary_text: t("markdown_formatting.summary_text")) do %>
+  <h1 class="govuk-heading-m"><%= t("markdown_formatting.title") %></h1>
+  <h2 class="govuk-heading-s"><%= t("markdown_formatting.create_a_link_heading") %></h2>
+  <p class="govuk-body"><%= t("markdown_formatting.link_is_made_up_of_two_parts") %></p>
+  <p class="govuk-body"><%= t("markdown_formatting.link_format_warning") %></p>
+  <p class="govuk-body"><%= t("markdown_formatting.link_instructions") %></p>
+  <p class="govuk-body">
+    <%= t("markdown_formatting.link_example_html", formatted_link: link_to("http://GOV.UK", "http://gov.uk")) %>
+  </p>
+  <h2 class="govuk-heading-s"><%= t("markdown_formatting.create_bullet_points_heading") %></h2>
   <ul class="govuk-list govuk-list--bullet">
-    <li>use asterisks (*) to create a bullet point (hyphens also work)</li>
-    <li>make sure there is one space after the asterisk</li>
-    <li>leave 1 empty line space before the bullets start, and one after</li>
+    <%= t("markdown_formatting.bullet_point_guidance_html") %>
   </ul>
-
-  <p class="govuk-body">For example:</p>
-  <p class="govuk-body">* list item 1<br>* list item 2</p>
-</div>
+  <p class="govuk-body"><%= t("markdown_formatting.for_example") %></p>
+  <p class="govuk-body"><%= t("markdown_formatting.list_item_one") %></p>
+  <p class="govuk-body"><%= t("markdown_formatting.list_item_two") %></p>
+<% end %>

--- a/app/views/publish/courses/_related_sidebar.html.erb
+++ b/app/views/publish/courses/_related_sidebar.html.erb
@@ -25,8 +25,4 @@
     <h3 class="govuk-heading-m" data-qa="course__use_content">Use this content again</h3>
     <p class="govuk-body">When you&#8217;ve added content to this page, you can copy it to other courses</p>
   <% end %>
-
-  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-
-  <%= render partial: "publish/courses/markdown_formatting" %>
 </div>

--- a/app/views/publish/courses/about_this_course/edit.html.erb
+++ b/app/views/publish/courses/about_this_course/edit.html.erb
@@ -43,6 +43,7 @@
       <%= f.govuk_text_area(:about_course,
                             value: @copied_fields_values&.dig("about_course") || @about_this_course_form.about_course,
                             label: { text: t("publish.providers.about_course.edit.about_this_course"), size: "s" },
+                            hint: -> { render partial: "publish/courses/markdown_formatting" },
                             max_words: 400,
                             rows: 20) %>
       <%= f.hidden_field(:goto_preview, value: params[:goto_preview]) %>

--- a/app/views/publish/courses/degrees/_additional_degree_subject_requirements.html.erb
+++ b/app/views/publish/courses/degrees/_additional_degree_subject_requirements.html.erb
@@ -12,6 +12,7 @@
       form_group: { id: "degree-subject-requirements" },
       label: { text: "Degree subject requirements" },
       data: { qa: "degree_subject_requirements__requirements" },
+      hint: -> { render partial: "publish/courses/markdown_formatting" },
       max_words: 250 %>
   <% end %>
 <% end %>

--- a/app/views/publish/courses/fees_and_financial_support/edit.html.erb
+++ b/app/views/publish/courses/fees_and_financial_support/edit.html.erb
@@ -33,6 +33,7 @@
       <%= f.govuk_text_area(
             :fee_details,
             label: { text: t("publish.providers.fees_and_financial_support.edit.label"), size: "s" },
+            hint: -> { render partial: "publish/courses/markdown_formatting" },
             value: @course_fees_and_financial_support_form.fee_details,
             rows: 15,
             max_words: 250,
@@ -51,7 +52,4 @@
           ) %>
     </p>
   </div>
-  <aside class="govuk-grid-column-one-third" data-qa="course__related_sidebar">
-    <%= render partial: "publish/courses/markdown_formatting" %>
-  </aside>
 </div>

--- a/app/views/publish/courses/interview_process/edit.html.erb
+++ b/app/views/publish/courses/interview_process/edit.html.erb
@@ -43,6 +43,7 @@
       <%= f.govuk_text_area(:interview_process,
                             value: @copied_fields_values&.dig("interview_process") || @interview_process_form.interview_process,
                             label: { text: t("publish.providers.interview_process.edit.interview_process_label"), size: "s" },
+                            hint: -> { render partial: "publish/courses/markdown_formatting" },
                             max_words: 250,
                             rows: 20) %>
       <%= f.govuk_submit t("publish.providers.interview_process.edit.submit_button") %>

--- a/app/views/publish/courses/school_placements/edit.html.erb
+++ b/app/views/publish/courses/school_placements/edit.html.erb
@@ -43,6 +43,7 @@
         value: @copied_fields_values&.dig("how_school_placements_work") ||
           @course_school_placements_form.how_school_placements_work,
         label: { text: CourseEnrichment.human_attribute_name("how_school_placements_work"), size: "s" },
+        hint: -> { render partial: "publish/courses/markdown_formatting" },
         max_words: 350,
         rows: 15) %>
       <%= f.hidden_field(:goto_preview, value: params[:goto_preview]) %>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -44,6 +44,7 @@
       <%= f.govuk_text_area(:train_with_us,
         form_group: { id: "train-with-us" },
         label: { text: "Training with your organisation", size: "m" },
+        hint: -> { render partial: "publish/courses/markdown_formatting" },
         max_words: 250,
         rows: 15) %>
 
@@ -60,7 +61,8 @@
 
       <%= f.govuk_text_area(:train_with_disability,
         form_group: { id: "train-with-disability" },
-        label: { text: "Training with disabilities and other needs", size: "s" },
+        label: { text: "Training with disabilities and other needs", size: "m" },
+        hint: -> { render partial: "publish/courses/markdown_formatting" },
         max_words: 250,
         rows: 15) %>
       <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>

--- a/app/views/publish/providers/accredited_providers/_hint.html.erb
+++ b/app/views/publish/providers/accredited_providers/_hint.html.erb
@@ -1,0 +1,2 @@
+<p><%= hint %></p>
+<%= render partial: "publish/courses/markdown_formatting" %>

--- a/app/views/publish/providers/accredited_providers/checks/show.html.erb
+++ b/app/views/publish/providers/accredited_providers/checks/show.html.erb
@@ -25,7 +25,7 @@
 
             component.with_row do |row|
               row.with_key { "About the accredited provider" }
-              row.with_value { @accredited_provider_form.description }
+              row.with_value { markdown @accredited_provider_form.description }
               row.with_action(text: "Change", href: new_publish_provider_recruitment_cycle_accredited_provider_path(goto_confirmation: true), visually_hidden_text: "accredited provider description")
             end
           end %>

--- a/app/views/publish/providers/accredited_providers/edit.html.erb
+++ b/app/views/publish/providers/accredited_providers/edit.html.erb
@@ -18,7 +18,7 @@
         <%= f.govuk_text_area(
           :description,
           label: { text: t(".title"), size: "l", tag: "h1" },
-          hint: { text: t(".hint") },
+          hint: -> { render "hint", hint: t(".hint") },
           caption: { text: @accredited_provider.provider_name, size: "l" },
           max_words: 100,
           rows: 10

--- a/app/views/publish/providers/accredited_providers/new.html.erb
+++ b/app/views/publish/providers/accredited_providers/new.html.erb
@@ -18,7 +18,7 @@
       <%= f.govuk_text_area(
         :description,
         label: { text: t(".title"), size: "l", tag: "h1" },
-        hint: { text: t(".hint") },
+        hint: -> { render "hint", hint: t(".hint") },
         caption: { text: t(".caption"), size: "l" },
         max_words: 100,
         rows: 10

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -28,7 +28,7 @@
 </h1>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <%= govuk_summary_list do |summary_list| %>
       <% enrichment_summary(
         summary_list,

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -34,7 +34,7 @@
         summary_list,
         :provider,
         "Training with your organisation",
-        @provider.train_with_us,
+        markdown(@provider.train_with_us),
         %w[train_with_us],
         action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-us",
         action_visually_hidden_text: "details about training with your organisation"
@@ -43,7 +43,7 @@
         summary_list,
         :provider,
         "Training with disabilities and other needs",
-        @provider.train_with_disability,
+        markdown(@provider.train_with_disability),
         %w[train_with_disability],
         action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-disability",
         action_visually_hidden_text: "details about training with disabilities and other needs"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,11 +11,11 @@ en:
       Put square brackets [ ] around the link text and round brackets ( ) around the link URL. Make sure there are no
       spaces between the brackets.
     link_example_html: "For example: [http://GOV.UK](https://gov.uk/) will show as %{formatted_link}"
-    create_bullet_points_heading: How to create bullet_points
+    create_bullet_points_heading: How to create bullet points
     bullet_point_guidance_html:
       <li>use asterisks or hyphens to create a bullet point</li>
       <li>make sure there is one space after the asterisk or hyphen</li>
-      <li>leave one empty line space before the bullet points start, and one after</li>
+      <li>leave one empty line space before the bullet points start and one after</li>
     for_example: "For example:"
     list_item_one: "* list item 1"
     list_item_two: "* list item 2"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,24 @@
 en:
+  markdown_formatting:
+    summary_text: Help formatting your text
+    title: How to format your text
+    create_a_link_heading: How to create a link
+    link_is_made_up_of_two_parts: >
+      Your link is made up of two parts, the link text which is what the reader will see, and the URL which is the
+      address the link will take them to.
+    link_format_warning: If you don't format the links properly, people will not be able to click on them.
+    link_instructions: >
+      Put square brackets [ ] around the link text and round brackets ( ) around the link URL. Make sure there are no
+      spaces between the brackets.
+    link_example_html: "For example: [http://GOV.UK](https://gov.uk/) will show as %{formatted_link}"
+    create_bullet_points_heading: How to create bullet_points
+    bullet_point_guidance_html:
+      <li>use asterisks or hyphens to create a bullet point</li>
+      <li>make sure there is one space after the asterisk or hyphen</li>
+      <li>leave one empty line space before the bullet points start, and one after</li>
+    for_example: "For example:"
+    list_item_one: "* list item 1"
+    list_item_two: "* list item 2"
   notification_banner:
     success: "Success"
     info: "Info"

--- a/spec/features/publish/courses/editing_course_about_this_course_spec.rb
+++ b/spec/features/publish/courses/editing_course_about_this_course_spec.rb
@@ -7,7 +7,10 @@ feature 'Editing about this course section' do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_about_course_edit_page
-    and_i_enter_information_into_the_about_course_field
+
+    then_i_see_markdown_formatting_guidance
+
+    when_i_enter_information_into_the_about_course_field
     and_i_submit_the_form
     then_about_course_data_has_changed
 
@@ -33,6 +36,13 @@ feature 'Editing about this course section' do
   end
 
   private
+
+  def then_i_see_markdown_formatting_guidance
+    page.find('span', text: 'Help formatting your text')
+    expect(page).to have_content 'How to format your text'
+    expect(page).to have_content 'How to create a link'
+    expect(page).to have_content 'How to create bullet points'
+  end
 
   def given_i_am_authenticated_as_a_provider_user
     given_i_am_authenticated(user: create(:user, :with_provider))
@@ -82,7 +92,7 @@ feature 'Editing about this course section' do
     fill_in 'About this course', with: ''
   end
 
-  def and_i_enter_information_into_the_about_course_field
+  def when_i_enter_information_into_the_about_course_field
     fill_in 'About this course', with: 'Here is very useful information about this course'
   end
 

--- a/spec/features/publish/courses/editing_course_interview_process_spec.rb
+++ b/spec/features/publish/courses/editing_course_interview_process_spec.rb
@@ -7,7 +7,9 @@ feature 'Editing interview process section' do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_interview_process_edit_page
-    and_i_enter_information_into_the_interview_process_field
+    then_i_see_markdown_formatting_guidance
+
+    when_i_enter_information_into_the_interview_process_field
     and_i_submit_the_form
     then_interview_process_data_has_changed
 
@@ -28,6 +30,13 @@ feature 'Editing interview process section' do
 
   def given_i_am_authenticated_as_a_provider_user
     given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def then_i_see_markdown_formatting_guidance
+    page.find('span', text: 'Help formatting your text')
+    expect(page).to have_content 'How to format your text'
+    expect(page).to have_content 'How to create a link'
+    expect(page).to have_content 'How to create bullet points'
   end
 
   def and_there_is_a_course_i_want_to_edit
@@ -65,7 +74,7 @@ feature 'Editing interview process section' do
     fill_in 'Interview process', with: Faker::Lorem.sentence(word_count: 251)
   end
 
-  def and_i_enter_information_into_the_interview_process_field
+  def when_i_enter_information_into_the_interview_process_field
     fill_in 'Interview process (optional)', with: 'Here is very useful information interview process'
   end
 

--- a/spec/features/publish/courses/editing_course_school_placements_spec.rb
+++ b/spec/features/publish/courses/editing_course_school_placements_spec.rb
@@ -7,7 +7,9 @@ feature 'Editing how placements work', { can_edit_current_and_next_cycles: false
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_publish_course_information_edit_page
-    and_i_set_information_about_the_course
+    then_i_see_markdown_formatting_guidance
+
+    when_i_enter_school_placements_information
     and_i_submit
     then_i_see_a_success_message
     and_the_course_information_is_updated
@@ -44,6 +46,13 @@ feature 'Editing how placements work', { can_edit_current_and_next_cycles: false
 
   def and_i_click_to_see_more_guidance
     page.find('span', text: 'See what we include in this section').click
+  end
+
+  def then_i_see_markdown_formatting_guidance
+    page.find('span', text: 'Help formatting your text')
+    expect(page).to have_content 'How to format your text'
+    expect(page).to have_content 'How to create a link'
+    expect(page).to have_content 'How to create bullet points'
   end
 
   def then_i_see_the_message_for_university_users
@@ -89,7 +98,7 @@ feature 'Editing how placements work', { can_edit_current_and_next_cycles: false
     )
   end
 
-  def and_i_set_information_about_the_course
+  def when_i_enter_school_placements_information
     @school_placements = 'This is a new school placements'
 
     fill_in 'How placements work', with: @school_placements

--- a/spec/features/publish/courses/editing_degree_requirements_spec.rb
+++ b/spec/features/publish/courses/editing_degree_requirements_spec.rb
@@ -15,6 +15,7 @@ feature 'Editing degree requirements', { can_edit_current_and_next_cycles: false
     when_i_set_a_required_grade
     then_i_should_see_the_subject_requirements_page
     then_i_should_see_the_reuse_content
+    then_i_see_markdown_formatting_guidance
     when_i_set_additional_requirements
     then_i_should_see_a_success_message('Degree requirements')
     and_the_required_grade_is_updated_with('two_one')
@@ -147,6 +148,13 @@ feature 'Editing degree requirements', { can_edit_current_and_next_cycles: false
 
   def then_i_should_see_the_reuse_content
     expect(publish_degree_subject_requirement_page).to have_use_content
+  end
+
+  def then_i_see_markdown_formatting_guidance
+    page.find('span', text: 'Help formatting your text')
+    expect(page).to have_content 'How to format your text'
+    expect(page).to have_content 'How to create a link'
+    expect(page).to have_content 'How to create bullet points'
   end
 
   def given_i_am_authenticated_as_a_provider_user

--- a/spec/features/publish/courses/gcse_equivalency_spec.rb
+++ b/spec/features/publish/courses/gcse_equivalency_spec.rb
@@ -16,10 +16,12 @@ feature 'GCSE equivalency requirements', { can_edit_current_and_next_cycles: fal
     and_i_see_equivalency_errors
 
     and_i_set_the_gcse_requirements
-    then_i_fill_the_equivalency_requirements
+    then_i_see_markdown_formatting_guidance
+
+    when_i_fill_the_equivalency_requirements
     and_i_click_save
 
-    and_i_am_on_the_course_page
+    then_i_am_on_the_course_page
     and_i_see_the_success_summary
   end
 
@@ -171,7 +173,14 @@ feature 'GCSE equivalency requirements', { can_edit_current_and_next_cycles: fal
     expect(page).to have_content('Select if you accept equivalency tests in English or maths')
   end
 
-  def then_i_fill_the_equivalency_requirements
+  def then_i_see_markdown_formatting_guidance
+    page.find('span', text: 'Help formatting your text')
+    expect(page).to have_content 'How to format your text'
+    expect(page).to have_content 'How to create a link'
+    expect(page).to have_content 'How to create bullet points'
+  end
+
+  def when_i_fill_the_equivalency_requirements
     publish_courses_gcse_requirements_page.english_equivalency.check
     publish_courses_gcse_requirements_page.maths_equivalency.check
     publish_courses_gcse_requirements_page.additional_requirements.set('Cycling Proficiency')
@@ -184,8 +193,10 @@ feature 'GCSE equivalency requirements', { can_edit_current_and_next_cycles: fal
       course.course_code
     )
   end
+  alias_method :then_i_am_on_the_course_page, :and_i_am_on_the_course_page
 
   def and_i_see_the_success_summary
     expect(publish_provider_courses_index_page.success_summary).to have_content(I18n.t('success.saved', value: 'GCSE requirements'))
   end
+  alias_method :then_i_see_the_success_summary, :and_i_see_the_success_summary
 end

--- a/spec/features/publish/editing_fees_and_financial_support_spec.rb
+++ b/spec/features/publish/editing_fees_and_financial_support_spec.rb
@@ -7,7 +7,9 @@ feature 'Editing fees and financial support section' do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_fees_and_financial_support_edit_page
-    and_i_enter_information_into_the_fees_and_financial_support_field
+    then_i_see_markdown_formatting_guidance
+
+    when_i_enter_information_into_the_fees_and_financial_support_field
     and_i_submit_the_form
     then_fees_and_financial_support_data_has_changed
 
@@ -38,6 +40,13 @@ feature 'Editing fees and financial support section' do
 
   def given_i_am_authenticated_as_a_provider_user
     given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def then_i_see_markdown_formatting_guidance
+    page.find('span', text: 'Help formatting your text')
+    expect(page).to have_content 'How to format your text'
+    expect(page).to have_content 'How to create a link'
+    expect(page).to have_content 'How to create bullet points'
   end
 
   def and_there_is_a_course_i_want_to_edit
@@ -76,7 +85,7 @@ feature 'Editing fees and financial support section' do
     fill_in 'Fees and financial support', with: Faker::Lorem.sentence(word_count: 251)
   end
 
-  def and_i_enter_information_into_the_fees_and_financial_support_field
+  def when_i_enter_information_into_the_fees_and_financial_support_field
     fill_in 'Fees and financial support (optional)', with: 'Here is very useful information fees and financial support'
   end
 

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -27,6 +27,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       and_i_click_link_or_button('Back')
       then_i_should_be_back_on_the_preview_page
       and_i_click_link_or_button('Enter details about the training provider')
+      then_i_see_markdown_formatting_guidance_for_each_field
       and_i_submit_a_valid_about_your_organisation
       then_i_should_be_back_on_the_preview_page
       then_i_should_see_the_updated_content('test training with your organisation')
@@ -133,6 +134,17 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     expect(publish_course_preview_page).to have_content '44A Albert Road'
     expect(publish_course_preview_page).to have_content 'London'
     expect(publish_course_preview_page).to have_content 'NW4 2SJ'
+  end
+
+  def then_i_see_markdown_formatting_guidance_for_each_field
+    %w[#publish-about-your-organisation-form-train-with-us-hint #publish-about-your-organisation-form-train-with-disability-hint].each do |section_id|
+      within("div#{section_id}") do
+        page.find('span', text: 'Help formatting your text')
+        expect(page).to have_content 'How to format your text'
+        expect(page).to have_content 'How to create a link'
+        expect(page).to have_content 'How to create bullet points'
+      end
+    end
   end
 
   def then_i_see_the_course_preview_details


### PR DESCRIPTION
### Context
Lots of general improvements to publish. [Trello card](https://trello.com/c/OEN8Do2i) 

### Changes proposed in this pull request
- Move the markdown formatting guidance out of the copy content side panel into its own component
- Render the markdown formatting guidance as part of the hint for questions where markdown should be possible
- Make sure the markdown is rendered in all the areas we would expect it to be. 

| Before     | After     |
| --------- | ------- |
| <img width="1102" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/44073106/3f5ba9c0-167e-45ac-9bd0-dc2de4e6091d"> | <img width="1082" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/44073106/8ba7d5ab-1174-482d-8335-7c6e6501f3e9"> |


### Guidance to review
Am I missing anywhere? 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
