### PR TITLE
Training with disabilities view on courses

### DIFF
--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -36,7 +36,7 @@ module CoursePreview
     def fee_uk_eu_link = fees_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
     def gcse_link = gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
     def how_school_placements_work_link = school_placements_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
-    def train_with_disability_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true, anchor: 'train-with-disability')
+    def train_with_disability_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true, anchor: 'train-with-disability')
     def train_with_us_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true, anchor: 'train-with-us')
 
     def about_accrediting_provider_link

--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -16,7 +16,7 @@
   <% end %>
   <li><%= govuk_link_to "International candidates", "#section-international-students" %></li>
   <% if provider.train_with_disability.present? || preview? %>
-    <li><%= govuk_link_to "Training with disabilities and other needs", "#section-train-with-disabilities" %></li>
+    <li><%= govuk_link_to "Training with disabilities", "#section-train-with-disabilities" %></li>
   <% end %>
   <li><%= govuk_link_to "Support and advice", "#section-advice" %></li>
   <% if course.application_status_open? %> <li><%= govuk_link_to "Apply", "#section-apply" %></li> <% end %>

--- a/app/controllers/concerns/goto_preview.rb
+++ b/app/controllers/concerns/goto_preview.rb
@@ -8,5 +8,4 @@ module GotoPreview
   end
 
   def goto_preview? = params.dig(param_form_key, :goto_preview) == 'true'
-  def goto_provider? = params.dig(param_form_key, :goto_provider) == 'true'
 end

--- a/app/controllers/find/courses/training_with_disabilities_controller.rb
+++ b/app/controllers/find/courses/training_with_disabilities_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Find
+  module Courses
+    class TrainingWithDisabilitiesController < Find::ApplicationController
+      before_action -> { render_not_found if provider.nil? }
+      before_action -> { render_not_found if provider.train_with_disability.blank? }
+
+      def show
+        @course = provider.courses.includes(
+          :enrichments,
+          subjects: [:financial_incentive],
+          site_statuses: [:site]
+        ).find_by!(course_code: params[:course_code]&.upcase).decorate
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/training_with_disabilities_controller.rb
+++ b/app/controllers/publish/courses/training_with_disabilities_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Publish
+  module Courses
+    class TrainingWithDisabilitiesController < PublishController
+      include CourseBasicDetailConcern
+      before_action :build_course, only: %i[show]
+
+      def show; end
+
+      private
+
+      def build_course
+        super
+        authorize @course
+      end
+    end
+  end
+end

--- a/app/forms/publish/about_your_organisation_form.rb
+++ b/app/forms/publish/about_your_organisation_form.rb
@@ -2,6 +2,8 @@
 
 module Publish
   class AboutYourOrganisationForm < BaseProviderForm
+    include Rails.application.routes.url_helpers
+
     validates :train_with_us, presence: { message: 'Enter details about training with you' }, if: :train_with_us_changed?
     validates :train_with_disability, presence: { message: 'Enter details about training with a disability' }, if: :train_with_disability_changed?
 
@@ -10,6 +12,12 @@ module Publish
 
     validate :add_enrichment_errors
 
+    def initialize(model, params: {}, redirect_params: {}, course_code: nil)
+      super(model, params:)
+      @redirect_params = redirect_params
+      @course_code = course_code
+    end
+
     FIELDS = %i[
       train_with_us
       train_with_disability
@@ -17,12 +25,42 @@ module Publish
     ].freeze
 
     attr_accessor(*FIELDS)
+    attr_reader :redirect_params, :course_code
 
     def accredited_bodies
       @accredited_bodies ||= provider.accredited_bodies.map do |ab|
         accredited_provider(**ab)
       end
     end
+
+    def update_success_path
+      case redirection_key
+      when 'goto_preview'
+        preview_publish_provider_recruitment_cycle_course_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year,
+          course_code
+        )
+      when 'goto_provider'
+        provider_publish_provider_recruitment_cycle_course_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year,
+          course_code
+        )
+      when 'goto_training_with_disabilities'
+        training_with_disabilities_publish_provider_recruitment_cycle_course_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year,
+          course_code
+        )
+      else
+        details_publish_provider_recruitment_cycle_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year
+        )
+      end
+    end
+    alias back_path update_success_path
 
     private
 
