### PR TITLE
Close the next cycle on QA

### DIFF
--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -33,6 +33,9 @@ current_recruitment_cycle_year: 2025
 
 features:
   send_request_data_to_bigquery: true
+    rollover:
+      can_edit_current_and_next_cycles: false
+
 
 find_valid_referers:
   - https://qa.find-teacher-training-courses.service.gov.uk


### PR DESCRIPTION
## Context

While QA is in the next cycle, we should close the second cycle because the 2026 cycle does not exist.
