### PR TITLE
Add update image tag for failback maintenance page

### DIFF
--- a/maintenance_page/scripts/failback.sh
+++ b/maintenance_page/scripts/failback.sh
@@ -27,5 +27,9 @@ kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/mani
 echo Delete maintenance service
 kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/manifests/maintenance/service_maintenance.yml
 
+echo Update image tag
+perl -p -e "s/#MAINTENANCE_IMAGE_TAG#/dummy-tag/" maintenance_page/manifests/maintenance/deployment_maintenance.yml.tmpl \
+    > maintenance_page/manifests/maintenance/deployment_maintenance.yml
+
 echo Delete maintenance app
 kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/manifests/maintenance/deployment_maintenance.yml


### PR DESCRIPTION
### Context

The disable maintenance workflow had an error

### Changes proposed in this pull request

Add 'update image tag' step into failback.sh for maintenance page



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
