### PR TITLE
[1779] Consolidate `apply_1` and `apply_2` deadlines into `apply_deadline`

### DIFF
--- a/app/components/find/deadline_banner_component.html.erb
+++ b/app/components/find/deadline_banner_component.html.erb
@@ -1,19 +1,9 @@
-<% if cycle_timetable.show_apply_1_deadline_banner? %>
+<% if cycle_timetable.show_apply_2_deadline_banner? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
     <% notification_banner.with_heading(text: "Apply now to get on a course starting in the #{cycle_timetable.cycle_year_range} academic year") %>
     <p class="govuk-body">Courses can fill up at any time, so you should apply as soon as you can.</p>
-    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= cycle_timetable.find_opens.to_fs(:month_and_year) %>, apply no later than <%= apply_1_deadline %>.</p>
+    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= cycle_timetable.find_opens.to_fs(:month_and_year) %>, apply no later than <%= apply_2_deadline %>.</p>
     <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than <%= apply_2_deadline %>.</p>
-  <% end %>
-<% elsif cycle_timetable.show_apply_2_deadline_banner? %>
-  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
-    <% notification_banner.with_heading(text: "If you’re applying for the first time since applications opened in #{find_opens}") %>
-    <p class="govuk-body">It’s no longer possible to apply for teacher training starting in the <%= cycle_timetable.cycle_year_range %> academic year.</p>
-    <p class="govuk-body">You can <%= govuk_link_to("start or continue your application", Settings.apply_base_url) %> to get it ready for courses starting in the <%= cycle_timetable.cycle_year_range(cycle_timetable.next_year) %> academic year.</p>
-    <p class="govuk-body">You’ll be able to find courses from <%= find_reopens %> and submit your application from <%= apply_reopens %>.</p>
-
-    <p class="govuk-notification-banner__heading">If your application did not lead to a place and you’re applying again</p>
-    <p class="govuk-body">You can continue to view and apply for courses starting in the <%= cycle_timetable.cycle_year_range %> academic year until <%= apply_2_deadline %>.</p>
   <% end %>
 <% elsif cycle_timetable.show_cycle_closed_banner? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>

--- a/app/components/find/deadline_banner_component.html.erb
+++ b/app/components/find/deadline_banner_component.html.erb
@@ -1,9 +1,9 @@
-<% if cycle_timetable.show_apply_2_deadline_banner? %>
+<% if cycle_timetable.show_apply_deadline_banner? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
     <% notification_banner.with_heading(text: "Apply now to get on a course starting in the #{cycle_timetable.cycle_year_range} academic year") %>
     <p class="govuk-body">Courses can fill up at any time, so you should apply as soon as you can.</p>
-    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= cycle_timetable.find_opens.to_fs(:month_and_year) %>, apply no later than <%= apply_2_deadline %>.</p>
-    <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than <%= apply_2_deadline %>.</p>
+    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= cycle_timetable.find_opens.to_fs(:month_and_year) %>, apply no later than <%= apply_deadline %>.</p>
+    <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than <%= apply_deadline %>.</p>
   <% end %>
 <% elsif cycle_timetable.show_cycle_closed_banner? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>

--- a/app/components/find/deadline_banner_component.rb
+++ b/app/components/find/deadline_banner_component.rb
@@ -18,10 +18,6 @@ module Find
 
     attr_reader :cycle_timetable
 
-    def apply_1_deadline
-      cycle_timetable.apply_1_deadline.to_fs(:govuk_date_and_time)
-    end
-
     def apply_2_deadline
       cycle_timetable.apply_2_deadline.to_fs(:govuk_date_and_time)
     end

--- a/app/components/find/deadline_banner_component.rb
+++ b/app/components/find/deadline_banner_component.rb
@@ -18,8 +18,8 @@ module Find
 
     attr_reader :cycle_timetable
 
-    def apply_2_deadline
-      cycle_timetable.apply_2_deadline.to_fs(:govuk_date_and_time)
+    def apply_deadline
+      cycle_timetable.apply_deadline.to_fs(:govuk_date_and_time)
     end
 
     def find_opens

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -14,11 +14,11 @@ module RecruitmentCycleHelper
   end
 
   def hint_text_for_mid_cycle
