### PR TITLE
[225] Update wording to reflect multiple study sites

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -30,7 +30,7 @@
       </h3>
 
       <p class="govuk-body">
-        The theoretical learning part of your course will be at the following location.
+        <%= "The theoretical learning part of your course will be at the following #{course.study_sites.many? ? 'locations' : 'location'}." %>
       </p>
 
       <ul class="govuk-list govuk-list--spaced" id="course_study_sites">


### PR DESCRIPTION
### Context

Our automated study sites wording on Find does not reflect that a user can have multiple study sites.

### Changes proposed in this pull request

Pluralize the word location if the user has multiple study sites.

The whole study sites section is not shown if the user doesn't have any study sites.

### Before at all times

<img width="708" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/fd621993-c687-45d0-b733-c36cc8f54913">


### After with a single study site

<img width="817" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/7d9d9d45-79dc-41f1-9ed8-774f7547e20e">


### After with multiple study sites

<img width="770" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/5b36aaa4-cd47-4709-813f-3b4b91aecb27">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
