### PR TITLE
Find Domain change - We will have to sustain 2 domains until the domain redirect is applied

### DIFF
--- a/app/lib/find_constraint.rb
+++ b/app/lib/find_constraint.rb
@@ -2,6 +2,6 @@
 
 class FindConstraint
   def matches?(request)
-    Settings.find_url&.include?(request.host) || request.host.include?('find-pr') || request.host.include?('find-review')
+    Settings.find_url&.include?(request.host) || Settings.extra_find_url&.include?(request.host) || request.host.include?('find-pr') || request.host.include?('find-review')
   end
 end

--- a/app/lib/find_constraint.rb
+++ b/app/lib/find_constraint.rb
@@ -2,6 +2,6 @@
 
 class FindConstraint
   def matches?(request)
-    Settings.find_url&.include?(request.host) || Settings.extra_find_url&.include?(request.host) || request.host.include?('find-pr') || request.host.include?('find-review')
+    request.host.include?('find')
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,13 +34,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = proc do |_source, request|
-    if Settings.find_url.include?(request.host)
-      Settings.find_assets_url
-    elsif Settings.extra_find_url&.include?(request.host)
-      Settings.extra_find_assets_url
-    end
-  end
+  # config.action_controller.asset_host = proc { |_source, request| }
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,11 @@ Rails.application.configure do
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = proc do |_source, request|
-    Settings.find_assets_url if Settings.find_url.include?(request.host)
+    if Settings.find_url.include?(request.host)
+      Settings.find_assets_url
+    elsif Settings.extra_find_url&.include?(request.host)
+      Settings.extra_find_assets_url
+    end
   end
 
   # Specifies the header that your server uses for sending files.

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  origin_urls = [Settings.base_url, Settings.find_url, Settings.extra_find_url].compact_blank
+
   allow do
-    origins Settings.base_url, Settings.find_url, Settings.extra_find_url
+    origins origin_urls
     resource '*', headers: :any, methods: %i[get post patch put]
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -2,7 +2,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins Settings.base_url, Settings.find_url
+    origins Settings.base_url, Settings.find_url, Settings.extra_find_url
     resource '*', headers: :any, methods: %i[get post patch put]
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,6 +59,7 @@ govuk_notify:
   user_added_as_organisation_to_training_partner_id: 47d3509f-eeac-49a5-a455-e4a911c93496
 publish_url: http://localhost:3000
 find_url: http://localhost:3002
+extra_find_url: http://localhost:3002
 mcbg:
   redis_password: <%= SecureRandom.base64 %>
 system_authentication_token: <%= SecureRandom.base64 %>

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -4,6 +4,7 @@ publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://find-teacher-training-courses.service.gov.uk
 find_assets_url: https://assets.find-postgraduate-teacher-training.service.gov.uk
+extra_find_assets_url: https://assets.find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -38,3 +38,4 @@ features:
 
 find_valid_referers:
   - https://www.find-postgraduate-teacher-training.service.gov.uk
+  - https://find-teacher-training-courses.service.gov.uk

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -3,8 +3,6 @@ publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://find-teacher-training-courses.service.gov.uk
-find_assets_url: https://assets.find-postgraduate-teacher-training.service.gov.uk
-extra_find_assets_url: https://assets.find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://find-teacher-training-courses.service.gov.uk
 find_assets_url: https://assets.find-postgraduate-teacher-training.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -3,7 +3,6 @@ publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://find-teacher-training-courses.service.gov.uk
-extra_find_assets_url: https://assets.find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -41,3 +41,4 @@ features:
 
 find_valid_referers:
   - https://www.find-postgraduate-teacher-training.service.gov.uk
+  - https://find-teacher-training-courses.service.gov.uk

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -3,6 +3,7 @@ publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://find-teacher-training-courses.service.gov.uk
+extra_find_assets_url: https://assets.find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,8 +2,9 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
-extra_find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 find_assets_url: https://qa-assets.find-postgraduate-teacher-training.service.gov.uk
+extra_find_assets_url: https://qa-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -34,3 +34,4 @@ features:
 
 find_valid_referers:
   - https://qa.find-postgraduate-teacher-training.service.gov.uk
