### PR TITLE
Hiding Other Requirements doesn't prevent course from being published in 2025

### DIFF
--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -18,7 +18,7 @@ module Publish
 
       authorize @course
 
-      @hide_other_requirements = provider.course_requirements_deprecated?
+      @show_other_requirements = !provider.course_requirements_deprecated?
 
       @errors = flash[:error_summary]
       flash.delete(:error_summary)

--- a/app/helpers/publish_helper.rb
+++ b/app/helpers/publish_helper.rb
@@ -40,4 +40,8 @@ module PublishHelper
       en_dash: '–'
     }
   end
+
+  def render_if(condition, &)
+    yield if condition
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -382,7 +382,7 @@ class Provider < ApplicationRecord
   end
 
   def course_requirements_deprecated?
-    recruitment_cycle.after_2024? || FeatureService.enabled?(:course_requirements_deprecated)
+    recruitment_cycle.after_2024?
   end
 
   private

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -139,7 +139,7 @@
       action_path: !course.is_withdrawn? && course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil
     ) %>
 
-  <% unless @hide_other_requirements %>
+  <% render_if(@show_other_requirements) do %>
     <% enrichment_summary(
       summary_list,
       :course,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,7 +92,6 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
-  course_requirements_deprecated: false
   teacher_degree_apprenticeship: false
   send_request_data_to_bigquery: false
   rollover:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -11,7 +11,6 @@ environment:
 
 features:
   teacher_degree_apprenticeship: true
-  course_requirements_deprecated: true
 
 find_valid_referers:
   - http://localhost:3001

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -31,7 +31,6 @@ basic_auth:
 features:
   send_request_data_to_bigquery: true
   teacher_degree_apprenticeship: true
-  course_requirements_deprecated: true
 
 find_valid_referers:
   - https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -13,7 +13,6 @@ search_ui:
 
 features:
   teacher_degree_apprenticeship: true
-  course_requirements_deprecated: true
 
 authentication:
   secret: secret

--- a/spec/features/publish/courses/editing_course_requirements_2024_spec.rb
+++ b/spec/features/publish/courses/editing_course_requirements_2024_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 feature 'Editing course requirements', { can_edit_current_and_next_cycles: false } do
   before do
     allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2024)
-    disable_features(:course_requirements_deprecated)
+
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_requirements_page

--- a/spec/features/publish/courses/editing_course_requirements_2025_spec.rb
+++ b/spec/features/publish/courses/editing_course_requirements_2025_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'Editing course deprecated requirements in 2025', { can_edit_current_and_next_cycles: false } do
   before do
     allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
-    enable_features(:course_requirements_deprecated)
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     provider

--- a/spec/features/publish/courses/publishing_a_course_2025_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_2025_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Regression test can be deleted in the next recruitment cycle
+
+require 'rails_helper'
+
+feature 'Publishing courses', can_edit_current_and_next_cycles: false do
+  scenario 'i can publish a course in 2025' do
+    given_the_current_recruitment_cycle_is_2025
+    and_i_am_authenticated_as_a_provider_user
+    and_there_is_a_course_i_want_to_publish
+    when_i_visit_the_course_page
+    and_i_click_the_publish_link
+    then_i_should_see_a_success_message
+    and_the_course_is_published
+  end
+
+  def and_i_am_authenticated_as_a_provider_user
+    @user = create(:user, :with_provider)
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_the_current_recruitment_cycle_is_2025
+    allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
+  end
+
+  def and_there_is_a_course_i_want_to_publish
+    given_a_course_exists(
+      :with_gcse_equivalency,
+      :with_accrediting_provider,
+      enrichments: [create(:course_enrichment, :initial_draft)],
+      sites: [create(:site, location_name: 'location 1')],
+      study_sites: [create(:site, :study_site)]
+    )
+  end
+
+  def when_i_visit_the_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
+  end
+
+  def and_i_click_the_publish_link
+    publish_provider_courses_show_page.course_button_panel.publish_button.click
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content('Your course has been published.')
+  end
+
+  def and_the_course_is_published
+    expect(course.reload.is_published?).to be(true)
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/features/publish/viewing_a_course_2024_spec.rb
+++ b/spec/features/publish/viewing_a_course_2024_spec.rb
@@ -7,8 +7,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   scenario 'i can view the course basic details' do
     allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2024)
-    enable_features(:course_requirements_deprecated)
-
     given_i_am_authenticated_as_a_provider_user(course: build(:course))
     when_i_visit_the_course_page
     and_i_click_on_basic_details

--- a/spec/features/publish/viewing_a_course_2025_spec.rb
+++ b/spec/features/publish/viewing_a_course_2025_spec.rb
@@ -8,7 +8,6 @@ feature 'Course show 2025', { can_edit_current_and_next_cycles: false } do
   before do
     allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
     create(:recruitment_cycle)
-    enable_features(:course_requirements_deprecated)
   end
 
   scenario 'i can not see other personal qualities or other requirements' do


### PR DESCRIPTION
### Context

We've added a route constraint to prevent some endpoints being accessible for the 2025 recruitment cycle.

However, these named routes are still evaluated even if they are not executed in the view.

### Changes proposed in this pull request

_Remove the Feature Flag for course requirements deprecation. It's not necessary becuase of the separation of courses by recruitment cycle._

Wrap the named routes in a block that executes conditionally to prevent routing error.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
