### PR TITLE
Setup test undergraduate courses data for Find

### DIFF
--- a/lib/tasks/undergraduate_courses.rake
+++ b/lib/tasks/undergraduate_courses.rake
@@ -20,17 +20,36 @@ namespace :undergraduate do
                  'Mathematics'
                end
 
+        level = if provider.provider_name.include?('Primary')
+                  :primary
+                else
+                  :secondary
+                end
+
+        subjects = if level == :primary
+                     [Subject.find_by!(subject_name: 'Primary')]
+                   else
+                     [Subject.find_by!(subject_name: 'Mathematics')]
+                   end
+
         FactoryBot.find_or_create(
           :course,
           :published_teacher_degree_apprenticeship,
-          :secondary,
+          level,
           :with_a_level_requirements,
           :with_gcse_equivalency,
           provider:,
+          funding: 'apprenticeship',
           name:,
-          subjects: [Subject.find_by!(subject_name: 'Mathematics')],
+          subjects:,
           applications_open_from: 2.days.ago,
-          site_statuses: [FactoryBot.build(:site_status, :findable, site: FactoryBot.build(:site, provider:))]
+          site_statuses: [
+            FactoryBot.build(
+              :site_status,
+              :findable,
+              site: FactoryBot.build(:site, provider:)
+            )
+          ]
         )
       end
     end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -261,8 +261,19 @@ FactoryBot.define do
     end
 
     trait :published_teacher_degree_apprenticeship do
+      enrichments do
+        [
+          build(
+            :course_enrichment,
+            :published,
+            course_length: '4 years',
+            fee_uk_eu: nil,
+            fee_international: nil,
+            required_qualifications: nil
+          )
+        ]
+      end
       open
-      published
       undergraduate
       with_full_time_sites
       with_teacher_degree_apprenticeship


### PR DESCRIPTION
## Context

For some time we won't have any TDA course so for now we need to generate many courses to test Find or Publish.

So this rake task create TDA courses and make sure the data is more correct (no fees, no secondary courses for primary schools, etc)

## Guidance to review

1. Run the rake task `rake undergraduate:create`
2. Does it work locally when searching on Find?