### PR TITLE
Update results format for the course index page

### DIFF
--- a/app/assets/stylesheets/components/find/_search-results.scss
+++ b/app/assets/stylesheets/components/find/_search-results.scss
@@ -7,7 +7,6 @@
 
 .app-search-results__item {
   @include govuk-responsive-margin(4, "bottom");
-  border-bottom: 1px solid $govuk-border-colour;
   display: block;
 }
 

--- a/app/assets/stylesheets/components/find/_summary-card.scss
+++ b/app/assets/stylesheets/components/find/_summary-card.scss
@@ -88,3 +88,12 @@
     display: none;
   }
 }
+
+.course-summary-card .govuk-summary-card__title-wrapper {
+  padding-top: govuk-spacing(2);
+}
+
+.course-summary-card .govuk-summary-card__title {
+  margin-bottom: 0;
+  margin-top: 0;
+}

--- a/app/components/find/courses/entry_requirements_component/view.html.erb
+++ b/app/components/find/courses/entry_requirements_component/view.html.erb
@@ -12,8 +12,8 @@
           <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :degree, is_preview: preview?(params)) %>
         <% else %>
           <p class="govuk-body">
-            <%= degree_grade_content(course) %>
-            <%= equivalent_qualification %>
+            <%= course.degree_grade_content %>
+            <%= course.equivalent_qualification %>
           </p>
         <% end %>
 

--- a/app/components/find/courses/entry_requirements_component/view.rb
+++ b/app/components/find/courses/entry_requirements_component/view.rb
@@ -23,28 +23,7 @@ module Find
           end
         end
 
-        def equivalent_qualification
-          if course.two_one? || course.two_two?
-            t('.above_or_equivalent_qualification_html')
-          elsif course.third_class?
-            t('.third_or_above_html')
-          else
-            t('.equivalent_qualification_html')
-          end
-        end
-
         private
-
-        def degree_grade_content(course)
-          degree_grade_hash = {
-            'two_one' => '2:1 bachelor’s degree',
-            'two_two' => '2:2 bachelor’s degree',
-            'third_class' => 'Bachelor’s degree',
-            'not_required' => 'Bachelor’s degree'
-          }
-
-          degree_grade_hash[course.degree_grade]
-        end
 
         def subject_knowledge_enhancement_content?
           if course.subjects.first.subject_code.nil?

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -16,7 +16,7 @@
     <% summary_list.with_row do |row| %>
       <% row.with_key(text: t(".course_fee")) %>
       <% row.with_value do %>
-        <%= course_fee_value %>
+        <%= course.course_fee_content %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -52,30 +52,6 @@ module Find
           end
         end
 
-        def course_fee_value
-          safe_join(
-            [
-              tag.b(number_to_currency(course.fee_uk_eu)),
-              formatted_uk_eu_fee_label,
-              tag.br,
-              tag.b(number_to_currency(course.fee_international)),
-              formatted_international_fee_label
-            ]
-          )
-        end
-
-        def formatted_uk_eu_fee_label
-          return if course.fee_uk_eu.blank?
-
-          " #{I18n.t('find.courses.summary_component.view.for_uk_citizens')}"
-        end
-
-        def formatted_international_fee_label
-          return if course.fee_international.blank?
-
-          " #{I18n.t('find.courses.summary_component.view.for_non_uk_citizens')}"
-        end
-
         def no_fee?
           course.fee_international.blank? && course.fee_uk_eu.blank?
         end

--- a/app/components/find/results/results_component.html.erb
+++ b/app/components/find/results/results_component.html.erb
@@ -25,8 +25,8 @@
         <% courses.each do |course| %>
           <%= render Find::Results::SearchResultComponent.new(
             course:,
-            has_sites: results.has_sites?(course),
-            filtered_by_location: results.location_filter?
+            filtered_by_location: results.location_filter?,
+            sites_count: results.sites_count(course)
           ) %>
         <% end %>
       </ul>

