### PR TITLE
Update course length data on search

### DIFF
--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -31,8 +31,10 @@
       <% end %>
     </dd>
 
-    <dt class="app-description-list__label">Study type</dt>
-    <dd data-qa="course__study_mode"><%= course.study_mode.humanize %></dd>
+    <% if course_length_with_study_mode.present? %>
+      <dt class="app-description-list__label"><%= t("course_length_with_study_mode.label") %></dt>
+      <dd data-qa="course__course_length_with_study_mode"><%= course_length_with_study_mode %></dd>
+    <% end %>
 
     <% if age_range_in_years_and_level.present? %>
       <dt class="app-description-list__label"><%= t("find.courses.summary_component.view.age_range") %></dt>

--- a/app/components/find/results/search_result_component.rb
+++ b/app/components/find/results/search_result_component.rb
@@ -7,7 +7,7 @@ module Find
 
       attr_reader :course
 
-      delegate :age_range_in_years_and_level, to: :course
+      delegate :age_range_in_years_and_level, :course_length_with_study_mode, to: :course
 
       def initialize(course:, filtered_by_location: false, has_sites: false)
         super

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -187,6 +187,13 @@ class CourseDecorator < ApplicationDecorator
     end
   end
 
+  def course_length_with_study_mode
+    [
+      length,
+      study_mode&.humanize&.downcase
+    ].compact_blank.join(' - ')
+  end
+
   def other_course_length?
     %w[OneYear TwoYears].exclude?(course_length) && !course_length.nil?
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1350,3 +1350,5 @@ en:
     url_ways_to_train_experienced_teacher: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/assessment-only-route-to-qts
     url: https://getintoteaching.education.gov.uk
   google_privacy_policy_url: "https://policies.google.com/technologies/cookies?hl=en-US#types-of-cookies"
+  course_length_with_study_mode:
+    label: "Course length"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1351,4 +1351,4 @@ en:
     url: https://getintoteaching.education.gov.uk
   google_privacy_policy_url: "https://policies.google.com/technologies/cookies?hl=en-US#types-of-cookies"
   course_length_with_study_mode:
-    label: "Course length"
+    label: Course length

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -8,6 +8,7 @@ module Find
       subject { described_class.new(course: build(:course)) }
 
       it { is_expected.to delegate_method(:age_range_in_years_and_level).to(:course) }
+      it { is_expected.to delegate_method(:course_length_with_study_mode).to(:course) }
     end
 
     context 'when the course specifies a required degree grade' do
@@ -166,6 +167,20 @@ module Find
         result = render_inline(described_class.new(course:))
 
         expect(result).to have_text('Age range 11 to 16 - secondary', normalize_ws: true)
+      end
+    end
+
+    context 'course length' do
+      it 'renders the course length with study mode' do
+        course = create(
+          :course,
+          enrichments: [build(:course_enrichment, :published, course_length: 'OneYear')],
+          study_mode: 'full_time'
+        )
+
+        result = render_inline(described_class.new(course:))
+
+        expect(result).to have_text('Course length 1 year - full time', normalize_ws: true)
       end
     end
   end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -1112,4 +1112,32 @@ describe CourseDecorator do
       end
     end
   end
+
+  describe '#course_length_with_study_mode' do
+    let(:course) do
+      create(
+        :course,
+        enrichments: [build(:course_enrichment, :published, course_length: 'OneYear')],
+        study_mode: 'full_time'
+      )
+    end
+
+    it 'returns the course length with the study mode' do
+      expect(decorated_course.course_length_with_study_mode).to eq('1 year - full time')
+    end
+
+    context 'when course length is missing' do
+      let(:course) do
+        create(
+          :course,
+          enrichments: [build(:course_enrichment, :published, course_length: nil)],
+          study_mode: 'full_time'
+        )
+      end
+
+      it 'return the study mode when course length is missing' do
+        expect(decorated_course.course_length_with_study_mode).to eq('full time')
+      end
+    end
+  end
 end

--- a/spec/features/find/search/course_results_spec.rb
+++ b/spec/features/find/search/course_results_spec.rb
@@ -34,8 +34,8 @@ feature 'results' do
     site2 = build(:site, location_name: 'site2')
     site_status1 = build(:site_status, :findable, site: site1)
     site_status2 = build(:site_status, :findable, site: site2)
-    create(:course, name: 'Hello there', site_statuses: [site_status1])
-    create(:course, name: 'Hello there', site_statuses: [site_status2])
+    create(:course, name: 'Hello there', site_statuses: [site_status1], enrichments: [build(:course_enrichment, :published, course_length: 'OneYear')], study_mode: :full_time)
+    create(:course, name: 'Hello there', site_statuses: [site_status2], enrichments: [build(:course_enrichment, :published, course_length: 'OneYear')], study_mode: :full_time)
   end
 
   def i_see_the_courses
@@ -45,7 +45,7 @@ feature 'results' do
       expect(first_course.course_name.text).to include('Hello there')
       expect(first_course.provider_name.text).to be_present
       expect(first_course.qualification.text).to include('QTS with PGCE')
-      expect(first_course.study_mode.text).to eq('Full time')
+      expect(first_course.course_length.text).to eq('1 year - full time')
       expect(first_course.funding_options.text).to eq('Teaching apprenticeship - with salary')
     end
   end

--- a/spec/support/page_objects/find/results.rb
+++ b/spec/support/page_objects/find/results.rb
@@ -8,7 +8,6 @@ module PageObjects
       class Courses < SitePrism::Section
         element :provider_name, '[data-qa="course__provider_name"]'
         element :course_name, '[data-qa="course__name"]'
-        element :study_mode, '[data-qa="course__study_mode"]'
         element :course_length, '[data-qa="course__course_length_with_study_mode"]'
         # TODO: nearest_location?
         element :qualification, '[data-qa="course__qualification"]'

--- a/spec/support/page_objects/find/results.rb
+++ b/spec/support/page_objects/find/results.rb
@@ -9,6 +9,7 @@ module PageObjects
         element :provider_name, '[data-qa="course__provider_name"]'
         element :course_name, '[data-qa="course__name"]'
         element :study_mode, '[data-qa="course__study_mode"]'
+        element :course_length, '[data-qa="course__course_length_with_study_mode"]'
         # TODO: nearest_location?
         element :qualification, '[data-qa="course__qualification"]'
         element :funding_options, '[data-qa="course__funding_options"]'


### PR DESCRIPTION
### Context

We want to update the "Study type" to "Course length" on Course Results to improve consistency between the results and the detail view

https://trello.com/c/2aQcYZBW

### Changes proposed in this pull request

- Updated the label from "Study type" to "Course length" on Course Results
- Updated the text rendered to include the Course length and Study mode

### Guidance to review

- View course results

| before | after |
|---|---|
| ![Capture-2024-07-18-114543](https://github.com/user-attachments/assets/2c08097c-1594-470f-9891-beac08a4e167) | ![Capture-2024-07-18-113950](https://github.com/user-attachments/assets/9ded142e-e534-4e9f-b66b-e891724619f6) |

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
