### PR TITLE
Add a callback to update `program_type` when `funding` updates

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -117,6 +117,8 @@ class Course < ApplicationRecord
   after_validation :remove_unnecessary_enrichments_validation_message
   before_save :set_applications_open_from
 
+  after_save :update_program_type!
+
   belongs_to :provider
 
   delegate :tda_active?, to: :provider, allow_nil: true
@@ -1048,6 +1050,10 @@ class Course < ApplicationRecord
 
   def set_applications_open_from
     self.applications_open_from ||= recruitment_cycle.application_start_date
+  end
+
+  def update_program_type!
+    ::Courses::AssignProgramTypeService.new.execute(funding, self)
   end
 
   def validate_start_date

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -117,7 +117,7 @@ class Course < ApplicationRecord
   after_validation :remove_unnecessary_enrichments_validation_message
   before_save :set_applications_open_from
 
-  after_save :update_program_type!
+  after_save :update_program_type!, if: :saved_change_to_funding?
 
   belongs_to :provider
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -508,8 +508,8 @@ class Course < ApplicationRecord
   end
 
   def program_type_description
-    if program.funding_type.salary? then ' with salary'
-    elsif program.funding_type.apprenticeship? then ' teaching apprenticeship'
+    if salary? then ' with salary'
+    elsif apprenticeship? then ' teaching apprenticeship'
     else
       ''
     end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -772,7 +772,7 @@ describe CourseDecorator do
     subject(:description) { course.decorate.description }
 
     context 'when PGCE with QTS' do
-      let(:course) { build_stubbed(:course, qualification: 'pgce_with_qts') }
+      let(:course) { build_stubbed(:course, funding: 'apprenticeship', qualification: 'pgce_with_qts') }
 
       it 'returns the correct page title' do
         expect(description).to eq('QTS with PGCE full time teaching apprenticeship')

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1980,6 +1980,7 @@ describe Course do
       },
       'PGCE with QTS full time with salary' => {
         study_mode: :full_time,
+        funding: 'salary',
         program_type: :school_direct_salaried_training_programme,
         qualification: :pgce_with_qts
       },
@@ -2002,7 +2003,7 @@ describe Course do
       subject do
         create(:course,
                study_mode: :full_time,
-               program_type: :school_direct_salaried_training_programme,
+               funding: 'salary',
                qualification: :pgce_with_qts)
       end
 
@@ -2013,7 +2014,7 @@ describe Course do
       subject do
         create(:course,
                study_mode: :part_time,
-               program_type: :pg_teaching_apprenticeship,
+               funding: 'apprenticeship',
                qualification: :pgde_with_qts)
       end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3366,6 +3366,95 @@ describe Course do
       end
     end
 
