### PR TITLE
Add google to content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
                        'https://*.sentry.io',
                        'https://*.google-analytics.com',
                        'https://*.analytics.google.com',
+                       'https://www.google.com',
                        *all_domains
 
     policy.style_src   :self, *all_domains


### PR DESCRIPTION
### Context

This is an attempt to fix the issue:

Refused to connect to 'https://www.google.com/pagead/landing ...'

