### PR TITLE
Update styling to match GiT website

### DIFF
--- a/app/assets/stylesheets/components/shared/_advice.scss
+++ b/app/assets/stylesheets/components/shared/_advice.scss
@@ -23,7 +23,7 @@
 }
 
 #section-advice-and-support {
-  border: 5px solid #f162a3;
+  border: 5px solid govuk-colour("pink");
   margin-bottom: 30px;
   padding: 20px;
   background: govuk-colour("light-grey");

--- a/app/assets/stylesheets/govuk_style_setup.scss
+++ b/app/assets/stylesheets/govuk_style_setup.scss
@@ -9,4 +9,4 @@ $mobile-small-start: 400px;
 $mobile-small-end: 401px;
 $mobile-big-start: 500px;
 $mobile-big-end: 501px;
-$git-brand-colour: #159964;
+$git-brand-colour: govuk-colour("orange");


### PR DESCRIPTION
### Context

We have components that we want styled similarly to the GiT website branding. 

### Changes proposed in this pull request

Updated CSS border colours so they are a closer match to the GiT branding

### Guidance to review

| before | after |
|---|---|
| ![03026c98fd598d46ddc798caf49c63f2](https://github.com/user-attachments/assets/97190c43-35d1-4b90-983c-26cf78d470af) | ![75a44cdf9da6a7b809e694a4c8d6ae99](https://github.com/user-attachments/assets/81b1b82d-8e6c-4fc7-84f0-5b1408a5b625) |
| ![d87e12f67c129923f0e1c7b8a4e68331](https://github.com/user-attachments/assets/10a24fd0-0ffe-4e7c-b5e8-e5a94e81367b) | ![d957447d4f63c41ebdb76118648ad824](https://github.com/user-attachments/assets/0c1ce1fd-dd4a-4867-a256-a72e33ed7876) |

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Inform data insights team due to database changes
