### PR TITLE
[2124] Add `funding` feature flag

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -527,6 +527,10 @@ class Course < ApplicationRecord
 
   delegate :funding_type, :visa_type, :fee_based?, :student_visa?, to: :program
 
+  def funding_type
+    FeatureService.enabled?(:db_backed_funding_type) ? funding : program.funding_type
+  end
+
   # https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c11-gcse-standard-equivalent
   def gcse_subjects_required
     case level

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,6 +94,7 @@ feedback:
 
 features:
   teacher_degree_apprenticeship: true
+  db_backed_funding_type: false
   send_request_data_to_bigquery: false
   rollover:
     # Normally a short period of time between rollover and the next cycle


### PR DESCRIPTION
## Context

We are introducing a new database backed `funding` column on the `course` table, replacing the non database backed `funding_type`. This change will allow us to manage funding directly through the database.

To ensure a smooth transition, we will initially place this change behind a feature flag. This approach will allow us to:

- Control the rollout of the new funding column.
- Backfill the `funding` column with existing data through a data migration.
- Provide an easy way to revert the change if necessary.
- The feature flag will remain off in all environments until the migration and feature implementation are complete. Once the feature has been stable in production for a sufficient period, we will remove the feature flag.

## Changes proposed in this pull request

- Add the feature flag
- Set to inactive by default
- Add logic to use our existing implementation when the flag is off
- Add logic to use the db backed funding column when the flag is on

## Guidance to review

:shipit: 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
