### PR TITLE
Change the content of the course view

### DIFF
--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -1,12 +1,12 @@
 <h2 class="govuk-heading-m">Contents</h2>
 <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
+  <li><%= govuk_link_to "Entry requirements", "#section-entry" %></li>
   <% if about_course.present? || preview? %>
     <li><%= govuk_link_to "Course summary", "#section-about" %></li>
   <% end %>
   <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" || preview? %>
     <li><%= govuk_link_to "Training locations", "#training-locations" %></li>
   <% end %>
-  <li><%= govuk_link_to "Entry requirements", "#section-entry" %></li>
   <% if provider.train_with_us.present? || about_accrediting_provider.present? || preview? %>
     <li><%= govuk_link_to "About the training provider", "#section-about-provider" %></li>
   <% end %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -52,19 +52,27 @@
         <%= helpers.markdown(course.additional_gcse_equivalencies) %>
       </p>
     <% end %>
+
+    <h3 class="govuk-heading-m"><%= t("find.get_into_teaching.qualifications_outside_uk") %> </h3>
+
+    <p class="govuk-body"><%= t("find.get_into_teaching.qualifications_outside_uk_body") %> </p>
+
+    <p class="govuk-body">
+
+      <%= govuk_link_to(t("find.get_into_teaching.apply_for_statement_of_comparability"),
+                        t("find.enic.statement_of_comparability.url"),
+                        target: "_blank",
+                        new_tab: true,
+                        rel: "noopener") %>
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("find.get_into_teaching.chat_online"),
+                        t("find.get_into_teaching.url_online_chat"),
+                        target: "_blank",
+                        new_tab: true,
+                        rel: "noopener") %>
+        <%= t("find.get_into_teaching.support_team") %>
+    </p>
   </div>
-
-  <% if course.personal_qualities.present? %>
-    <h3 class="govuk-heading-m">Personal qualities</h3>
-    <div data-qa="course__personal_qualities">
-      <%= helpers.markdown(course.personal_qualities) %>
-    </div>
-  <% end %>
-
-  <% if course.other_requirements.present? %>
-    <h3 class="govuk-heading-m">Other requirements</h3>
-    <div data-qa="course__other_requirements">
-      <%= helpers.markdown(course.other_requirements) %>
-    </div>
-  <% end %>
 </div>

--- a/app/components/find/courses/international_students_component/view.html.erb
+++ b/app/components/find/courses/international_students_component/view.html.erb
@@ -21,23 +21,5 @@
     <%= t("find.international_candidates.#{visa_type}.#{sponsorship_availability}.html") %>
 
     <p class="govuk-body">Learn more about <%= govuk_link_to("training to teach in England as an international student", t("find.get_into_teaching.url_train_to_teach_as_international_candidate")) %>.</p>
-
-    <h3 class="govuk-heading-m">Qualifications gained outside the UK</h3>
-    <p class="govuk-body">If you studied for your qualifications outside of the UK you should apply for a statement of comparability from UK European Network of Information Centres (UK ENIC). This will show us how your qualifications compare to UK qualifications.</p>
-
-    <p class="govuk-body">
-      <%= govuk_link_to("Apply for a statement of comparability (opens in new tab)",
-                        t("find.enic.statement_of_comparability.url"),
-                        target: "_blank",
-                        rel: "noopener") %>
-    </p>
-
-    <p class="govuk-body">
-      <%= govuk_link_to("You can chat online (opens in new tab)",
-                        t("find.get_into_teaching.url_online_chat"),
-                        target: "_blank",
-                        rel: "noopener") %>
-        with the Get Into Teaching support team for guidance on the UK equivalents of your qualifications.
-    </p>
   </div>
 </div>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -34,13 +34,13 @@
 
     <%= render Find::Courses::ContentsComponent::View.new(@course) %>
 
+    <%= render Find::Courses::EntryRequirementsComponent::View.new(course: @course) %>
+
     <% if @course.published_about_course.present? %>
       <%= render partial: "find/courses/about_course", locals: { course: @course } %>
     <% end %>
 
     <%= render Find::Courses::AboutSchoolsComponent::View.new(@course) %>
-
-    <%= render Find::Courses::EntryRequirementsComponent::View.new(course: @course) %>
 
     <% if @course.salaried? %>
       <%= render partial: "find/courses/salary", locals: { course: @course } %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -27,11 +27,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render Find::Courses::ContentsComponent::View.new(course) %>
 
