### PR TITLE
Add hidden text translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,6 +328,7 @@ en:
           course_length_and_fees_heading: Course length and fees
           course_length_and_salary_heading: Course length and salary
           course_length_label: Course length
+          course_length_hidden_text: course length
           fee_for_uk_students_label: Fee for UK students
           fee_for_uk_students_hidden_text: fee for UK students
           fee_for_international_students_label: Fee for international students


### PR DESCRIPTION
### Context

The hidden text translation is missing, this is causing translation errors.

### Changes proposed in this pull request

Add the translation.

### Guidance to review

#### Before

<img width="1777" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/baa7964f-a618-42b2-bae1-3ef2fa631871">


#### After

<img width="1178" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/1d60f5fe-bf15-47e5-adbf-4c0d975e4d19">

