### PR TITLE
[1876] Ensure `program_type` is updated when `provider_type` changes

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -13,6 +13,8 @@ class Provider < ApplicationRecord
   before_save :update_searchable, if: :accredited_provider?
   before_create :set_defaults
 
+  after_save :update_courses_program_type, if: :provider_type_previously_changed?
+
   has_associated_audits
   audited except: :changed_at
 
@@ -380,6 +382,13 @@ class Provider < ApplicationRecord
   end
 
   private
+
+  def update_courses_program_type
+    courses.each do |course|
+      Courses::AssignProgramTypeService.new.execute(course.funding_type, course)
+      course.save
+    end
+  end
 
   def accredited_provider_codes
     accrediting_provider_enrichments&.map(&:UcasProviderCode) || []

--- a/app/services/courses/assign_program_type_service.rb
+++ b/app/services/courses/assign_program_type_service.rb
@@ -3,29 +3,46 @@
 module Courses
   class AssignProgramTypeService
     def execute(funding_type, course)
-      program_type = {
-        'salary' => calculate_salary_program(course),
-        'apprenticeship' => :pg_teaching_apprenticeship,
-        'fee' => calculate_fee_program(course)
-      }.fetch(funding_type, course.program_type)
+      provider_type = course.provider.provider_type
+      program_type = determine_program_type(funding_type, provider_type, course)
 
       course.program_type = program_type
     end
 
     private
 
-    def calculate_salary_program(course)
-      return :scitt_salaried_programme if course.provider.scitt?
-      return :higher_education_salaried_programme if course.provider.university?
-
-      :school_direct_salaried_training_programme
+    def determine_program_type(funding_type, provider_type, course)
+      case funding_type
+      when 'salary'
+        calculate_salary_program(provider_type)
+      when 'apprenticeship'
+        :pg_teaching_apprenticeship
+      when 'fee'
+        calculate_fee_program(provider_type)
+      else
+        course.program_type # Default to current program_type if funding_type is not recognised
+      end
     end
 
-    def calculate_fee_program(course)
-      return :school_direct_training_programme unless course.self_accredited?
-      return :scitt_programme if course.provider.scitt?
+    def calculate_salary_program(provider_type)
+      case provider_type
+      when 'scitt'
+        :scitt_salaried_programme
+      when 'university'
+        :higher_education_salaried_programme
+      else
+        :school_direct_salaried_training_programme
+      end
+    end
 
-      :higher_education_programme
+    def calculate_fee_program(provider_type)
+      if provider_type == 'scitt'
+        :scitt_programme
+      elsif provider_type == 'university'
+        :higher_education_programme
+      else
+        :school_direct_training_programme
+      end
     end
   end
 end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -535,7 +535,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def provider
-    @user.providers.first
+    @user.providers.first.reload
   end
 
   def course

--- a/spec/models/course/assign_program_type_spec.rb
+++ b/spec/models/course/assign_program_type_spec.rb
@@ -3,19 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'AssignProgramType' do
-  describe '#funding_type=' do
-    before do
-      subject.funding_type = funding_type
-    end
-
-    describe 'when funding type is salary' do
-      let(:funding_type) { 'salary' }
-
-      context 'an externally accredited courses' do
-        subject { create(:course, :with_accrediting_provider) }
-
-        its(:program_type) { is_expected.to eq('school_direct_salaried_training_programme') }
-      end
+  describe Courses::AssignProgramTypeService do
+    describe '#execute' do
+      let(:service) { described_class.new }
 
       context 'a self accredited course' do
         subject { create(:course, :self_accredited) }
@@ -25,41 +15,67 @@ RSpec.describe 'AssignProgramType' do
           expect(subject.errors.count).to eq 0
         end
       end
-    end
 
-    describe 'when funding type is apprenticeship' do
-      subject { create(:course, :with_scitt) }
+      context 'when funding type is salary' do
+        let(:funding_type) { 'salary' }
 
-      let(:funding_type) { 'apprenticeship' }
+        it 'sets the correct program type for SCITT providers' do
+          provider = create(:provider, :scitt)
+          course = create(:course, provider:, funding_type:)
+          service.execute(funding_type, course)
 
-      its(:program_type) { is_expected.to eq('pg_teaching_apprenticeship') }
-    end
+          expect(course.program_type).to eq('scitt_salaried_programme')
+        end
 
-    describe 'when funding type is fee' do
-      let(:funding_type) { 'fee' }
+        it 'sets the correct program type for university providers' do
+          provider = create(:provider, :university)
+          course = create(:course, provider:, funding_type:)
+          service.execute(funding_type, course)
+          expect(course.program_type).to eq('higher_education_salaried_programme')
+        end
 
