### PR TITLE
[1750] Reset previously defaulted enrichment attributes back to nil (TDA courses)

### DIFF
--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -52,6 +52,9 @@ module Publish
 
       def handle_qualification_update
         if undergraduate_to_other_qualification?
+
+          @course.enrichments.find_or_initialize_draft.update(course_length: nil, salary_details: nil)
+
           redirect_to funding_type_publish_provider_recruitment_cycle_course_path(
             @course.provider_code,
             @course.recruitment_cycle_year,

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -90,7 +90,11 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_there_is_a_tda_course_i_want_to_edit
-    given_a_course_exists(:undergraduate_degree_with_qts)
+    given_a_course_exists(:undergraduate_degree_with_qts, enrichments: [course_enrichment])
+  end
+
+  def course_enrichment
+    @course_enrichment ||= build(:course_enrichment, :draft, course_length: :FourYears, salary_details: 'foobar')
   end
 
   def and_there_is_a_non_qts_course_i_want_to_edit
@@ -220,6 +224,9 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     expect(course.funding_type == 'salary').to be(true)
     expect(course.can_sponsor_skilled_worker_visa).to be(true)
     expect(course.can_sponsor_student_visa).to be(false)
+
+    expect(course.enrichments.find_or_initialize_draft.course_length).to be_nil
+    expect(course.enrichments.find_or_initialize_draft.salary_details).to be_nil
   end
 
   def and_i_should_be_on_the_course_details_page


### PR DESCRIPTION
### Context

Certain defaults are set when a TDA course is created. We need to ensure all of these are set back to nil when a user changes from a TDA course to a non TDA course.

### Changes proposed in this pull request

Set the following enrichment attributes back to nil when changing a TDA course to a non TDA course:

- `course_length`
- `salary_details`

### Guidance to review

The controllers are heavy, there is a card to try and refactor the whole flow.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
