### PR TITLE
New format for Course show entry requirements

### DIFF
--- a/app/components/find/courses/a_level_component/view.html.erb
+++ b/app/components/find/courses/a_level_component/view.html.erb
@@ -2,18 +2,22 @@
   <p class="govuk-body">
     <%= a_level_subject_requirement %>
   </p>
+
+  <% unless course.accept_pending_a_level.nil? %>
+    <span class="govuk-hint govuk-!-font-size-16">
+      <%= pending_a_level_summary_content %>
+    </span>
+  <% end %>
 <% end %>
 
-<% unless course.accept_pending_a_level.nil? %>
-  <p class="govuk-body"><%= pending_a_level_summary_content %></p>
-<% end %>
+<% if course.any_a_levels? %>
+  <%= govuk_details(classes: ["govuk-!-margin-top-2"], summary_text: t(".equivalency_tests")) do %>
+    <p class="govuk-body"><%= a_level_equivalency_summary_content %></p>
 
-<% unless course.accept_a_level_equivalency.nil? %>
-  <p class="govuk-body"><%= a_level_equivalency_summary_content %></p>
-<% end %>
-
-<% if course.accept_a_level_equivalency? && course.additional_a_level_equivalencies.present? %>
-  <p class="govuk-body">
-    <%= course.additional_a_level_equivalencies %>
-  </p>
+    <% if course.additional_a_level_equivalencies.present? %>
+      <p class="govuk-body">
+        <%= course.additional_a_level_equivalencies %>
+      </p>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -1,60 +1,90 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-entry">Entry requirements</h2>
-  <h3 class="govuk-heading-m">Qualifications needed</h3>
+  <h2 class="govuk-heading-l" id="section-entry"><%= t(".heading") %> </h2>
   <div data-qa="course__required_qualifications">
 
-    <% unless course.teacher_degree_apprenticeship? %>
-      <% if course.degree_grade.nil? && course.additional_degree_subject_requirements.nil? %>
-        <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :degree, is_preview: preview?(params)) %>
-      <% else %>
-        <p class="govuk-body"><%= degree_grade_content(course) %></p>
+  <%= govuk_summary_list(actions: false) do |summary_list| %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: qualification_required) %>
+      <% row.with_value do %>
+
+      <% unless course.teacher_degree_apprenticeship? %>
+        <% if course.degree_grade.nil? && course.additional_degree_subject_requirements.nil? %>
+          <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :degree, is_preview: preview?(params)) %>
+        <% else %>
+          <p class="govuk-body">
+            <%= degree_grade_content(course) %>
+            <%= equivalent_qualification %>
+          </p>
+        <% end %>
 
         <% if course.degree_subject_requirements.present? %>
-          <p class="govuk-body">
-            <%= helpers.markdown(course.degree_subject_requirements) %>
-          </p>
-        <% end %>
-
-        <% if course.secondary_course? %>
-          <% if course.engineers_teach_physics? %>
+          <%= govuk_details(classes: ["govuk-!-margin-top-2"], summary_text: t(".degree_subject_requirements")) do %>
             <p class="govuk-body">
-              This <%= govuk_link_to "Engineers teach physics", t("find.get_into_teaching.url_engineers_teach_physics") %> course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.
+              <%= helpers.markdown(course.degree_subject_requirements) %>
             </p>
+
+            <% if course.secondary_course? %>
+              <% if course.engineers_teach_physics? %>
+                <p class="govuk-body">
+                  This <%= govuk_link_to "Engineers teach physics", t("find.get_into_teaching.url_engineers_teach_physics") %> course is designed for candidates who have a background in materials science and engineering. If your degree is in physics, please apply to our physics course.
+                </p>
+              <% end %>
+            <% end %>
+
+            <% if subject_knowledge_enhancement_content? %>
+              <p class="govuk-body">
+                If you need to improve your subject knowledge, you may be asked to complete a <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
+              </p>
+            <% end %>
           <% end %>
         <% end %>
+      <% end %>
 
