### PR TITLE
Change and remove a required A level

### DIFF
--- a/app/components/a_level_subject_requirement_row_component.rb
+++ b/app/components/a_level_subject_requirement_row_component.rb
@@ -13,10 +13,14 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
   end
 
   def row_value
+    "#{subject_name}#{grade_display(minimum_grade)}"
+  end
+
+  def subject_name
     if other_subject?
-      "#{other_subject}#{grade_display(minimum_grade)}"
+      other_subject
     else
-      "#{I18n.t("helpers.label.what_a_level_is_required.subject_options.#{subject}")}#{grade_display(minimum_grade)}"
+      I18n.t("helpers.label.what_a_level_is_required.subject_options.#{subject}").to_s
     end
   end
 

--- a/app/controllers/publish/courses/a_level_requirements/a_level_requirements_controller.rb
+++ b/app/controllers/publish/courses/a_level_requirements/a_level_requirements_controller.rb
@@ -40,6 +40,12 @@ module Publish
           redirect_to publish_provider_recruitment_cycle_courses_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year) unless @course.teacher_degree_apprenticeship?
         end
 
+        def load_a_level_subject_requirement
+          return if params[:uuid].blank?
+
+          @a_level_subject_requirement = @course.find_a_level_subject_requirement!(params[:uuid])
+        end
+
         def assign_course
           @course = provider.courses.find_by!(course_code: params[:course_code])
           @course_decorator = CourseDecorator.new(@course)

--- a/app/controllers/publish/courses/a_level_requirements/remove_a_level_subject_confirmation_controller.rb
+++ b/app/controllers/publish/courses/a_level_requirements/remove_a_level_subject_confirmation_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    module ALevelRequirements
+      class RemoveALevelSubjectConfirmationController < ALevelRequirementsController
+        before_action :load_a_level_subject_requirement
+
+        def destroy
+          @wizard = ALevelsWizard.new(
+            current_step:,
+            provider: @provider,
+            course: @course,
+            step_params:
+          )
+
+          if @wizard.valid_step?
+            @wizard.destroy
+            redirect_to @wizard.next_step_path
+          else
+            render :new
+          end
+        end
+
+        def step_params
+          params[current_step] ||= ActionController::Parameters.new
+          params[current_step].merge!(@a_level_subject_requirement.slice(:uuid, :subject, :other_subject))
+          params
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller.rb
+++ b/app/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller.rb
@@ -5,7 +5,6 @@ module Publish
     module ALevelRequirements
       class WhatALevelIsRequiredController < ALevelRequirementsController
         before_action :load_a_level_subject_requirement
-        after_action :set_flash_message, only: :step_params
 
         def step_params
           params[current_step] = ActionController::Parameters.new(@a_level_subject_requirement) if @a_level_subject_requirement.present?
@@ -13,12 +12,6 @@ module Publish
         end
 
         private
-
-        def load_a_level_subject_requirement
-          return if params[:uuid].blank?
-
-          @a_level_subject_requirement = @course.find_a_level_subject_requirement!(params[:uuid])
-        end
 
         def add_flash_message
           flash[:success] = t("course.#{@wizard.current_step.model_name.i18n_key}.success_message")

--- a/app/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller.rb
+++ b/app/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller.rb
@@ -4,12 +4,24 @@ module Publish
   module Courses
     module ALevelRequirements
       class WhatALevelIsRequiredController < ALevelRequirementsController
-        def add_flash_message
-          flash[:success] = t("course.#{@wizard.current_step.model_name.i18n_key}.success_message")
-        end
+        before_action :load_a_level_subject_requirement
+        after_action :set_flash_message, only: :step_params
 
         def step_params
+          params[current_step] = ActionController::Parameters.new(@a_level_subject_requirement) if @a_level_subject_requirement.present?
           params
+        end
+
+        private
+
+        def load_a_level_subject_requirement
+          return if params[:uuid].blank?
+
+          @a_level_subject_requirement = @course.find_a_level_subject_requirement!(params[:uuid])
+        end
+
+        def add_flash_message
+          flash[:success] = t("course.#{@wizard.current_step.model_name.i18n_key}.success_message")
         end
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -802,6 +802,13 @@ class Course < ApplicationRecord
     enrichments.where(status: 'published').order(last_published_timestamp_utc: :desc).first
   end
 
+  def find_a_level_subject_requirement!(uuid)
+    requirement = a_level_subject_requirements.find { |req| req['uuid'] == uuid }
+    raise ActiveRecord::RecordNotFound unless requirement
+
+    requirement.with_indifferent_access
+  end
+
   private
 
   def add_site!(site:)

--- a/app/views/publish/courses/a_level_requirements/add_a_level_to_a_list/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/add_a_level_to_a_list/new.html.erb
@@ -41,7 +41,13 @@
           <% @wizard.current_step.subjects.each do |subject| %>
             <%= summary_list.with_row do |row| %>
               <%= row.with_key(classes: "govuk-!-font-weight-regular") { render ALevelSubjectRequirementRowComponent.new(subject) } %>
