### PR TITLE
A levels  - Add find preview for TDA courses on publish

### DIFF
--- a/app/components/a_level_row_component.rb
+++ b/app/components/a_level_row_component.rb
@@ -14,16 +14,12 @@ class ALevelRowComponent < ViewComponent::Base
   end
 
   def a_level_subject_row_content(a_level_subject_requirement)
-    row_value = ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement).row_value
+    a_level_subject_requirement_row_component = ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement)
 
-    if @course.accept_a_level_equivalency?
-      [
-        row_value,
-        I18n.t('course.a_level_equivalencies.suffix')
-      ].join(', ')
-    else
-      row_value
-    end
+    a_level_subject_requirement_row_component.add_equivalency_suffix(
+      course:,
+      row_value: a_level_subject_requirement_row_component.row_value
+    )
   end
 
   def pending_a_level_summary_content

--- a/app/components/a_level_subject_requirement_row_component.rb
+++ b/app/components/a_level_subject_requirement_row_component.rb
@@ -33,7 +33,7 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
     if other_subject?
       other_subject
     else
-      I18n.t("helpers.label.what_a_level_is_required.plural_subject_options.#{subject}", count: IN_WORDS[count]).to_s
+      I18n.t("helpers.label.what_a_level_is_required.plural_subject_options.#{subject}", count_in_words: IN_WORDS[count]).to_s
     end
   end
 

--- a/app/components/a_level_subject_requirement_row_component.rb
+++ b/app/components/a_level_subject_requirement_row_component.rb
@@ -5,15 +5,20 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
 
   MINIMUM_GRADES = %w[A B C D E].freeze
   MAX_GRADE = 'A*'
+  IN_WORDS = %w[zero one two three four].freeze # Avoiding the need to add a gem number.in_words for a simple conversion
 
   def initialize(a_level_subject_requirement)
     super
 
-    @a_level_subject_requirement = a_level_subject_requirement
+    @a_level_subject_requirement = a_level_subject_requirement.with_indifferent_access
   end
 
   def row_value
-    "#{subject_name}#{grade_display(minimum_grade)}"
+    "#{subject_name}#{grade}"
+  end
+
+  def plural_row_value(count:)
+    "#{plural_subject_name(count:)}#{grade}"
   end
 
   def subject_name
@@ -24,9 +29,15 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
     end
   end
 
-  private
+  def plural_subject_name(count:)
+    if other_subject?
+      other_subject
+    else
+      I18n.t("helpers.label.what_a_level_is_required.plural_subject_options.#{subject}", count: IN_WORDS[count]).to_s
+    end
+  end
 
-  def grade_display(minimum_grade)
+  def grade
     return '' if minimum_grade.blank?
 
     if MINIMUM_GRADES.include?(minimum_grade)
@@ -38,6 +49,23 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
     end
   end
 
+  def other_subject?
+    subject == 'other_subject'
+  end
+
+  def add_equivalency_suffix(course:, row_value:)
+    if course.accept_a_level_equivalency?
+      [
+        row_value,
+        I18n.t('course.a_level_equivalencies.suffix')
+      ].join(', ')
+    else
+      row_value
+    end
+  end
+
+  private
+
   def minimum_grade
     a_level_subject_requirement[:minimum_grade_required]
   end
@@ -48,9 +76,5 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
 
   def other_subject
     a_level_subject_requirement[:other_subject]
-  end
-
-  def other_subject?
-    subject == 'other_subject'
   end
 end

--- a/app/components/find/courses/a_level_component/grouped_a_level_subject_requirements.rb
+++ b/app/components/find/courses/a_level_component/grouped_a_level_subject_requirements.rb
@@ -11,7 +11,7 @@ module Find
           @a_level_subject_requirements = Array(course.a_level_subject_requirements)
         end
 
-        def to_a
+        def to_a_level_equivalency_array
           grouped_a_level_subject_requirements.map do |a_level_subject_requirement, count|
             component = ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement)
 

--- a/app/components/find/courses/a_level_component/grouped_a_level_subject_requirements.rb
+++ b/app/components/find/courses/a_level_component/grouped_a_level_subject_requirements.rb
@@ -26,7 +26,7 @@ module Find
         private
 
         def grouped_a_level_subject_requirements
-          @a_level_subject_requirements.group_by(&:itself).transform_values(&:count)
+          @a_level_subject_requirements.group_by { |req| req.except('uuid') }.transform_values(&:count)
         end
       end
     end

--- a/app/components/find/courses/a_level_component/grouped_a_level_subject_requirements.rb
+++ b/app/components/find/courses/a_level_component/grouped_a_level_subject_requirements.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Find
+  module Courses
+    module ALevelComponent
+      class GroupedALevelSubjectRequirements
+        attr_reader :course, :a_level_subject_requirements
+
+        def initialize(course)
+          @course = course
+          @a_level_subject_requirements = Array(course.a_level_subject_requirements)
+        end
+
+        def to_a
+          grouped_a_level_subject_requirements.map do |a_level_subject_requirement, count|
+            component = ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement)
+
+            if count > 1
+              component.add_equivalency_suffix(course:, row_value: component.plural_row_value(count:))
+            else
+              component.add_equivalency_suffix(course:, row_value: component.row_value)
+            end
+          end
+        end
+
+        private
+
+        def grouped_a_level_subject_requirements
+          @a_level_subject_requirements.group_by(&:itself).transform_values(&:count)
+        end
+      end
+    end
+  end
+end

