### PR TITLE
[1876] Ensure `program_type_service` correctly handles TDA courses

### DIFF
--- a/app/services/courses/assign_program_type_service.rb
+++ b/app/services/courses/assign_program_type_service.rb
@@ -16,7 +16,11 @@ module Courses
       when 'salary'
         calculate_salary_program(provider_type)
       when 'apprenticeship'
-        :pg_teaching_apprenticeship
+        if course.teacher_degree_apprenticeship?
+          course.program_type
+        else
+          :pg_teaching_apprenticeship
+        end
       when 'fee'
         calculate_fee_program(provider_type)
       else

--- a/spec/models/course/assign_program_type_spec.rb
+++ b/spec/models/course/assign_program_type_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe 'AssignProgramType' do
           service.execute(funding_type, course)
           expect(course.program_type).to eq('pg_teaching_apprenticeship')
         end
+
+        it 'keeps the teacher_degree_apprenticeship program type' do
+          provider = create(:provider)
+          course = create(:course, :with_teacher_degree_apprenticeship, provider:)
+          service.execute(course.funding_type, course)
+          expect(course.program_type).to eq('teacher_degree_apprenticeship')
+        end
       end
 
       context 'when funding type is fee' do


### PR DESCRIPTION
### Context

A TDA course is an apprenticeship, but it has its own `program_type`. We need to ensure the `program_type_service` does not override that.

### Changes proposed in this pull request

If the `program_type` is  `teacher_degree_apprenticeship`, it should remain that and not change to `pg_teaching_apprenticeship`.


### Guidance to review

- Create a TDA course in the next cycle
- Update the `provider_type`
- Check that the `program_type` is still `teacher_degree_apprenticeship`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