-              <%= row.with_action(text: "Change", href: "#") %>
+              <%= row.with_action(text: "Change", href:
+                    publish_provider_recruitment_cycle_course_a_levels_what_a_level_is_required_path(
+                      @provider.provider_code,
+                      @provider.recruitment_cycle_year,
+                      @course.course_code,
+                      uuid: subject["uuid"]
+                    )) %>
               <%= row.with_action(text: "Remove", href: "#") %>
             <% end %>
           <% end %>

--- a/app/views/publish/courses/a_level_requirements/add_a_level_to_a_list/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/add_a_level_to_a_list/new.html.erb
@@ -48,7 +48,13 @@
                       @course.course_code,
                       uuid: subject["uuid"]
                     )) %>
-              <%= row.with_action(text: "Remove", href: "#") %>
+               <%= row.with_action(text: "Remove", href:
+                    publish_provider_recruitment_cycle_course_a_levels_remove_a_level_subject_confirmation_path(
+                      @provider.provider_code,
+                      @provider.recruitment_cycle_year,
+                      @course.course_code,
+                      uuid: subject["uuid"]
+                    )) %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/publish/courses/a_level_requirements/add_a_level_to_a_list/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/add_a_level_to_a_list/new.html.erb
@@ -46,14 +46,14 @@
                       @provider.provider_code,
                       @provider.recruitment_cycle_year,
                       @course.course_code,
-                      uuid: subject["uuid"]
+                      uuid: subject.fetch("uuid")
                     )) %>
                <%= row.with_action(text: "Remove", href:
                     publish_provider_recruitment_cycle_course_a_levels_remove_a_level_subject_confirmation_path(
                       @provider.provider_code,
                       @provider.recruitment_cycle_year,
                       @course.course_code,
-                      uuid: subject["uuid"]
+                      uuid: subject.fetch("uuid")
                     )) %>
             <% end %>
           <% end %>

--- a/app/views/publish/courses/a_level_requirements/remove_a_level_subject_confirmation/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/remove_a_level_subject_confirmation/new.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, title_with_error_prefix(t("course.#{@wizard.current_step.model_name.i18n_key}.heading"), @wizard.current_step.errors && @wizard.current_step.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+      publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
+        @provider.provider_code,
+        @provider.recruitment_cycle_year,
+        @course.course_code
+      )
+    ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard.current_step, url:
+        publish_provider_recruitment_cycle_course_a_levels_remove_a_level_subject_confirmation_path(
+          @provider.provider_code,
+          @provider.recruitment_cycle_year,
+          @course.course_code,
+          uuid: @wizard.current_step.uuid
+        ), method: :delete do |form| %>
+        <%= form.govuk_error_summary %>
+
+        <%= form.govuk_radio_buttons_fieldset :confirmation, legend: { size: "l", text: t("course.#{@wizard.current_step.model_name.i18n_key}.heading", subject: @wizard.current_step.subject), tag: "h1" }, caption: { text: @course_decorator.name_and_code, size: "l" } do %>
+          <%= form.govuk_radio_button :confirmation, :yes, link_errors: true %>
+          <%= form.govuk_radio_button :confirmation, :no %>
+        <% end %>
+
+        <%= form.submit t("continue"), class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/a_level_requirements/what_a_level_is_required/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/what_a_level_is_required/new.html.erb
@@ -5,8 +5,7 @@
       publish_provider_recruitment_cycle_course_a_levels_are_any_a_levels_required_for_this_course_path(
         @provider.provider_code,
         @provider.recruitment_cycle_year,
-        @course.course_code,
-        are_any_a_levels_required_for_this_course: { answer: "yes" }
+        @course.course_code
       )
     ) %>
 <% end %>

--- a/app/views/publish/courses/a_level_requirements/what_a_level_is_required/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/what_a_level_is_required/new.html.erb
@@ -1,13 +1,23 @@
 <% content_for :page_title, title_with_error_prefix(t("course.#{@wizard.current_step.model_name.i18n_key}.heading"), @wizard.current_step.errors && @wizard.current_step.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_course_a_levels_are_any_a_levels_required_for_this_course_path(
-        @provider.provider_code,
-        @provider.recruitment_cycle_year,
-        @course.course_code
-      )
-    ) %>
+  <% if @a_level_subject_requirement.present? %>
+    <%= govuk_back_link_to(
+        publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
+          @provider.provider_code,
+          @provider.recruitment_cycle_year,
+          @course.course_code
+        )
+      ) %>
+  <% else %>
+    <%= govuk_back_link_to(
+        publish_provider_recruitment_cycle_course_a_levels_are_any_a_levels_required_for_this_course_path(
+          @provider.provider_code,
+          @provider.recruitment_cycle_year,
+          @course.course_code
+        )
+      ) %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish/courses/a_level_requirements/what_a_level_is_required/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/what_a_level_is_required/new.html.erb
@@ -21,6 +21,10 @@
         ) do |form| %>
         <%= form.govuk_error_summary %>
 