--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -1,55 +1,78 @@
 <li class="app-search-results__item" data-qa="course">
-  <h2 class="app-search-result__item-title">
-    <%= govuk_link_to find_course_path(provider_code: course.provider_code, course_code: course.course_code), data: { qa: "course__link" } do %>
-      <span class="app-search-result__provider-name" data-qa="course__provider_name"><%= helpers.smart_quotes(course.provider.provider_name) %></span>
-      <span class="app-search-result__course-name" data-qa="course__name"><%= course.name_and_code %></span>
-    <% end %>
-  </h2>
-  <dl class="app-description-list app-description-list--search-result">
-
-    <dt class="app-description-list__label">Fee or salary</dt>
-    <dd data-qa="course__funding_options"><%= course.funding %>
-      <br>
-      <p class="govuk-hint"><%= course.funding_option %>
-    </dd>
-
-    <% unless no_fee? %>
-      <dt class="app-description-list__label">Course fee</dt>
-      <dd data-qa="course__fee"><%= course_fee_value %></dd>
-    <% end %>
-
-    <dt class="app-description-list__label">Visa sponsorship</dt>
-    <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_status %></dd>
-
-    <dt class="app-description-list__label">Qualification</dt>
-    <dd data-qa="course__qualification">
-      <% if accredited_provider %>
-        <p class="govuk-body"><%= formatted_qualification %></p>
-        <p class="govuk-hint"><%= accredited_provider %></p>
-      <% else %>
-        <%= formatted_qualification %>
+  <%= govuk_summary_card(classes: ["course-summary-card"], title: coure_title_link) do |card| %>
+    <%= card.with_summary_list(actions: false, classes: ["govuk-summary-list--no-border"]) do |summary_list| %>
+      <% if filtered_by_location? && has_sites? %>
+        <% summary_list.with_row do |row| %>
+          <% if course.provider.decorate.website.present? %>
+            <% row.with_key(text: location_label) %>
+            <% row.with_value do %>
+              <% if course.university_based? %>
+                <%= render partial: "find/results/university", locals: { course: } %>
+              <% else %>
+                <%= render partial: "find/results/non_university", locals: { course: } %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
       <% end %>
-    </dd>
 
-    <% if course_length_with_study_mode.present? %>
-      <dt class="app-description-list__label"><%= t("course_length_with_study_mode.label") %></dt>
-      <dd data-qa="course__course_length_with_study_mode"><%= course_length_with_study_mode %></dd>
-    <% end %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".fee_or_salary")) %>
+        <% row.with_value do %>
+          <%= course.funding %>
+          <br>
+          <span class="govuk-hint govuk-!-font-size-16"><%= course.funding_option %></span>
+        <% end %>
+      <% end %>
 
-    <% if age_range_in_years_and_level.present? %>
-      <dt class="app-description-list__label"><%= t("find.courses.summary_component.view.age_range") %></dt>
-      <dd data-qa="course__age_range_in_years"><%= age_range_in_years_and_level %></dd>
-    <% end %>
+      <% unless no_fee? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t(".course_fee")) %>
+          <% row.with_value(text: course.course_fee_content) %>
+        <% end %>
+      <% end %>
 
-    <% if filtered_by_location? && has_sites? %>
-      <% if course.university_based? %>
-        <%= render partial: "find/results/university", locals: { course: } %>
-      <% else %>
-        <%= render partial: "find/results/non_university", locals: { course: } %>
+      <% if course_length_with_study_mode.present? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t("course_length_with_study_mode.label")) %>
+          <% row.with_value(text: course_length_with_study_mode) %>
+        <% end %>
+      <% end %>
+
+      <% if age_range_in_years_and_level.present? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: t("find.courses.summary_component.view.age_range")) %>
+          <% row.with_value(text: age_range_in_years_and_level) %>
+        <% end %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".qualification")) %>
+        <% row.with_value do %>
+          <% if accredited_provider %>
+            <%= formatted_qualification %>
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16"><%= accredited_provider %></span>
+          <% else %>
+            <%= formatted_qualification %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".degree_required")) %>
+        <% row.with_value do %>
+          <p class="govuk-body">
+            <%= degree_required_status %>
+            <%= course.equivalent_qualification %>
+          </p>
+        <% end %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: t(".visa_sponsorship")) %>
+        <% row.with_value(text: visa_sponsorship_status) %>
       <% end %>
     <% end %>
