### PR TITLE
Fix back to results back button

### DIFF
--- a/app/components/find/results/results_component.html.erb
+++ b/app/components/find/results/results_component.html.erb
@@ -26,7 +26,8 @@
           <%= render Find::Results::SearchResultComponent.new(
             course:,
             filtered_by_location: results.location_filter?,
-            sites_count: results.sites_count(course)
+            sites_count: results.sites_count(course),
+            search_params:
           ) %>
         <% end %>
       </ul>

--- a/app/components/find/results/results_component.rb
+++ b/app/components/find/results/results_component.rb
@@ -5,12 +5,13 @@ module Find
     class ResultsComponent < ViewComponent::Base
       include ::ViewHelper
 
-      attr_reader :results, :courses
+      attr_reader :results, :courses, :search_params
 
-      def initialize(results:, courses:)
+      def initialize(results:, courses:, search_params:)
         super
         @results = results
         @courses = courses
+        @search_params = search_params
       end
     end
   end

--- a/app/components/find/results/search_result_component.rb
+++ b/app/components/find/results/search_result_component.rb
@@ -9,11 +9,12 @@ module Find
 
       delegate :age_range_in_years_and_level, :course_length_with_study_mode, to: :course
 
-      def initialize(course:, filtered_by_location: false, sites_count: 0)
+      def initialize(course:, search_params:, filtered_by_location: false, sites_count: 0)
         super
         @course = course.decorate
         @filtered_by_location = filtered_by_location
         @sites_count = sites_count
+        @search_params = search_params
       end
 
       def filtered_by_location?
@@ -27,7 +28,7 @@ module Find
       def coure_title_link
         t(
           '.course_title_html',
-          course_path: find_course_path(provider_code: course.provider_code, course_code: course.course_code),
+          course_path: find_course_path(provider_code: course.provider_code, course_code: course.course_code, search_params: @search_params.to_query),
           provider_name: helpers.smart_quotes(course.provider.provider_name),
           course_name: course.name_and_code
         )

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -9,6 +9,7 @@ module Find
     before_action -> { render_not_found if provider.nil? }
 
     before_action :render_feedback_component, only: :show
+    before_action :set_search_params, only: :show
 
     def show
       @course = provider.courses.includes(
@@ -18,6 +19,63 @@ module Find
       ).find_by!(course_code: params[:course_code]&.upcase).decorate
 
       render_not_found unless @course.is_published?
+    end
+
+    def legacy_paramater_keys
+      %i[
+        fulltime
+        hasvacancies
+        lat
+        lng
+        parttime
+        prev_l
+        prev_lat
+        prev_lng
+        prev_loc
+        prev_lq
+        prev_query
+        prev_rad
+        qualifications
+        query
+        rad
+        senCourses
+      ]
+    end
+
+    def set_search_params
+      return if params[:search_params].blank?
+
+      session[:search_params] = ActionController::Parameters.new(
+        Rack::Utils.parse_nested_query(params[:search_params])
+      ).permit(
+        *legacy_paramater_keys,
+        :visa_status,
+        :age_group,
+        :c,
+        :can_sponsor_visa,
+        :degree_required,
+        :engineers_teach_physics,
+        :funding,
+        :has_vacancies,
+        :university_degree_status,
+        :applications_open,
+        :l,
+        :latitude,
+        :loc,
+        :long,
+        :longitude,
+        :lq,
+        :radius,
+        :send_courses,
+        :sortby,
+        'provider.provider_name',
+        c: [],
+        qualification: [],
+        qualifications: [], # Legacy
+        study_type: [],
+        subjects: [],
+        subject_codes: [] # Legacy
+      )
     end
   end
 end

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -7,6 +7,8 @@ module Find
     def index
       matched_params = MatchOldParams.call(request.query_parameters)
 
