### PR TITLE
Change overnight backup to run at 0100 UTC

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -1,8 +1,8 @@
 name: Database Backup and Restore
 
 on:
-  schedule: # 03:00 UTC
-    - cron: "0 3 * * *"
+  schedule: # 01:00 UTC
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       overwriteThisMorningsBackup:


### PR DESCRIPTION
### Context

There's been an increase in overnight backup failures.
Some are in the initial connection to the webapp at 0400 when the backup starts, and it could be related to what looks like a  regular process that occurs around this time.

<img width="1219" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/94844345/cbfab261-ec7d-4a28-8f8a-2b94db0bf3be">

<img width="328" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/94844345/281f83c3-ed06-4986-b0f6-7f81e9f44b6f">

### Changes proposed in this pull request

Change the backup start time from 03:00 UTC to 01:00 UTC

### Guidance to review

Confirm ok with the change in time

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
