### PR TITLE
Update Publish course validation links

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -52,11 +52,11 @@ module ViewHelper
       base_errors_hash(provider_code, course)[message]
     else
       {
-        about_course: "#{base}/about?display_errors=true#publish-course-information-form-about-course-field-error",
-        how_school_placements_work: "#{base}/about?display_errors=true#publish-course-information-form-how-school-placements-work-field-error",
+        about_course: "#{base}/about-this-course?display_errors=true#publish-course-information-form-about-course-field-error",
+        how_school_placements_work: "#{base}/school-placements?display_errors=true#publish-course-information-form-how-school-placements-work-field-error",
         fee_uk_eu: "#{base}/fees?display_errors=true#fee_uk_eu-error",
         fee_international: "#{base}/fees?display_errors=true#fee_internation-error",
-        course_length: "#{base + (course.fee_based? ? '/fees' : '/salary')}?display_errors=true#course_length-error",
+        course_length: "#{base}/length?display_errors=true#course_length-error",
         salary_details: "#{base}/salary?display_errors=true#salary_details-error",
         required_qualifications: "#{base}/requirements?display_errors=true#required_qualifications_wrapper",
         age_range_in_years: "#{base}/age-range?display_errors=true",

--- a/spec/features/publish/courses/publishing_a_course_with_validation_errors_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_with_validation_errors_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false } do
+  scenario 'The error links target the correct pages' do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_an_invalid_course_i_want_to_publish
+
+    when_i_visit_the_course_page
+    and_i_click_the_publish_link
+    then_i_see_validation_errors
+
+    when_i_click_the_about_course_error
+    then_i_am_on_the_about_course_page
+    when_i_complete_the_about_course
+    then_i_am_on_the_course_page
+
+    when_i_click_the_publish_link
+    and_i_click_the_school_placements_error
+    then_i_am_on_the_school_placements_page
+    when_i_complete_the_school_placements
+    then_i_am_on_the_course_page
+
+    when_i_click_the_publish_link
+    and_i_click_the_course_length_error
+    then_i_am_on_the_course_length_page
+    when_i_complete_the_course_length
+    then_i_am_on_the_course_page
+
+    when_i_click_the_publish_link
+    and_i_click_the_salary_error
+    then_i_am_on_the_course_salary_page
+    when_i_complete_the_course_salary
+    then_i_am_on_the_course_page
+
+    when_i_click_the_publish_link
+    and_i_click_the_degree_error
+    then_i_am_on_the_degrees_page
+    when_i_complete_the_degree_requirements
+    then_i_am_on_the_course_page
+
+    when_i_click_the_publish_link
+    and_i_click_the_gcse_error
+    then_i_am_on_the_gcse_page
+    when_i_complete_the_gcse_requirements
+
+    then_i_am_on_the_course_page
+
+    and_i_click_the_publish_link
+    then_i_see_a_success_message
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_content('Your course has been published.')
+  end
+
+  def when_i_complete_the_school_placements
+    fill_in 'publish-course-school-placements-form-how-school-placements-work-field-error', with: 'School placements information'
+    click_link_or_button 'Update how placements work'
+  end
+
+  def when_i_complete_the_about_course
+    fill_in 'publish-course-about-this-course-form-about-course-field-error', with: 'About course information'
+    click_link_or_button 'Update about this course'
+  end
+
+  def when_i_complete_the_course_length
+    choose '1 year'
+    click_link_or_button 'Update course length'
+  end
+
+  def when_i_complete_the_course_salary
+    fill_in 'publish-course-salary-form-salary-details-field-error', with: 'About course salary details'
+    click_link_or_button 'Save'
+  end
+
+  def when_i_complete_the_gcse_requirements
+    choose 'Yes', id: 'publish-gcse-requirements-form-accept-pending-gcse-field-error'
+    choose 'No', id: 'publish-gcse-requirements-form-accept-gcse-equivalency-field'
+    click_link_or_button 'Update GCSEs and equivalency tests'
+  end
+
+  def when_i_complete_the_degree_requirements
+    choose 'No'
+    click_link_or_button 'Save'
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    @user = create(:user, :with_provider)
+    given_i_am_authenticated(user: @user)
+  end
+
+  def then_i_see_validation_errors
+    within '.govuk-error-summary' do
+      expect(page).to have_content('Enter information about this course')
+      expect(page).to have_content('Enter details about how placements work')
+      expect(page).to have_content('Enter a course length')
+      expect(page).to have_content('Enter details about the salary for this course')
+      expect(page).to have_content('Enter degree requirements')
+      expect(page).to have_content('Enter GCSE requirements')
+    end
+  end
+
+  def when_i_click_the_about_course_error
+    within '.govuk-error-summary' do
+      page.find_link('Enter information about this course').click
+    end
+  end
+
+  def and_i_click_the_school_placements_error
+    within '.govuk-error-summary' do
+      page.find_link('Enter details about how placements work').click
+    end
+  end
+
+  def and_i_click_the_course_length_error
+    within '.govuk-error-summary' do
+      page.find_link('Enter a course length').click
+    end
+  end
+
+  def and_i_click_the_salary_error
+    within '.govuk-error-summary' do
+      page.find_link('Enter details about the salary for this course').click
+    end
+  end
+
+  def and_i_click_the_degree_error
+    within '.govuk-error-summary' do
+      page.find_link('Enter degree requirements').click
+    end
+  end
+
+  def and_i_click_the_gcse_error
+    within '.govuk-error-summary' do
+      page.find_link('Enter GCSE requirements').click
+    end
+  end
+
+  def then_i_am_on_the_about_course_page
+    expect(page).to have_current_path(/about-this-course/)
+  end
+
+  def then_i_am_on_the_school_placements_page
+    expect(page).to have_current_path(/school-placements/)
+  end
+
+  def then_i_am_on_the_course_length_page
+    expect(page).to have_current_path(/length/)
+  end
+
+  def then_i_am_on_the_course_salary_page
+    expect(page).to have_current_path(/salary/)
+  end
+
+  def then_i_am_on_the_degrees_page
+    expect(page).to have_current_path(%r{degrees/start})
+  end
+
+  def then_i_am_on_the_gcse_page
+    expect(page).to have_current_path(/gcses-pending-or-equivalency-tests/)
+  end
+
+  def and_there_is_an_invalid_course_i_want_to_publish
+    given_a_course_exists(
+      :with_accrediting_provider,
+      degree_grade: nil,
+      enrichments: [create(:course_enrichment, :without_content, about_course: '')],
+      sites: [create(:site, location_name: 'location 1')],
+      study_sites: [create(:site, :study_site)]
+    )
+  end
+
+  def when_i_visit_the_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
+    )
+  end
+
+  def then_i_am_on_the_course_page
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{course.course_code}")
+  end
+
+  def and_i_click_the_publish_link
+    publish_provider_courses_show_page.course_button_panel.publish_button.click
+  end
+  alias_method :when_i_click_the_publish_link, :and_i_click_the_publish_link
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,7 +17,7 @@ describe ApplicationHelper do
 
       it 'returns correct content' do
         expect(enrichment_error_link(:course, 'about_course', 'Something about the course'))
