### PR TITLE
Move school placements into its own view

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -49,19 +49,11 @@
         <%= course.placements_heading %>
       </h3>
 
-      <p class="govuk-body">
-        We work with the following schools to provide your school placements.
-      </p>
+      <p class="govuk-body"><%= t(".work_with_schools") %></p>
 
-      <ul class="govuk-list govuk-list--spaced" id="course_school_placements">
-        <% course.preview_site_statuses.each do |site_status| %>
-          <li>
-            <strong><%= smart_quotes(site_status.site.location_name) %></strong>
-            <br>
-            <%= smart_quotes(site_status.site.decorate.full_address) %>
-          </li>
-        <% end %>
-      </ul>
+      <p class="govuk-body">
+        <%= govuk_link_to(t(".view_list_of_school_placements"), placements_url) %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -38,6 +38,21 @@ module Find
           course_information_config.show_placement_guidance?(:program_type)
         end
 
+        def placements_url
+          if course.has_unpublished_changes? || (course.is_published? && course.is_running?)
+            URI.join(
+              Settings.search_ui.base_url,
+              find_placements_path(course.provider_code, course.course_code)
+            ).to_s
+          else
+            placements_publish_provider_recruitment_cycle_course_path(
+              course.provider_code,
+              course.recruitment_cycle_year,
+              course.course_code
+            )
+          end
+        end
+
         private
 
         def course_information_config

--- a/app/controllers/find/placements_controller.rb
+++ b/app/controllers/find/placements_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Find
+  class PlacementsController < ApplicationController
+    before_action -> { render_not_found if provider.nil? }
+
+    def index
+      @course = provider.courses.includes(
+        :enrichments,
+        subjects: [:financial_incentive],
+        site_statuses: [:site]
+      ).find_by!(course_code: params[:course_code]&.upcase).decorate
+
+      render_not_found unless @course.is_published?
+    end
+  end
+end

--- a/app/controllers/publish/courses/school_placements_controller.rb
+++ b/app/controllers/publish/courses/school_placements_controller.rb
@@ -8,6 +8,10 @@ module Publish
 
       before_action :authorise_with_pundit
 
+      def index
+        @course = course
+      end
+
       def edit
         @course_school_placements_form = CourseSchoolPlacementsForm.new(course_enrichment)
         @copied_fields = copy_content_check(::Courses::Copy::SCHOOL_PLACEMENTS_FIELDS)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -100,6 +100,7 @@ class Course < ApplicationRecord
   belongs_to :provider
 
   delegate :tda_active?, to: :provider, allow_nil: true
+  delegate :provider_name, :provider_code, to: :provider, allow_nil: true
 
   belongs_to :accrediting_provider,
              ->(c) { where(recruitment_cycle: c.recruitment_cycle) },

--- a/app/views/find/placements/index.html.erb
+++ b/app/views/find/placements/index.html.erb
@@ -1,0 +1,21 @@
+<%= content_for :page_title do %>
+  <%= t(
+    "find.courses.placements.heading",
+    provider_name: @course.provider_name
+  ) %>
+<% end %>
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    href: search_ui_course_page_url(
+      provider_code: @course.provider_code,
+      course_code: @course.course_code
+    ),
+    text: t(
+      "find.courses.placements.back",
+      course_name: @course.name,
+      course_code: @course.course_code
+    )
+  ) %>
+<% end %>
+
+<%= render partial: "shared/courses/placements", locals: { course: @course } %>

--- a/app/views/publish/courses/school_placements/index.html.erb
+++ b/app/views/publish/courses/school_placements/index.html.erb
@@ -1,0 +1,22 @@
+<%= content_for :page_title do %>
+  <%= t(
+    "publish.providers.courses.placements.heading",
+    provider_name: @course.provider_name
+  ) %>
+<% end %>
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    href: preview_publish_provider_recruitment_cycle_course_path(
+      @course.provider_code,
+      @course.recruitment_cycle_year,
+      @course.course_code
+    ),
+    text: t(
+      "publish.providers.courses.placements.back",
+      course_name: @course.name,
+      course_code: @course.course_code
+    )
+  ) %>
+<% end %>
+
+<%= render partial: "shared/courses/placements", locals: { course: @course } %>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,0 +1,21 @@
+<h1 class="govuk-heading-xl">
+  <%= t(".heading", provider_name: course.provider_name) %>
+</h1>
+
+<%= govuk_warning_text(text: t(".warning")) %>
+
+<p class="govuk-body">
+  <%= t(".will_place_you", provider_name: course.provider_name) %>
+</p>
+
+<p class="govuk-body"><%= t(".schools_to_be_placed") %></p>
+
+<ul class="govuk-list govuk-list--spaced" id="course_school_placements">
+  <% course.preview_site_statuses.each do |site_status| %>
+    <li>
+      <strong><%= smart_quotes(site_status.site.location_name) %></strong>
+      <br>
+      <%= smart_quotes(site_status.site.decorate.full_address) %>
+    </li>
+  <% end %>
+</ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,11 @@
 en:
+  shared:
+    courses:
+      placements:
+        heading: School placements at %{provider_name}
+        warning: You can’t pick which schools you will be in.
+        will_place_you: '%{provider_name} will place you in different schools you can travel to during your training.'
+        schools_to_be_placed: 'The schools you could be placed in are:'
   markdown_formatting:
     summary_text: Help formatting your text
     title: How to format your text
@@ -389,6 +396,9 @@ en:
   publish:
     providers:
       courses:
+        placements:
+          heading: School placements at %{provider_name}
+          back: Back to %{course_name} (%{course_code})
         description_content:
           course_information_heading: Course information
           about_course_label: About this course

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -70,6 +70,13 @@ en:
       primary_title: Primary courses with subject specialisms
       secondary_title: Which secondary subjects do you want to teach?
     courses:
