### PR TITLE
[2288] Improve Locations (1/6) Add Training Location Information to course Page

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -16,6 +16,16 @@
       <% end %>
     <% end %>
 
+    <% if course.fee_based? %>
+      <p class="govuk-body">
+        You’ll be placed in schools for most of your course to get classroom experience. You will also spend time at a location where you will study.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        You will spend most of your time in one school which will employ you. You will also spend some time in another school and at a location where you will study.
+      </p>
+    <% end %>
+
     <% if course.published_how_school_placements_work.present? %>
       <%= markdown(course.published_how_school_placements_work) %>
     <% elsif course.how_school_placements_work.present? %>

--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -26,6 +26,8 @@
       </p>
     <% end %>
 
+      <%= render Find::Courses::TrainingLocations::View.new(course:, preview: preview?(params)) %>
+
     <% if course.published_how_school_placements_work.present? %>
       <%= markdown(course.published_how_school_placements_work) %>
     <% elsif course.how_school_placements_work.present? %>

--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -43,17 +43,5 @@
       <% end %>
       </ul>
     <% end %>
-
-    <% if course.site_statuses.map(&:site).uniq.any? %>
-      <h3 class="govuk-heading-m">
-        <%= course.placements_heading %>
-      </h3>
-
-      <p class="govuk-body"><%= t(".work_with_schools") %></p>
-
-      <p class="govuk-body">
-        <%= govuk_link_to(t(".view_list_of_school_placements"), placements_url) %>
-      </p>
-    <% end %>
   </div>
 </div>

--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -8,7 +8,7 @@
   <% end %>
   <li><%= govuk_link_to t(".fees_and_financial_support"), "#section-financial-support" %></li>
   <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" || preview? %>
-    <li><%= govuk_link_to t(".how_school_placements_work"), "#training-locations" %></li>
+    <li><%= govuk_link_to t(".where_you_will_train"), "#training-locations" %></li>
   <% end %>
   <% if interview_process.present? %>
     <li><%= govuk_link_to t(".interview_process"), "#section-interviews" %></li>

--- a/app/components/find/courses/training_locations/view.html.erb
+++ b/app/components/find/courses/training_locations/view.html.erb
@@ -1,25 +1,26 @@
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Placement schools</dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-body"><%= potential_placements_text %></p>
-          <%= govuk_link_to(t("view_list_of_school_placements"), placements_url) %>
-          <p class="govuk-hint">Locations can change and are not guaranteed</p>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Where you will study</dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-body"><%= potential_study_sites_text %></p>
-          <ul class="govuk-list govuk-list--spaced">
-            <% course.study_sites.each do |study_site| %>
-              <li>
-                <p class="govuk-hint"><strong><%= smart_quotes(study_site.location_name) %></strong><br>
-                 <%= smart_quotes(study_site.decorate.full_address) %></p>
-              </li>
-            <% end %>
-          </ul>
-        </dd>
-      </div>
-    </dl>
+<%= govuk_summary_list(actions: false) do |summary_list| %>
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key { "Placement schools" } %>
+    <%= row.with_value do %>
+      <p class="govuk-body"><%= potential_placements_text %></p>
+      <%= govuk_link_to(t("view_list_of_school_placements"), placements_url) %>
+      <p class="govuk-hint">Locations can change and are not guaranteed</p>
+    <% end %>
+  <% end %>
+  <%= summary_list.with_row do |row| %>
+    <%= row.with_key { "Where you will study" } %>
+    <%= row.with_value do %>
+      <p class="govuk-body"><%= potential_study_sites_text %></p>
+      <ul class="govuk-list govuk-list--spaced">
+        <% course.study_sites.each do |study_site| %>
+          <li>
+            <p class="govuk-hint">
+              <strong><%= smart_quotes(study_site.location_name) %></strong><br>
+              <%= smart_quotes(study_site.decorate.full_address) %>
+            </p>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/find/courses/training_locations/view.html.erb
+++ b/app/components/find/courses/training_locations/view.html.erb
@@ -4,7 +4,7 @@
     <%= row.with_value do %>
       <p class="govuk-body"><%= potential_placements_text %></p>
       <%= govuk_link_to(t("view_list_of_school_placements"), placements_url) %>
