### PR TITLE
Add provider E69 to rake task for enabling `selectable_schools`

### DIFF
--- a/lib/tasks/update_selectable_schools.rake
+++ b/lib/tasks/update_selectable_schools.rake
@@ -3,7 +3,7 @@
 module DataMigrations
   class SetSelectableSchoolsOnProviders
     def change
-      provider_codes = %w[E65 2CG 2CH 2CJ 2CK 2C1 1EX 1QU CS01 2X4 1ZO]
+      provider_codes = %w[E65 2CG 2CH 2CJ 2CK 2C1 1EX 1QU CS01 2X4 1ZO E69]
       Provider.where(provider_code: provider_codes).update_all(selectable_school: true)
     end
   end


### PR DESCRIPTION
## Context

Add another provider to the set of providers that should have `selectable_school` enabled for 2025.

## Changes proposed in this pull request

See the [Trello ticket](https://trello.com/c/pDpPujWe/2203-add-datamigration-to-set-selectable-school-on-providers) for the list of providers to enable

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
