### PR TITLE
Update Teacher Training API to return `selectable_school`

### DIFF
--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -23,7 +23,8 @@ module API
                    :telephone,
                    :email,
                    :can_sponsor_skilled_worker_visa,
-                   :can_sponsor_student_visa
+                   :can_sponsor_student_visa,
+                   :selectable_school
 
         attribute :accredited_body do
           @object.accredited_provider?

--- a/bin/build-docs
+++ b/bin/build-docs
@@ -1,0 +1,7 @@
+#!/bin/env bash
+
+docker build --target middleman -t publish-docs .
+mkdir -p public/docs
+container_id=$(docker create publish-docs)
+docker cp $container_id:/public/. public/docs
+docker rm $container_id

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -6,6 +6,10 @@ weight: 2
 # Release Notes
 
 
+## 20 August 2024
+
+- Add `selectable_school` property to `ProviderAttributes`. Providers with this value as true allow Candidates to choose specific school placements in the User Interface.
+
 ## 19 July 2023
 
 - Add `discard` filter to `ProviderFilter`. This boolean field returns only decomissioned providers. `discarded_at` is returned in the `ProviderAttributes`.

--- a/guides/api.md
+++ b/guides/api.md
@@ -19,9 +19,6 @@ Use the following command to generate OpenAPI specification:
 ```sh
 bundle exec rake rswag:specs:swaggerize
 ```
-```sh
-bundle exec rake rswag:specs:swaggerize
-```
 
 3. We build the documentation in a separate container to the main app and copy the contents into the main image.
 

--- a/guides/api.md
+++ b/guides/api.md
@@ -7,15 +7,36 @@ Our API is documented using [OpenAPI](https://swagger.io/specification/). You ca
 We use [Tech Docs](https://github.com/alphagov/tech-docs-gem) to build documentation. To update documentation, run the command below which will generate an open api specification file. The docker build will then take these files to generate the static site.
 
 
+### Develop and test API documentation
+
+
+1. If we want to change the documentation, go to `swagger/public_vx` and make changes to the yml files.
+
+2. Run the swaggerize command to generate a new api_spec.json
+
 Use the following command to generate OpenAPI specification:
 
 ```sh
 bundle exec rake rswag:specs:swaggerize
 ```
-
-
-To develop and preview the tech docs you can start and run with [Middleman](https://github.com/middleman/middleman)
-
 ```sh
-cd docs && bundle install && bundle exec middleman
+bundle exec rake rswag:specs:swaggerize
 ```
+
+3. We build the documentation in a separate container to the main app and copy the contents into the main image.
+
+
+```shell
+bin/build-docs
+```
+
+This will:
+
+1. build a container only of the docs
+2. copy the built docs to `public/docs`
+3. allow you to visit `http://publish.localhost:3001/docs/` and see your changes
+
+#### Confirm the openapi specs
+
+    http://publish.localhost:3001/api-docs/public_v1/api_spec.json
+

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -338,7 +338,8 @@ RSpec.describe API::Public::V1::ProvidersController do
                 telephone
                 email
                 can_sponsor_skilled_worker_visa
-                can_sponsor_student_visa]
+                can_sponsor_student_visa
+                selectable_school]
           end
 
           before do
@@ -540,7 +541,8 @@ RSpec.describe API::Public::V1::ProvidersController do
             'telephone' => provider.telephone,
             'email' => provider.email,
             'can_sponsor_student_visa' => provider.can_sponsor_student_visa,
-            'can_sponsor_skilled_worker_visa' => provider.can_sponsor_skilled_worker_visa
+            'can_sponsor_skilled_worker_visa' => provider.can_sponsor_skilled_worker_visa,
+            'selectable_school' => provider.selectable_school
           }
         }
       end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
     can_sponsor_student_visa { [true, false].sample }
     can_sponsor_skilled_worker_visa { [true, false].sample }
     synonyms { Faker::Lorem.words(number: 0..3) }
+    selectable_school { true }
 
     trait :with_name do
       provider_name { 'Test Name' }

--- a/spec/serializers/api/public/v1/serializable_provider_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_provider_spec.rb
@@ -15,6 +15,7 @@ describe API::Public::V1::SerializableProvider do
   it { is_expected.to have_type 'providers' }
 
   it { is_expected.to have_attribute(:postcode).with_value(provider.postcode) }