-        <% if subject_knowledge_enhancement_content? %>
+      <%= render Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View.new(course:, preview: preview?(params)) %>
+
+      <% end %>
+    <% end %>
+
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".gcses")) %>
+      <% row.with_value do %>
+        <% if (course.accept_pending_gcse.nil? || course.accept_gcse_equivalency.nil?) %>
+          <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :gcse, is_preview: preview?(params)) %>
+        <% else %>
           <p class="govuk-body">
-            If you need to improve your subject knowledge, you may be asked to complete a <%= govuk_link_to "subject knowledge enhancement (SKE) course.", t("find.get_into_teaching.url_subject_knowledge_enhancement") %>
+            <%= required_gcse_content(course) %>
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16">
+              <%= t(".above_or_equivalent_qualification") %>
+            </span>
           </p>
+
+          <span class="govuk-hint govuk-!-font-size-16">
+            <%= pending_gcse_content(course) %>
+          </span>
+
+          <%= govuk_details(classes: ["govuk-!-margin-top-2"], summary_text: t(".equivalency_tests")) do %>
+            <p class="govuk-body">
+              <%= gcse_equivalency_content(course) %>
+            </p>
+
+            <% if course.additional_gcse_equivalencies.present? %>
+              <p class="govuk-body">
+                <%= helpers.markdown(course.additional_gcse_equivalencies) %>
+              </p>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>
 
-    <%= render Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View.new(course:, preview: preview?(params)) %>
-
-    <% if (course.accept_pending_gcse.nil? || course.accept_gcse_equivalency.nil?) %>
-      <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :gcse, is_preview: preview?(params)) %>
-    <% else %>
-
-      <p class="govuk-body">
-        <%= required_gcse_content(course) %>
-      </p>
-
-      <p class="govuk-body">
-        <%= pending_gcse_content(course) %>
-      </p>
-
-      <p class="govuk-body">
-        <%= gcse_equivalency_content(course) %>
-      </p>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: t(".visa_sponsorship")) %>
+      <% row.with_value do %>
+        <%= render Find::Courses::InternationalStudentsComponent::View.new(course:) %>
+      <% end %>
     <% end %>
-
-    <% if course.additional_gcse_equivalencies.present? %>
-      <p class="govuk-body">
-        <%= helpers.markdown(course.additional_gcse_equivalencies) %>
-      </p>
-    <% end %>
+  <% end %>
 
     <h3 class="govuk-heading-m"><%= t("find.get_into_teaching.qualifications_outside_uk") %> </h3>
 

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -15,14 +15,32 @@ module Find
           @course = course
         end
 
+        def qualification_required
+          if course.teacher_degree_apprenticeship?
+            t('.a_levels')
+          else
+            t('.degree')
+          end
+        end
+
+        def equivalent_qualification
+          if course.two_one? || course.two_two?
+            t('.above_or_equivalent_qualification_html')
+          elsif course.third_class?
+            t('.third_or_above_html')
+          else
+            t('.equivalent_qualification_html')
+          end
+        end
+
         private
 
         def degree_grade_content(course)
           degree_grade_hash = {
-            'two_one' => 'An undergraduate degree at class 2:1 or above, or equivalent.',
-            'two_two' => 'An undergraduate degree at class 2:2 or above, or equivalent.',
-            'third_class' => 'An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.',
-            'not_required' => 'An undergraduate degree, or equivalent.'
+            'two_one' => '2:1 bachelor’s degree',
+            'two_two' => '2:2 bachelor’s degree',
+            'third_class' => 'Bachelor’s degree',
+            'not_required' => 'Bachelor’s degree'
           }
 
           degree_grade_hash[course.degree_grade]
@@ -39,9 +57,9 @@ module Find
         def required_gcse_content(course)
           case course.level
           when 'primary'
-            "Grade #{course.gcse_grade_required} (C) or above in English, maths and science, or equivalent qualification."
+            "Grade #{course.gcse_grade_required} (C) in English, maths and science"
           when 'secondary'
-            "Grade #{course.gcse_grade_required} (C) or above in English and maths, or equivalent qualification."
+            "Grade #{course.gcse_grade_required} (C) in English and maths"
           end
         end
 

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -65,11 +65,4 @@
       <% row.with_value(text: l(start_date&.to_date, format: :short)) %>
     <% end %>
   <% end %>
