### PR TITLE
Use a SKE subject code in entry requirements component preview

### DIFF
--- a/spec/components/find/courses/entry_requirements_component/view_preview.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_preview.rb
@@ -52,7 +52,7 @@ module Find
         end
 
         def mock_ske_course_attributes
-          mock_course_attributes.merge({ subjects: [Subject.new(subject_name: 'SKE Subject', subject_code: 'C1')] })
+          mock_course_attributes.merge({ subjects: [Subject.new(subject_name: 'SKE Subject', subject_code: 'G1')] })
         end
 
         def mock_primary_maths_ske_course_attributes


### PR DESCRIPTION
## Context

Our Component Preview is not showing the SKE notice because the Subject code used in it doesn't correspond to a subject for which the SKE notice should be displayed

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

![image](https://github.com/user-attachments/assets/928b0212-0ee7-40e7-89f1-4d8f28347537)

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
