### PR TITLE
[2267] Implement `training_route`

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -14,7 +14,7 @@ class Course < ApplicationRecord
     %w[postgraduate fee] => 'fee_funded_initial_teacher_training',
     %w[postgraduate salary] => 'school_direct_salaried',
     %w[postgraduate apprenticeship] => 'postgraduate_teacher_apprenticeship',
-    %w[undergraduate salary] => 'teacher_degree_apprenticeship'
+    %w[undergraduate apprenticeship] => 'teacher_degree_apprenticeship'
   }.freeze
 
   after_initialize :set_defaults

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,6 +10,13 @@ class Course < ApplicationRecord
 
   A_LEVEL_ATTRIBUTES = %i[a_level_subject_requirements accept_pending_a_level accept_a_level_equivalency additional_a_level_equivalencies].freeze
 
+  TRAINING_ROUTE_MAP = {
+    %w[postgraduate fee] => 'fee_funded_initial_teacher_training',
+    %w[postgraduate salary] => 'school_direct_salaried',
+    %w[postgraduate apprenticeship] => 'postgraduate_teacher_apprenticeship',
+    %w[undergraduate salary] => 'teacher_degree_apprenticeship'
+  }.freeze
+
   after_initialize :set_defaults
 
   before_discard do
@@ -750,6 +757,10 @@ class Course < ApplicationRecord
 
   def funding_type=(funding_type)
     Courses::AssignProgramTypeService.new.execute(funding_type, self)
+  end
+
+  def training_route
+    TRAINING_ROUTE_MAP.fetch([course_type, funding_type], 'unknown_training_route')
   end
 
   def ensure_site_statuses_match_study_mode

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3450,4 +3450,31 @@ describe Course do
       end
     end
   end
+
+  describe '#training_route' do
+    it 'returns teacher_degree_apprenticeship for undergraduate and salaried' do
+      course = build(:course, funding: 'salary', course_type: 'undergraduate')
+      expect(course.training_route).to eq('teacher_degree_apprenticeship')
+    end
+
+    it 'returns school_direct_salaried for postgraduate and salaried' do
+      course = build(:course, funding: 'salary', course_type: 'postgraduate')
+      expect(course.training_route).to eq('school_direct_salaried')
+    end
+
+    it 'returns postgraduate_teaching_apprenticeship for postgraduate and apprenticeship' do
+      course = build(:course, funding: 'apprenticeship', course_type: 'postgraduate')
+      expect(course.training_route).to eq('postgraduate_teacher_apprenticeship')
+    end
+
+    it 'returns fee_funded_initial_teacher_training for postgraduate and fee' do
+      course = build(:course, funding: 'fee', course_type: 'postgraduate')
+      expect(course.training_route).to eq('fee_funded_initial_teacher_training')
+    end
+
+    it 'returns unknown_training_route for unknown course_type and funding_type combination' do
+      course = build(:course, funding: 'fee', course_type: 'undergraduate')
+      expect(course.training_route).to eq('unknown_training_route')
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3452,8 +3452,8 @@ describe Course do
   end
 
   describe '#training_route' do
-    it 'returns teacher_degree_apprenticeship for undergraduate and salaried' do
-      course = build(:course, funding: 'salary', course_type: 'undergraduate')
+    it 'returns teacher_degree_apprenticeship for undergraduate and apprenticeship' do
+      course = build(:course, funding: 'apprenticeship', course_type: 'undergraduate')
       expect(course.training_route).to eq('teacher_degree_apprenticeship')
     end
 


### PR DESCRIPTION
## Context

Adding a way to calculate `training_route` based on a courses `funding` and `course type`.

This is in line with Register, for the routes which apply to Publish.

https://becoming-a-teacher.design-history.education.gov.uk/becoming-a-teacher/routes-into-teaching/

![image](https://github.com/user-attachments/assets/60d3abf6-a6e2-4414-a2a5-9b8faf9979f4)


## Changes proposed in this pull request

Implement a hash map to easily return `training_route` based on the different combinations of course types and funding types.

## Guidance to review

- Do the values returned make sense to you? They are in line with Register to help make our services more consistent.

- Any thoughts on having this as  a database backed column? I decided not to do this, as `training_route` should always be calculated the same way, it didn't make sense to me to combine two strings and put it in a new column.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