-
-    <dt class="app-description-list__label">Degree required</dt>
-    <dd data-qa="course__degree_required"><%= degree_required_status %></dd>
-  </dl>
+  <% end %>
 </li>

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -2,6 +2,7 @@
 
 class CourseDecorator < ApplicationDecorator
   include ActiveSupport::NumberHelper
+  include ActionView::Helpers::TranslationHelper
 
   delegate_all
 
@@ -471,6 +472,39 @@ class CourseDecorator < ApplicationDecorator
     !teacher_degree_apprenticeship?
   end
 
+  def equivalent_qualification
+    if two_one? || two_two?
+      translate('shared.decorators.course.above_or_equivalent_qualification_html')
+    elsif third_class?
+      translate('shared.decorators.course.third_or_above_html')
+    else
+      translate('shared.decorators.course.equivalent_qualification_html')
+    end
+  end
+
+  def degree_grade_content
+    degree_grade_hash = {
+      'two_one' => I18n.t('shared.decorators.course.two_one_degree'),
+      'two_two' => I18n.t('shared.decorators.course.two_two_degree'),
+      'third_class' => I18n.t('shared.decorators.course.third_class_degree'),
+      'not_required' => I18n.t('shared.decorators.course.degree_not_required')
+    }
+
+    degree_grade_hash[degree_grade]
+  end
+
+  def course_fee_content
+    safe_join(
+      [
+        bold_tag(number_to_currency(fee_uk_eu)),
+        formatted_uk_eu_fee_label,
+        tag.br,
+        bold_tag(number_to_currency(fee_international)),
+        formatted_international_fee_label
+      ]
+    )
+  end
+
   private
 
   def not_on_find
@@ -535,5 +569,23 @@ class CourseDecorator < ApplicationDecorator
 
   def format_name(subjects)
     subjects.map(&:subject_name).join('<br>').html_safe
+  end
+
+  def formatted_uk_eu_fee_label
+    return if fee_uk_eu.blank?
+
+    " #{I18n.t('find.courses.summary_component.view.for_uk_citizens')}"
+  end
+
+  def formatted_international_fee_label
+    return if fee_international.blank?
+
+    " #{I18n.t('find.courses.summary_component.view.for_non_uk_citizens')}"
+  end
+
+  def bold_tag(value)
+    return if value.blank?
+
+    tag.b(value)
   end
 end

--- a/app/view_objects/find/results_view.rb
+++ b/app/view_objects/find/results_view.rb
@@ -146,10 +146,6 @@ module Find
       ]
     end
 
-    def has_sites?(course)
-      !new_or_running_sites_with_vacancies_for(course).empty?
-    end
-
     def sites_count(course)
       new_or_running_sites_with_vacancies_for(course).count
     end

--- a/app/views/find/results/_non_university.html.erb
+++ b/app/views/find/results/_non_university.html.erb
@@ -2,22 +2,17 @@
 <% nearest_address = @results_view.nearest_address(course) %>
 <% nearest_location_name = @results_view.nearest_location_name(course) %>
 
