### PR TITLE
Fix address to avoid flakey spec when generating single quotes address

### DIFF
--- a/spec/forms/support/provider_contact_form_spec.rb
+++ b/spec/forms/support/provider_contact_form_spec.rb
@@ -27,14 +27,18 @@ module Support
 
     describe '#full_address' do
       subject { provider_contact_form.full_address }
+      let(:params) do
+        {
+          address1: '2431 Collins Tunnel',
+          address2: 'Willow Village',
+          address3: 'OHara Row',
+          town: 'Yundtside',
+          address4: 'Idaho',
+          postcode: 'UN5 8BA'
+        }
+      end
       let(:expected_full_address) do
-        # Decode html entities before comparison to prevent a flaky test from apostrophes
-        CGI.unescapeHTML(params.slice(:address1,
-                                      :address2,
-                                      :address3,
-                                      :town,
-                                      :address4,
-                                      :postcode).values.join('<br> '))
+        params.slice(:address1, :address2, :address3, :town, :address4, :postcode).values.join('<br> ')
       end
 
       it 'matches the expected full address' do


### PR DESCRIPTION
### Context

There is a flakey spec that sometimes are triggered when [deployment ](https://github.com/DFE-Digital/publish-teacher-training/actions/runs/10094751223/job/27913477990).

```
expected: "2431 Collins Tunnel<br> Willow Village<br> O'Hara Row<br> Yundtside<br> Idaho<br> UN5 8BA"
            got: "2431 Collins Tunnel<br> Willow Village<br> O&#39;Hara Row<br> Yundtside<br> Idaho<br> UN5 8BA"
```

Fixing so it never happens again.