-    "#{I18n.t('find.cycles.today_is_mid_cycle.description')} (#{Find::CycleTimetable.find_opens.to_fs(:govuk_date)} to #{Find::CycleTimetable.apply_2_deadline.to_fs(:govuk_date)})"
+    "#{I18n.t('find.cycles.today_is_mid_cycle.description')} (#{Find::CycleTimetable.find_opens.to_fs(:govuk_date)} to #{Find::CycleTimetable.apply_deadline.to_fs(:govuk_date)})"
   end
 
-  def hint_text_for_after_apply_2_deadline_passed
-    "#{I18n.t('find.cycles.today_is_after_apply_2_deadline_passed.description')} (#{Find::CycleTimetable.apply_2_deadline.to_fs(:govuk_date)} to #{Find::CycleTimetable.find_closes.to_fs(:govuk_date)})"
+  def hint_text_for_after_apply_deadline_passed
+    "#{I18n.t('find.cycles.today_is_after_apply_deadline_passed.description')} (#{Find::CycleTimetable.apply_deadline.to_fs(:govuk_date)} to #{Find::CycleTimetable.find_closes.to_fs(:govuk_date)})"
   end
 
   def hint_text_for_today_is_after_find_closes

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -17,10 +17,6 @@ module RecruitmentCycleHelper
     "#{I18n.t('find.cycles.today_is_mid_cycle.description')} (#{Find::CycleTimetable.find_opens.to_fs(:govuk_date)} to #{Find::CycleTimetable.apply_2_deadline.to_fs(:govuk_date)})"
   end
 
-  def hint_text_for_after_apply_1_deadline_passed
-    "#{I18n.t('find.cycles.today_is_after_apply_1_deadline_passed.description')} (#{Find::CycleTimetable.apply_1_deadline.to_fs(:govuk_date)} to #{Find::CycleTimetable.apply_2_deadline.to_fs(:govuk_date)})"
-  end
-
   def hint_text_for_after_apply_2_deadline_passed
     "#{I18n.t('find.cycles.today_is_after_apply_2_deadline_passed.description')} (#{Find::CycleTimetable.apply_2_deadline.to_fs(:govuk_date)} to #{Find::CycleTimetable.find_closes.to_fs(:govuk_date)})"
   end

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -8,7 +8,7 @@ module Find
         apply_opens: Time.zone.local(2020, 10, 13, 9),
         first_deadline_banner: Time.zone.local(2021, 7, 12, 9),
         apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
-        apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
+        apply_deadline: Time.zone.local(2021, 9, 21, 18),
         find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59)
       },
       2022 => {
@@ -16,7 +16,7 @@ module Find
         apply_opens: Time.zone.local(2021, 10, 12, 9),
         first_deadline_banner: Time.zone.local(2022, 8, 2, 9),
         apply_1_deadline: Time.zone.local(2022, 9, 6, 18),
-        apply_2_deadline: Time.zone.local(2022, 9, 20, 18),
+        apply_deadline: Time.zone.local(2022, 9, 20, 18),
         find_closes: Time.zone.local(2022, 10, 3, 23, 59, 59)
       },
       2023 => {
@@ -25,22 +25,21 @@ module Find
 
         first_deadline_banner: Time.zone.local(2023, 8, 1, 9), # 5 weeks before Apply 1 deadline
         apply_1_deadline: Time.zone.local(2023, 9, 5, 18), # First Tuesday of September
-        apply_2_deadline: Time.zone.local(2023, 9, 19, 18), # 2 weeks after Apply 1 deadline
+        apply_deadline: Time.zone.local(2023, 9, 19, 18), # 2 weeks after Apply 1 deadline
         find_closes: Time.zone.local(2023, 10, 2, 23, 59, 59) # The evening before Find opens in the new cycle
       },
       2024 => {
         find_opens: Time.zone.local(2023, 10, 3, 9), # First Tuesday of October
         apply_opens: Time.zone.local(2023, 10, 10, 9), # Second Tuesday of October
-        first_deadline_banner: Time.zone.local(2024, 7, 30, 9), # 5 weeks before Apply 1 deadline
-        apply_2_deadline: Time.zone.local(2024, 9, 17, 18), # 2 weeks after Apply 1 deadline
+        first_deadline_banner: Time.zone.local(2024, 7, 30, 9),
+        apply_deadline: Time.zone.local(2024, 9, 17, 18),
         find_closes: Time.zone.local(2024, 9, 30, 23, 59, 59) # The evening before Find opens in the new cycle
       },
       2025 => {
         find_opens: Time.zone.local(2024, 10, 1, 9),
         apply_opens: Time.zone.local(2024, 10, 8, 9),
         first_deadline_banner: Time.zone.local(2025, 7, 12, 9),
-        apply_1_deadline: Time.zone.local(2025, 9, 7, 18),
-        apply_2_deadline: Time.zone.local(2025, 9, 21, 18),
+        apply_deadline: Time.zone.local(2025, 9, 21, 18),
         find_closes: Time.zone.local(2025, 10, 4, 23, 59, 59)
       },
       2026 => {
@@ -49,7 +48,7 @@ module Find
         find_opens: Time.zone.local(2024, 10, 5, 9),
         apply_opens: Time.zone.local(2024, 10, 12, 9),
         first_deadline_banner: Time.zone.local(2025, 7, 12, 9),
-        apply_2_deadline: Time.zone.local(2025, 9, 21, 18),
+        apply_deadline: Time.zone.local(2025, 9, 21, 18),
         find_closes: Time.zone.local(2025, 10, 4, 23, 59, 59)
       }
     }.freeze