@@ -80,6 +118,10 @@ module Publish
       end }
 
       attr_accessor :provider_name, :provider_code, :description
+    end
+
+    def redirection_key
+      redirect_params.select { |_k, v| v == 'true' }&.keys&.first
     end
   end
 end

--- a/app/helpers/find/goto_preview_helper.rb
+++ b/app/helpers/find/goto_preview_helper.rb
@@ -14,8 +14,8 @@ module Find
       params[:goto_provider] || params.dig(param_form_key, :goto_provider)
     end
 
-    def goto_provider?(param_form_key:, params:)
-      goto_provider_value(param_form_key:, params:) == 'true'
+    def goto_training_with_disabilities_value(param_form_key:, params:)
+      params[:goto_training_with_disabilities] || params.dig(param_form_key, :goto_training_with_disabilities)
     end
 
     def back_link_path(param_form_key:, params:, provider_code:, recruitment_cycle_year:, course_code:)

--- a/app/helpers/preview_helper.rb
+++ b/app/helpers/preview_helper.rb
@@ -4,6 +4,7 @@ module PreviewHelper
   def preview?(params)
     params[:action] == 'preview' ||
       params[:action].nil? ||
-      (params[:controller] == 'publish/courses/providers' && params[:action] == 'show')
+      (params[:controller] == 'publish/courses/providers' && params[:action] == 'show') ||
+      (params[:controller] == 'publish/courses/training_with_disabilities' && params[:action] == 'show')
   end
 end

--- a/app/views/find/courses/_train_with_disabilities.html.erb
+++ b/app/views/find/courses/_train_with_disabilities.html.erb
@@ -1,10 +1,11 @@
-<div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-train-with-disabilities">Training with disabilities and other needs</h2>
-  <div data-qa="course__train_with_disabilities">
-    <% if course.provider.train_with_disability.present? %>
-      <%= markdown(course.provider.train_with_disability) %>
-    <% else %>
-      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :train_with_disability, is_preview: preview?(params)) %>
-    <% end %>
-  </div>
+<h1 class="govuk-heading-xl" id="section-train-with-disabilities">
+  <%= t(".heading", provider_name: course.provider_name) %>
+</h1>
+
+<div data-qa="course__train_with_disabilities">
+  <% if course.provider.train_with_disability.present? %>
+    <%= markdown(course.provider.train_with_disability) %>
+  <% else %>
+    <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :train_with_disability, is_preview: preview?(params)) %>
+  <% end %>
 </div>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -54,7 +54,19 @@
     <%= render Find::Courses::InternationalStudentsComponent::View.new(course: @course) %>
 
     <% if @provider.train_with_disability.present? %>
-      <%= render partial: "find/courses/train_with_disabilities", locals: { course: @course } %>
+      <h2 class="govuk-heading-l" id="section-train-with-disabilities">
+        <%= t(".training_with_disabilities") %>
+      </h2>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(
+          t(".training_with_disabilities_link", provider_name: @course.provider_name),
+          find_training_with_disabilities_path(
+            @course.provider_code,
+            @course.course_code
+          )
+        ) %>
+      </p>
     <% end %>
 
     <%= render partial: "find/courses/advice", locals: { course: @course } %>

--- a/app/views/find/courses/training_with_disabilities/show.html.erb
+++ b/app/views/find/courses/training_with_disabilities/show.html.erb
@@ -1,0 +1,29 @@
+<%= content_for :page_title do %>
+  <%= t(".heading", provider_name: @course.provider_name) %>
+<% end %>
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    href: search_ui_course_page_url(
+      provider_code: @course.provider_code,
+      course_code: @course.course_code
+    ),
+    text: t(
+      ".back",
+      course_name: @course.name,
+      course_code: @course.course_code
+    )
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "find/courses/train_with_disabilities", locals: { course: @course } %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(
+        t(".contact", provider_name: @course.provider_name),
+        find_provider_path(@course.provider_code, @course.course_code)
+      ) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -43,7 +43,20 @@
 
     <%= render Find::Courses::InternationalStudentsComponent::View.new(course:) %>
 