-      <p class="govuk-hint">Locations can change and are not guaranteed</p>
+      <p class="govuk-hint govuk-!-font-size-16">Locations can change and are not guaranteed</p>
     <% end %>
   <% end %>
   <%= summary_list.with_row do |row| %>
@@ -14,7 +14,7 @@
       <ul class="govuk-list govuk-list--spaced">
         <% course.study_sites.each do |study_site| %>
           <li>
-            <p class="govuk-hint">
+            <p class="govuk-hint govuk-!-font-size-16">
               <strong><%= smart_quotes(study_site.location_name) %></strong><br>
               <%= smart_quotes(study_site.decorate.full_address) %>
             </p>

--- a/app/components/find/courses/training_locations/view.html.erb
+++ b/app/components/find/courses/training_locations/view.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_summary_list(actions: false) do |summary_list| %>
   <%= summary_list.with_row do |row| %>
-    <%= row.with_key { "Placement schools" } %>
+    <%= row.with_key { top_heading } %>
     <%= row.with_value do %>
       <p class="govuk-body"><%= potential_placements_text %></p>
       <%= govuk_link_to(t("view_list_of_school_placements"), placements_url) %>
@@ -8,7 +8,7 @@
     <% end %>
   <% end %>
   <%= summary_list.with_row do |row| %>
-    <%= row.with_key { "Where you will study" } %>
+    <%= row.with_key { bottom_heading } %>
     <%= row.with_value do %>
       <p class="govuk-body"><%= potential_study_sites_text %></p>
       <ul class="govuk-list govuk-list--spaced">

--- a/app/components/find/courses/training_locations/view.html.erb
+++ b/app/components/find/courses/training_locations/view.html.erb
@@ -1,0 +1,25 @@
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Placement schools</dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body"><%= potential_placements_text %></p>
+          <%= govuk_link_to(t("view_list_of_school_placements"), placements_url) %>
+          <p class="govuk-hint">Locations can change and are not guaranteed</p>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Where you will study</dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body"><%= potential_study_sites_text %></p>
+          <ul class="govuk-list govuk-list--spaced">
+            <% course.study_sites.each do |study_site| %>
+              <li>
+                <p class="govuk-hint"><strong><%= smart_quotes(study_site.location_name) %></strong><br>
+                 <%= smart_quotes(study_site.decorate.full_address) %></p>
+              </li>
+            <% end %>
+          </ul>
+        </dd>
+      </div>
+    </dl>

--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -28,13 +28,29 @@ module Find
         end
 
         def potential_placements_text
-          pluralize(course.sites.size, 'potential placement location')
+          if course.fee_based?
+            pluralize(course.sites.size, 'potential placement location')
+          else
+            pluralize(course.sites.size, 'potential employing school')
+          end
         end
 
         def potential_study_sites_text
-          return 'No study sites' if course.study_sites.none?
+          return 'Not listed yet' if course.study_sites.none?
 
-          pluralize(course.study_sites.size, 'potential study site')
+          if course.study_sites.one?
+            '1 study site'
+          else
+            "#{course.study_sites.size} potential study sites"
+          end
+        end
+
+        def top_heading
+          course.fee_based? ? 'Placement schools' : 'Employing schools'
+        end
+
+        def bottom_heading
+          'Where you will study'
         end
       end
     end

