### PR TITLE
[2027] Update apply deadline banner in publish

### DIFF
--- a/app/components/find/deadline_banner_component.html.erb
+++ b/app/components/find/deadline_banner_component.html.erb
@@ -1,9 +1,7 @@
 <% if cycle_timetable.show_apply_deadline_banner? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
-    <% notification_banner.with_heading(text: "Apply now to get on a course starting in the #{cycle_timetable.cycle_year_range} academic year") %>
-    <p class="govuk-body">Courses can fill up at any time, so you should apply as soon as you can.</p>
-    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= cycle_timetable.find_opens.to_fs(:month_and_year) %>, apply no later than <%= apply_deadline %>.</p>
-    <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than <%= apply_deadline %>.</p>
+    <% notification_banner.with_heading(text: t("apply_deadline_banner.heading", cycle_year_range:, apply_deadline:)) %>
+    <p class="govuk-body"><%= t("apply_deadline_banner.text") %></p>
   <% end %>
 <% elsif cycle_timetable.show_cycle_closed_banner? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>

--- a/app/components/find/deadline_banner_component.rb
+++ b/app/components/find/deadline_banner_component.rb
@@ -22,6 +22,10 @@ module Find
       cycle_timetable.apply_deadline.to_fs(:govuk_date_and_time)
     end
 
+    def cycle_year_range
+      cycle_timetable.cycle_year_range
+    end
+
     def find_opens
       cycle_timetable.find_opens.to_fs(:month_and_year)
     end

--- a/config/locales/deadline_banner_component.yml
+++ b/config/locales/deadline_banner_component.yml
@@ -1,0 +1,4 @@
+en:
+  apply_deadline_banner:
+    heading: The deadline for applying to courses starting in %{cycle_year_range} is %{apply_deadline}
+    text: Courses may fill up before then. Check course availability with the provider.

--- a/spec/components/find/deadline_banner_component_preview.rb
+++ b/spec/components/find/deadline_banner_component_preview.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Find
+  class DeadlineBannerComponentPreview < ViewComponent::Preview
+    def show_apply_deadline_banner
+      render(
+        Find::DeadlineBannerComponent.new(
+          flash_empty: true,
+          cycle_timetable: ShowApplyDeadlineBannerCycleTimetable
+        )
+      )
+    end
+
+    def show_cycle_closed_banner
+      render(
+        Find::DeadlineBannerComponent.new(
+          flash_empty: true,
+          cycle_timetable: ShowCycleClosedBannerTimetable
+        )
+      )
+    end
+  end
+
+  class ShowApplyDeadlineBannerCycleTimetable < CycleTimetable
+    def self.show_apply_deadline_banner?
+      true
+    end
+
+    def self.show_cycle_closed_banner?
+      false
+    end
+  end
+
+  class ShowCycleClosedBannerTimetable < CycleTimetable
+    def self.show_apply_deadline_banner?
+      false
+    end
+
+    def self.show_cycle_closed_banner?
+      true
+    end
+  end
+end

--- a/spec/components/find/deadline_banner_component_spec.rb
+++ b/spec/components/find/deadline_banner_component_spec.rb
@@ -19,9 +19,10 @@ module Find
         Timecop.travel(CycleTimetable.first_deadline_banner + 1.hour) do
           result = render_inline(described_class.new(flash_empty: true))
 
-          expect(result.text).to include('Courses can fill up at any time, so you should apply as soon as you can.')
-          expect(result.text).not_to include("You can continue to view and apply for courses until 6pm on #{CycleTimetable.apply_deadline.strftime('%e %B %Y')}")
-          expect(result.text).not_to include('as there’s no guarantee that the courses currently shown on this website will be on offer next year.')
+          cycle_year_range = Find::CycleTimetable.cycle_year_range
+          apply_deadline = Find::CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time)
+          expect(result.text).to include("The deadline for applying to courses starting in #{cycle_year_range} is #{apply_deadline}")
+          expect(result.text).to include('Courses may fill up before then. Check course availability with the provider.')
         end
       end
     end

--- a/spec/features/find/switcher_cycles_spec.rb
+++ b/spec/features/find/switcher_cycles_spec.rb
@@ -19,7 +19,7 @@ feature 'switcher cycle' do
     then_i_click_on_update_button
     and_i_should_see_the_success_banner
     and_i_visit_find_results_page
-    and_i_see_deadline_banner('Apply now to get on a course starting in the 2023 to 2024 academic year')
+    and_i_see_mid_cycle_banner
   end
 
   scenario 'Update to Apply deadline has passed' do
@@ -78,6 +78,13 @@ feature 'switcher cycle' do
 
   def and_i_visit_the_find_homepage
     visit '/'
+  end
+
+  def and_i_see_mid_cycle_banner
+    cycle_year_range = Find::CycleTimetable.cycle_year_range
+    apply_deadline = Find::CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time)
+    banner_text = "The deadline for applying to courses starting in #{cycle_year_range} is #{apply_deadline}"
+    and_i_see_deadline_banner(banner_text)
   end
 
   def and_i_see_deadline_banner(banner_text)


### PR DESCRIPTION
### Context
We’ve identified some banners in publish that need updating as part of the end of cycle.

This ticket is just related to the banner users see after 30 July, alerting them of the apply deadline.

We [agreed in this slack thread](https://ukgovernmentdfe.slack.com/archives/C077NRS8K8D/p1720520008204449) that we would use the same content as the banner we show candidates who are applying for courses

https://trello.com/c/myMbTZ4Q

### Changes proposed in this pull request
- Updated text
- Added preview for deadline banner

Before
 ![image](https://github.com/DFE-Digital/publish-teacher-training/assets/44073106/184d78b7-fd8c-4615-aaa2-bb18acf3c13f) 

After
![image](https://github.com/DFE-Digital/publish-teacher-training/assets/44073106/14cc658d-40ed-46cb-85da-2dbbaf9781ad) 

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