+        <% if @a_level_subject_requirement.present? %>
+          <%= form.hidden_field(:uuid) %>
+        <% end %>
+
         <h1 class="govuk-heading-l">
           <span class="govuk-caption-l">
             <%= @course_decorator.name_and_code %>

--- a/app/wizards/a_level_steps/remove_a_level_subject_confirmation.rb
+++ b/app/wizards/a_level_steps/remove_a_level_subject_confirmation.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ALevelSteps
+  class RemoveALevelSubjectConfirmation < DfE::Wizard::Step
+    delegate :course, :exit_path, to: :wizard
+    attr_accessor :uuid, :confirmation, :other_subject
+    attr_writer :subject
+
+    validates :uuid, presence: true
+
+    validate do |record|
+      record.errors.add(:confirmation, :blank, subject: record.subject) if record.confirmation.blank?
+    end
+
+    def self.permitted_params
+      %i[uuid subject other_subject confirmation]
+    end
+
+    def subject
+      ALevelSubjectRequirementRowComponent.new(
+        subject: @subject,
+        other_subject:
+      ).subject_name
+    end
+
+    def next_step
+      if confirm_deletion? && no_a_level_subject_requirements?
+        :exit
+      else
+        :add_a_level_to_a_list
+      end
+    end
+
+    def confirm_deletion?
+      confirmation == 'yes'
+    end
+
+    def no_a_level_subject_requirements?
+      a_level_subject_requirements.empty?
+    end
+
+    private
+
+    def a_level_subject_requirements
+      Array(course.a_level_subject_requirements)
+    end
+  end
+end

--- a/app/wizards/a_level_steps/remove_a_level_subject_confirmation.rb
+++ b/app/wizards/a_level_steps/remove_a_level_subject_confirmation.rb
@@ -24,14 +24,14 @@ module ALevelSteps
     end
 
     def next_step
-      if confirm_deletion? && no_a_level_subject_requirements?
+      if deletion_confirmed? && no_a_level_subject_requirements?
         :exit
       else
         :add_a_level_to_a_list
       end
     end
 
-    def confirm_deletion?
+    def deletion_confirmed?
       confirmation == 'yes'
     end
 

--- a/app/wizards/a_levels_wizard.rb
+++ b/app/wizards/a_levels_wizard.rb
@@ -5,12 +5,14 @@ class ALevelsWizard < DfE::Wizard::Base
 
   delegate :course_code, to: :course
   delegate :provider_code, :recruitment_cycle_year, to: :course
+  delegate :destroy, to: :store
 
   steps do
     [
       { are_any_a_levels_required_for_this_course: ALevelSteps::AreAnyALevelsRequiredForThisCourse },
       { what_a_level_is_required: ALevelSteps::WhatALevelIsRequired },
       { add_a_level_to_a_list: ALevelSteps::AddALevelToAList },
+      { remove_a_level_subject_confirmation: ALevelSteps::RemoveALevelSubjectConfirmation },
       { consider_pending_a_level: ALevelSteps::ConsiderPendingALevel },
       { a_level_equivalencies: ALevelSteps::ALevelEquivalencies }
     ]

--- a/app/wizards/a_levels_wizard_store.rb
+++ b/app/wizards/a_levels_wizard_store.rb
@@ -13,4 +13,8 @@ class ALevelsWizardStore < DfE::Wizard::Store
 
     true
   end
+
+  def destroy
+    RemoveALevelSubjectConfirmationStore.new(wizard).destroy if current_step_name == :remove_a_level_subject_confirmation
+  end
 end

--- a/app/wizards/remove_a_level_subject_confirmation_store.rb
+++ b/app/wizards/remove_a_level_subject_confirmation_store.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class RemoveALevelSubjectConfirmationStore < DfE::Wizard::Store
+  delegate :course, to: :wizard
+  delegate :uuid, to: :current_step
+
+  def destroy
+    return unless current_step.confirm_deletion?
+
+    a_level_subject_requirements = course.a_level_subject_requirements.reject { |req| req['uuid'] == uuid }
+
+    if a_level_subject_requirements.present?
+      course.update!(a_level_subject_requirements:)
+    else
+      course.update!(
+        a_level_requirements: nil,
+        a_level_subject_requirements: [],
+        accept_pending_a_level: nil,
+        accept_a_level_equivalency: nil,
+        additional_a_level_equivalencies: nil
+      )
+    end
+  end
+end

--- a/app/wizards/remove_a_level_subject_confirmation_store.rb
+++ b/app/wizards/remove_a_level_subject_confirmation_store.rb
@@ -5,7 +5,7 @@ class RemoveALevelSubjectConfirmationStore < DfE::Wizard::Store
   delegate :uuid, to: :current_step
 
   def destroy
