### PR TITLE
A levels add max character length validation to minimum grade required

### DIFF
--- a/app/validators/chars_count_validator.rb
+++ b/app/validators/chars_count_validator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CharsCountValidator < ActiveModel::EachValidator
+  # Rails default Length Validators does not give you the possibility
+  # to pass a block for overwriting the too long message when reaches the
+  # maximum chars
+  #
+  #  class Person
+  #    validates :name, chars_count: { maximum: 100 }
+  #  end
+  #
+  #  In locale:
+  #
+  #  activemodel:
+  #    errors:
+  #      person:
+  #        attributes:
+  #          name:
+  #            chars_count:
+  #              one: Name must be %{maximum} characters or less. You have %{count} character too many.
+  #              other: Name must be %{maximum} characters or less. You have %{count} characters too many.
+  #
+  def validate_each(record, attribute, value)
+    return unless value && value.length > options[:maximum]
+
+    i18n_key = "#{record.class.i18n_scope}.errors.models.#{record.model_name.i18n_key}.attributes.#{attribute}.chars_count"
+
+    excess_characters = value.length - options[:maximum]
+    custom_message = options[:message] || I18n.t(
+      i18n_key,
+      maximum: options[:maximum],
+      count: excess_characters,
+      default: 'is too long (maximum is %<maximum>s characters, excess characters: %<count>s)'
+    )
+    record.errors.add(attribute, custom_message)
+  end
+end

--- a/app/wizards/a_level_steps/what_a_level_is_required.rb
+++ b/app/wizards/a_level_steps/what_a_level_is_required.rb
@@ -2,7 +2,7 @@
 
 module ALevelSteps
   class WhatALevelIsRequired < DfE::Wizard::Step
-    MAXIMUM_GRADE_CHARACTERS = 30
+    MAXIMUM_GRADE_CHARACTERS = 50
     attr_accessor :subject, :other_subject, :minimum_grade_required
     attr_writer :uuid
 

--- a/app/wizards/a_level_steps/what_a_level_is_required.rb
+++ b/app/wizards/a_level_steps/what_a_level_is_required.rb
@@ -2,6 +2,7 @@
 
 module ALevelSteps
   class WhatALevelIsRequired < DfE::Wizard::Step
+    MAXIMUM_GRADE_CHARACTERS = 30
     attr_accessor :subject, :other_subject, :minimum_grade_required
     attr_writer :uuid
 
@@ -9,6 +10,7 @@ module ALevelSteps
 
     validates :subject, presence: true
     validates :other_subject, presence: true, if: -> { subject == 'other_subject' }
+    validates :minimum_grade_required, chars_count: { maximum: MAXIMUM_GRADE_CHARACTERS }, allow_blank: true
 
     def self.permitted_params
       %i[uuid subject other_subject minimum_grade_required]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -853,6 +853,10 @@ en:
               blank: Select a subject
             other_subject:
               blank: Select a subject
+            minimum_grade_required:
+              chars_count:
+                one: Grade must be %{maximum} characters or less. You have %{count} character too many.
+                other: Grade must be %{maximum} characters or less. You have %{count} characters too many.
         add_a_level_to_a_list:
           attributes:
             add_another_a_level:

--- a/spec/wizards/a_level_steps/what_a_level_is_required_spec.rb
+++ b/spec/wizards/a_level_steps/what_a_level_is_required_spec.rb
@@ -17,6 +17,32 @@ RSpec.describe ALevelSteps::WhatALevelIsRequired, type: :model do
       expect(wizard_step.errors.added?(:subject, :blank)).to be true
     end
 
+    context 'when minimum grade required is too long' do
+      let(:excess_characters) { 5 }
+      let(:character_limit) { described_class::MAXIMUM_GRADE_CHARACTERS }
+
+      it 'adds an error message' do
+        wizard_step.minimum_grade_required = 'A' * (character_limit + excess_characters)
+        expect(wizard_step).not_to be_valid
+        expect(wizard_step.errors[:minimum_grade_required]).to include(
+          "Grade must be #{character_limit} characters or less. You have #{excess_characters} characters too many."
+        )
+      end
+    end
+
+    context 'when minimum grade required is too long by one character' do
+      let(:excess_characters) { 1 }
+      let(:character_limit) { described_class::MAXIMUM_GRADE_CHARACTERS }
+
+      it 'adds an error message' do
+        wizard_step.minimum_grade_required = 'A' * (character_limit + excess_characters)
+        expect(wizard_step).not_to be_valid
+        expect(wizard_step.errors[:minimum_grade_required]).to include(
+          "Grade must be #{character_limit} characters or less. You have #{excess_characters} character too many."
+        )
+      end
+    end
+
     context 'when subject is "other_subject"' do
       before do
         wizard_step.subject = 'other_subject'


### PR DESCRIPTION
### Context

Added a max character validation for the minimum grade required on the A level page "What A level is required?".

### Changes proposed in this pull request

<img width="576" alt="Screenshot 2024-06-28 at 14 48 09" src="https://github.com/DFE-Digital/publish-teacher-training/assets/27509/d19b64b4-bb50-43ec-b647-c3a888ddb5b4">

### Guidance to review

1. Does it work?
2. Does the error validation link works?

## Trello card

https://trello.com/c/rOBwmvpX/1869-a-levels-add-length-validation-to-minimum-grade-required