### PR TITLE
Degree required for undergraduate should be mentioned differently

### DIFF
--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -63,8 +63,12 @@
         <% row.with_key(text: t(".degree_required")) %>
         <% row.with_value do %>
           <p class="govuk-body">
-            <%= degree_required_status %>
-            <%= course.equivalent_qualification %>
+            <% if course.undergraduate_degree_type? %>
+              <%= t(".no_degree_required") %>
+            <% else %>
+              <%= degree_required_status %>
+              <%= course.equivalent_qualification %>
+            <% end %>
           </p>
         <% end %>
       <% end %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -193,6 +193,7 @@ en:
         training_with_disabilities_link: Find out about training with disabilities and other needs at %{provider_name}.
     results:
       search_result_component:
+        no_degree_required: No degree required
         location:
           one: Location
           other: Nearest location

--- a/spec/features/find/search/undergraduate/course_results_spec.rb
+++ b/spec/features/find/search/undergraduate/course_results_spec.rb
@@ -48,6 +48,7 @@ feature 'Questions and results for undergraduate courses' do
     when_i_uncheck_all_the_filters
     and_i_click_apply_filters
     then_i_am_on_results_page
+    and_i_can_see_that_degree_is_not_required
     and_some_filters_are_hidden_for_undergraduate_courses
     and_some_filters_are_visible_for_undergraduate_courses
   end
@@ -381,6 +382,12 @@ feature 'Questions and results for undergraduate courses' do
   def when_i_uncheck_all_the_filters
     uncheck 'Only show courses open for applications'
     uncheck 'Only show courses with a SEND specialism'
+  end
+
+  def and_i_can_see_that_degree_is_not_required
+    expect(page).to have_content(
+      "Degree required\nNo degree required\n"
+    ).twice
   end
 
   def and_i_click_apply_filters


### PR DESCRIPTION
## Context

On find results page, the degree required row should not show any degree requirements.

## Changes

<img width="630" alt="Screenshot 2024-09-16 at 16 04 28" src="https://github.com/user-attachments/assets/e7426d40-0ee4-4f79-ae8b-8dc3b6f71565">

## Test

1. Create and publish a TDA course on publish
2. Make sure Find is on 2025 cycle
3. Search on Find and answer that you don't have a degree, see the results page for undergraduate courses