-<dt class="app-description-list__label">
-  <%= number_of_sites > 1 ? "Nearest location" : "Location" %>
-</dt>
-<dd>
-  <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %>
-  <% if number_of_sites > 1 %>
-    <div class="govuk-!-margin-top-0">
-      (Nearest of <%= number_of_sites %> schools to choose from)
-    </div>
-  <% end %>
-
-  <span class="app-description-list__hint govuk-!-padding-top-2">Location</span>
-  <% if nearest_location_name != "Main Site" %>
-    <%= nearest_location_name %><br>
-  <% end %>
-  <div class="app-text-ellipsis">
-    <%= nearest_address %>
+<%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %>
+<% if number_of_sites > 1 %>
+  <div class="govuk-!-margin-top-0">
+    (Nearest of <%= number_of_sites %> schools to choose from)
   </div>
-</dd>
+<% end %>
+
+<span class="app-description-list__hint govuk-!-padding-top-2">Location</span>
+<% if nearest_location_name != "Main Site" %>
+  <%= nearest_location_name %><br>
+<% end %>
+<div class="app-text-ellipsis">
+  <%= nearest_address %>
+</div>

--- a/app/views/find/results/_university.html.erb
+++ b/app/views/find/results/_university.html.erb
@@ -1,29 +1,24 @@
-<dt class="app-description-list__label">Location</dt>
-
-<dd>
-  <ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0">
-    <li>
-      <% if course.further_education? %>
-        <span class="app-description-list__hint govuk-!-margin-top-0">University</span>
-      <% else %>
-        <span class="app-description-list__hint govuk-!-margin-top-0">Placement schools</span>
-        <%= govuk_details(summary_text: @results_view.placement_schools_summary(course)) do %>
-          <p>You can't pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
-          <p>Universities usually work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
-          <!-- TODO course_path -->
-          <%#= govuk_link_to 'More about placements on this course', course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools') %>
-        <% end %>
-        You'll be placed in schools for most of your course
-        <span class="app-description-list__hint govuk-!-padding-top-2">University</span>
+<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0">
+  <li>
+    <% if course.further_education? %>
+      <span class="app-description-list__hint govuk-!-margin-top-0">University</span>
+    <% else %>
+      <span class="app-description-list__hint govuk-!-margin-top-0">Placement schools</span>
+      <%= govuk_details(classes: ["govuk-!-margin-bottom-0"], summary_text: @results_view.placement_schools_summary(course)) do %>
+        <p>You can't pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
+        <!-- TODO course_path -->
+        <%#= govuk_link_to 'More about placements on this course', course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools') %>
       <% end %>
+      You'll be placed in schools for most of your course
+      <span class="app-description-list__hint govuk-!-padding-top-2">University</span>
+    <% end %>
 
-      <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %>
+    <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %>
+    <br>
+    <% if @results_view.sites_count(course) > 1 %>
+      (Nearest of <%= @results_view.sites_count(course) %> schools to choose from)
       <br>
-      <% if @results_view.sites_count(course) > 1 %>
-        (Nearest of <%= @results_view.sites_count(course) %> schools to choose from)
-        <br>
-      <% end %>
-      You'll be at university only some of the time
-    </li>
-  </ul>
-</dd>
+    <% end %>
+    You'll be at university only some of the time
+  </li>
+</ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,31 @@
 en:
   shared:
+    decorators:
+      course:
+        two_one_degree: 2:1 bachelor’s degree
+        two_two_degree: 2:2 bachelor’s degree
+        third_class_degree: Bachelor’s degree
+        degree_not_required: Bachelor’s degree
+        above_or_equivalent_qualification_html:
+          <br>
+          <span class="govuk-hint govuk-!-font-size-16">
+            or above or equivalent qualification
+          </span>
+        equivalent_qualification_html:
+          <br>
+          <span class="govuk-hint govuk-!-font-size-16">
+            or equivalent qualification
+          </span>
+        third_or_above_html:
+          <br>
+          <span class="govuk-hint govuk-!-font-size-16">
+            or equivalent qualification
+          </span>
+          <br>
+          <br>
+          <span class="govuk-hint govuk-!-font-size-16">
+            This should be an honours degree (Third or above), or equivalent
+          </span>
     courses:
       provider:
         heading: Contact %{provider_name}

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -111,26 +111,6 @@ en:
           degree_subject_requirements: Degree subject requirements
           a_levels: A levels
           above_or_equivalent_qualification: or above, or equivalent qualification
