### PR TITLE
[1839] Make course list sortable

### DIFF
--- a/app/components/sortable_table_header.html.erb
+++ b/app/components/sortable_table_header.html.erb
@@ -1,0 +1,4 @@
+<button type="button">
+  <%= link_to full_title, { sort: column, direction: }, class: "govuk-link govuk-link--no-visited-state" %>
+  <span class="govuk-visually-hidden">Sort by <%= title.downcase %></span>
+</button>

--- a/app/components/sortable_table_header.rb
+++ b/app/components/sortable_table_header.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class SortableTableHeader < ViewComponent::Base
+  attr_reader :column, :params, :title
+
+  def initialize(column:, params:, title:)
+    super
+    @column = column
+    @params = params
+    @title = title
+  end
+
+  def direction
+    column == params[:sort] && params[:direction] == 'ascending' ? 'descending' : 'ascending'
+  end
+
+  def full_title
+    "#{title} #{column_title_suffix(column)}"
+  end
+
+  private
+
+  def column_title_suffix(column)
+    if column == 'course'
+      direction == 'descending' ? '(z-a)' : '(a-z)'
+    else
+      ''
+    end
+  end
+end

--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -91,6 +91,10 @@ module Publish
       end
     end
 
+    def courses_by_accrediting_provider
+      @sorted_courses_by_accrediting_provider = ::Courses::Fetch.by_accrediting_provider_dynamically_sorted_list(provider, sort: params[:sort], direction: params[:direction])
+    end
+
     private
 
     def course_params
@@ -122,10 +126,6 @@ module Publish
       @provider ||= recruitment_cycle.providers
                                      .includes(courses: %i[sites site_statuses enrichments provider])
                                      .find_by!(provider_code: params[:provider_code])
-    end
-
-    def courses_by_accrediting_provider
-      @courses_by_accrediting_provider ||= ::Courses::Fetch.by_accrediting_provider(provider)
     end
 
     def self_accredited_courses

--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -91,10 +91,6 @@ module Publish
       end
     end
 
-    def courses_by_accrediting_provider
-      @sorted_courses_by_accrediting_provider = ::Courses::Fetch.by_accrediting_provider_dynamically_sorted_list(provider, sort: params[:sort], direction: params[:direction])
-    end
-
     private
 
     def course_params
@@ -126,6 +122,10 @@ module Publish
       @provider ||= recruitment_cycle.providers
                                      .includes(courses: %i[sites site_statuses enrichments provider])
                                      .find_by!(provider_code: params[:provider_code])
+    end
+
+    def courses_by_accrediting_provider
+      @sorted_courses_by_accrediting_provider = ::Courses::Fetch.by_accrediting_provider_dynamically_sorted_list(provider, sort: params[:sort], direction: params[:direction])
     end
 
     def self_accredited_courses

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,6 +36,12 @@ module ApplicationHelper
     end
   end
 
+  def sorted(column, title = nil)
+    title ||= column.titleize
+    direction = column == params[:sort] && params[:direction] == 'asc' ? 'desc' : 'asc'
+    link_to title, sort: column, direction:
+  end
+
   # TODO: refactor enrichment_summary method to not use an instance variable
   def enrichment_summary(summary_list, model, key, value, fields, action_path: nil, action_visually_hidden_text: nil, render_errors: true)
     action = render_action(action_path, action_visually_hidden_text || key.downcase)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,8 +38,8 @@ module ApplicationHelper
 
   def sorted(column, title = nil)
     title ||= column.titleize
-    direction = column == params[:sort] && params[:direction] == 'asc' ? 'desc' : 'asc'
-    link_to title, sort: column, direction:
+    direction = column == params[:sort] && params[:direction] == 'ascending' ? 'descending' : 'ascending'
+    link_to title, { sort: column, direction: }, class: 'govuk-link'
   end
 
   # TODO: refactor enrichment_summary method to not use an instance variable

