### PR TITLE
Change back link when user comes from the course page while trying to publish the course

### DIFF
--- a/app/views/publish/courses/a_level_requirements/a_level_equivalencies/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/a_level_equivalencies/new.html.erb
@@ -1,13 +1,23 @@
 <% content_for :page_title, title_with_error_prefix(t("course.#{@wizard.current_step.model_name.i18n_key}.heading"), @wizard.current_step.errors && @wizard.current_step.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_course_a_levels_consider_pending_a_level_path(
-        @provider.provider_code,
-        @provider.recruitment_cycle_year,
-        @course.course_code
-      )
-    ) %>
+  <% if params[:display_errors].present? %>
+    <%= govuk_back_link_to(
+        publish_provider_recruitment_cycle_course_path(
+          @provider.provider_code,
+          @provider.recruitment_cycle_year,
+          @course.course_code
+        )
+      ) %>
+  <% else %>
+    <%= govuk_back_link_to(
+        publish_provider_recruitment_cycle_course_a_levels_consider_pending_a_level_path(
+          @provider.provider_code,
+          @provider.recruitment_cycle_year,
+          @course.course_code
+        )
+      ) %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish/courses/a_level_requirements/consider_pending_a_level/new.html.erb
+++ b/app/views/publish/courses/a_level_requirements/consider_pending_a_level/new.html.erb
@@ -1,13 +1,23 @@
 <% content_for :page_title, title_with_error_prefix(t("course.#{@wizard.current_step.model_name.i18n_key}.heading"), @wizard.current_step.errors && @wizard.current_step.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
-        @provider.provider_code,
-        @provider.recruitment_cycle_year,
-        @course.course_code
-      )
-    ) %>
+  <% if params[:display_errors].present? %>
+    <%= govuk_back_link_to(
+        publish_provider_recruitment_cycle_course_path(
+          @provider.provider_code,
+          @provider.recruitment_cycle_year,
+          @course.course_code
+        )
+      ) %>
+  <% else %>
+    <%= govuk_back_link_to(
+        publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
+          @provider.provider_code,
+          @provider.recruitment_cycle_year,
+          @course.course_code
+        )
+      ) %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
+++ b/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
@@ -29,6 +29,7 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
     when_i_click_on_the_pending_a_level_error
     then_i_am_on_the_consider_pending_a_level_page
     and_i_see_the_pending_a_level_error
+    and_the_back_link_points_to_the_course_page
 
     when_i_choose_yes
     and_i_click_continue
@@ -39,6 +40,7 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
 
     when_i_click_on_the_a_level_equivalencies
     then_i_am_on_the_a_level_equivalencies_page
+    and_the_back_link_points_to_the_course_page
 
     when_i_choose_yes
     and_i_click_update_a_levels
@@ -279,5 +281,15 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
   def then_the_course_is_published
     expect(page).to have_content('Your course has been published.')
     expect(@course.reload.is_published?).to be true
+  end
+
+  def and_the_back_link_points_to_the_course_page
+    expect(page.find_link(text: 'Back')[:href]).to eq(
+      publish_provider_recruitment_cycle_course_path(
+        @provider.provider_code,
+        2025,
+        @course.course_code
+      )
+    )
   end
 end


### PR DESCRIPTION
### Context

Given I have a TDA course
And no A levels
When I try to publish a course
And I click on the error message
And I am on A level page (accept pending A level OR equivalency page) 
And I click back
Then I should be on the course page

### Guidance to review

1. Does the back links work from course page and from normal wizard?
