### PR TITLE
[2303] Deprecate `funding_type`

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -570,6 +570,8 @@ class Course < ApplicationRecord
   end
 
   def funding_type
+    ActiveSupport::Deprecation.new.warn('`funding_type` is deprecated and will be removed. Please use `funding` instead.')
+
     if FeatureService.enabled?(:db_backed_funding_type)
       not_set? ? program.funding_type : funding
     else

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3087,6 +3087,19 @@ describe Course do
       allow(Settings.features).to receive(:db_backed_funding_type).and_return(false)
     end
 
+    context 'deprecation warning' do
+      it 'issues a deprecation warning when `funding_type` is called' do
+        deprecation_instance = instance_double(ActiveSupport::Deprecation)
+        allow(ActiveSupport::Deprecation).to receive(:new).and_return(deprecation_instance)
+        expect(deprecation_instance).to receive(:warn).with(
+          '`funding_type` is deprecated and will be removed. Please use `funding` instead.'
+        )
+
+        course = described_class.new
+        course.funding_type
+      end
+    end
+
     context 'when program_type is nil' do
       it 'returns nil' do
         course = described_class.new(program_type: nil)
@@ -3119,6 +3132,19 @@ describe Course do
   describe '#funding_type (with db_backed_funding enabled)' do
     before do
       allow(Settings.features).to receive(:db_backed_funding_type).and_return(true)
+    end
+
+    context 'deprecation warning' do
+      it 'issues a deprecation warning when `funding_type` is called' do
+        deprecation_instance = instance_double(ActiveSupport::Deprecation)
+        allow(ActiveSupport::Deprecation).to receive(:new).and_return(deprecation_instance)
+        expect(deprecation_instance).to receive(:warn).with(
+          '`funding_type` is deprecated and will be removed. Please use `funding` instead.'
+        )
+
+        course = described_class.new
+        course.funding_type
+      end
     end
 
     context 'when program_type is nil' do


### PR DESCRIPTION
## Context

We are deprecating `funding_type`. The database backed `funding` column should be used instead going forward.

## Changes proposed in this pull request

Put a deprecation warning on `funding_type`

## Guidance to review

Is this the correct way to do the deprecation warning now? Is there a more appropriate way?

https://everydayrails.com/2021/07/31/rails-custom-deprecation-warnings.html

`ActiveSupport::Deprecation.warn` was deprecated in rails 7.1 and [removed in rails 7.2](https://www.redmine.org/issues/41141#:~:text=The%20usage%20of%20ActiveSupport%3A%3A,with%20a%20custom%20deprecation%20object.)

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
