### PR TITLE
Decrease alert_window_size to 1h for stg monitors

### DIFF
--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -18,7 +18,7 @@
     }
   },
   "enable_find": true,
-  "alert_window_size": "PT6H",
+  "alert_window_size": "PT1H",
   "additional_hostnames": [
     "staging.publish-teacher-training-courses.service.gov.uk",
     "staging.find-postgraduate-teacher-training.service.gov.uk",


### PR DESCRIPTION
### Context

Increase of alert window to PT6H requires a change in the terraform-module as it fails with

Metric Alert Name: "s189t01-ptt-stg-pg-storage"): unexpected status 400 (400 Bad Request) with response: ***"code":"BadRequest","message":"Evaluation frequency must be greater than or equal to five minutes since the period is greater than four hours. 

### Changes proposed in this pull request

Change window back to PT1H until the module is updated

### Guidance to review

make staging terraform-plan

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
