### PR TITLE
[2349] Add a link to the Find service's Feature Flags in Publish Support Interface

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -25,7 +25,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def find_url(provider = object.provider)
-    h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
+    h.x_find_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
   end
 
   def description
@@ -35,7 +35,7 @@ class CourseDecorator < ApplicationDecorator
   def on_find(provider = object.provider)
     if object.findable?
       if current_cycle_and_open?
-        h.govuk_link_to('Yes - view online', h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code))
+        h.govuk_link_to('Yes - view online', h.x_find_course_page_url(provider_code: provider.provider_code, course_code: object.course_code))
       else
         "No - live on #{l(Settings.next_cycle_open_date.to_date, format: :govuk_short)}"
       end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -19,7 +19,7 @@ module ViewHelper
   end
 
   def x_find_course_page_url(provider_code:, course_code:)
-    x_find_url("/course/#{provider_code}/#{course_code}")
+    x_find_url(find_course_path(provider_code, course_code))
   end
 
   def bat_contact_email_address

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -14,12 +14,12 @@ module ViewHelper
     )
   end
 
-  def search_ui_url(relative_path)
-    URI.join(Settings.search_ui.base_url, relative_path).to_s
+  def x_find_url(relative_path)
+    URI.join(Settings.find_url, relative_path).to_s
   end
 
-  def search_ui_course_page_url(provider_code:, course_code:)
-    search_ui_url("/course/#{provider_code}/#{course_code}")
+  def x_find_course_page_url(provider_code:, course_code:)
+    x_find_url("/course/#{provider_code}/#{course_code}")
   end
 
   def bat_contact_email_address

