### PR TITLE
Change course_type to degree_type

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -764,7 +764,7 @@ class Course < ApplicationRecord
   end
 
   def training_route
-    TRAINING_ROUTE_MAP.fetch([course_type, funding_type], 'unknown_training_route')
+    TRAINING_ROUTE_MAP.fetch([degree_type, funding_type], 'unknown_training_route')
   end
 
   def ensure_site_statuses_match_study_mode

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3569,27 +3569,27 @@ describe Course do
 
   describe '#training_route' do
     it 'returns teacher_degree_apprenticeship for undergraduate and apprenticeship' do
-      course = build(:course, funding: 'apprenticeship', course_type: 'undergraduate')
+      course = build(:course, funding: 'apprenticeship', degree_type: 'undergraduate')
       expect(course.training_route).to eq('teacher_degree_apprenticeship')
     end
 
     it 'returns school_direct_salaried for postgraduate and salaried' do
-      course = build(:course, funding: 'salary', course_type: 'postgraduate')
+      course = build(:course, funding: 'salary', degree_type: 'postgraduate')
       expect(course.training_route).to eq('school_direct_salaried')
     end
 
     it 'returns postgraduate_teaching_apprenticeship for postgraduate and apprenticeship' do
-      course = build(:course, funding: 'apprenticeship', course_type: 'postgraduate')
+      course = build(:course, funding: 'apprenticeship', degree_type: 'postgraduate')
       expect(course.training_route).to eq('postgraduate_teacher_apprenticeship')
     end
 
     it 'returns fee_funded_initial_teacher_training for postgraduate and fee' do
-      course = build(:course, funding: 'fee', course_type: 'postgraduate')
+      course = build(:course, funding: 'fee', degree_type: 'postgraduate')
       expect(course.training_route).to eq('fee_funded_initial_teacher_training')
     end
 
-    it 'returns unknown_training_route for unknown course_type and funding_type combination' do
-      course = build(:course, funding: 'fee', course_type: 'undergraduate')
+    it 'returns unknown_training_route for unknown degree_type and funding_type combination' do
+      course = build(:course, funding: 'fee', degree_type: 'undergraduate')
       expect(course.training_route).to eq('unknown_training_route')
     end
   end


### PR DESCRIPTION
course_type is being dropped, degree_type is the replacement

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
