### PR TITLE
[2114] Add `course_type` enum

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -42,6 +42,11 @@ class Course < ApplicationRecord
     open: 1
   }, _prefix: :application_status
 
+  enum course_type: {
+    postgraduate: 'postgraduate',
+    undergraduate: 'undergraduate'
+  }, _suffix: :course_type
+
   enum program_type: {
     higher_education_programme: 'HE',
     higher_education_salaried_programme: 'HES',

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2900,6 +2900,51 @@ describe Course do
     end
   end
 
+  describe 'course_type enum' do
+    subject(:course) { create(:course) }
+
+    context 'default' do
+      it 'sets the value as postgraduate' do
+        expect(course.course_type).to eq('postgraduate')
+      end
+    end
+
+    context 'undergraduate course' do
+      it 'sets the value to undergraduate' do
+        course.undergraduate_course_type!
+        expect(course.reload.course_type).to eq('undergraduate')
+      end
+    end
+
+    context 'postgraduate course' do
+      it 'sets the value to postgraduate' do
+        course.postgraduate_course_type!
+        expect(course.reload.course_type).to eq('postgraduate')
+      end
+    end
+
+    context 'validation' do
+      it 'raises an error when setting an invalid course_type' do
+        expect { course.update!(course_type: 'invalid') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'predicate methods' do
+      it 'returns true for postgraduate?' do
+        expect(course.postgraduate_course_type?).to be true
+      end
+
+      it 'returns false for undergraduate?' do
+        expect(course.undergraduate_course_type?).to be false
+      end
+
+      it 'returns true for undergraduate? after setting to undergraduate' do
+        course.undergraduate_course_type!
+        expect(course.undergraduate_course_type?).to be true
+      end
+    end
+  end
+
   describe '#is_primary?' do
     context 'when course is primary' do
       subject { build(:course, level: :primary) }


### PR DESCRIPTION
### Context

Following on from #4415 we are defining an enum for `course_type`  

### Changes proposed in this pull request

- Add `course_type` enum (_suffix is required because of naming clash)

### Guidance to review

See: https://github.com/DFE-Digital/publish-teacher-training/pull/4415#discussion_r1699656588

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
