### PR TITLE
[2123] Update `course_type` to `undergraduate` for Teacher Degree Apprenticeship courses

### DIFF
--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -63,6 +63,7 @@ module Publish
         if undergraduate_to_other_qualification?
           @course.enrichments.find_or_initialize_draft.update(course_length: nil, salary_details: nil)
           @course.update(
+            course_type: 'postgraduate',
             a_level_subject_requirements: [],
             accept_pending_a_level: nil,
             accept_a_level_equivalency: nil,

--- a/app/services/publish/courses/assign_tda_attributes_service.rb
+++ b/app/services/publish/courses/assign_tda_attributes_service.rb
@@ -8,15 +8,17 @@ module Publish
       end
 
       def call
-        @course.assign_attributes(funding_type: 'apprenticeship',
-                                  study_mode: 'full_time',
-                                  program_type: 'teacher_degree_apprenticeship',
-                                  can_sponsor_student_visa: false,
-                                  can_sponsor_skilled_worker_visa: false,
-                                  degree_grade: 'not_required',
-                                  additional_degree_subject_requirements: false,
-                                  degree_subject_requirements: nil,
-                                  course_type: 'undergraduate')
+        @course.assign_attributes(
+          course_type: 'undergraduate',
+          funding_type: 'apprenticeship',
+          study_mode: 'full_time',
+          program_type: 'teacher_degree_apprenticeship',
+          can_sponsor_student_visa: false,
+          can_sponsor_skilled_worker_visa: false,
+          degree_grade: 'not_required',
+          additional_degree_subject_requirements: false,
+          degree_subject_requirements: nil
+        )
 
         if @course.enrichments.blank?
           course_enrichment = @course.enrichments.find_or_initialize_draft

--- a/app/services/publish/courses/assign_tda_attributes_service.rb
+++ b/app/services/publish/courses/assign_tda_attributes_service.rb
@@ -15,7 +15,8 @@ module Publish
                                   can_sponsor_skilled_worker_visa: false,
                                   degree_grade: 'not_required',
                                   additional_degree_subject_requirements: false,
-                                  degree_subject_requirements: nil)
+                                  degree_subject_requirements: nil,
+                                  course_type: 'undergraduate')
 
         if @course.enrichments.blank?
           course_enrichment = @course.enrichments.find_or_initialize_draft

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -39,6 +39,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
       and_there_is_a_qts_course_i_want_to_edit
       when_i_visit_the_course_outcome_page_in_the_next_cycle
       and_i_choose_undergraduate_degree_with_qts
+      and_the_course_type_is_postgraduate
       and_i_submit
       then_the_default_options_for_a_tda_course_should_be_applied
     end
@@ -49,7 +50,9 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
         and_the_tda_feature_flag_is_active
         and_there_is_a_tda_course_i_want_to_edit
         when_i_visit_the_course_outcome_page_in_the_next_cycle
+        and_the_course_type_is_undergraduate
         and_i_choose_qts
+        and_the_course_type_is_postgraduate
         and_the_back_link_points_to_the_outcome_page
         and_i_choose_the_fee_paying
         and_the_back_link_points_to_the_funding_type_page
@@ -76,7 +79,9 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
         and_the_tda_feature_flag_is_active
         and_there_is_a_tda_course_i_want_to_edit
         when_i_visit_the_course_outcome_page_in_the_next_cycle
+        and_the_course_type_is_undergraduate
         and_i_choose_qts
+        and_the_course_type_is_postgraduate
         and_the_back_link_points_to_the_outcome_page
         and_i_choose_salaried
         and_the_back_link_points_to_the_funding_type_page
@@ -106,7 +111,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_there_is_a_tda_course_i_want_to_edit
-    given_a_course_exists(:undergraduate_degree_with_qts, enrichments: [course_enrichment])
+    given_a_course_exists(:undergraduate_degree_with_qts, course_type: 'undergraduate')
   end
 
   def course_enrichment
@@ -213,8 +218,17 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     )
   end
 
+  def and_the_course_type_is_undergraduate
+    expect(course.undergraduate_course_type?).to be(true)
+  end
+
+  def and_the_course_type_is_postgraduate
+    expect(course.reload.postgraduate_course_type?).to be(true)
+  end
+
   def then_the_default_options_for_a_tda_course_should_be_applied
     course.reload
+    expect(course.undergraduate_course_type?).to be(true)
     expect(course.full_time?).to be(true)
     expect(course.funding_type == 'apprenticeship').to be(true)
     expect(course.can_sponsor_skilled_worker_visa).to be false

--- a/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
+++ b/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Publish::Courses::AssignTdaAttributesService do
       expect(course.additional_degree_subject_requirements).to be(false)
       expect(course.degree_subject_requirements).to be_nil
       expect(course.degree_grade).to eq('not_required')
+      expect(course.course_type).to eq('undergraduate')
     end
   end
 end


### PR DESCRIPTION
## Context

We have added a new `course_type` column to our database. 

The majority of our course will be `postgraduate`, the TDA courses are the only exception. Currently there is only one TDA course.

## Changes proposed in this pull request

- Set `course_type` to `undergraduate` when creating a TDA course.
- Set `course_type` to `undergraduate` when changing to a TDA course.
- Set `course_type` back to `postgraduate` when changing from a TDA course to a non TDA course.

## Guidance to review

- Create a non TDA course, check the `course_type` is `postgraduate`
- Change the course to a TDA course, check the `course_type` is now `undergraduate`
- Change the course back to a non TDA course, check the `course_type` is `postgraduate` once again.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
