### PR TITLE
Add specific support and advice content for TDA courses

### DIFF
--- a/app/views/find/courses/_advice.html.erb
+++ b/app/views/find/courses/_advice.html.erb
@@ -1,17 +1,31 @@
 <div id="section-advice-and-support">
   <h2 class="govuk-heading-m" id="section-advice"><%= t(".heading") %></h2>
   <span class="govuk-body">
-    <%= t(
-          ".body_html",
-          teacher_training_advisor_link: govuk_link_to(
-            t(".get_a_teacher_training_advisor_link_text"),
-            find_get_into_teaching_redirect_path(
-              @course.provider_code,
-              @course.course_code,
-              "teacher_training_advisers"
-            )
-          ),
-          contact_git_link:
+    <% if course.postgraduate_course_type? %>
+      <%= t(
+            ".postgraduate.body_html",
+            teacher_training_advisor_link: govuk_link_to(
+              t(".get_a_teacher_training_advisor_link_text"),
+              find_get_into_teaching_redirect_path(
+                @course.provider_code,
+                @course.course_code,
+                "teacher_training_advisers"
+              )
+            ),
+            contact_git_link:
+              govuk_link_to(
+                t(".contact_get_into_teaching_link_text"),
+                find_get_into_teaching_redirect_path(
+                  @course.provider_code,
+                  @course.course_code,
+                  "help_and_support"
+                )
+              )
+          ) %>
+    <% else %>
+      <%= t(
+            ".undergraduate.body_html",
+            contact_git_link:
             govuk_link_to(
               t(".contact_get_into_teaching_link_text"),
               find_get_into_teaching_redirect_path(
@@ -20,6 +34,7 @@
                 "help_and_support"
               )
             )
-        ) %>
+          ) %>
+    <% end %>
   </span>
 </div>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -85,7 +85,11 @@ en:
           course_fees: The course fees for UK citizens in %{cycle_range} are %{fee}.
       advice:
         heading: Support and advice
-        body_html: You can %{teacher_training_advisor_link} or %{contact_git_link} for free support
+        postgraduate:
+          body_html: You can %{teacher_training_advisor_link} or %{contact_git_link} for free support
+        undergraduate:
+          body_html: You can %{contact_git_link} for free support
+
         get_a_teacher_training_advisor_link_text: get a teacher training advisor
         contact_get_into_teaching_link_text: contact Get Into Teaching
       train_with_disabilities:

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -263,6 +263,7 @@ FactoryBot.define do
     trait :published_teacher_degree_apprenticeship do
       open
       published
+      undergraduate
       with_full_time_sites
       with_teacher_degree_apprenticeship
       resulting_in_undergraduate_degree_with_qts

--- a/spec/features/find/search/undergraduate/viewing_a_course_spec.rb
+++ b/spec/features/find/search/undergraduate/viewing_a_course_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Viewing an undergraduate course' do
+  include Rails.application.routes.url_helpers
+
+  after do
+    Timecop.return
+  end
+
+  scenario 'user visits get into teaching advice page' do
+    given_there_is_a_findable_undergraduate_course
+    and_i_am_in_the_2025_cycle
+    when_i_visit_the_course_page
+    and_i_click_to_contact_get_into_teaching
+    then_i_am_redirected_to_the_git_help_and_support_page
+  end
+
+  def given_there_is_a_findable_undergraduate_course
+    recruitment_cycle = create(:recruitment_cycle, year: 2025)
+    user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    provider = user.providers.first
+    create(:provider, :accredited_provider, provider_code: '1BJ')
+    accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    provider.accrediting_provider_enrichments = []
+    provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
+      {
+        UcasProviderCode: accredited_provider.provider_code,
+        Description: 'description'
+      }
+    )
+    @course = create(:course, :published_teacher_degree_apprenticeship, :secondary, provider:, name: 'Biology', subjects: [find_or_create(:secondary_subject, :biology)])
+  end
+
+  def and_i_am_in_the_2025_cycle
+    Timecop.travel(Find::CycleTimetable.find_reopens)
+    allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
+  end
+
+  def when_i_visit_the_course_page
+    visit find_course_path(
+      provider_code: @course.provider.provider_code,
+      course_code: @course.course_code
+    )
+  end
+
+  def and_i_click_to_contact_get_into_teaching
+    expect(page).to have_content('Support and advice')
+    expect(page).to have_content('You can contact Get Into Teaching for free support')
+    click_link_or_button('contact Get Into Teaching')
+  end
+
+  def then_i_am_redirected_to_the_git_help_and_support_page
+    expect(page.current_url).to eq(
+      'https://getintoteaching.education.gov.uk/help-and-support'
+    )
+  end
+end


### PR DESCRIPTION
## Context

TDA courses are not eligible for teacher training advisers.

This ticket is to display a variation of the support and advice section for TDA courses.

## Changes

![Screenshot_2024-07-24_at_14 35 15](https://github.com/user-attachments/assets/c005b618-9212-4b47-9c98-c6f88a48d0aa)
