### PR TITLE
Display A levels on publish summary page

### DIFF
--- a/app/components/a_level_row_component.html.erb
+++ b/app/components/a_level_row_component.html.erb
@@ -2,7 +2,7 @@
   <% if @course.a_level_requirements.present? %>
     <% Array(@course.a_level_subject_requirements).map do |a_level_subject_requirement| %>
       <p class="govuk-body">
-        <%= a_level_subject_row_content(ActiveSupport::HashWithIndifferentAccess.new(a_level_subject_requirement)) %>
+        <%= a_level_subject_row_content(a_level_subject_requirement.with_indifferent_access) %>
       </p>
     <% end %>
 

--- a/app/components/a_level_row_component.html.erb
+++ b/app/components/a_level_row_component.html.erb
@@ -1,7 +1,28 @@
 <% if course.a_levels_requirements_answered? %>
-  <p class="govuk-summary-list-value govuk-!-margin-top-0">
-    <%= a_level_requirement_content %>
-  </p>
+  <% if @course.a_level_requirements.present? %>
+    <% Array(@course.a_level_subject_requirements).map do |a_level_subject_requirement| %>
+      <p class="govuk-body">
+        <%= a_level_subject_row_content(ActiveSupport::HashWithIndifferentAccess.new(a_level_subject_requirement)) %>
+      </p>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= pending_a_level_summary_content %>
+    </p>
+
+    <p class="govuk-body">
+      <%= a_level_equivalency_summary_content %>
+    </p>
+
+    <% if @course.accept_a_level_equivalency? && @course.additional_a_level_equivalencies.present? %>
+      <p class="govuk-body">
+      <%= @course.additional_a_level_equivalencies %>
+      </p>
+    <% end %>
+  <% else %>
+    <%= a_level_not_required_content %>
+  <% end %>
+
 <% else %>
   <%= govuk_inset_text(classes: inset_text_css_classes) do %>
     <p class="govuk-heading-s app-inset-text__title"><%= t("publish.providers.courses.description_content.a_levels_heading") %></p>

--- a/app/components/a_level_row_component.html.erb
+++ b/app/components/a_level_row_component.html.erb
@@ -6,13 +6,17 @@
       </p>
     <% end %>
 
-    <p class="govuk-body">
-      <%= pending_a_level_summary_content %>
-    </p>
+    <% unless @course.accept_pending_a_level.nil? %>
+      <p class="govuk-body">
+        <%= pending_a_level_summary_content %>
+      </p>
+    <% end %>
 
-    <p class="govuk-body">
-      <%= a_level_equivalency_summary_content %>
-    </p>
+    <% unless @course.accept_a_level_equivalency.nil? %>
+      <p class="govuk-body">
+        <%= a_level_equivalency_summary_content %>
+      </p>
+    <% end %>
 
     <% if @course.accept_a_level_equivalency? && @course.additional_a_level_equivalencies.present? %>
       <p class="govuk-body">

--- a/app/components/a_level_row_component.rb
+++ b/app/components/a_level_row_component.rb
@@ -27,11 +27,11 @@ class ALevelRowComponent < ViewComponent::Base
   end
 
   def pending_a_level_summary_content
-    I18n.t("course.consider_pending_a_level.row.#{@course.accept_pending_a_level?}")
+    I18n.t("course.consider_pending_a_level.row.#{@course.accept_pending_a_level?}") unless @course.accept_pending_a_level.nil?
   end
 
   def a_level_equivalency_summary_content
-    I18n.t("course.a_level_equivalencies.row.#{@course.accept_a_level_equivalency?}")
+    I18n.t("course.a_level_equivalencies.row.#{@course.accept_a_level_equivalency?}") unless @course.accept_a_level_equivalency.nil?
   end
 
   def inset_text_css_classes

--- a/app/components/a_level_row_component.rb
+++ b/app/components/a_level_row_component.rb
@@ -9,10 +9,29 @@ class ALevelRowComponent < ViewComponent::Base
     @errors = errors&.values&.flatten
   end
 
