### PR TITLE
[2049] End rollover 2024

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,8 +41,8 @@ cookies:
     name: _consented_to_analytics_cookies
     expire_after_days: 182
 
-current_recruitment_cycle_year: 2024
-next_cycle_open_date: 2024-10-1
+current_recruitment_cycle_year: 2025
+next_cycle_open_date: 2025-10-1 # TBC
 
 govuk_notify:
   api_key: please_change_me
@@ -97,7 +97,7 @@ features:
     # actually starting when it would be set to false
     has_current_cycle_started?: true
     # During rollover providers should be able to edit current & next recruitment cycle courses
-    can_edit_current_and_next_cycles: true
+    can_edit_current_and_next_cycles: false
 
 cookies:
   session:

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -26,12 +26,8 @@ authentication:
 basic_auth:
   enabled: true
 
-current_recruitment_cycle_year: 2025
-
 features:
   send_request_data_to_bigquery: true
-  rollover:
-    can_edit_current_and_next_cycles: false
 
 
 find_valid_referers:

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -76,34 +76,6 @@ describe Find::Courses::TrainingLocations::View, type: :component do
       end
     end
 
-    context 'when preview is true for a 2024 provider and the provider does not have selectable_school enabled' do
-      let(:year) { 2024 }
-      let(:selectable_school) { false }
-      let(:preview) { true }
-
-      it 'renders a link to the publish path' do
-        expect(subject).to have_link(
-          'View list of school placements',
-          href: url_helpers.placements_publish_provider_recruitment_cycle_course_path(
-            course.provider_code,
-            course.recruitment_cycle_year,
-            course.course_code
-          )
-        )
-      end
-    end
-
-    context 'when preview is false for a 2024 provider and the provider has selectable_school enabled' do
-      let(:year) { 2024 }
-      let(:selectable_school) { true }
-      let(:preview) { false }
-
-      it 'renders a link to the find path' do
-        expect(subject).to have_link('View list of school placements',
-                                     href: url_helpers.find_placements_path(course.provider_code, course.course_code))
-      end
-    end
-
     context 'when preview is false after find opens in 2025 and provider has selectable_school enabled' do
       let(:year) { 2025 }
       let(:selectable_school) { true }

--- a/spec/controllers/publish/courses/outcome_controller_spec.rb
+++ b/spec/controllers/publish/courses/outcome_controller_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Publish::Courses::OutcomeController do
-  let(:recruitment_cycle) { create(:recruitment_cycle, year: 2025) }
-  let(:user) { create(:user, providers: [build(:provider, recruitment_cycle:)]) }
+  let(:user) { create(:user, providers: [build(:provider)]) }
   let(:provider) { user.providers.first }
 
   before do

--- a/spec/features/find/result_page_filters/back_to_results_spec.rb
+++ b/spec/features/find/result_page_filters/back_to_results_spec.rb
@@ -22,6 +22,9 @@ RSpec.feature 'Back to results back button' do
     and_i_select_the_primary_subject_checkbox
     and_i_click_continue
 
+    and_i_choose_yes_i_have_a_degree
+    and_i_click_continue
+
     and_i_select_my_visa_status
     and_i_click_find_courses
 
@@ -43,6 +46,10 @@ RSpec.feature 'Back to results back button' do
     create(:course, :published, :with_salary, application_status: 'open', site_statuses: [build(:site_status, :findable)])
 
     create(:course, :secondary, :published, :with_salary, application_status: 'open', site_statuses: [build(:site_status, :findable)])
+  end
+
+  def and_i_choose_yes_i_have_a_degree
+    choose 'Yes, I have a degree or am studying for one'
   end
 
   def when_i_visit_the_start_page

--- a/spec/features/find/result_page_filters/engineers_teach_physics_spec.rb
+++ b/spec/features/find/result_page_filters/engineers_teach_physics_spec.rb
@@ -14,12 +14,14 @@ RSpec.feature 'Engineers teach physics' do
 
   scenario 'Candidate searches for physics subject' do
     given_i_choose_physics
