### PR TITLE
Give a course with no enrichments being rolled over an enrichment

### DIFF
--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -44,8 +44,9 @@ module Courses
     end
 
     def copy_latest_enrichment_to_course(course, new_course)
+      course.enrichments << CourseEnrichment.new(course:, status: 'draft') if course.enrichments.blank?
+
       last_enrichment = course.enrichments.most_recent.first
-      return if last_enrichment.blank?
 
       @enrichments_copy_to_course.execute(enrichment: last_enrichment, new_course:)
     end

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -107,7 +107,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       when_i_click_the_rollover_course_button
       then_i_should_see_the_course_show_page_with_success_message
       when_i_click_the_view_rollover_link
-      then_i_should_see_the_draft_course_on_the_show_page
+      then_i_should_see_the_rolled_over_course_on_the_show_page
     end
   end
 
@@ -156,8 +156,8 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   alias_method :and_i_should_see_the_rolled_over_course_show_page, :then_i_should_see_the_rolled_over_course_show_page
 
-  def then_i_should_see_the_draft_course_on_the_show_page
-    expect(page).to have_content 'Draft'
+  def then_i_should_see_the_rolled_over_course_on_the_show_page
+    expect(page).to have_content 'Rolled over'
   end
 
   def then_i_should_see_the_course_show_page_with_success_message


### PR DESCRIPTION
### Context

When we manually rollover a course it has a `content_status` of `draft` but we want a manually rolled over course to have a `content_status` of `rolled_over`.

They are currently `draft` because they don't have any enrichments and in these cases we default the `content_status` to `draft`.

The code that causes the `content_status` to get set to rolled over is never hit in `content_service_status.rb` because there is no enrichment to `dup`.

### Changes proposed in this pull request

Give a course being rolled over an enrichment if it doesn't have any enrichments.

### Guidance to review

Does this cause any unexpected side effects? 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