--- a/app/components/find/courses/a_level_component/view.html.erb
+++ b/app/components/find/courses/a_level_component/view.html.erb
@@ -1,0 +1,17 @@
+<% if a_levels_not_required? %>
+  <p class="govuk-body"><%= a_levels_not_required_content %></p>
+<% else %>
+  <% a_level_subject_requirements.each do |a_level_subject_requirement| %>
+    <p class="govuk-body">
+      <%= a_level_subject_requirement %>
+    </p>
+  <% end %>
+  <p class="govuk-body"><%= pending_a_level_summary_content %></p>
+  <p class="govuk-body"><%= a_level_equivalency_summary_content %></p>
+
+  <% if course.accept_a_level_equivalency? && course.additional_a_level_equivalencies.present? %>
+    <p class="govuk-body">
+    <%= course.additional_a_level_equivalencies %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/components/find/courses/a_level_component/view.html.erb
+++ b/app/components/find/courses/a_level_component/view.html.erb
@@ -11,7 +11,7 @@
 
   <% if course.accept_a_level_equivalency? && course.additional_a_level_equivalencies.present? %>
     <p class="govuk-body">
-    <%= course.additional_a_level_equivalencies %>
+      <%= course.additional_a_level_equivalencies %>
     </p>
   <% end %>
 <% end %>

--- a/app/components/find/courses/a_level_component/view.rb
+++ b/app/components/find/courses/a_level_component/view.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Find
+  module Courses
+    module ALevelComponent
+      class View < ViewComponent::Base
+        attr_reader :course
+
+        def initialize(course:)
+          @course = course
+          @a_level_row_component = ALevelRowComponent.new(course:)
+
+          super
+        end
+
+        def a_levels_not_required?
+          course.a_levels_requirements_answered? && course.a_level_requirements.blank?
+        end
+
+        def a_levels_not_required_content
+          I18n.t('find.courses.a_level.a_levels_not_required')
+        end
+
+        def a_level_subject_requirements
+          GroupedALevelSubjectRequirements.new(course).to_a
+        end
+
+        def pending_a_level_summary_content
+          if course.accept_pending_a_level?
+            I18n.t('find.courses.a_level.consider_pending_a_level')
+          else
+            I18n.t('find.courses.a_level.not_consider_pending_a_level')
+          end
+        end
+
+        def a_level_equivalency_summary_content
+          if course.accept_a_level_equivalency?
+            I18n.t('find.courses.a_level.consider_a_level_equivalency')
+          else
+            I18n.t('find.courses.a_level.not_consider_a_level_equivalency')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/find/courses/a_level_component/view.rb
+++ b/app/components/find/courses/a_level_component/view.rb
@@ -22,7 +22,7 @@ module Find
         end
 
         def a_level_subject_requirements
-          GroupedALevelSubjectRequirements.new(course).to_a
+          GroupedALevelSubjectRequirements.new(course).to_a_level_equivalency_array
         end
 
         def pending_a_level_summary_content

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -31,13 +31,7 @@
       <% end %>
     <% end %>
 
-    <% if course.teacher_degree_apprenticeship? %>
-      <p class="govuk-body">A levels</p>
-
-      <%= render Find::Courses::ALevelComponent::View.new(course:) %>
-
-      <p class="govuk-body">GCSEs</p>
-    <% end %>
+    <%= render Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View.new(course:) %>
 
     <% if (course.accept_pending_gcse.nil? || course.accept_gcse_equivalency.nil?) %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :gcse, is_preview: preview?(params)) %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -3,32 +3,33 @@
   <h3 class="govuk-heading-m">Qualifications needed</h3>
   <div data-qa="course__required_qualifications">
 
-    <% if course.degree_grade.nil? && course.additional_degree_subject_requirements.nil? %>
+    <% unless course.teacher_degree_apprenticeship? %>
+      <% if course.degree_grade.nil? && course.additional_degree_subject_requirements.nil? %>
         <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :degree, is_preview: preview?(params)) %>
-    <% else %>
-      <p class="govuk-body"><%= degree_grade_content(course) %></p>
+      <% else %>
+        <p class="govuk-body"><%= degree_grade_content(course) %></p>
 
         <% if course.degree_subject_requirements.present? %>
           <p class="govuk-body">
             <%= helpers.markdown(course.degree_subject_requirements) %>
           </p>
-      <% end %>
+        <% end %>
 
-      <% if course.secondary_course? %>
-        <% if course.engineers_teach_physics? %>
+        <% if course.secondary_course? %>
+          <% if course.engineers_teach_physics? %>
+            <p class="govuk-body">
+              This <%= govuk_link_to "Engineers teach physics", t("find.get_into_teaching.url_engineers_teach_physics") %> course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.
+            </p>
+          <% end %>
+        <% end %>
+
+        <% if subject_knowledge_enhancement_content? %>
           <p class="govuk-body">
-            This <%= govuk_link_to "Engineers teach physics", t("find.get_into_teaching.url_engineers_teach_physics") %> course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.
+            If you need to improve your subject knowledge, you may be asked to complete a <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
           </p>
         <% end %>
       <% end %>