@@ -88,8 +87,8 @@ module Find
       date(:first_deadline_banner)
     end
 
-    def self.apply_2_deadline
-      date(:apply_2_deadline)
+    def self.apply_deadline
+      date(:apply_deadline)
     end
 
     def self.find_opens
@@ -109,23 +108,23 @@ module Find
     end
 
     def self.preview_mode?
-      Time.zone.now.between?(apply_2_deadline, find_closes)
+      Time.zone.now.between?(apply_deadline, find_closes)
     end
 
     def self.find_down? = phase_in_time?(:today_is_after_find_closes)
 
     def self.mid_cycle? = phase_in_time?(:today_is_after_find_opens)
 
-    def self.show_apply_2_deadline_banner? = phase_in_time?(:today_is_mid_cycle)
+    def self.show_apply_deadline_banner? = phase_in_time?(:today_is_mid_cycle)
 
-    def self.show_cycle_closed_banner? = phase_in_time?(:today_is_after_apply_2_deadline_passed)
+    def self.show_cycle_closed_banner? = phase_in_time?(:today_is_after_apply_deadline_passed)
 
     def self.phases_in_time
       {
         today_is_after_find_closes: Time.zone.now.between?((find_closes.in_time_zone('London') - 1.hour), (find_reopens.in_time_zone('London') - 1.hour)),
-        today_is_after_find_opens: Time.zone.now.between?((find_opens.in_time_zone('London') - 1.hour), apply_2_deadline),
-        today_is_mid_cycle: Time.zone.now.between?(first_deadline_banner, apply_2_deadline),
-        today_is_after_apply_2_deadline_passed: Time.zone.now.between?(apply_2_deadline, find_closes)
+        today_is_after_find_opens: Time.zone.now.between?((find_opens.in_time_zone('London') - 1.hour), apply_deadline),
+        today_is_mid_cycle: Time.zone.now.between?(first_deadline_banner, apply_deadline),
+        today_is_after_apply_deadline_passed: Time.zone.now.between?(apply_deadline, find_closes)
       }
     end
 
@@ -167,7 +166,7 @@ module Find
     def self.fake_point_in_recruitment_cycle
       %i[
         today_is_mid_cycle
-        today_is_after_apply_2_deadline_passed
+        today_is_after_apply_deadline_passed
         today_is_after_find_closes
         today_is_after_find_opens
       ]

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -36,11 +36,11 @@ module Find
         find_closes: Time.zone.local(2024, 9, 30, 23, 59, 59) # The evening before Find opens in the new cycle
       },
       2025 => {
-        find_opens: Time.zone.local(2024, 10, 1, 9),
-        apply_opens: Time.zone.local(2024, 10, 8, 9),
-        first_deadline_banner: Time.zone.local(2025, 7, 12, 9),
-        apply_deadline: Time.zone.local(2025, 9, 21, 18),
-        find_closes: Time.zone.local(2025, 10, 4, 23, 59, 59)
+        find_opens: Time.zone.local(2024, 10, 1, 9), # CONFIRMED
+        apply_opens: Time.zone.local(2024, 10, 8, 9), # CONFIRMED
+        first_deadline_banner: Time.zone.local(2025, 7, 12, 9), # TBC
+        apply_deadline: Time.zone.local(2025, 9, 17, 18), # CONFIRMED
+        find_closes: Time.zone.local(2025, 9, 25, 23, 59, 59) # TBC
       },
       2026 => {
         # NOTE: the dates from below here are not the finalised but are required

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -32,7 +32,6 @@ module Find
         find_opens: Time.zone.local(2023, 10, 3, 9), # First Tuesday of October
         apply_opens: Time.zone.local(2023, 10, 10, 9), # Second Tuesday of October
         first_deadline_banner: Time.zone.local(2024, 7, 30, 9), # 5 weeks before Apply 1 deadline
-        apply_1_deadline: Time.zone.local(2024, 9, 3, 18), # First Tuesday of September
         apply_2_deadline: Time.zone.local(2024, 9, 17, 18), # 2 weeks after Apply 1 deadline
         find_closes: Time.zone.local(2024, 9, 30, 23, 59, 59) # The evening before Find opens in the new cycle
       },
