### PR TITLE
Allow API to 404 when no recruitment cycle is found

### DIFF
--- a/app/controllers/api/public/v1/application_controller.rb
+++ b/app/controllers/api/public/v1/application_controller.rb
@@ -10,7 +10,7 @@ module API
 
         def recruitment_cycle
           year = params[:recruitment_cycle_year]
-          @recruitment_cycle ||= RecruitmentCycle.find_by(year:) || RecruitmentCycle.current_recruitment_cycle
+          @recruitment_cycle ||= RecruitmentCycle.find_by(year:) || RecruitmentCycle.current_recruitment_cycle!
         end
       end
     end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -11,6 +11,10 @@ class RecruitmentCycle < ApplicationRecord
   validates :year, presence: true
 
   class << self
+    def current_recruitment_cycle!
+      find_by!(year: Settings.current_recruitment_cycle_year)
+    end
+
     def current_recruitment_cycle
       find_by(year: Settings.current_recruitment_cycle_year)
     end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -6,6 +6,19 @@ RSpec.describe API::Public::V1::ProvidersController do
   describe '#index' do
     let(:recruitment_cycle) { find_or_create :recruitment_cycle }
 
+    context "when the recruitment cycle doesn't exist" do
+      it 'returns a not found response' do
+        allow(RecruitmentCycle).to receive(:find_by).and_return(nil)
+        allow(RecruitmentCycle).to receive(:current_recruitment_cycle!).and_raise(ActiveRecord::RecordNotFound)
+
+        get :index, params: {
+          recruitment_cycle_year: 2024
+        }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context 'when there are no providers' do
       before do
         get :index, params: {


### PR DESCRIPTION
## Context

Handles [Method Not Found Error](https://dfe-teacher-services.sentry.io/issues/4233014348/?alert_rule_id=11137790&alert_type=issue&notification_uuid=3d612f94-fbda-4c93-a06a-77e687acbfcf&project=1377944)

## Changes proposed in this pull request

- Added a `RecruitmentCycle#current_recruitment_cycle!` method which will raise a `RecordNotFound` error if the cycle does not exist. The API will return a 404 at this point rather than continue to call `#providers` on a `nil` value

## Guidance to review



## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