--- a/app/services/courses/fetch.rb
+++ b/app/services/courses/fetch.rb
@@ -21,7 +21,7 @@ module Courses
 
         courses_by_provider.transform_values do |courses|
           sorted_courses = courses.sort_by { |course| sort_column(course, sort) }
-          sorted_courses.reverse! if sort_direction(direction) == 'desc'
+          sorted_courses.reverse! if sort_direction(direction) == 'descending'
           sorted_courses.map(&:decorate)
         end
       end
@@ -47,7 +47,7 @@ module Courses
       end
 
       def sort_direction(direction)
-        %w[asc desc].include?(direction) ? direction : 'asc'
+        %w[ascending descending].include?(direction) ? direction : 'ascending'
       end
 
       def status_order(course)

--- a/app/services/courses/fetch.rb
+++ b/app/services/courses/fetch.rb
@@ -11,21 +11,53 @@ module Courses
       end
 
       def by_accrediting_provider(provider)
+        sort_courses_by_accredited_provider(provider) do |provider_name, courses|
+          [provider_name, courses.sort_by { |course| [course.name, course.course_code] }.map(&:decorate)]
+        end
+      end
+
+      def by_accrediting_provider_dynamically_sorted_list(provider, sort:, direction:)
+        courses_by_provider = sort_courses_by_accredited_provider(provider)
+
+        courses_by_provider.transform_values do |courses|
+          sorted_courses = courses.sort_by { |course| sort_column(course, sort) }
+          sorted_courses.reverse! if sort_direction(direction) == 'desc'
+          sorted_courses.map(&:decorate)
+        end
+      end
+
+      private
+
+      def sort_courses_by_accredited_provider(provider)
         # rubocop:disable Style/MultilineBlockChain
-        # rubocop:disable Style/HashTransformValues
         provider
           .courses
           .group_by do |course|
-            course.accrediting_provider&.provider_name || provider.provider_name
-          rescue StandardError
-            provider.provider_name
-          end
-          .sort_by { |accrediting_provider, _| accrediting_provider.downcase }
-          .to_h do |provider_name, courses|
-            [provider_name, courses.sort_by { |course| [course.name, course.course_code] }.map(&:decorate)]
-          end
+          course.accrediting_provider&.provider_name || provider.provider_name
+        rescue StandardError
+          provider.provider_name
+        end
+        .sort_by { |accrediting_provider, _| accrediting_provider.downcase }
+          .to_h
         # rubocop:enable Style/MultilineBlockChain
-        # rubocop:enable Style/HashTransformValues
+      end
+
+      def sort_column(course, sort)
+        sort == 'status' ? status_order(course) : course.name
+      end
+
+      def sort_direction(direction)
+        %w[asc desc].include?(direction) ? direction : 'asc'
+      end
+
+      def status_order(course)
+        content_status_order = %i[draft rolled_over scheduled open closed published_with_unpublished_changes published withdrawn]
+        application_status_order = { 'open' => 0, 'closed' => 1 }
+
+        content_index = content_status_order.index(course.content_status) || content_status_order.size
+        application_index = application_status_order[course.application_status] || application_status_order.size
+
+        [content_index, application_index]
       end
     end
   end

--- a/app/views/publish/courses/_course_table.html.erb
+++ b/app/views/publish/courses/_course_table.html.erb
@@ -2,16 +2,10 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" aria-sort="<%= params[:sort] == "course" ? params[:direction] : "none" %>">
-        <button type="button">
-          <%= sorted "course", "Course #{params[:direction] == 'ascending' ? '(a-z)' : '(z-a)'}" %>
-          <span class="govuk-visually-hidden">Sort by course</span>
-        </button>
+         <%= render SortableTableHeader.new(column: "course", params:, title: "Course") %>
       </th>
       <th class="govuk-table__header" aria-sort="<%= params[:sort] == "status" ? params[:direction] : "none" %>">
-        <button type="button">
-          <%= sorted "status" %>
-          <span class="govuk-visually-hidden">Sort by status</span>
-        </button>
+        <%= render SortableTableHeader.new(column: "status", params:, title: "Status") %>
       </th>
       <th class="govuk-table__header">
        Is it on <abbr class="app-!-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?

