### PR TITLE
Add script hash to rails CSP configuration

### DIFF
--- a/app/views/layouts/_add_js_enabled_class_to_body.html.erb
+++ b/app/views/layouts/_add_js_enabled_class_to_body.html.erb
@@ -1,3 +1,4 @@
-<script nonce='<%= content_security_policy_nonce %>'>
+<%# If this script changes at all, be sure to update config/initializers/content_security_policy.rb %>
+<script>
   document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 </script>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -26,6 +26,7 @@ Rails.application.configure do
     policy.script_src  :self,
                        'https://www.google-analytics.com',
                        'https://www.googletagmanager.com',
+                       "'sha256-aBGeCwtg0DKytYpKh9kIMvmYL0sooy9+McqPAZ5feTk='", # add_js_enabled_class_to_body.html.erb
                        *all_domains
 
     policy.connect_src :self,


### PR DESCRIPTION
### Context

  Add the hash of the inline script to the Content Security Policy header from the server.

  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script

### Changes proposed in this pull request

### Guidance to review

1. Open Dev tools
2. Visit the root of the application
3. Clear cookies
4. Refresh the page with CTRL-r
5. See no CSP errors in the console.

This actually highlights other areas where the attempt to add a nonce value is not working.

This fixes the issue in the ticket though.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
