### PR TITLE
Make sure undergraduate courses and non duplicates appear on the API

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -16,7 +16,7 @@ module API
         private
 
         def courses
-          @courses ||= CourseSearchService.call(
+          @courses ||= APICourseSearchService.call(
             filter: params[:filter],
             sort: params[:sort],
             course_scope: recruitment_cycle.courses

--- a/app/controllers/api/public/v1/providers/courses_controller.rb
+++ b/app/controllers/api/public/v1/providers/courses_controller.rb
@@ -21,8 +21,8 @@ module API
           private
 
           def courses
-            @courses ||= CourseSearchService.call(filter: params[:filter],
-                                                  course_scope: provider.courses)
+            @courses ||= APICourseSearchService.call(filter: params[:filter],
+                                                     course_scope: provider.courses)
           end
 
           def course

--- a/app/services/api_course_search_service.rb
+++ b/app/services/api_course_search_service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class APICourseSearchService < CourseSearchService
+  def default_course_order(outer_scope)
+    outer_scope.order('course.id': :asc)
+  end
+
+  def filter_by_course_type(scope)
+    scope # we want to return all course types in the API
+  end
+end

--- a/app/services/api_course_search_service.rb
+++ b/app/services/api_course_search_service.rb
@@ -2,7 +2,7 @@
 
 class APICourseSearchService < CourseSearchService
   def default_course_order(outer_scope)
-    outer_scope.order('course.id': :asc)
+    outer_scope.order('course.created_at': :asc)
   end
 
   def filter_by_course_type(scope)

--- a/app/services/api_course_search_service.rb
+++ b/app/services/api_course_search_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class APICourseSearchService < CourseSearchService
-  def default_course_order(outer_scope)
+  def course_order(outer_scope)
     outer_scope.order('course.created_at': :asc)
   end
 

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -85,7 +85,9 @@ class CourseSearchService
 
   private
 
-  # Method signature
+  # This method provides a default ordering for courses.
+  # It can be overridden in subclasses to apply different ordering logic
+  # for various contexts, such as the API.
   def default_course_order(outer_scope)
     outer_scope
   end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -75,7 +75,7 @@ class CourseSearchService
           outer_scope.order(:distance)
         end
     else
-      outer_scope = default_course_order(outer_scope)
+      outer_scope = course_order(outer_scope)
     end
 
     outer_scope
@@ -85,10 +85,9 @@ class CourseSearchService
 
   private
 
-  # This method provides a default ordering for courses.
-  # It can be overridden in subclasses to apply different ordering logic
+  # This method can be overridden in subclasses to apply different ordering logic
   # for various contexts, such as the API.
-  def default_course_order(outer_scope)
+  def course_order(outer_scope)
     outer_scope
   end
 

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -21,7 +21,7 @@ class CourseSearchService
 
   def call
     scope = course_scope
-    scope = scope.with_course_type(course_type)
+    scope = filter_by_course_type(scope)
     scope = scope.with_salary if funding_filter_salary?
     scope = scope.with_qualifications(qualifications) if qualifications.any?
     scope = scope.application_status_open if applications_open?
@@ -74,6 +74,8 @@ class CourseSearchService
         else
           outer_scope.order(:distance)
         end
+    else
+      outer_scope = default_course_order(outer_scope)
     end
 
     outer_scope
@@ -82,6 +84,15 @@ class CourseSearchService
   private_class_method :new
 
   private
+
+  # Method signature
+  def default_course_order(outer_scope)
+    outer_scope
+  end
+
+  def filter_by_course_type(scope)
+    scope.with_course_type(course_type)
+  end
 
   def course_type
     return :undergraduate if @course_type_answer_determiner.show_undergraduate_courses?

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe API::Public::V1::CoursesController do
           end
 
           expect(ids.size).to eq(ids.uniq.size)
-          expect(ids).to eq(ids.sort)
         end
       end
 

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -110,10 +110,8 @@ RSpec.describe API::Public::V1::CoursesController do
               per_page: 3
             }
 
-            ids << response.parsed_body['data'].pluck('id')
+            ids += response.parsed_body['data'].pluck('id')
           end
-
-          ids.flatten!
 
           expect(ids.size).to eq(ids.uniq.size)
           expect(ids).to eq(ids.sort)

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe API::Public::V1::CoursesController do
       end
 
       context 'avoids duplication' do
-        it 'does not return duplicates across multiple pages ordering by id' do
+        it 'does not return duplicates across multiple pages by ordering the courses' do
           provider.courses << build_list(:course, 30, provider:)
           ids = []
 

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
     end
 
     context 'avoids duplication' do
-      it 'does not return duplicates across multiple pages ordering by id' do
+      it 'does not return duplicates across multiple pages by ordering the courses' do
         provider.courses << build_list(:course, 30, provider:)
         ids = []
 

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
         end
 
         expect(ids.size).to eq(ids.uniq.size)
-        expect(ids).to eq(ids.sort)
       end
     end
 

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -89,10 +89,8 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
             per_page: 3
           }
 
