### PR TITLE
Make sure faker does not load in boot time

### DIFF
--- a/lib/tasks/undergraduate_courses.rake
+++ b/lib/tasks/undergraduate_courses.rake
@@ -5,6 +5,7 @@ require_relative '../../spec/strategies/find_or_create_strategy'
 namespace :undergraduate do
   desc 'Create TDA courses'
   task create: :environment do
+    require 'factory_bot_rails'
     require 'faker'
     Faker::Config.locale = 'en-GB'
     providers_count = ENV.fetch('PROVIDERS_COUNT', 100)

--- a/lib/tasks/undergraduate_courses.rake
+++ b/lib/tasks/undergraduate_courses.rake
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require_relative '../../spec/strategies/find_or_create_strategy'
-Faker::Config.locale = 'en-GB'
 
 namespace :undergraduate do
   desc 'Create TDA courses'
   task create: :environment do
+    require 'faker'
+    Faker::Config.locale = 'en-GB'
     providers_count = ENV.fetch('PROVIDERS_COUNT', 100)
 
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
## Context

All qa, staging and other envs are not starting the pod due to faker gem, so let's load inside of the task.

## Error

```
bin/rails aborted!
NameError: uninitialized constant Faker (NameError)

Faker::Config.locale = 'en-GB'
     ^^^^^^^^
/app/lib/tasks/undergraduate_courses.rake:4:in `<main>'
```