### PR TITLE
Fix the course summary for TDA

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -487,6 +487,8 @@ class Course < ApplicationRecord
   end
 
   def description
+    return qualifications_description if teacher_degree_apprenticeship?
+
     study_mode_string = (full_time_or_part_time? ? ', ' : ' ') +
                         study_mode_description
     qualifications_description + study_mode_string + program_type_description

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1983,7 +1983,7 @@ describe Course do
         program_type: :school_direct_salaried_training_programme,
         qualification: :pgce_with_qts
       },
-      'Teacher degree apprenticeship with QTS full time teaching apprenticeship' => {
+      'Teacher degree apprenticeship with QTS' => {
         study_mode: :full_time,
         program_type: :teacher_degree_apprenticeship,
         qualification: :undergraduate_degree_with_qts


### PR DESCRIPTION
### Context

This will also change the description/summary of the course that apply gets from publish. But the sync job should handle this correct as it's just a small content change to the description.

### Changes proposed in this pull request

| before | after |
| -- | -- |
| ![image (2)](https://github.com/user-attachments/assets/9fcc8835-937e-472b-a206-57175a4c8820) | ![Screenshot from 2024-08-01 11-39-40](https://github.com/user-attachments/assets/ffbc4e3c-07ce-4046-afac-4c820550ff6f) |

### API:
![Screenshot from 2024-08-01 11-38-01](https://github.com/user-attachments/assets/114b030b-0500-4a97-b29b-677e9cbb1f32)
https://publish-review-4418.test.teacherservices.cloud/api/public/v1/recruitment_cycles/2025/providers/4A3/courses/Y704

### Guidance to review
Go on publish review app and check if content of the course is correct on the index page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
