### PR TITLE
Create tda courses script and enable new cycle in QA

### DIFF
--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -29,8 +29,10 @@ authentication:
 basic_auth:
   enabled: true
 
+current_recruitment_cycle_year: 2025
 features:
   send_request_data_to_bigquery: true
+  teacher_degree_apprenticeship: true
 
 find_valid_referers:
   - https://qa.find-teacher-training-courses.service.gov.uk

--- a/lib/tasks/undergraduate_courses.rake
+++ b/lib/tasks/undergraduate_courses.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative '../../spec/strategies/find_or_create_strategy'
+Faker::Config.locale = 'en-GB'
+
+namespace :undergraduate do
+  desc 'Create TDA courses'
+  task create: :environment do
+    providers_count = ENV.fetch('PROVIDERS_COUNT', 100)
+
+    ActiveRecord::Base.transaction do
+      recruitment_cycle = RecruitmentCycle.find_by!(year: '2025')
+      recruitment_cycle.providers.limit(providers_count).each do |provider|
+        is_send = [true, false].sample
+        name = if is_send
+                 'Mathematics (SEND)'
+               else
+                 'Mathematics'
+               end
+
+        FactoryBot.find_or_create(
+          :course,
+          :published_teacher_degree_apprenticeship,
+          :secondary,
+          :with_a_level_requirements,
+          :with_gcse_equivalency,
+          provider:,
+          name:,
+          subjects: [Subject.find_by!(subject_name: 'Mathematics')],
+          applications_open_from: 2.days.ago,
+          site_statuses: [FactoryBot.build(:site_status, :findable, site: FactoryBot.build(:site, provider:))]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

For the bug party tomorrow, I am enabling the new cycle (to test Find) and add a script that adds new undergraduate (TDA) courses.

To run:

```
rake undergraduate:create # will create 100 undergraduate courses for the first 100 providers from 2025 cycle
PROVIDERS_COUNT=1000 rake undergraduate:create # will create 1000 undergraduate courses for the first 1000 providers from 2025 cycle
```