### PR TITLE
[2016] Prevent the creation of a user which already exists under the same provider

### DIFF
--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -27,7 +27,7 @@ module Publish
     end
 
     def create
-      @user_form = UserForm.new(current_user, user, params: user_params)
+      @user_form = UserForm.new(current_user, user, params: user_params, provider:)
       if @user_form.stash
         redirect_to publish_provider_check_user_path(provider_code: params[:provider_code])
       else

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -31,7 +31,7 @@ module Support
 
       def create
         provider
-        @user_form = UserForm.new(current_user, user, params: user_params)
+        @user_form = UserForm.new(current_user, user, params: user_params, provider:)
         if @user_form.stash
           redirect_to support_recruitment_cycle_provider_check_user_path
         else

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -10,12 +10,24 @@ class UserForm < Form
 
   attr_accessor(*FIELDS)
 
+  def initialize(identifier_model, model, params: {}, provider: nil)
+    @provider = provider
+    super(identifier_model, model, params:)
+  end
+
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true
   validates :email, email_address: true
+  validate :email_unique_for_provider
 
   def compute_fields
     model.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+  end
+
+  private
+
+  def email_unique_for_provider
+    errors.add(:email, 'Email address already in use') if @provider&.users&.exists?(email:)
   end
 end

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -33,6 +33,16 @@ feature 'Adding user to organisation as a provider user', { can_edit_current_and
 
       then_it_should_display_the_correct_error_messages
     end
+
+    scenario 'With an email that already exists' do
+      given_i_visit_the_publish_users_new_page
+      and_i_fill_in_first_name
+      and_i_fill_in_last_name
+      and_i_fill_in_email_with_one_that_is_already_associated_with_the_provider
+      when_i_continue
+      then_i_see_the_validation_error_message
+      and_i_am_still_on_the_same_page
+    end
   end
 
   describe 'Viewing a user in an organisation' do
@@ -121,8 +131,8 @@ feature 'Adding user to organisation as a provider user', { can_edit_current_and
 
   def given_i_am_authenticated_as_a_provider_user
     @provider = create(:provider, provider_name: "Batman's Chocolate School")
-    @user = create(:user, first_name: 'Mr', last_name: 'User', providers: [@provider])
-    @user2 = create(:user, first_name: 'Mr', last_name: 'Cool', providers: [@provider])
+    @user = create(:user, first_name: 'Mr', last_name: 'User', email: 'mruser@fake.com', providers: [@provider])
+    @user2 = create(:user, first_name: 'Mr', last_name: 'Cool', email: 'mrcool@fake.com', providers: [@provider])
     given_i_am_authenticated(user: @user)
   end
 
@@ -152,9 +162,15 @@ feature 'Adding user to organisation as a provider user', { can_edit_current_and
     publish_users_new_page.email.set('willy.wonka@bat-school.com')
   end
 
+  def and_i_fill_in_email_with_one_that_is_already_associated_with_the_provider
+    publish_users_new_page.email.set('mruser@fake.com')
+  end
+
   def and_i_continue
     click_link_or_button 'Continue'
   end
+
+  alias_method :when_i_continue, :and_i_continue
 
   def and_i_am_on_the_check_page
     expect(publish_users_check_page).to be_displayed(provider_code: @provider.provider_code)
@@ -315,5 +331,13 @@ feature 'Adding user to organisation as a provider user', { can_edit_current_and
 
   def user_in_db_with_name(first_name)
     Provider.find_by(provider_name: "Batman's Chocolate School").users.exists?(first_name:)
+  end
+
+  def then_i_see_the_validation_error_message
+    expect(page).to have_css('.govuk-error-summary__body', text: 'Email address already in use')
+  end
+
+  def and_i_am_still_on_the_same_page
+    expect(publish_users_index_page).to be_displayed(provider_code: @provider.provider_code)
   end
 end

--- a/spec/features/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/features/support/providers/users/adding_user_to_provider_spec.rb
@@ -36,6 +36,16 @@ feature 'Adding user to provider as an admin', :with_publish_constraint, { can_e
 
       then_it_should_display_the_correct_error_messages
     end
+
+    scenario 'With an email that already exists' do
+      given_i_visit_the_support_provider_users_new_page
+      and_i_fill_in_first_name
+      and_i_fill_in_last_name
+      and_i_fill_in_email_with_one_that_is_already_associated_with_the_provider
+      when_i_continue
+      then_i_see_the_validation_error_message
+      and_i_am_still_on_the_same_page
+    end
   end
 
   def and_there_is_a_provider
@@ -46,9 +56,15 @@ feature 'Adding user to provider as an admin', :with_publish_constraint, { can_e
     support_provider_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
   end
 
+  def given_i_visit_the_support_provider_users_new_page
+    support_provider_users_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
+  end
+
   def and_i_continue
     support_provider_user_users_new_page.submit.click
   end
+
+  alias_method :when_i_continue, :and_i_continue
 
   def given_i_visit_the_support_provider_users_new_page
     support_provider_user_users_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
@@ -64,6 +80,10 @@ feature 'Adding user to provider as an admin', :with_publish_constraint, { can_e
 
   def and_i_fill_in_email
     support_provider_user_users_new_page.email.set('viola_fisher@boyle.io')
+  end
+
+  def and_i_fill_in_email_with_one_that_is_already_associated_with_the_provider
+    support_provider_user_users_new_page.email.set(@provider.users.first.email)
   end
 
   def and_i_click_add_user
@@ -106,6 +126,14 @@ feature 'Adding user to provider as an admin', :with_publish_constraint, { can_e
 
   def and_i_enter_a_new_first_name
     support_provider_user_users_new_page.first_name.set('Aba')
+  end
+
+  def then_i_see_the_validation_error_message
+    expect(page).to have_css('.govuk-error-summary__body', text: 'Email address already in use')
+  end
+
+  def and_i_am_still_on_the_same_page
+    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers/#{@provider.id}/users")
   end
 
   def given_i_am_authenticated_as_an_admin_user


### PR DESCRIPTION
### Context

With out current implementation a user can add another user even if they already exist under that provider. This then updates the already existing user with the new first name and last name.

### Changes proposed in this pull request

This will prevent submission of the `/new` page if the email address that is inputted already exists in the database under the provider.

### Guidance to review

Try to add a user with an email which already used in the provider that you are logged in as.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
