### PR TITLE
Redesign visa sponsorship on course page

### DIFF
--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -14,7 +14,6 @@
   <% if interview_process.present? %>
     <li><%= govuk_link_to "Interview process", "#section-interviews" %></li>
   <% end %>
-  <li><%= govuk_link_to "International candidates", "#section-international-students" %></li>
   <% if provider.train_with_disability.present? || preview? %>
     <li><%= govuk_link_to "Training with disabilities", "#section-train-with-disabilities" %></li>
   <% end %>

--- a/app/components/find/courses/international_students_component/view.html.erb
+++ b/app/components/find/courses/international_students_component/view.html.erb
@@ -1,5 +1,4 @@
-<div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-international-students">International candidates</h2>
+<%= govuk_details(summary_text: visa_sponsorship_summary) do %>
   <div data-qa="course__international_students">
 
     <% if apprenticeship? %>
@@ -10,7 +9,9 @@
         EEA, Switzerland, Gibraltar, or the UK for at least the previous 3 years will also be eligible.</p>
     <% end %>
 
-    <p class="govuk-body"><%= apprenticeship? ? "You’ll also" : "You’ll" %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
+    <p class="govuk-body"><%= apprenticeship? ? "You’ll also" : "You’ll" %> need the <%= right_required %> in the UK</p>
+
+    <p class="govuk-body">You already have this if, for example, you:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>are an Irish citizen</li>
@@ -18,8 +19,11 @@
       <li>have indefinite leave to remain in the UK</li>
     </ul>
 
-    <%= t("find.international_candidates.#{visa_type}.#{sponsorship_availability}.html") %>
+    <%= t(
+      "find.international_candidates.#{visa_type}.#{sponsorship_availability}.html",
+      provider_url: x_provider_url
+    ) %>
 
     <p class="govuk-body">Learn more about <%= govuk_link_to("training to teach in England as an international student", t("find.get_into_teaching.url_train_to_teach_as_international_candidate")) %>.</p>
   </div>
-</div>
+<% end %>

--- a/app/components/find/courses/international_students_component/view.rb
+++ b/app/components/find/courses/international_students_component/view.rb
@@ -4,9 +4,15 @@ module Find
   module Courses
     module InternationalStudentsComponent
       class View < ViewComponent::Base
+        include ::ViewHelper
+        include PreviewHelper
         attr_reader :course
 
-        delegate :apprenticeship?, to: :course
+        delegate :apprenticeship?,
+                 :salaried?,
+                 :can_sponsor_student_visa,
+                 :can_sponsor_skilled_worker_visa,
+                 to: :course
 
         def initialize(course:)
           super
@@ -31,6 +37,16 @@ module Find
 
         def course_subject_codes
           @course_subject_codes ||= course.subjects.pluck(:subject_code).compact
+        end
+
+        def visa_sponsorship_summary
+          if !salaried? && can_sponsor_student_visa
+            t('.student_visas_can_be_sponsored')
+          elsif salaried? && can_sponsor_skilled_worker_visa
+            t('.skilled_worker_visas_can_be_sponsored')
+          else
+            t('.visas_cannot_be_sponsored')
+          end
         end
       end
     end

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -68,6 +68,8 @@
 
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".visa_sponsorship")) %>
-    <% row.with_value(text: visa_sponsorship_row) %>
+    <% row.with_value do %>
+      <%= render Find::Courses::InternationalStudentsComponent::View.new(course:) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -75,30 +75,6 @@ module Find
         def show_apply_from_row?
           course.applications_open_from&.future?
         end
-
-        def x_provider_url
-          if preview?(params)
-            provider_publish_provider_recruitment_cycle_course_path(
-              course.provider_code,
-              course.recruitment_cycle_year,
-              course.course_code
-            )
-          else
-            find_provider_path(course.provider_code, course.course_code)
-          end
-        end
-
-        def x_accrediting_provider_url
-          if preview?(params)
-            accredited_by_publish_provider_recruitment_cycle_course_path(
-              course.provider_code,
-              course.recruitment_cycle_year,
-              course.course_code
-            )
-          else
-            find_accrediting_provider_path(course.provider_code, course.course_code)
-          end
-        end
       end
     end
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -151,6 +151,30 @@ module ViewHelper
 
   alias cns classnames
 
+  def x_provider_url
+    if preview?(params)
+      provider_publish_provider_recruitment_cycle_course_path(
+        course.provider_code,
+        course.recruitment_cycle_year,
+        course.course_code
+      )
+    else
+      find_provider_path(course.provider_code, course.course_code)
+    end
+  end
+
+  def x_accrediting_provider_url
+    if preview?(params)
+      accredited_by_publish_provider_recruitment_cycle_course_path(
+        course.provider_code,
+        course.recruitment_cycle_year,
+        course.course_code
+      )
+    else
+      find_accrediting_provider_path(course.provider_code, course.course_code)
+    end
+  end
+
   private
 
   def base_errors_hash(provider_code, course)

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -51,8 +51,6 @@
       <%= render partial: "find/courses/interview_process", locals: { course: @course } %>
     <% end %>
 
