### PR TITLE
Move field from pii to hidden pii

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,0 +1,4 @@
+---
+shared:
+  user:
+    - sign_in_user_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,4 +1,2 @@
 ---
-:shared:
-  :user:
-  - sign_in_user_id
+shared: {}


### PR DESCRIPTION
### Context

We are sending the hidden PII fields separately from other fields that we send to Bigquery.

This means on Bigquery the fields will obfuscated depending on the policy permissions the user has when querying.

For more information about the hidden API there are more details in the Readme:
https://github.com/DFE-Digital/dfe-analytics
