### PR TITLE
[1980] Set `personal_qualities` and `other_requirements` to nil during rollover

### DIFF
--- a/app/services/enrichments/copy_to_course_service.rb
+++ b/app/services/enrichments/copy_to_course_service.rb
@@ -4,10 +4,8 @@ module Enrichments
   class CopyToCourseService
     def execute(enrichment:, new_course:)
       new_enrichment = enrichment.dup
-      new_json_data = new_enrichment.json_data.dup
-      new_json_data.delete('PersonalQualities')
-      new_json_data.delete('OtherRequirements')
-      new_enrichment.json_data = new_json_data
+      new_enrichment.personal_qualities = nil
+      new_enrichment.other_requirements = nil
       new_enrichment.last_published_timestamp_utc = nil
       new_enrichment.rolled_over!
       new_course.enrichments << new_enrichment

--- a/spec/services/enrichments/copy_to_course_service_spec.rb
+++ b/spec/services/enrichments/copy_to_course_service_spec.rb
@@ -27,22 +27,8 @@ describe Enrichments::CopyToCourseService do
 
     its(:about_course) { is_expected.to eq published_enrichment.about_course }
     its(:last_published_timestamp_utc) { is_expected.to be_nil }
+    its(:other_requirements) { is_expected.to be_nil }
+    its(:personal_qualities) { is_expected.to be_nil }
     it { is_expected.to be_rolled_over }
-
-    it 'removes PersonalQualities from the json_data' do
-      expect(subject.json_data).not_to have_key('PersonalQualities')
-    end
-
-    it 'removes OtherRequirements from the json_data' do
-      expect(subject.json_data).not_to have_key('OtherRequirements')
-    end
-
-    it 'sets other_requirements to nil' do
-      expect(subject.other_requirements).to be_nil
-    end
-
-    it 'sets personal_qualities to nil' do
-      expect(subject.personal_qualities).to be_nil
-    end
   end
 end


### PR DESCRIPTION
### Context

We previously opened a PR to delete the keys. This causes validation to kick in and prevents the rollover script from executing properly. 

We still have `personal_qualities` and  `other_requirements` in the current cycle.

### Changes proposed in this pull request

 Set `personal_qualities` and `other_requirements` to `nil` during rollover.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
