### PR TITLE
Add rake task to set selectable_school to true

### DIFF
--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -3,12 +3,7 @@
 require: rubocop-rails
 
 Rails/SkipsModelValidations:
-  Exclude:
-    - 'spec/**/*'
-    - 'db/**/*'
-    - 'app/models/course.rb'
-    - 'app/models/provider.rb'
-    - 'lib/tasks/migrate_user_organisation_to_user_permission.rake'
+  Enabled: false
 
 Rails/ThreeStateBooleanColumn:
   Exclude:

--- a/lib/tasks/update_selectable_schools.rake
+++ b/lib/tasks/update_selectable_schools.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DataMigrations
+  class SetSelectableSchoolsOnProviders
+    def change
+      provider_codes = %w[E65 2CG 2CH 2CJ 2CK 2C1 1EX 1QU CS01 2X4 1ZO]
+      Provider.where(provider_code: provider_codes).update_all(selectable_school: true) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+end
+
+desc 'Set Selectable Schools on 11 providers'
+task set_selectable_schools: :environment do |_, _args|
+  DataMigrations::SetSelectableSchoolsOnProviders.new.change
+end

--- a/lib/tasks/update_selectable_schools.rake
+++ b/lib/tasks/update_selectable_schools.rake
@@ -4,7 +4,7 @@ module DataMigrations
   class SetSelectableSchoolsOnProviders
     def change
       provider_codes = %w[E65 2CG 2CH 2CJ 2CK 2C1 1EX 1QU CS01 2X4 1ZO]
-      Provider.where(provider_code: provider_codes).update_all(selectable_school: true) # rubocop:disable Rails/SkipsModelValidations
+      Provider.where(provider_code: provider_codes).update_all(selectable_school: true)
     end
   end
 end

--- a/spec/lib/tasks/update_selectable_school_rake_spec.rb
+++ b/spec/lib/tasks/update_selectable_school_rake_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+describe 'set_selectable_schools' do
+  Rails.application.load_tasks if Rake::Task.tasks.empty?
+  subject(:set_selectable_schools_task) do
+    Rake::Task['set_selectable_schools'].invoke
+  end
+
+  let(:target_provider) { create(:provider, provider_code: 'E65', selectable_school: false) }
+  let(:ignore_provider) { create(:provider, provider_code: 'Z00', selectable_school: false) }
+
+  it 'updates the providers selectable_school to true' do
+    expect(target_provider.selectable_school).to be(false)
+    expect(ignore_provider.selectable_school).to be(false)
+
+    set_selectable_schools_task
+
+    expect(target_provider.reload.selectable_school).to be(true)
+    expect(ignore_provider.reload.selectable_school).to be(false)
+  end
+end


### PR DESCRIPTION
## Context

  We've identified 11 Provider who wish for their candidates to choose a
  school placement. This rake task updates the providers accordingly.

## Changes proposed in this pull request

Add Rake task to update specific providers `selectable_school` to true.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