-    <%= render Find::Courses::InternationalStudentsComponent::View.new(course: @course) %>
-
     <% if @provider.train_with_disability.present? %>
       <h2 class="govuk-heading-l" id="section-train-with-disabilities">
         <%= t(".training_with_disabilities") %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -41,8 +41,6 @@
       <%= render partial: "find/courses/interview_process", locals: { course: } %>
     <% end %>
 
-    <%= render Find::Courses::InternationalStudentsComponent::View.new(course:) %>
-
     <h2 class="govuk-heading-l" id="section-train-with-disabilities">
       <%= t(".training_with_disabilities") %>
     </h2>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -73,6 +73,11 @@ en:
     courses:
       train_with_disabilities:
         heading: Training with disabilities and other needs at %{provider_name}
+      international_students_component:
+        view:
+          student_visas_can_be_sponsored: Student visas can be sponsored
+          skilled_worker_visas_can_be_sponsored: Skilled Worker visas can be sponsored
+          visas_cannot_be_sponsored: Visas cannot be sponsored
       summary_component:
         view:
           fee_or_salary: Fee or salary
@@ -149,27 +154,21 @@ en:
       skilled_worker_visa:
         not_available:
           html:
-            <p class="govuk-body">If you do not already have the right to work in the UK, you may need to apply for a visa. The main visa for salaried courses is the <a class="govuk-link" href="https://www.gov.uk/skilled-worker-visa">Skilled Worker visa.</a></p>
-            <p class="govuk-body">Sponsorship for a Skilled Worker visa is not available for this course.</p>
-            <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
-            <p class="govuk-body">You can also <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
+            <p class="govuk-body">If you do not already have the right to study in the UK, you may need to <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees"> apply for your visa to train to teach in England</a>.</p>
         available:
           html:
-            <p class="govuk-body">If you do not already have the right to work in the UK for the duration of this course, you may need to apply for a Skilled Worker visa.</p>
+            <p class="govuk-body">If you do not already have the right to work in the UK, you may need to <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees"> apply for your visa to train to teach in England</a>.</p>
             <p class="govuk-body">To do this, you’ll need to be sponsored by your employer.</p>
-            <p class="govuk-body">Before you apply for this course, contact us to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.</p>
+            <p class="govuk-body">Before you apply for this course, <a class="govuk-link" href=%{provider_url}>contact the training provider</a> to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.</p>
       student_visa:
         not_available:
           html:
-            <p class="govuk-body">If you do not already have the right to study in the UK, you may need to apply for a visa.</p>
-            <p class="govuk-body">Sponsorship for a student visa is not available for this course.</p>
-            <p class="govuk-body">If you need a visa, filter your course search to find courses with visa sponsorship.</p>
-            <p class="govuk-body">You can also <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees">learn more about different types of visa</a> which allow you to train to be a teacher without being sponsored.</p>
+            <p class="govuk-body">If you do not already have the right to study in the UK, you may need to <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees"> apply for your visa to train to teach in England</a>.</p>
         available:
           html:
-            <p class="govuk-body">If you do not already have the right to study in the UK for the duration of this course, you may need to apply for a Student visa.</p>
+            <p class="govuk-body">If you do not already have the right to study in the UK, you may need to <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees"> apply for your visa to train to teach in England</a>.</p>
             <p class="govuk-body">To do this, you’ll need to be sponsored by your training provider.</p>
-            <p class="govuk-body">Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.</p>
+            <p class="govuk-body">Before you apply for this course, <a class="govuk-link" href=%{provider_url}>contact the training provider</a> to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.</p>
       entitlement:
         html:
           <p class="govuk-body">You may be entitled to £10,000 from the UK government to help with the financial costs of moving to England.</p>

--- a/spec/components/find/courses/international_students_component/view_spec.rb
+++ b/spec/components/find/courses/international_students_component/view_spec.rb
@@ -16,10 +16,6 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     it 'tells candidates they’ll need the right to study' do
       expect(page).to have_text('You’ll need the right to study in the UK')
     end
-
-    it 'tells candidates sponsorship is not available' do
-      expect(page).to have_text('Sponsorship for a student visa is not available for this course')
-    end
   end
 
   context 'when the course is fee-paying and does sponsor Student visas' do
@@ -37,7 +33,7 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     end
 
     it 'tells candidates visa sponsorship may be available, but they should check' do
