### PR TITLE
Added age range to course summary in search results

### DIFF
--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -34,6 +34,11 @@
     <dt class="app-description-list__label">Study type</dt>
     <dd data-qa="course__study_mode"><%= course.study_mode.humanize %></dd>
 
+    <% if age_range_in_years_and_level.present? %>
+      <dt class="app-description-list__label"><%= t("find.courses.summary_component.view.age_range") %></dt>
+      <dd data-qa="course__age_range_in_years"><%= age_range_in_years_and_level %></dd>
+    <% end %>
+
     <% if filtered_by_location? && has_sites? %>
       <% if course.university_based? %>
         <%= render partial: "find/results/university", locals: { course: } %>

--- a/app/components/find/results/search_result_component.rb
+++ b/app/components/find/results/search_result_component.rb
@@ -7,6 +7,8 @@ module Find
 
       attr_reader :course
 
+      delegate :age_range_in_years_and_level, to: :course
+
       def initialize(course:, filtered_by_location: false, has_sites: false)
         super
         @course = course.decorate

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -253,6 +253,14 @@ class CourseDecorator < ApplicationDecorator
     I18n.t("edit_options.age_range_in_years.#{object.age_range_in_years}.label", default: object.age_range_in_years.humanize)
   end
 
+  def age_range_in_years_and_level
+    if secondary_course?
+      "#{age_range_in_years.humanize} - #{level}"
+    else
+      age_range_in_years.humanize
+    end
+  end
+
   def applications_open_first_label(recruitment_cycle)
     if current_cycle?
       'As soon as the course is on Find - recommended'

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -4,6 +4,12 @@ require 'rails_helper'
 
 module Find
   describe Results::SearchResultComponent, type: :component do
+    context 'delegations' do
+      subject { described_class.new(course: build(:course)) }
+
+      it { is_expected.to delegate_method(:age_range_in_years_and_level).to(:course) }
+    end
+
     context 'when the course specifies a required degree grade' do
       it 'renders correct message' do
         course = build(
@@ -148,6 +154,16 @@ module Find
         expect(result.text).not_to include('UK students')
         expect(result.text).not_to include('International students: £14,000')
         expect(result.text).not_to include('Course fee')
+      end
+    end
+
+    context 'when there is an age_range_in_years_and_level' do
+      it 'renders the age range and level' do
+        course = build_stubbed(:course)
+
+        result = render_inline(described_class.new(course:))
+
+        expect(result).to have_text('Age range Some Range and Level', normalize_ws: true)
       end
     end
   end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -1068,4 +1068,48 @@ describe CourseDecorator do
       end
     end
   end
+
+  describe '#age_range_in_years_and_level' do
+    context 'when the course is a secondary course' do
+      let(:course) do
+        build_stubbed(
+          :course,
+          level: 'secondary',
+          age_range_in_years: '11_to_16'
+        )
+      end
+
+      it 'renders the age range with the level' do
+        expect(decorated_course.age_range_in_years_and_level).to eq('11 to 16 - secondary')
+      end
+    end
+
+    context 'when the course is a primary course' do
+      let(:course) do
+        build_stubbed(
+          :course,
+          level: 'primary',
+          age_range_in_years: '11_to_16'
+        )
+      end
+
+      it 'renders the age range with the level' do
+        expect(decorated_course.age_range_in_years_and_level).to eq('11 to 16')
+      end
+    end
+
+    context 'when the course is a further education course' do
+      let(:course) do
+        build_stubbed(
+          :course,
+          level: 'further_education',
+          age_range_in_years: '11_to_16'
+        )
+      end
+
+      it 'renders the age range with the level' do
+        expect(decorated_course.age_range_in_years_and_level).to eq('11 to 16')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

We want to add the Age Range and Level to Course Results to highlight differences between courses

https://trello.com/c/Iwh2Yc1n

### Changes proposed in this pull request

Added age range with level to Course results

### Guidance to review

- View course results

![Capture-2024-07-17-144301](https://github.com/user-attachments/assets/13301073-2b52-44a0-a88a-5d6dec4dcb64)
![Capture-2024-07-17-144459](https://github.com/user-attachments/assets/b7d77412-16a4-4f0f-b7e8-7e27b724f87e)



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