-          .to eq("<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--error\"><a class=\"govuk-link\" href=\"/publish/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#publish-course-information-form-about-course-field-error\">Something about the course</a></div>")
+          .to eq("<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--error\"><a class=\"govuk-link\" href=\"/publish/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about-this-course?display_errors=true#publish-course-information-form-about-course-field-error\">Something about the course</a></div>")
       end
     end
   end
@@ -54,7 +54,7 @@ describe ApplicationHelper do
         expect(subject).to have_css('.govuk-summary-list__key', text: 'About course')
         expect(subject).to have_css('.govuk-summary-list__value > .app-inset-text--error > a', text: error_message)
 
-        expect(subject).to have_link(error_message, href: "/publish/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about?display_errors=true#publish-course-information-form-about-course-field-error")
+        expect(subject).to have_link(error_message, href: "/publish/organisations/#{@provider.provider_code}/#{@course.recruitment_cycle_year}/courses/#{@course.course_code}/about-this-course?display_errors=true#publish-course-information-form-about-course-field-error")
       end
     end
   end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -8,7 +8,7 @@ describe ViewHelper do
     let(:course) { build(:course, provider:) }
 
     it 'returns enrichment error URL' do
-      expect(enrichment_error_url(provider_code: 'A1', course:, field: 'about_course')).to eq("/publish/organisations/A1/#{course.recruitment_cycle_year}/courses/#{course.course_code}/about?display_errors=true#publish-course-information-form-about-course-field-error")
+      expect(enrichment_error_url(provider_code: 'A1', course:, field: 'about_course')).to eq("/publish/organisations/A1/#{course.recruitment_cycle_year}/courses/#{course.course_code}/about-this-course?display_errors=true#publish-course-information-form-about-course-field-error")
     end
 
     it 'returns enrichment error URL for base error' do


### PR DESCRIPTION
### Context

  Ensure that the links shown to providers alerting them of validation
  errors on a course bring them to the relevant pages to correct the
  course and allow them to publish.



### Changes proposed in this pull request

### Guidance to review

[Screencast from 21-06-24 16:27:23.webm](https://github.com/DFE-Digital/publish-teacher-training/assets/135042929/1fdeee37-5c3e-4fa9-8348-c2ec2cfa8444)


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