+  - https://qa.find-teacher-training-courses.service.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 find_assets_url: https://qa-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,7 +2,6 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
-extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 find_assets_url: https://qa-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 find_assets_url: https://qa-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -3,8 +3,6 @@ publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
-find_assets_url: https://qa-assets.find-postgraduate-teacher-training.service.gov.uk
-extra_find_assets_url: https://qa-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -2,7 +2,6 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
-extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:
@@ -34,3 +35,4 @@ features:
 
 find_valid_referers:
   - https://qa.find-postgraduate-teacher-training.service.gov.uk
+  - https://qa.find-teacher-training-courses.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -7,6 +7,7 @@ environment:
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -7,6 +7,7 @@ environment:
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -7,7 +7,6 @@ environment:
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
-extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -7,7 +7,7 @@ environment:
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
-extra_find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -7,6 +7,7 @@ environment:
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -7,7 +7,6 @@ environment:
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
-extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/rollover.yml
+++ b/config/settings/rollover.yml
@@ -2,7 +2,6 @@ gcp_api_key: please_change_me
 publish_api_url: https://publish-teacher-training-rollover.london.cloudapps.digital
 publish_url: https://publish-rollover.london.cloudapps.digital
 find_url: https://find-rollover.london.cloudapps.digital
-#find_assets_url: https://sandbox-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://apply-rollover.london.cloudapps.digital
 # apply-rollover doesnt exist
 

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -22,3 +22,4 @@ dfe_signin:
 
 find_valid_referers:
   - https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+  - https://sandbox.find-teacher-training-courses.service.gov.uk

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -4,6 +4,7 @@ publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 find_assets_url: https://sandbox-assets.find-postgraduate-teacher-training.service.gov.uk
+extra_find_assets_url: https://sandbox-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
 environment:

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -3,8 +3,6 @@ publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.go
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
-find_assets_url: https://sandbox-assets.find-postgraduate-teacher-training.service.gov.uk
-extra_find_assets_url: https://sandbox-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
 environment:

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 find_assets_url: https://sandbox-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 

--- a/config/settings/sandbox_aks.yml
+++ b/config/settings/sandbox_aks.yml
@@ -3,7 +3,6 @@ publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.go
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
-extra_find_assets_url: https://sandbox-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
 environment:

--- a/config/settings/sandbox_aks.yml
+++ b/config/settings/sandbox_aks.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
 environment:

--- a/config/settings/sandbox_aks.yml
+++ b/config/settings/sandbox_aks.yml
@@ -21,3 +21,4 @@ dfe_signin:
 
 find_valid_referers:
   - https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+  - https://sandbox.find-teacher-training-courses.service.gov.uk

--- a/config/settings/sandbox_aks.yml
+++ b/config/settings/sandbox_aks.yml
@@ -3,6 +3,7 @@ publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.go
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
+extra_find_assets_url: https://sandbox-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
 environment:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
 find_assets_url: https://staging-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -31,3 +31,4 @@ features:
 
 find_valid_referers:
   - https://staging.find-postgraduate-teacher-training.service.gov.uk
+  - https://staging.find-teacher-training-courses.service.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -3,8 +3,6 @@ publish_api_url: https://staging.api.publish-teacher-training-courses.service.go
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
-find_assets_url: https://staging-assets.find-postgraduate-teacher-training.service.gov.uk
-extra_find_assets_url: https://staging-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -4,6 +4,7 @@ publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
 find_assets_url: https://staging-assets.find-postgraduate-teacher-training.service.gov.uk