+      @search_params = matched_params
+
       @results_view = ResultsView.new(query_parameters: matched_params)
       @filters_view = ResultFilters::FiltersView.new(params: matched_params)
       @courses = @results_view.courses.page params[:page]

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -4,7 +4,7 @@
   <%= content_for(:before_content) do %>
     <%= govuk_back_link(
       text: t("find.courses.show.back_to_search"),
-      href: request.referer,
+      href: find_results_path(session[:search_params]),
       html_attributes: {
         data: { qa: "page-back" }
       }

--- a/app/views/find/results/index.html.erb
+++ b/app/views/find/results/index.html.erb
@@ -2,5 +2,6 @@
 
 <%= render Find::Results::ResultsComponent.new(
   results: @results_view,
-  courses: @courses
+  courses: @courses,
+  search_params: @search_params
 ) %>

--- a/spec/components/find/results/results_component_spec.rb
+++ b/spec/components/find/results/results_component_spec.rb
@@ -12,6 +12,16 @@ module Find
     end
 
     context 'when there are no search results' do
+      let(:search_params) do
+        { 'age_group' => 'primary',
+          'applications_open' => 'true',
+          'can_sponsor_visa' => 'false',
+          'has_vacancies' => 'true',
+          'l' => '2',
+          'subjects' => ['00'],
+          'visa_status' => 'false' }
+      end
+
       let(:results_view) do
         instance_double(
           Find::ResultsView,
@@ -29,7 +39,7 @@ module Find
 
       it 'renders a "No courses found" message when there are no results' do
         component = render_inline(
-          described_class.new(results: results_view, courses:)
+          described_class.new(results: results_view, courses:, search_params:)
         )
 
         expect(component.text).to include('No courses found')
@@ -37,13 +47,23 @@ module Find
 
       it 'renders the inset text' do
         component = render_inline(
-          described_class.new(results: results_view, courses:)
+          described_class.new(results: results_view, courses:, search_params:)
         )
         expect(component.text).to include('event near you')
       end
     end
 
     context 'when there are 10 matching courses' do
+      let(:search_params) do
+        { 'age_group' => 'primary',
+          'applications_open' => 'true',
+          'can_sponsor_visa' => 'false',
+          'has_vacancies' => 'true',
+          'l' => '2',
+          'subjects' => ['00'],
+          'visa_status' => 'false' }
+      end
+
       let(:results_view) do
         instance_double(
           Find::ResultsView,
@@ -68,12 +88,13 @@ module Find
         allow(Results::SearchResultComponent).to receive(:new).and_return(plain: '')
 
         component = render_inline(
-          described_class.new(results: results_view, courses:)
+          described_class.new(results: results_view, courses:, search_params:)
         )
 
         courses.each do |course|
           expect(Results::SearchResultComponent).to have_received(:new).with(
             course:,
+            search_params:,
             filtered_by_location: false,
             sites_count: 2
           )
@@ -84,12 +105,13 @@ module Find
 
       it 'renders the inset text' do
         component = render_inline(
-          described_class.new(results: results_view, courses:)
+          described_class.new(results: results_view, courses:, search_params:)
         )
 
         courses.each do |course|
           expect(Results::SearchResultComponent).to have_received(:new).with(
             course:,
+            search_params:,
             filtered_by_location: false,
             sites_count: 2
           )

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -4,8 +4,18 @@ require 'rails_helper'
 
 module Find
   describe Results::SearchResultComponent, type: :component do
+    let(:search_params) do
+      { 'age_group' => 'primary',
+        'applications_open' => 'true',
+        'can_sponsor_visa' => 'false',
+        'has_vacancies' => 'true',
+        'l' => '2',
+        'subjects' => ['00'],
+        'visa_status' => 'false' }
+    end
+
     context 'delegations' do
-      subject { described_class.new(course: build(:course)) }
+      subject { described_class.new(course: build(:course), search_params:) }
 
       it { is_expected.to delegate_method(:age_range_in_years_and_level).to(:course) }
       it { is_expected.to delegate_method(:course_length_with_study_mode).to(:course) }
@@ -17,7 +27,7 @@ module Find
           :course,
           degree_grade: :two_one
         )
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).to include(
           '2:1 bachelor’s degree',
@@ -34,7 +44,7 @@ module Find
           can_sponsor_student_visa: false,
           can_sponsor_skilled_worker_visa: true
         )
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).to include(
           'Skilled Worker visas can be sponsored'
@@ -50,7 +60,7 @@ module Find
           can_sponsor_student_visa: false,
           can_sponsor_skilled_worker_visa: true
         )
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).to include(
           'Visas cannot be sponsored'
@@ -61,7 +71,7 @@ module Find
     context 'when the provider specifies student visa sponsorship' do
       it 'renders correct message when only one kind of visa is sponsored' do
         course = build(:course, :can_sponsor_student_visa, :fee_type_based)
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).to include(
           'Student visas can be sponsored'
@@ -74,7 +84,7 @@ module Find
           can_sponsor_student_visa: false,
           can_sponsor_skilled_worker_visa: false
         )
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).to include(
           'Visas cannot be sponsored'
@@ -88,7 +98,7 @@ module Find
           :course,
           accrediting_provider: build(:provider, :accredited_provider, provider_name: 'ACME SCITT A1')
         )
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).to include('QTS ratified by ACME SCITT A1')
       end
@@ -100,7 +110,7 @@ module Find
           :course,
           accrediting_provider: nil
         )
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).not_to include('QTS ratified by')
       end
@@ -110,7 +120,7 @@ module Find
       it 'renders the uk fees' do
         course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
         expect(result.text).to include('£9,250 for UK citizens')
         expect(result.text).to include('Course fee')
       end
@@ -120,7 +130,7 @@ module Find
       it 'renders the international fees' do
         course = create(:course, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
 
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
         expect(result.text).to include('£14,000 for Non-UK citizens')
       end
     end
@@ -129,7 +139,7 @@ module Find
       it 'renders the uk fees and not the internation fee label' do
         course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250, fee_international: nil)]).decorate
 
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).to include('£9,250 for UK citizens')
         expect(result.text).not_to include('Non-UK citizens')