-          ids << response.parsed_body['data'].pluck('id')
+          ids += response.parsed_body['data'].pluck('id')
         end
-
-        ids.flatten!
 
         expect(ids.size).to eq(ids.uniq.size)
         expect(ids).to eq(ids.sort)

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -43,6 +43,62 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
       end
     end
 
+    context 'returns all course types' do
+      it 'returns undergraduate and postgraduate' do
+        undergraduate_course = create(:course, :published_teacher_degree_apprenticeship, provider:)
+        postgraduate_course = create(:course, :published_postgraduate, provider:)
+        provider.courses << [undergraduate_course, postgraduate_course]
+
+        get :index, params: {
+          recruitment_cycle_year: recruitment_cycle.year,
+          provider_code: provider.provider_code
+        }
+
+        actual = json_response['data'].map do |data|
+          {
+            id: data['id'],
+            qualifications: data['attributes']['qualifications'],
+            program_type: data['attributes']['program_type']
+          }
+        end
+
+        expect(actual).to include({
+                                    id: undergraduate_course.id.to_s,
+                                    qualifications: %w[qts undergraduate_degree],
+                                    program_type: 'teacher_degree_apprenticeship'
+                                  })
+
+        expect(actual).to include({
+                                    id: postgraduate_course.id.to_s,
+                                    qualifications: %w[qts pgce],
+                                    program_type: 'pg_teaching_apprenticeship'
+                                  })
+      end
+    end
+
+    context 'avoids duplication' do
+      it 'does not return duplicates across multiple pages ordering by id' do
+        provider.courses << build_list(:course, 30, provider:)
+        ids = []
+
+        (1..10).each do |page|
+          get :index, params: {
+            recruitment_cycle_year: recruitment_cycle.year,
+            provider_code: provider.provider_code,
+            page:,
+            per_page: 3
+          }
+
+          ids << response.parsed_body['data'].pluck('id')
+        end
+
+        ids.flatten!
+
+        expect(ids.size).to eq(ids.uniq.size)
+        expect(ids).to eq(ids.sort)
+      end
+    end
+
     context 'with pagination' do
       let!(:courses) { create_list(:course, 3, provider:) }
       let(:pagination) do

--- a/spec/services/api_course_search_service_spec.rb
+++ b/spec/services/api_course_search_service_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe APICourseSearchService do
       end
     end
 
-    context 'when ordering courses by id' do
-      it 'orders courses by id ascending' do
-        course_three = create(:course, id: 3)
-        course_one = create(:course, id: 1)
-        course_four = create(:course, id: 4)
-        course_two = create(:course, id: 2)
+    context 'when ordering courses by creation date' do
+      it 'orders courses by created at ascending' do
+        course_three = create(:course, created_at: 4.days.ago)
+        course_one = create(:course, created_at: 10.days.ago)
+        course_four = create(:course, created_at: 1.day.ago)
+        course_two = create(:course, created_at: 9.days.ago)
 
         expect(result.pluck(:id)).to eq(
           [course_one.id, course_two.id, course_three.id, course_four.id]

--- a/spec/services/api_course_search_service_spec.rb
+++ b/spec/services/api_course_search_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe APICourseSearchService do
+  describe '.call' do
+    subject(:result) { described_class.call(filter:, sort:, course_scope: Course.all) }
+
+    let(:filter) { {} }
+    let(:sort) { nil }
+
+    context 'when filtering by course type' do
+      it 'returns all course types' do
+        undergraduate_course = create(:course, :published_teacher_degree_apprenticeship)
+        postgraduate_course = create(:course, :published_postgraduate)
+
+        expect(result).to contain_exactly(undergraduate_course, postgraduate_course)
+      end
+    end
+
+    context 'when ordering courses by id' do
+      it 'orders courses by id ascending' do
+        course_three = create(:course, id: 3)
+        course_one = create(:course, id: 1)
+        course_four = create(:course, id: 4)
+        course_two = create(:course, id: 2)
+
+        expect(result.pluck(:id)).to eq(
+          [course_one.id, course_two.id, course_three.id, course_four.id]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need to make sure undergraduate AND postgraduate courses are returned on the API.

This was necessary because the CourseSearchService is used in Find web service although there we will have to filter by course type always on the current designs.

Also added the order by to remove the duplications to be happening on the API