-          above_or_equivalent_qualification_html:
-            <br>
-            <span class="govuk-hint govuk-!-font-size-16">
-              or above or equivalent qualification
-            </span>
-          equivalent_qualification_html:
-            <br>
-            <span class="govuk-hint govuk-!-font-size-16">
-              or equivalent qualification
-            </span>
-          third_or_above_html:
-            <br>
-            <span class="govuk-hint govuk-!-font-size-16">
-              or equivalent qualification
-            </span>
-            <br>
-            <br>
-            <span class="govuk-hint govuk-!-font-size-16">
-              This should be an honours degree (Third or above), or equivalent
-            </span>
       about_course:
         heading: Course details
       summary_component:
@@ -146,7 +126,7 @@ en:
           provider: Provider
           accredited_by: Accredited by
           for_uk_citizens: for UK citizens
-          for_non_uk_citizens: for non-UK citizens
+          for_non_uk_citizens: for Non-UK citizens
       providers:
         show:
           heading: About %{provider_name}
@@ -190,6 +170,18 @@ en:
         back_to_search: Back to search results
         training_with_disabilities: Training with disabilities
         training_with_disabilities_link: Find out about training with disabilities and other needs at %{provider_name}.
+    results:
+      search_result_component:
+        location:
+          one: Location
+          other: Nearest location
+        nearest_location: Nearest location
+        fee_or_salary: Fee or salary
+        course_fee: Course fee
+        qualification: Qualification
+        degree_required: Degree required
+        visa_sponsorship: Visa sponsorship
+        course_title_html: <a class="govuk-link govuk-!-font-size-24" data-qa="course__link" href=%{course_path}><span class="app-search-result__provider-name" data-qa="course__provider_name">%{provider_name}</span><span class="app-search-result__course-name" data-qa="course__name">%{course_name}</span></a>
     scholarships:
       physics:
         body: Institute of Physics

--- a/spec/components/find/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_preview.rb
@@ -122,6 +122,14 @@ module Find
           def teacher_degree_apprenticeship?
             false
           end
+
+          def degree_grade_content
+            I18n.t('shared.decorators.course.two_one_degree')
+          end
+
+          def equivalent_qualification
+            I18n.t('shared.decorators.course.above_or_equivalent_qualification_html').html_safe
+          end
         end
       end
     end

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -298,6 +298,43 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
     end
   end
 