@@ -140,7 +150,7 @@ module Find
       it 'renders the international fees but not the uk fee label' do
         course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: 14_000)]).decorate
 
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).not_to include('for UK citizens')
         expect(result.text).to include('£14,000 for Non-UK citizens')
@@ -151,7 +161,7 @@ module Find
       it 'does not render the row' do
         course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]).decorate
 
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result.text).not_to include('for UK citizens')
         expect(result.text).not_to include('£14,000 for Non-UK citizens')
@@ -165,7 +175,7 @@ module Find
                                level: 'secondary',
                                age_range_in_years: '11_to_16')
 
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result).to have_text('Age range 11 to 16 - secondary', normalize_ws: true)
       end
@@ -179,7 +189,7 @@ module Find
           study_mode: 'full_time'
         )
 
-        result = render_inline(described_class.new(course:))
+        result = render_inline(described_class.new(course:, search_params:))
 
         expect(result).to have_text('Course length 1 year - full time', normalize_ws: true)
       end

--- a/spec/features/find/result_page_filters/back_to_results_spec.rb
+++ b/spec/features/find/result_page_filters/back_to_results_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Back to results back button' do
+  include FiltersFeatureSpecsHelper
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+    given_there_are_primary_courses_in_england
+    allow_any_instance_of(Find::ViewHelper).to receive(:permitted_referrer?).and_return(true)
+  end
+
+  scenario 'Candidate selects a course, selects the provider, then clicks back to the course and then back to the results page' do
+    when_i_visit_the_start_page
+
+    and_i_select_the_across_england_radio_button
+    and_i_click_continue
+
+    and_i_select_the_primary_subject_textbox
+    and_i_click_continue
+
+    and_i_select_the_primary_subject_checkbox
+    and_i_click_continue
+
+    and_i_select_my_visa_status
+    and_i_click_find_courses
+
+    and_i_see_the_number_of_courses
+
+    i_select_a_course
+    i_click_on_the_provider_name
+
+    i_click_on_back_button_to_course
+    i_click_on_back_to_results
+
+    and_then_i_am_taken_back_to_the_results_page
+  end
+
+  private
+
+  def given_there_are_primary_courses_in_england
+    @primary_course = create(:course, :published, :with_salary, application_status: 'open', site_statuses: [build(:site_status, :findable)])
+    create(:course, :published, :with_salary, application_status: 'open', site_statuses: [build(:site_status, :findable)])
+
+    create(:course, :secondary, :published, :with_salary, application_status: 'open', site_statuses: [build(:site_status, :findable)])
+  end
+
+  def when_i_visit_the_start_page
+    find_courses_by_location_or_training_provider_page.load
+  end
+
+  def and_i_select_the_across_england_radio_button
+    find_courses_by_location_or_training_provider_page.across_england.choose
+  end
+
+  def and_i_click_continue
+    click_link_or_button 'Continue'
+  end
+
+  def and_i_select_the_primary_subject_textbox
+    choose 'Primary'
+  end
+
+  def and_i_select_the_primary_subject_checkbox
+    check 'Primary'
+  end
+
+  def and_i_select_my_visa_status
+    choose 'No'
+  end
+
+  def and_i_click_find_courses
+    click_link_or_button 'Find courses'
+  end
+  alias_method :when_i_click_find_courses, :and_i_click_find_courses
+
+  def and_i_see_the_number_of_courses
+    expect(find_results_page.courses.count).to eq(2)
+  end
+
+  def i_select_a_course
+    click_link_or_button @primary_course.name
+  end
+
+  def i_click_on_the_provider_name
+    click_link_or_button @primary_course.provider.provider_name
+  end
+
+  def i_click_on_back_button_to_course
+    click_link_or_button "Back to #{@primary_course.name}"
+  end
+
+  def i_click_on_back_to_results
+    click_link_or_button 'Back to search results'
+  end
+
+  def and_then_i_am_taken_back_to_the_results_page
+    expect(page).to have_current_path(find_results_path)
+  end
+end


### PR DESCRIPTION
Ticket: https://trello.com/c/UdZgqSEa/2133-bug-back-to-search-results-button-navigates-to-incorrect-page

## Context

This is a known bug. It's because the course details page back link goes to whatever previous page you visited. So if your previous page wasn't the results page, you will be redirected to a different page(whatever your previous one was)I think this was implemented like this to preserve the search filter/parameters of the results page when going back to the results page and the details page didn't have that many links you could click on.

## Changes proposed in this pull request

Update the back link to go back to the results page with the search params that the user selected when they first visited the site.

## Guidance to review

- Visit http://find.localhost:3001/
- Set your preferences
- Select a course
- Within that course click on the provider name link
- Click the back button
- Then click the back button to go back to the results page
- You should now see the same number of courses as you did when you first landed on the results page

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