-
-  <% summary_list.with_row do |row| %>
-    <% row.with_key(text: t(".visa_sponsorship")) %>
-    <% row.with_value do %>
-      <%= render Find::Courses::InternationalStudentsComponent::View.new(course:) %>
-    <% end %>
-  <% end %>
 <% end %>

--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
@@ -1,5 +1,3 @@
-<h4 class="govuk-heading-s">A levels</h4>
-
 <% if any_a_levels_answered? %>
   <%= render Find::Courses::ALevelComponent::View.new(course:) %>
 <% else %>
@@ -12,5 +10,3 @@
       ) %>
   <% end %>
 <% end %>
-
-<h4 class="govuk-heading-s">GCSEs</h4>

--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.rb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.rb
@@ -4,7 +4,6 @@ module Find
   module Courses
     module TeacherDegreeApprenticeshipEntryRequirements
       class View < ViewComponent::Base
-        A_LEVEL_ATTRIBUTES = %i[a_level_subject_requirements accept_pending_a_level accept_a_level_equivalency additional_a_level_equivalencies].freeze
         attr_reader :course, :preview
 
         def initialize(course:, preview:)
@@ -19,7 +18,7 @@ module Find
         end
 
         def any_a_levels_answered?
-          !preview || A_LEVEL_ATTRIBUTES.any? { |attribute| course.public_send(attribute).present? }
+          !preview || course.any_a_levels?
         end
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,6 +8,8 @@ class Course < ApplicationRecord
   include Courses::EditOptions
   include TimeFormat
 
+  A_LEVEL_ATTRIBUTES = %i[a_level_subject_requirements accept_pending_a_level accept_a_level_equivalency additional_a_level_equivalencies].freeze
+
   after_initialize :set_defaults
 
   before_discard do
@@ -814,6 +816,10 @@ class Course < ApplicationRecord
     site_statuses.each do |site_status|
       update_vac_status('full_time', site_status)
     end
+  end
+
+  def any_a_levels?
+    A_LEVEL_ATTRIBUTES.any? { |attribute| public_send(attribute).present? }
   end
 
   private

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -81,6 +81,40 @@ en:
           student_visas_can_be_sponsored: Student visas can be sponsored
           skilled_worker_visas_can_be_sponsored: Skilled Worker visas can be sponsored
           visas_cannot_be_sponsored: Visas cannot be sponsored
+      a_level_component:
+        view:
+          equivalency_tests: Equivalency tests
+      entry_requirements_component:
+        view:
+          heading: Entry requirements
+          visa_sponsorship: Visa sponsorship
+          gcses: GCSEs
+          degree: Degree
+          or_equivalent_qualification: or equivalent qualification
+          equivalency_tests: Equivalency tests
+          degree_subject_requirements: Degree subject requirements
+          a_levels: A levels
+          above_or_equivalent_qualification: or above, or equivalent qualification
+          above_or_equivalent_qualification_html:
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16">
+              or above or equivalent qualification
+            </span>
+          equivalent_qualification_html:
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16">
+              or equivalent qualification
+            </span>
+          third_or_above_html:
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16">
+              or equivalent qualification
+            </span>
+            <br>
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16">
+              This should be an honours degree (Third or above), or equivalent
+            </span>
       summary_component:
         view:
           fee_or_salary: Fee or salary
@@ -92,7 +126,6 @@ en:
           qualification: Qualification
           provider: Provider
           accredited_by: Accredited by
-          visa_sponsorship: Visa sponsorship
       providers:
         show:
           heading: About %{provider_name}

--- a/spec/components/find/courses/a_level_component/view_spec.rb
+++ b/spec/components/find/courses/a_level_component/view_spec.rb
@@ -145,7 +145,18 @@ RSpec.describe Find::Courses::ALevelComponent::View, type: :component do
   end
 
   context 'when not considering candidates who need A level equivalency tests' do