+  context 'when course two_one' do
+    it 'renders correct message' do
+      course = build(:course, degree_grade: :two_one)
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include(
+        '2:1 bachelor’s degree',
+        'or above or equivalent qualification'
+      )
+    end
+  end
+
+  context 'when course is third_class' do
+    it 'renders correct message' do
+      course = build(:course, degree_grade: :third_class)
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include(
+        'Bachelor’s degree',
+        'or equivalent qualification',
+        'This should be an honours degree (Third or above), or equivalent'
+      )
+    end
+  end
+
+  context 'when course is not_required' do
+    it 'renders correct message' do
+      course = build(:course, degree_grade: :not_required)
+      result = render_inline(described_class.new(course: course.decorate))
+
+      expect(result.text).to include(
+        'Bachelor’s degree',
+        'or equivalent qualification'
+      )
+    end
+  end
+
   it 'includes the qualifications gain outside of UK section' do
     course = build(
       :course,
@@ -385,60 +422,6 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
         render_inline(component)
 
         expect(component.qualification_required).to eq('A levels')
-      end
-    end
-  end
-
-  describe '#equivalent_qualification' do
-    context 'when course is two_one' do
-      let(:course) { build(:course, degree_grade: :two_one) }
-
-      it "returns 'or above or equivalent qualification'" do
-        component = described_class.new(course: course.decorate)
-        render_inline(component)
-
-        expect(component.equivalent_qualification).to eq(
-          '<br> <span class="govuk-hint govuk-!-font-size-16"> or above or equivalent qualification </span>'
-        )
-      end
-    end
-
-    context 'when course is two_two' do
-      let(:course) { build(:course, degree_grade: :two_two) }
-
-      it "returns 'or above or equivalent qualification'" do
-        component = described_class.new(course: course.decorate)
-        render_inline(component)
-
-        expect(component.equivalent_qualification).to eq(
-          '<br> <span class="govuk-hint govuk-!-font-size-16"> or above or equivalent qualification </span>'
-        )
-      end
-    end
-
-    context 'when course is third_class' do
-      let(:course) { build(:course, degree_grade: :third_class) }
-
-      it 'returns third and above' do
-        component = described_class.new(course: course.decorate)
-        render_inline(component)
-
-        expect(component.equivalent_qualification).to eq(
-          '<br> <span class="govuk-hint govuk-!-font-size-16"> or equivalent qualification </span> <br> <br> <span class="govuk-hint govuk-!-font-size-16"> This should be an honours degree (Third or above), or equivalent </span>'
-        )
-      end
-    end
-
-    context 'when course is not_required' do
-      let(:course) { build(:course, degree_grade: :not_required) }
-
-      it 'returns not required' do
-        component = described_class.new(course: course.decorate)
-        render_inline(component)
-
-        expect(component.equivalent_qualification).to eq(
-          '<br> <span class="govuk-hint govuk-!-font-size-16"> or equivalent qualification </span>'
-        )
       end
     end
   end

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -141,7 +141,7 @@ module Find
             course = create(:course, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
 
             result = render_inline(described_class.new(course))
-            expect(result.text).to include('£14,000 for non-UK citizens')
+            expect(result.text).to include('£14,000 for Non-UK citizens')
           end
         end
 
@@ -152,7 +152,7 @@ module Find
             result = render_inline(described_class.new(course))
 
             expect(result.text).to include('£9,250 for UK citizens')
-            expect(result.text).not_to include('for non-UK citizens')
+            expect(result.text).not_to include('for Non-UK citizens')
           end
         end
 
@@ -163,7 +163,7 @@ module Find
             result = render_inline(described_class.new(course))
 
             expect(result.text).not_to include('for UK citizens')
-            expect(result.text).to include('£14,000 for non-UK citizens')
+            expect(result.text).to include('£14,000 for Non-UK citizens')
           end
         end
 
@@ -174,7 +174,7 @@ module Find
             result = render_inline(described_class.new(course))
 
             expect(result.text).not_to include('for UK citizens')
-            expect(result.text).not_to include('£14,000 for non-UK citizens')
+            expect(result.text).not_to include('£14,000 for Non-UK citizens')
             expect(result.text).not_to include('Course fee')
           end
         end

--- a/spec/components/find/results/results_component_spec.rb
+++ b/spec/components/find/results/results_component_spec.rb
@@ -20,7 +20,8 @@ module Find
           subjects: [],
           number_of_courses_string: 'No courses',
           no_results_found?: true,
-          has_results?: false
+          has_results?: false,
+          sites_count: 0
         )
       end
 
@@ -52,8 +53,8 @@ module Find
           number_of_courses_string: '10 courses',
           no_results_found?: false,
           has_results?: true,
-          has_sites?: true,
-          location_filter?: false
+          location_filter?: false,
+          sites_count: 2
         )
       end
 
@@ -73,8 +74,8 @@ module Find
         courses.each do |course|
           expect(Results::SearchResultComponent).to have_received(:new).with(
             course:,
-            has_sites: true,
-            filtered_by_location: false
+            filtered_by_location: false,
+            sites_count: 2
           )
         end
 