-
-      <% if subject_knowledge_enhancement_content? %>
-        <p class="govuk-body">
-          If you need to improve your subject knowledge, you may be asked to complete a <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
-        </p>
-      <% end %>
-     <% end %>
-    </p>
+    <% end %>
 
     <% if course.teacher_degree_apprenticeship? %>
       <p class="govuk-body">A levels</p>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -30,6 +30,14 @@
      <% end %>
     </p>
 
+    <% if course.teacher_degree_apprenticeship? %>
+      <p class="govuk-body">A levels</p>
+
+      <%= render Find::Courses::ALevelComponent::View.new(course:) %>
+
+      <p class="govuk-body">GCSEs</p>
+    <% end %>
+
     <% if (course.accept_pending_gcse.nil? || course.accept_gcse_equivalency.nil?) %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :gcse, is_preview: preview?(params)) %>
     <% else %>

--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
@@ -1,0 +1,5 @@
+<h4 class="govuk-body">A levels</h4>
+
+<%= render Find::Courses::ALevelComponent::View.new(course:) %>
+
+<h4 class="govuk-body">GCSEs</h4>

--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
@@ -1,5 +1,7 @@
-<h4 class="govuk-body">A levels</h4>
+<h4 class="govuk-heading-s">A levels</h4>
 
-<%= render Find::Courses::ALevelComponent::View.new(course:) %>
+<% if course.a_levels_requirements_answered? %>
+  <%= render Find::Courses::ALevelComponent::View.new(course:) %>
+<% end %>
 
-<h4 class="govuk-body">GCSEs</h4>
+<h4 class="govuk-heading-s">GCSEs</h4>

--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.rb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Find
+  module Courses
+    module TeacherDegreeApprenticeshipEntryRequirements
+      class View < ViewComponent::Base
+        attr_reader :course
+
+        def initialize(course:)
+          @course = course
+
+          super
+        end
+
+        def render?
+          course.teacher_degree_apprenticeship?
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,11 +305,11 @@ en:
           any_science_subject: Any science subject
           other_subject: Choose a subject
         plural_subject_options:
-          any_subject: Any %{count} subjects
-          any_stem_subject: Any %{count} STEM subjects
-          any_modern_foreign_language: Any %{count} modern foreign languages
-          any_humanities_subject: Any %{count} humanities subjects
-          any_science_subject: Any %{count} science subjects
+          any_subject: Any %{count_in_words} subjects
+          any_stem_subject: Any %{count_in_words} STEM subjects
+          any_modern_foreign_language: Any %{count_in_words} modern foreign languages
+          any_humanities_subject: Any %{count_in_words} humanities subjects
+          any_science_subject: Any %{count_in_words} science subjects
       add_a_level_to_a_list:
         add_another_a_level_options:
           "yes": "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,6 +304,12 @@ en:
           any_humanities_subject: Any humanities subject
           any_science_subject: Any science subject
           other_subject: Choose a subject
+        plural_subject_options:
+          any_subject: Any %{count} subjects
+          any_stem_subject: Any %{count} STEM subjects
+          any_modern_foreign_language: Any %{count} modern foreign languages
+          any_humanities_subject: Any %{count} humanities subjects
+          any_science_subject: Any %{count} science subjects
       add_a_level_to_a_list:
         add_another_a_level_options:
           "yes": "Yes"

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -84,15 +84,6 @@ en:
         not_consider_pending_a_level: We will not consider candidates with pending A levels.
         consider_a_level_equivalency: We’ll consider candidates who need to take A level equivalency tests.
         not_consider_a_level_equivalency: We will not consider candidates who need to take A level equivalency tests.
-        a_level_requirements:
-          plural: Any %{count} %{subject} subjects
-        a_level_subjects:
-          any_subject: "any subject"
-          any_stem_subject: "STEM"
-          any_modern_foreign_language: "Modern Foreign Language"
-          any_humanities_subject: "Humanities"
-          any_science_subject: "Science"
-          other_subject: "other"
       show:
         back_to_search: Back to search results
     scholarships:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -17,7 +17,7 @@ en:
         description: Candidates can browse courses on Find. Courses returned are from the next recruitment cycle
       updated: Cycle schedule updated
     enic:
-      statement_of_comparability: 
+      statement_of_comparability:
         url: https://www.enic.org.uk/Qualifications/SOC/Default.aspx
     qualifications:
       qts: "QTS"
@@ -25,6 +25,7 @@ en:
       pgce_with_qts: "QTS with PGCE"
       pgde: "PGDE"
       pgde_with_qts: "PGDE with QTS"
+      undergraduate_degree_with_qts: Teacher degree apprenticeship with QTS
     location_filter:
       errors:
         no_option: Select find courses by location or by training provider
@@ -77,6 +78,21 @@ en:
       placements:
         heading: School placements at %{provider_name}
         back: Back to %{course_name} (%{course_code})
