### PR TITLE
[1873] Render 404 if course should not be on Find

### DIFF
--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -14,6 +14,8 @@ module Find
         subjects: [:financial_incentive],
         site_statuses: [:site]
       ).find_by!(course_code: params[:course_code]&.upcase).decorate
+
+      render_not_found unless @course.is_published?
     end
   end
 end

--- a/spec/features/find/viewing_courses_in_various_states_spec.rb
+++ b/spec/features/find/viewing_courses_in_various_states_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'viewing courses in various states' do
+  scenario 'viewing a published course' do
+    given_there_is_a_published_course
+    when_i_visit_the_course_page
+    then_i_should_see_the_course
+  end
+
+  scenario 'viewing a published with unpublished changes course' do
+    given_there_is_a_published_with_unpublished_changes_course
+    when_i_visit_the_course_page
+    then_i_should_see_the_course
+  end
+
+  scenario 'viewing a draft course' do
+    given_there_is_a_draft_course
+    when_i_visit_the_course_page
+    then_i_should_see_page_not_found
+  end
+
+  scenario 'viewing a rolled over course' do
+    given_there_is_a_rolled_over_course
+    when_i_visit_the_course_page
+    then_i_should_see_page_not_found
+  end
+
+  scenario 'viewing a withdrawn course' do
+    given_there_is_a_withdrawn_course
+    when_i_visit_the_course_page
+    then_i_should_see_page_not_found
+  end
+
+  def given_there_is_a_published_course
+    @course ||= create(
+      :course,
+      enrichments: [
+        build(
+          :course_enrichment,
+          :published
+        )
+      ]
+    )
+  end
+
+  def when_i_visit_the_find_show_page
+    find_results_page.load
+  end
+
+  def when_i_visit_the_course_page
+    find_course_show_page.load(provider_code: @course.provider.provider_code, course_code: @course.course_code)
+  end
+
+  def then_i_should_see_the_course
+    expect(page.status_code).to eq(200)
+  end
+
+  def then_i_should_see_page_not_found
+    expect(page.status_code).to eq(404)
+  end
+
+  def given_there_is_a_draft_course
+    @course ||= create(
+      :course,
+      enrichments: [
+        build(
+          :course_enrichment,
+          :draft
+        )
+      ]
+    )
+  end
+
+  def given_there_is_a_rolled_over_course
+    @course ||= create(
+      :course,
+      enrichments: [
+        build(
+          :course_enrichment,
+          :rolled_over
+        )
+      ]
+    )
+  end
+
+  def given_there_is_a_published_with_unpublished_changes_course
+    @course ||= create(
+      :course,
+      enrichments: [
+        build(
+          :course_enrichment,
+          :subsequent_draft
+        )
+      ]
+    )
+  end
+
+  def given_there_is_a_withdrawn_course
+    @course ||= create(
+      :course,
+      enrichments: [
+        build(
+          :course_enrichment,
+          :withdrawn
+        )
+      ]
+    )
+  end
+end


### PR DESCRIPTION
### Context

Courses which are draft, rolled over and withdrawn should not be on Find. Currently you can access these courses if you manually type in the URL.

These courses are already hidden from the Find search and wont be shown in the results page.

### Changes proposed in this pull request

Render a 404 if the course is in a state where it should not be on Find.

### Before

- https://qa.publish-teacher-training-courses.service.gov.uk/publish/organisations/4Y1/2024/courses/E588
- https://qa.find-postgraduate-teacher-training.service.gov.uk/course/4Y1/E588

<img width="791" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/99090588-2e66-4aa4-888a-101aa97741e0">


### After

- https://publish-review-4312.test.teacherservices.cloud/publish/organisations/4Y1/2024/courses/E588
- https://find-review-4312.test.teacherservices.cloud/course/4Y1/E588

<img width="938" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/fad5c4d9-e92b-4bf6-a79c-64b44db39017">



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
