### PR TITLE
Enable TDA in staging and QA

### DIFF
--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -31,6 +31,7 @@ basic_auth:
 
 features:
   send_request_data_to_bigquery: true
+  teacher_degree_apprenticeship: true
 
 find_valid_referers:
   - https://qa.find-teacher-training-courses.service.gov.uk

--- a/config/settings/staging_aks.yml
+++ b/config/settings/staging_aks.yml
@@ -28,6 +28,7 @@ environment:
 
 features:
   send_request_data_to_bigquery: true
+  teacher_degree_apprenticeship: true
 
 find_valid_referers:
   - https://staging.find-teacher-training-courses.service.gov.uk


### PR DESCRIPTION
## Context

Enabling TDA in staging and QA.

## Why?

* To test integrations with Apply
* To facilitate demos
* For everyone in the team has access to how TDA is working though our apps