-    let(:course) { create(:course, accept_a_level_equivalency: false).decorate }
+    let(:course) do
+      create(
+        :course,
+        a_level_subject_requirements:,
+        accept_a_level_equivalency: false
+      ).decorate
+    end
+    let(:a_level_subject_requirements) do
+      [
+        { 'subject' => 'any_stem_subject' }
+      ]
+    end
 
     it 'renders the correct content when A level equivalency tests are not considered' do
       expect(result).to include('We will not consider candidates who need to take A level equivalency tests.')

--- a/spec/components/find/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_preview.rb
@@ -72,6 +72,10 @@ module Find
             accept_science_gcse_equivalency: true,
             additional_gcse_equivalencies: 'much much more',
             computed_subject_name_or_names: 'Biology',
+            funding_type: 'salary',
+            can_sponsor_skilled_worker_visa: true,
+            provider_code: 'provider_code',
+            course_code: 'course_code',
             subjects: [Subject.new(subject_name: 'foo', subject_code: 'sc')] }
         end
 
@@ -81,7 +85,7 @@ module Find
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :computed_subject_name_or_names, :campaign_name, :subjects)
+          attr_accessor(:degree_grade, :degree_subject_requirements, :level, :name, :gcse_grade_required, :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :computed_subject_name_or_names, :campaign_name, :subjects, :funding_type, :can_sponsor_skilled_worker_visa, :provider_code, :course_code)
 
           def enrichment_attribute(params)
             send(params)
@@ -93,6 +97,22 @@ module Find
 
           def secondary_course?
             level == 'secondary'
+          end
+
+          def two_one?
+            degree_grade == 0
+          end
+
+          def two_two?
+            degree_grade == 1
+          end
+
+          def salaried?
+            funding_type == 'salary' || funding_type == 'apprenticeship'
+          end
+
+          def apprenticeship?
+            funding_type.to_s == 'apprenticeship'
           end
 
           def engineers_teach_physics?

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -26,7 +26,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders A levels and GCSEs only and ignores degrees' do
       expected_text = <<~TEXT
-        Entry requirements Qualifications needed A levels Any subject - Grade A or above, or equivalent qualification We’ll consider candidates with pending A levels. We’ll consider candidates who need to take A level equivalency tests. Some text GCSEs Grade 4 (C) or above in English, maths and science, or equivalent qualification. We will not consider candidates with pending GCSEs. We will not consider candidates who need to take a GCSE equivalency test.
+        Entry requirements A levels Any subject - Grade A or above, or equivalent qualification We’ll consider candidates with pending A levels. Equivalency tests We’ll consider candidates who need to take A level equivalency tests. Some text GCSEs Grade 4 (C) in English, maths and science or above, or equivalent qualification We will not consider candidates with pending GCSEs. Equivalency tests We will not consider candidates who need to take a GCSE equivalency test.
       TEXT
 
       expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to include(expected_text.strip)
@@ -42,7 +42,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(result).to have_link(ske_url_name, href: ske_url)
+
+      within('.govuk-details__summary') do
+        expect(result).to have_link(ske_url_name, href: ske_url)
+      end
     end
   end
 
@@ -55,7 +58,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(result).to have_link(ske_url_name, href: ske_url)
+
+      within('.govuk-details__summary') do
+        expect(result).to have_link(ske_url_name, href: ske_url)
+      end
     end
   end
 
@@ -68,7 +74,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(result).to have_link(ske_url_name, href: ske_url)
+
+      within('.govuk-details__summary') do
+        expect(result).to have_link(ske_url_name, href: ske_url)
+      end
     end
   end
 
@@ -76,12 +85,17 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     let(:subjects) { [build(:secondary_subject, :mathematics), build(:secondary_subject, :english)] }
 
     it 'renders correct message' do
-      expect(result.text).to include(ske_text)
+      within('.govuk-details__summary') do
+        expect(result.text).to include(ske_text)
+      end
     end
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(result).to have_link(ske_url_name, href: ske_url)
+
+      within('.govuk-details__summary') do
+        expect(result).to have_link(ske_url_name, href: ske_url)
+      end
     end
   end
 
@@ -103,7 +117,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders the correct link' do
       render_inline(described_class.new(course: course.decorate))
