### PR TITLE
[2336] Add `training_route` and `degree_type` to the API

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -50,7 +50,9 @@ module API
                    :can_sponsor_skilled_worker_visa,
                    :can_sponsor_student_visa,
                    :campaign_name,
-                   :application_status
+                   :application_status,
+                   :training_route,
+                   :degree_type
 
         attribute :about_accredited_body do
           @object.accrediting_provider_description

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -5,6 +5,13 @@ weight: 2
 
 # Release Notes
 
+## 19 September 2024
+
+- Add `training_route` field to `CourseAttributes`. This is a string, corresponding to the courses training route, based on the funding and degree type.
+
+## 19 September 2024
+
+- Add `degree_type` field to `CourseAttributes`. This is a string, corresponding to whether the course is undergraduate or postgraduate.
 
 ## 20 August 2024
 

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -356,7 +356,9 @@ RSpec.describe API::Public::V1::CoursesController do
                 can_sponsor_skilled_worker_visa
                 can_sponsor_student_visa
                 campaign_name
-                application_status]
+                application_status
+                training_route
+                degree_type]
           end
 
           before do

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -80,6 +80,8 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:can_sponsor_student_visa) }
   it { is_expected.to have_attribute(:campaign_name) }
   it { is_expected.to have_attribute(:application_status) }
+  it { is_expected.to have_attribute(:training_route) }
+  it { is_expected.to have_attribute(:degree_type) }
 
   context 'when bursary amount is present' do
     let(:course) { create(:course, :with_accrediting_provider, :secondary, enrichments: [enrichment], subjects: [find_or_create(:secondary_subject, :classics)]) }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -574,6 +574,28 @@
               "open",
               "closed"
             ]
+          },
+          "training_route": {
+            "type": "string",
+            "nullable": false,
+            "description": "The course training route corresponding to different combinations of course types and funding types",
+            "example": "fee_funded_initial_teacher_training",
+            "enum": [
+              "fee_funded_initial_teacher_training",
+              "school_direct_salaried",
+              "postgraduate_teacher_apprenticeship",
+              "teacher_degree_apprenticeship"
+            ]
+          },
+          "degree_type": {
+            "type": "string",
+            "nullable": false,
+            "description": "The type of degree on the course",
+            "example": "postgraduate",
+            "enum": [
+              "postgraduate",
+              "undergraduate"
+            ]
           }
         }
       },

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -403,3 +403,21 @@ properties:
     enum:
       - open
       - closed
+  training_route:
+    type: string
+    nullable: false
+    description: "The course training route corresponding to different combinations of course types and funding types"
+    example: "fee_funded_initial_teacher_training"
+    enum:
+      - fee_funded_initial_teacher_training
+      - school_direct_salaried
+      - postgraduate_teacher_apprenticeship
+      - teacher_degree_apprenticeship
+  degree_type:
+    type: string
+    nullable: false
+    description: "The type of degree on the course"
+    example: "postgraduate"
+    enum:
+      - postgraduate
+      - undergraduate


### PR DESCRIPTION
## Context

- We added `degree_type` as a new column on the course table. 

- We added a calculated `training_route` method to the course model based on `funding` and `degree_type`. 

This PR exposes both of those ☝🏼  on the public API.

## Changes proposed in this pull request

- Expose `degree_type` column as an attribute on the public API
- Expose `training_route` column as an attribute on the public API
- Update docs

## Guidance to review

**Locally (easy)** 

- `api/public/v1/recruitment_cycles/2024/providers/1BJ/courses/2JQP`


**Review app (easier)** 

- https://publish-review-4529.test.teacherservices.cloud/api/public/v1/recruitment_cycles/2024/providers/1BJ/courses/2JQP

**Screenshot - important bits highlighted in yellow (easiest)**

<img width="649" alt="image" src="https://github.com/user-attachments/assets/82a84787-beed-4fe3-85f3-976ea38bc286">

<img width="612" alt="image" src="https://github.com/user-attachments/assets/e2ca4a9d-8557-4e9a-bd19-d2b8293fa4bf">


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
