### PR TITLE
Provider can set selectable school property

### DIFF
--- a/app/controllers/publish/providers/school_placements_controller.rb
+++ b/app/controllers/publish/providers/school_placements_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Publish
+  module Providers
+    class SchoolPlacementsController < PublishController
+      def edit
+        authorize(provider, :edit?)
+
+        @provider = provider
+      end
+
+      def update
+        authorize(provider, :update?)
+
+        if @provider.update(provider_params)
+          flash[:success] = I18n.t('success.published')
+
+          redirect_to details_publish_provider_recruitment_cycle_path(
+            provider.provider_code,
+            recruitment_cycle.year
+          )
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def provider_params
+        params.require(:provider).permit(:selectable_school)
+      end
+    end
+  end
+end

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -24,11 +24,11 @@
 <% end %>
 
 <h1 class="govuk-heading-l">
-  Organisation details
+  <%= t(".page_title") %>
 </h1>
 
 <h2 class="govuk-heading-m">
-  About your organisation
+  <%= t(".about") %>
 </h2>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -54,7 +54,7 @@
     <% end %>
 
     <% unless @provider.provider_type == 'lead_school' %>
-      <h2 class="govuk-heading-m">Visa sponsorship</h2>
+      <h2 class="govuk-heading-m"><%= t(".visa_sponsorship") %></h2>
       <%= govuk_summary_list do |summary_list| %>
         <% enrichment_summary(
              summary_list,
@@ -78,19 +78,19 @@
       <% end %>
     <% end %>
 
-    <h2 class="govuk-heading-m">School placements</h2>
+    <h2 class="govuk-heading-m"><%= t(".school_placements") %></h2>
     <%= govuk_summary_list do |summary_list| %>
       <% enrichment_summary(
         summary_list,
         :provider,
-        "Let candidates choose preferred schools",
+        t(".selectable_school_label"),
         @provider.selectable_school ? "Yes" : "No",
         %w[selectable_school],
         action_path: school_placements_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
         action_visually_hidden_text: "school placement display"
       ) %>
     <% end %>
-    <h2 class="govuk-heading-m">Contact details</h2>
+    <h2 class="govuk-heading-m"><%= t(".contact_details") %></h2>
     <%= govuk_summary_list do |summary_list| %>
       <% enrichment_summary(
         summary_list,

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -27,6 +27,9 @@
   Organisation details
 </h1>
 
+<h2 class="govuk-heading-m">
+  About your organisation
+</h2>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_summary_list do |summary_list| %>

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -78,6 +78,18 @@
       <% end %>
     <% end %>
 
+    <h2 class="govuk-heading-m">School placements</h2>
+    <%= govuk_summary_list do |summary_list| %>
+      <% enrichment_summary(
+        summary_list,
+        :provider,
+        "Let candidates choose preferred schools",
+        @provider.selectable_school ? "Yes" : "No",
+        %w[selectable_school],
+        action_path: school_placements_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+        action_visually_hidden_text: "school placement display"
+      ) %>
+    <% end %>
     <h2 class="govuk-heading-m">Contact details</h2>
     <%= govuk_summary_list do |summary_list| %>
       <% enrichment_summary(

--- a/app/views/publish/providers/school_placements/edit.html.erb
+++ b/app/views/publish/providers/school_placements/edit.html.erb
@@ -22,7 +22,7 @@
       </h1>
 
       <%= f.govuk_radio_buttons_fieldset(:selectable_school,
-                                         legend: { text: "Let candidates select their preferred schools when applying" }) do %>
+                                         legend: { text: t(".selectable_school_label") }) do %>
         <%= f.govuk_radio_button :selectable_school, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :selectable_school, false, label: { text: "No" } %>
       <% end %>

--- a/app/views/publish/providers/school_placements/edit.html.erb
+++ b/app/views/publish/providers/school_placements/edit.html.erb
@@ -1,0 +1,33 @@
+<% page_title = "School placements" %>
+<% content_for :page_title, title_with_error_prefix(page_title, @provider.errors.present?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @provider,
+      url: school_placements_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      method: :put,
+      local: true
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+        <%= page_title %>
+      </h1>
+
+      <%= f.govuk_radio_buttons_fieldset(:selectable_school,
+                                         legend: { text: "Let candidates select their preferred schools when applying" }) do %>
+        <%= f.govuk_radio_button :selectable_school, true, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :selectable_school, false, label: { text: "No" } %>
+      <% end %>
+
+      <%= f.govuk_submit "Update school placement preferences" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,6 +444,13 @@ en:
         training_with_disabilities: Training with disabilities
         training_with_disabilities_link: Find out about training with disabilities and other needs at %{provider_name}.
     providers:
+      details:
+        page_title: Organisation details
+        about: About your organisation
+        school_placements: School placements
+        contact_details: Contact details
+        visa_sponsorship: Visa sponsorship
+        selectable_school_label: Let candidates choose preferred schools
       courses:
         accredited_provider:
           show:
@@ -536,6 +543,7 @@ en:
         edit:
           page_title: How placements work - %{course_name_and_code}
           submit_button: Update how placements work
+          selectable_school_label: Let candidates select their preferred schools when applying
           guidance_text_html:
             <p class="govuk-body">Give candidates information about the schools they will be training in</p>
             <p class="govuk-body">Tell them:</p>

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -296,6 +296,8 @@ namespace :publish, as: :publish do
 
         get '/contact', on: :member, to: 'contacts#edit'
         put '/contact', on: :member, to: 'contacts#update'
+        get '/school_placements', on: :member, to: 'school_placements#edit'
+        put '/school_placements', on: :member, to: 'school_placements#update'
         get '/student-visa', on: :member, to: 'student_visa#edit'
         get '/skilled-worker-visa', on: :member, to: 'skilled_worker_visa#edit'
         put '/student-visa', on: :member, to: 'student_visa#update'

--- a/spec/features/publish/edit_provider_details_spec.rb
+++ b/spec/features/publish/edit_provider_details_spec.rb
@@ -8,6 +8,7 @@ feature 'About Your Organisation section', { can_edit_current_and_next_cycles: f
     when_i_visit_the_details_page
     then_i_can_edit_info_about_training_with_us
     then_i_can_edit_info_about_disabilities_and_other_needs
+    then_i_can_edit_school_placements
   end
 
   def given_i_am_a_provider_user_as_a_provider_user
@@ -59,6 +60,21 @@ feature 'About Your Organisation section', { can_edit_current_and_next_cycles: f
     expect(page).to have_content 'Your changes have been published'
     within_summary_row 'Training with disabilities and other needs' do
       expect(page).to have_content 'Updated: training with disabilities'
+    end
+  end
+
+  def then_i_can_edit_school_placements
+    within(publish_provider_details_show_page.selectable_school) do
+      expect(page).to have_content('Yes')
+    end
+    publish_provider_details_show_page.selectable_school_change_link.click
+    expect(page.find_by_id('provider-selectable-school-true-field')).to be_checked
+    page.find('input#provider-selectable-school-field').click
+    page.click_on('Update school placement preferences')
+
+    publish_provider_details_show_page.selectable_school.click
+    within(publish_provider_details_show_page.selectable_school) do
+      expect(page).to have_content('No')
     end
   end
 end

--- a/spec/support/page_objects/publish/provider_details_show.rb
+++ b/spec/support/page_objects/publish/provider_details_show.rb
@@ -12,6 +12,8 @@ module PageObjects
       element :student_visa_link, '[data-qa=enrichment__can_sponsor_student_visa] a'
       element :skilled_worker_visa_link, '[data-qa=enrichment__can_sponsor_skilled_worker_visa] a'
       element :email_link, '[data-qa=enrichment__email] a'
+      element :selectable_school, '[data-qa=enrichment__selectable_school]'
+      element :selectable_school_change_link, '[data-qa=enrichment__selectable_school] a'
     end
   end
 end


### PR DESCRIPTION
## Context

Providers have the ability to change the setting which shows/hides the School Placements page to candidates when they are applying of any of their courses.

This only affects the courses for which the provider is the training provider.


## Changes proposed in this pull request

Add provider controls for turning on and off the school placement selection in apply and also showing / hiding the link on Find courses that shows the list of potential placement schools available.

## Guidance to review

[Screencast from 25-09-24 09:01:00.webm](https://github.com/user-attachments/assets/4d235a67-1620-44fe-a797-958aa0b54d3f)


## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
