### PR TITLE
Edge case - Redirect away from adding more A level subjects when maximum A levels

### DIFF
--- a/app/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller.rb
+++ b/app/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller.rb
@@ -4,7 +4,7 @@ module Publish
   module Courses
     module ALevelRequirements
       class WhatALevelIsRequiredController < ALevelRequirementsController
-        before_action :load_a_level_subject_requirement
+        before_action :load_a_level_subject_requirement, :verify_maximum_a_level_subject_requirements
 
         def step_params
           params[current_step] = ActionController::Parameters.new(@a_level_subject_requirement) if @a_level_subject_requirement.present?
@@ -15,6 +15,24 @@ module Publish
 
         def add_flash_message
           flash[:success] = t("course.#{@wizard.current_step.model_name.i18n_key}.success_message")
+        end
+
+        def verify_maximum_a_level_subject_requirements
+          return unless maximum_a_level_subject_requirements? && no_uuid?
+
+          redirect_to publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
+            provider.provider_code,
+            provider.recruitment_cycle_year,
+            @course.course_code
+          )
+        end
+
+        def maximum_a_level_subject_requirements?
+          Array(@course.a_level_subject_requirements).size >= ALevelSteps::AddALevelToAList::MAXIMUM_NUMBER_OF_A_LEVEL_SUBJECTS
+        end
+
+        def no_uuid?
+          params[:uuid].blank? && params.dig(current_step, :uuid).blank?
         end
       end
     end

--- a/spec/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller_spec.rb
+++ b/spec/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller_spec.rb
@@ -13,8 +13,11 @@ module Publish
             :course,
             :with_teacher_degree_apprenticeship,
             provider:,
-            a_level_subject_requirements: [{ uuid: 'a-uuid', subject: 'any_subject' }]
+            a_level_subject_requirements:
           )
+        end
+        let(:a_level_subject_requirements) do
+          [{ uuid: 'a-uuid', subject: 'any_subject' }]
         end
 
         before do
@@ -49,6 +52,103 @@ module Publish
             it 'renders the :new template' do
               get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code }
               expect(response).to render_template(:new)
+            end
+          end
+
+          context 'when uuid is not provided and maximum A level subject requirements' do
+            let(:a_level_subject_requirements) do
+              4.times.map { |number| { uuid: "a-uuid-#{number}", subject: 'any_subject' } }
+            end
+
+            it 'redirects to A level list page' do
+              get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code }
+              expect(response).to redirect_to(
+                publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
+                  provider.provider_code,
+                  provider.recruitment_cycle_year,
+                  course.course_code
+                )
+              )
+            end
+          end
+
+          context 'when uuid is provided and maximum A level subject requirements' do
+            let(:a_level_subject_requirements) do
+              4.times.map { |number| { uuid: "a-uuid-#{number}", subject: 'any_subject' } }
+            end
+
+            it 'renders the page so user can edit the A level subject requirement' do
+              get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code, uuid: 'a-uuid-1' }
+              expect(response).to render_template(:new)
+            end
+          end
+        end
+
+        describe 'POST #create' do
+          context 'when uuid is not provided and maximum A level subject requirements' do
+            let(:a_level_subject_requirements) do
+              4.times.map { |number| { uuid: "a-uuid-#{number}", subject: 'any_subject' } }
+            end
+
+            before do
+              post :create, params: {
+                provider_code: provider.provider_code,
+                recruitment_cycle_year: provider.recruitment_cycle_year,
+                course_code: course.course_code,
+                what_a_level_is_required: {
+                  subject: 'any_science_subject'
+                }
+              }
+            end
+
+            it 'redirects to A level list page' do
+              expect(response).to redirect_to(
+                publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
+                  provider.provider_code,
+                  provider.recruitment_cycle_year,
+                  course.course_code
+                )
+              )
+            end
+
+            it 'does not create more A level subject requirements' do
+              expect(course.reload.a_level_subject_requirements.size).to be 4
+            end
+          end
+
+          context 'when uuid is provided and maximum A level subject requirements' do
+            let(:a_level_subject_requirements) do
+              4.times.map { |number| { uuid: "a-uuid-#{number}", subject: 'any_subject' } }
+            end
+
+            before do
+              post :create, params: {
+                provider_code: provider.provider_code,
+                recruitment_cycle_year: provider.recruitment_cycle_year,
+                course_code: course.course_code,
+                what_a_level_is_required: {
+                  uuid: 'a-uuid-1',
+                  subject: 'any_science_subject'
+                }
+              }
+            end
+
+            it 'redirects to A level list page' do
+              expect(response).to redirect_to(
+                publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
+                  provider.provider_code,
+                  provider.recruitment_cycle_year,
+                  course.course_code
+                )
+              )
+            end
+
+            it 'does not create more A level subject requirements' do
+              expect(course.reload.a_level_subject_requirements.size).to be 4
+            end
+
+            it 'updates A level subject requirements' do
+              expect(course.reload.find_a_level_subject_requirement!('a-uuid-1')[:subject]).to eq('any_science_subject')
             end
           end
         end


### PR DESCRIPTION
### Context

If the user add 4 levels and somehow (manually) tries to enter on the add A level page - we should redirect away.

If the user enters manually on the What A level is required or via back in the browser and try to create another A level, the user will be redirect to the list as there are already 4 A levels.

### Changes proposed in this pull request

Redirect away when user tries to create more than 4 A level subject requirements.

### Guidance to review

1. Are you able to create 5 A levels?
2. Everything is working?
3. Is the change A level subject when there is 4 maximum, still working? (automated and manual tests say yes but good to review!)