+    and_i_choose_yes_i_have_a_degree
     and_i_provide_my_visa_status
     then_i_see_that_the_etp_checkbox_is_unchecked
   end
 
   scenario 'Candidate searches for any other subject' do
     given_i_choose_music
+    and_i_choose_yes_i_have_a_degree
     and_i_provide_my_visa_status
     then_i_dont_see_the_etp_checkbox
   end
@@ -61,5 +63,14 @@ RSpec.feature 'Engineers teach physics' do
 
   def then_i_dont_see_the_etp_checkbox
     expect(find_results_page).to have_no_text('Only show Engineers teach physics courses')
+  end
+
+  def and_i_choose_yes_i_have_a_degree
+    choose 'Yes, I have a degree or am studying for one'
+    and_i_click_continue
+  end
+
+  def and_i_click_continue
+    click_link_or_button 'Continue'
   end
 end

--- a/spec/features/find/search/across_england/primary_spec.rb
+++ b/spec/features/find/search/across_england/primary_spec.rb
@@ -42,13 +42,21 @@ feature 'Searching across England' do
 
     when_i_select_the_primary_subject_textbox
     and_i_click_continue
+
+    and_i_choose_yes_i_have_a_degree
+    and_i_click_continue
+
     then_i_should_see_the_visa_status_page
 
     when_i_click_find_courses
     then_i_should_see_a_validation_error
 
     when_i_click_back
+    and_i_click_back
     then_i_should_see_the_subjects_form
+    and_i_click_continue
+
+    and_i_choose_yes_i_have_a_degree
     and_i_click_continue
 
     when_i_select_my_visa_status
@@ -131,6 +139,8 @@ feature 'Searching across England' do
   end
   alias_method :when_i_click_find_courses, :and_i_click_find_courses
 
+  alias_method :and_i_click_back, :when_i_click_back
+
   def then_i_should_see_a_subjects_validation_error
     expect(page).to have_content('Select at least one primary subject you want to teach')
   end
@@ -143,6 +153,10 @@ feature 'Searching across England' do
     expect(page).to have_content('Do you need visa sponsorship?')
   end
 
+  def and_i_choose_yes_i_have_a_degree
+    choose 'Yes, I have a degree or am studying for one'
+  end
+
   def when_i_select_my_visa_status
     choose 'No'
   end
@@ -152,7 +166,7 @@ feature 'Searching across England' do
   end
 
   def then_i_should_see_the_find_results_page
-    expect(page).to have_current_path('/results?age_group=primary&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00&visa_status=false')
+    expect(page).to have_current_path('/results?age_group=primary&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00&university_degree_status=true&visa_status=false')
   end
 
   def and_i_should_see_the_correct_courses

--- a/spec/features/find/search/across_england/secondary_spec.rb
+++ b/spec/features/find/search/across_england/secondary_spec.rb
@@ -32,6 +32,8 @@ feature 'Searching across England' do
 
     when_i_select_the_secondary_subject
     and_i_click_continue
+    and_i_choose_yes_i_have_a_degree
+    and_i_click_continue
     then_i_should_see_the_visa_status_page
 
     when_i_choose_no_to_visa_sponsorship
@@ -67,6 +69,10 @@ feature 'Searching across England' do
   end
 
   private
+
+  def and_i_choose_yes_i_have_a_degree
+    choose 'Yes, I have a degree or am studying for one'
+  end
 
   def and_i_see_that_the_visa_checkbox_is_not_checked
     expect(page).to have_no_checked_field('Only show courses with visa sponsorship')
@@ -167,7 +173,7 @@ feature 'Searching across England' do
   end
 
   def then_i_should_see_the_find_results_page
-    expect(page).to have_current_path('/results?age_group=secondary&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=C1&visa_status=false')
+    expect(page).to have_current_path('/results?age_group=secondary&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=C1&university_degree_status=true&visa_status=false')
   end
 
   def and_i_should_see_the_correct_courses

--- a/spec/features/find/search/editing_a_search_spec.rb
+++ b/spec/features/find/search/editing_a_search_spec.rb
@@ -32,6 +32,8 @@ feature 'Editing a search' do
     and_i_click_continue
     and_i_select_the_primary_subject_checkbox
     and_i_click_continue