--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Find
+  module Courses
+    module TrainingLocations
+      class View < ViewComponent::Base
+        include PublishHelper
+        include PreviewHelper
+
+        attr_reader :course, :preview
+
+        def initialize(course:, preview: false)
+          @course = course
+          @preview = preview
+          super
+        end
+
+        def placements_url
+          if preview
+            placements_publish_provider_recruitment_cycle_course_path(
+              course.provider_code,
+              course.recruitment_cycle_year,
+              course.course_code
+            )
+          else
+            find_placements_path(course.provider_code, course.course_code)
+          end
+        end
+
+        def potential_placements_text
+          "#{course.sites.size} potential placement #{course.sites.many? ? 'locations' : 'location'}"
+        end
+
+        def potential_study_sites_text
+          return 'No study sites' if course.study_sites.none?
+
+          "#{course.study_sites.size} potential study #{course.study_sites.many? ? 'sites' : 'site'}"
+        end
+      end
+    end
+  end
+end

--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -28,13 +28,13 @@ module Find
         end
 
         def potential_placements_text
-          "#{course.sites.size} potential placement #{course.sites.many? ? 'locations' : 'location'}"
+          pluralize(course.sites.size, 'potential placement location')
         end
 
         def potential_study_sites_text
           return 'No study sites' if course.study_sites.none?
 
-          "#{course.study_sites.size} potential study #{course.study_sites.many? ? 'sites' : 'site'}"
+          pluralize(course.study_sites.size, 'potential study site')
         end
       end
     end

--- a/config/locales/en/components/find/training_locations.yml
+++ b/config/locales/en/components/find/training_locations.yml
@@ -1,0 +1,2 @@
+en:
+  view_list_of_school_placements: View list of school placements

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -177,7 +177,6 @@ en:
       about_schools_component:
         view:
           heading: Where you will train
-          view_list_of_school_placements: View list of school placements
           work_with_schools: We work with the following schools to provide your school placements.
       placements:
         heading: School placements at %{provider_name}

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -176,7 +176,7 @@ en:
           contact: Contact %{provider_name}
       about_schools_component:
         view:
-          heading: How school placements work
+          heading: Where you will train
           view_list_of_school_placements: View list of school placements
           work_with_schools: We work with the following schools to provide your school placements.
       placements:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -108,7 +108,7 @@ en:
       contents_component:
         view:
           course_details: Course details
-          how_school_placements_work: How school placements work
+          where_you_will_train: Where you will train
           training_with_disabilities: Training with disabilities
           fees_and_financial_support: Fees and financial support
           salary: Salary

--- a/spec/components/find/courses/about_schools_component/view_preview.rb
+++ b/spec/components/find/courses/about_schools_component/view_preview.rb
@@ -4,11 +4,21 @@ module Find
   module Courses
     module AboutSchoolsComponent
       class ViewPreview < ViewComponent::Preview
-        def hei_minimum
+        def hei_minimum_without_salary
           course = Course.new(course_code: 'FIND',
                               provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current),
                               program_type: 'higher_education_programme',
-                              level: 'further_education').decorate
+                              level: 'further_education',
+                              funding: 'fee').decorate
+          render Find::Courses::AboutSchoolsComponent::View.new(course)
+        end
+
+        def hei_minimum_with_salary
+          course = Course.new(course_code: 'FIND',
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current),
+                              program_type: 'higher_education_programme',
+                              level: 'further_education',
+                              funding: 'salary').decorate
           render Find::Courses::AboutSchoolsComponent::View.new(course)
         end
 
@@ -45,6 +55,7 @@ module Find
           FakeCourse.new(provider: Provider.new(provider_code: 'DFE'),
                          provider_code: '1BJ',
                          course_code: 'ZZZZ',
+                         is_fee_based: true,
                          published_how_school_placements_work: 'you will go on placement and learn more',
                          placements_heading: 'How placements work',
                          program_type: 'higher_education_programme',
@@ -58,7 +69,7 @@ module Find
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:provider, :provider_code, :course_code, :published_how_school_placements_work, :placements_heading, :program_type, :study_sites, :site_statuses)
+          attr_accessor(:provider, :provider_code, :course_code, :published_how_school_placements_work, :placements_heading, :program_type, :study_sites, :site_statuses, :is_fee_based)
 
           def higher_education_programme?
             true
