### PR TITLE
Redesign support and advice section on course page

### DIFF
--- a/app/assets/stylesheets/components/shared/_advice.scss
+++ b/app/assets/stylesheets/components/shared/_advice.scss
@@ -21,3 +21,10 @@
 .app-advice__body > *:last-child {
   margin-bottom: 0;
 }
+
+#section-advice-and-support {
+  border: 5px solid #f162a3;
+  margin-bottom: 30px;
+  padding: 20px;
+  background: govuk-colour("light-grey");
+}

--- a/app/views/find/courses/_advice.html.erb
+++ b/app/views/find/courses/_advice.html.erb
@@ -1,13 +1,4 @@
-<div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-advice">Support and advice</h2>
-  <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to "teacher training adviser", t("get_into_teaching.url_get_an_advisor") %>
-  for free. They’re all experienced teachers who can help you to prepare your application, book school
-    experience, and access exclusive teaching events.</p>
-  <p class="govuk-body">You can also call <%= t("service_name.get_into_teaching") %> on <%= t("get_into_teaching.tel") %>, or
-    <%= govuk_link_to "chat online", t("get_into_teaching.url_online_chat") %>
-    <%= t("get_into_teaching.opening_times") %> (except public holidays).</p>
-
-  <p class="govuk-body">Find out about the different ways to train <%= govuk_link_to("if you do not have a degree", t("get_into_teaching.url_ways_to_train_no_degree")) %>, or <%= govuk_link_to("are already an experienced teacher", t("get_into_teaching.url_ways_to_train_experienced_teacher")) %>.</p>
-
-  <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to("contact us by email", subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})") %>.</p>
+<div id="section-advice-and-support">
+  <h2 class="govuk-heading-m" id="section-advice"><%= t(".heading") %></h2>
+  <p class="govuk-body"><%= t(".body_html") %></p>
 </div>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -23,10 +23,10 @@
   </div>
 </div>
 
-<%= render Find::Courses::SummaryComponent::View.new(@course) %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render Find::Courses::SummaryComponent::View.new(@course) %>
+
     <% if @course.application_status_closed? %>
       <%= render partial: "find/courses/course_closed" %>
     <% end %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -15,14 +15,14 @@
   <%= course.name_and_code %>
 </h1>
 
-<%= render Find::Courses::SummaryComponent::View.new(course) %>
-
-<!--The reason for the Apply component duplication here is because we want to keep the warning text at the top but Keep the Apply button and end of cycle text at the bottom-->
-
-<%= render Find::Courses::ApplyComponent::View.new(course) if course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render Find::Courses::SummaryComponent::View.new(course) %>
+
+    <!--The reason for the Apply component duplication here is because we want to keep the warning text at the top but Keep the Apply button and end of cycle text at the bottom-->
+
+    <%= render Find::Courses::ApplyComponent::View.new(course) if course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
+
     <%= render Find::Courses::ContentsComponent::View.new(course) %>
 
     <%= render Find::Courses::EntryRequirementsComponent::View.new(course:) %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -71,6 +71,9 @@ en:
       primary_title: Primary courses with subject specialisms
       secondary_title: Which secondary subjects do you want to teach?
     courses:
+      advice:
+        heading: Support and advice
+        body_html: You can <a class="govuk-link" href="https://getintoteaching.education.gov.uk/teacher-training-advisers"> get a teacher training adviser</a> or <a class="govuk-link" href="https://getintoteaching.education.gov.uk/help-and-support"> contact Get Into Teaching</a> for free support.
       train_with_disabilities:
         heading: Training with disabilities and other needs at %{provider_name}
       international_students_component:


### PR DESCRIPTION
### Context

This simplifies the content and adds some styling to the support and advice section of the course page.

It also moves the summary component of the course page in the govuk 2 thirds body to match the rest of the content.

### Guidance to review

Review the support and advice section for a course, in publish and find

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes

![Screenshot from 2024-07-12 10-59-24](https://github.com/user-attachments/assets/57a3ced3-2202-45ba-860a-47821137eb7c)

