### PR TITLE
Revert "Bump faraday from 2.10.1 to 2.11.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,12 +262,12 @@ GEM
     fakefs (2.5.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
-    faraday (2.11.0)
-      faraday-net_http (>= 2.0, < 3.4)
+    faraday (2.10.1)
+      faraday-net_http (>= 2.0, < 3.2)
       logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.3.0)
+    faraday-net_http (3.1.1)
       net-http
     faraday-net_http_persistent (2.1.0)
       faraday (~> 2.5)


### PR DESCRIPTION
Reverts #4477 

We are getting lots of Sentry errors: 

https://dfe-teacher-services.sentry.io/issues/5787597219/?alert_rule_id=11137790&alert_type=issue&notification_uuid=0cd3e231-72f2-493a-861a-aeae48f542a7&project=1377944&referrer=slack

Faraday handles the encoding of URL parameters when making HTTP requests. Also, faraday-net_http was indirectly updated, which might have introduced unexpected behaviour or compatibility issues.

We will merge and monitor.

