### PR TITLE
Change Find service name now that we are accepting undersgraduate courses

### DIFF
--- a/app/components/find/phase_banner/view.html.erb
+++ b/app/components/find/phase_banner/view.html.erb
@@ -5,6 +5,6 @@
       colour: environment_colour
     }
   ) do %>
-    Give feedback or report a problem: <%= bat_contact_mail_to subject: "Feedback about Find postgraduate teacher training", no_visited_state: true %>
+  Give feedback or report a problem: <%= bat_contact_mail_to subject: "Feedback about #{t('service_name.find')}", no_visited_state: true %>
   <% end %>
 </div>

--- a/app/jobs/find/slack_notification_job.rb
+++ b/app/jobs/find/slack_notification_job.rb
@@ -22,7 +22,7 @@ module Find
 
     def post_to_slack(text)
       payload = {
-        username: 'Find postgraduate teacher training',
+        username: 'Find teacher training courses',
         channel: SLACK_CHANNEL,
         text:,
         mrkdwn: true,

--- a/app/views/find/pages/accessibility.html.erb
+++ b/app/views/find/pages/accessibility.html.erb
@@ -5,7 +5,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Accessibility statement</h1>
 
-      <p class="govuk-body">This statement applies to the Find postgraduate teacher training service (Find).</p>
+      <p class="govuk-body">This statement applies to the <%= t("service_name.find") %> service (Find).</p>
 
       <h2 class="govuk-body">The service is run by the Department for Education (DfE). It’s designed to be used by as many people as possible. You should be able to:</h2>
 
@@ -50,7 +50,7 @@
       <h3 class="govuk-heading-s">Compliance status</h3>
 
     <p class="govuk-body">
-      Find postgraduate teacher training is compliant with the <%= govuk_link_to "Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard", "https://www.w3.org/TR/WCAG21/" %>.
+      <%= t("service_name.find") %> is compliant with the <%= govuk_link_to "Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard", "https://www.w3.org/TR/WCAG21/" %>.
     </p>
 
     <h2 class="govuk-heading-m">What we’re doing to improve accessibility</h2>

--- a/app/views/find/pages/privacy.html.erb
+++ b/app/views/find/pages/privacy.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, "Find postgraduate teacher training privacy notice" %>
+<% content_for :page_title, "t('service_name.find') privacy notice" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Find postgraduate teacher training privacy notice</h1>
+    <h1 class="govuk-heading-l"><%= t("service_name.find") %> privacy notice</h1>
 
     <h2 class="govuk-heading-m">Who we are</h2>
     <p class="govuk-body">
-      This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of Find postgraduate teacher training (&#8216;Find&#8217;).
+      This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of <%= t("service_name.find") %> (&#8216;Find&#8217;).
     </p>
 
     <h2 class="govuk-heading-m">Why our use of your personal data is lawful</h2>
@@ -17,7 +17,7 @@
       We receive your personal data in the form of your IP address and any postcode which you use to search for courses on the service. We use it to track traffic to the service and continuously improve our service to better meet users&#8217; needs.
     </p>
     <p class="govuk-body">
-      If you use other digital services for which the data controller is also the DfE (for example, Apply for postgraduate teacher training, or a Get Into Teaching service), we may use your IP address to understand how you are using these services. This allows us to ensure that public funds are being spent effectively.
+      If you use other digital services for which the data controller is also the DfE (for example, Apply for teacher training, or a Get Into Teaching service), we may use your IP address to understand how you are using these services. This allows us to ensure that public funds are being spent effectively.
     </p>
     <p class="govuk-body">
       In some instances, we may also collect your email address for similar purposes.

--- a/app/views/find/pages/privacy.html.erb
+++ b/app/views/find/pages/privacy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "t('service_name.find') privacy notice" %>
+<% content_for :page_title, "#{t('service_name.find')} privacy notice" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/find/pages/terms.html.erb
+++ b/app/views/find/pages/terms.html.erb
@@ -6,20 +6,20 @@
       <h1 class="govuk-heading-l">Terms and conditions</h1>
 
       <h2 class="govuk-heading-m">Using our website</h2>
-      <p class="govuk-body">The &#8216;Find postgraduate teacher training&#8217; service is maintained for your personal use and viewing. Access and use by you of this site constitutes your acceptance of these terms and conditions. This takes effect from the date on which you first use this website.</p>
+      <p class="govuk-body">The &#8216;<%= t("service_name.find") %>&#8217; service is maintained for your personal use and viewing. Access and use by you of this site constitutes your acceptance of these terms and conditions. This takes effect from the date on which you first use this website.</p>
 
-      <h2 class="govuk-heading-m">Linking to Find postgraduate teacher training </h2>
-      <p class="govuk-body">We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The &#8216;Find postgraduate teacher training&#8217; pages must be displayed in the user&#8217;s entire browser window.</p>
+      <h2 class="govuk-heading-m">Linking to <%= t("service_name.find") %> </h2>
+      <p class="govuk-body">We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The &#8216;<%= t("service_name.find") %>&#8217; pages must be displayed in the user&#8217;s entire browser window.</p>
 
-      <h2 class="govuk-heading-m">Linking from Find postgraduate teacher training</h2>
+      <h2 class="govuk-heading-m">Linking from <%= t("service_name.find") %></h2>
       <p class="govuk-body">We are not responsible for the content or reliability of the websites we link to and do not necessarily endorse the views expressed within them. We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.</p>
 
       <h2 class="govuk-heading-m">Virus protection</h2>
       <p class="govuk-body">We make every effort to check and test material at all stages of production. It is always wise for you to run an anti-virus program on all material downloaded from the Internet. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.</p>
 
       <h2 class="govuk-heading-m">Disclaimer</h2>
-      <p class="govuk-body">Find postgraduate teacher training and material relating to government information, products and services (or to third party information, products and services), is provided &#8216;as is&#8217;, without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
-      <p class="govuk-body">We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the &#8216;Find postgraduate teacher training&#8217;.</p>
+      <p class="govuk-body"><%= t("service_name.find") %> and material relating to government information, products and services (or to third party information, products and services), is provided &#8216;as is&#8217;, without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
+      <p class="govuk-body">We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the &#8216;<%= t("service_name.find") %>&#8217;.</p>
       <p class="govuk-body">These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
     </div>
   </div>

--- a/app/views/pages/add_an_organisation.html.erb
+++ b/app/views/pages/add_an_organisation.html.erb
@@ -21,7 +21,7 @@
     <p class="govuk-body">
         If you are a new initial teacher training (ITT) provider, we can set up your organisation on Publish teacher
         training courses (Publish). You’ll then be able to publish courses to
-        <%= govuk_link_to("Find postgraduate teacher training courses (Find)", t("links.find_website_url")) %>.
+        <%= govuk_link_to("#{t('service_name.find')} (Find)", t("links.find_website_url")) %>.
     </p>
 
     <p class="govuk-body">To do this:</p>

--- a/app/views/pages/add_schools_and_study_sites.html.erb
+++ b/app/views/pages/add_schools_and_study_sites.html.erb
@@ -31,7 +31,7 @@
     </p>
 
     <p class="govuk-body">
-      Over 80% of course searches on Find postgraduate teacher training (Find) are done by location, so it’s important that all location details have been added so courses can be found easily in searches.
+      Over 80% of course searches on <%= t("service_name.find") %> (Find) are done by location, so it’s important that all location details have been added so courses can be found easily in searches.
     </p>
 
     <p class="govuk-body">To be able to publish a course, you’ll need to attach at least one school and at least one study site to it.</p>

--- a/app/views/pages/course_summary_examples.erb
+++ b/app/views/pages/course_summary_examples.erb
@@ -31,7 +31,7 @@
       Based on our research into how candidates read course descriptions and our <%= govuk_link_to "guidance on writing descriptions for Publish teacher training courses", help_writing_course_descriptions_path %>, here are some ‘Course summary’ examples.
     </p>
     <p class="govuk-body">
-      The examples are based on real descriptions that are currently live on Find postgraduate teacher training.
+      The examples are based on real descriptions that are currently live on <%= t('service_name.find') %>.
     </p>
 
     <h2 id="example-1" class="govuk-heading-m">
@@ -107,11 +107,11 @@
     <h3 class="govuk-heading-s">Primary (264 words)</h3>
 
     <p class="govuk-body">
-      The Becoming a Teacher (BAT) primary course leads to Qualified Teacher Status (QTS) and a 
-      Post-Graduate Certificate in Education (PGCE). You will train across the 5-11 age range, where you will learn 
+      The Becoming a Teacher (BAT) primary course leads to Qualified Teacher Status (QTS) and a
+      Post-Graduate Certificate in Education (PGCE). You will train across the 5-11 age range, where you will learn
       from experienced practitioners, particularly your personal mentor.
 
-      You’ll spend four days per week on placement in our partnership schools. In addition, you will join the rest of 
+      You’ll spend four days per week on placement in our partnership schools. In addition, you will join the rest of
       your cohort one day per week for training with the BAT SCITT.
     </p>
 

--- a/app/views/pages/help_writing_course_descriptions.html.erb
+++ b/app/views/pages/help_writing_course_descriptions.html.erb
@@ -36,7 +36,7 @@
         <li>avoiding jargon and using common words</li>
         <li>using as few words as possible</li>
     </ul>
-    <p class="govuk-body">On Find postgraduate teacher training, the 'Course summary' is the first description candidates will read. See our <%= govuk_link_to "examples of course summaries", course_summary_examples_path %> that follow best practice for online content.</p>
+    <p class="govuk-body">On <%= t("service_name.find") %>, the 'Course summary' is the first description candidates will read. See our <%= govuk_link_to "examples of course summaries", course_summary_examples_path %> that follow best practice for online content.</p>
     <p class="govuk-body">Read more about <%= govuk_link_to "how to write for the web", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk" %>.</p>
   </div>
 </div>

--- a/app/views/pages/how_to_use_this_service.html.erb
+++ b/app/views/pages/how_to_use_this_service.html.erb
@@ -14,7 +14,7 @@
     <h1 class="govuk-heading-l">How to use this service</h1>
 
     <p class="govuk-body">
-      Publish teacher training courses (Publish) gives initial teacher training providers a way to create courses and publish them to Find postgraduate teacher training (Find).
+      Publish teacher training courses (Publish) gives initial teacher training providers a way to create courses and publish them to <%= t("service_name.find") %> (Find).
     </p>
 
     <p class="govuk-body">Candidates can then use Find to search for courses and apply to them.</p>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -31,7 +31,7 @@
 
     <h2 class="govuk-heading-m">How we will use your information</h2>
     <p class="govuk-body">
-      We store your IP address in order to track traffic to the service and continuously improve our service to better meet users&#8217; needs. If you use other digital services for which the data controller is also the DfE (for example, Manage postgraduate teacher training applications), we may also use your IP address to understand how you are using these services. This allows us to ensure that public funds are being spent effectively.
+      We store your IP address in order to track traffic to the service and continuously improve our service to better meet users&#8217; needs. If you use other digital services for which the data controller is also the DfE (for example, Manage teacher training applications), we may also use your IP address to understand how you are using these services. This allows us to ensure that public funds are being spent effectively.
     </p>
     <p class="govuk-body">
       Personally identifiable contact information that is published in course listings is available in the public domain via an application programming interface (API). We are not responsible for how a third party handles any personal information you choose to include in a course listing.

--- a/app/views/pages/roll_over_courses_to_a_new_recruitment_cycle.html.erb
+++ b/app/views/pages/roll_over_courses_to_a_new_recruitment_cycle.html.erb
@@ -54,7 +54,7 @@
 
     <p class="govuk-body">
       When your course is ready, you can publish it. It will not go live on
-      <%= govuk_link_to("Find postgraduate teacher training courses (Find)", t("links.find_website_url")) %>
+      <%= govuk_link_to("#{t('service_name.find')} (Find)", t("links.find_website_url")) %>
       straight away. Instead, the course will be ‘Scheduled’ until Find opens at the beginning of October.
       Candidates will then be able to search for your course.
     </p>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -115,7 +115,7 @@
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        listings for postgraduate teacher training courses that aren’t relevant to the service, such as but not limited to non-teacher training courses, undergraduate courses, non-primary and secondary courses and non-English courses
+        listings for teacher training courses that aren't relevant to the service, such as but not limited to non-teacher training courses, non-primary and secondary courses and non-English courses
       </li>
       <li>
         listings for unconfirmed or non-existent courses

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -115,7 +115,7 @@
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        listings for teacher training courses that aren't relevant to the service, such as but not limited to non-teacher training courses, non-primary and secondary courses and non-English courses
+        listings for teacher training courses that aren’t relevant to the service, such as but not limited to non-teacher training courses, non-primary and secondary courses and non-English courses
       </li>
       <li>
         listings for unconfirmed or non-existent courses

--- a/app/views/publish/courses/_course_table.html.erb
+++ b/app/views/publish/courses/_course_table.html.erb
@@ -4,7 +4,7 @@
       <th class="govuk-table__header">Course</th>
       <th class="govuk-table__header">Status</th>
       <th class="govuk-table__header">
-       Is it on <abbr class="app-!-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
+       Is it on <abbr class="app-!-text-decoration-underline-dotted" title="<%= t("service_name.find") %>">Find</abbr>?
       </th>
       <th class="govuk-table__header">Applications</th>
     </tr>

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -16,7 +16,7 @@
      <%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
     <% else %>
       <%= govuk_link_to search_ui_course_page_url(provider_code: course.provider.provider_code, course_code: course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
-      View on Find <span class="govuk-visually-hidden">postgraduate teacher training</span>
+      View on Find <span class="govuk-visually-hidden">teacher training courses</span>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/publish/notifications/index.html.erb
+++ b/app/views/publish/notifications/index.html.erb
@@ -22,7 +22,7 @@
         We’ll tell you when a training provider:
       </p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-        <li>publishes a new course on Find postgraduate teacher training</li>
+        <li>publishes a new course on <%= t("service_name.find") %></li>
         <li>makes a change to an existing course</li>
         <li>withdraws a course</li>
       </ul>

--- a/app/views/publish/shared/_aside_information_box.html.erb
+++ b/app/views/publish/shared/_aside_information_box.html.erb
@@ -7,7 +7,7 @@
 
     <h2 class="govuk-heading-s">Your courses for the <%= "#{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}" %> cycle</h2>
     <p class="govuk-body">
-      Courses you publish for the <%= "#{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}" %> cycle will be made available on Find postgraduate teacher training for candidates to view.
+      Courses you publish for the <%= "#{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}" %> cycle will be made available on <%= t("service_name.find") %> for candidates to view.
     </p>
 
     <h2 class="govuk-heading-s">Support and guidance</h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
     updated: "Cycle schedule updated"
   service_name:
     publish: "Publish teacher training courses"
-    find: "Find postgraduate teacher training"
+    find: "Find teacher training courses"
     support: "Publish support console"
     get_into_teaching: "Get Into Teaching"
   header:
@@ -1217,7 +1217,7 @@ en:
     published: "Your changes have been published"
     saved: "%{value} updated"
     added: "%{items_added} added"
-    changes_ttl: "Changes will appear on Find postgraduate teacher training within 15 minutes."
+    changes_ttl: "Changes will appear on Find teacher training courses within 15 minutes."
     visa_partner_warning: "Changing your answer will not change visa information for courses you or your training partners have already created."
     visa_warning: "Changing your answer will not change visa information for courses you have already created."
     visa_changes: "Visa sponsorship updated"

--- a/service_unavailable_page/web/public/internal/find.html
+++ b/service_unavailable_page/web/public/internal/find.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Sorry, the service is unavailable - Find postgraduate teacher training - GOV.UK</title>
+    <title>Sorry, the service is unavailable - Find teacher training courses - GOV.UK</title>
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -39,7 +39,7 @@
             </span>
           </a>
         </div>
-        <div class="govuk-header__product-name">Find postgraduate teacher training </div>
+        <div class="govuk-header__product-name">Find teacher training courses</div>
       </div>
     </header>
     <div class="govuk-width-container">

--- a/spec/components/find/phase_banner/view_spec.rb
+++ b/spec/components/find/phase_banner/view_spec.rb
@@ -5,6 +5,14 @@ require 'rails_helper'
 module Find
   module PhaseBanner
     RSpec.describe View, type: :component do
+      it 'renders the feedback link' do
+        result = render_inline(described_class.new)
+
+        mailto_link = result.css('a.govuk-link.govuk-link--no-visited-state')[0]
+        expect(mailto_link['href']).to include('subject=Feedback%20about%20Find%20teacher%20training%20courses')
+        expect(page.text).to include('Give feedback or report a problem: becomingateacher@digital.education.gov.uk')
+      end
+
       {
         'development' => 'grey',
         'qa' => 'orange',

--- a/spec/features/find/view_pages_spec.rb
+++ b/spec/features/find/view_pages_spec.rb
@@ -15,13 +15,13 @@ feature 'View pages' do
 
   scenario 'Navigate to /privacy-policy' do
     visit '/privacy'
-    expect(page).to have_css('h1', text: 'Find postgraduate teacher training privacy notice')
+    expect(page).to have_css('h1', text: 'Find teacher training courses privacy notice')
   end
 
   scenario 'Navigate to /accessibility' do
     visit '/accessibility'
     expect(page).to have_css('h1', text: 'Accessibility statement')
-    expect(page).to have_text('This statement applies to the Find postgraduate teacher training service (Find)')
+    expect(page).to have_text('This statement applies to the Find teacher training courses service (Find)')
   end
 
   scenario 'Redirect to /cycle-has-ended when cycle open' do

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -6,7 +6,7 @@ info:
   contact:
     name: DfE
     email: becomingateacher@digital.education.gov.uk
-  description: "API for DfE's postgraduate teacher training course service."
+  description: "API for DfE's teacher training course service."
 servers:
   - url: https://api.publish-teacher-training-courses.service.gov.uk/api/public/{version}
     description: "Production url."


### PR DESCRIPTION
### Context

We need to update the new service name for Find, so that we can enable Teacher Degree Apprenticeship (TDA) courses.

The new service name is:

Find teacher training courses

### Guidance to review

1. Check each page changed on this PR on the review app and the service name should match with the above.
2. Is there any other place mentioning postgraduate that we should change?

### What this PR does not do?

It doesn't change the links. This will be done in a future card/PR.



