### PR TITLE
[2116] Add `funding` enum

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -47,6 +47,13 @@ class Course < ApplicationRecord
     undergraduate: 'undergraduate'
   }, _suffix: :course_type
 
+  enum funding: {
+    not_set: 'not_set',
+    fee: 'fee',
+    salary: 'salary',
+    apprenticeship: 'apprenticeship'
+  }
+
   enum program_type: {
     higher_education_programme: 'HE',
     higher_education_salaried_programme: 'HES',

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2945,6 +2945,72 @@ describe Course do
     end
   end
 
+  describe 'funding enum' do
+    subject(:course) { create(:course) }
+
+    context 'default' do
+      it 'sets the default value as not_set' do
+        expect(course.funding).to eq('not_set')
+      end
+    end
+
+    context 'fee funding' do
+      it 'sets the value to fee' do
+        course.fee!
+        expect(course.reload.funding).to eq('fee')
+      end
+    end
+
+    context 'salary funding' do
+      it 'sets the value to salary' do
+        course.salary!
+        expect(course.reload.funding).to eq('salary')
+      end
+    end
+
+    context 'apprenticeship funding' do
+      it 'sets the value to apprenticeship' do
+        course.apprenticeship!
+        expect(course.reload.funding).to eq('apprenticeship')
+      end
+    end
+
+    context 'validation' do
+      it 'raises an error when setting an invalid funding' do
+        expect { course.update!(funding: 'invalid') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'predicate methods' do
+      it 'returns true for not_set?' do
+        expect(course.not_set?).to be true
+      end
+
+      it 'returns false for fee?' do
+        expect(course.fee?).to be false
+      end
+
+      it 'returns false for salary?' do
+        expect(course.salary?).to be false
+      end
+
+      it 'returns true for fee? after setting to fee' do
+        course.fee!
+        expect(course.fee?).to be true
+      end
+
+      it 'returns true for salary? after setting to salary' do
+        course.salary!
+        expect(course.salary?).to be true
+      end
+
+      it 'returns true for apprenticeship? after setting to apprenticeship' do
+        course.apprenticeship!
+        expect(course.apprenticeship?).to be true
+      end
+    end
+  end
+
   describe '#is_primary?' do
     context 'when course is primary' do
       subject { build(:course, level: :primary) }


### PR DESCRIPTION
### Context

Following on from  #4421 we are defining an enum for `funding`. 

Once #4421 is merged, this PR will be rebased to remove the migration.✅ 

### Changes proposed in this pull request

- Add `funding` enum.

### Guidance to review

- ~~**Only the second commit needs to be reviewed, the first commit should be reviewed in #4421.**~~

- Are the predicate methods ok?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Inform data insights team due to database changes