-  def a_level_requirement_content
-    return if @course.a_level_requirements.present?
-
+  def a_level_not_required_content
     I18n.t('publish.providers.courses.description_content.a_levels_not_required')
+  end
+
+  def a_level_subject_row_content(a_level_subject_requirement)
+    row_value = ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement).row_value
+
+    if @course.accept_a_level_equivalency?
+      [
+        row_value,
+        I18n.t('course.a_level_equivalencies.suffix')
+      ].join(', ')
+    else
+      row_value
+    end
+  end
+
+  def pending_a_level_summary_content
+    I18n.t("course.consider_pending_a_level.row.#{@course.accept_pending_a_level?}")
+  end
+
+  def a_level_equivalency_summary_content
+    I18n.t("course.a_level_equivalencies.row.#{@course.accept_a_level_equivalency?}")
   end
 
   def inset_text_css_classes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,10 +327,17 @@ en:
     consider_pending_a_level:
       heading: Will you consider candidates with pending A levels?
       hint: These are candidates who expect to have the qualification before the beginning of the course. You can give them an offer, on the condition that they pass their A levels.
+      row:
+        "true": "Candidates with pending A levels will be considered."
+        "false": "Candidates with pending A levels will not be considered."
     a_level_equivalencies:
       heading: Will you consider candidates who need to take an equivalency test for their A levels?
       submit: Update A levels
       hint: For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay
+      suffix: or equivalent qualification
+      row:
+        "true": "Equivalency tests will be considered."
+        "false": "Equivalency tests will not be considered."
     new:
       level:
         special_educational_needs_and_disabilities:

--- a/spec/components/a_level_row_component_spec.rb
+++ b/spec/components/a_level_row_component_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ALevelRowComponent do
+  it 'renders the a_level_not_required_content when a level requirements are not present' do
+    course = create(:course, a_level_requirements: false)
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).to include(I18n.t('publish.providers.courses.description_content.a_levels_not_required'))
+  end
+
+  it 'renders the a_level_subject_row_content when a level requirements and subject requirements are present' do
+    a_level_subject_requirement = { 'subject' => 'other_subject', 'other_subject' => 'Math', 'minimum_grade_required' => 'A' }
+    course = create(:course, a_level_requirements: true, a_level_subject_requirements: [a_level_subject_requirement])
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).to include('Math - Grade A or above')
+  end
+
+  it 'renders the pending a level summary content for acceptance when course accepts pending a levels' do
+    course = create(:course, accept_pending_a_level: true, a_level_requirements: true)
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).to include(I18n.t('course.consider_pending_a_level.row.true'))
+  end
+
+  it 'renders the pending a level summary content for non-acceptance when course does not accept pending a levels' do
+    course = create(:course, accept_pending_a_level: false, a_level_requirements: true)
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).to include(I18n.t('course.consider_pending_a_level.row.false'))
+  end
+
+  it 'renders the a level equivalency summary content for acceptance when course accepts a level equivalencies' do
+    course = create(:course, accept_a_level_equivalency: true, a_level_requirements: true)
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).to include(I18n.t('course.a_level_equivalencies.row.true'))
+  end
+
+  it 'renders the a level equivalency summary content for non-acceptance when course does not accept a level equivalencies' do
+    course = create(:course, accept_a_level_equivalency: false, a_level_requirements: true)
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).to include(I18n.t('course.a_level_equivalencies.row.false'))
+  end
+
+  it 'renders the additional a level equivalencies content when present' do
+    course = create(:course, accept_a_level_equivalency: true, additional_a_level_equivalencies: 'Some additional information', a_level_requirements: true)
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).to include('Some additional information')
+  end
+
+  it 'does not render the additional a level equivalencies when no equivalencies' do
+    course = create(:course, accept_a_level_equivalency: false, additional_a_level_equivalencies: 'Some additional information', a_level_requirements: true)
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).not_to include('Some additional information')
+  end
+
+  it 'returns false for has_errors?' do
+    course = create(:course)
+    component = described_class.new(course: course.decorate)
+
+    expect(component.has_errors?).to be(false)
+  end
+end

