### PR TITLE
Git and provider website redirects

### DIFF
--- a/app/components/find/courses/contact_details_component/view.html.erb
+++ b/app/components/find/courses/contact_details_component/view.html.erb
@@ -7,7 +7,7 @@
     <% if course.provider.decorate.website.present? %>
       <% row.with_key(text: t(".school_website")) %>
       <% row.with_value do %>
-        <%= govuk_link_to course.provider.decorate.website, course.provider.decorate.website %>
+        <%= govuk_link_to course.provider.decorate.website, find_provider_website_path(course.provider_code, course.course_code) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/controllers/concerns/get_into_teaching_redirect.rb
+++ b/app/controllers/concerns/get_into_teaching_redirect.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module GetIntoTeachingRedirect
+  extend ActiveSupport::Concern
+
+  def git_redirect
+    redirect_to I18n.t("get_into_teaching.#{git_url_locale_key}"), allow_other_host: true
+  end
+
+  private
+
+  def git_path_param
+    params[:git_path]
+  end
+
+  def git_url_locale_key
+    "url_#{git_path_param}"
+  end
+end

--- a/app/controllers/concerns/provider_website_redirect.rb
+++ b/app/controllers/concerns/provider_website_redirect.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ProviderWebsiteRedirect
+  extend ActiveSupport::Concern
+
+  def provider_website
+    redirect_to provider.decorate.website, allow_other_host: true
+  end
+end

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -3,6 +3,8 @@
 module Find
   class CoursesController < ApplicationController
     include ApplyRedirect
+    include GetIntoTeachingRedirect
+    include ProviderWebsiteRedirect
 
     before_action -> { render_not_found if provider.nil? }
 

--- a/app/views/find/courses/_advice.html.erb
+++ b/app/views/find/courses/_advice.html.erb
@@ -1,4 +1,25 @@
 <div id="section-advice-and-support">
   <h2 class="govuk-heading-m" id="section-advice"><%= t(".heading") %></h2>
-  <span class="govuk-body"><%= t(".body_html") %></span>
+  <span class="govuk-body">
+    <%= t(
+          ".body_html",
+          teacher_training_advisor_link: govuk_link_to(
+            t(".get_a_teacher_training_advisor_link_text"),
+            find_get_into_teaching_redirect_path(
+              @course.provider_code,
+              @course.course_code,
+              "teacher_training_advisers"
+            )
+          ),
+          contact_git_link:
+            govuk_link_to(
+              t(".contact_get_into_teaching_link_text"),
+              find_get_into_teaching_redirect_path(
+                @course.provider_code,
+                @course.course_code,
+                "help_and_support"
+              )
+            )
+        ) %>
+  </span>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -856,6 +856,7 @@ en:
               taken: "Provider code already taken"
             provider_type:
               blank: "Provider type can't be blank"
+              format: Accredited provider cannot be a school
             email:
               blank: "^Enter email address"
             website:
@@ -883,8 +884,6 @@ en:
             accredited_provider_id:
               blank: Enter the accredited provider ID
               format: Enter a valid accredited provider ID - it must be 4 digits starting with a 1 or a 5
-            provider_type:
-              format: Accredited provider cannot be a school
         organisation:
           attributes:
             name:
@@ -1374,6 +1373,8 @@ en:
     url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
     url_ways_to_train_no_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
     url_ways_to_train_experienced_teacher: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/assessment-only-route-to-qts
+    url_teacher_training_advisers: https://getintoteaching.education.gov.uk/teacher-training-advisers
+    url_help_and_support: https://getintoteaching.education.gov.uk/help-and-support
     url: https://getintoteaching.education.gov.uk
   google_privacy_policy_url: "https://policies.google.com/technologies/cookies?hl=en-US#types-of-cookies"
   course_length_with_study_mode:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -78,7 +78,9 @@ en:
           course_fees: The course fees for UK citizens in %{cycle_range} are %{fee}.
       advice:
         heading: Support and advice
-        body_html: You can <a class="govuk-link" href="https://getintoteaching.education.gov.uk/teacher-training-advisers"> get a teacher training adviser</a> or <a class="govuk-link" href="https://getintoteaching.education.gov.uk/help-and-support"> contact Get Into Teaching</a> for free support.
+        body_html: You can %{teacher_training_advisor_link} or %{contact_git_link} for free support
+        get_a_teacher_training_advisor_link_text: get a teacher training advisor
+        contact_get_into_teaching_link_text: contact Get Into Teaching
       train_with_disabilities:
         heading: Training with disabilities and other needs at %{provider_name}
       international_students_component:

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -15,6 +15,8 @@ namespace :find, path: '/' do
   get '/course/:provider_code/:course_code', to: 'courses#show', as: 'course'
   get '/course/:provider_code/:course_code/placements', to: 'placements#index', as: :placements
   get '/course/:provider_code/:course_code/apply', to: 'courses#apply', as: :apply
