### PR TITLE
[2304] Improve locations: 2/6 Add logic to hide school placements

### DIFF
--- a/app/components/find/courses/about_schools_component/view.html.erb
+++ b/app/components/find/courses/about_schools_component/view.html.erb
@@ -35,25 +35,5 @@
     <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :how_school_placements_work, is_preview: preview?(params)) %>
     <% end %>
-
-    <% if course.study_sites.any? %>
-      <h3 class="govuk-heading-m">
-        Study sites
-      </h3>
-
-      <p class="govuk-body">
-        <%= "The theoretical learning part of your course will be at the following #{course.study_sites.many? ? 'locations' : 'location'}." %>
-      </p>
-
-      <ul class="govuk-list govuk-list--spaced" id="course_study_sites">
-        <% course.study_sites.each do |study_site| %>
-          <li>
-            <strong><%= smart_quotes(study_site.location_name) %></strong>
-            <br>
-            <%= smart_quotes(study_site.decorate.full_address) %>
-          </li>
-      <% end %>
-      </ul>
-    <% end %>
   </div>
 </div>

--- a/app/components/find/courses/training_locations/view.html.erb
+++ b/app/components/find/courses/training_locations/view.html.erb
@@ -3,7 +3,7 @@
     <%= row.with_key { top_heading } %>
     <%= row.with_value do %>
       <p class="govuk-body"><%= potential_placements_text %></p>
-      <%= govuk_link_to(t("view_list_of_school_placements"), placements_url) %>
+      <%= govuk_link_to(t("view_list_of_school_placements"), placements_url) if show_school_placements_link? %>
       <p class="govuk-hint govuk-!-font-size-16">Locations can change and are not guaranteed</p>
     <% end %>
   <% end %>

--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -10,9 +10,9 @@ module Find
         attr_reader :course, :preview
 
         def initialize(course:, preview: false)
+          super
           @course = course
           @preview = preview
-          super
         end
 
         def placements_url
@@ -51,6 +51,25 @@ module Find
 
         def bottom_heading
           'Where you will study'
+        end
+
+        def show_school_placements_link?
+          # This is necessary for some component previews to load.
+          # I don't have time to debug component previews right now.
+          # This code will be removed after the beginning of the 2025 cycle
+          # anyway
+          return false if course.provider.recruitment_cycle.blank?
+
+          recruitment_cycle_before_2025? || recruitment_cycle_2025_or_greater_and_selectable_schools?
+        end
+
+        def recruitment_cycle_before_2025?
+          course.provider.recruitment_cycle_year.to_i < 2025
+        end
+
+        def recruitment_cycle_2025_or_greater_and_selectable_schools?
+          course.provider.recruitment_cycle_year.to_i >= 2025 &&
+            course.provider.selectable_school?
         end
       end
     end

--- a/app/components/find/results/search_result_component.html.erb
+++ b/app/components/find/results/search_result_component.html.erb
@@ -1,5 +1,5 @@
 <li class="app-search-results__item" data-qa="course">
-  <%= govuk_summary_card(classes: ["course-summary-card"], title: coure_title_link) do |card| %>
+  <%= govuk_summary_card(classes: ["course-summary-card"], title: course_title_link) do |card| %>
     <%= card.with_summary_list(actions: false, classes: ["govuk-summary-list--no-border"]) do |summary_list| %>
       <% if filtered_by_location? && has_sites? %>
         <% summary_list.with_row do |row| %>

--- a/app/components/find/results/search_result_component.rb
+++ b/app/components/find/results/search_result_component.rb
@@ -25,7 +25,7 @@ module Find
         @sites_count.positive?
       end
 
-      def coure_title_link
+      def course_title_link
         t(
           '.course_title_html',
           course_path: find_course_path(provider_code: course.provider_code, course_code: course.course_code, search_params: @search_params.to_query),

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -89,8 +89,8 @@ module Find
       date(:apply_deadline)
     end
 
-    def self.find_opens
-      date(:find_opens, current_year)
+    def self.find_opens(year = current_year)
+      date(:find_opens, year)
     end
 
     def self.find_reopens

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -64,21 +64,6 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
     end
   end
 
-  context 'course with study sites' do
-    it 'renders the component' do
-      provider = build(:provider)
-      course = build(:course,
-                     provider:,
-                     study_sites: [
-                       build(:site, :study_site)
-                     ]).decorate
-
-      result = render_inline(described_class.new(course))
-
-      expect(result.text).to include('Study sites')
-    end
-  end
-
   context 'course without multiple sites' do
     it 'renders the component' do
       provider = build(:provider)

--- a/spec/components/find/courses/training_locations/view_preview.rb
+++ b/spec/components/find/courses/training_locations/view_preview.rb
@@ -73,6 +73,24 @@ module Find
                               provider: Provider.new(provider_code: 'DFE', recruitment_cycle: RecruitmentCycle.current)).decorate
           render Find::Courses::TrainingLocations::View.new(course:)
         end