--- a/app/views/publish/courses/_course_table.html.erb
+++ b/app/views/publish/courses/_course_table.html.erb
@@ -1,11 +1,17 @@
 <table class="govuk-table app-table--vertical-align-middle app-table--courses">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header">
-        <%= sorted "course" %>
+      <th class="govuk-table__header" aria-sort="<%= params[:sort] == "course" ? params[:direction] : "none" %>">
+        <button type="button">
+          <%= sorted "course", "Course #{params[:direction] == 'ascending' ? '(a-z)' : '(z-a)'}" %>
+          <span class="govuk-visually-hidden">Sort by course</span>
+        </button>
       </th>
-      <th class="govuk-table__header">
-        <%= sorted "status" %>
+      <th class="govuk-table__header" aria-sort="<%= params[:sort] == "status" ? params[:direction] : "none" %>">
+        <button type="button">
+          <%= sorted "status" %>
+          <span class="govuk-visually-hidden">Sort by status</span>
+        </button>
       </th>
       <th class="govuk-table__header">
        Is it on <abbr class="app-!-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?

--- a/app/views/publish/courses/_course_table.html.erb
+++ b/app/views/publish/courses/_course_table.html.erb
@@ -1,8 +1,12 @@
 <table class="govuk-table app-table--vertical-align-middle app-table--courses">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header">Course</th>
-      <th class="govuk-table__header">Status</th>
+      <th class="govuk-table__header">
+        <%= sorted "course" %>
+      </th>
+      <th class="govuk-table__header">
+        <%= sorted "status" %>
+      </th>
       <th class="govuk-table__header">
        Is it on <abbr class="app-!-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
       </th>

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -11,7 +11,7 @@
   </section>
 <% end %>
 
-<% @courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
+<% @sorted_courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
   <section data-qa="courses__table-section">
     <h2 class="govuk-heading-m">
       <span class="govuk-caption-m">Accredited provider</span>

--- a/spec/components/sortable_table_header_preview.rb
+++ b/spec/components/sortable_table_header_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SortableTableHeaderPreview < ViewComponent::Preview
+  def course_ascending
+    render(SortableTableHeader.new(column: 'course', title: 'Course (a-z)', params: ActionController::Parameters.new(sort: 'course', direction: 'ascending')))
+  end
+
+  def course_descending
+    render(SortableTableHeader.new(column: 'course', title: 'Course (z-a)', params: ActionController::Parameters.new(sort: 'course', direction: 'descending')))
+  end
+
+  def course_status
+    render(SortableTableHeader.new(column: 'status', title: 'Status', params: ActionController::Parameters.new(sort: 'course', direction: 'descending')))
+  end
+end

--- a/spec/components/sortable_table_header_spec.rb
+++ b/spec/components/sortable_table_header_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SortableTableHeader, type: :component do
+  describe '.direction' do
+    it "returns 'descending' when column matches sort and direction is 'ascending'" do
+      params = ActionController::Parameters.new(sort: 'course', direction: 'ascending')
+      title = "Course #{params[:direction] == 'ascending' ? '(a-z)' : '(z-a)'}"
+
+      sortable_table_header = described_class.new(column: 'course', params:, title:)
+      expect(sortable_table_header.direction).to eq('descending')
+    end
+
+    it "returns 'descending' when column matches sort and direction is 'descending'" do
+      params = ActionController::Parameters.new(sort: 'course', direction: 'descending')
+      title = "Course #{params[:direction] == 'ascending' ? '(a-z)' : '(z-a)'}"
+
+      sortable_table_header = described_class.new(column: 'course', params:, title:)
+      expect(sortable_table_header.direction).to eq('ascending')
+    end
+
+    it "returns 'ascending' when column does not match sort or direction is not 'ascending'" do
+      params = ActionController::Parameters.new(sort: 'status', direction: 'descending')
+
+      sortable_table_header = described_class.new(column: 'status', params:, title: "Course #{params[:direction] == 'ascending' ? '(a-z)' : '(z-a)'}")
+      expect(sortable_table_header.direction).to eq('ascending')
+    end
+  end
+end

