### PR TITLE
Hide Financial support in 2025

### DIFF
--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -77,7 +77,7 @@
       action_visually_hidden_text: t("publish.providers.courses.description_content.fee_details_hidden_text")
     ) %>
 
-    <% if course.financial_support.present? %>
+    <% if course.financial_support.present? && !@provider.recruitment_cycle.after_2024? %>
       <% enrichment_summary(
         summary_list,
         :course,


### PR DESCRIPTION
### Context

 - Hide Financial support in Course Description view if the Recruitment Cycle is 2025
 - ~Merge fee details and financial support into fee details when rolling over a course from 2024 to 2025~

~There is a word limit on Fee details.~

~I've clipped the text copied to fee details so it fits in the validation.~

**This PR now only hides the fincial support on the Course description. We elected to contact each provider that has content in Financial Support and manuallly copy it across to 2025 if they wish. This avoids any potential issues in rollover.**

### Changes proposed in this pull request
|2024|2025|
|---|---|
|![image](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/629535dc-7e5e-4a1c-ba00-ae8f50a27725)|![image](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/c6ef7772-efa3-4d3d-9ad6-4854028821b0)|

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
