### PR TITLE
Don't show the A level change link when the course is withdrawn

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -48,6 +48,8 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def a_level_change_path
+    return if object.is_withdrawn?
+
     if object.a_level_subject_requirements.present?
       h.publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
         object.provider.provider_code,

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -962,6 +962,20 @@ describe CourseDecorator do
   describe '#a_level_change_path' do
     subject(:a_level_change_path) { course.decorate.a_level_change_path }
 
+    context 'when course is withdrawn' do
+      let(:course) do
+        build(
+          :course,
+          :with_a_level_requirements,
+          :withdrawn
+        )
+      end
+
+      it 'returns nil' do
+        expect(a_level_change_path).to be_nil
+      end
+    end
+
     context 'when course does not have an A level subject requirement' do
       let(:course) do
         build(


### PR DESCRIPTION
### Context

Do not show the A levels change link for a withdrawn course.

### Changes proposed in this pull request

Remove the change link for a withdrawn course.

## Trello card

https://trello.com/c/y0tYPgD4/2005-bug-tda-incorrectly-able-to-change-a-levels-on-a-withdrawn-course

### What this PR does not address?

If you access the pages directly you can edit, but this is log in a different card therefore in a different PR: https://trello.com/c/BQDAr1dm/2017-bug-can-access-the-edit-page-of-a-withdrawn-course-by-navigating-directly-to-url-using-course-code?search_id=dba419e6-1429-4ebb-8e24-2bd430913acd