-    return unless current_step.confirm_deletion?
+    return unless current_step.deletion_confirmed?
 
     a_level_subject_requirements = course.a_level_subject_requirements.reject { |req| req['uuid'] == uuid }
 

--- a/app/wizards/what_a_level_is_required_store.rb
+++ b/app/wizards/what_a_level_is_required_store.rb
@@ -38,8 +38,9 @@ class WhatALevelIsRequiredStore < DfE::Wizard::Store
     {
       uuid:,
       subject:,
-      other_subject: other_subject.presence,
       minimum_grade_required: minimum_grade_required.presence
-    }.compact
+    }.tap do |requirements|
+      requirements[:other_subject] = other_subject if subject == 'other_subject'
+    end.compact
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,6 +301,10 @@ en:
         add_another_a_level_options:
           "yes": "Yes"
           "no": "No"
+      remove_a_level_subject_confirmation:
+        confirmation_options:
+          "yes": "Yes"
+          "no": "No"
       consider_pending_a_level:
         pending_a_level_options:
           "yes": "Yes"
@@ -324,6 +328,8 @@ en:
       success_message: You have added a required A level
     add_a_level_to_a_list:
       heading: Required A levels
+    remove_a_level_subject_confirmation:
+      heading: Are you sure you want to remove %{subject}?
     consider_pending_a_level:
       heading: Will you consider candidates with pending A levels?
       hint: These are candidates who expect to have the qualification before the beginning of the course. You can give them an offer, on the condition that they pass their A levels.
@@ -868,6 +874,10 @@ en:
           attributes:
             add_another_a_level:
               blank: Select if you want to add another A level
+        remove_a_level_subject_confirmation:
+          attributes:
+            confirmation:
+              blank: Select if you want to remove %{subject}
         consider_pending_a_level:
           attributes:
             pending_a_level:

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -166,6 +166,8 @@ namespace :publish, as: :publish do
         post '/a-levels-or-equivalency-tests/what-a-level-is-required', to: 'courses/a_level_requirements/what_a_level_is_required#create'
         get '/a-levels-or-equivalency-tests/add-a-level-to-list', to: 'courses/a_level_requirements/add_a_level_to_a_list#new', as: :a_levels_add_a_level_to_a_list
         post '/a-levels-or-equivalency-tests/add-a-level-to-list', to: 'courses/a_level_requirements/add_a_level_to_a_list#create'
+        get '/a-levels-or-equivalency-tests/remove-a-level-subject-confirmation/:uuid', to: 'courses/a_level_requirements/remove_a_level_subject_confirmation#new', as: :a_levels_remove_a_level_subject_confirmation
+        delete '/a-levels-or-equivalency-tests/remove-a-level-subject-confirmation/:uuid', to: 'courses/a_level_requirements/remove_a_level_subject_confirmation#destroy'
         get '/a-levels-or-equivalency-tests/consider-pending-a-level', to: 'courses/a_level_requirements/consider_pending_a_level#new', as: :a_levels_consider_pending_a_level
         post '/a-levels-or-equivalency-tests/consider-pending-a-level', to: 'courses/a_level_requirements/consider_pending_a_level#create'
         get '/a-levels-or-equivalency-tests/a-level-equivalencies', to: 'courses/a_level_requirements/a_level_equivalencies#new', as: :a_levels_a_level_equivalencies

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -162,7 +162,7 @@ namespace :publish, as: :publish do
 
         get '/a-levels-or-equivalency-tests/required-for-this-course', to: 'courses/a_level_requirements/are_any_a_levels_required_for_this_course#new', as: :a_levels_are_any_a_levels_required_for_this_course
         post '/a-levels-or-equivalency-tests/required-for-this-course', to: 'courses/a_level_requirements/are_any_a_levels_required_for_this_course#create'
-        get '/a-levels-or-equivalency-tests/what-a-level-is-required', to: 'courses/a_level_requirements/what_a_level_is_required#new', as: :a_levels_what_a_level_is_required
+        get '/a-levels-or-equivalency-tests/what-a-level-is-required(/:uuid)', to: 'courses/a_level_requirements/what_a_level_is_required#new', as: :a_levels_what_a_level_is_required
         post '/a-levels-or-equivalency-tests/what-a-level-is-required', to: 'courses/a_level_requirements/what_a_level_is_required#create'
         get '/a-levels-or-equivalency-tests/add-a-level-to-list', to: 'courses/a_level_requirements/add_a_level_to_a_list#new', as: :a_levels_add_a_level_to_a_list
         post '/a-levels-or-equivalency-tests/add-a-level-to-list', to: 'courses/a_level_requirements/add_a_level_to_a_list#create'

--- a/spec/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller_spec.rb
+++ b/spec/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller_spec.rb
@@ -6,7 +6,52 @@ module Publish
   module Courses
     module ALevelRequirements
       describe WhatALevelIsRequiredController do
