### PR TITLE
Return nil if age_range_in_years is blank

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -254,6 +254,8 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def age_range_in_years_and_level
+    return if age_range_in_years.blank?
+
     if secondary_course?
       "#{age_range_in_years.humanize} - #{level}"
     else


### PR DESCRIPTION
### Context

`age_range_in_years` can be blank 🤦‍♂️ this is causing [errors](https://dfe-teacher-services.sentry.io/issues/5618386329/?referrer=slack&notification_uuid=30e095ab-0276-46d1-abbd-f053929ca39f&alert_rule_id=11137790&alert_type=issue)
Error introduced in #4381 

### Changes proposed in this pull request

Add a check for blank age ranges

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
