### PR TITLE
Change Find domain links in all of our services

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo is home to three services:
 
-- A service for candidates to [find teacher training](https://www.find-teacher-training-courses.service.gov.uk)
+- A service for candidates to [find teacher training](https://find-teacher-training-courses.service.gov.uk)
 - A service for providers to [publish teacher training courses](https://www.publish-teacher-training-courses.service.gov.uk)
 - An API to retrieve data on [teacher training courses](https://api.publish-teacher-training-courses.service.gov.uk/)
 
@@ -23,7 +23,7 @@ This repo is home to three services:
 
 | Name        | URL                                                                    | Description
 | ----------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------
-| Production  | [www](https://www.find-teacher-training-courses.service.gov.uk)   | Public site
+| Production  | [www](https://find-teacher-training-courses.service.gov.uk)   | Public site
 | Staging     | [staging](https://staging.find-teacher-training-courses.service.gov.uk)| For internal use by DfE to test deploys
 | QA          | [qa](https://qa.find-teacher-training-courses.service.gov.uk)     | For internal use by DfE for testing. Automatically deployed from main
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo is home to three services:
 
-- A service for candidates to [find teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk)
+- A service for candidates to [find teacher training](https://www.find-teacher-training-courses.service.gov.uk)
 - A service for providers to [publish teacher training courses](https://www.publish-teacher-training-courses.service.gov.uk)
 - An API to retrieve data on [teacher training courses](https://api.publish-teacher-training-courses.service.gov.uk/)
 
@@ -23,9 +23,9 @@ This repo is home to three services:
 
 | Name        | URL                                                                    | Description
 | ----------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------
-| Production  | [www](https://www.find-postgraduate-teacher-training.service.gov.uk)   | Public site
-| Staging     | [staging](https://staging.find-postgraduate-teacher-training.service.gov.uk)| For internal use by DfE to test deploys
-| QA          | [qa](https://qa.find-postgraduate-teacher-training.service.gov.uk)     | For internal use by DfE for testing. Automatically deployed from main
+| Production  | [www](https://www.find-teacher-training-courses.service.gov.uk)   | Public site
+| Staging     | [staging](https://staging.find-teacher-training-courses.service.gov.uk)| For internal use by DfE to test deploys
+| QA          | [qa](https://qa.find-teacher-training-courses.service.gov.uk)     | For internal use by DfE for testing. Automatically deployed from main
 
 ### Publish
 

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -9,7 +9,7 @@ CanonicalRails.setup do |config|
 
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
-  config.host = 'www.find-postgraduate-teacher-training.service.gov.uk'
+  config.host = 'find-teacher-training-courses.service.gov.uk'
   config.port # = '3000'
 
   # http://en.wikipedia.org/wiki/URL_normalization

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,6 +10,7 @@ Rails.application.configure do
   config.content_security_policy do |policy|
     local_domains = %w[https://publish.localhost https://find.localhost]
     prod_domains = [
+      'https://*.find-teacher-training-courses.service.gov.uk',
       'https://*.find-postgraduate-teacher-training.service.gov.uk',
       'https://*.publish-teacher-training-courses.service.gov.uk'
     ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1249,7 +1249,7 @@ en:
     visa_changes: "Visa sponsorship updated"
     user_removed: "User removed"
   links:
-    find_website_url: "https://www.find-postgraduate-teacher-training.service.gov.uk/"
+    find_website_url: "https://find-teacher-training-courses.service.gov.uk/"
     dfe_signin: https://services.signin.education.gov.uk
     get_information_schools: "https://www.get-information-schools.service.gov.uk/"
     ability_net: "https://mcmw.abilitynet.org.uk/"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,13 +1,13 @@
 gcp_api_key: please_change_me
 publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
-find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://find-teacher-training-courses.service.gov.uk
 extra_find_url: https://find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 
 search_ui:
-  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://find-teacher-training-courses.service.gov.uk
 
 base_url: https://www.publish-teacher-training-courses.service.gov.uk
 
@@ -37,5 +37,5 @@ features:
   send_request_data_to_bigquery: true
 
 find_valid_referers:
-  - https://www.find-postgraduate-teacher-training.service.gov.uk
+  - https://find-teacher-training-courses.service.gov.uk
   - https://find-teacher-training-courses.service.gov.uk

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -1,13 +1,13 @@
 gcp_api_key: please_change_me
 publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
-find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://find-teacher-training-courses.service.gov.uk
 extra_find_url: https://find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 
 search_ui:
-  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://find-teacher-training-courses.service.gov.uk
 
 base_url: https://www.publish-teacher-training-courses.service.gov.uk
 
@@ -41,5 +41,5 @@ features:
   send_request_data_to_bigquery: true
 
 find_valid_referers:
-  - https://www.find-postgraduate-teacher-training.service.gov.uk
+  - https://find-teacher-training-courses.service.gov.uk
   - https://find-teacher-training-courses.service.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,12 +1,12 @@
 gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
-find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://qa.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:
-  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://qa.find-teacher-training-courses.service.gov.uk
 
 # URL of this app for the callback after sigining in
 base_url: https://qa.publish-teacher-training-courses.service.gov.uk
@@ -33,5 +33,5 @@ features:
   send_request_data_to_bigquery: true
 
 find_valid_referers:
-  - https://qa.find-postgraduate-teacher-training.service.gov.uk
+  - https://qa.find-teacher-training-courses.service.gov.uk
   - https://qa.find-teacher-training-courses.service.gov.uk

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -1,12 +1,12 @@
 gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
-find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://qa.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
 search_ui:
-  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://qa.find-teacher-training-courses.service.gov.uk
 
 # URL of this app for the callback after sigining in
 base_url: https://qa.publish-teacher-training-courses.service.gov.uk
@@ -33,5 +33,5 @@ features:
   send_request_data_to_bigquery: true
 
 find_valid_referers:
-  - https://qa.find-postgraduate-teacher-training.service.gov.uk
+  - https://qa.find-teacher-training-courses.service.gov.uk
   - https://qa.find-teacher-training-courses.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -6,11 +6,11 @@ environment:
   name: "review"
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
-find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://qa.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
-  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://qa.find-teacher-training-courses.service.gov.uk
 
 authentication:
   secret: secret

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -6,11 +6,11 @@ environment:
   name: "review"
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
-find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://qa.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 search_ui:
-  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://qa.find-teacher-training-courses.service.gov.uk
 
 authentication:
   secret: secret

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -1,7 +1,7 @@
 gcp_api_key: please_change_me
 publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
-find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
@@ -10,7 +10,7 @@ environment:
   name: "sandbox"
 
 search_ui:
-  base_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 
 base_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 
@@ -21,5 +21,5 @@ dfe_signin:
   user_search_url: https://support.signin.education.gov.uk/users
 
 find_valid_referers:
-  - https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+  - https://sandbox.find-teacher-training-courses.service.gov.uk
   - https://sandbox.find-teacher-training-courses.service.gov.uk

--- a/config/settings/sandbox_aks.yml
+++ b/config/settings/sandbox_aks.yml
@@ -1,7 +1,7 @@
 gcp_api_key: please_change_me
 publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
-find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 
@@ -10,7 +10,7 @@ environment:
   name: "sandbox"
 
 search_ui:
-  base_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://sandbox.find-teacher-training-courses.service.gov.uk
 
 base_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 
@@ -21,5 +21,5 @@ dfe_signin:
   user_search_url: https://support.signin.education.gov.uk/users
 
 find_valid_referers:
-  - https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+  - https://sandbox.find-teacher-training-courses.service.gov.uk
   - https://sandbox.find-teacher-training-courses.service.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,12 +1,12 @@
 gcp_api_key: please_change_me
 publish_api_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
-find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://staging.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:
-  base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://staging.find-teacher-training-courses.service.gov.uk
 
 # URL of this app for the callback after sigining in
 base_url: https://staging.publish-teacher-training-courses.service.gov.uk
@@ -30,5 +30,5 @@ features:
   send_request_data_to_bigquery: true
 
 find_valid_referers:
-  - https://staging.find-postgraduate-teacher-training.service.gov.uk
+  - https://staging.find-teacher-training-courses.service.gov.uk
   - https://staging.find-teacher-training-courses.service.gov.uk

--- a/config/settings/staging_aks.yml
+++ b/config/settings/staging_aks.yml
@@ -1,12 +1,12 @@
 gcp_api_key: please_change_me
 publish_api_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
-find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://staging.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
 search_ui:
-  base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+  base_url: https://staging.find-teacher-training-courses.service.gov.uk
 
 # URL of this app for the callback after sigining in
 base_url: https://staging.publish-teacher-training-courses.service.gov.uk
@@ -30,5 +30,5 @@ features:
   send_request_data_to_bigquery: true
 
 find_valid_referers:
-  - https://staging.find-postgraduate-teacher-training.service.gov.uk
+  - https://staging.find-teacher-training-courses.service.gov.uk
   - https://staging.find-teacher-training-courses.service.gov.uk

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,7 +3,7 @@ govuk_notify:
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
-find_url: https://www2.find-teacher-training-courses.service.gov.uk
+find_url: https://find-teacher-training-courses.service.gov.uk
 bg_jobs:
   save_statistic:
     cron: "0 0 * * *" # daily at midnight

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,7 +3,7 @@ govuk_notify:
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
-find_url: https://www2.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://www2.find-teacher-training-courses.service.gov.uk
 bg_jobs:
   save_statistic:
     cron: "0 0 * * *" # daily at midnight

--- a/maintenance_page/manifests/production_aks/ingress_external_to_main.yml
+++ b/maintenance_page/manifests/production_aks/ingress_external_to_main.yml
@@ -1,11 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: www.find-postgraduate-teacher-training.service.gov.uk
+  name: find-teacher-training-courses.service.gov.uk
 spec:
   ingressClassName: nginx
   rules:
-  - host: www.find-postgraduate-teacher-training.service.gov.uk
+  - host: find-teacher-training-courses.service.gov.uk
     http:
       paths:
       - pathType: ImplementationSpecific

--- a/maintenance_page/manifests/production_aks/ingress_external_to_maintenance.yml
+++ b/maintenance_page/manifests/production_aks/ingress_external_to_maintenance.yml
@@ -1,11 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: www.find-postgraduate-teacher-training.service.gov.uk
+  name: find-teacher-training-courses.service.gov.uk
 spec:
   ingressClassName: nginx
   rules:
-  - host: www.find-postgraduate-teacher-training.service.gov.uk
+  - host: find-teacher-training-courses.service.gov.uk
     http:
       paths:
       - pathType: ImplementationSpecific

--- a/maintenance_page/manifests/qa_aks/ingress_external_to_main.yml
+++ b/maintenance_page/manifests/qa_aks/ingress_external_to_main.yml
@@ -1,11 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: qa.find-postgraduate-teacher-training.service.gov.uk
+  name: qa.find-teacher-training-courses.service.gov.uk
 spec:
   ingressClassName: nginx
   rules:
-  - host: qa.find-postgraduate-teacher-training.service.gov.uk
+  - host: qa.find-teacher-training-courses.service.gov.uk
     http:
       paths:
       - pathType: ImplementationSpecific

--- a/maintenance_page/manifests/qa_aks/ingress_external_to_maintenance.yml
+++ b/maintenance_page/manifests/qa_aks/ingress_external_to_maintenance.yml
@@ -1,11 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: qa.find-postgraduate-teacher-training.service.gov.uk
+  name: qa.find-teacher-training-courses.service.gov.uk
 spec:
   ingressClassName: nginx
   rules:
-  - host: qa.find-postgraduate-teacher-training.service.gov.uk
+  - host: qa.find-teacher-training-courses.service.gov.uk
     http:
       paths:
       - pathType: ImplementationSpecific

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@
 User-agent: *
 Disallow: /
 Allow: https://find-teacher-training-courses.service.gov.uk/sitemap.xml
-Sitemap: https://www.find-teacher-training-courses.service.gov.uk/sitemap.xml
+Sitemap: https://find-teacher-training-courses.service.gov.uk/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 User-agent: *
 Disallow: /
-Allow: https://www.find-postgraduate-teacher-training.service.gov.uk/sitemap.xml
-Sitemap: https://www.find-postgraduate-teacher-training.service.gov.uk/sitemap.xml
+Allow: https://find-teacher-training-courses.service.gov.uk/sitemap.xml
+Sitemap: https://www.find-teacher-training-courses.service.gov.uk/sitemap.xml

--- a/service_unavailable_page/web/nginx.conf
+++ b/service_unavailable_page/web/nginx.conf
@@ -41,7 +41,7 @@ http {
 
   server {
     listen       {{port}};
-    server_name  www.find-postgraduate-teacher-training.service.gov.uk qa.find-postgraduate-teacher-training.service.gov.uk;
+    server_name  www.find-teacher-training-courses.service.gov.uk qa.find-teacher-training-courses.service.gov.uk;
     root         public;
 
     # Request to / returns 403 (directory index forbidden)

--- a/service_unavailable_page/web/nginx.conf
+++ b/service_unavailable_page/web/nginx.conf
@@ -41,7 +41,7 @@ http {
 
   server {
     listen       {{port}};
-    server_name  www.find-teacher-training-courses.service.gov.uk qa.find-teacher-training-courses.service.gov.uk;
+    server_name  find-teacher-training-courses.service.gov.uk qa.find-teacher-training-courses.service.gov.uk;
     root         public;
 
     # Request to / returns 403 (directory index forbidden)


### PR DESCRIPTION
### Context

The Find domain has change.

We should point to the new domain.

### Guidance to review

1. All links pointing to find are updated to use the new domain?
2. Is the content security policy working?
3. Is the maintenance page working?