+      a_level:
+        a_levels_not_required: A levels are not required for this course
+        consider_pending_a_level: We’ll consider candidates with pending A levels.
+        not_consider_pending_a_level: We will not consider candidates with pending A levels.
+        consider_a_level_equivalency: We’ll consider candidates who need to take A level equivalency tests.
+        not_consider_a_level_equivalency: We will not consider candidates who need to take A level equivalency tests.
+        a_level_requirements:
+          plural: Any %{count} %{subject} subjects
+        a_level_subjects:
+          any_subject: "any subject"
+          any_stem_subject: "STEM"
+          any_modern_foreign_language: "Modern Foreign Language"
+          any_humanities_subject: "Humanities"
+          any_science_subject: "Science"
+          other_subject: "other"
       show:
         back_to_search: Back to search results
     scholarships:

--- a/spec/components/find/courses/a_level_component/grouped_a_level_subject_requirements_spec.rb
+++ b/spec/components/find/courses/a_level_component/grouped_a_level_subject_requirements_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements do
   subject(:grouped_a_level_subject_requirements) do
-    described_class.new(course).to_a
+    described_class.new(course).to_a_level_equivalency_array
   end
 
   let(:course) { create(:course, a_level_subject_requirements:).decorate }
   let(:a_level_subject_requirements) { [] }
 