-    <%= render partial: "find/courses/train_with_disabilities", locals: { course: } %>
+    <h2 class="govuk-heading-l" id="section-train-with-disabilities">
+      <%= t(".training_with_disabilities") %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(
+        t(".training_with_disabilities_link", provider_name: course.provider_name),
+        training_with_disabilities_publish_provider_recruitment_cycle_course_path(
+          course.provider_code,
+          course.recruitment_cycle_year,
+          course.course_code
+        )
+      ) %>
+    </p>
 
     <%= render partial: "find/courses/advice", locals: { course: } %>
 

--- a/app/views/publish/courses/training_with_disabilities/show.html.erb
+++ b/app/views/publish/courses/training_with_disabilities/show.html.erb
@@ -1,0 +1,34 @@
+<%= content_for :page_title do %>
+  <%= t(".heading", provider_name: @course.provider_name) %>
+<% end %>
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    href: preview_publish_provider_recruitment_cycle_course_path(
+      @course.provider_code,
+      @course.recruitment_cycle_year,
+      @course.course_code
+    ),
+    text: t(
+      ".back",
+      course_name: @course.name,
+      course_code: @course.course_code
+    )
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "find/courses/train_with_disabilities", locals: { course: } %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(
+        t(".contact", provider_name: @course.provider_name),
+        provider_publish_provider_recruitment_cycle_course_path(
+          @course.provider_code,
+          @course.recruitment_cycle_year,
+          @course.course_code
+        )
+      ) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -10,19 +10,7 @@
     ) do |f| %>
 
       <% content_for :before_content do %>
-       <% if goto_provider?(param_form_key: f.object_name.to_sym, params:) %>
-         <%= govuk_back_link_to(
-            provider_publish_provider_recruitment_cycle_course_path(
-              @provider.provider_code,
-              @provider.recruitment_cycle_year,
-              params[:course_code] || params.dig(f.object_name.to_sym, :course_code)
-            )
-          ) %>
-       <% elsif goto_preview?(param_form_key: f.object_name.to_sym, params:) %>
-        <%= govuk_back_link_to(preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, (params[:course_code] || params.dig(f.object_name.to_sym, :course_code)))) %>
-        <% else %>
-          <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
-        <% end %>
+        <%= govuk_back_link_to(@about_form.back_path) %>
       <% end %>
 
       <%= f.govuk_error_summary %>

--- a/app/views/publish/providers/about.html.erb
+++ b/app/views/publish/providers/about.html.erb
@@ -75,6 +75,7 @@
         rows: 15) %>
       <%= f.hidden_field(:goto_preview, value: goto_preview_value(param_form_key: f.object_name.to_sym, params:)) %>
       <%= f.hidden_field(:goto_provider, value: goto_provider_value(param_form_key: f.object_name.to_sym, params:)) %>
+      <%= f.hidden_field(:goto_training_with_disabilities, value: goto_training_with_disabilities_value(param_form_key: f.object_name.to_sym, params:)) %>
       <%= f.hidden_field(:course_code, value: params[:course_code] || params.dig(f.object_name.to_sym, :course_code)) %>
 
       <%= f.govuk_submit "Save and publish" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,15 @@ en:
     add: "Add user"
     update: "Update user"
   publish:
+    courses:
+      training_with_disabilities:
+        show:
+          heading: Training with disabilities and other needs at %{provider_name}
+          back: Back to %{course_name} (%{course_code})
+          contact: Contact %{provider_name}
+      preview:
+        training_with_disabilities: Training with disabilities
+        training_with_disabilities_link: Find out about training with disabilities and other needs at %{provider_name}.
     providers:
       courses:
         accredited_provider:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -71,6 +71,8 @@ en:
       primary_title: Primary courses with subject specialisms
       secondary_title: Which secondary subjects do you want to teach?
     courses:
+      train_with_disabilities:
+        heading: Training with disabilities and other needs at %{provider_name}
       summary_component:
         view:
           fee_or_salary: Fee or salary
@@ -104,6 +106,11 @@ en:
           telephone: Telephone
           school_website: School Website
           address: Address
+      training_with_disabilities:
+        show:
+          heading: Training with disabilities and other needs at %{provider_name}
+          back: Back to %{course_name} (%{course_code})
+          contact: Contact %{provider_name}
       about_schools_component:
         view:
           view_list_of_school_placements: View list of school placements
