### PR TITLE
[1837] Update dates for 2025 cycle

### DIFF
--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -37,6 +37,14 @@ module Find
         find_closes: Time.zone.local(2024, 9, 30, 23, 59, 59) # The evening before Find opens in the new cycle
       },
       2025 => {
+        find_opens: Time.zone.local(2024, 10, 1, 9),
+        apply_opens: Time.zone.local(2024, 10, 8, 9),
+        first_deadline_banner: Time.zone.local(2025, 7, 12, 9),
+        apply_1_deadline: Time.zone.local(2025, 9, 7, 18),
+        apply_2_deadline: Time.zone.local(2025, 9, 21, 18),
+        find_closes: Time.zone.local(2025, 10, 4, 23, 59, 59)
+      },
+      2026 => {
         # NOTE: the dates from below here are not the finalised but are required
         # for the current implementation
         find_opens: Time.zone.local(2024, 10, 5, 9),


### PR DESCRIPTION
### Context

The `applications_open_from` date on all the rolled over courses where they were using the default date in the previous cycle were defaulting to the 12th of October instead of the 8th of October in the new cycle.

This is because we need to update our dates for the 2025 recruitment cycle, now that they have been confirmed.

Failing linter is unrelated, [once this gets merged](https://github.com/DFE-Digital/publish-teacher-training/pull/4296) I will rebase and they will pass.

### Changes proposed in this pull request

Update the following dates for the 2025 recruitment cycle: 

- `find_opens`
- `apply_opens`

### Guidance to review

- Ensure the dates match the published dates here: 

https://www.apply-for-teacher-training.service.gov.uk/provider/service-guidance/dates-and-deadlines

- Ensure our services are aligned: 

https://github.com/DFE-Digital/apply-for-teacher-training/blob/b46659febe48f18ff0d3c8a70eaf3d2af6115677/app/services/cycle_timetable.rb#L81-L95

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