+  it { is_expected.to have_attribute(:selectable_school).with_value(provider.selectable_school) }
   it { is_expected.to have_attribute(:provider_type).with_value(provider.provider_type) }
   it { is_expected.to have_attribute(:region_code).with_value(provider.region_code) }
   it { is_expected.to have_attribute(:train_with_disability).with_value(provider.train_with_disability) }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -7,7 +7,7 @@
       "name": "DfE",
       "email": "becomingateacher@digital.education.gov.uk"
     },
-    "description": "API for DfE's postgraduate teacher training course service."
+    "description": "API for DfE's teacher training course service."
   },
   "servers": [
     {
@@ -335,14 +335,14 @@
             "nullable": true,
             "format": "markdown",
             "description": "This field is being deprecated after 2024 recruitment cycle.",
-            "example": ""
+            "example": null
           },
           "personal_qualities": {
             "type": "string",
             "nullable": true,
             "format": "markdown",
             "description": "This field is being deprecated after 2024 recruitment cycle.",
-            "example": ""
+            "example": null
           },
           "program_type": {
             "type": "string",
@@ -1272,6 +1272,12 @@
             "example": "2023-07-18T15:23:15Z",
             "format": "date-time",
             "nullable": true
+          },
+          "selectable_school": {
+            "type": "boolean",
+            "description": "Can candidates choose their placement school",
+            "example": true,
+            "nullable": false
           }
         }
       },
@@ -2243,7 +2249,7 @@
           },
           {
             "description": "Get the second page of courses for a provider",
-            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/provideers/B20/courses?page[page]=2"
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses?page[page]=2"
           }
         ],
         "responses": {
@@ -2272,7 +2278,7 @@
             "name": "year",
             "in": "path",
             "required": true,
-            "description": "The starting year of the recruitment cycle.Also accepts \"current\" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg \"1066\") is provided",
+            "description": "The starting year of the recruitment cycle. Also accepts \"current\" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg \"1066\") is provided",
             "example": 2024,
             "schema": {
               "type": "string"

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -207,21 +207,15 @@ properties:
     nullable: true
     format: markdown
     description: >-
-      Any non-academic qualifications or documents the applicant may need.
-    example: >-
-      You'll need to provide confirmation you have the health and
-      physical capacity to commence training, and a Disclosure and
-      Barring Service (DBS) certificate.
+      This field is being deprecated after 2024 recruitment cycle.
+    example:
   personal_qualities:
     type: string
     nullable: true
     format: markdown
     description: >-
-      Any skills, motivation and experience the provider is looking for in applicants.
-    example: >-
-      We are looking for applicants who have the potential to become
-      outstanding teachers, and who are able to work independently on
-      their studies while training in a school context.
+      This field is being deprecated after 2024 recruitment cycle.
+    example:
   program_type:
     type: string
     description: >-

--- a/swagger/public_v1/component_schemas/ProviderAttributes.yml
+++ b/swagger/public_v1/component_schemas/ProviderAttributes.yml
@@ -150,3 +150,8 @@ properties:
     example: "2023-07-18T15:23:15Z"
     format: date-time
     nullable: true
+  selectable_school:
+    type: boolean
+    description: "Can candidates choose their placement school"
+    example: true
+    nullable: false


### PR DESCRIPTION
## Context

We have added a property to Provider, `selectable_school`. We want to provider this property via the API.

This property must be documented in the API docs.

## Changes proposed in this pull request

 - Add `selectable_school` to the ProviderAttributes API response.
 - Update documentation on how to develop the API docs

## Guidance to review

https://publish-review-4465.test.teacherservices.cloud/docs/#about

### API response
```sh
curl -H 'content-type: application/json' http://publish.localhost:3001/api/public/v1/recruitment_cycles/2024/providers/2AT | jq '.data.attributes.selectable_school'
```

### API docs
http://publish.localhost:3001/api_docs`

![image](https://github.com/user-attachments/assets/1a140f15-05e7-4126-9436-e175177b5f28)

![image](https://github.com/user-attachments/assets/a14e8020-5d55-4eaa-9ac4-e061f968c1af)


### Trello Ticket
[Update Publish API to return selectable school as part of the Providers API](https://trello.com/c/pew33sLd/2202-update-publish-api-to-return-selectable-school-as-part-of-the-providers-api)

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