+    and_i_choose_yes_i_have_a_degree
+    and_i_click_continue
     and_i_choose_yes_to_visa_sponsorship
     and_i_click_find_courses
     and_i_see_that_the_visa_checkbox_is_checked
@@ -60,6 +62,10 @@ feature 'Editing a search' do
     expect(find_field('Primary')).to be_checked
   end
 
+  def and_i_choose_yes_i_have_a_degree
+    choose 'Yes, I have a degree or am studying for one'
+  end
+
   def and_i_select_the_primary_radio_button
     find_age_groups_page.primary.choose
   end
@@ -78,7 +84,7 @@ feature 'Editing a search' do
 
   def then_i_should_see_the_find_results_page
     expect(find_results_page).to be_displayed
-    expect(find_results_page.current_url).to end_with('/results?age_group=primary&applications_open=true&can_sponsor_visa=true&has_vacancies=true&l=2&subjects%5B%5D=00&visa_status=true')
+    expect(find_results_page.current_url).to end_with('/results?age_group=primary&applications_open=true&can_sponsor_visa=true&has_vacancies=true&l=2&subjects%5B%5D=00&university_degree_status=true&visa_status=true')
   end
 
   def when_i_change_my_search_query
@@ -99,7 +105,7 @@ feature 'Editing a search' do
 
   def then_i_should_see_the_subjects_form
     expect(find_primary_subjects_page.current_url).to end_with(
-      '/subjects?age_group=primary&applications_open=true&can_sponsor_visa=true&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00&visa_status=true'
+      '/subjects?age_group=primary&applications_open=true&can_sponsor_visa=true&has_vacancies=true&l=2&qualification%5B%5D=qts&qualification%5B%5D=pgce_with_qts&qualification%5B%5D=pgce+pgde&send_courses=false&study_type%5B%5D=full_time&study_type%5B%5D=part_time&subjects%5B%5D=00&university_degree_status=true&visa_status=true'
     )
   end
 

--- a/spec/features/find/search/undergraduate/course_results_spec.rb
+++ b/spec/features/find/search/undergraduate/course_results_spec.rb
@@ -85,24 +85,6 @@ feature 'Questions and results for undergraduate courses' do
     and_some_filters_are_visible_for_undergraduate_courses
   end
 
-  scenario 'in the 2024 cycle with the TDA feature active' do
-    given_i_have_2024_courses
-    and_i_am_in_the_2024_cycle
-    and_the_tda_feature_flag_is_active
-    when_i_visit_the_start_page
-    and_i_select_the_across_england_radio_button
-    and_i_click_continue
-    and_i_choose_secondary
-    and_i_click_continue
-    and_i_choose_subjects
-    and_i_click_continue
-    then_i_am_on_the_visa_status_page
-    when_i_choose_no
-    and_i_click_find_courses
-    then_i_am_on_results_page
-    and_all_filters_are_visible
-  end
-
   scenario 'in the 2025 cycle with the TDA feature active and searching for further education courses' do
     given_i_have_2025_courses
     and_i_am_in_the_2025_cycle
@@ -186,8 +168,7 @@ feature 'Questions and results for undergraduate courses' do
   end
 
   scenario 'when there are no results' do
-    given_2025_cycle_started
-    and_the_tda_feature_flag_is_active
+    given_the_tda_feature_flag_is_active
     when_i_visit_the_start_page
     and_i_choose_to_find_courses_by_location
     and_i_add_a_location
@@ -205,7 +186,7 @@ feature 'Questions and results for undergraduate courses' do
   end
 
   def given_i_have_2025_courses
-    _, provider = setup_recruitment_cycle(year: 2025)
+    provider = create(:provider)
 
     @biology_course = create(:course, :published_teacher_degree_apprenticeship, :secondary, provider:, name: 'Biology', subjects: [find_or_create(:secondary_subject, :biology)])
     @history_course = create(:course, :published_teacher_degree_apprenticeship, :secondary, provider:, name: 'History', subjects: [find_or_create(:secondary_subject, :history)])
