### PR TITLE
Update section headers for courses

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="training-locations">Training locations</h2>
+  <h2 class="govuk-heading-l" id="training-locations"><%= t(".heading") %> </h2>
   <div data-qa="course__about_schools">
     <% if show_higher_education_guidance? %>
       <%= render Shared::AdviceComponent::View.new(title: "Where you will train") do %>

--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -1,22 +1,22 @@
-<h2 class="govuk-heading-m">Contents</h2>
+<h2 class="govuk-heading-m"><%= t(".heading") %> </h2>
 <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
   <li><%= govuk_link_to "Entry requirements", "#section-entry" %></li>
   <% if about_course.present? || preview? %>
-    <li><%= govuk_link_to "Course summary", "#section-about" %></li>
+    <li><%= govuk_link_to t(".course_details"), "#section-about" %></li>
   <% end %>
+  <li><%= govuk_link_to t(".fees_and_financial_support"), "#section-financial-support" %></li>
   <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" || preview? %>
-    <li><%= govuk_link_to "Training locations", "#training-locations" %></li>
+    <li><%= govuk_link_to t(".how_school_placements_work"), "#training-locations" %></li>
   <% end %>
   <% if salaried? %>
-    <li><%= govuk_link_to "Salary", "#section-salary" %></li>
+    <li><%= govuk_link_to t(".salary"), "#section-salary" %></li>
   <% end %>
-  <li><%= govuk_link_to "Fees and financial support", "#section-financial-support" %></li>
   <% if interview_process.present? %>
-    <li><%= govuk_link_to "Interview process", "#section-interviews" %></li>
+    <li><%= govuk_link_to t(".interview_process"), "#section-interviews" %></li>
   <% end %>
   <% if provider.train_with_disability.present? || preview? %>
-    <li><%= govuk_link_to "Training with disabilities", "#section-train-with-disabilities" %></li>
+    <li><%= govuk_link_to t(".training_with_disabilities"), "#section-train-with-disabilities" %></li>
   <% end %>
-  <li><%= govuk_link_to "Support and advice", "#section-advice" %></li>
-  <% if course.application_status_open? %> <li><%= govuk_link_to "Apply", "#section-apply" %></li> <% end %>
+  <li><%= govuk_link_to t(".support_and_advice"), "#section-advice" %></li>
+  <% if course.application_status_open? %> <li><%= govuk_link_to t(".apply"), "#section-apply" %></li> <% end %>
 </ul>

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -1,3 +1,7 @@
+<h2 class="govuk-heading-l">
+  <%= t(".course_summary") %>
+</h2>
+
 <%= govuk_summary_list(actions: false, classes: ["govuk-summary-list--no-border"]) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".fee_or_salary")) %>

--- a/app/views/find/courses/_about_course.html.erb
+++ b/app/views/find/courses/_about_course.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-about">Course summary</h2>
+  <h2 class="govuk-heading-l" id="section-about"><%= t(".heading") %> </h2>
   <div data-qa="course__about_course">
     <% if course.published_about_course.present? %>
       <%= markdown(course.published_about_course) %>

--- a/app/views/find/courses/_advice.html.erb
+++ b/app/views/find/courses/_advice.html.erb
@@ -1,4 +1,4 @@
 <div id="section-advice-and-support">
   <h2 class="govuk-heading-m" id="section-advice"><%= t(".heading") %></h2>
-  <p class="govuk-body"><%= t(".body_html") %></p>
+  <span class="govuk-body"><%= t(".body_html") %></span>
 </div>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -39,24 +39,24 @@
       <%= render partial: "find/courses/about_course", locals: { course: @course } %>
     <% end %>
 
+    <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
+
     <%= render Find::Courses::AboutSchoolsComponent::View.new(@course, preview: preview?(params)) %>
 
     <% if @course.salaried? %>
       <%= render partial: "find/courses/salary", locals: { course: @course } %>
     <% end %>
 
-    <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
-
     <% if @course.published_interview_process.present? %>
       <%= render partial: "find/courses/interview_process", locals: { course: @course } %>
     <% end %>
 
     <% if @provider.train_with_disability.present? %>
-      <h2 class="govuk-heading-l" id="section-train-with-disabilities">
+      <h2 class="govuk-heading-m" id="section-train-with-disabilities">
         <%= t(".training_with_disabilities") %>
       </h2>
 