+  get '/course/:provider_code/:course_code/git/:git_path', to: 'courses#git_redirect', as: :get_into_teaching_redirect
+  get '/course/:provider_code/:course_code/provider/website', to: 'courses#provider_website', as: :provider_website
   get '/results', to: 'results#index', as: 'results'
   get '/location-suggestions', to: 'location_suggestions#index'
   get '/cycle-has-ended', to: 'pages#cycle_has_ended', as: 'cycle_has_ended'

--- a/spec/components/find/courses/contact_details_component/view_preview.rb
+++ b/spec/components/find/courses/contact_details_component/view_preview.rb
@@ -5,22 +5,23 @@ module Find
     module ContactDetailsComponent
       class ViewPreview < ViewComponent::Preview
         def with_email
-          course = Course.new(provider: Provider.new(provider_code: 'DFE', email: 'learn@learsomuch.com')).decorate
+          course = Course.new(course_code: 'TEST', provider: Provider.new(provider_code: 'DFE', email: 'learn@learsomuch.com')).decorate
           render Find::Courses::ContactDetailsComponent::View.new(course)
         end
 
         def with_telephone
-          course = Course.new(provider: Provider.new(provider_code: 'DFE', telephone: '0207 123 1234')).decorate
+          course = Course.new(course_code: 'TEST', provider: Provider.new(provider_code: 'DFE', telephone: '0207 123 1234')).decorate
           render Find::Courses::ContactDetailsComponent::View.new(course)
         end
 
         def with_website
-          course = Course.new(provider: Provider.new(provider_code: 'DFE', website: 'www.gov.uk')).decorate
+          course = Course.new(course_code: 'TEST', provider: Provider.new(provider_code: 'DFE', website: 'www.gov.uk')).decorate
           render Find::Courses::ContactDetailsComponent::View.new(course)
         end
 
         def with_all
-          course = Course.new(provider: Provider.new(
+          course = Course.new(course_code: 'TEST', provider: Provider.new(
+            provider_code: 'DFE',
             email: 'learn@learsomuch.com',
             telephone: '0207 123 1234',
             website: 'www.gov.uk'

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -99,6 +99,27 @@ feature 'Viewing a findable course' do
     then_i_should_be_on_the_course_page
   end
 
+  scenario 'user visits get into teaching advice pages' do
+    given_there_is_a_findable_course
+    when_i_visit_the_course_page
+    and_i_click('get a teacher training advisor')
+    then_i_am_redirected_to_the_training_advisor_page
+
+    when_i_visit_the_course_page
+    and_i_click('contact Get Into Teaching')
+    then_i_am_redirected_to_the_git_help_and_support_page
+  end
+
+  scenario 'user visits the provider page' do
+    given_there_is_a_findable_course
+    when_i_visit_the_course_page
+    and_i_click(@provider.provider_name)
+    then_i_am_on_the_provider_contact_details_page
+
+    when_i_click(@provider.decorate.website)
+    then_i_am_redirected_to_the_provider_website
+  end
+
   private
 
   def given_there_is_a_findable_course
@@ -342,6 +363,7 @@ feature 'Viewing a findable course' do
   def when_i_click(button)
     click_on(button)
   end
+  alias_method :and_i_click, :when_i_click
 
   def then_i_should_be_on_the_school_placements_page
     @course.site_statuses.new_or_running.map(&:site).uniq.each do |site|
@@ -388,6 +410,22 @@ feature 'Viewing a findable course' do
         "/course/#{@course.provider_code}/#{@course.course_code}"
       ).to_s
     )
+  end
+
+  def then_i_am_redirected_to_the_training_advisor_page
+    expect(page.current_url).to eq('https://getintoteaching.education.gov.uk/teacher-training-advisers')
+  end
+
+  def then_i_am_redirected_to_the_git_help_and_support_page
+    expect(page.current_url).to eq('https://getintoteaching.education.gov.uk/help-and-support')
+  end
+
+  def then_i_am_on_the_provider_contact_details_page
+    expect(page).to have_current_path(find_provider_path(@course.provider_code, @course.course_code), ignore_query: true)
+  end
+
+  def then_i_am_redirected_to_the_provider_website
+    expect(page.current_url).to eq provider.decorate.website
   end
 
   def then_i_should_be_on_the_training_with_disabilities_page


### PR DESCRIPTION
### Context

We have improved our course pages and we need a way of monitoring how our users are interacting with them

[Trello card](https://trello.com/c/y3NKamG9)

### Changes proposed in this pull request
The redirect allows us to capture the initial click in big query before sending people out to the provider or get-into-teaching websites.

### Guidance to review
We can only tests that the redirects take us where we ultimately want to go. We will only know that they are being registered in BigQuery in production.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