@@ -216,7 +197,7 @@ feature 'Questions and results for undergraduate courses' do
   end
 
   def given_i_have_2025_courses_in_different_locations
-    _, provider = setup_recruitment_cycle(year: 2025)
+    provider = create(:provider)
 
     @york_biology_course = create(
       :course,
@@ -252,42 +233,9 @@ feature 'Questions and results for undergraduate courses' do
     )
   end
 
-  def setup_recruitment_cycle(year:, provider_code: 'IBJ')
-    recruitment_cycle = create(:recruitment_cycle, year:)
-    user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
-    provider = user.providers.first
-    create(:provider, :accredited_provider, provider_code:)
-    accredited_provider = create(:provider, :accredited_provider, provider_code:, recruitment_cycle:)
-    provider.accrediting_provider_enrichments = []
-    provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
-      {
-        UcasProviderCode: accredited_provider.provider_code,
-        Description: 'description'
-      }
-    )
-    [recruitment_cycle, provider]
-  end
-
-  def given_i_have_2024_courses
-    _, provider = setup_recruitment_cycle(year: 2024)
-
-    create(:course, :resulting_in_pgce_with_qts, provider:, name: 'Chemistry')
-    create(:course, :resulting_in_pgce_with_qts, provider:, name: 'Mathematics')
-  end
-
   def and_i_am_in_the_2025_cycle
     Timecop.travel(Find::CycleTimetable.find_reopens)
     allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
-  end
-
-  def given_2025_cycle_started
-    setup_recruitment_cycle(year: 2025, provider_code: '1BL')
-    and_i_am_in_the_2025_cycle
-  end
-
-  def and_i_am_in_the_2024_cycle
-    Timecop.travel(Find::CycleTimetable.find_opens)
-    allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2024)
   end
 
   def and_the_tda_feature_flag_is_active
@@ -545,4 +493,6 @@ feature 'Questions and results for undergraduate courses' do
       'Find out more about teacher degree apprenticeship (TDA) courses.'
     )
   end
+
+  alias_method :given_the_tda_feature_flag_is_active, :and_the_tda_feature_flag_is_active
 end

--- a/spec/features/find/search/undergraduate/viewing_a_course_spec.rb
+++ b/spec/features/find/search/undergraduate/viewing_a_course_spec.rb
@@ -18,11 +18,10 @@ feature 'Viewing an undergraduate course' do
   end
 
   def given_there_is_a_findable_undergraduate_course
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     provider = user.providers.first
-    create(:provider, :accredited_provider, provider_code: '1BJ')
-    accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    create(:provider, :accredited_provider, provider_code: '1BK')
+    accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ')
     provider.accrediting_provider_enrichments = []
     provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -136,11 +136,10 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -34,10 +34,10 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
   context 'TDA course' do
     scenario 'changing the outcome from non TDA to TDA' do
-      given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+      given_i_am_authenticated_as_a_provider_user
       and_the_tda_feature_flag_is_active
       and_there_is_a_qts_course_i_want_to_edit
-      when_i_visit_the_course_outcome_page_in_the_next_cycle
+      when_i_visit_the_course_outcome_page
       and_i_choose_undergraduate_degree_with_qts
       and_the_degree_type_is_postgraduate
       and_i_submit
@@ -46,10 +46,10 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
     context 'fee course' do
       scenario 'changing the outcome from TDA to non TDA' do
-        given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+        given_i_am_authenticated_as_a_provider_user
         and_the_tda_feature_flag_is_active
         and_there_is_a_tda_course_i_want_to_edit
-        when_i_visit_the_course_outcome_page_in_the_next_cycle
+        when_i_visit_the_course_outcome_page
         and_the_degree_type_is_undergraduate
         and_i_choose_qts
         and_the_degree_type_is_postgraduate
@@ -75,10 +75,10 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
 
     context 'salaried course' do
       scenario 'changing the outcome from TDA to non TDA' do
