### PR TITLE
Add qualification tda content

### DIFF
--- a/app/components/find/courses/qualifications_summary_component/view.html.erb
+++ b/app/components/find/courses/qualifications_summary_component/view.html.erb
@@ -53,4 +53,13 @@
       This course does not lead to qualified teacher status (QTS).
     </p>
   <% end %>
+<% when "Teacher degree apprenticeship with QTS" %>
+  <%= govuk_details(summary_text: t(".tda_with_qts")) do %>
+    <p class="govuk-body">
+      <%= t(
+        ".tda_with_qts_content_html",
+        tda_link: govuk_link_to(t(".find_out_more_about_tda"), t("find.get_into_teaching.url_tda"))
+      ) %>
+    </p>
+  <% end %>
 <% end %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -113,6 +113,11 @@ en:
           above_or_equivalent_qualification: or above, or equivalent qualification
       about_course:
         heading: Course details
+      qualifications_summary_component:
+        view:
+          tda_with_qts: Teacher degree apprenticeship (TDA) with QTS
+          tda_with_qts_content_html: On a teacher degree apprenticeship you’ll work in a school and earn a salary while getting a bachelor’s degree and qualified teacher status (QTS). %{tda_link}
+          find_out_more_about_tda: Find out more about teacher degree apprenticeships
       summary_component:
         view:
           fee_or_salary: Fee or salary
@@ -233,6 +238,7 @@ en:
       learn_more_about_non_uk_qualifications_html: Learn more about how to <a class="govuk-link" href="https://getintoteaching.education.gov.uk/non-uk-teachers/non-uk-qualifications">check your qualifications meet the required standard</a>.
       tel: 0800 389 2500
       opening_times: "Monday to Friday, 8.30am to 5.30pm"
+      url_tda: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/teacher-degree-apprenticeships
       url_engineers_teach_physics: https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics
       url_get_an_advisor: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
       url_online_chat: https://getintoteaching.education.gov.uk/help-and-support

--- a/spec/components/find/courses/qualifications_summary_component/view_spec.rb
+++ b/spec/components/find/courses/qualifications_summary_component/view_spec.rb
@@ -43,4 +43,12 @@ describe Find::Courses::QualificationsSummaryComponent::View, type: :component d
       expect(result.text).to include('A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).')
     end
   end
+
+  context 'Teacher degree apprenticeship with QTS' do
+    it 'renders correct text' do
+      result = render_inline(described_class.new('Teacher degree apprenticeship with QTS'))
+
+      expect(result.text).to include('On a teacher degree apprenticeship you’ll work in a school and earn a salary while getting a bachelor’s degree and qualified teacher status (QTS). Find out more about teacher degree apprenticeships')
+    end
+  end
 end


### PR DESCRIPTION
### Context

There wasn't any content for tda qualification in the summary component for the course page.

### Changes proposed in this pull request

| before | after |
| -- | -- |
| ![Screenshot from 2024-07-31 14-16-16](https://github.com/user-attachments/assets/55bc9225-c5d3-41a2-b038-c0a0c48b491a) | ![Screenshot from 2024-07-31 14-12-08](https://github.com/user-attachments/assets/cd28b6fa-b7e2-4821-9d40-c53d14ec2837) |

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
