### PR TITLE
Add google double click to content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -32,6 +32,7 @@ Rails.application.configure do
 
     policy.connect_src :self,
                        'https://stats.g.doubleclick.net',
+                       'https://googleads.g.doubleclick.net',
                        'https://*.sentry.io',
                        'https://*.google-analytics.com',
                        'https://*.analytics.google.com',


### PR DESCRIPTION
### Context

A continuation of #4406 

This is an attempt to fix the issue:

Refused to connect to 'https://googleads.g.doubleclick.net/ ... '

