### PR TITLE
When you click validation error, focus should be on the first radio

### DIFF
--- a/app/views/publish/courses/a_level_requirements/a_level_equivalencies/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/a_level_equivalencies/new.html.erb
@@ -21,8 +21,7 @@
         <%= form.govuk_error_summary %>
 
         <%= form.govuk_radio_buttons_fieldset :accept_a_level_equivalency, legend: { size: "l", text: t("course.#{@wizard.current_step.model_name.i18n_key}.heading"), tag: "h1" }, caption: { text: @course_decorator.name_and_code, size: "l" } do %>
-
-          <%= form.govuk_radio_button :accept_a_level_equivalency, :yes do %>
+          <%= form.govuk_radio_button :accept_a_level_equivalency, :yes, link_errors: true do %>
             <%= form.govuk_text_area :additional_a_level_equivalencies, max_words: @wizard.current_step.class::MAXIMUM_ADDITIONAL_A_LEVEL_EQUIVALENCY_WORDS, hint: { text: t("course.#{@wizard.current_step.model_name.i18n_key}.hint") }, label: { class: "govuk-!-font-weight-bold" } %>
           <% end %>
           <%= form.govuk_radio_button :accept_a_level_equivalency, :no %>


### PR DESCRIPTION
### Context

There is an accessibility issue when the validation is triggered on the equivalency page. 

## Changes 

When you click validation error, focus should be on the first radio

![image (2)](https://github.com/user-attachments/assets/3d54807b-82f2-47f9-8533-dea1817c6d73)

### Guidance to review

1. Does it focus when you click in the validation error message?
