### PR TITLE
Add missing govuk-link

### DIFF
--- a/app/views/sign_in/_default_signin_content.html.erb
+++ b/app/views/sign_in/_default_signin_content.html.erb
@@ -6,7 +6,7 @@
 
   <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe", class: "qa-sign_in_button") %>
 
-  <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to <%= I18n.t("service_name.publish") %>, email <%= support_email %>.</p>
+  <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to <%= I18n.t("service_name.publish") %>, email <%= support_email(classes: "govuk-link") %>.</p>
   <% elsif params[:support] == "true" %>
     <%= render Persona.new(
       email_address: "becomingateacher+admin-integration-tests@digital.education.gov.uk",


### PR DESCRIPTION
### Context

The govuk-link class is missing in the mailto link on our sign in page. We should add it.

#### Before

<img width="584" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/cabfdca5-900b-41f8-9d38-25577661e89b">

#### After

<img width="644" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/5147ed37-33eb-4be4-b7e0-390cc3c3c9c5">



### Guidance to review

🚢 