--- a/app/views/find/courses/accrediting_providers/show.html.erb
+++ b/app/views/find/courses/accrediting_providers/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    href: search_ui_course_page_url(
+    href: x_find_course_page_url(
       provider_code: @course.provider_code,
       course_code: @course.course_code
     ),

--- a/app/views/find/courses/providers/show.html.erb
+++ b/app/views/find/courses/providers/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    href: search_ui_course_page_url(
+    href: x_find_course_page_url(
       provider_code: @course.provider_code,
       course_code: @course.course_code
     ),

--- a/app/views/find/courses/training_with_disabilities/show.html.erb
+++ b/app/views/find/courses/training_with_disabilities/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    href: search_ui_course_page_url(
+    href: x_find_course_page_url(
       provider_code: @course.provider_code,
       course_code: @course.course_code
     ),

--- a/app/views/find/placements/index.html.erb
+++ b/app/views/find/placements/index.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    href: search_ui_course_page_url(
+    href: x_find_course_page_url(
       provider_code: @course.provider_code,
       course_code: @course.course_code
     ),

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -15,7 +15,7 @@
     <% if course.scheduled? %>
      <%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
     <% else %>
-      <%= govuk_link_to search_ui_course_page_url(provider_code: course.provider.provider_code, course_code: course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
+      <%= govuk_link_to x_find_course_page_url(provider_code: course.provider.provider_code, course_code: course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
       View on Find <span class="govuk-visually-hidden">teacher training courses</span>
       <% end %>
     <% end %>

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,4 +1,5 @@
 <%= render TabNavigation.new(items: [
 { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
-{ name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) }
+{ name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
+{ name: "Find - Feature Flags", url: x_find_url(find_feature_flags_path) }
 ]) %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,8 +4,7 @@ environment:
 support_email: becomingateacher@digital.education.gov.uk
 campaign_email: itt.engagement@education.gov.uk
 
-search_ui:
-  base_url: https://find.localhost
+find_url: https://find.localhost
 
 # URL of this app for the callback after sigining in
 base_url: https://localhost:3001
@@ -57,9 +56,6 @@ govuk_notify:
   new_user_added_by_support_team_id: 4da327dd-907a-4619-abe6-45f348bb2fa3
   remove_user_from_organisation_id: e75ad04e-4efa-4b1a-ae65-b007758483f4
   user_added_as_organisation_to_training_partner_id: 47d3509f-eeac-49a5-a455-e4a911c93496
-publish_url: http://localhost:3000
-find_url: http://localhost:3002
-extra_find_url: http://localhost:3002
 mcbg:
   redis_password: <%= SecureRandom.base64 %>
 system_authentication_token: <%= SecureRandom.base64 %>

--- a/config/settings/loadtest.yml
+++ b/config/settings/loadtest.yml
@@ -7,9 +7,6 @@ apply_base_url: https://apply-loadtest.london.cloudapps.digital
 # URL of this app for the callback after signing in
 base_url: https://publish-loadtest.london.cloudapps.digital
 
-search_ui:
-  base_url: https://find-loadtest.london.cloudapps.digital
-
 environment:
   label: "Load test"
   name: "loadtest"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -6,9 +6,6 @@ extra_find_url: https://find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 
-search_ui:
-  base_url: https://find-teacher-training-courses.service.gov.uk
-
 base_url: https://www.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -6,9 +6,6 @@ extra_find_url: https://find-teacher-training-courses.service.gov.uk
 
 STATE_CHANGE_SLACK_URL: replace_me
 
-search_ui:
-  base_url: https://find-teacher-training-courses.service.gov.uk
-
 base_url: https://www.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -5,9 +5,6 @@ find_url: https://qa.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
-search_ui:
-  base_url: https://qa.find-teacher-training-courses.service.gov.uk
-
 # URL of this app for the callback after sigining in
 base_url: https://qa.publish-teacher-training-courses.service.gov.uk
 

--- a/config/settings/qa_aks.yml
+++ b/config/settings/qa_aks.yml
@@ -5,9 +5,6 @@ find_url: https://qa.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 
-search_ui:
-  base_url: https://qa.find-teacher-training-courses.service.gov.uk
-
 # URL of this app for the callback after sigining in
 base_url: https://qa.publish-teacher-training-courses.service.gov.uk
 

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -9,8 +9,6 @@ publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
-search_ui:
-  base_url: https://qa.find-teacher-training-courses.service.gov.uk
 
 authentication:
   secret: secret

--- a/config/settings/review_aks.yml
+++ b/config/settings/review_aks.yml
@@ -9,8 +9,6 @@ publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://qa.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
-search_ui:
-  base_url: https://qa.find-teacher-training-courses.service.gov.uk
 
 authentication:
   secret: secret

--- a/config/settings/rollover.yml
+++ b/config/settings/rollover.yml
@@ -9,9 +9,6 @@ environment:
   label: "Rollover"
   name: "rollover"
 
-search_ui:
-  base_url: https://find-rollover.london.cloudapps.digital
-
 base_url: https://publish-rollover.london.cloudapps.digital
 
 dfe_signin:

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -9,9 +9,6 @@ environment:
   label: "Sandbox"
   name: "sandbox"
 
-search_ui:
-  base_url: https://sandbox.find-teacher-training-courses.service.gov.uk
-
 base_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:

--- a/config/settings/sandbox_aks.yml
+++ b/config/settings/sandbox_aks.yml
@@ -9,9 +9,6 @@ environment:
   label: "Sandbox"
   name: "sandbox"
 
-search_ui:
-  base_url: https://sandbox.find-teacher-training-courses.service.gov.uk
-
 base_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -5,9 +5,6 @@ find_url: https://staging.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
-search_ui:
-  base_url: https://staging.find-teacher-training-courses.service.gov.uk
-
 # URL of this app for the callback after sigining in
 base_url: https://staging.publish-teacher-training-courses.service.gov.uk
 

--- a/config/settings/staging_aks.yml
+++ b/config/settings/staging_aks.yml
@@ -5,9 +5,6 @@ find_url: https://staging.find-teacher-training-courses.service.gov.uk
 extra_find_url: https://staging.find-teacher-training-courses.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 
-search_ui:
-  base_url: https://staging.find-teacher-training-courses.service.gov.uk
-
 # URL of this app for the callback after sigining in
 base_url: https://staging.publish-teacher-training-courses.service.gov.uk
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -75,10 +75,6 @@ describe CourseDecorator do
     expect(decorated_course.is_send?).to eq('No')
   end
 
-  # it "returns the Find URL" do
-  #   expect(decorated_course.find_url).to eq("#{Settings.search_ui.base_url}/course/#{provider.provider_code}/#{course.course_code}")
-  # end
-
   it 'returns course length' do
     allow(course.enrichments).to receive(:most_recent).and_return([course_enrichment])
 

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -422,7 +422,7 @@ feature 'Viewing a findable course' do
   def then_i_should_be_on_the_course_page
     expect(page.current_url).to eq(
       URI.join(
-        Settings.search_ui.base_url,
+        Settings.find_url,
         "/course/#{@course.provider_code}/#{@course.course_code}"
       ).to_s
     )

--- a/spec/requests/find/feature_flags_spec.rb
+++ b/spec/requests/find/feature_flags_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Find
+  describe '/feature-flags' do
+    before do
+      host! 'www.find-example.com'
+    end
+
+    it 'responds with unauthorized without basic auth' do
+      get '/feature-flags'
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'responds with 200 without basic auth' do
+      get '/feature-flags', headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'password') }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We use FeatureFlags to control some aspects of the Find services state. These FeatureFlags are not easily found. We can add a link to the feature flags in the Publish Support console.



## Changes proposed in this pull request

1. Add a link in the Publish Support console Navigation Bar to the Find Feature Flags
2. Replace `Settings.search_ui.base_url` with `Settings.find_url`
3. Replace ViewHelper#search_ui_url` with `#x_find_url`
The `x_` prefix is to help easily distinguish a method we've added from rails named routes that are generated. 

## Guidance to review

![image](https://github.com/user-attachments/assets/1f181d62-375b-4d73-bb00-441a8e83c63b)


## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