+    <%= render Find::Courses::EntryRequirementsComponent::View.new(course:) %>
+
     <%= render partial: "find/courses/about_course", locals: { course: } %>
 
     <%= render Find::Courses::AboutSchoolsComponent::View.new(course) %>
-
-    <%= render Find::Courses::EntryRequirementsComponent::View.new(course:) %>
 
     <% if course.salaried? %>
       <%= render partial: "find/courses/salary", locals: { course: } %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -119,6 +119,11 @@ en:
         html:
           <p class="govuk-body">You may be entitled to £10,000 from the UK government to help with the financial costs of moving to England.</p>
     get_into_teaching:
+      apply_for_statement_of_comparability: Apply for a statement of comparability
+      chat_online: You can chat online
+      support_team: with the Get Into Teaching support team for guidance on the UK equivalents of your qualifications.
+      qualifications_outside_uk: Qualifications gained outside the UK
+      qualifications_outside_uk_body: If you studied for your qualifications outside of the UK you should apply for a statement of comparability from UK European Network of Information Centres (UK ENIC). This will show us how your qualifications compare to UK qualifications.
       tel: 0800 389 2500
       opening_times: "Monday to Friday, 8.30am to 5.30pm"
       url_engineers_teach_physics: https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -245,4 +245,20 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       )
     end
   end
+
+  it 'includes the qualifications gain outside of UK section' do
+    course = build(
+      :course,
+      degree_grade: 'two_two',
+      additional_degree_subject_requirements: true,
+      degree_subject_requirements: 'Certificate must be printed on green paper.'
+    )
+    render_inline(described_class.new(course: course.decorate))
+
+    expect(page).to have_css('h3', text: 'Qualifications gained outside the UK')
+
+    expect(page).to have_text('If you studied for your qualifications outside of the UK you should apply for a statement of comparability from UK European Network of Information Centres (UK ENIC). This will show us how your qualifications compare to UK qualifications.')
+
+    expect(page).to have_link('Apply for a statement of comparability (opens in new tab)')
+  end
 end

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -20,18 +20,6 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     it 'tells candidates sponsorship is not available' do
       expect(page).to have_text('Sponsorship for a student visa is not available for this course')
     end
-
-    it 'renders the h3 qualifications gained outside the UK' do
-      expect(page).to have_css('h3', text: 'Qualifications gained outside the UK')
-    end
-
-    it 'tells candidates about qualifications gained outside of the UK' do
-      expect(page).to have_text('If you studied for your qualifications outside of the UK you should apply for a statement of comparability from UK European Network of Information Centres (UK ENIC). This will show us how your qualifications compare to UK qualifications.')
-    end
-
-    it 'renders the enic link' do
-      expect(page).to have_link('Apply for a statement of comparability (opens in new tab)')
-    end
   end
 
   context 'when the course is fee-paying and does sponsor Student visas' do

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -250,14 +250,6 @@ feature 'Viewing a findable course' do
       'Certificate must be print in blue ink'
     )
 
-    expect(find_course_show_page.personal_qualities).to have_content(
-      @course.latest_published_enrichment.personal_qualities
-    )
-
-    expect(find_course_show_page.other_requirements).to have_content(
-      @course.latest_published_enrichment.other_requirements
-    )
-
     expect(find_course_show_page.train_with_us).to have_content(
       provider.train_with_us
     )

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -228,14 +228,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       'Financial support from the training provider'
     )
 
-    expect(publish_course_preview_page.personal_qualities).to have_content(
-      decorated_course.personal_qualities
-    )
-
-    expect(publish_course_preview_page.other_requirements).to have_content(
-      decorated_course.other_requirements
-    )
-
     expect(publish_course_preview_page.train_with_us).to have_content(
       provider.train_with_us
     )


### PR DESCRIPTION
### Context

Currently, entry requirements are listed further down the page and contain information on personal qualities and other requirements, which can be problematic for candidates.

We want to update the order and content of this section.

### Changes proposed in this pull request

- The Entry requirements section is moved above the Course summary section.
- The 'Personal qualities' and 'Other requirements' sections are removed.
- The section 'Qualifications gained outside the UK' is moved to the 'Entry requirements' section.

### Guidance to review

Review the preview page of a course and the course on find page and compare it to the ticket requirements screenshot on this PR

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes

### Ticket requirements:

![www find-postgraduate-teacher-training service gov uk_course_1TZ_2KGW_(1)](https://github.com/DFE-Digital/publish-teacher-training/assets/11318084/b9c21224-12b3-4e53-8238-73a026555380)