--- a/spec/features/publish/sorting_courses_list_spec.rb
+++ b/spec/features/publish/sorting_courses_list_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Sorting courses list', { can_edit_current_and_next_cycles: false } do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+    when_i_visit_the_courses_page
+  end
+
+  scenario 'i can sort alphabetically' do
+    when_i_click_on_the_course_a_z_heading
+    then_i_see_courses_ordered_alphabetically_ascending
+
+    when_i_click_on_the_course_z_a_heading
+    then_i_see_courses_ordered_alphabetically_descending
+  end
+
+  scenario 'i can sort by status' do
+    when_i_click_on_the_status_heading
+    then_i_see_courses_ordered_by_status
+
+    when_i_click_on_the_status_heading
+    then_i_see_courses_ordered_by_status_in_reverse
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          create(:provider, :accredited_provider, sites: [build(:site)], courses: [build(:course, :open, :published, name: 'A'), build(:course, :closed, :published, name: 'B'), build(:course, :withdrawn, name: 'C')])
+        ]
+      )
+    )
+  end
+
+  def when_i_visit_the_courses_page
+    publish_provider_courses_index_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def course
+    @course ||= provider.courses.first
+  end
+
+  def when_i_click_on_the_course_a_z_heading
+    click_on('Course (a-z)')
+  end
+
+  def when_i_click_on_the_course_z_a_heading
+    click_on('Course (z-a)')
+  end
+
+  def when_i_click_on_the_status_heading
+    click_on('Status')
+  end
+
+  def then_i_see_courses_ordered_alphabetically_ascending
+    expect(page).to have_css('tbody.govuk-table__body tr.govuk-table__row:nth-child(1) a', text: 'A')
+    expect(page).to have_css('tbody.govuk-table__body tr.govuk-table__row:nth-child(2) a', text: 'B')
+    expect(page).to have_css('tbody.govuk-table__body tr.govuk-table__row:nth-child(3) a', text: 'C')
+  end
+
+  def then_i_see_courses_ordered_alphabetically_descending
+    expect(page).to have_css('tbody.govuk-table__body tr.govuk-table__row:nth-child(1) a', text: 'C')
+    expect(page).to have_css('tbody.govuk-table__body tr.govuk-table__row:nth-child(2) a', text: 'B')
+    expect(page).to have_css('tbody.govuk-table__body tr.govuk-table__row:nth-child(3) a', text: 'A')
+  end
+
+  def then_i_see_courses_ordered_by_status
+    expect(page).to have_css('tbody.govuk-table__body tr:nth-child(1) .govuk-tag--turquoise', text: 'Open')
+    expect(page).to have_css('tbody.govuk-table__body tr:nth-child(2) .govuk-tag--purple', text: 'Closed')
+    expect(page).to have_css('tbody.govuk-table__body tr:nth-child(3) .govuk-tag--red', text: 'Withdrawn')
+  end
+
+  def then_i_see_courses_ordered_by_status_in_reverse
+    expect(page).to have_css('tbody.govuk-table__body tr:nth-child(1) .govuk-tag--red', text: 'Withdrawn')
+    expect(page).to have_css('tbody.govuk-table__body tr:nth-child(2) .govuk-tag--purple', text: 'Closed')
+    expect(page).to have_css('tbody.govuk-table__body tr:nth-child(3) .govuk-tag--turquoise', text: 'Open')
+  end
+end

--- a/spec/services/courses/fetch_spec.rb
+++ b/spec/services/courses/fetch_spec.rb
@@ -17,4 +17,43 @@ describe Courses::Fetch do
              )).to eq(course)
     end
   end