@@ -50,7 +49,6 @@ module Find
         find_opens: Time.zone.local(2024, 10, 5, 9),
         apply_opens: Time.zone.local(2024, 10, 12, 9),
         first_deadline_banner: Time.zone.local(2025, 7, 12, 9),
-        apply_1_deadline: Time.zone.local(2025, 9, 7, 18),
         apply_2_deadline: Time.zone.local(2025, 9, 21, 18),
         find_closes: Time.zone.local(2025, 10, 4, 23, 59, 59)
       }
@@ -90,10 +88,6 @@ module Find
       date(:first_deadline_banner)
     end
 
-    def self.apply_1_deadline
-      date(:apply_1_deadline)
-    end
-
     def self.apply_2_deadline
       date(:apply_2_deadline)
     end
@@ -122,9 +116,7 @@ module Find
 
     def self.mid_cycle? = phase_in_time?(:today_is_after_find_opens)
 
-    def self.show_apply_1_deadline_banner? = phase_in_time?(:today_is_mid_cycle)
-
-    def self.show_apply_2_deadline_banner? = phase_in_time?(:today_is_after_apply_1_deadline_passed)
+    def self.show_apply_2_deadline_banner? = phase_in_time?(:today_is_mid_cycle)
 
     def self.show_cycle_closed_banner? = phase_in_time?(:today_is_after_apply_2_deadline_passed)
 
@@ -132,8 +124,7 @@ module Find
       {
         today_is_after_find_closes: Time.zone.now.between?((find_closes.in_time_zone('London') - 1.hour), (find_reopens.in_time_zone('London') - 1.hour)),
         today_is_after_find_opens: Time.zone.now.between?((find_opens.in_time_zone('London') - 1.hour), apply_2_deadline),
-        today_is_mid_cycle: Time.zone.now.between?(first_deadline_banner, apply_1_deadline),
-        today_is_after_apply_1_deadline_passed: Time.zone.now.between?(apply_1_deadline, apply_2_deadline),
+        today_is_mid_cycle: Time.zone.now.between?(first_deadline_banner, apply_2_deadline),
         today_is_after_apply_2_deadline_passed: Time.zone.now.between?(apply_2_deadline, find_closes)
       }
     end
