### PR TITLE
Fix wrong attribute name when previewing the course

### DIFF
--- a/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.rb
+++ b/app/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view.rb
@@ -4,7 +4,7 @@ module Find
   module Courses
     module TeacherDegreeApprenticeshipEntryRequirements
       class View < ViewComponent::Base
-        A_LEVEL_ATTRIBUTES = %i[a_level_subject_requirements accept_pending_gcse accept_a_level_equivalency additional_a_level_equivalencies].freeze
+        A_LEVEL_ATTRIBUTES = %i[a_level_subject_requirements accept_pending_a_level accept_a_level_equivalency additional_a_level_equivalencies].freeze
         attr_reader :course, :preview
 
         def initialize(course:, preview:)

--- a/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
+++ b/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
@@ -50,7 +50,7 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
         :with_teacher_degree_apprenticeship,
         :resulting_in_undergraduate_degree_with_qts,
         a_level_subject_requirements: [],
-        accept_pending_gcse: nil,
+        accept_pending_a_level: nil,
         accept_a_level_equivalency: nil,
         additional_a_level_equivalencies: nil
       )
@@ -71,7 +71,7 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
         :with_teacher_degree_apprenticeship,
         :resulting_in_undergraduate_degree_with_qts,
         a_level_subject_requirements: [],
-        accept_pending_gcse: nil,
+        accept_pending_a_level: nil,
         accept_a_level_equivalency: nil,
         additional_a_level_equivalencies: nil
       )


### PR DESCRIPTION
### Context

I added the wrong attribute name for #4375 

It should be A levels not GCSE.
