### PR TITLE
Add SSL check for find-teacher-training-courses

### DIFF
--- a/terraform/aks/statuscake.tf
+++ b/terraform/aks/statuscake.tf
@@ -4,6 +4,7 @@ module "statuscake" {
   source = "./vendor/modules/aks//monitoring/statuscake"
 
   uptime_urls = compact(concat([module.web_application["main"].probe_url], local.statuscake_additional_hostnames))
+  ssl_urls    = compact([var.external_url])
 
   contact_groups = var.statuscake_contact_groups
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -40,6 +40,11 @@ variable "enable_monitoring" {
 
 variable "enable_logit" { default = false }
 
+variable "external_url" {
+  default     = null
+  description = "Healthcheck URL for StatusCake monitoring"
+}
+
 variable "statuscake_contact_groups" {
   type    = list(number)
   default = []

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -27,6 +27,7 @@
   "enable_monitoring": true,
   "enable_logit": true,
   "statuscake_contact_groups": [204421, 282453],
+  "external_url": "https://find-teacher-training-courses.service.gov.uk/ping",
   "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
   "postgres_enable_high_availability": true,
   "postgres_azure_maintenance_window": {


### PR DESCRIPTION
## Context

The certificate expires every 6 months and must be revalidated or users will lose access to the site.

https://trello.com/c/N5YIQd6A/1982-ssl-check-for-find-teacher-training-courses

## Changes proposed in this pull request

Add SSL check for the apex domain [find-teacher-training-courses.service.gov.uk](http://find-teacher-training-courses.service.gov.uk/)


## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [x] Attach PR to Trello card