+        let(:provider) { user.providers.first }
+        let(:user) { create(:user, :with_provider) }
+        let(:course) do
+          create(
+            :course,
+            :with_teacher_degree_apprenticeship,
+            provider:,
+            a_level_subject_requirements: [{ uuid: 'a-uuid', subject: 'any_subject' }]
+          )
+        end
+
+        before do
+          allow(controller).to receive(:authenticate).and_return(true)
+          controller.instance_variable_set(:@current_user, user)
+        end
+
         it_behaves_like 'an A level requirements controller'
+
+        describe 'GET #new' do
+          context 'when uuid is provided and found' do
+            before do
+              get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code, uuid: 'a-uuid' }
+            end
+
+            it 'assign the existing subject requirement to current step' do
+              current_step = assigns(:wizard).current_step
+              expect(current_step.uuid).to eq('a-uuid')
+              expect(current_step.subject).to eq('any_subject')
+            end
+          end
+
+          context 'when uuid is provided but not found' do
+            it 'raises ActiveRecord::RecordNotFound' do
+              expect do
+                get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code, uuid: 'someuuid' }
+              end.to raise_error(ActiveRecord::RecordNotFound)
+            end
+          end
+
+          context 'when uuid is not provided' do
+            it 'renders the :new template' do
+              get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code }
+              expect(response).to render_template(:new)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -141,6 +141,25 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     and_i_see_the_updated_a_level_subject_requirement
 
     when_i_click_to_remove_the_a_level_subject
+    then_i_am_on_the_confirming_removal_of_a_level_subject
+
+    when_i_click_continue
+    then_i_see_an_error_message_for_the_confirming_removal_of_a_level_subject_page
+
+    when_i_choose_yes
+    and_i_click_continue
+    then_i_am_on_the_add_another_a_level_subject_page
+    and_the_subject_requirement_is_deleted
+
+    when_i_click_to_remove_the_a_level_subject
+    and_i_choose_no
+    and_i_click_continue
+    then_i_am_on_the_add_another_a_level_subject_page
+    and_the_subject_requirement_is_not_deleted
+
+    when_i_delete_all_subject_requirements
+    then_i_am_on_the_course_description_tab
+    and_there_are_no_a_level_requirements_for_the_course
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -203,6 +222,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
   def when_i_choose_no
     choose 'No'
   end
+  alias_method :and_i_choose_no, :when_i_choose_no
 
   def then_i_am_on_the_course_description_tab
     expect(page).to have_current_path(
@@ -231,6 +251,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
   def when_i_choose_yes
     choose 'Yes'
   end
+  alias_method :and_i_choose_yes, :when_i_choose_yes
 
   def when_i_click_to_change_a_level_requirements
     click_on 'Change A levels'
@@ -474,5 +495,51 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
         uuid: @course.reload.a_level_subject_requirements.first['uuid']
       )
     )
+  end
+
+  def then_i_am_on_the_confirming_removal_of_a_level_subject
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_a_levels_remove_a_level_subject_confirmation_path(
+        @provider.provider_code,
+        2025,
+        @course.course_code,
+        uuid: @course.reload.a_level_subject_requirements.first['uuid']
+      )
+    )
+    expect(page).to have_content('Are you sure you want to remove Any science subject?')
+  end
+
+  def then_i_see_an_error_message_for_the_confirming_removal_of_a_level_subject_page
+    expect(page).to have_content('Select if you want to remove Any science subject')
+  end
+
+  def and_the_subject_requirement_is_deleted
+    expect(page).to have_no_content('Any science subject')
+    expect(@course.reload.a_level_subject_requirements.size).to be 3
+  end
+
+  def and_the_subject_requirement_is_not_deleted
+    expect(page).to have_content('Any STEM subject')
+    expect(page).to have_content('Any humanities subject')
+    expect(page).to have_content('Mathematics')
+    expect(@course.reload.a_level_subject_requirements.size).to be 3
+  end
+
+  def when_i_delete_all_subject_requirements
+    3.times do
+      when_i_click_to_remove_the_a_level_subject
+      and_i_choose_yes
+      and_i_click_continue
+    end
+  end
+
+  def and_there_are_no_a_level_requirements_for_the_course
+    expect(@course.reload.a_level_subject_requirements).to be_empty
+    expect(@course.accept_pending_a_level).to be_nil
+    expect(@course.accept_a_level_equivalency).to be_nil
+    expect(@course.additional_a_level_equivalencies).to be_nil
+
+    expect(page).to have_content('A levels and equivalency tests')
+    expect(page).to have_content('Enter A levels and equivalency test requirements')
   end
 end

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -126,6 +126,21 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     when_i_click_update_a_levels
     then_i_am_on_the_course_description_tab
     and_i_see_the_a_level_requirements_for_the_course