@@ -118,6 +125,8 @@ en:
         not_consider_a_level_equivalency: We will not consider candidates who need to take A level equivalency tests.
       show:
         back_to_search: Back to search results
+        training_with_disabilities: Training with disabilities
+        training_with_disabilities_link: Find out about training with disabilities and other needs at %{provider_name}.
     scholarships:
       physics:
         body: Institute of Physics

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -22,6 +22,7 @@ namespace :find, path: '/' do
   scope module: :courses, path: '/courses' do
     get '/:provider_code/:course_code/provider', to: 'providers#show', as: :provider
     get '/:provider_code/:course_code/accredited-by', to: 'accrediting_providers#show', as: :accrediting_provider
+    get '/:provider_code/:course_code/training-with-disabilities', to: 'training_with_disabilities#show', as: :training_with_disabilities
   end
 
   get '/feature-flags', to: 'feature_flags#index'

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -254,6 +254,8 @@ namespace :publish, as: :publish do
         get '/study-sites', on: :member, to: 'courses/study_sites#edit'
         put '/study-sites', on: :member, to: 'courses/study_sites#update'
 
+        get '/training-with-disabilities', on: :member, to: 'courses/training_with_disabilities#show'
+
         get '/applications-open', on: :member, to: 'courses/applications_open#edit'
         put '/applications-open', on: :member, to: 'courses/applications_open#update'
 

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -27,7 +27,7 @@ module CoursePreview
           how_school_placements_work:
         school_placements_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true),
           train_with_disability:
-        "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_preview: true)}#train-with-disability",
+        "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true)}#train-with-disability",
           train_with_us:
         "#{about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true)}#train-with-us",
           about_accrediting_provider:

--- a/spec/controllers/concerns/goto_preview_spec.rb
+++ b/spec/controllers/concerns/goto_preview_spec.rb
@@ -38,26 +38,4 @@ describe GotoPreview do
       end
     end
   end
-
-  describe '#goto_provider?' do
-    subject do
-      test_class.goto_provider?
-    end
-
-    context 'params is empty' do
-      let(:params) { {} }
-
-      it 'returns falsey' do
-        expect(subject).to be_falsey
-      end
-    end
-
-    context 'params has param_form_key with goto_provider set to "true"' do
-      let(:params) { { param_form_key: { goto_provider: 'true' } } }
-
-      it 'returns truthy' do
-        expect(subject).to be_truthy
-      end
-    end
-  end
 end

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'Viewing a findable course' do
   include PublishHelper
+  include Rails.application.routes.url_helpers
 
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
@@ -85,6 +86,15 @@ feature 'Viewing a findable course' do
     when_i_click("Back to #{@course.name} (#{course.course_code})")
     when_i_click(@course.accrediting_provider.provider_name)
     then_i_should_be_on_the_accrediting_provider_page
+    when_i_click("Back to #{@course.name} (#{course.course_code})")
+    then_i_should_be_on_the_course_page
+  end
+
+  scenario 'user views the training with disabilities page' do
+    given_there_is_a_findable_course
+    when_i_visit_the_course_page
+    when_i_click("Find out about training with disabilities and other needs at #{@course.provider_name}")
+    then_i_should_be_on_the_training_with_disabilities_page
     when_i_click("Back to #{@course.name} (#{course.course_code})")
     then_i_should_be_on_the_course_page
   end
@@ -259,8 +269,8 @@ feature 'Viewing a findable course' do
       'Certificate must be print in blue ink'
     )
 
-    expect(find_course_show_page.train_with_disability).to have_content(
-      provider.train_with_disability
+    expect(find_course_show_page).to have_content(
+      'Training with disabilities'
     )
 
     expect(find_course_show_page.school_placements).to have_no_content('Suspended site with vacancies')
@@ -377,6 +387,17 @@ feature 'Viewing a findable course' do
         Settings.search_ui.base_url,
         "/course/#{@course.provider_code}/#{@course.course_code}"
       ).to_s
+    )
+  end
+
+  def then_i_should_be_on_the_training_with_disabilities_page
+    expect(find_course_show_page.train_with_disability).to have_content(
+      provider.train_with_disability
+    )
+
+    expect(page).to have_link(
+      "Contact #{course.provider_name}",
+      href: find_provider_path(@course.provider_code, @course.course_code)
     )
   end
 end

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 feature 'Course show', { can_edit_current_and_next_cycles: false } do
+  include Rails.application.routes.url_helpers
   context 'bursaries and scholarships is announced' do
     before do
       FeatureFlag.activate(:bursaries_and_scholarships_announced)
