### PR TITLE
Increase alert_window_size to 1h for stg monitors

### DIFF
--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -18,7 +18,7 @@
     }
   },
   "enable_find": true,
-  "alert_window_size": "PT30M",
+  "alert_window_size": "PT1H",
   "additional_hostnames": [
     "staging.publish-teacher-training-courses.service.gov.uk",
     "staging.find-postgraduate-teacher-training.service.gov.uk",


### PR DESCRIPTION
### Context

https://trello.com/c/BoARcUFk/1922-publish-increase-staging-db-cpu-alert-window

To stop the alerts for staging postgres db cpu usage during the nightly backup restore

### Changes proposed in this pull request

Increase alert_window_size from 30m to 1h

### Guidance to review

make staging deploy-plan

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
