### PR TITLE
[2061] Fix tests which will fail when the current cycle ends

### DIFF
--- a/spec/components/add_course_button_preview.rb
+++ b/spec/components/add_course_button_preview.rb
@@ -42,7 +42,7 @@ class AddCourseButtonPreview < ViewComponent::Preview
     end
 
     def recruitment_cycle_year
-      2024
+      Settings.current_recruitment_cycle_year
     end
 
     def accredited_provider?

--- a/spec/features/publish/courses/editing_study_sites_spec.rb
+++ b/spec/features/publish/courses/editing_study_sites_spec.rb
@@ -64,7 +64,7 @@ feature 'updating study sites on a course', { can_edit_current_and_next_cycles: 
   end
 
   def when_i_am_authenticated_as_a_provider_user_with_study_sites
-    providers = [build(:provider, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site)], courses: [build(:course, :with_accrediting_provider, applications_open_from: '2023-10-10', start_date: '2023-10-10')])]
+    providers = [build(:provider, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site)], courses: [build(:course, :with_accrediting_provider)])]
     @user = create(:user, providers:)
     given_i_am_authenticated(user: @user)
   end


### PR DESCRIPTION
### Context

Fixing a couple of tests which will fail when the current cycle ends. 

### Changes proposed in this pull request

Fix the tests dynamically so they work in both cycles.

### Guidance to review

Do the tests pass all the time regardless of the cycle?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