-      <p class="govuk-body">
+      <p class="govuk-body govuk-!-margin-bottom-8">
         <%= govuk_link_to(
           t(".training_with_disabilities_link", provider_name: @course.provider_name),
           find_training_with_disabilities_path(

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -29,23 +29,23 @@
 
     <%= render partial: "find/courses/about_course", locals: { course: } %>
 
+    <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
+
     <%= render Find::Courses::AboutSchoolsComponent::View.new(course, preview: preview?(params)) %>
 
     <% if course.salaried? %>
       <%= render partial: "find/courses/salary", locals: { course: } %>
     <% end %>
 
-    <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
-
     <% if course.interview_process.present? %>
       <%= render partial: "find/courses/interview_process", locals: { course: } %>
     <% end %>
 
-    <h2 class="govuk-heading-l" id="section-train-with-disabilities">
+    <h2 class="govuk-heading-m" id="section-train-with-disabilities">
       <%= t(".training_with_disabilities") %>
     </h2>
 
-    <p class="govuk-body">
+    <p class="govuk-body govuk-!-margin-bottom-8">
       <%= govuk_link_to(
         t(".training_with_disabilities_link", provider_name: course.provider_name),
         training_with_disabilities_publish_provider_recruitment_cycle_course_path(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,7 +269,7 @@ en:
     course_preview:
       missing_information:
         about_this_course:
-          text: "Enter course summary"
+          text: "Enter course details"
         a_levels:
           text: "Enter A levels and equivalency test requirements"
         degree:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -84,6 +84,17 @@ en:
       a_level_component:
         view:
           equivalency_tests: Equivalency tests
+      contents_component:
+        view:
+          course_details: Course details
+          how_school_placements_work: How school placements work
+          training_with_disabilities: Training with disabilities
+          fees_and_financial_support: Fees and financial support
+          salary: Salary
+          interview_process: Interview process
+          support_and_advice: Support and advice
+          apply: Apply
+          heading: Contents
       entry_requirements_component:
         view:
           heading: Entry requirements
@@ -115,9 +126,12 @@ en:
             <span class="govuk-hint govuk-!-font-size-16">
               This should be an honours degree (Third or above), or equivalent
             </span>
+      about_course:
+        heading: Course details
       summary_component:
         view:
           fee_or_salary: Fee or salary
+          course_summary: Course summary
           course_fee: Course fee
           course_length: Course length
           age_range: Age range
@@ -154,6 +168,7 @@ en:
           contact: Contact %{provider_name}
       about_schools_component:
         view:
+          heading: How school placements work
           view_list_of_school_placements: View list of school placements
           work_with_schools: We work with the following schools to provide your school placements.
       placements:

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -44,7 +44,7 @@ module CoursePreview
         end
       end
 
-      include_examples 'course with missing information', :about_this_course, 'Enter course summary'
+      include_examples 'course with missing information', :about_this_course, 'Enter course details'
       include_examples 'course with missing information', :degree, 'Enter degree requirements'
       include_examples 'course with missing information', :fee_uk_eu, 'Enter details about fees and financial support'
       include_examples 'course with missing information', :gcse, 'Enter GCSE and equivalency test requirements'

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -15,7 +15,7 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
 
         result = render_inline(described_class.new(course))
 
-        expect(result.text).to include('Training locations')
+        expect(result.text).to include('How school placements work')
       end
     end
   end

--- a/spec/components/find/courses/contents_component/view_spec.rb
+++ b/spec/components/find/courses/contents_component/view_spec.rb
@@ -15,7 +15,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('Training locations')
+      expect(result.text).to include('How school placements work')
     end
   end
 
@@ -31,7 +31,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('Training locations')
+      expect(result.text).to include('How school placements work')
     end
   end
 
@@ -46,7 +46,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).not_to include('Training locations')
+      expect(result.text).not_to include('How school placements work')
     end
   end
 

--- a/spec/features/publish/courses/editing_course_about_this_course_from_preview_page_spec.rb
+++ b/spec/features/publish/courses/editing_course_about_this_course_from_preview_page_spec.rb
@@ -36,7 +36,7 @@ feature 'Editing about this course from the course preview page' do
   end
 
   def and_i_click_course_summary
-    click_on 'Enter course summary'
+    click_on 'Enter course details'
   end
 
   def then_i_see_the_about_this_course_page


### PR DESCRIPTION
### Context

This commit updates the course contents summary list to make it easier
for users to navigate the course show/preview page. This is part of a
course page redesign.

### Changes proposed in this pull request
Updated the items in the `app/components/find/courses/contents_component`


| before | after |
|---|---|
| ![Screenshot from 2024-07-19 12-04-29](https://github.com/user-attachments/assets/509340fb-5349-49db-913c-89f5b8c08849) | ![Screenshot from 2024-07-19 11-51-43](https://github.com/user-attachments/assets/64566b87-8742-49ea-ac6b-b1e56c6f587c) |


### Guidance to review

View a course on find and preview it on publish, does the contents_component make sense?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
