### PR TITLE
Update data migrate to version 11.0.0.rc3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,7 +141,7 @@ gem 'propshaft'
 gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.14.1'
 
 # For running data migrations
-gem 'data_migrate', '9.4.2'
+gem 'data_migrate', '11.0.0.rc3'
 
 # For outgoing http requests
 gem 'http'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     csv (3.3.0)
-    data_migrate (9.4.2)
+    data_migrate (11.0.0.rc3)
       activerecord (>= 6.1)
       railties (>= 6.1)
     database_cleaner (2.0.2)
@@ -806,7 +806,7 @@ DEPENDENCIES
   config
   cssbundling-rails (~> 1.4)
   custom_error_message!
-  data_migrate (= 9.4.2)
+  data_migrate (= 11.0.0.rc3)
   database_cleaner
   dfe-analytics!
   dfe-wizard!


### PR DESCRIPTION
## Context

Upgrade the data migrate gem to 11 rc3 which is pretty much ready to be 11.0

We are getting errors: 

https://dfe-teacher-services.sentry.io/issues/5787827580/?alert_rule_id=11137790&alert_type=issue&notification_uuid=8bebb020-94ef-47d9-9df3-c8628f5aabf8&project=1377944&referrer=slack


## Guidance to review

<img width="383" alt="image" src="https://github.com/user-attachments/assets/0d4a3a96-e7cb-489e-bd56-eb8266501e9b">


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
