### PR TITLE
Add enable and disable maintenance page workflows

### DIFF
--- a/.github/workflows/disable-maintenance.yml
+++ b/.github/workflows/disable-maintenance.yml
@@ -1,0 +1,32 @@
+name: Disable maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: choice
+        options:
+        - qa
+        - production
+
+jobs:
+  disable-maintenance:
+    name: Disable maintenance app
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets[format('AZURE_CREDENTIALS_{0}_AKS', github.event.inputs.environment)] }}
+
+    - name: Set ARM and kubelogin environment
+      uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}_AKS', github.event.inputs.environment)] }}
+
+    - name: Disable maintenance app
+      run: make ${{ inputs.environment }}_aks disable-maintenance

--- a/.github/workflows/enable-maintenance.yml
+++ b/.github/workflows/enable-maintenance.yml
@@ -1,0 +1,43 @@
+name: Enable maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: choice
+        options:
+        - qa
+        - production
+
+jobs:
+  enable-maintenance:
+    name: Enable maintenance app
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build and push docker image
+      id: build-image
+      uses: DFE-Digital/github-actions/build-docker-image@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        dockerfile-path: maintenance_page/Dockerfile
+        docker-repository: ghcr.io/dfe-digital/publish-maintenance
+        context: maintenance_page
+
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets[format('AZURE_CREDENTIALS_{0}_AKS', github.event.inputs.environment)] }}
+
+    - name: Set ARM and kubelogin environment
+      uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}_AKS', github.event.inputs.environment)] }}
+
+    - name: Deploy maintenance app
+      run: make ${{ inputs.environment }}_aks maintenance-fail-over
+      env:
+        MAINTENANCE_IMAGE_TAG: ${{steps.build-image.outputs.tag}}


### PR DESCRIPTION
### Context

We need to add workflows for maintenance page

### Changes proposed in this pull request

- Workflow for enabling maintenance page

- Workflow for disabling maintenance page


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