-        given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
+        given_i_am_authenticated_as_a_provider_user
         and_the_tda_feature_flag_is_active
         and_there_is_a_tda_course_i_want_to_edit
-        when_i_visit_the_course_outcome_page_in_the_next_cycle
+        when_i_visit_the_course_outcome_page
         and_the_degree_type_is_undergraduate
         and_i_choose_qts
         and_the_degree_type_is_postgraduate
@@ -91,15 +91,6 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
         then_i_see_the_correct_attributes_in_the_database_for_salaried
       end
     end
-  end
-
-  def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
-    next_cycle_providers = [build(:provider, :next_recruitment_cycle, :accredited_provider,
-                                  courses: [create(:course, :with_accrediting_provider)],
-                                  sites: [build(:site), build(:site)],
-                                  study_sites: [build(:site, :study_site)])]
-    @next_cycle_user = create(:user, providers: next_cycle_providers)
-    given_i_am_authenticated(user: @next_cycle_user)
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -153,7 +144,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   end
 
   def then_i_am_shown_the_correct_qts_options
-    expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('QTS', 'QTS with PGCE', 'PGDE with QTS')
+    expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('QTS', 'QTS with PGCE', 'PGDE with QTS', 'Teacher degree apprenticeship (TDA) with QTS')
   end
 
   def then_i_am_shown_the_correct_non_qts_options
@@ -193,29 +184,12 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     @current_user.providers.first
   end
 
-  def given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
-    next_cycle_providers = [build(:provider, :accredited_provider, :next_recruitment_cycle,
-                                  courses: [create(:course, :with_accrediting_provider, study_mode: 'part_time', funding: 'fee', can_sponsor_skilled_worker_visa: true)])]
-    @next_cycle_user = create(:user, providers: next_cycle_providers)
-    given_i_am_authenticated(user: @next_cycle_user)
-  end
-
-  def next_cycle_provider
-    @provider ||= @current_user.providers.first
-  end
-
   def and_the_tda_feature_flag_is_active
     allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   def and_there_is_a_qts_course_i_want_to_edit
     given_a_course_exists(:resulting_in_qts, study_mode: 'part_time', funding_type: 'fee', can_sponsor_skilled_worker_visa: true)
-  end
-
-  def when_i_visit_the_course_outcome_page_in_the_next_cycle
-    publish_courses_outcome_edit_page.load(
-      provider_code: next_cycle_provider.provider_code, recruitment_cycle_year: next_cycle_provider.recruitment_cycle_year, course_code: next_cycle_provider.courses.first.course_code
-    )
   end
 
   def and_the_degree_type_is_undergraduate

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -218,11 +218,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def given_i_am_authenticated_as_a_school_direct_provider_user
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {
@@ -239,7 +238,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     @user = create(
       :user,
       providers: [
-        create(:provider, :scitt, recruitment_cycle: build(:recruitment_cycle, year: 2025), sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
+        create(:provider, :scitt, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
       ]
     )
     given_i_am_authenticated(

--- a/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
+++ b/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
@@ -67,11 +67,10 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {

--- a/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
+++ b/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
@@ -17,11 +17,10 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    recruitment_cycle = create(:recruitment_cycle, year: 2025)
-    @user = create(:user, providers: [build(:provider, recruitment_cycle:, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
     create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BJ', recruitment_cycle:)
+    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -326,7 +326,7 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
       :open,
       :secondary,
       funding: 'fee',
-      applications_open_from: Time.zone.tomorrow,
+      applications_open_from: RecruitmentCycle.current.application_start_date,
       accrediting_provider:,
       site_statuses:, enrichments: [course_enrichment],
       study_sites: [study_site],


### PR DESCRIPTION
## Context

**This PR will end rollover. Do not merge until Tuesday 1st of October 2024.**

This PR will close the `2024` recruitment cycle and the `2025` recruitment cycle will become the `current_recruitment_cycle`.


## Changes proposed in this pull request

- Update `recruitment_cycle_year`
- Remove rollover settings from QA (these would now be duplicated)
- Fix failing tests

## Guidance to review

Have a general click around on the review app and ensure all the functionality still works as expected.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