+
+  describe '.by_accrediting_provider_dynamically_sorted_list' do
+    context 'when sorting alphabetically by course name' do
+      let(:provider) { build(:provider, courses: [course_a, course_b, course_c]) }
+      let(:course_a) { build(:course, name: 'a') }
+      let(:course_b) { build(:course, name: 'b') }
+      let(:course_c) { build(:course, name: 'c') }
+
+      it 'sorts courses in ascending order' do
+        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'course', direction: 'asc')
+        expect(sorted_courses.values.flatten).to eq([course_a, course_b, course_c])
+      end
+
+      it 'sorts courses in descending order' do
+        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'course', direction: 'desc')
+        expect(sorted_courses.values.flatten).to eq([course_c, course_b, course_a])
+      end
+    end
+
+    context 'when sorting by status' do
+      let(:provider) { build(:provider, courses: [draft_course, open_course, closed_course, withdrawn_course, rolled_over_course, published_with_unpublished_changes_course]) }
+      let(:open_course) { build(:course, :open, :published) }
+      let(:closed_course) { build(:course, :closed, :published) }
+      let(:withdrawn_course) { build(:course, :withdrawn) }
+      let(:draft_course) { build(:course, enrichments: [build(:course_enrichment, :draft)]) }
+      let(:rolled_over_course) { build(:course, enrichments: [build(:course_enrichment, :rolled_over)]) }
+      let(:published_with_unpublished_changes_course) { build(:course, enrichments: [build(:course_enrichment, :subsequent_draft)]) }
+
+      it 'sorts courses by content_status and application_status in the correct ascending order' do
+        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'status', direction: 'asc')
+        expect(sorted_courses.values.flatten).to eq([draft_course, rolled_over_course, published_with_unpublished_changes_course, open_course, closed_course, withdrawn_course])
+      end
+
+      it 'sorts courses by content_status and application_status in descending order' do
+        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'status', direction: 'desc')
+        expect(sorted_courses.values.flatten).to eq([withdrawn_course, closed_course, open_course, published_with_unpublished_changes_course, rolled_over_course, draft_course])
+      end
+    end
+  end
 end

--- a/spec/services/courses/fetch_spec.rb
+++ b/spec/services/courses/fetch_spec.rb
@@ -26,12 +26,12 @@ describe Courses::Fetch do
       let(:course_c) { build(:course, name: 'c') }
 
       it 'sorts courses in ascending order' do
-        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'course', direction: 'asc')
+        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'course', direction: 'ascending')
         expect(sorted_courses.values.flatten).to eq([course_a, course_b, course_c])
       end
 
       it 'sorts courses in descending order' do
-        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'course', direction: 'desc')
+        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'course', direction: 'descending')
         expect(sorted_courses.values.flatten).to eq([course_c, course_b, course_a])
       end
     end
@@ -46,12 +46,12 @@ describe Courses::Fetch do
       let(:published_with_unpublished_changes_course) { build(:course, enrichments: [build(:course_enrichment, :subsequent_draft)]) }
 
       it 'sorts courses by content_status and application_status in the correct ascending order' do
-        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'status', direction: 'asc')
+        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'status', direction: 'ascending')
         expect(sorted_courses.values.flatten).to eq([draft_course, rolled_over_course, published_with_unpublished_changes_course, open_course, closed_course, withdrawn_course])
       end
 
       it 'sorts courses by content_status and application_status in descending order' do
-        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'status', direction: 'desc')
+        sorted_courses = described_class.by_accrediting_provider_dynamically_sorted_list(provider, sort: 'status', direction: 'descending')
         expect(sorted_courses.values.flatten).to eq([withdrawn_course, closed_course, open_course, published_with_unpublished_changes_course, rolled_over_course, draft_course])
       end
     end


### PR DESCRIPTION
### Context

We are introducing new sorting capabilities for courses. You can now sort courses alphabetically (in both ascending and descending order) as well as by a predefined sequence based on `content_status` and `application_status`.

### Changes proposed in this pull request

- Change the "Course" header into a clickable link that sorts the list from a-z or z-a

- The clickable link dynamically renders a-z or z-a depending on which one it's ordered by.

- Add arrows next to the new links which represent the direction (ascending or descending)


### Guidance to review

Create courses with a wide range of status's and ensure the sorting works as expected. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
