### PR TITLE
Fixes sentry error where the study mode param is not always an array

### DIFF
--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -72,7 +72,11 @@ module Courses
     end
 
     def study_mode
-      @study_mode ||= course_params['study_mode']&.flatten&.compact&.uniq
+      @study_mode ||= if course_params['study_mode'].nil?
+                        nil
+                      else
+                        Array(course_params['study_mode'])&.flatten&.compact&.uniq
+                      end
     end
 
     def study_site_ids

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -165,6 +165,37 @@ describe Courses::CreationService do
         expect(subject.errors).to be_empty
       end
     end
+
+    context 'study_mode param is a string' do
+      let(:valid_course_params) do
+        {
+          'age_range_in_years' => '12_to_17',
+          'applications_open_from' => recruitment_cycle.application_start_date,
+          'funding' => 'salary',
+          'is_send' => '0',
+          'level' => 'secondary',
+          'qualification' => 'pgce_with_qts',
+          'start_date' => "September #{recruitment_cycle.year}",
+          'study_mode' => 'part_time',
+          'sites_ids' => [site.id],
+          'study_sites_ids' => [study_site.id],
+          'subjects_ids' => [secondary_subject.id],
+          'master_subject_id' => secondary_subject.id,
+          'course_code' => 'D0CK'
+        }
+      end
+
+      it 'creates a course' do
+        expect(subject.is_send).to be(false)
+        expect(subject.sites.map(&:id)).to eq([site.id])
+        expect(subject.study_sites.map(&:id)).to eq([study_site.id])
+        expect(subject.course_subjects.map { _1.subject.id }).to eq([secondary_subject.id])
+        expect(subject.course_code).to be_nil
+        expect(subject.name).to eq('Biology')
+        expect(subject.study_mode).to eq 'part_time'
+        expect(subject.errors).to be_empty
+      end
+    end
   end
 
   context 'secondary course with db_backed_funding_type disabled' do


### PR DESCRIPTION
## Context

Fix this sentry error https://dfe-teacher-services.sentry.io/issues/5568099106/?alert_rule_id=11137790&alert_type=issue&notification_uuid=0a46756c-9f13-400d-8c6f-c522c786e80b&project=1377944&referrer=slack

## Changes proposed in this pull request

Coerce the study mode params into an array in the creation service.

## Guidance to review



## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
