### PR TITLE
[2367] Scale pods for start of cycle

### DIFF
--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -8,7 +8,7 @@
   "resource_group_name": "s189p01-ptt-pd-rg",
   "main_app": {
     "main": {
-      "replicas": 4,
+      "replicas": 8,
       "max_memory": "3Gi"
     }
   },


### PR DESCRIPTION
## Context

We know that a large proportion of the total number of applications are made within the first week of apply opening (8 October). In the run up to this, potential candidates will be searching for courses as soon as find opens on 1 October. 

## Changes proposed in this pull request

Increases the number of web replicas. We will revert this change after apply has been open for a week (15 October). 

## Guidance to review

We are not increasing the workers at this point, but can do it on the fly if required. 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [x] Attach PR to Trello card