-  describe '#to_a' do
+  describe '#to_a_level_equivalency_array' do
     context 'with up to 4 singular subjects' do
       let(:a_level_subject_requirements) do
         [

--- a/spec/components/find/courses/a_level_component/grouped_a_level_subject_requirements_spec.rb
+++ b/spec/components/find/courses/a_level_component/grouped_a_level_subject_requirements_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements do
+  subject(:grouped_a_level_subject_requirements) do
+    described_class.new(course).to_a
+  end
+
+  let(:course) { create(:course, a_level_subject_requirements:).decorate }
+  let(:a_level_subject_requirements) { [] }
+
+  describe '#to_a' do
+    context 'with up to 4 singular subjects' do
+      let(:a_level_subject_requirements) do
+        [
+          { 'subject' => 'any_subject' },
+          { 'subject' => 'any_stem_subject' },
+          { 'subject' => 'any_modern_foreign_language', 'minimum_grade_required' => 'A' },
+          { 'subject' => 'other_subject', 'other_subject' => 'Geography' }
+        ]
+      end
+
+      it 'renders the correct content' do
+        expect(grouped_a_level_subject_requirements).to eq([
+                                                             'Any subject', 'Any STEM subject', 'Any modern foreign language - Grade A or above', 'Geography'
+                                                           ])
+      end
+    end
+
+    context 'when any stem subjects are the same' do
+      let(:a_level_subject_requirements) do
+        [
+          { 'subject' => 'any_stem_subject' },
+          { 'subject' => 'any_stem_subject' }
+        ]
+      end
+
+      it 'renders the correct content' do
+        expect(grouped_a_level_subject_requirements).to eq(
+          ['Any two STEM subjects']
+        )
+      end
+    end
+
+    context 'when any stem subjects and grade are the same' do
+      let(:a_level_subject_requirements) do
+        [
+          { 'subject' => 'any_stem_subject', minimum_grade_required: 'B' },
+          { 'subject' => 'any_stem_subject', minimum_grade_required: 'B' }
+        ]
+      end
+
+      it 'renders the correct content' do
+        expect(grouped_a_level_subject_requirements).to eq(
+          ['Any two STEM subjects - Grade B or above']
+        )
+      end
+    end
+
+    context 'when any modern foreign language subjects are the same' do
+      let(:a_level_subject_requirements) do
+        [
+          { 'subject' => 'any_modern_foreign_language' },
+          { 'subject' => 'any_modern_foreign_language' }
+        ]
+      end
+
+      it 'renders the correct content' do
+        expect(grouped_a_level_subject_requirements).to eq(['Any two modern foreign languages'])
+      end
+    end
+
+    context 'when any modern foreign language subjects are the same but grades are different' do
+      let(:a_level_subject_requirements) do
+        [
+          { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
+          { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'B' }
+        ]
+      end
+
+      it 'renders the correct content' do
+        expect(grouped_a_level_subject_requirements).to eq([
+                                                             'Any modern foreign language - Grade A or above', 'Any modern foreign language - Grade B or above'
+                                                           ])
+      end
+    end
+
+    context 'when equivalency and any modern foreign language subjects are the same but grades are different' do
+      let(:course) { create(:course, :with_a_level_requirements, a_level_subject_requirements:).decorate }
+
+      let(:a_level_subject_requirements) do
+        [
+          { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
+          { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' }
+        ]
+      end
+
+      it 'renders the correct content' do
+        expect(grouped_a_level_subject_requirements).to eq([
+                                                             'Any two modern foreign languages - Grade A or above, or equivalent qualification'
+                                                           ])
+      end
+    end
+
+    context 'when any other subjects are the same' do
+      let(:a_level_subject_requirements) do
+        [
+          { 'subject' => 'other_subject', 'other_subject' => 'Geography' },
+          { 'subject' => 'other_subject', 'other_subject' => 'Geography' }
+        ]
+      end
+
+      it 'renders the correct content' do
+        expect(grouped_a_level_subject_requirements).to eq(%w[Geography])
+      end
+    end
+
+    context 'when considering candidates who need A level equivalency tests' do
+      let(:course) { create(:course, :with_a_level_requirements).decorate }
+
+      it 'renders the subject with equivalency' do
+        expect(grouped_a_level_subject_requirements).to eq([
+                                                             'Any subject - Grade A or above, or equivalent qualification'
+                                                           ])
+      end
+    end
+  end
+end

--- a/spec/components/find/courses/a_level_component/grouped_a_level_subject_requirements_spec.rb
+++ b/spec/components/find/courses/a_level_component/grouped_a_level_subject_requirements_spec.rb
@@ -14,25 +14,30 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
     context 'with up to 4 singular subjects' do
       let(:a_level_subject_requirements) do
         [
-          { 'subject' => 'any_subject' },
-          { 'subject' => 'any_stem_subject' },
-          { 'subject' => 'any_modern_foreign_language', 'minimum_grade_required' => 'A' },
-          { 'subject' => 'other_subject', 'other_subject' => 'Geography' }
+          { 'uuid' => 'uuid-1', 'subject' => 'any_subject' },
+          { 'uuid' => 'uuid-2', 'subject' => 'any_stem_subject' },
+          { 'uuid' => 'uuid-3', 'subject' => 'any_modern_foreign_language', 'minimum_grade_required' => 'A' },
+          { 'uuid' => 'uuid-4', 'subject' => 'other_subject', 'other_subject' => 'Geography' }
         ]
       end
 
       it 'renders the correct content' do
-        expect(grouped_a_level_subject_requirements).to eq([
-                                                             'Any subject', 'Any STEM subject', 'Any modern foreign language - Grade A or above', 'Geography'
-                                                           ])
+        expect(grouped_a_level_subject_requirements).to eq(
+          [
+            'Any subject',
+            'Any STEM subject',
+            'Any modern foreign language - Grade A or above',
+            'Geography'
+          ]
+        )
       end
     end
 
     context 'when any stem subjects are the same' do
       let(:a_level_subject_requirements) do
         [
-          { 'subject' => 'any_stem_subject' },
-          { 'subject' => 'any_stem_subject' }
+          { 'uuid' => 'uuid-1', 'subject' => 'any_stem_subject' },
+          { 'uuid' => 'uuid-2', 'subject' => 'any_stem_subject' }
         ]
       end
 
@@ -46,8 +51,8 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
     context 'when any stem subjects and grade are the same' do
       let(:a_level_subject_requirements) do
         [
-          { 'subject' => 'any_stem_subject', minimum_grade_required: 'B' },
-          { 'subject' => 'any_stem_subject', minimum_grade_required: 'B' }
+          { 'uuid' => 'uuid-1', 'subject' => 'any_stem_subject', minimum_grade_required: 'B' },
+          { 'uuid' => 'uuid-2', 'subject' => 'any_stem_subject', minimum_grade_required: 'B' }
         ]
       end
 
@@ -61,8 +66,8 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
     context 'when any modern foreign language subjects are the same' do
       let(:a_level_subject_requirements) do
         [
-          { 'subject' => 'any_modern_foreign_language' },
-          { 'subject' => 'any_modern_foreign_language' }
+          { 'uuid' => 'uuid-1', 'subject' => 'any_modern_foreign_language' },
+          { 'uuid' => 'uuid-2', 'subject' => 'any_modern_foreign_language' }
         ]
       end
 
@@ -74,15 +79,18 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
     context 'when any modern foreign language subjects are the same but grades are different' do
       let(:a_level_subject_requirements) do
         [
-          { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
-          { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'B' }
+          { 'uuid' => 'uuid-1', 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
+          { 'uuid' => 'uuid-2', 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'B' }
         ]
       end
 
       it 'renders the correct content' do
-        expect(grouped_a_level_subject_requirements).to eq([
-                                                             'Any modern foreign language - Grade A or above', 'Any modern foreign language - Grade B or above'
-                                                           ])
+        expect(grouped_a_level_subject_requirements).to eq(
+          [
+            'Any modern foreign language - Grade A or above',
+            'Any modern foreign language - Grade B or above'
+          ]
+        )
       end
     end
 
@@ -91,23 +99,25 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
 
       let(:a_level_subject_requirements) do
         [
-          { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
-          { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' }
+          { 'uuid' => 'uuid-1', 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
+          { 'uuid' => 'uuid-2', 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' }
         ]
       end
 
       it 'renders the correct content' do
-        expect(grouped_a_level_subject_requirements).to eq([
-                                                             'Any two modern foreign languages - Grade A or above, or equivalent qualification'
-                                                           ])
+        expect(grouped_a_level_subject_requirements).to eq(
+          [
+            'Any two modern foreign languages - Grade A or above, or equivalent qualification'
+          ]
+        )
       end
     end
 
     context 'when any other subjects are the same' do
       let(:a_level_subject_requirements) do
         [
-          { 'subject' => 'other_subject', 'other_subject' => 'Geography' },
-          { 'subject' => 'other_subject', 'other_subject' => 'Geography' }
+          { 'uuid' => 'uuid-1', 'subject' => 'other_subject', 'other_subject' => 'Geography' },
+          { 'uuid' => 'uuid-2', 'subject' => 'other_subject', 'other_subject' => 'Geography' }
         ]
       end
 
@@ -116,13 +126,51 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       end
     end
 
+    context 'when duplicate with A level with equivalency tests' do
+      let(:course) { create(:course, :with_a_level_requirements, a_level_subject_requirements:).decorate }
+      let(:a_level_subject_requirements) do
+        [
+          { 'uuid' => 'uuid-1', 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
+          { 'uuid' => 'uuid-2', 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' }
+        ]
+      end
+
+      it 'renders the subject with equivalency' do
+        expect(grouped_a_level_subject_requirements).to eq(
+          [
+            'Any two modern foreign languages - Grade A or above, or equivalent qualification'
+          ]
+        )
+      end
+    end
+
+    context 'when duplicate with A level with equivalency tests without grade' do
+      let(:course) { create(:course, :with_a_level_requirements, a_level_subject_requirements:).decorate }
+      let(:a_level_subject_requirements) do
+        [
+          { 'uuid' => 'uuid-1', 'subject' => 'any_modern_foreign_language' },
+          { 'uuid' => 'uuid-2', 'subject' => 'any_modern_foreign_language' }
+        ]
+      end
+
+      it 'renders the subject with equivalency' do
+        expect(grouped_a_level_subject_requirements).to eq(
+          [
+            'Any two modern foreign languages, or equivalent qualification'
+          ]
+        )
+      end
+    end
+
     context 'when considering candidates who need A level equivalency tests' do
       let(:course) { create(:course, :with_a_level_requirements).decorate }
 
       it 'renders the subject with equivalency' do
-        expect(grouped_a_level_subject_requirements).to eq([
-                                                             'Any subject - Grade A or above, or equivalent qualification'
-                                                           ])
+        expect(grouped_a_level_subject_requirements).to eq(
+          [
+            'Any subject - Grade A or above, or equivalent qualification'
+          ]
+        )
       end
     end
   end

--- a/spec/components/find/courses/a_level_component/view_spec.rb
+++ b/spec/components/find/courses/a_level_component/view_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Find::Courses::ALevelComponent::View, type: :component do
+  subject(:result) { render_inline(described_class.new(course:)).text }
+
+  let(:course) { create(:course, a_level_subject_requirements:).decorate }
+  let(:a_level_subject_requirements) { [] }
+
+  context 'when A-levels are not required' do
+    let(:course) { create(:course, a_level_requirements: false).decorate }
+
+    it 'renders the correct content' do
+      expect(result).to include('A levels are not required for this course')
+    end
+  end
+
+  context 'with up to 4 singular subjects' do
+    let(:a_level_subject_requirements) do
+      [
+        { 'subject' => 'any_subject' },
+        { 'subject' => 'any_stem_subject' },
+        { 'subject' => 'any_modern_foreign_language', 'minimum_grade_required' => 'A' },
+        { 'subject' => 'other_subject', 'other_subject' => 'Geography' }
+      ]
+    end
+
+    it 'renders the correct content' do
+      expect(result).to include(
+        'Any subject', 'Any STEM subject', 'Any modern foreign language - Grade A or above', 'Geography'
+      )
+    end
+  end
+
+  context 'when any stem subjects are the same' do
+    let(:a_level_subject_requirements) do
+      [
+        { 'subject' => 'any_stem_subject' },
+        { 'subject' => 'any_stem_subject' }
+      ]
+    end
+
+    it 'renders the correct content' do
+      expect(result).to include(
+        'Any two STEM subjects'
+      )
+    end
+  end
+
+  context 'when any stem subjects and grade are the same' do
+    let(:a_level_subject_requirements) do
+      [
+        { 'subject' => 'any_stem_subject', minimum_grade_required: 'B' },
+        { 'subject' => 'any_stem_subject', minimum_grade_required: 'B' }
+      ]
+    end
+
+    it 'renders the correct content' do
+      expect(result).to include(
+        'Any two STEM subjects - Grade B or above'
+      )
+    end
+  end
+
+  context 'when any modern foreign language subjects are the same' do
+    let(:a_level_subject_requirements) do
+      [
+        { 'subject' => 'any_modern_foreign_language' },
+        { 'subject' => 'any_modern_foreign_language' }
+      ]
+    end
+
+    it 'renders the correct content' do
+      expect(result).to include('Any two modern foreign languages')
+    end
+  end
+
+  context 'when any modern foreign language subjects are the same but grades are different' do
+    let(:a_level_subject_requirements) do
+      [
+        { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
+        { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'B' }
+      ]
+    end
+
+    it 'renders the correct content' do
+      expect(result).to include(
+        'Any modern foreign language - Grade A or above',
+        'Any modern foreign language - Grade B or above'
+      )
+    end
+  end
+
+  context 'when equivalency and any modern foreign language subjects are the same but grades are different' do
+    let(:course) { create(:course, :with_a_level_requirements, a_level_subject_requirements:).decorate }
+
+    let(:a_level_subject_requirements) do
+      [
+        { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' },
+        { 'subject' => 'any_modern_foreign_language', minimum_grade_required: 'A' }
+      ]
+    end
+
+    it 'renders the correct content' do
+      expect(result).to include(
+        'Any two modern foreign languages - Grade A or above, or equivalent qualification'
+      )
+    end
+  end
+
+  context 'when any other subjects are the same' do
+    let(:a_level_subject_requirements) do
+      [
+        { 'subject' => 'other_subject', 'other_subject' => 'Geography' },
+        { 'subject' => 'other_subject', 'other_subject' => 'Geography' }
+      ]
+    end
+
+    it 'renders the correct content' do
+      expect(result).to include(
+        'Geography'
+      )
+    end
+  end
+
+  context 'when considering candidates with pending A levels' do
+    let(:course) { create(:course, :with_a_level_requirements, accept_pending_a_level: true).decorate }
+
+    it 'renders the correct content when pending A levels are considered' do
+      expect(result).to include('We’ll consider candidates with pending A levels.')
+    end
+  end
+
+  context 'when not considering candidates with pending A levels' do
+    let(:course) { create(:course, :with_a_level_requirements, accept_pending_a_level: false).decorate }
+
+    it 'renders the correct content when pending A levels are not considered' do
+      expect(result).to include('We will not consider candidates with pending A levels.')
+    end
+  end
+
+  context 'when considering candidates who need A level equivalency tests' do
+    let(:course) { create(:course, :with_a_level_requirements).decorate }
+
+    it 'renders the correct content when A level equivalency tests are considered' do
+      expect(result).to include('We’ll consider candidates who need to take A level equivalency tests.')
+    end
+
+    it 'renders the subject with equivalency' do
+      expect(result).to include('Any subject - Grade A or above, or equivalent qualification')
+    end
+  end
+
+  context 'when not considering candidates who need A level equivalency tests' do
+    let(:course) { create(:course, accept_a_level_equivalency: false).decorate }
+
+    it 'renders the correct content when A level equivalency tests are not considered' do
+      expect(result).to include('We will not consider candidates who need to take A level equivalency tests.')
+    end
+  end
+end

--- a/spec/components/find/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_preview.rb
@@ -100,6 +100,10 @@ module Find
           def engineers_teach_physics?
             campaign_name&.to_sym == :engineers_teach_physics
           end
+
+          def teacher_degree_apprenticeship?
+            false
+          end
         end
       end
     end

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -10,6 +10,29 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
   let(:ske_url_name) { 'subject knowledge enhancement (SKE) course.' }
   let(:ske_url) { 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement' }
 
+  context 'when teacher degree apprenticeship course' do
+    let(:subject_name) { :physics }
+    let(:course) do
+      build(
+        :course,
+        :with_teacher_degree_apprenticeship,
+        :with_a_level_requirements,
+        :resulting_in_undergraduate_degree_with_qts,
+        subjects:,
+        accept_gcse_equivalency: false,
+        accept_pending_gcse: false
+      )
+    end
+
+    it 'renders A levels and GCSEs only and ignores degrees' do
+      expected_text = <<~TEXT
+        Entry requirements Qualifications needed A levels Any subject - Grade A or above, or equivalent qualification We’ll consider candidates with pending A levels. We’ll consider candidates who need to take A level equivalency tests. Some text GCSEs Grade 4 (C) or above in English, maths and science, or equivalent qualification. We will not consider candidates with pending GCSEs. We will not consider candidates who need to take a GCSE equivalency test.
+      TEXT
+
+      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to include(expected_text.strip)
+    end
+  end
+
   context 'when physics is selected' do
     let(:subject_name) { :physics }
 

--- a/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
+++ b/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
+  let(:course) { build(:course) }
+  let(:result) { render_inline(described_class.new(course: course.decorate)) }
+
+  context 'when teacher degree apprenticeship course' do
+    let(:course) do
+      build(
+        :course,
+        :with_teacher_degree_apprenticeship,
+        :with_a_level_requirements,
+        :resulting_in_undergraduate_degree_with_qts,
+        accept_gcse_equivalency: false,
+        accept_pending_gcse: false,
+        additional_a_level_equivalencies: 'Some text about A level equivalencies'
+      )
+    end
+
+    it 'renders A levels and GCSEs only and ignores degrees' do
+      expected_text = <<~TEXT
+        A levels Any subject - Grade A or above, or equivalent qualification We’ll consider candidates with pending A levels. We’ll consider candidates who need to take A level equivalency tests. Some text about A level equivalencies GCSEs
+      TEXT
+
+      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to include(expected_text.strip)
+    end
+  end
+
+  context 'when not teacher degree apprenticeship course' do
+    let(:course) do
+      build(
+        :course,
+        :with_higher_education
+      )
+    end
+
+    it 'renders nothing' do
+      expect(result.text).to eq('')
+    end
+  end
+end

--- a/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
+++ b/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
@@ -40,4 +40,22 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
       expect(result.text).to eq('')
     end
   end
+
+  context 'when there are no A levels' do
+    let(:course) do
+      build(
+        :course,
+        :with_teacher_degree_apprenticeship,
+        :resulting_in_undergraduate_degree_with_qts,
+        a_level_requirements: nil,
+        a_level_subject_requirements: [],
+        accept_pending_gcse: nil,
+        additional_a_level_equivalencies: nil
+      )
+    end
+
+    it 'renders the headings' do
+      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to eq('A levels GCSEs')
+    end
+  end
 end

--- a/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
+++ b/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
@@ -43,7 +43,12 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       :with_a_level_requirements,
       :resulting_in_undergraduate_degree_with_qts,
       provider: @provider,
-      additional_a_level_equivalencies: 'Some additional text about A level equivalencies'
+      additional_a_level_equivalencies: 'Some additional text about A level equivalencies',
+      a_level_subject_requirements: [
+        { 'uuid' => 'uuid-1', 'subject' => 'any_subject', 'minimum_grade_required' => 'A' },
+        { 'uuid' => 'uuid-1', 'subject' => 'any_modern_foreign_language', 'minimum_grade_required' => 'A*' },
+        { 'uuid' => 'uuid-2', 'subject' => 'any_modern_foreign_language', 'minimum_grade_required' => 'A*' }
+      ]
     )
   end
 
@@ -66,6 +71,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   def then_i_see_the_a_level_requirements_content
     expect(page).to have_content('A levels')
     expect(page).to have_content('Any subject - Grade A or above, or equivalent qualification')
+    expect(page).to have_content('Any two modern foreign languages - Grade A*, or equivalent qualification')
     expect(page).to have_content('We’ll consider candidates with pending A levels.')
     expect(page).to have_content('We’ll consider candidates who need to take A level equivalency tests.')
     expect(page).to have_content('Some additional text about A level equivalencies')

--- a/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
+++ b/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Course show', { can_edit_current_and_next_cycles: false } do
+  scenario 'when viewing a teacher degree apprenticeship course' do
+    given_i_am_authenticated_as_a_provider_user
+    and_the_tda_feature_flag_is_active
+    and_i_have_a_teacher_degree_apprenticeship_course
+
+    when_i_visit_the_course_page
+    then_i_should_see_the_link_to_preview
+
+    when_i_click_to_preview_the_course
+    then_i_see_the_a_level_requirements_content
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    recruitment_cycle = create(:recruitment_cycle, year: 2025)
+    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @provider = @user.providers.first
+    create(:provider, :accredited_provider, provider_code: '1BJ')
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @provider.accrediting_provider_enrichments = []
+    @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
+      {
+        UcasProviderCode: @accredited_provider.provider_code,
+        Description: 'description'
+      }
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_the_tda_feature_flag_is_active
+    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
+  end
+
+  def and_i_have_a_teacher_degree_apprenticeship_course
+    @course = create(
+      :course,
+      :with_teacher_degree_apprenticeship,
+      :with_a_level_requirements,
+      :resulting_in_undergraduate_degree_with_qts,
+      provider: @provider,
+      additional_a_level_equivalencies: 'Some additional text about A level equivalencies'
+    )
+  end
+
+  def when_i_visit_the_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: @provider.provider_code,
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+      course_code: @course.course_code
+    )
+  end
+
+  def then_i_should_see_the_link_to_preview
+    expect(page).to have_content('Preview course')
+  end
+
+  def when_i_click_to_preview_the_course
+    click_on 'Preview course'
+  end
+
+  def then_i_see_the_a_level_requirements_content
+    expect(page).to have_content('A levels')
+    expect(page).to have_content('Any subject - Grade A or above, or equivalent qualification')
+    expect(page).to have_content('We’ll consider candidates with pending A levels.')
+    expect(page).to have_content('We’ll consider candidates who need to take A level equivalency tests.')
+    expect(page).to have_content('Some additional text about A level equivalencies')
+  end
+end

--- a/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
+++ b/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
@@ -13,6 +13,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
     when_i_click_to_preview_the_course
     then_i_see_the_a_level_requirements_content
+    and_i_do_not_see_the_degree_content
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -48,7 +49,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
         { 'uuid' => 'uuid-1', 'subject' => 'any_subject', 'minimum_grade_required' => 'A' },
         { 'uuid' => 'uuid-1', 'subject' => 'any_modern_foreign_language', 'minimum_grade_required' => 'A*' },
         { 'uuid' => 'uuid-2', 'subject' => 'any_modern_foreign_language', 'minimum_grade_required' => 'A*' }
-      ]
+      ],
+      degree_grade: nil,
+      additional_degree_subject_requirements: nil,
+      degree_subject_requirements: nil
     )
   end
 
@@ -75,5 +79,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     expect(page).to have_content('We’ll consider candidates with pending A levels.')
     expect(page).to have_content('We’ll consider candidates who need to take A level equivalency tests.')
     expect(page).to have_content('Some additional text about A level equivalencies')
+  end
+
+  def and_i_do_not_see_the_degree_content
+    expect(page).to have_no_content('An undergraduate degree, or equivalent')
+    expect(page).to have_no_content('Enter degree requirements')
   end
 end


### PR DESCRIPTION
### Context

We need to add the ability for providers to input A level requirements for TDA courses on Publish, in order to enable TDA applications.

Once they have inputted their A level requirements, they need to preview how this will look for candidates on Find.

### Changes proposed in this pull request

<img width="462" alt="Screenshot 2024-07-01 at 19 41 02" src="https://github.com/DFE-Digital/publish-teacher-training/assets/27509/c21f6da4-1e55-4c75-85d2-9f6c48e497ff">

### Guidance to review

1. Does the grouping working?
2. Does other subject works?
3. Does the GCSEs word appear?
4. Does degrees content are hidden?

To enable TDA you need to enable rollover and be on 2025 cycle.

## Trello card

https://trello.com/c/1mxaXiCk/1808-a-levels-add-find-preview-for-tda-courses-on-publish