@@ -66,6 +77,10 @@ module Find
 
           def preview_site_statuses
             site_statuses.sort_by { |status| status.site.location_name }
+          end
+
+          def fee_based?
+            is_fee_based
           end
         end
       end

--- a/spec/components/find/courses/about_schools_component/view_preview.rb
+++ b/spec/components/find/courses/about_schools_component/view_preview.rb
@@ -48,6 +48,7 @@ module Find
                          placements_heading: 'How placements work',
                          program_type: 'scitt_programme',
                          study_sites: [fake_study_site],
+                         sites: [fake_study_site],
                          site_statuses: [SiteStatus.new(id: 2_245_455, course_id: 12_983_436, publish: 'published', site_id: 11_228_658, status: 'running', vac_status: 'part_time_vacancies'), SiteStatus.new(id: 22_454_556, course_id: 12_983_436, publish: 'published', site_id: 11_228_659, status: 'running', vac_status: 'part_time_vacancies')])
         end
 
@@ -60,6 +61,7 @@ module Find
                          placements_heading: 'How placements work',
                          program_type: 'higher_education_programme',
                          study_sites: [fake_study_site],
+                         sites: [fake_study_site],
                          site_statuses: [SiteStatus.new(id: 2_245_455, course_id: 12_983_436, publish: 'published', site_id: 11_228_658, status: 'running', vac_status: 'part_time_vacancies'), SiteStatus.new(id: 22_454_556, course_id: 12_983_436, publish: 'published', site_id: 11_228_659, status: 'running', vac_status: 'part_time_vacancies')])
         end
 
@@ -69,7 +71,7 @@ module Find
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:provider, :provider_code, :course_code, :published_how_school_placements_work, :placements_heading, :program_type, :study_sites, :site_statuses, :is_fee_based)
+          attr_accessor(:provider, :provider_code, :course_code, :published_how_school_placements_work, :placements_heading, :program_type, :study_sites, :site_statuses, :is_fee_based, :sites)
 
           def higher_education_programme?
             true

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -15,7 +15,7 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
 
         result = render_inline(described_class.new(course))
 
-        expect(result.text).to include('How school placements work')
+        expect(result.text).to include('Where you will train')
       end
     end
   end
@@ -31,31 +31,36 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
     end
   end
 
-  context 'course with site' do
-    it 'renders the school placement heading' do
-      provider = build(:provider)
+  context 'salaried course' do
+    it 'renders the correct content' do
       course = build(:course,
-                     provider:,
-                     site_statuses: [
-                       build(:site_status, site: build(:site))
-                     ]).decorate
+                     funding: 'salary').decorate
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include(course.placements_heading)
+      expect(result.text).to include('You will spend most of your time in one school which will employ you. You will also spend some time in another school and at a location where you will study.')
     end
   end
 
-  context 'course with no site' do
-    it 'does not render the school placement heading' do
-      provider = build(:provider)
+  context 'apprenticeship course' do
+    it 'renders the correct content' do
       course = build(:course,
-                     site_statuses: [],
-                     provider:).decorate
+                     funding: 'apprenticeship').decorate
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).not_to include(course.placements_heading)
+      expect(result.text).to include('You will spend most of your time in one school which will employ you. You will also spend some time in another school and at a location where you will study.')
+    end
+  end
+
+  context 'fee paying course' do
+    it 'renders the correct content' do
+      course = build(:course,
+                     funding: 'fee').decorate
+
+      result = render_inline(described_class.new(course))
+
+      expect(result.text).to include('You’ll be placed in schools for most of your course to get classroom experience. You will also spend time at a location where you will study.')
     end
   end
 
@@ -171,54 +176,6 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
         result = render_inline(described_class.new(course))
 
         expect(result.text).not_to include('Advice from Get Into Teaching Where you will train')
