### PR TITLE
Show specific no results message when searching undergraduate courses

### DIFF
--- a/app/components/find/results/no_results_component.html.erb
+++ b/app/components/find/results/no_results_component.html.erb
@@ -20,4 +20,13 @@
       You can try another search, for example by changing <%= "subject".pluralize(subjects.size) %> or location<% if results.with_salaries? %> or searching for courses that do not offer a salary<% end %>.
     </p>
   <% end %>
+
+  <% if show_undergraduate_courses? %>
+    <p class="govuk-body">
+      <%= t(".undergraduate.message_html", contact: govuk_mail_to(Settings.support_email)) %>
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to(t(".undergraduate.find_out_more_about_tda"), t("find.get_into_teaching.url_tda")) %>
+    </p>
+  <% end %>
 </div>

--- a/app/components/find/results/no_results_component.rb
+++ b/app/components/find/results/no_results_component.rb
@@ -7,7 +7,7 @@ module Find
 
       attr_reader :results
 
-      delegate :devolved_nation?, :country, :subjects, :with_salaries?, to: :results
+      delegate :devolved_nation?, :country, :subjects, :with_salaries?, :show_undergraduate_courses?, to: :results
 
       def initialize(results:)
         super

--- a/app/view_objects/find/results_view.rb
+++ b/app/view_objects/find/results_view.rb
@@ -207,6 +207,14 @@ module Find
       @all_subjects ||= Subject.select(:subject_name, :subject_code).order(:subject_name).all
     end
 
+    def show_undergraduate_courses?
+      Find::DegreeTypeAnswerDeterminer.new(
+        age_group: query_parameters['age_group'],
+        visa_status: query_parameters['visa_status'],
+        university_degree_status: query_parameters['university_degree_status']
+      ).show_undergraduate_courses?
+    end
+
     private
 
     def latitude

--- a/config/locales/en/components/find/no_results_component.yml
+++ b/config/locales/en/components/find/no_results_component.yml
@@ -1,0 +1,7 @@
+en:
+  find:
+    results:
+      no_results_component:
+        undergraduate:
+          message_html: There are not many teacher degree apprenticeship (TDA) courses on the service at the moment. You can try again soon when there may be more courses, or get in touch with us at %{contact}.
+          find_out_more_about_tda: Find out more about teacher degree apprenticeship (TDA) courses.

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -15,3 +15,5 @@ search_ui:
 authentication:
   secret: secret
   mode: persona
+
+current_recruitment_cycle_year: 2025

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -15,5 +15,3 @@ search_ui:
 authentication:
   secret: secret
   mode: persona
-
-current_recruitment_cycle_year: 2025

--- a/spec/components/find/results/no_results_component_spec.rb
+++ b/spec/components/find/results/no_results_component_spec.rb
@@ -4,12 +4,17 @@ require 'rails_helper'
 
 module Find
   describe Results::NoResultsComponent, type: :component do
+    let(:no_results_extra_message) do
+      'There are not many teacher degree apprenticeship (TDA) courses on the service at the moment. You can try again soon when there may be more courses, or get in touch with us at becomingateacher@digital.education.gov.uk.'
+    end
+
     it 'renders nothing if there are results' do
       results_view = instance_double(
         Find::ResultsView,
         country: 'Scotland',
         devolved_nation?: true,
-        no_results_found?: false
+        no_results_found?: false,
+        show_undergraduate_courses?: false
       )
       component = render_inline(described_class.new(results: results_view))
 
@@ -22,7 +27,8 @@ module Find
           Find::ResultsView,
           country: 'Scotland',
           devolved_nation?: true,
-          no_results_found?: true
+          no_results_found?: true,
+          show_undergraduate_courses?: false
         )
         component = render_inline(described_class.new(results: results_view))
 
@@ -35,7 +41,8 @@ module Find
             Find::ResultsView,
             country: 'Scotland',
             devolved_nation?: true,
-            no_results_found?: true
+            no_results_found?: true,
+            show_undergraduate_courses?: false
           )
           component = render_inline(described_class.new(results: results_view))
 
@@ -49,7 +56,8 @@ module Find
             Find::ResultsView,
             country: 'Wales',
             devolved_nation?: true,
-            no_results_found?: true
+            no_results_found?: true,
+            show_undergraduate_courses?: false
           )
           component = render_inline(described_class.new(results: results_view))
 
@@ -63,12 +71,45 @@ module Find
             Find::ResultsView,
             country: 'Northern Ireland',
             devolved_nation?: true,
-            no_results_found?: true
+            no_results_found?: true,
+            show_undergraduate_courses?: false
           )
           component = render_inline(described_class.new(results: results_view))
 
           expect(component).to have_link('Learn more about teacher training in Northern Ireland', href: 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland')
         end
+      end
+    end
+
+    context 'when no results for undergraduate' do
+      it 'does show extra message' do
+        results_view = Find::ResultsView.new(
+          query_parameters: ActionController::Parameters.new(
+            'age_group' => 'secondary',
+            'can_sponsor_visa' => 'false',
+            'has_vacancies' => 'true',
+            'university_degree_status' => 'false',
+            'visa_status' => 'false'
+          )
+        )
+        component = render_inline(described_class.new(results: results_view))
+        expect(component.text).to include(no_results_extra_message)
+      end
+    end
+
+    context 'when no results for postgraduate' do
+      it 'does not show extra message' do
+        results_view = Find::ResultsView.new(
+          query_parameters: ActionController::Parameters.new(
+            'age_group' => 'secondary',
+            'can_sponsor_visa' => 'false',
+            'has_vacancies' => 'true',
+            'university_degree_status' => 'true',
+            'visa_status' => 'false'
+          )
+        )
+        component = render_inline(described_class.new(results: results_view))
+        expect(component.text).not_to include(no_results_extra_message)
       end
     end
 
@@ -81,7 +122,8 @@ module Find
             devolved_nation?: false,
             subjects: %w[Math English],
             with_salaries?: false,
-            no_results_found?: true
+            no_results_found?: true,
+            show_undergraduate_courses?: false
           )
           component = render_inline(described_class.new(results: results_view))
 
@@ -99,7 +141,8 @@ module Find
             devolved_nation?: false,
             subjects: %w[Math],
             with_salaries?: false,
-            no_results_found?: true
+            no_results_found?: true,
+            show_undergraduate_courses?: false
           )
           component = render_inline(described_class.new(results: results_view))
 
@@ -116,7 +159,8 @@ module Find
             devolved_nation?: false,
             subjects: %w[Math],
             with_salaries?: true,
-            no_results_found?: true
+            no_results_found?: true,
+            show_undergraduate_courses?: false
           )
           component = render_inline(described_class.new(results: results_view))
 

--- a/spec/components/find/results/results_component_spec.rb
+++ b/spec/components/find/results/results_component_spec.rb
@@ -20,7 +20,8 @@ module Find
           subjects: [],
           number_of_courses_string: 'No courses',
           no_results_found?: true,
-          has_results?: false
+          has_results?: false,
+          show_undergraduate_courses?: false
         )
       end
 


### PR DESCRIPTION
## Context

When Teacher Degree Apprenticeships launches it is likely there will be no or very little courses available.

This may cause a dead end on the search results page, which isn’t a good user journey.

Adding a more detailed explanation could help users.

This is a short term solution and there are talks for a long term solution if this problem persists.

## Changes

![screencapture-find-localhost-results-2024-09-26-17_50_59](https://github.com/user-attachments/assets/fefc1330-6aef-436a-94bc-d88aeb9fa290)


## Guidance to review

1. Enter on review
2. Answer that you don't have a degree
3. See no results page and see content