+
+        def show_training_locations_link_disabled
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new, Site.new],
+                              funding: 'salary',
+                              study_sites: [Site.new, Site.new],
+                              provider: Provider.new(provider_code: 'DFE', selectable_school: false, recruitment_cycle: FactoryBot.build(:recruitment_cycle, year: 2025))).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
+
+        def show_training_locations_link_enabled
+          course = Course.new(course_code: 'FIND',
+                              sites: [Site.new, Site.new],
+                              funding: 'salary',
+                              study_sites: [Site.new, Site.new],
+                              provider: Provider.new(provider_code: 'DFE', selectable_school: true, recruitment_cycle: FactoryBot.build(:recruitment_cycle, year: 2025))).decorate
+          render Find::Courses::TrainingLocations::View.new(course:)
+        end
       end
     end
   end

--- a/spec/components/find/courses/training_locations/view_preview.rb
+++ b/spec/components/find/courses/training_locations/view_preview.rb
@@ -74,7 +74,7 @@ module Find
           render Find::Courses::TrainingLocations::View.new(course:)
         end
 
-        def show_training_locations_link_disabled
+        def show_training_locations_school_placements_link_disabled
           course = Course.new(course_code: 'FIND',
                               sites: [Site.new, Site.new],
                               funding: 'salary',

--- a/spec/components/find/courses/training_locations/view_preview.rb
+++ b/spec/components/find/courses/training_locations/view_preview.rb
@@ -83,7 +83,7 @@ module Find
           render Find::Courses::TrainingLocations::View.new(course:)
         end
 
-        def show_training_locations_link_enabled
+        def show_training_locations_school_placements_link_enabled
           course = Course.new(course_code: 'FIND',
                               sites: [Site.new, Site.new],
                               funding: 'salary',

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 describe Find::Courses::TrainingLocations::View, type: :component do
-  include Rails.application.routes.url_helpers
-
   subject { render_inline(described_class.new(course:, preview:)) }
 
   let(:preview) { false }
@@ -135,5 +133,9 @@ describe Find::Courses::TrainingLocations::View, type: :component do
         expect(component.potential_study_sites_text).to eq('Not listed yet')
       end
     end
+  end
+
+  def url_helpers
+    Rails.application.routes.url_helpers
   end
 end

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -104,7 +104,7 @@ describe Find::Courses::TrainingLocations::View, type: :component do
       end
     end
 
-    context 'when preview is false after find opens 2025 and provider = selectable_school' do
+    context 'when preview is false after find opens in 2025 and provider has selectable_school enabled' do
       let(:year) { 2025 }
       let(:selectable_school) { true }
 

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -76,7 +76,7 @@ describe Find::Courses::TrainingLocations::View, type: :component do
       end
     end
 
-    context 'when preview = true for 2024 provider and provider != selectable_school' do
+    context 'when preview is true for a 2024 provider and the provider does not have selectable_school enabled' do
       let(:year) { 2024 }
       let(:selectable_school) { false }
       let(:preview) { true }

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -54,15 +54,20 @@ describe Find::Courses::TrainingLocations::View, type: :component do
   end
 
   describe '#placements_url' do
-    let(:course) { create(:course) }
+    let(:provider) { create(:provider, recruitment_cycle: find_or_create(:recruitment_cycle, year:), selectable_school:) }
+    let(:course) { create(:course, provider:) }
+    let(:year) { 2025 }
+    let(:selectable_school) { false }
 
-    context 'when preview is true' do
+    context 'when preview = true, before 2025 find opens and provider != selectable_school' do
       let(:preview) { true }
+      let(:year) { 2025 }
+      let(:selectable_school) { false }
 
-      it 'renders a link to the publish path' do
-        expect(subject).to have_link(
+      it 'renders link to the publish path for 2025 provider' do
+        expect(subject).to have_no_link(
           'View list of school placements',
-          href: placements_publish_provider_recruitment_cycle_course_path(
+          href: url_helpers.placements_publish_provider_recruitment_cycle_course_path(
             course.provider_code,
             course.recruitment_cycle_year,
             course.course_code
@@ -71,12 +76,41 @@ describe Find::Courses::TrainingLocations::View, type: :component do
       end
     end
 
-    context 'when preview is false' do
+    context 'when preview = true for 2024 provider and provider != selectable_school' do
+      let(:year) { 2024 }
+      let(:selectable_school) { false }
+      let(:preview) { true }
+
+      it 'renders a link to the publish path' do
+        expect(subject).to have_link(
+          'View list of school placements',
+          href: url_helpers.placements_publish_provider_recruitment_cycle_course_path(
+            course.provider_code,
+            course.recruitment_cycle_year,
+            course.course_code
+          )
+        )
+      end
+    end
+
+    context 'when preview = false for 2024 provider and provider = selectable_school' do
+      let(:year) { 2024 }
+      let(:selectable_school) { true }
       let(:preview) { false }
 
       it 'renders a link to the find path' do
         expect(subject).to have_link('View list of school placements',
-                                     href: find_placements_path(course.provider_code, course.course_code))
+                                     href: url_helpers.find_placements_path(course.provider_code, course.course_code))
+      end
+    end
+
+    context 'when preview is false after find opens 2025 and provider = selectable_school' do
+      let(:year) { 2025 }
+      let(:selectable_school) { true }
+
+      it 'renders a link to the find path' do
+        expect(subject).to have_link('View list of school placements',
+                                     href: url_helpers.find_placements_path(course.provider_code, course.course_code))
       end
     end
   end

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -93,7 +93,7 @@ describe Find::Courses::TrainingLocations::View, type: :component do
       end
     end
 
-    context 'when preview = false for 2024 provider and provider = selectable_school' do
+    context 'when preview is false for a 2024 provider and the provider has selectable_school enabled' do
       let(:year) { 2024 }
       let(:selectable_school) { true }
       let(:preview) { false }

--- a/spec/components/find/deadline_banner_component_preview.rb
+++ b/spec/components/find/deadline_banner_component_preview.rb
@@ -29,38 +29,4 @@ module Find
       )
     end
   end
-
-  class ShowApplyDeadlineBannerCycleTimetable < CycleTimetable
-    def self.show_apply_deadline_banner?
-      true
-    end
-
-    def self.show_cycle_closed_banner?
-      false
-    end
-  end
-
-  class ShowCycleClosedBannerTimetable < CycleTimetable
-    def self.show_apply_deadline_banner?
-      false
-    end
-
-    def self.show_cycle_closed_banner?
-      true
-    end
-  end
-
-  class ShowApplyOpensSoonBannerTimetable < CycleTimetable
-    def self.show_apply_deadline_banner?
-      false
-    end
-
-    def self.show_cycle_closed_banner?
-      false
-    end
-
-    def self.show_apply_opens_soon_banner?
-      true
-    end
-  end
 end

--- a/spec/components/find/show_apply_deadline_banner_cycle_timetable.rb
+++ b/spec/components/find/show_apply_deadline_banner_cycle_timetable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Find
+  class ShowApplyDeadlineBannerCycleTimetable < CycleTimetable
+    def self.show_apply_deadline_banner?
+      true
+    end
+
+    def self.show_cycle_closed_banner?
+      false
+    end
+  end
+end

--- a/spec/components/find/show_apply_opens_soon_banner_timetable.rb
+++ b/spec/components/find/show_apply_opens_soon_banner_timetable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Find
+  class ShowApplyOpensSoonBannerTimetable < CycleTimetable
+    def self.show_apply_deadline_banner?
+      false
+    end
+
+    def self.show_cycle_closed_banner?
+      true
+    end
+  end
+end

--- a/spec/components/find/show_cycle_closed_banner_timetable.rb
+++ b/spec/components/find/show_cycle_closed_banner_timetable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Find
+  class ShowCycleClosedBannerTimetable < CycleTimetable
+    def self.show_apply_deadline_banner?
+      false
+    end
+
+    def self.show_cycle_closed_banner?
+      false
+    end
+
+    def self.show_apply_opens_soon_banner?
+      true
+    end
+  end
+end

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -138,13 +138,28 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     end
   end
 
+  scenario 'user sees no school placements in 2025' do
+    create(:recruitment_cycle, :next)
+    Timecop.travel(1.month.since(Find::CycleTimetable.find_opens(2025))) do
+      allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
+      given_i_am_authenticated(user: user_with_fee_based_course)
+      provider.update(selectable_school: false)
+      when_i_visit_the_publish_course_preview_page
+      then_i_see_no_school_placements_link
+    end
+  end
+
   scenario 'user views school placements' do
-    given_i_am_authenticated(user: user_with_fee_based_course)
-    when_i_visit_the_publish_course_preview_page
-    and_i_click_link_or_button('View list of school placements')
-    then_i_should_be_on_the_school_placements_page
-    and_i_click_link_or_button("Back to #{@course.name} (#{course.course_code})")
-    then_i_should_be_back_on_the_preview_page
+    create(:recruitment_cycle, :next)
+    Timecop.travel(1.month.since(Find::CycleTimetable.find_opens(2025))) do
+      allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
+      given_i_am_authenticated(user: user_with_fee_based_course)
+      when_i_visit_the_publish_course_preview_page
+      and_i_click_link_or_button('View list of school placements')
+      then_i_should_be_on_the_school_placements_page
+      and_i_click_link_or_button("Back to #{@course.name} (#{course.course_code})")
+      then_i_should_be_back_on_the_preview_page
+    end
   end
 
   scenario 'user views provider and accredited_provider' do
@@ -260,6 +275,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     expect(publish_course_preview_page).to have_content 'Maths A level'
 
     expect(publish_course_preview_page).to have_study_sites_table
+
     expect(publish_course_preview_page).to have_link('View list of school placements')
 
     expect(publish_course_preview_page).to have_course_advice
@@ -531,5 +547,9 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
         @course.course_code
       )
     )
+  end
+
+  def then_i_see_no_school_placements_link
+    expect(publish_course_preview_page).to have_no_link('View list of school placements')
   end
 end

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -274,8 +274,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     expect(publish_course_preview_page).to have_content '2:1 bachelor’s degree or above or equivalent qualification'
     expect(publish_course_preview_page).to have_content 'Maths A level'
 
-    expect(publish_course_preview_page).to have_study_sites_table
-
     expect(publish_course_preview_page).to have_link('View list of school placements')
 
     expect(publish_course_preview_page).to have_course_advice

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -50,6 +50,24 @@ module Find
       end
     end
 
+    describe '.find_opens(year)' do
+      context 'when no argument is passed' do
+        it 'returns find_opens date for 2021' do
+          Timecop.travel(Time.zone.local(2021, 1, 1, 12, 0, 0)) do
+            expect(described_class.find_opens).to eq(Time.zone.local(2020, 10, 6, 9))
+          end
+        end
+      end
+
+      context 'when passing 2024 as argument' do
+        it 'returns find_opens date for 2024' do
+          Timecop.travel(Time.zone.local(2021, 11, 1, 12, 0, 0)) do
+            expect(described_class.find_opens(2024)).to eq(Time.zone.local(2023, 10, 3, 9))
+          end
+        end
+      end
+    end
+
     describe '.preview_mode?' do
       it 'returns true when it is after the Apply deadline but before Find closes' do
         Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do


### PR DESCRIPTION
## Context

In the 2025 Recruitment Cycle, some providers will allow candidates to choose preferred school placement locations.
For those providers we will show a link on the Find Course page so the candidates can see the potential school placements.

For the providers who will not give the candidates the opportunity to choose a preferred school placement, we do not show that link.

> The link to view school placements and the separate page is hidden by default.
> 
> Logic is added to only display the link and the separate page when providers have asked for an exception.
> 
> Schedule the change to go live on 1 October 2024


**I have not blocked the path to the school placements page, I feel this can be deprioritised.**

## Changes proposed in this pull request

**Hide View School placements link for courses in 2025+ where school_selectable is false for the provider**

**Extras**
 - Remove Study Sites copy from Find courses#show template (Urgent request)
 - Move Find::CycleTimetable classes to own files so Rails can reload them in development
 - Fix a typo
 - Include ActiveSupport TimeHelpers in all specs (`travel_to`, `travel` etc)

## Guidance to review

_Harris NioT_ is `selectable_school: true` in the [review app](https://publish-review-4531.test.teacherservices.cloud/publish/organisations/1TZ/2025/courses/B695)

[Preview for course in 2025 that has selectable_schools](https://publish-review-4531.test.teacherservices.cloud/publish/organisations/1TZ/2025/courses/B695/preview)

[Preview for course in 2025 that does not have selectable_schools](https://publish-review-4531.test.teacherservices.cloud/publish/organisations/2AT/2025/courses/AK12/preview)


#### Previews
https://publish-review-4531.test.teacherservices.cloud/view_components/find/courses/training_locations/view

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [x] Attach PR to Trello card