-      expect(page).to have_text('Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
+      expect(page).to have_text('Before you apply for this course, contact the training provider to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
     end
 
     it 'does not tell candidates the 3-year residency rule' do
@@ -64,7 +60,7 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
     end
 
     it 'tells candidates visa sponsorship may be available, but they should check' do
-      expect(page).to have_text('Before you apply for this course, contact us to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
+      expect(page).to have_text('Before you apply for this course, contact the training provider to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
     end
   end
 
@@ -80,10 +76,6 @@ describe Find::Courses::InternationalStudentsComponent::View, type: :component d
 
     it 'tells candidates they’ll need the right to work' do
       expect(page).to have_text('You’ll need the right to work in the UK')
-    end
-
-    it 'tells candidates visa sponsorship is not available' do
-      expect(page).to have_text('Sponsorship for a Skilled Worker visa is not available for this course')
     end
 
     it 'does not tell candidates the 3-year residency rule' do

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -189,6 +189,10 @@ feature 'Viewing a findable course' do
     )
 
     expect(find_course_show_page).to have_content(
+      'Student visas can be sponsored'
+    )
+
+    expect(find_course_show_page).to have_content(
       '11 to 18'
     )
 
@@ -240,11 +244,6 @@ feature 'Viewing a findable course' do
 
     expect(find_course_show_page.required_qualifications).to have_no_content(
       @course.latest_published_enrichment.required_qualifications
-    )
-
-    expect(find_course_show_page).to have_international_students
-    expect(find_course_show_page.international_students).to have_content(
-      'Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.'
     )
 
     expect(find_course_show_page.required_qualifications).to have_content(

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -188,6 +188,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     )
 
     expect(publish_course_preview_page).to have_content(
+      'Visas cannot be sponsored'
+    )
+
+    expect(publish_course_preview_page).to have_content(
       '11 to 18'
     )
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 describe ViewHelper do
+  include PreviewHelper
+  include Rails.application.routes.url_helpers
+
   describe '#enrichment_error_url' do
     let(:provider) { build(:provider, recruitment_cycle: build(:recruitment_cycle)) }
     let(:course) { build(:course, provider:) }
@@ -25,6 +28,63 @@ describe ViewHelper do
 
     it 'returns provider enrichment error URL' do
       expect(provider_enrichment_error_url(provider:, field: 'email')).to eq("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/contact?display_errors=true#provider_email")
+    end
+  end
+
+  describe '#x_provider_url' do
+    let(:course) { create(:course) }
+
+    context 'when preview? is true' do
+      def preview?(_) = true
+
+      it 'returns the publish provider url' do
+        expect(x_provider_url).to eq(
+          provider_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code
+          )
+        )
+      end
+    end
+
+    context 'when preview? is false' do
+      def preview?(_) = false
+
+      it 'returns the find provider url' do
+        expect(x_provider_url).to eq(
+          find_provider_path(course.provider_code, course.course_code)
+        )
+      end
+    end
+  end
+
+  describe '#x_accrediting_provider_url
+' do
+    let(:course) { create(:course) }
+
+    context 'when preview? is true' do
+      def preview?(_) = true
+
+      it 'returns the publish accrediting provider url' do
+        expect(x_accrediting_provider_url).to eq(
+          accredited_by_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code
+          )
+        )
+      end
+    end
+
+    context 'when preview? is false' do
+      def preview?(_) = false
+
+      it 'returns the find accrediting provider url' do
+        expect(x_accrediting_provider_url).to eq(
+          find_accrediting_provider_path(course.provider_code, course.course_code)
+        )
+      end
     end
   end
 end

--- a/spec/support/page_objects/find/course_show.rb
+++ b/spec/support/page_objects/find/course_show.rb
@@ -26,7 +26,6 @@ module PageObjects
       element :required_qualifications, '[data-qa=course__required_qualifications]'
       element :train_with_us, '[data-qa=course__about_provider]'
       element :about_accrediting_provider, '[data-qa=course__about_accrediting_provider]'
-      element :international_students, '[data-qa=course__international_students]'
       element :train_with_disability, '[data-qa=course__train_with_disabilities]'
       element :course_advice, '#section-advice'
       element :course_apply, '#section-apply'


### PR DESCRIPTION
### Context

The International students section is going to be removed from the
publis/find course show pages. This is part of a redesign of the course
page to make it easier for users to view the information without being
overwhelmed

The visa sponsorship content will now be in a drop-down details tag. The
content inside has also been tweaked.

### Changes proposed in this pull request

`InternationalStudentsComponent` now will display the info in a details tag.

Moved the provider_url helper methods in a more global place.

### Guidance to review

View a course on publish and find and open the visa sponsorship dropdown

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes



https://github.com/DFE-Digital/publish-teacher-training/assets/11318084/a4bc44e4-a659-4235-8b2d-7a26a3bbff21