+
+    when_i_click_to_change_a_level_requirements
+    and_i_click_continue
+    and_i_click_to_change_the_subject
+    then_i_am_on_the_what_a_level_is_required_page_editing_the_subject
+    and_any_subject_is_chosen
+    and_minimum_grade_required_has_a_value
+
+    when_i_choose_any_science_subject
+    and_add_any_grade_as_minimum_grade_required
+    and_i_click_continue
+    then_i_am_on_the_add_another_a_level_subject_page
+    and_i_see_the_updated_a_level_subject_requirement
+
+    when_i_click_to_remove_the_a_level_subject
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -231,7 +246,8 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
         @provider.provider_code,
         2025,
         @course.course_code
-      )
+      ),
+      ignore_query: true
     )
   end
 
@@ -327,7 +343,8 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
         @provider.provider_code,
         @provider.recruitment_cycle_year,
         @course.course_code
-      )
+      ),
+      ignore_query: true
     )
   end
   alias_method :and_i_am_on_the_add_another_a_level_subject_page, :then_i_am_on_the_add_another_a_level_subject_page
@@ -414,5 +431,48 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     expect(page).to have_content('Candidates with pending A levels will not be considered.')
     expect(page).to have_content('Equivalency tests will be considered.')
     expect(page).to have_content('Some additional A level equivalencies text')
+  end
+
+  def and_i_click_to_change_the_subject
+    click_on('Change', match: :first)
+  end
+
+  def and_any_subject_is_chosen
+    expect(page).to have_checked_field('what-a-level-is-required-subject-any-subject-field')
+  end
+
+  def and_minimum_grade_required_has_a_value
+    expect(find_field('Minimum grade required (optional)').value).to eq 'C'
+  end
+
+  def when_i_choose_any_science_subject
+    choose 'Any science subject'
+  end
+
+  def and_add_any_grade_as_minimum_grade_required
+    fill_in 'Minimum grade required (optional)', with: 'B'
+  end
+
+  def and_i_see_the_updated_a_level_subject_requirement
+    and_there_are_only_four_subjects # it should update and not create another one
+  end
+
+  def and_there_are_only_four_subjects
+    expect(@course.reload.a_level_subject_requirements.size).to be 4
+  end
+
+  def when_i_click_to_remove_the_a_level_subject
+    click_on 'Remove', match: :first
+  end
+
+  def then_i_am_on_the_what_a_level_is_required_page_editing_the_subject
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_a_levels_what_a_level_is_required_path(
+        @provider.provider_code,
+        2025,
+        @course.course_code,
+        uuid: @course.reload.a_level_subject_requirements.first['uuid']
+      )
+    )
   end
 end

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -131,6 +131,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     and_i_click_continue
     and_i_click_to_change_the_subject
     then_i_am_on_the_what_a_level_is_required_page_editing_the_subject
+    and_the_back_link_points_to_add_a_level_to_the_list
     and_any_subject_is_chosen
     and_minimum_grade_required_has_a_value
 
@@ -541,5 +542,15 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
 
     expect(page).to have_content('A levels and equivalency tests')
     expect(page).to have_content('Enter A levels and equivalency test requirements')
+  end
+
+  def and_the_back_link_points_to_add_a_level_to_the_list
+    expect(page.find_link(text: 'Back')[:href]).to eq(
+      publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
+        @provider.provider_code,
+        @provider.recruitment_cycle_year,
+        @course.course_code
+      )
+    )
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -169,6 +169,28 @@ describe Course do
     end
   end
 
