### PR TITLE
Reformat summary course 

### DIFF
--- a/app/components/find/courses/fees_component/view.html.erb
+++ b/app/components/find/courses/fees_component/view.html.erb
@@ -14,18 +14,19 @@
           </thead>
           <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">UK students</td>
+            <td class="govuk-table__cell"><%= t(".uk_citizens") %></td>
+
             <td class="govuk-table__cell" data-qa="course__uk_fees"><%= number_to_currency(fee_uk_eu) %></td>
           </tr>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">International students</td>
+            <td class="govuk-table__cell"><%= t(".non_uk_citizens") %></td>
             <td class="govuk-table__cell" data-qa="course__international_fees"><%= number_to_currency(fee_international) %></td>
           </tr>
           </tbody>
         </table>
       <% else %>
         <p class="govuk-body">
-          The course fees for UK students in <%= cycle_range %> are <%= number_to_currency(fee_uk_eu) %>.
+          <%= t(".course_fees", cycle_range:, fee: number_to_currency(fee_uk_eu)) %>
         </p>
       <% end %>
     </div>

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -2,7 +2,7 @@
   <%= t(".course_summary") %>
 </h2>
 
-<%= govuk_summary_list(actions: false, classes: ["govuk-summary-list--no-border"]) do |summary_list| %>
+<%= govuk_summary_list(actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".fee_or_salary")) %>
     <% row.with_value do %>
@@ -15,7 +15,9 @@
   <% unless no_fee? %>
     <% summary_list.with_row do |row| %>
       <% row.with_key(text: t(".course_fee")) %>
-      <% row.with_value(text: course_fee_value) %>
+      <% row.with_value do %>
+        <%= course_fee_value %>
+      <% end %>
     <% end %>
   <% end %>
 
@@ -65,7 +67,7 @@
 
   <% if start_date.present? %>
     <% summary_list.with_row do |row| %>
-      <% row.with_key(text: t(".date_course_start")) %>
+      <% row.with_key(text: t(".start_date")) %>
       <% row.with_value(text: l(start_date&.to_date, format: :short)) %>
     <% end %>
   <% end %>

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -53,19 +53,27 @@ module Find
         end
 
         def course_fee_value
-          safe_join([formatted_uk_eu_fee_label, tag.br, formatted_international_fee_label])
+          safe_join(
+            [
+              tag.b(number_to_currency(course.fee_uk_eu)),
+              formatted_uk_eu_fee_label,
+              tag.br,
+              tag.b(number_to_currency(course.fee_international)),
+              formatted_international_fee_label
+            ]
+          )
         end
 
         def formatted_uk_eu_fee_label
           return if course.fee_uk_eu.blank?
 
-          "UK students: #{number_to_currency(course.fee_uk_eu)}"
+          " #{I18n.t('find.courses.summary_component.view.for_uk_citizens')}"
         end
 
         def formatted_international_fee_label
           return if course.fee_international.blank?
 
-          "International students: #{number_to_currency(course.fee_international)}"
+          " #{I18n.t('find.courses.summary_component.view.for_non_uk_citizens')}"
         end
 
         def no_fee?

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -71,6 +71,11 @@ en:
       primary_title: Primary courses with subject specialisms
       secondary_title: Which secondary subjects do you want to teach?
     courses:
+      fees_component:
+        view:
+          uk_citizens: UK citizens
+          non_uk_citizens: Non-UK citizens
+          course_fees: The course fees for UK citizens in %{cycle_range} are %{fee}.
       advice:
         heading: Support and advice
         body_html: You can <a class="govuk-link" href="https://getintoteaching.education.gov.uk/teacher-training-advisers"> get a teacher training adviser</a> or <a class="govuk-link" href="https://getintoteaching.education.gov.uk/help-and-support"> contact Get Into Teaching</a> for free support.
@@ -136,10 +141,12 @@ en:
           course_length: Course length
           age_range: Age range
           date_can_apply: Date you can apply from
-          date_course_start: Date course starts
+          start_date: Start date
           qualification: Qualification
           provider: Provider
           accredited_by: Accredited by
+          for_uk_citizens: for UK citizens
+          for_non_uk_citizens: for non-UK citizens
       providers:
         show:
           heading: About %{provider_name}