-      end
-    end
-  end
-
-  describe '#placements_url' do
-    context 'when course is published' do
-      it 'returns the find url' do
-        provider = build(:provider)
-        course = build(
-          :course,
-          :published,
-          provider:,
-          site_statuses: [
-            build(:site_status, :findable, site: build(:site))
-          ]
-        ).decorate
-
-        result = render_inline(described_class.new(course))
-
-        expect(result).to have_link(
-          'View list of school placements',
-          href: find_placements_path(course.provider_code, course.course_code)
-        )
-      end
-    end
-
-    context 'when course is not published' do
-      it 'returns the publish url' do
-        provider = create(:provider)
-        course = create(
-          :course,
-          provider:,
-          site_statuses: [
-            create(:site_status, :findable, site: create(:site))
-          ]
-        ).decorate
-
-        result = render_inline(described_class.new(course, preview: true))
-        url = placements_publish_provider_recruitment_cycle_course_path(
-          course.provider_code,
-          course.recruitment_cycle_year,
-          course.course_code
-        )
-
-        expect(result).to have_link(
-          'View list of school placements',
-          href: url
-        )
       end
     end
   end

--- a/spec/components/find/courses/contents_component/view_spec.rb
+++ b/spec/components/find/courses/contents_component/view_spec.rb
@@ -15,7 +15,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('How school placements work')
+      expect(result.text).to include('Where you will train')
     end
   end
 
@@ -31,7 +31,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('How school placements work')
+      expect(result.text).to include('Where you will train')
     end
   end
 
@@ -46,7 +46,7 @@ describe Find::Courses::ContentsComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).not_to include('How school placements work')
+      expect(result.text).not_to include('Where you will train')
     end
   end
 

--- a/spec/components/find/courses/training_locations/view_preview.rb
+++ b/spec/components/find/courses/training_locations/view_preview.rb
@@ -4,32 +4,71 @@ module Find
   module Courses
     module TrainingLocations
       class ViewPreview < ViewComponent::Preview
-        def no_study_sites_and_one_placement
+        def no_study_sites_and_one_placement_fee_paying
           course = Course.new(course_code: 'FIND',
                               sites: [Site.new],
+                              funding: 'fee',
                               provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
           render Find::Courses::TrainingLocations::View.new(course:)
         end
 
-        def one_study_site_and_one_placement
+        def one_study_site_and_one_placement_fee_paying
           course = Course.new(course_code: 'FIND',
                               sites: [Site.new],
+                              funding: 'fee',
                               study_sites: [Site.new],
                               provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
           render Find::Courses::TrainingLocations::View.new(course:)
         end
 
-        def two_study_sites_and_one_placement
+        def two_study_sites_and_one_placement_fee_paying
           course = Course.new(course_code: 'FIND',
                               sites: [Site.new],
+                              funding: 'fee',
                               study_sites: [Site.new, Site.new],
                               provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
           render Find::Courses::TrainingLocations::View.new(course:)
         end
 
-        def two_study_sites_and_two_placements
+        def two_study_sites_and_two_placements_fee_paying
           course = Course.new(course_code: 'FIND',
                               sites: [Site.new, Site.new],
+                              funding: 'fee',
+                              study_sites: [Site.new, Site.new],
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+
+        def no_study_sites_and_one_placement_salaried
+          course = Course.new(course_code: 'FIND',
+                              funding: 'salary',
+                              sites: [Site.new],
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+
+        def one_study_site_and_one_placement_salaried
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new],
+                              funding: 'salary',
+                              study_sites: [Site.new],
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+
+        def two_study_sites_and_one_placement_salaried
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new],
+                              funding: 'salary',
+                              study_sites: [Site.new, Site.new],
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+
+        def two_study_sites_and_two_placements_salaried
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new, Site.new],
+                              funding: 'salary',
                               study_sites: [Site.new, Site.new],
                               provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
           render Find::Courses::TrainingLocations::View.new(course:)

--- a/spec/components/find/courses/training_locations/view_preview.rb
+++ b/spec/components/find/courses/training_locations/view_preview.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Find
+  module Courses
+    module TrainingLocations
+      class ViewPreview < ViewComponent::Preview
+        def no_study_sites_and_one_placement
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new],
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+
+        def one_study_site_and_one_placement
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new],
+                              study_sites: [Site.new],
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+
+        def two_study_sites_and_one_placement
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new],
+                              study_sites: [Site.new, Site.new],
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+
+        def two_study_sites_and_two_placements
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new, Site.new],
+                              study_sites: [Site.new, Site.new],
+                              provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+      end
+    end
+  end
+end

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -71,7 +71,7 @@ describe Find::Courses::TrainingLocations::View, type: :component do
 
   describe 'potential_placement_schools_text' do
     context 'when there is one school' do
