### PR TITLE
Rubocop changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
   - rubocop-capybara
   - rubocop-factory_bot
 

--- a/Gemfile
+++ b/Gemfile
@@ -179,6 +179,7 @@ group :development, :test do
   gem 'rubocop-factory_bot'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
+  gem 'rubocop-rspec_rails'
 
   # run specs in parallel
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -655,6 +655,9 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rspec (3.0.1)
       rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
@@ -858,6 +861,7 @@ DEPENDENCIES
   rubocop-factory_bot
   rubocop-rails
   rubocop-rspec
+  rubocop-rspec_rails
   rubypants
   schema_to_scaffold
   sentry-rails

--- a/config/rubocop/naming.yml
+++ b/config/rubocop/naming.yml
@@ -13,12 +13,9 @@ Naming/MethodName:
   Exclude:
     - 'app/models/accrediting_provider_enrichment.rb'
 
+# Allow numbers in variable names
 Naming/VariableNumber:
-  Exclude:
-    - 'app/serializers/api/public/v1/serializable_location.rb'
-    - 'app/serializers/api/public/v1/serializable_provider.rb'
-    - 'spec/serializers/api/public/v1/serializable_location_spec.rb'
-    - 'spec/serializers/api/public/v1/serializable_provider_spec.rb'
+  Enabled: false
 
 Naming/PredicateName:
   Exclude:

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -205,6 +205,12 @@ RSpec/InstanceVariable:
 RSpec/PredicateMatcher:
   Enabled: false
 
+RSpecRails/HaveHttpStatus:
+  Exclude:
+    - 'spec/smoke/api/v1/courses_spec.rb'
+    - 'spec/smoke/api/v1/healthcheck_spec.rb'
+    - 'spec/smoke/api/v1/providers_spec.rb'
+
 RSpec/DescribeClass:
   Enabled: false
 

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -1,7 +1,5 @@
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html
 
-require: rubocop-rspec
-
 RSpec/ExampleLength:
   Enabled: false
 
@@ -212,3 +210,8 @@ RSpec/DescribeClass:
 
 RSpec/NamedSubject:
   Enabled: false
+
+RSpec/Dialect:
+  PreferredMethods:
+    - "scenario"
+    - "feature"


### PR DESCRIPTION
### Context

Rubocop updated to v3 recently, some things were not attended to during the upgrade.

Also disable numbers in variables cop, it is not helpful

### Changes proposed in this pull request

1. Rubocop RSpecRails exists now: Add it to the gem file and require it in rubocop.yml
2. Add `RSpecRails/HaveHttpStatus` and `RSpec/Dialect` back in
3. ignore restrictions around numbers in variable names.

### Guidance to review