+extra_find_assets_url: https://staging-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/staging_aks.yml
+++ b/config/settings/staging_aks.yml
@@ -3,7 +3,6 @@ publish_api_url: https://staging.api.publish-teacher-training-courses.service.go
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
-extra_find_assets_url: https://staging-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/staging_aks.yml
+++ b/config/settings/staging_aks.yml
@@ -3,6 +3,7 @@ publish_api_url: https://staging.api.publish-teacher-training-courses.service.go
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
+extra_find_assets_url: https://staging-assets.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/config/settings/staging_aks.yml
+++ b/config/settings/staging_aks.yml
@@ -30,3 +30,4 @@ features:
 
 find_valid_referers:
   - https://staging.find-postgraduate-teacher-training.service.gov.uk
+  - https://staging.find-teacher-training-courses.service.gov.uk

--- a/config/settings/staging_aks.yml
+++ b/config/settings/staging_aks.yml
@@ -2,6 +2,7 @@ gcp_api_key: please_change_me
 publish_api_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:

--- a/spec/lib/find_constraint_spec.rb
+++ b/spec/lib/find_constraint_spec.rb
@@ -14,52 +14,27 @@ describe FindConstraint do
     )
   end
 
-  let(:find_url) { 'find_url' }
-  let(:host) { 'find_url' }
-  let(:extra_find_url) { 'some_url' }
+  context 'when request host start with find' do
+    let(:host) { 'find-teacher-training' }
 
-  describe '#matched?' do
-    before do
-      Settings.find_url = find_url
-      Settings.extra_find_url = extra_find_url
+    it 'returns true' do
+      expect(subject).to be true
     end
+  end
 
-    context 'Settings.find_url is same as host' do
-      it 'returns true' do
-        expect(subject).to be_truthy
-      end
+  context 'when request host is in other environments' do
+    let(:host) { 'qa.find-teacher-training' }
+
+    it 'returns true' do
+      expect(subject).to be true
     end
+  end
 
-    context 'when request host matches extra_find_url' do
-      let(:host) { 'some_url' }
+  context 'when request host does not start with find' do
+    let(:host) { 'publish-teacher-training' }
 
-      it 'returns true' do
-        expect(subject).to be_truthy
-      end
-    end
-
-    context 'Settings.find_url is different to host' do
-      let(:host) { 'find_different_url' }
-
-      it 'returns false' do
-        expect(subject).to be_falsey
-      end
-    end
-
-    context 'Review environment' do
-      let(:host) { 'find-pr-123' }
-
-      it 'returns true' do
-        expect(subject).to be_truthy
-      end
-    end
-
-    context 'Settings.find_url is nil' do
-      let(:find_url) { nil }
-
-      it 'returns false' do
-        expect(subject).to be_falsey
-      end
+    it 'returns false' do
+      expect(subject).to be false
     end
   end
 end

--- a/spec/lib/find_constraint_spec.rb
+++ b/spec/lib/find_constraint_spec.rb
@@ -16,13 +16,23 @@ describe FindConstraint do
 
   let(:find_url) { 'find_url' }
   let(:host) { 'find_url' }
+  let(:extra_find_url) { 'some_url' }
 
   describe '#matched?' do
     before do
       Settings.find_url = find_url
+      Settings.extra_find_url = extra_find_url
     end
 
     context 'Settings.find_url is same as host' do
+      it 'returns true' do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context 'when request host matches extra_find_url' do
+      let(:host) { 'some_url' }
+
       it 'returns true' do
         expect(subject).to be_truthy
       end


### PR DESCRIPTION
## Context

Due to undergraduate courses appearing we will change Find domain.

Because this repo contain several domains into the same app we need to change the application logic to allow a new domain.

We’ll look to handle multiple domains (to enable a seamless transition from one domain to the other).

1. Allow multiple domains to function
2. Infra team to set up redirect from old to new domain
3. We remove this second domain and renamed the old domain to the new one in the app.

### Changes proposed in this pull request

Allow multiple domains to function

### Guidance to review

1. Does it needs change anywhere else?