-      context 'an externally accredited course' do
-        subject { create(:course, :with_accrediting_provider) }
-
-        its(:program_type) { is_expected.to eq('school_direct_training_programme') }
-      end
-
-      context 'a SCITTs self accredited courses' do
-        subject { create(:course, provider:) }
-
-        let(:provider) { build(:provider, :scitt) }
-
-        its(:program_type) do
-          is_expected.to eq('scitt_programme')
+        it 'sets the correct program type for lead school providers' do
+          provider = create(:provider, :lead_school)
+          course = create(:course, provider:, funding_type:)
+          service.execute(funding_type, course)
+          expect(course.program_type).to eq('school_direct_salaried_training_programme')
         end
       end
 
-      context 'a HEIs self accredited courses' do
-        subject { create(:course, provider:) }
+      context 'when funding type is apprenticeship' do
+        let(:funding_type) { 'apprenticeship' }
 
-        let(:provider) { build(:provider, :university) }
+        it 'sets the program type to pg_teaching_apprenticeship' do
+          provider = create(:provider)
+          course = create(:course, provider:, funding_type:)
+          service.execute(funding_type, course)
+          expect(course.program_type).to eq('pg_teaching_apprenticeship')
+        end
+      end
 
-        its(:program_type) { is_expected.to eq('higher_education_programme') }
+      context 'when funding type is fee' do
+        let(:funding_type) { 'fee' }
+
+        it 'sets the correct program type for externally accredited courses' do
+          provider = create(:provider, :lead_school)
+          course = create(:course, funding_type:, provider:)
+          service.execute(funding_type, course)
+          expect(course.program_type).to eq('school_direct_training_programme')
+        end
+
+        it 'sets the correct program type for SCITT courses' do
+          provider = create(:provider, :scitt)
+          course = create(:course, provider:, funding_type:)
+          service.execute(funding_type, course)
+          expect(course.program_type).to eq('scitt_programme')
+        end
+
+        it 'sets the correct program type for HEI self-accredited courses' do
+          provider = create(:provider, :university)
+          course = create(:course, :with_accrediting_provider, provider:, funding_type:)
+          service.execute(funding_type, course)
+          expect(course.program_type).to eq('higher_education_programme')
+        end
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3099,7 +3099,7 @@ describe Course do
 
       context 'when the provider is self accredited and not a SCITT' do
         it 'sets the funding_type to salary and the program_type to higher_education_programme' do
-          provider = build(:provider, accrediting_provider: :accredited_provider, provider_type: nil)
+          provider = build(:provider, accrediting_provider: :accredited_provider, provider_type: 'university')
           course = build(:course, provider:, funding_type: 'fee')
 
           expect(course.funding_type).to eq('fee')

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1016,4 +1016,17 @@ describe Provider do
       end
     end
   end
+
+  describe '#update_courses_program_type' do
+    let(:provider) { create(:provider, :lead_school) }
+    let!(:course1) { create(:course, provider:, funding_type: 'salary') }
+    let!(:course2) { create(:course, provider:, funding_type: 'fee') }
+
+    it 'updates program_type for all associated courses when provider_type changes' do
+      provider.update(provider_type: 'scitt')
+      expect { course1.reload.program_type }.to change(course1, :program_type).from('school_direct_salaried_training_programme').to('scitt_salaried_programme')
+
+      expect { course2.reload.program_type }.to change(course2, :program_type).from('school_direct_training_programme').to('scitt_programme')
+    end
+  end
 end

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Courses::CopyToProviderService do
     end
 
     it 'still copies the course to the provider' do
-      new_course = new_provider.courses.first
+      new_course = new_provider.reload.courses.first
       expect(new_course.course_code).to eq(course.course_code)
       expect(new_provider.courses.count).to eq(1)
     end


### PR DESCRIPTION
### Context

- Currently when you update the `provider_type` on the provider the `program_type` on the course isn't updated.

### Changes proposed in this pull request

Add an `after_save` callback to loop through and recalculate the `program_type` on courses after the `provider_type` has been changed.

### Guidance to review

- Check the `program_type` of a course in the rails console: `RecruitmentCycle.current.providers.find_by(provider_code: {provider_code}).courses.course_code(course_code: {course_code}).program_type`

- change the `provider_type` in support, e.g: `/support/2025/providers/21213/edit`

<img width="497" alt="image" src="https://github.com/user-attachments/assets/482de2c5-f5c2-4d3f-abb4-8c6b347768ed">

- Ensure the `program_type` has correctly updated on all the courses.

- Ensure the other cycle courses haven't inadvertently been affected.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
