### PR TITLE
Add search radius filter to undergraduate results

### DIFF
--- a/app/views/find/result_filters/_all.html.erb
+++ b/app/views/find/result_filters/_all.html.erb
@@ -6,6 +6,7 @@
   <div class="app-filter__content">
   <%= form.submit "Apply filters", name: nil, class: "govuk-button", data: { qa: "apply-filters" } %>
     <% if @filters_view.show_undergraduate_courses? %>
+      <%= render "find/result_filters/radius", form: %>
       <%= render "find/result_filters/send_filter", form: %>
       <%= render "find/result_filters/applications_open_filter", form: %>
       <%= render "find/result_filters/hidden_fields", form: %>

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -15,5 +15,3 @@ search_ui:
 authentication:
   secret: secret
   mode: persona
-
-current_recruitment_cycle_year: 2025

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -16,3 +16,4 @@ authentication:
   secret: secret
   mode: persona
 
+current_recruitment_cycle_year: 2025


### PR DESCRIPTION
## Context

Observed during Bug Party 3 (10th Sept).

when you search for a TDA course by entering a location (not across England), there is no search radius drop down in the left filters.

We should show when searching by location

## Changes

<img width="326" alt="Screenshot 2024-09-18 at 13 54 59" src="https://github.com/user-attachments/assets/8dd8f2a0-e6eb-4cbc-a237-52b7754520b7">

## Test

1. Search by location
2. When on degree question (choose "yes I have a degree" for postgraduate results and "No, I do not have a degree" for undergraduate results.
3. Check filters