--- a/spec/components/a_level_row_component_spec.rb
+++ b/spec/components/a_level_row_component_spec.rb
@@ -68,6 +68,24 @@ RSpec.describe ALevelRowComponent do
     expect(rendered_component.text).not_to include('Some additional information')
   end
 
+  it 'does not render the pending A level if the question is not answered' do
+    a_level_subject_requirement = { 'subject' => 'other_subject', 'other_subject' => 'Math', 'minimum_grade_required' => 'A' }
+    course = create(:course, accept_pending_a_level: nil, a_level_requirements: true, a_level_subject_requirements: [a_level_subject_requirement])
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).not_to include('Candidates with pending A levels will')
+  end
+
+  it 'does not render the equivalency A level if the question is not answered' do
+    a_level_subject_requirement = { 'subject' => 'other_subject', 'other_subject' => 'Math', 'minimum_grade_required' => 'A' }
+    course = create(:course, accept_a_level_equivalency: nil, a_level_requirements: true, a_level_subject_requirements: [a_level_subject_requirement])
+    component = described_class.new(course: course.decorate)
+    rendered_component = render_inline(component)
+
+    expect(rendered_component.text).not_to include('Equivalency tests will ')
+  end
+
   it 'returns false for has_errors?' do
     course = create(:course)
     component = described_class.new(course: course.decorate)

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -122,6 +122,10 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     when_i_enter_on_a_level_equivalencies
     then_the_yes_option_is_chosen_in_a_level_equivalencies
     and_i_see_the_additional_a_level_equivalencies_text
+
+    when_i_click_update_a_levels
+    then_i_am_on_the_course_description_tab
+    and_i_see_the_a_level_requirements_for_the_course
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -356,9 +360,10 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     )
   end
 
-  def and_i_click_update_a_levels
+  def when_i_click_update_a_levels
     click_on 'Update A levels'
   end
+  alias_method :and_i_click_update_a_levels, :when_i_click_update_a_levels
 
   def then_i_see_an_error_message_for_the_a_level_equivalencies
     expect(page).to have_content('Select if you will consider candidates who need to take equivalency tests').twice
@@ -399,5 +404,15 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
 
   def and_i_see_the_additional_a_level_equivalencies_text
     expect(page.find('textarea').value).to eq('Some additional A level equivalencies text')
+  end
+
+  def and_i_see_the_a_level_requirements_for_the_course
+    expect(page).to have_content('Any subject - Grade C or above, or equivalent')
+    expect(page).to have_content('Any STEM subject - Grade C or above, or equivalent')
+    expect(page).to have_content('Any humanities subject, or equivalent')
+    expect(page).to have_content('Mathematics, or equivalent')
+    expect(page).to have_content('Candidates with pending A levels will not be considered.')
+    expect(page).to have_content('Equivalency tests will be considered.')
+    expect(page).to have_content('Some additional A level equivalencies text')
   end
 end


### PR DESCRIPTION
### Context

We need to display the A levels required for TDA a courses on Publish.

The “A levels” row in on the “Description” tab displays the required A levels, including the different variations if Grade is added, and if pending or equivalency tests are accepted.

### Changes proposed in this pull request

<img width="398" alt="Screenshot 2024-06-28 at 14 35 34" src="https://github.com/DFE-Digital/publish-teacher-training/assets/27509/448341c3-ff4f-48b0-bb5b-8dba578f1ec7">

### Guidance to review

1. Does it work in any scenarios with content being added?


### Trello card

https://trello.com/c/91pWQbZL/1792-a-levels-7-7-display-a-levels-on-publish-summary-page-and-find-preview-for-tda-courses-on-publish