@@ -176,7 +167,6 @@ module Find
     def self.fake_point_in_recruitment_cycle
       %i[
         today_is_mid_cycle
-        today_is_after_apply_1_deadline_passed
         today_is_after_apply_2_deadline_passed
         today_is_after_find_closes
         today_is_after_find_opens

--- a/app/views/find/switcher/cycles.html.erb
+++ b/app/views/find/switcher/cycles.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_radio_button :cycle_schedule_name, "real", label: { text: t("find.cycles.real.name") } %>
       <%= f.govuk_radio_divider %>
       <%= f.govuk_radio_button :cycle_schedule_name, "today_is_mid_cycle", label: { text: t("find.cycles.today_is_mid_cycle.name") }, hint: { text: hint_text_for_mid_cycle } %>
-      <%= f.govuk_radio_button :cycle_schedule_name, "today_is_after_apply_2_deadline_passed", label: { text: t("find.cycles.today_is_after_apply_2_deadline_passed.name") }, hint: { text: hint_text_for_after_apply_2_deadline_passed } %>
+      <%= f.govuk_radio_button :cycle_schedule_name, "today_is_after_apply_deadline_passed", label: { text: t("find.cycles.today_is_after_apply_deadline_passed.name") }, hint: { text: hint_text_for_after_apply_deadline_passed } %>
       <%= f.govuk_radio_button :cycle_schedule_name, "today_is_after_find_closes", label: { text: t("find.cycles.today_is_after_find_closes.name") }, hint: { text: hint_text_for_today_is_after_find_closes } %>
       <%= f.govuk_radio_button :cycle_schedule_name, "today_is_after_find_opens", label: { text: t("find.cycles.today_is_after_find_opens.name") }, hint: { text: hint_text_for_today_is_after_find_opens } %>
     <% end %>
@@ -29,7 +29,7 @@
 <h2 class="govuk-heading-m">Deadlines</h2>
 
 <%= render Find::Utility::SummaryListComponent.new(rows: {
-  "Apply 2 deadline" => Find::CycleTimetable.apply_2_deadline.to_fs(:govuk_date),
+  "Apply deadline" => Find::CycleTimetable.apply_deadline.to_fs(:govuk_date),
   "Find closes on" => Find::CycleTimetable.find_closes.to_fs(:govuk_date),
   "Find reopens on" => Find::CycleTimetable.find_reopens.to_fs(:govuk_date)
 }) %>

--- a/app/views/find/switcher/cycles.html.erb
+++ b/app/views/find/switcher/cycles.html.erb
@@ -7,7 +7,6 @@
       <%= f.govuk_radio_button :cycle_schedule_name, "real", label: { text: t("find.cycles.real.name") } %>
       <%= f.govuk_radio_divider %>
       <%= f.govuk_radio_button :cycle_schedule_name, "today_is_mid_cycle", label: { text: t("find.cycles.today_is_mid_cycle.name") }, hint: { text: hint_text_for_mid_cycle } %>
-      <%= f.govuk_radio_button :cycle_schedule_name, "today_is_after_apply_1_deadline_passed", label: { text: t("find.cycles.today_is_after_apply_1_deadline_passed.name") }, hint: { text: hint_text_for_after_apply_1_deadline_passed } %>
       <%= f.govuk_radio_button :cycle_schedule_name, "today_is_after_apply_2_deadline_passed", label: { text: t("find.cycles.today_is_after_apply_2_deadline_passed.name") }, hint: { text: hint_text_for_after_apply_2_deadline_passed } %>
       <%= f.govuk_radio_button :cycle_schedule_name, "today_is_after_find_closes", label: { text: t("find.cycles.today_is_after_find_closes.name") }, hint: { text: hint_text_for_today_is_after_find_closes } %>
       <%= f.govuk_radio_button :cycle_schedule_name, "today_is_after_find_opens", label: { text: t("find.cycles.today_is_after_find_opens.name") }, hint: { text: hint_text_for_today_is_after_find_opens } %>
@@ -30,7 +29,6 @@
 <h2 class="govuk-heading-m">Deadlines</h2>
 
 <%= render Find::Utility::SummaryListComponent.new(rows: {
-  "Apply 1 deadline" => Find::CycleTimetable.apply_1_deadline.to_fs(:govuk_date),
   "Apply 2 deadline" => Find::CycleTimetable.apply_2_deadline.to_fs(:govuk_date),
   "Find closes on" => Find::CycleTimetable.find_closes.to_fs(:govuk_date),
   "Find reopens on" => Find::CycleTimetable.find_reopens.to_fs(:govuk_date)

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -6,9 +6,6 @@ en:
       today_is_mid_cycle:
         name: Mid cycle and deadlines should be displayed
         description: Candidates can see upcoming application deadlines
-      today_is_after_apply_1_deadline_passed:
-        name: Apply 1 deadline has passed
-        description: Candidates can no longer submit their initial application
       today_is_after_apply_2_deadline_passed:
         name: Apply 2 deadline has passed
         description: Candidates can no longer submit any subsequent applications

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -6,8 +6,8 @@ en:
       today_is_mid_cycle:
         name: Mid cycle and deadlines should be displayed
         description: Candidates can see upcoming application deadlines
-      today_is_after_apply_2_deadline_passed:
-        name: Apply 2 deadline has passed
+      today_is_after_apply_deadline_passed:
+        name: Apply deadline has passed
         description: Candidates can no longer submit any subsequent applications
       today_is_after_find_closes:
         name: Find has closed

--- a/spec/components/find/deadline_banner_component_spec.rb
+++ b/spec/components/find/deadline_banner_component_spec.rb
@@ -14,25 +14,13 @@ module Find
       end
     end
 
-    context 'when it is after the first_deadline_banner and before the apply_1_deadline' do
+    context 'when it is after the first_deadline_banner and before the apply_2_deadline' do
       it 'renders the banner with information about apply_1 and apply_2 deadlines' do
         Timecop.travel(CycleTimetable.first_deadline_banner + 1.hour) do
           result = render_inline(described_class.new(flash_empty: true))
 
           expect(result.text).to include('Courses can fill up at any time, so you should apply as soon as you can.')
           expect(result.text).not_to include("You can continue to view and apply for courses until 6pm on #{CycleTimetable.apply_2_deadline.strftime('%e %B %Y')}")
-          expect(result.text).not_to include('as there’s no guarantee that the courses currently shown on this website will be on offer next year.')
-        end
-      end
-    end
-
-    context 'when it is after the apply_1_deadline and before the apply_2_deadline' do
-      it 'renders the banner with information about apply_1 and apply_2 deadlines' do
-        Timecop.travel(CycleTimetable.apply_1_deadline + 1.hour) do
-          result = render_inline(described_class.new(flash_empty: true))
-
-          expect(result.text).to include('If your application did not lead to a place and you’re applying again')
-          expect(result.text).not_to include('Courses can fill up at any time, so you should apply as soon as you can.')
           expect(result.text).not_to include('as there’s no guarantee that the courses currently shown on this website will be on offer next year.')
         end
       end

--- a/spec/components/find/deadline_banner_component_spec.rb
+++ b/spec/components/find/deadline_banner_component_spec.rb
@@ -14,26 +14,26 @@ module Find
       end
     end
 
-    context 'when it is after the first_deadline_banner and before the apply_2_deadline' do
-      it 'renders the banner with information about apply_1 and apply_2 deadlines' do
+    context 'when it is after the first_deadline_banner and before the apply_deadline' do
+      it 'renders the banner with information about the apply deadline' do
         Timecop.travel(CycleTimetable.first_deadline_banner + 1.hour) do
           result = render_inline(described_class.new(flash_empty: true))
 
           expect(result.text).to include('Courses can fill up at any time, so you should apply as soon as you can.')
-          expect(result.text).not_to include("You can continue to view and apply for courses until 6pm on #{CycleTimetable.apply_2_deadline.strftime('%e %B %Y')}")
+          expect(result.text).not_to include("You can continue to view and apply for courses until 6pm on #{CycleTimetable.apply_deadline.strftime('%e %B %Y')}")
           expect(result.text).not_to include('as there’s no guarantee that the courses currently shown on this website will be on offer next year.')
         end
       end
     end
 
-    context 'when it is after the apply_2_deadline and before the find_closes' do
-      it 'renders the banner with information about apply_1 and apply_2 deadlines' do
-        Timecop.travel(CycleTimetable.apply_2_deadline + 1.hour) do
+    context 'when it is after the apply_deadline and before the find_closes' do
+      it 'renders the banner with information about the apply deadline' do
+        Timecop.travel(CycleTimetable.apply_deadline + 1.hour) do
           result = render_inline(described_class.new(flash_empty: true))
 
           expect(result.text).to include("Courses starting in the #{CycleTimetable.cycle_year_range} academic year are closed")
           expect(result.text).not_to include('Courses can fill up at any time, so you should apply as soon as you can.')
-          expect(result.text).not_to include("If your application did not lead to a place and you’re applying again, apply no later than 6pm on #{CycleTimetable.apply_2_deadline.strftime('%e %B %Y')}.")
+          expect(result.text).not_to include("If your application did not lead to a place and you’re applying again, apply no later than 6pm on #{CycleTimetable.apply_deadline.strftime('%e %B %Y')}.")
         end
       end
     end

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -16,7 +16,7 @@ feature 'Viewing a findable course' do
     end
 
     scenario 'course page shows correct course information' do
-      Timecop.freeze(Find::CycleTimetable.apply_2_deadline - 1.hour) do
+      Timecop.freeze(Find::CycleTimetable.apply_deadline - 1.hour) do
         when_i_visit_the_course_page
         then_i_should_see_the_course_information
       end
@@ -24,7 +24,7 @@ feature 'Viewing a findable course' do
 
     context 'end of cycle' do
       before do
-        Timecop.freeze(Find::CycleTimetable.apply_2_deadline + 1.hour)
+        Timecop.freeze(Find::CycleTimetable.apply_deadline + 1.hour)
 
         when_i_visit_the_course_page
       end

--- a/spec/features/find/switcher_cycles_spec.rb
+++ b/spec/features/find/switcher_cycles_spec.rb
@@ -22,9 +22,9 @@ feature 'switcher cycle' do
     and_i_see_deadline_banner('Apply now to get on a course starting in the 2023 to 2024 academic year')
   end
 
-  scenario 'Update to Apply 2 deadline has passed' do
+  scenario 'Update to Apply deadline has passed' do
     when_i_visit_switcher_cycle_page
-    and_i_choose('Apply 2 deadline has passed')
+    and_i_choose('Apply deadline has passed')
     then_i_click_on_update_button
     and_i_should_see_the_success_banner
     and_i_visit_find_results_page

--- a/spec/features/find/switcher_cycles_spec.rb
+++ b/spec/features/find/switcher_cycles_spec.rb
@@ -22,15 +22,6 @@ feature 'switcher cycle' do
     and_i_see_deadline_banner('Apply now to get on a course starting in the 2023 to 2024 academic year')
   end
 
-  scenario 'Update to Apply 1 deadline has passed' do
-    when_i_visit_switcher_cycle_page
-    and_i_choose('Apply 1 deadline has passed')
-    then_i_click_on_update_button
-    and_i_should_see_the_success_banner
-    and_i_visit_find_results_page
-    and_i_see_deadline_banner('You can continue to view and apply for courses starting in')
-  end
-
   scenario 'Update to Apply 2 deadline has passed' do
     when_i_visit_switcher_cycle_page
     and_i_choose('Apply 2 deadline has passed')

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -9,7 +9,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     end
 
     scenario 'i can view the course basic details' do
-      Timecop.travel(Find::CycleTimetable.apply_2_deadline - 1.hour) do
+      Timecop.travel(Find::CycleTimetable.apply_deadline - 1.hour) do
         given_i_am_authenticated(user: user_with_fee_based_course)
         when_i_visit_the_publish_course_preview_page
         then_i_see_the_course_preview_details
@@ -108,7 +108,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   context 'bursaries and scholarships is not announced' do
     scenario 'i can view the course basic details' do
-      Timecop.travel(Find::CycleTimetable.apply_2_deadline - 1.hour) do
+      Timecop.travel(Find::CycleTimetable.apply_deadline - 1.hour) do
         given_i_am_authenticated(user: user_with_fee_based_course)
         when_i_visit_the_publish_course_preview_page
         then_i_see_the_course_preview_details

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -7,8 +7,8 @@ module Find
     let(:one_hour_before_find_opens) { described_class.find_opens - 1.hour }
     let(:one_hour_after_find_opens) { described_class.find_opens + 1.hour }
     let(:one_hour_before_first_deadline_banner) { described_class.first_deadline_banner - 1.hour }
-    let(:one_hour_before_apply_2_deadline) { described_class.apply_2_deadline - 1.hour }
-    let(:one_hour_after_apply_2_deadline) { described_class.apply_2_deadline + 1.hour }
+    let(:one_hour_before_apply_deadline) { described_class.apply_deadline - 1.hour }
+    let(:one_hour_after_apply_deadline) { described_class.apply_deadline + 1.hour }
     let(:one_hour_after_find_closes) { described_class.find_closes + 1.hour }
     let(:one_hour_after_find_reopens) { described_class.find_reopens + 1.hour }
 
@@ -51,13 +51,13 @@ module Find
     end
 
     describe '.preview_mode?' do
-      it 'returns true when it is after the Apply 2 deadline but before Find closes' do
+      it 'returns true when it is after the Apply deadline but before Find closes' do
         Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
           expect(described_class.preview_mode?).to be true
         end
       end
 
-      it 'returns false before the Apply 2 deadline' do
+      it 'returns false before the Apply deadline' do
         Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
           expect(described_class.preview_mode?).to be false
         end
@@ -97,7 +97,7 @@ module Find
         end
       end
 
-      it 'returns false after the apply_2_deadline' do
+      it 'returns false after the apply_deadline' do
         Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
           expect(described_class.mid_cycle?).to be false
         end
@@ -111,28 +111,28 @@ module Find
       end
     end
 
-    describe '.show_apply_2_deadline_banner?' do
-      it 'returns true when it is after the apply_1_deadline and before the apply_2_deadline' do
-        Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
-          expect(described_class.show_apply_2_deadline_banner?).to be true
+    describe '.show_apply_deadline_banner?' do
+      it 'returns true when it is after the first_deadline_banner and before the apply_deadline' do
+        Timecop.travel(Time.zone.local(2024, 7, 30, 19, 0, 0)) do
+          expect(described_class.show_apply_deadline_banner?).to be true
         end
       end
 
-      it 'returns false before the after the apply_2_deadline' do
+      it 'returns false before the after the apply_deadline' do
         Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
-          expect(described_class.show_apply_2_deadline_banner?).to be false
+          expect(described_class.show_apply_deadline_banner?).to be false
         end
       end
 
       it 'returns false before the first_deadline_banner' do
         Timecop.travel(Time.zone.local(2021, 7, 7, 12, 0, 0)) do
-          expect(described_class.show_apply_2_deadline_banner?).to be false
+          expect(described_class.show_apply_deadline_banner?).to be false
         end
       end
     end
 
     describe '.show_cycle_closed_banner?' do
-      it 'returns true when it is after the apply_2_deadline and before Find closes' do
+      it 'returns true when it is after the apply_deadline and before Find closes' do
         Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
           expect(described_class.show_cycle_closed_banner?).to be true
         end
@@ -144,7 +144,7 @@ module Find
         end
       end
 
-      it 'returns false before the apply_2_deadline' do
+      it 'returns false before the apply_deadline' do
         Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
           expect(described_class.show_cycle_closed_banner?).to be false
         end

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -7,8 +7,6 @@ module Find
     let(:one_hour_before_find_opens) { described_class.find_opens - 1.hour }
     let(:one_hour_after_find_opens) { described_class.find_opens + 1.hour }
     let(:one_hour_before_first_deadline_banner) { described_class.first_deadline_banner - 1.hour }
-    let(:one_hour_before_apply_1_deadline) { described_class.apply_1_deadline - 1.hour }
-    let(:one_hour_after_apply_1_deadline) { described_class.apply_1_deadline + 1.hour  }
     let(:one_hour_before_apply_2_deadline) { described_class.apply_2_deadline - 1.hour }
     let(:one_hour_after_apply_2_deadline) { described_class.apply_2_deadline + 1.hour }
     let(:one_hour_after_find_closes) { described_class.find_closes + 1.hour }
@@ -113,26 +111,6 @@ module Find
       end
     end
 
-    describe '.show_apply_1_deadline_banner?' do
-      it 'returns true when it is after the deadline_banner and before the apply_1_deadline' do
-        Timecop.travel(Time.zone.local(2021, 9, 7, 17, 0, 0)) do
-          expect(described_class.show_apply_1_deadline_banner?).to be true
-        end
-      end
-
-      it 'returns false after the the apply_1_deadline' do
-        Timecop.travel(Time.zone.local(2021, 9, 7, 19, 0, 0)) do
-          expect(described_class.show_apply_1_deadline_banner?).to be false
-        end
-      end
-
-      it 'returns false before the deadline_banner' do
-        Timecop.travel(Time.zone.local(2021, 7, 12, 8, 0, 0)) do
-          expect(described_class.show_apply_1_deadline_banner?).to be false
-        end
-      end
-    end
-
     describe '.show_apply_2_deadline_banner?' do
       it 'returns true when it is after the apply_1_deadline and before the apply_2_deadline' do
         Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
@@ -146,8 +124,8 @@ module Find
         end
       end
 
-      it 'returns false before the apply_1_deadline' do
-        Timecop.travel(Time.zone.local(2021, 9, 7, 17, 0, 0)) do
+      it 'returns false before the first_deadline_banner' do
+        Timecop.travel(Time.zone.local(2021, 7, 7, 12, 0, 0)) do
           expect(described_class.show_apply_2_deadline_banner?).to be false
         end
       end


### PR DESCRIPTION
### Context

We are consolidating the `apply_1` and `apply_2` deadlines into one `apply_deadline`. This is overhanging tech debt from before we had continuous applications. 

### Changes proposed in this pull request

- Remove the `apply_1_deadline` banner and all related code
- Rename `apply_2_deadline` to `apply_deadline`
- Update the date of the `apply_deadline`

### Guidance to review

Does all the functionality still work without the two deadlines? Are their any edge cases that might catch us out?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
