### PR TITLE
Rollout workload identity federation to all environments 

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -25,11 +25,6 @@ DfE::Analytics.configure do |config|
   #
   config.bigquery_dataset = Settings.google.bigquery.dataset
 
-  # Service account JSON key for the BigQuery API. See
-  # https://cloud.google.com/bigquery/docs/authentication/service-account-file
-  #
-  config.bigquery_api_json_key = Settings.google.bigquery.api_json_key
-
   # Enables the EntityTableCheckJob
   #
   config.entity_table_checks_enabled = true

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -52,4 +52,9 @@ DfE::Analytics.configure do |config|
   # to all events we send to BigQuery.
   #
   # config.environment = ENV.fetch('RAILS_ENV', 'development')
+
+  # Whether to use azure workload identity federation for authentication
+  # instead of the BigQuery API JSON Key. Note that this also will also
+  # use a new version of the BigQuery streaming APIs.
+  config.azure_federated_auth = true
 end

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -61,4 +61,6 @@ module "worker_application" {
   replicas      = each.value.replicas
   enable_logit  = var.enable_logit
   probe_command = ["pgrep", "-f", "sidekiq"]
+
+  enable_gcp_wif = true
 }


### PR DESCRIPTION
### Context

This is part of a wider BigQuery Assurance piece to to harden the security around BigQuery.

It allows the use of OAuth mechanism for authentication to BigQuery rather than relying on plain text JSON API Keys.

The Data Insights ticket is [here](https://trello.com/c/IDG7vXFy).

### Changes proposed in this pull request

Enable Azure workload identity federation within DfE Analytics.

Set GOOGLE_CLOUD_CREDENTIALS secret in the key vault for each environment. 

### Guidance to review

See [Dfe Analytics GEM](https://github.com/DFE-Digital/dfe-analytics) for further details.

This change involves the following steps
- Set GOOGLE_CLOUD_CREDENTIALS by downloading from GCP. This should be done for each environment.
- Enable WIF in the Azure Infrastructure
- Enable WIF in the App. We can remove references to the the JSON API Key at the same time
- Enable WIF in the Review App and test sending of data to BIgQuery. This can be disabled after testing
- Release to production

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
