### PR TITLE
Removed configuration which raises an error for unpermitted params.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,6 @@ module ManageCoursesBackend
 
     config.action_mailer.delivery_job = 'ActionMailer::MailDeliveryJob'
     config.action_mailer.deliver_later_queue_name = 'mailers'
-    config.action_controller.action_on_unpermitted_parameters = :raise
 
     config.session_store :cookie_store, key: Settings.cookies.session.name, httponly: true
 


### PR DESCRIPTION
### Context

This is not needed as the unpermitted parameters are filtered out before being used. Raising an error is really only recommended for development purposes.

Sentry error: https://dfe-teacher-services.sentry.io/issues/4537046100/?referrer=slack&notification_uuid=d3ec59e7-1eb2-4928-bd00-195b4f64a3c0&alert_rule_id=11137790&alert_type=issue

### Changes proposed in this pull request

Removed configuration which raises an error for unpermitted params.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