--- a/spec/components/find/courses/fees_component/view_spec.rb
+++ b/spec/components/find/courses/fees_component/view_spec.rb
@@ -12,8 +12,8 @@ describe Find::Courses::FeesComponent::View, type: :component do
       result = render_inline(described_class.new(course))
       expect(result.text).to include('Student type')
       expect(result.text).to include('Fees to pay')
-      expect(result.text).to include('UK students')
-      expect(result.text).to include('International students')
+      expect(result.text).to include('UK citizens')
+      expect(result.text).to include('Non-UK citizens')
       expect(result.text).not_to include('The course fees for UK students')
     end
   end
@@ -26,7 +26,7 @@ describe Find::Courses::FeesComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
       expect(result.text).not_to include('International students')
-      expect(result.text).to include('The course fees for UK students')
+      expect(result.text).to include('The course fees for UK citizens')
     end
   end
 end

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -19,7 +19,7 @@ module Find
             'Qualification',
             'Provider',
             'Date you can apply from',
-            'Date course starts'
+            'Start date'
           )
         end
 
@@ -131,7 +131,7 @@ module Find
             course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 
             result = render_inline(described_class.new(course))
-            expect(result.text).to include('UK students: £9,250')
+            expect(result.text).to include('£9,250 for UK citizens')
             expect(result.text).to include('Course fee')
           end
         end
@@ -141,7 +141,7 @@ module Find
             course = create(:course, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
 
             result = render_inline(described_class.new(course))
-            expect(result.text).to include('International students: £14,000')
+            expect(result.text).to include('£14,000 for non-UK citizens')
           end
         end
 
@@ -151,8 +151,8 @@ module Find
 
             result = render_inline(described_class.new(course))
 
-            expect(result.text).to include('UK students: £9,250')
-            expect(result.text).not_to include('International students')
+            expect(result.text).to include('£9,250 for UK citizens')
+            expect(result.text).not_to include('for non-UK citizens')
           end
         end
 
@@ -162,8 +162,8 @@ module Find
 
             result = render_inline(described_class.new(course))
 
-            expect(result.text).not_to include('UK students')
-            expect(result.text).to include('International students: £14,000')
+            expect(result.text).not_to include('for UK citizens')
+            expect(result.text).to include('£14,000 for non-UK citizens')
           end
         end
 
@@ -173,8 +173,8 @@ module Find
 
             result = render_inline(described_class.new(course))
 
-            expect(result.text).not_to include('UK students')
-            expect(result.text).not_to include('International students: £14,000')
+            expect(result.text).not_to include('for UK citizens')
+            expect(result.text).not_to include('£14,000 for non-UK citizens')
             expect(result.text).not_to include('Course fee')
           end
         end

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -313,7 +313,7 @@ feature 'Viewing a findable course' do
 
   def then_i_should_only_see_the_uk_fees
     expect(find_course_show_page).to have_content(
-      "The course fees for UK students in #{RecruitmentCycle.current.year} to #{RecruitmentCycle.current.year.to_i + 1} are £9,250"
+      "The course fees for UK citizens in #{RecruitmentCycle.current.year} to #{RecruitmentCycle.current.year.to_i + 1} are £9,250"
     )
 
     expect(find_course_show_page).not_to have_international_fees

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -365,7 +365,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_see_the_the_course_fee
-    expect(page).to have_text "The course fees for UK students in #{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1} are £100."
+    expect(page).to have_text "The course fees for UK citizens in #{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1} are £100."
   end
 
   def and_i_submit_and_continue_through_the_two_forms


### PR DESCRIPTION
### Context

This is part of the course show/preview page redesign.
We want to make it easier for users to view this page.

### Changes proposed in this pull request
Edit `app/components/find/courses/summary_component.rb`

| before | after |
|---|---|
| ![Screenshot from 2024-07-19 15-50-35](https://github.com/user-attachments/assets/3955cc5d-4904-42ab-aa8b-078cb9d94ae5) | ![Screenshot from 2024-07-19 15-52-27](https://github.com/user-attachments/assets/cef8b5df-520d-48c6-b03b-dd68e23a0880) |


### Guidance to review

View a course on publish as preview and one on find. Does the summary component make sense?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