-      it 'returns 1 potential placement location' do
+      it 'returns one potential placement location' do
         expect(component.potential_placements_text).to eq('1 potential placement location')
       end
     end
@@ -95,7 +95,7 @@ describe Find::Courses::TrainingLocations::View, type: :component do
     context 'when there are two study sites' do
       let(:course) { create(:course, :with_full_time_sites, study_sites: [build(:site, :study_site), build(:site, :study_site)]) }
 
-      it 'returns q potential placement locations' do
+      it 'returns two potential study sites' do
         expect(component.potential_study_sites_text).to eq('2 potential study sites')
       end
     end
@@ -103,7 +103,7 @@ describe Find::Courses::TrainingLocations::View, type: :component do
     context 'when there are no study sites' do
       let(:course) { create(:course, :with_full_time_sites, study_sites: []) }
 
-      it 'returns q potential placement locations' do
+      it 'returns no study sites' do
         expect(component.potential_study_sites_text).to eq('No study sites')
       end
     end

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Find::Courses::TrainingLocations::View, type: :component do
+  include Rails.application.routes.url_helpers
+
+  subject { render_inline(described_class.new(course:, preview:)) }
+
+  let(:course) { create(:course, :with_full_time_sites, study_sites: [build(:site, :study_site)]) }
+  let(:study_site) { course.study_sites.first.decorate }
+  let(:preview) { false }
+  let(:component) { described_class.new(course:, preview:) }
+
+  describe '#render' do
+    context 'when displaying school placements' do
+      it "renders the 'school placements' key" do
+        expect(subject).to have_css('.govuk-summary-list__key', text: 'Placement schools')
+      end
+
+      it 'renders the link to school placements' do
+        expect(subject).to have_link('View list of school placements')
+      end
+
+      it 'renders the hint about school placements not being guaranteed' do
+        expect(subject).to have_css('.govuk-hint', text: 'Locations can change and are not guaranteed')
+      end
+    end
+
+    context 'when displaying study site (singular)' do
+      it "renders the 'Where you will study' key" do
+        expect(subject).to have_css('.govuk-summary-list__key', text: 'Where you will study')
+      end
+
+      it 'renders the potential placement location text' do
+        expect(subject).to have_css('.govuk-body', text: '1 potential placement location')
+      end
+
+      it 'renders the study site names and addresses' do
+        expect(subject).to have_css('.govuk-hint strong', text: study_site.location_name)
+        expect(subject).to have_css('.govuk-hint', text: study_site.full_address)
+      end
+    end
+  end
+
+  describe '#placements_url' do
+    context 'when preview is true' do
+      let(:preview) { true }
+
+      it 'renders a link to the placements publish path' do
+        expect(subject).to have_link(
+          'View list of school placements',
+          href: placements_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code
+          )
+        )
+      end
+    end
+
+    context 'when preview is false' do
+      let(:preview) { false }
+
+      it 'returns the find placements path' do
+        expect(subject).to have_link('View list of school placements',
+                                     href: find_placements_path(course.provider_code, course.course_code))
+      end
+    end
+  end
+
+  describe 'potential_placement_schools_text' do
+    context 'when there is one school' do
+      it 'returns 1 potential placement location' do
+        expect(component.potential_placements_text).to eq('1 potential placement location')
+      end
+    end
+
+    context 'when there are three schools' do
+      let(:course) { create(:course, sites: [create(:site), create(:site), create(:site)]) }
+
+      it 'returns three potential placement locations' do
+        expect(component.potential_placements_text).to eq('3 potential placement locations')
+      end
+    end
+  end
+
+  describe 'potential_study_sites_text' do
+    context 'when there is one study site' do
+      it 'returns 1 potential placement location' do
+        expect(component.potential_study_sites_text).to eq('1 potential study site')
+      end
+    end
+
+    context 'when there are two study sites' do
+      let(:course) { create(:course, :with_full_time_sites, study_sites: [build(:site, :study_site), build(:site, :study_site)]) }
+
+      it 'returns q potential placement locations' do
+        expect(component.potential_study_sites_text).to eq('2 potential study sites')
+      end
+    end
+
+    context 'when there are no study sites' do
+      let(:course) { create(:course, :with_full_time_sites, study_sites: []) }
+
+      it 'returns q potential placement locations' do
+        expect(component.potential_study_sites_text).to eq('No study sites')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We are improving the way we display school placements and study sites to candidates.