-      expect(result).to have_link(ske_url_name, href: ske_url)
+
+      within('.govuk-details__summary') do
+        expect(result).to have_link(ske_url_name, href: ske_url)
+      end
     end
   end
 
@@ -148,7 +165,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       result = render_inline(described_class.new(course: course.decorate))
 
       expect(result.text).to include(
-        'Grade 4 (C) or above in English, maths and science, or equivalent qualification.'
+        'Grade 4 (C) in English, maths and science'
+      )
+      expect(result.text).to include(
+        'or above or equivalent qualification'
       )
       expect(result.text).not_to include(
         "Your degree subject should be in #{course.name} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way"
@@ -171,7 +191,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       result = render_inline(described_class.new(course: course.decorate))
 
       expect(result.text).to include(
-        'Grade 5 (C) or above in English and maths, or equivalent qualification.'
+        'Grade 5 (C) in English and maths'
+      )
+      expect(result.text).to include(
+        'or above, or equivalent qualification'
       )
     end
 
@@ -208,7 +231,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
         result = render_inline(described_class.new(course: course.decorate))
 
         expect(result.text).to include(
-          'Grade 5 (C) or above in English and maths, or equivalent qualification.'
+          'Grade 5 (C) in English and maths'
+        )
+        expect(result.text).to include(
+          'or above, or equivalent qualification'
         )
       end
     end
@@ -261,7 +287,10 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       result = render_inline(described_class.new(course: course.decorate))
 
       expect(result.text).to include(
-        '2:2 or above, or equivalent.'
+        '2:2 bachelor’s degree'
+      )
+      expect(result.text).to include(
+        'or above or equivalent qualification'
       )
       expect(result.text).to include(
         'Certificate must be printed on green paper.'
@@ -283,5 +312,131 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     expect(page).to have_text('If you studied for your qualifications outside of the UK you should apply for a statement of comparability from UK European Network of Information Centres (UK ENIC). This will show us how your qualifications compare to UK qualifications.')
 
     expect(page).to have_link('Apply for a statement of comparability (opens in new tab)')
+  end
+
+  context 'when course is fee paying and can sponsor student visas' do
+    let(:course) do
+      build(
+        :course,
+        :fee_type_based,
+        can_sponsor_student_visa: true,
+        provider: build(:provider)
+      )
+    end
+
+    it 'displays that student visas can be sponsored' do
+      expect(result.text).to include('Student visas can be sponsored')
+    end
+  end
+
+  context 'when course is salaried and can sponsor skilled worker visas' do
+    let(:course) do
+      build(
+        :course,
+        :with_salary,
+        can_sponsor_skilled_worker_visa: true,
+        provider: build(:provider)
+      )
+    end
+
+    it 'displays that skilled worker visas can be sponsored' do
+      expect(result.text).to include('Skilled Worker visas can be sponsored')
+    end
+  end
+
+  context 'when course cannot sponsor visas' do
+    let(:course) do
+      build(
+        :course,
+        can_sponsor_student_visa: false,
+        can_sponsor_skilled_worker_visa: false,
+        provider: build(:provider)
+      )
+    end
+
+    it 'displays that visas cannot be sponsored' do
+      expect(result.text).to include('Visas cannot be sponsored')
+    end
+  end
+
+  describe '#qualification_required' do
+    let(:course) { build(:course) }
+
+    it 'returns Degree' do
+      component = described_class.new(course: course.decorate)
+      render_inline(component)
+
+      expect(component.qualification_required).to eq('Degree')
+    end
+
+    context 'when teacher_degree_apprenticeship' do
+      let(:course) do
+        build(
+          :course,
+          :with_teacher_degree_apprenticeship
+        )
+      end
+
+      it 'returns A levels' do
+        component = described_class.new(course: course.decorate)
+        render_inline(component)
+
+        expect(component.qualification_required).to eq('A levels')
+      end
+    end
+  end
+
+  describe '#equivalent_qualification' do
+    context 'when course is two_one' do
+      let(:course) { build(:course, degree_grade: :two_one) }
+
+      it "returns 'or above or equivalent qualification'" do
+        component = described_class.new(course: course.decorate)
+        render_inline(component)
+
+        expect(component.equivalent_qualification).to eq(
+          '<br> <span class="govuk-hint govuk-!-font-size-16"> or above or equivalent qualification </span>'
+        )
+      end
+    end
+
+    context 'when course is two_two' do
+      let(:course) { build(:course, degree_grade: :two_two) }
+
+      it "returns 'or above or equivalent qualification'" do
+        component = described_class.new(course: course.decorate)
+        render_inline(component)
+
+        expect(component.equivalent_qualification).to eq(
+          '<br> <span class="govuk-hint govuk-!-font-size-16"> or above or equivalent qualification </span>'
+        )
+      end
+    end
+
+    context 'when course is third_class' do
+      let(:course) { build(:course, degree_grade: :third_class) }
+
+      it 'returns third and above' do
+        component = described_class.new(course: course.decorate)
+        render_inline(component)
+
+        expect(component.equivalent_qualification).to eq(
+          '<br> <span class="govuk-hint govuk-!-font-size-16"> or equivalent qualification </span> <br> <br> <span class="govuk-hint govuk-!-font-size-16"> This should be an honours degree (Third or above), or equivalent </span>'
+        )
+      end
+    end
+
+    context 'when course is not_required' do
+      let(:course) { build(:course, degree_grade: :not_required) }
+
+      it 'returns not required' do
+        component = described_class.new(course: course.decorate)
+        render_inline(component)
+
+        expect(component.equivalent_qualification).to eq(
+          '<br> <span class="govuk-hint govuk-!-font-size-16"> or equivalent qualification </span>'
+        )
+      end
+    end
   end
 end

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -19,8 +19,7 @@ module Find
             'Qualification',
             'Provider',
             'Date you can apply from',
-            'Date course starts',
-            'Visa sponsorship'
+            'Date course starts'
           )
         end
 
@@ -124,51 +123,6 @@ module Find
             result = render_inline(described_class.new(course))
 
             expect(result.text).to include('3 to 7')
-          end
-        end
-
-        context 'when course is fee paying and can sponsor student visas' do
-          it 'displays that student visas can be sponsored' do
-            course = build(
-              :course,
-              :fee_type_based,
-              can_sponsor_student_visa: true,
-              provider: build(:provider)
-            ).decorate
-
-            result = render_inline(described_class.new(course))
-
-            expect(result.text).to include('Student visas can be sponsored')
-          end
-        end
-
-        context 'when course is salaried and can sponsor skilled worker visas' do
-          it 'displays that skilled worker visas can be sponsored' do
-            course = build(
-              :course,
-              :with_salary,
-              can_sponsor_skilled_worker_visa: true,
-              provider: build(:provider)
-            ).decorate
-
-            result = render_inline(described_class.new(course))
-
-            expect(result.text).to include('Skilled Worker visas can be sponsored')
-          end
-        end
-
-        context 'when course cannot sponsor visas' do
-          it 'displays that visas cannot be sponsored' do
-            course = build(
-              :course,
-              can_sponsor_student_visa: false,
-              can_sponsor_skilled_worker_visa: false,
-              provider: build(:provider)
-            ).decorate
-
-            result = render_inline(described_class.new(course))
-
-            expect(result.text).to include('Visas cannot be sponsored')
           end
         end
 

--- a/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
+++ b/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
@@ -22,7 +22,7 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
 
     it 'renders A levels and GCSEs only and ignores degrees' do
       expected_text = <<~TEXT
-        A levels Any subject - Grade A or above, or equivalent qualification We’ll consider candidates with pending A levels. We’ll consider candidates who need to take A level equivalency tests. Some text about A level equivalencies GCSEs
+        Any subject - Grade A or above, or equivalent qualification We’ll consider candidates with pending A levels. Equivalency tests We’ll consider candidates who need to take A level equivalency tests. Some text about A level equivalencies
       TEXT
 
       expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to include(expected_text.strip)
@@ -58,7 +58,7 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
 
     it 'renders the headings and enter A levels text' do
       expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to eq(
-        'A levels Enter A levels and equivalency test requirements GCSEs'
+        'Enter A levels and equivalency test requirements'
       )
     end
   end
@@ -78,9 +78,7 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
     end
 
     it 'renders the headings' do
-      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to eq(
-        'A levels GCSEs'
-      )
+      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to eq('')
     end
   end
 end

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -247,7 +247,10 @@ feature 'Viewing a findable course' do
     )
 
     expect(find_course_show_page.required_qualifications).to have_content(
-      'Grade 4 (C) or above in English and maths, or equivalent qualification.'
+      'Grade 4 (C) in English and maths'
+    )
+    expect(find_course_show_page.required_qualifications).to have_content(
+      'or above, or equivalent qualification'
     )
     expect(find_course_show_page.required_qualifications).to have_content(
       'We’ll consider candidates with pending GCSEs.'
@@ -260,7 +263,7 @@ feature 'Viewing a findable course' do
     )
 
     expect(find_course_show_page.required_qualifications).to have_content(
-      '2:1 or above, or equivalent.'
+      '2:1 bachelor’s degree or above or equivalent qualification'
     )
     expect(find_course_show_page.required_qualifications).to have_content(
       'Certificate must be print in blue ink'

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -72,7 +72,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       then_i_should_be_back_on_the_preview_page
       and_i_click_link_or_button('Enter degree requirements')
       and_i_submit_and_continue_through_the_two_forms
-      then_i_should_see_the_updated_content('An undergraduate degree, or equivalent.')
+      then_i_should_see_the_updated_content('Bachelor’s degree or equivalent qualification')
     end
 
     scenario 'blank gcse requirements' do
@@ -251,7 +251,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       'Training with disabilities'
     )
 
