### PR TITLE
[2061] Fix tests which will fail when rollover ends (spike)

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,7 +42,7 @@ cookies:
     name: _consented_to_analytics_cookies
     expire_after_days: 182
 
-current_recruitment_cycle_year: 2024
+current_recruitment_cycle_year: 2025
 next_cycle_open_date: 2024-10-1
 
 govuk_notify:

--- a/spec/components/add_course_button_preview.rb
+++ b/spec/components/add_course_button_preview.rb
@@ -42,7 +42,7 @@ class AddCourseButtonPreview < ViewComponent::Preview
     end
 
     def recruitment_cycle_year
-      2024
+      Settings.current_recruitment_cycle_year
     end
 
     def accredited_provider?

--- a/spec/controllers/publish/courses/outcome_controller_spec.rb
+++ b/spec/controllers/publish/courses/outcome_controller_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Publish::Courses::OutcomeController do
-  let(:recruitment_cycle) { create(:recruitment_cycle, year: 2025) }
-  let(:user) { create(:user, providers: [build(:provider, recruitment_cycle:)]) }
+  let(:user) { create(:user, providers: [build(:provider)]) }
   let(:provider) { user.providers.first }
 
   before do

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -136,11 +136,10 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {
@@ -161,7 +160,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
   end
 
   def when_i_visit_the_course_description_tab
-    publish_provider_courses_show_page.load(provider_code: @provider.provider_code, recruitment_cycle_year: 2025, course_code: @course.course_code)
+    publish_provider_courses_show_page.load(provider_code: @provider.provider_code, recruitment_cycle_year: @provider.recruitment_cycle_year, course_code: @course.course_code)
   end
 
   def then_i_see_a_levels_row

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -34,7 +34,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
   context 'TDA course' do
     scenario 'changing the outcome from non TDA to TDA' do
-      given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+      given_i_am_authenticated_as_a_provider_user
       and_the_tda_feature_flag_is_active
       and_there_is_a_qts_course_i_want_to_edit
       when_i_visit_the_course_outcome_page_in_the_next_cycle
@@ -45,7 +45,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
     context 'fee course' do
       scenario 'changing the outcome from TDA to non TDA' do
-        given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+        given_i_am_authenticated_as_a_provider_user
         and_the_tda_feature_flag_is_active
         and_there_is_a_tda_course_i_want_to_edit
         when_i_visit_the_course_outcome_page_in_the_next_cycle
@@ -72,7 +72,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
     context 'salaried course' do
       scenario 'changing the outcome from TDA to non TDA' do
-        given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+        given_i_am_authenticated_as_a_provider_user
         and_the_tda_feature_flag_is_active
         and_there_is_a_tda_course_i_want_to_edit
         when_i_visit_the_course_outcome_page_in_the_next_cycle
@@ -86,15 +86,6 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
         then_i_see_the_correct_attributes_in_the_database_for_salaried
       end
     end
-  end
-
-  def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
-    next_cycle_providers = [build(:provider, :next_recruitment_cycle, :accredited_provider,
-                                  courses: [create(:course, :with_accrediting_provider)],
-                                  sites: [build(:site), build(:site)],
-                                  study_sites: [build(:site, :study_site)])]
-    @next_cycle_user = create(:user, providers: next_cycle_providers)
-    given_i_am_authenticated(user: @next_cycle_user)
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -148,7 +139,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   end
 
   def then_i_am_shown_the_correct_qts_options
-    expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('QTS', 'QTS with PGCE', 'PGDE with QTS')
+    expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('QTS', 'QTS with PGCE', 'PGDE with QTS', 'Teacher degree apprenticeship (TDA) with QTS')
   end
 
   def then_i_am_shown_the_correct_non_qts_options

--- a/spec/features/publish/courses/editing_study_sites_spec.rb
+++ b/spec/features/publish/courses/editing_study_sites_spec.rb
@@ -64,7 +64,7 @@ feature 'updating study sites on a course', { can_edit_current_and_next_cycles: 
   end
 
   def when_i_am_authenticated_as_a_provider_user_with_study_sites
-    providers = [build(:provider, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site)], courses: [build(:course, :with_accrediting_provider, applications_open_from: '2023-10-10', start_date: '2023-10-10')])]
+    providers = [build(:provider, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site)], courses: [build(:course, :with_accrediting_provider)])]
     @user = create(:user, providers:)
     given_i_am_authenticated(user: @user)
   end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -219,11 +219,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def given_i_am_authenticated_as_a_school_direct_provider_user
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {
@@ -240,7 +239,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     @user = create(
       :user,
       providers: [
-        create(:provider, :scitt, recruitment_cycle: build(:recruitment_cycle, year: 2025), sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
+        create(:provider, :scitt, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
       ]
     )
     given_i_am_authenticated(

--- a/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
+++ b/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
@@ -65,11 +65,10 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {

--- a/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
+++ b/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
@@ -17,11 +17,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -306,7 +306,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       :open,
       :secondary,
       :fee_type_based,
-      applications_open_from: Time.zone.tomorrow,
+      applications_open_from: RecruitmentCycle.current.application_start_date,
       accrediting_provider:,
       site_statuses:, enrichments: [course_enrichment],
       study_sites: [study_site],


### PR DESCRIPTION
### Context

Following on from #4383 these will also fail when the current recruitment cycle closes.

These test mainly fail due to TDA being a 2025 cycle feature only, i.e not available in the current cycle.

These tests make more sense to fix when the time comes because:

- The next recruitment cycle will become the current recruitment cycle

- We should be able to remove the TDA feature flag and recruitment cycle check at this point

This branch will act as a spike and can also be re-opened when the time comes if desired.

### Changes proposed in this pull request

- Fix failing tests when the `current_recruitment_cycle_year` is updated to 2025.


### Guidance to review

Is everything still fully tested?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
