### PR TITLE
[1996] Update validation error message for `applications_open_from`

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -968,13 +968,9 @@ class Course < ApplicationRecord
     if applications_open_from.blank? || applications_open_from.is_a?(Struct)
       errors.add(:applications_open_from, :blank)
     elsif valid_date_range.exclude?(applications_open_from)
-      chosen_date = short_date(applications_open_from)
-      start_date = short_date(recruitment_cycle.application_start_date)
-      end_date = short_date(recruitment_cycle.application_end_date)
       errors.add(
         :applications_open_from,
-        "#{chosen_date} is not valid for the #{provider.recruitment_cycle.year} cycle. " \
-        "A valid date must be between #{start_date} and #{end_date}"
+        "The date when applications open must be between #{recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{recruitment_cycle.application_end_date.to_fs(:govuk_date)}"
       )
     end
   end

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -93,7 +93,7 @@ module Support
 
           expect(subject.errors.messages.count).to eq(2)
           expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the #{Settings.current_recruitment_cycle_year} cycle")
-          expect(subject.errors.messages[:applications_open_from]).to include("04/08/2000 is not valid for the #{Settings.current_recruitment_cycle_year} cycle. A valid date must be between 01/10/#{Settings.current_recruitment_cycle_year.to_i - 1} and 30/09/#{Settings.current_recruitment_cycle_year}")
+          expect(subject.errors.messages[:applications_open_from]).to include("The date when applications open must be between #{course.recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{course.recruitment_cycle.application_end_date.to_fs(:govuk_date)}")
         end
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -575,7 +575,7 @@ describe Course do
             course.valid?(:new)
             error = course.errors.messages[:applications_open_from]
             expect(error).not_to be_empty
-            expect(error.first).to include('is not valid')
+            expect(error.first).to include("The date when applications open must be between #{recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{recruitment_cycle.application_end_date.to_fs(:govuk_date)}")
           end
         end
 
@@ -604,7 +604,7 @@ describe Course do
         it 'requires a applications_open_from date inside of the current recruitment cycle' do
           error = course.errors.messages[:applications_open_from]
           expect(error).not_to be_empty
-          expect(error.first).to include("is not valid for the #{Settings.current_recruitment_cycle_year} cycle. A valid date must be between")
+          expect(error.first).to include("The date when applications open must be between #{recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{recruitment_cycle.application_end_date.to_fs(:govuk_date)}")
         end
       end
 


### PR DESCRIPTION
### Context

The `applications_open_from` recruitment cycle range error message is not in line with style guide.

### Before

<img width="961" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/102f9935-a0d9-48f2-8ee3-6f91a450da03">


### After

<img width="847" alt="image" src="https://github.com/DFE-Digital/publish-teacher-training/assets/50492247/dfb393f0-739c-4660-ba45-8eb372ed8642">


### Guidance to review

https://design-system.service.gov.uk/components/date-input/#error-messages

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