## Fee Paying Before

<img width="579" alt="image" src="https://github.com/user-attachments/assets/0945b071-6f13-40bf-b4a1-480bd3b066fc">


## Fee Paying After

<img width="628" alt="image" src="https://github.com/user-attachments/assets/209da7a2-bd41-4929-bdae-cae96da1887c">

## Salaried Before

<img width="555" alt="image" src="https://github.com/user-attachments/assets/6bcbbf82-67fc-4715-985f-103e481659be">

## Salaried After

<img width="566" alt="image" src="https://github.com/user-attachments/assets/cba3d946-48df-4baa-9f80-798ec0a3d7d9">


## Changes proposed

- Add new text (different depending on salaried course or not)
- Update heading and contents link
- Add component to render the new table
- Loop through school placements attached to the course and render them in the table
- Loop through study sites attached to the course and render them in the table
- Pluralise study sites and school placements if there is more than one


## Guidance to review

- Visit the course show page on Find and look at the component
- Update the course to have more study sites/school placements
- Remove all the school placements
- Etc

Feeling lazy and can't be bothered? ☝🏼 

I've done the work for you:

[no_study_sites_and_one_placement_fee_paying](https://publish-review-4522.test.teacherservices.cloud/view_components/find/courses/training_locations/view/no_study_sites_and_one_placement_fee_paying)
[no_study_sites_and_one_placement_salaried](https://publish-review-4522.test.teacherservices.cloud/view_components/find/courses/training_locations/view/no_study_sites_and_one_placement_salaried)
[one_study_site_and_one_placement_fee_paying](https://publish-review-4522.test.teacherservices.cloud/view_components/find/courses/training_locations/view/one_study_site_and_one_placement_fee_paying)
[one_study_site_and_one_placement_salaried](https://publish-review-4522.test.teacherservices.cloud/view_components/find/courses/training_locations/view/one_study_site_and_one_placement_salaried)
[two_study_sites_and_one_placement_fee_paying](https://publish-review-4522.test.teacherservices.cloud/view_components/find/courses/training_locations/view/two_study_sites_and_one_placement_fee_paying)
[two_study_sites_and_one_placement_salaried](https://publish-review-4522.test.teacherservices.cloud/view_components/find/courses/training_locations/view/two_study_sites_and_one_placement_salaried)
[two_study_sites_and_two_placements_fee_paying](https://publish-review-4522.test.teacherservices.cloud/view_components/find/courses/training_locations/view/two_study_sites_and_two_placements_fee_paying)
[two_study_sites_and_two_placements_salaried](https://publish-review-4522.test.teacherservices.cloud/view_components/find/courses/training_locations/view/two_study_sites_and_two_placements_salaried)

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
