### PR TITLE
[2039] Activate TDA and rollover in all environments

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,14 +93,14 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
-  teacher_degree_apprenticeship: false
+  teacher_degree_apprenticeship: true
   send_request_data_to_bigquery: false
   rollover:
     # Normally a short period of time between rollover and the next cycle
     # actually starting when it would be set to false
     has_current_cycle_started?: true
     # During rollover providers should be able to edit current & next recruitment cycle courses
-    can_edit_current_and_next_cycles: false
+    can_edit_current_and_next_cycles: true
 
 cookies:
   session:

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -39,13 +39,6 @@ google_tag_manager:
 
 features:
   send_request_data_to_bigquery: true
-  teacher_degree_apprenticeship: true
-  rollover:
-    # Normally a short period of time between rollover and the next cycle
-    # actually starting when it would be set to false
-    has_current_cycle_started?: true
-    # During rollover providers should be able to edit current & next recruitment cycle courses
-    can_edit_current_and_next_cycles: true
 
 find_valid_referers:
   - https://www.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -31,7 +31,6 @@ basic_auth:
 
 features:
   send_request_data_to_bigquery: true
-  teacher_degree_apprenticeship: true
 
 find_valid_referers:
   - https://qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -12,9 +12,6 @@ apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
   base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 
-features:
-  teacher_degree_apprenticeship: true
-
 authentication:
   secret: secret
   mode: persona

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_current_and_next_cycles do
+feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_current_and_next_cycles: false } do
   scenario 'adding a level requirements' do
     given_i_am_authenticated_as_a_provider_user
     and_the_tda_feature_flag_is_active
@@ -26,13 +26,13 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     and_i_add_a_minimum_grade_required
     and_i_click_continue
 
-    then_i_see_the_subject_i_choosen
+    then_i_see_the_subject_i_selected
     and_i_am_on_the_add_another_a_level_subject_page
     and_i_see_the_success_message_that_i_added_an_a_level
 
     when_i_click_continue
     then_i_see_an_error_message_for_the_add_a_level_to_a_list_page
-    and_i_see_the_subject_i_choosen
+    and_i_see_the_subject_i_selected
 
     when_i_choose_yes
     and_i_click_continue
@@ -257,7 +257,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     fill_in 'Minimum grade required (optional)', with: 'C'
   end
 
-  def then_i_see_the_subject_i_choosen
+  def then_i_see_the_subject_i_selected
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
         @provider.provider_code,
@@ -268,7 +268,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
     )
     expect(page).to have_content('Any subject - Grade C or above')
   end
-  alias_method :and_i_see_the_subject_i_choosen, :then_i_see_the_subject_i_choosen
+  alias_method :and_i_see_the_subject_i_selected, :then_i_see_the_subject_i_selected
 
   def then_i_see_an_error_message_for_the_add_a_level_to_a_list_page
     and_i_see_there_is_a_problem
@@ -284,7 +284,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', :can_edit_c
   end
 
   def then_i_see_the_two_subjects_i_already_added
-    and_i_see_the_subject_i_choosen
+    and_i_see_the_subject_i_selected
     expect(page).to have_content('Any STEM subject - Grade C or above')
   end
 

--- a/spec/features/publish/editing_notification_preference_spec.rb
+++ b/spec/features/publish/editing_notification_preference_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-feature 'Opting into notifications' do
+feature 'Opting into notifications', { can_edit_current_and_next_cycles: false } do
   before do
     given_i_am_authenticated_as_an_accredited_provider_user
     when_i_visit_accredited_provider_page

--- a/spec/models/concerns/courses/edit_options_spec.rb
+++ b/spec/models/concerns/courses/edit_options_spec.rb
@@ -80,7 +80,7 @@ describe 'Course with edit options' do
 
     context "for a course that's not further education" do
       it 'returns only QTS options for users to choose between' do
-        expect(course.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts])
+        expect(course.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts undergraduate_degree_with_qts])
         course.qualification_options.each do |q|
           expect(q.include?('qts')).to be_truthy
         end


### PR DESCRIPTION
### Context

Now that courses have been rolled over in all the various environments and TDA is active in production, we should activate the flags in all environments.

### Guidance to review

🚢
