### PR TITLE
Add link to add A levels requirements from preview page

### DIFF
--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -31,7 +31,7 @@
       <% end %>
     <% end %>
 
-    <%= render Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View.new(course:) %>
+    <%= render Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View.new(course:, preview: preview?(params)) %>
 
     <% if (course.accept_pending_gcse.nil? || course.accept_gcse_equivalency.nil?) %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :gcse, is_preview: preview?(params)) %>

--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
@@ -1,5 +1,16 @@
 <h4 class="govuk-heading-s">A levels</h4>
 
-<%= render Find::Courses::ALevelComponent::View.new(course:) %>
+<% if any_a_levels_answered? %>
+  <%= render Find::Courses::ALevelComponent::View.new(course:) %>
+<% else %>
+  <%= govuk_inset_text do %>
+    <%= govuk_link_to t('components.course_preview.missing_information.a_levels.text'),
+      publish_provider_recruitment_cycle_course_a_levels_what_a_level_is_required_path(
+        course.provider.provider_code,
+        course.provider.recruitment_cycle_year,
+        course.course_code
+      ) %>
+  <% end %>
+<% end %>
 
 <h4 class="govuk-heading-s">GCSEs</h4>

--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.html.erb
@@ -4,7 +4,7 @@
   <%= render Find::Courses::ALevelComponent::View.new(course:) %>
 <% else %>
   <%= govuk_inset_text do %>
-    <%= govuk_link_to t('components.course_preview.missing_information.a_levels.text'),
+    <%= govuk_link_to t("components.course_preview.missing_information.a_levels.text"),
       publish_provider_recruitment_cycle_course_a_levels_what_a_level_is_required_path(
         course.provider.provider_code,
         course.provider.recruitment_cycle_year,

--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.rb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.rb
@@ -4,16 +4,22 @@ module Find
   module Courses
     module TeacherDegreeApprenticeshipEntryRequirements
       class View < ViewComponent::Base
-        attr_reader :course
+        A_LEVEL_ATTRIBUTES = %i[a_level_subject_requirements accept_pending_gcse accept_a_level_equivalency additional_a_level_equivalencies].freeze
+        attr_reader :course, :preview
 
-        def initialize(course:)
+        def initialize(course:, preview:)
           @course = course
+          @preview = preview
 
           super
         end
 
         def render?
           course.teacher_degree_apprenticeship?
+        end
+
+        def any_a_levels_answered?
+          !preview || A_LEVEL_ATTRIBUTES.any? { |attribute| course.public_send(attribute).present? }
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,6 +270,8 @@ en:
       missing_information:
         about_this_course:
           text: "Enter course summary"
+        a_levels:
+          text: "Enter A levels and equivalency test requirements"
         degree:
           text: "Enter degree requirements"
         fee_uk_eu:

--- a/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
+++ b/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
   let(:course) { build(:course) }
-  let(:result) { render_inline(described_class.new(course: course.decorate)) }
+  let(:preview) { false }
+  let(:result) { render_inline(described_class.new(course: course.decorate, preview:)) }
 
   context 'when teacher degree apprenticeship course' do
     let(:course) do
@@ -41,7 +42,8 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
     end
   end
 
-  context 'when there are no A levels' do
+  context 'when preview and there are no A levels' do
+    let(:preview) { true }
     let(:course) do
       build(
         :course,
@@ -49,12 +51,36 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
         :resulting_in_undergraduate_degree_with_qts,
         a_level_subject_requirements: [],
         accept_pending_gcse: nil,
+        accept_a_level_equivalency: nil,
+        additional_a_level_equivalencies: nil
+      )
+    end
+
+    it 'renders the headings and enter A levels text' do
+      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to eq(
+        'A levels Enter A levels and equivalency test requirements GCSEs'
+      )
+    end
+  end
+
+  context 'when not preview and there are no A levels' do
+    let(:preview) { false }
+    let(:course) do
+      build(
+        :course,
+        :with_teacher_degree_apprenticeship,
+        :resulting_in_undergraduate_degree_with_qts,
+        a_level_subject_requirements: [],
+        accept_pending_gcse: nil,
+        accept_a_level_equivalency: nil,
         additional_a_level_equivalencies: nil
       )
     end
 
     it 'renders the headings' do
-      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to eq('A levels GCSEs')
+      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to eq(
+        'A levels GCSEs'
+      )
     end
   end
 end


### PR DESCRIPTION
### Context

When there are no A level and the user clicks to preview the course, a link to enter A levels should be there.

```
GIVEN I have created a TDA course
AND there are no A level requirements
WHEN I look at the preview and navigate to the A levels
THEN I should see a link to add A levels
```

### Changes proposed in this pull request

<img width="479" alt="Screenshot 2024-07-16 at 10 00 58" src="https://github.com/user-attachments/assets/5e608dd8-eeb9-4ae0-a163-ba85ae49ddc8">

### Guidance to review

1. Does it work on preview?
