### PR TITLE
Update next cycle open date

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,7 +43,7 @@ cookies:
     expire_after_days: 182
 
 current_recruitment_cycle_year: 2024
-next_cycle_open_date: 2024-10-3
+next_cycle_open_date: 2024-10-1
 
 govuk_notify:
   api_key: please_change_me


### PR DESCRIPTION
### Context

Find opens on the 1st of October this year, not the 3rd.

### Before

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/4c5c19f4-d17c-4a13-b821-52b52c80673c">


### After

<img width="1019" alt="image" src="https://github.com/user-attachments/assets/e7f3675d-e3e5-4175-9d35-3905a8a84413">


### Guidance to review

🚢 

