### PR TITLE
[1884] Add 2026 cycle dates to codebase

### DIFF
--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -39,17 +39,15 @@ module Find
         find_opens: Time.zone.local(2024, 10, 1, 9), # CONFIRMED
         apply_opens: Time.zone.local(2024, 10, 8, 9), # CONFIRMED
         first_deadline_banner: Time.zone.local(2025, 7, 12, 9), # TBC
-        apply_deadline: Time.zone.local(2025, 9, 17, 18), # CONFIRMED
-        find_closes: Time.zone.local(2025, 9, 25, 23, 59, 59) # TBC
+        apply_deadline: Time.zone.local(2025, 9, 16, 18), # CONFIRMED
+        find_closes: Time.zone.local(2025, 9, 30, 23, 59, 59) # CONFIRMED
       },
       2026 => {
-        # NOTE: the dates from below here are not the finalised but are required
-        # for the current implementation
-        find_opens: Time.zone.local(2024, 10, 5, 9),
-        apply_opens: Time.zone.local(2024, 10, 12, 9),
-        first_deadline_banner: Time.zone.local(2025, 7, 12, 9),
-        apply_deadline: Time.zone.local(2025, 9, 21, 18),
-        find_closes: Time.zone.local(2025, 10, 4, 23, 59, 59)
+        find_opens: Time.zone.local(2025, 10, 1, 9), # CONFIRMED
+        apply_opens: Time.zone.local(2025, 10, 8, 9), # CONFIRMED
+        first_deadline_banner: Time.zone.local(2026, 7, 12, 9), # TBC
+        apply_deadline: Time.zone.local(2026, 9, 16, 18), # CONFIRMED
+        find_closes: Time.zone.local(2026, 9, 30, 23, 59, 59) # TBC
       }
     }.freeze
 


### PR DESCRIPTION
## Context

As we approach the new cycle, we will need to have the next cycle defined, so adding it now. There are still some dates to be confirmed, but the opening dates and reject by default dates are agreed.

## Changes proposed in this pull request

This PR keeps the dates in sync with the dates defined in Apply. See [this PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9678)

- Added dates with an note about what needs to be confirmed later.
- Updated the 2025 dates that have been confirmed.

## Guidance to review


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
