### PR TITLE
Revert "Bump pagy from 9.0.6 to 9.0.8"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,7 +499,7 @@ GEM
     optimist (3.1.0)
     os (1.1.4)
     ostruct (0.6.0)
-    pagy (9.0.8)
+    pagy (9.0.6)
     parallel (1.26.3)
     parallel_tests (4.7.1)
       parallel


### PR DESCRIPTION
Reverts DFE-Digital/publish-teacher-training#4481

Could be the cause of Sentry errors that started occurring today. We will revert and monitor: 

https://dfe-teacher-services.sentry.io/issues/5787597219/?alert_rule_id=11137790&alert_type=issue&notification_uuid=302a01e6-c872-418b-bc1b-44851eb7b0e4&project=1377944&referrer=slack