+  describe '#find_a_level_subject_requirement!' do
+    let(:course) { create(:course, a_level_subject_requirements:) }
+
+    context 'when a requirement with the specified uuid exists' do
+      let(:uuid) { 'valid_uuid' }
+      let(:a_level_subject_requirements) { [{ uuid: 'valid_uuid', subject: 'Subject Requirement' }] }
+
+      it 'returns the subject requirement' do
+        expect(course.find_a_level_subject_requirement!(uuid)).to eq(a_level_subject_requirements.first.with_indifferent_access)
+      end
+    end
+
+    context 'when no requirement with the specified uuid exists' do
+      let(:uuid) { 'nonexistent_uuid' }
+      let(:a_level_subject_requirements) { [] }
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { course.find_a_level_subject_requirement!(uuid) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
   describe '#applicable_for_engineers_teach_physics?' do
     subject { course.applicable_for_engineers_teach_physics? }
 

--- a/spec/wizards/a_level_steps/remove_a_level_subject_confirmation_spec.rb
+++ b/spec/wizards/a_level_steps/remove_a_level_subject_confirmation_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ALevelSteps::RemoveALevelSubjectConfirmation do
+  subject(:wizard_step) { described_class.new(wizard:) }
+
+  let(:provider) { create(:provider) }
+  let(:course) { create(:course, provider:) }
+  let(:wizard) do
+    ALevelsWizard.new(
+      current_step: :remove_a_level_subject_confirmation,
+      provider:,
+      course:,
+      step_params: ActionController::Parameters.new(
+        remove_a_level_subject_confirmation: ActionController::Parameters.new({ uuid:, confirmation: })
+      )
+    )
+  end
+  let(:uuid) { SecureRandom.uuid }
+  let(:confirmation) { 'yes' }
+
+  before { wizard_step.confirmation = confirmation }
+
+  describe 'validations' do
+    context 'when confirmation is present' do
+      it 'is valid' do
+        wizard_step.uuid = uuid
+        wizard_step.confirmation = 'yes'
+        expect(wizard_step).to be_valid
+
+        wizard_step.confirmation = 'no'
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context 'when any subject and confirmation is not present' do
+      it 'is not valid' do
+        wizard_step.subject = 'any_subject'
+        wizard_step.confirmation = nil
+        expect(wizard_step).not_to be_valid
+        expect(wizard_step.errors[:confirmation]).to include('Select if you want to remove Any subject')
+      end
+    end
+
+    context 'when other subject and confirmation is not present' do
+      it 'is not valid' do
+        wizard_step.subject = 'other_subject'
+        wizard_step.other_subject = 'Mathematics'
+        wizard_step.confirmation = nil
+        expect(wizard_step).not_to be_valid
+        expect(wizard_step.errors[:confirmation]).to include('Select if you want to remove Mathematics')
+      end
+    end
+
+    context 'when uuid is not present' do
+      it 'is not valid' do
+        wizard_step.uuid = nil
+        expect(wizard_step).not_to be_valid
+        expect(wizard_step.errors.added?(:uuid, :blank)).to be true
+      end
+    end
+  end
+
+  describe '.permitted_params' do
+    it 'returns permitted params' do
+      expect(described_class.permitted_params).to eq(%i[uuid subject other_subject confirmation])
+    end
+  end
+
+  describe '#next_step' do
+    context 'when confirming and no a_level_subject_requirements anymore' do
+      let(:confirmation) { 'yes' }
+      let(:course) { create(:course, a_level_subject_requirements: [], provider:) }
+
+      it 'returns :exit' do
+        expect(wizard_step.next_step).to eq(:exit)
+      end
+    end
+
+    context 'when confirming and a_level_subject_requirements are present' do
+      let(:confirmation) { 'yes' }
+      let(:course) { create(:course, :with_a_level_requirements, provider:) }
+
+      it 'returns :add_a_level_to_a_list' do
+        expect(wizard_step.next_step).to eq(:add_a_level_to_a_list)
+      end
+    end
+
+    context 'when answering no to confirm' do
+      let(:confirmation) { 'no' }
+
+      it 'returns :add_a_level_to_a_list' do
+        expect(wizard_step.next_step).to eq(:add_a_level_to_a_list)
+      end
+    end
+  end
+end

--- a/spec/wizards/a_levels_wizard_store_spec.rb
+++ b/spec/wizards/a_levels_wizard_store_spec.rb
@@ -128,4 +128,29 @@ RSpec.describe ALevelsWizardStore do
       end
     end
   end
+
+  describe '#destroy' do
+    context 'when current step name is :remove_a_level_subject_confirmation' do
+      let(:current_step) { :remove_a_level_subject_confirmation }
+
+      it 'calls destroy on RemoveALevelSubjectConfirmationStore' do
+        remove_store = instance_double(RemoveALevelSubjectConfirmationStore)
+        allow(RemoveALevelSubjectConfirmationStore).to receive(:new).with(wizard).and_return(remove_store)
+        allow(remove_store).to receive(:destroy)
+
+        store.destroy
+
+        expect(remove_store).to have_received(:destroy)
+      end
+    end
+
+    context 'when current step name is not :remove_a_level_subject_confirmation' do
+      let(:current_step) { :some_other_step }
+
+      it 'does not call destroy on RemoveALevelSubjectConfirmationStore' do
+        expect(RemoveALevelSubjectConfirmationStore).not_to receive(:new)
+        store.destroy
+      end
+    end
+  end
 end

--- a/spec/wizards/remove_a_level_subject_confirmation_store_spec.rb
+++ b/spec/wizards/remove_a_level_subject_confirmation_store_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RemoveALevelSubjectConfirmationStore do
+  subject(:store) { described_class.new(wizard) }
+
+  let(:wizard) do
+    ALevelsWizard.new(
+      current_step: :remove_a_level_subject_confirmation,
+      provider:,
+      course:,
+      step_params: ActionController::Parameters.new(
+        { remove_a_level_subject_confirmation: ActionController::Parameters.new(step_params) }
+      )
+    )
+  end
+  let(:provider) { create(:provider) }
+  let(:course) { create(:course, :with_a_level_requirements, a_level_subject_requirements:) }
+  let(:a_level_subject_requirements) do
+    [
+      { 'uuid' => 'the-uuid-1', 'subject' => 'any_subject', 'minimum_grade_required' => 'B' },
+      { 'uuid' => 'the-uuid-2', 'subject' => 'other_subject', 'other_subject' => 'Mathematics', 'minimum_grade_required' => 'A' }
+    ]
+  end
+  let(:step_params) do
+    { uuid: 'the-uuid-1', confirmation: }
+  end
+  let(:confirmation) { nil }
+
+  describe '#destroy' do
+    context 'when confirmation is yes' do
+      let(:confirmation) { 'yes' }
+
+      it 'removes the hash with the given uuid from a_level_subject_requirements and updates the course' do
+        expect(course.a_level_subject_requirements.size).to eq(2)
+
+        store.destroy
+
+        expect(course.reload.a_level_subject_requirements.size).to eq(1)
+        expect(course.a_level_subject_requirements.any? { |req| req['uuid'] == 'the-uuid-1' }).to be_falsey
+      end
+    end
+
+    context 'when removing the last A level subject requirement' do
+      let(:confirmation) { 'yes' }
+      let(:a_level_subject_requirements) do
+        [
+          { 'uuid' => 'the-uuid-1', 'subject' => 'any_subject', 'minimum_grade_required' => 'B' }
+        ]
+      end
+
+      it 'sets specific fields to nil if a_level_subject_requirements becomes empty' do
+        store.destroy
+
+        expect(course.reload.a_level_subject_requirements).to be_empty
+        expect(course.reload.a_level_requirements).to be_nil
+        expect(course.accept_pending_a_level).to be_nil
+        expect(course.accept_a_level_equivalency).to be_nil
+        expect(course.additional_a_level_equivalencies).to be_nil
+      end
+    end
+
+    context 'when confirmation is not yes' do
+      let(:confirmation) { 'no' }
+
+      it 'does not remove any hash and does not alter the a_level_subject_requirements' do
+        expect(course).not_to receive(:find_a_level_subject_requirement!)
+
+        store.destroy
+
+        expect(course.reload.a_level_subject_requirements.size).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/wizards/what_a_level_is_required_store_spec.rb
+++ b/spec/wizards/what_a_level_is_required_store_spec.rb
@@ -77,12 +77,46 @@ RSpec.describe WhatALevelIsRequiredStore do
     end
 
     context 'when updating an A level other subject requirements' do
-      let(:course) { create(:course, :with_a_level_requirements, a_level_subject_requirements: [{ uuid: 'm3n4o5p6', subject: 'any_stem_subject' }]) }
-      let(:step_params) { { subject: 'other_subject', other_subject: 'Mathematics', minimum_grade_required: 'D', uuid: 'm3n4o5p6' } }
+      let(:course) do
+        create(
+          :course,
+          :with_a_level_requirements,
+          a_level_subject_requirements: [{ uuid: 'm3n4o5p6', subject: 'any_stem_subject' }]
+        )
+      end
+      let(:step_params) do
+        { subject: 'other_subject', other_subject: 'Mathematics', minimum_grade_required: 'D', uuid: 'm3n4o5p6' }
+      end
 
       it 'updates the course a_level_subject_requirements correctly' do
         expect { subject }.to change { wizard.course.reload.a_level_subject_requirements }
           .to([{ 'subject' => 'other_subject', 'other_subject' => 'Mathematics', 'minimum_grade_required' => 'D', 'uuid' => 'm3n4o5p6' }])
+      end
+    end
+
+    context 'when updating an A level from other subject to any subject' do
+      let(:course) do
+        create(
+          :course,
+          :with_a_level_requirements,
+          a_level_subject_requirements: [{ uuid: 'm3n4o5p6', subject: 'other_subject', other_subject: 'Mathematics' }]
+        )
+      end
+      let(:step_params) do
+        { subject: 'any_subject', other_subject: 'Mathematics', minimum_grade_required: 'D', uuid: 'm3n4o5p6' }
+      end
+
+      it 'updates the course a_level_subject_requirements correctly' do
+        store.save
+        course.reload
+
+        expect(course.a_level_subject_requirements).to eq([
+                                                            {
+                                                              'uuid' => 'm3n4o5p6',
+                                                              'subject' => 'any_subject',
+                                                              'minimum_grade_required' => 'D'
+                                                            }
+                                                          ])
       end
     end
   end


### PR DESCRIPTION
### Context

We need to add the ability for providers to change or remove a required A level they have added to TDA a course on Publish, in order to enable TDA applications.

### Changes proposed in this pull request

<img width="158" alt="Screenshot 2024-07-01 at 10 08 23" src="https://github.com/DFE-Digital/publish-teacher-training/assets/27509/1a6dc786-689c-471b-88e0-025dd4657a7f">

### Guidance to review

1. Does the validations work?
2. Does the change work? (from other subject to any subject and vice versa)
3. Does the remove work? (when you remove any or all subjects)

To enable the TDA locally you need to run the rollover script and be on 2025 cycle (see rollover guide for more details)

### Trello card

https://trello.com/c/ic2phanj/1789-a-levels-4-7-add-change-and-remove-a-required-a-level-question-page-for-tda-courses-on-publish