### PR TITLE
[453] Omit course start day field on support

### DIFF
--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -20,7 +20,7 @@
         <% end %>
       </div>
 
-      <%= f.govuk_date_field(:start_date, legend: { text: "Start date" }) %>
+      <%= f.govuk_date_field(:start_date, omit_day: true, legend: { text: "Start date" }) %>
 
       <%= f.govuk_date_field(:applications_open_from, legend: { text: "Applications open from date" }) %>
 

--- a/spec/features/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/features/support/providers/courses/editing_a_course_spec.rb
@@ -21,7 +21,7 @@ feature 'Edit provider course details' do
     scenario 'I can edit a course details' do
       when_i_fill_in_course_code_with valid_course_code
       and_i_fill_in_course_title_with valid_course_name
-      and_i_fill_in_course_start_date_with valid_date_day, valid_date_month, valid_date_year
+      and_i_fill_in_course_start_date_with valid_date_month, valid_date_year
       and_i_fill_in_course_application_open_from_with valid_date_day, valid_date_month, valid_date_year
       and_i_select_the_send_checkbox
       and_i_click_the_continue_button
@@ -38,7 +38,7 @@ feature 'Edit provider course details' do
     scenario 'I cannot use invalid course details' do
       when_i_fill_in_course_code_with existing_course_code
       and_i_fill_in_course_title_with valid_course_name
-      and_i_fill_in_course_start_date_with valid_date_day, valid_date_month, invalid_date_year
+      and_i_fill_in_course_start_date_with valid_date_month, invalid_date_year
       and_i_fill_in_course_application_open_from_with valid_date_day, valid_date_month, invalid_date_year
       and_i_click_the_continue_button
       then_i_see_the_error_summary
@@ -46,7 +46,7 @@ feature 'Edit provider course details' do
     end
 
     scenario 'I cannot use invalid date format' do
-      when_i_fill_in_course_start_date_with invalid_date_day, invalid_date_month, valid_date_year
+      when_i_fill_in_course_start_date_with invalid_date_month, valid_date_year
       and_i_fill_in_course_application_open_from_with invalid_date_day, invalid_date_month, valid_date_year
       and_i_click_the_continue_button
       then_i_see_the_error_summary
@@ -57,7 +57,7 @@ feature 'Edit provider course details' do
     scenario 'I cannot use a blank course details' do
       when_i_fill_in_course_code_with blank_value
       and_i_fill_in_course_title_with blank_value
-      and_i_fill_in_course_start_date_with blank_value, blank_value, blank_value
+      and_i_fill_in_course_start_date_with blank_value, blank_value
       and_i_fill_in_course_application_open_from_with blank_value, blank_value, blank_value
       and_i_click_the_continue_button
       then_i_see_the_error_summary
@@ -150,8 +150,7 @@ feature 'Edit provider course details' do
     support_provider_course_edit_page.name.set(course_name)
   end
 
-  def when_i_fill_in_course_start_date_with(day, month, year)
-    support_provider_course_edit_page.start_date_day.set(day)
+  def when_i_fill_in_course_start_date_with(month, year)
     support_provider_course_edit_page.start_date_month.set(month)
     support_provider_course_edit_page.start_date_year.set(year)
   end
@@ -183,7 +182,6 @@ feature 'Edit provider course details' do
   end
 
   def then_i_see_the_updated_start_date
-    expect(support_provider_course_edit_page.start_date_day.value).to eq(valid_date_day)
     expect(support_provider_course_edit_page.start_date_month.value).to eq(valid_date_month)
     expect(support_provider_course_edit_page.start_date_year.value).to eq(valid_date_year)
   end

--- a/spec/support/page_objects/support/provider/course_edit.rb
+++ b/spec/support/page_objects/support/provider/course_edit.rb
@@ -8,7 +8,6 @@ module PageObjects
 
         element :course_code, '#support-edit-course-form-course-code-field'
         element :name, '#support-edit-course-form-name-field'
-        element :start_date_day, '#support_edit_course_form_start_date_3i'
         element :start_date_month, '#support_edit_course_form_start_date_2i'
         element :start_date_year, '#support_edit_course_form_start_date_1i'
         element :application_open_from_day, '#support_edit_course_form_applications_open_from_3i'


### PR DESCRIPTION
### Context

Our support console in Publish allows someone to set a course as any day in any month.

However, if the provider went through the normal flow of creating a course, this is impossible. We default this to the first of the month. We should align the two.

We do not render this to the candidate, so it will not make any difference to candidates, but will help keep our data consistent.

There will be follow up work to set all course start days to the 1st of the month.

### Changes proposed in this pull request

Remove the day field from support

### Before

<img width="609" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/f0cffc70-a726-4568-bc66-67fe30396cc2">


### After

<img width="624" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/78c28dc6-8389-49e6-a858-2a5a2275e27b">




### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
