### PR TITLE
DataMigrate 9.4.4 has been yanked from RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,7 +141,7 @@ gem 'propshaft'
 gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.14.1'
 
 # For running data migrations
-gem 'data_migrate', '~> 9.4.4'
+gem 'data_migrate', '9.4.2'
 
 # For outgoing http requests
 gem 'http'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     csv (3.3.0)
-    data_migrate (9.4.4)
+    data_migrate (9.4.2)
       activerecord (>= 6.1)
       railties (>= 6.1)
     database_cleaner (2.0.2)
@@ -807,7 +807,7 @@ DEPENDENCIES
   config
   cssbundling-rails (~> 1.4)
   custom_error_message!
-  data_migrate (~> 9.4.4)
+  data_migrate (= 9.4.2)
   database_cleaner
   dfe-analytics!
   dfe-wizard!


### PR DESCRIPTION
## Context

  DataMigrate 9.4.4 has been yanked from RubyGems
  https://rubygems.org/gems/data_migrate

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