@@ -89,8 +90,8 @@ module Find
         courses.each do |course|
           expect(Results::SearchResultComponent).to have_received(:new).with(
             course:,
-            has_sites: true,
-            filtered_by_location: false
+            filtered_by_location: false,
+            sites_count: 2
           )
         end
         expect(component.text).to include('event near you')

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -20,7 +20,8 @@ module Find
         result = render_inline(described_class.new(course:))
 
         expect(result.text).to include(
-          'An undergraduate degree at class 2:1 or above, or equivalent'
+          '2:1 bachelor’s degree',
+          'or above or equivalent qualification'
         )
       end
     end
@@ -110,7 +111,7 @@ module Find
         course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 
         result = render_inline(described_class.new(course:))
-        expect(result.text).to include('UK students: £9,250')
+        expect(result.text).to include('£9,250 for UK citizens')
         expect(result.text).to include('Course fee')
       end
     end
@@ -120,7 +121,7 @@ module Find
         course = create(:course, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
 
         result = render_inline(described_class.new(course:))
-        expect(result.text).to include('International students: £14,000')
+        expect(result.text).to include('£14,000 for Non-UK citizens')
       end
     end
 
@@ -130,8 +131,8 @@ module Find
 
         result = render_inline(described_class.new(course:))
 
-        expect(result.text).to include('UK students: £9,250')
-        expect(result.text).not_to include('International students')
+        expect(result.text).to include('£9,250 for UK citizens')
+        expect(result.text).not_to include('Non-UK citizens')
       end
     end
 
@@ -141,8 +142,8 @@ module Find
 
         result = render_inline(described_class.new(course:))
 
-        expect(result.text).not_to include('UK students')
-        expect(result.text).to include('International students: £14,000')
+        expect(result.text).not_to include('for UK citizens')
+        expect(result.text).to include('£14,000 for Non-UK citizens')
       end
     end
 
@@ -152,8 +153,8 @@ module Find
 
         result = render_inline(described_class.new(course:))
 
-        expect(result.text).not_to include('UK students')
-        expect(result.text).not_to include('International students: £14,000')
+        expect(result.text).not_to include('for UK citizens')
+        expect(result.text).not_to include('£14,000 for Non-UK citizens')
         expect(result.text).not_to include('Course fee')
       end
     end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -1140,4 +1140,122 @@ describe CourseDecorator do
       end
     end
   end
+
+  describe '#equivalent_qualification' do
+    context 'when course degree grare is two_one' do
+      let(:course) { build(:course, degree_grade: :two_one) }
+
+      it 'returns or above or equivalent qualification' do
+        expect(decorated_course.equivalent_qualification).to eq(
+          '<br> <span class="govuk-hint govuk-!-font-size-16"> or above or equivalent qualification </span>'
+        )
+      end
+    end
+
+    context 'when course degree grare is two_two' do
+      let(:course) { build(:course, degree_grade: :two_two) }
+
+      it 'returns or above or equivalent qualification' do
+        expect(decorated_course.equivalent_qualification).to eq(
+          '<br> <span class="govuk-hint govuk-!-font-size-16"> or above or equivalent qualification </span>'
+        )
+      end
+    end
+
+    context 'when course degree grade is third_class' do
+      let(:course) { build(:course, degree_grade: :third_class) }
+
+      it 'returns third and above' do
+        expect(decorated_course.equivalent_qualification).to eq(
+          '<br> <span class="govuk-hint govuk-!-font-size-16"> or equivalent qualification </span> <br> <br> <span class="govuk-hint govuk-!-font-size-16"> This should be an honours degree (Third or above), or equivalent </span>'
+        )
+      end
+    end
+
+    context 'when course degree grade is not_required' do
+      let(:course) { build(:course, degree_grade: :not_required) }
+
+      it 'returns not required' do
+        expect(decorated_course.equivalent_qualification).to eq(
+          '<br> <span class="govuk-hint govuk-!-font-size-16"> or equivalent qualification </span>'
+        )
+      end
+    end
+  end
+
+  describe '#degree_grade_content' do
+    context 'when course degree grare is two_one' do
+      let(:course) { build(:course, degree_grade: :two_one) }
+
+      it 'returns two one degree' do
+        expect(decorated_course.degree_grade_content).to eq(
+          '2:1 bachelor’s degree'
+        )
+      end
+    end
+
+    context 'when course degree grare is two_two' do
+      let(:course) { build(:course, degree_grade: :two_two) }
+
+      it 'returns two two degree' do
+        expect(decorated_course.degree_grade_content).to eq(
+          '2:2 bachelor’s degree'
+        )
+      end
+    end
+
+    context 'when course degree grare is third_class' do
+      let(:course) { build(:course, degree_grade: :third_class) }
+
+      it 'returns third_class degree' do
+        expect(decorated_course.degree_grade_content).to eq(
+          'Bachelor’s degree'
+        )
+      end
+    end
+
+    context 'when course degree grare is not_required' do
+      let(:course) { build(:course, degree_grade: :not_required) }
+
+      it 'returns not_require degree' do
+        expect(decorated_course.degree_grade_content).to eq(
+          'Bachelor’s degree'
+        )
+      end
+    end
+  end
+
+  describe '#course_fee_content' do
+    context 'when course is for uk citizens' do
+      let(:course) do
+        create(
+          :course,
+          enrichments: [build(:course_enrichment, :published, fee_uk_eu: 100, fee_international: nil)],
+          study_mode: 'full_time'
+        )
+      end
+
+      it 'returns fee for uk citizens' do
+        expect(decorated_course.course_fee_content).to eq(
+          '<b>£100</b> for UK citizens<br>'
+        )
+      end
+    end
+
+    context 'when course is for uk and non citizens' do
+      let(:course) do
+        create(
+          :course,
+          enrichments: [build(:course_enrichment, :published, fee_uk_eu: 100, fee_international: 200)],
+          study_mode: 'full_time'
+        )
+      end
+
+      it 'returns fee for uk and non citizens' do
+        expect(decorated_course.course_fee_content).to eq(
+          '<b>£100</b> for UK citizens<br><b>£200</b> for Non-UK citizens'
+        )
+      end
+    end
+  end
 end

--- a/spec/features/find/search/course_results_spec.rb
+++ b/spec/features/find/search/course_results_spec.rb
@@ -44,9 +44,9 @@ feature 'results' do
       # list by provider?
       expect(first_course.course_name.text).to include('Hello there')
       expect(first_course.provider_name.text).to be_present
-      expect(first_course.qualification.text).to include('QTS with PGCE')
-      expect(first_course.course_length.text).to eq('1 year - full time')
-      expect(first_course.funding_options.text).to eq('Teaching apprenticeship - with salary')
+      expect(first_course).to have_text('QTS with PGCE')
+      expect(first_course).to have_text('1 year - full time')
+      expect(first_course).to have_text('Teaching apprenticeship - with salary')
     end
   end
 


### PR DESCRIPTION
### Context

This is part of a redesign of the course pages and will bring the results page in line with the show/details page

It also includes a refactor of some methods that are used to display the course information on the results page as well on the details page. This way we can change the content in 1 place and have it mirrored in 2 places and will help with content consistency.

### Changes proposed in this pull request

| before | after |
| -- | -- |
| ![Screenshot from 2024-07-23 11-49-36](https://github.com/user-attachments/assets/e6240142-c1cd-4d5a-9db4-0e704c63e4f9) | ![Screenshot from 2024-07-23 11-48-58](https://github.com/user-attachments/assets/0e28e719-21cd-455e-8d27-d3463083b2a1) |

### Guidance to review

Go on review app and search for courses

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