+      about_schools_component:
+        view:
+          view_list_of_school_placements: View list of school placements
+          work_with_schools: We work with the following schools to provide your school placements.
+      placements:
+        heading: School placements at %{provider_name}
+        back: Back to %{course_name} (%{course_code})
       show:
         back_to_search: Back to search results
     scholarships:

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -13,6 +13,7 @@ namespace :find, path: '/' do
   get '/privacy', to: 'pages#privacy', as: :privacy
   get '/terms-conditions', to: 'pages#terms', as: :terms
   get '/course/:provider_code/:course_code', to: 'courses#show', as: 'course'
+  get '/course/:provider_code/:course_code/placements', to: 'placements#index', as: :placements
   get '/course/:provider_code/:course_code/apply', to: 'courses#apply', as: :apply
   get '/results', to: 'results#index', as: 'results'
   get '/location-suggestions', to: 'location_suggestions#index'

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -179,6 +179,7 @@ namespace :publish, as: :publish do
         patch '/interview-process', on: :member, to: 'courses/interview_process#update'
         get '/school-placements', on: :member, to: 'courses/school_placements#edit'
         patch '/school-placements', on: :member, to: 'courses/school_placements#update'
+        get '/placements', on: :member, to: 'courses/school_placements#index', as: :placements
 
         # This feature is deprecated and will be removed after the beginning of
         # 2025 recruitment cycle.

--- a/spec/controllers/find/placements_controller_spec.rb
+++ b/spec/controllers/find/placements_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Find
+  describe PlacementsController do
+    before do
+      Timecop.travel(Find::CycleTimetable.mid_cycle)
+    end
+
+    describe '#placements' do
+      context 'when provider is not pressent' do
+        it 'renders the not found page' do
+          get :index, params: {
+            provider_code: 'ABC',
+            course_code: '123'
+          }
+
+          expect(response).to render_template('errors/not_found')
+        end
+      end
+
+      context 'when course is not published' do
+        it 'renders the not found page' do
+          provider = create(:provider)
+          course = create(:course, provider:)
+
+          get :index, params: {
+            provider_code: provider.provider_code,
+            course_code: course.course_code
+          }
+
+          expect(response).to render_template('errors/not_found')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -68,6 +68,13 @@ feature 'Viewing a findable course' do
     end
   end
 
+  scenario 'user views school placements' do
+    given_there_is_a_findable_course
+    when_i_visit_the_course_page
+    when_i_click('View list of school placements')
+    then_i_should_be_on_the_school_placements_page
+  end
+
   private
 
   def given_there_is_a_findable_course
@@ -280,9 +287,7 @@ feature 'Viewing a findable course' do
 
     expect(find_course_show_page.school_placements).to have_no_content('Suspended site with vacancies')
 
-    @course.site_statuses.new_or_running.map(&:site).uniq.each do |site|
-      expect(find_course_show_page).to have_content(smart_quotes(site.decorate.full_address))
-    end
+    expect(find_course_show_page).to have_link('View list of school placements')
 
     expect(find_course_show_page).to have_course_advice
 
@@ -344,5 +349,15 @@ feature 'Viewing a findable course' do
       :accredited_provider,
       provider_name: 'Accrediting Provider 1'
     )
+  end
+
+  def when_i_click(button)
+    click_on(button)
+  end
+
+  def then_i_should_be_on_the_school_placements_page
+    @course.site_statuses.new_or_running.map(&:site).uniq.each do |site|
+      expect(find_course_show_page).to have_content(smart_quotes(site.decorate.full_address))
+    end
   end
 end

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -127,6 +127,13 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     end
   end
 
+  scenario 'user views school placements' do
+    given_i_am_authenticated(user: user_with_fee_based_course)
+    when_i_visit_the_publish_course_preview_page
+    when_i_click('View list of school placements')
+    then_i_should_be_on_the_school_placements_page
+  end
+
   private
 
   def then_i_see_custom_address
@@ -272,7 +279,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     )
 
     expect(publish_course_preview_page).to have_study_sites_table
-    expect(publish_course_preview_page).to have_school_placements_table
+    expect(publish_course_preview_page).to have_link('View list of school placements')
 
     expect(publish_course_preview_page).to have_course_advice
 
@@ -474,5 +481,13 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   def and_i_do_not_see_financial_support
     expect(publish_course_preview_page).not_to have_scholarship_amount
     expect(publish_course_preview_page).not_to have_bursary_amount
+  end
+
+  def when_i_click(button)
+    click_on(button)
+  end
+
+  def then_i_should_be_on_the_school_placements_page
+    expect(publish_course_preview_page).to have_school_placements_table
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -22,6 +22,9 @@ describe Course do
   its(:to_s) { is_expected.to eq("Biology (#{course.provider.provider_code}/3X9F) [#{course.recruitment_cycle}]") }
   its(:modular) { is_expected.to eq('') }
 
+  it { is_expected.to delegate_method(:provider_name).to(:provider).allow_nil }
+  it { is_expected.to delegate_method(:provider_code).to(:provider).allow_nil }
+
   describe '#campaign_name' do
     it 'assigns the campaign' do
       course.engineers_teach_physics!


### PR DESCRIPTION
### Context

Currently, school placements are listed on course pages, which can be
problematic for candidates as there is quite a lot of content on this
page.
We want to move this information to a separate page.

### Changes proposed in this pull request

New route/controller and view for the placements.
Link to the new view from the course show page, in find and publish

### Guidance to review

Review the show page of the course in publish(preview) and in find.
You should see a link to the school placements

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes


https://github.com/DFE-Digital/publish-teacher-training/assets/11318084/b35474b1-9ff6-4d7f-b351-7fdd9ac206e4


