### PR TITLE
Revert "Activate rollover in QA"

### DIFF
--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -32,12 +32,6 @@ basic_auth:
 features:
   send_request_data_to_bigquery: true
   teacher_degree_apprenticeship: true
-  rollover:
-    # Normally a short period of time between rollover and the next cycle
-    # actually starting when it would be set to false
-    has_current_cycle_started?: true
-    # During rollover providers should be able to edit current & next recruitment cycle courses
-    can_edit_current_and_next_cycles: true
 
 find_valid_referers:
   - https://qa.find-postgraduate-teacher-training.service.gov.uk


### PR DESCRIPTION
Rollover is no longer active in QA, we should disable it again.