-    expect(publish_course_preview_page).to have_content '2:1 or above, or equivalent'
+    expect(publish_course_preview_page).to have_content '2:1 bachelor’s degree or above or equivalent qualification'
     expect(publish_course_preview_page).to have_content 'Maths A level'
 
     expect(publish_course_preview_page).to have_study_sites_table

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3108,4 +3108,56 @@ describe Course do
       end
     end
   end
+
+  describe '#any_a_levels?' do
+    it 'returns false if no a levels' do
+      course = build(:course)
+
+      expect(course.any_a_levels?).to be_falsy
+    end
+
+    context 'when a_level_subject_requirements is present' do
+      it 'returns true' do
+        course = build(
+          :course,
+          a_level_subject_requirements: [{ uuid: SecureRandom.uuid, subject: 'any_subject', minimum_grade_required: 'A' }]
+        )
+
+        expect(course.any_a_levels?).to be_truthy
+      end
+    end
+
+    context 'when accept_pending_a_level is present' do
+      it 'returns true' do
+        course = build(
+          :course,
+          accept_pending_a_level: true
+        )
+
+        expect(course.any_a_levels?).to be_truthy
+      end
+    end
+
+    context 'when accept_a_level_equivalency is present' do
+      it 'returns true' do
+        course = build(
+          :course,
+          accept_a_level_equivalency: true
+        )
+
+        expect(course.any_a_levels?).to be_truthy
+      end
+    end
+
+    context 'when additional_a_level_equivalencies is present' do
+      it 'returns true' do
+        course = build(
+          :course,
+          additional_a_level_equivalencies: 'Can you juggle?'
+        )
+
+        expect(course.any_a_levels?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

This is part of a redesign of the course show page both on apply and
find.

This will put all the entry requirements info into a summary list with
details(dropdown) which should help the user navigate this page better

### Changes proposed in this pull request

Entry requirements are in a summary list with details tags
Visa sponsorship is part of the entry requirements

![Screenshot from 2024-07-17 16-58-40](https://github.com/user-attachments/assets/e0258d23-5fe2-44dd-86c6-d6071b61a901)

TDA:
![Screenshot from 2024-07-18 10-30-27](https://github.com/user-attachments/assets/356f6609-31fc-40c5-b3d0-3bea5f7cf455)



### Guidance to review

Check the preview course page on publish and the course show page on find.
For TDA and other course entry requirement options

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