@@ -37,14 +38,17 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     scenario 'blank training with disabilities and other needs' do
       given_i_am_authenticated(user: user_with_no_course_enrichments)
       when_i_visit_the_publish_course_preview_page
+      and_i_click_link_or_button("Find out about training with disabilities and other needs at #{@course.provider_name}")
       and_i_click_link_or_button('Enter details about training with disabilities and other needs')
       then_i_should_be_on_about_your_organisation_page
       and_i_click_link_or_button('Back')
-      then_i_should_be_back_on_the_preview_page
+      then_i_should_be_on_the_training_with_disabilities_page
       and_i_click_link_or_button('Enter details about training with disabilities and other needs')
       and_i_submit_a_valid_about_your_organisation
-      then_i_should_be_back_on_the_preview_page
+      then_i_should_be_on_the_training_with_disabilities_page
       then_i_should_see_the_updated_content('test training with disabilities')
+      and_i_click_link_or_button("Back to #{@course.name} (#{course.course_code})")
+      then_i_should_be_back_on_the_preview_page
     end
 
     scenario 'blank school placements section' do
@@ -239,8 +243,8 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       'Financial support from the training provider'
     )
 
-    expect(publish_course_preview_page.train_with_disability).to have_content(
-      provider.train_with_disability
+    expect(publish_course_preview_page).to have_content(
+      'Training with disabilities'
     )
 
     expect(publish_course_preview_page).to have_content '2:1 or above, or equivalent'
@@ -502,6 +506,21 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
     expect(publish_course_preview_page.about_accrediting_provider).to have_content(
       decorated_course.about_accrediting_provider
+    )
+  end
+
+  def then_i_should_be_on_the_training_with_disabilities_page
+    expect(publish_course_preview_page.train_with_disability).to have_content(
+      provider.train_with_disability
+    )
+
+    expect(page).to have_link(
+      "Contact #{course.provider_name}",
+      href: provider_publish_provider_recruitment_cycle_course_path(
+        @course.provider_code,
+        @course.recruitment_cycle_year,
+        @course.course_code
+      )
     )
   end
 end

--- a/spec/forms/publish/about_your_organisation_form_spec.rb
+++ b/spec/forms/publish/about_your_organisation_form_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Publish
+  describe AboutYourOrganisationForm, type: :model do
+    include Rails.application.routes.url_helpers
+    let(:params) do
+      {
+        train_with_us:,
+        train_with_disability:
+      }
+    end
+    let(:train_with_us) { 'train_with_us' }
+    let(:train_with_disability) { 'train_with_disability' }
+    let(:provider) do
+      create(
+        :provider,
+        accrediting_provider_enrichments: [
+          { UcasProviderCode: accredited_provider.provider_code }
+        ]
+      )
+    end
+    let(:accredited_provider) { create(:provider, :accredited_provider) }
+    let(:redirect_params) { { 'goto_preview' => 'true' } }
+    let(:course_code) { create(:course) }
+
+    subject { described_class.new(provider, params:, redirect_params:, course_code:) }
+
+    context 'validations' do
+      it { is_expected.to validate_presence_of(:train_with_us).with_message('Enter details about training with you') }
+      it { is_expected.to validate_presence_of(:train_with_disability).with_message('Enter details about training with a disability') }
+
+      context 'traing_with_us word count is invalid' do
+        let(:train_with_us) { Faker::Lorem.sentence(word_count: 251) }
+
+        it 'is not valid when traing_with_us is over 250 words' do
+          expect(subject.valid?).to be_falsey
+          expect(subject.errors[:train_with_us]).to include('Reduce the word count for training with you')
+        end
+      end
+
+      context 'train_with_disability word count is invalid' do
+        let(:train_with_disability) { Faker::Lorem.sentence(word_count: 251) }
+
+        it 'is not valid when train_with_disability is over 250 words' do
+          expect(subject.valid?).to be_falsey
+          expect(subject.errors[:train_with_disability]).to include('Reduce the word count for training with disabilities and other needs')
+        end
+      end
+    end
+
+    describe '#accredited_bodies' do
+      it 'returns an array of accredited_providers' do
+        expect(subject.accredited_bodies).to include(
+          have_attributes(
+            provider_name: accredited_provider.provider_name,
+            provider_code: accredited_provider.provider_code
+          )
+        )
+      end
+    end
+
+    describe '#update_success_path' do
+      context 'when goto_preview is true' do
+        it 'returns the goto_preview path' do
+          expect(subject.update_success_path).to eq(
+            preview_publish_provider_recruitment_cycle_course_path(
+              provider.provider_code,
+              provider.recruitment_cycle_year,
+              course_code
+            )
+          )
+        end
+      end
+
+      context 'when goto_provider is true' do
+        let(:redirect_params) { { 'goto_provider' => 'true' } }
+
+        it 'returns the goto_provider path' do
+          expect(subject.update_success_path).to eq(
+            provider_publish_provider_recruitment_cycle_course_path(
+              provider.provider_code,
+              provider.recruitment_cycle_year,
+              course_code
+            )
+          )
+        end
+      end
+
+      context 'when goto_training_with_disabilities is true' do
+        let(:redirect_params) { { 'goto_training_with_disabilities' => 'true' } }
+
+        it 'returns the goto_training_with_disabilities path' do
+          expect(subject.update_success_path).to eq(
+            training_with_disabilities_publish_provider_recruitment_cycle_course_path(
+              provider.provider_code,
+              provider.recruitment_cycle_year,
+              course_code
+            )
+          )
+        end
+      end
+
+      context 'when there is no redirect_params' do
+        let(:redirect_params) { {} }
+
+        it 'returns the details path' do
+          expect(subject.update_success_path).to eq(
+            details_publish_provider_recruitment_cycle_path(
+              provider.provider_code,
+              provider.recruitment_cycle_year
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/find/goto_preview_helper_spec.rb
+++ b/spec/helpers/find/goto_preview_helper_spec.rb
@@ -96,44 +96,6 @@ module Find
       end
     end
 
-    describe '#goto_provider?' do
-      subject do
-        goto_provider?(param_form_key:, params:)
-      end
-
-      context 'params is empty' do
-        let(:params) { {} }
-
-        it 'returns falsey' do
-          expect(subject).to be_falsey
-        end
-      end
-
-      context 'params has goto_provider set to "true"' do
-        let(:params) { { goto_provider: 'true' } }
-
-        it 'returns truthy' do
-          expect(subject).to be_truthy
-        end
-      end
-
-      context 'params has param_form_key with goto_provider set to "true"' do
-        let(:params) { { param_form_key: { goto_provider: 'true' } } }
-
-        it 'returns the value "true"' do
-          expect(subject).to be_truthy
-        end
-      end
-
-      context 'params has param_form_key with goto_provider set to "false"' do
-        let(:params) { { param_form_key: { goto_provider: 'false' } } }
-
-        it 'returns the value "false"' do
-          expect(subject).to be_falsey
-        end
-      end
-    end
-
     describe '#back_link_path' do
       let(:course) { build(:course) }
 


### PR DESCRIPTION
### Context

The course show page on find and the preview page on publish contains
too much information that might be off-putting for the user.

This commit tries to fix this by putting this section into its own view
accessible from the course page

### Changes proposed in this pull request

347fce874492a8cb967521fa7b5679f0128af0cd This implements the view/controller/routes changes

91f3fa13a3c6efc513817597003e403847f3179a This is a bit of a refactor of the `goto` methods that tell the `about_your_organisation` form where to redirect

Description of 91f3fa13a3c6efc513817597003e403847f3179a:
There are a few `goto` methods that tell the about your organisation
form where to redirect the user after update or when the user clicks the
back links.

Basically, both back links and update success methods can go to the same
path based on the `goto` param.

Because of this and the ever growing of these `goto` params I moved some
logic that calculates the redirection in the
about_your_organisation_form. This way it can be tested properly.

### Guidance to review

Review the code and check if the training for disabilities page works

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes


https://github.com/DFE-Digital/publish-teacher-training/assets/11318084/cc95a55b-3e85-4e7c-9c7f-213f831a3fdf