+    describe '#update_program_type!' do
+      context 'when the provider is a Lead School' do
+        context 'changing funding from fee to apprenticeship' do
+          it 'changes the program_type from school_direct_training_programme to pg_teaching_apprenticeship' do
+            course = build(:course, program_type: 'school_direct_training_programme')
+
+            expect(course.program_type).to eq('school_direct_training_programme')
+
+            course.update(funding: 'apprenticeship')
+            expect(course.program_type).to eq('pg_teaching_apprenticeship')
+          end
+        end
+
+        context 'changing funding from fee to salary' do
+          it 'changes the program_type from school_direct_training_programme to school_direct_salaried_training_programme' do
+            course = build(:course, program_type: 'school_direct_training_programme')
+
+            expect(course.program_type).to eq('school_direct_training_programme')
+
+            course.update(funding: 'salary')
+            expect(course.program_type).to eq('school_direct_salaried_training_programme')
+          end
+        end
+
+        context 'changing funding from salary to fee' do
+          it 'changes the program_type from school_direct_training_programme to school_direct_salaried_training_programme' do
+            course = build(:course, program_type: 'school_direct_salaried_training_programme')
+
+            expect(course.program_type).to eq('school_direct_salaried_training_programme')
+
+            course.update(funding: 'fee')
+            expect(course.program_type).to eq('school_direct_training_programme')
+          end
+        end
+      end
+
+      context 'when the provider is a scitt' do
+        context 'changing funding from fee to salary' do
+          it 'changes the program_type from scitt_program to scitt_salaried_programme' do
+            provider = build(:provider, provider_type: 'scitt')
+            course = build(:course, provider:, program_type: 'scitt_programme')
+
+            expect(course.program_type).to eq('scitt_programme')
+
+            course.update(funding: 'salary')
+            expect(course.program_type).to eq('scitt_salaried_programme')
+          end
+        end
+
+        context 'changing funding from salary to fee' do
+          it 'changes the program_type from scitt_salaried_programme to scitt_programme' do
+            provider = build(:provider, provider_type: 'scitt')
+            course = build(:course, provider:, program_type: 'scitt_salaried_programme')
+
+            expect(course.program_type).to eq('scitt_salaried_programme')
+
+            course.update(funding: 'fee')
+            expect(course.program_type).to eq('scitt_programme')
+          end
+        end
+      end
+
+      context 'when the provider is a hei' do
+        context 'changing funding from fee to salary' do
+          it 'changes the program_type from higher_education_programme to higher_education_salaried_programme' do
+            provider = build(:provider, provider_type: 'university')
+            course = build(:course, provider:, program_type: 'higher_education_programme')
+
+            expect(course.program_type).to eq('higher_education_programme')
+
+            course.update(funding: 'salary')
+            expect(course.program_type).to eq('higher_education_salaried_programme')
+          end
+        end
+
+        context 'changing funding from fee to salaried' do
+          it 'changes the program_type from higher_education_salaried_programme to higher_education_programme' do
+            provider = build(:provider, provider_type: 'university')
+            course = build(:course, provider:, program_type: 'higher_education_salaried_programme')
+
+            expect(course.program_type).to eq('higher_education_salaried_programme')
+
+            course.update(funding: 'fee')
+            expect(course.program_type).to eq('higher_education_programme')
+          end
+        end
+      end
+    end
+
     context 'setting the funding_type to fee' do
       context 'when the provider is not self accredited' do
         it 'sets the funding_type to salary and the program_type to school_direct_training_programme' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3429,7 +3429,7 @@ describe Course do
         end
       end
 
-      context 'when the provider is a hei' do
+      context 'when the provider is a HEI' do
         context 'changing funding from fee to salary' do
           it 'changes the program_type from higher_education_programme to higher_education_salaried_programme' do
             provider = build(:provider, provider_type: 'university')

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
   subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   let(:enrichment) { build(:course_enrichment, :published) }
-  let(:course) { create(:course, :with_accrediting_provider, enrichments: [enrichment]) }
+  let(:course) { create(:course, :with_accrediting_provider, enrichments: [enrichment], funding: 'apprenticeship') }
   let(:resource) { described_class.new(object: course) }
 
   before do

--- a/spec/serializers/api/public/v1/serializable_course_with_db_backed_funding_type_feature_disabled_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_with_db_backed_funding_type_feature_disabled_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
   subject { JSON.parse(resource.as_jsonapi.to_json) }
 
   let(:enrichment) { build(:course_enrichment, :published) }
-  let(:course) { create(:course, :with_accrediting_provider, enrichments: [enrichment]) }
+  let(:course) { create(:course, :with_accrediting_provider, enrichments: [enrichment], funding: 'apprenticeship') }
   let(:resource) { described_class.new(object: course) }
 
   before do


### PR DESCRIPTION
## Context

We need to ensure `program_type` stays in sync with the `funding` column, as although this will be deprecated, we and other services are still dependent on it. 

## Changes proposed in this pull request

Add a callback to `Course` which updates `program_type` every time the `funding` is updated. (On the UI or in the console).

## Guidance to review

- Check `course.program_type` on an unpublished course
- Update `funding` on the course (in the UI or console)
- Check `course.reload.program_type` on the course again and ensure it has been updated to the correct `program_type`
- Ensure the correct text is displayed for the updated course on the course index page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
