### PR TITLE
2382 course fee is wrong when changing non tda to tda course

### DIFF
--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -23,7 +23,8 @@ module Find
                  :study_mode,
                  :salaried?,
                  :can_sponsor_student_visa,
-                 :can_sponsor_skilled_worker_visa, to: :course
+                 :can_sponsor_skilled_worker_visa,
+                 :no_fee?, to: :course
 
         def initialize(course)
           super
@@ -50,10 +51,6 @@ module Find
           else
             'Visas cannot be sponsored'
           end
-        end
-
-        def no_fee?
-          course.fee_international.blank? && course.fee_uk_eu.blank?
         end
 
         def show_apply_from_row?

--- a/app/components/find/results/search_result_component.rb
+++ b/app/components/find/results/search_result_component.rb
@@ -7,7 +7,9 @@ module Find
 
       attr_reader :course, :sites_count
 
-      delegate :age_range_in_years_and_level, :course_length_with_study_mode, to: :course
+      delegate :age_range_in_years_and_level,
+               :course_length_with_study_mode,
+               :no_fee?, to: :course
 
       def initialize(course:, results_view:, filtered_by_location: false)
         super
@@ -81,10 +83,6 @@ module Find
         else
           'Visas cannot be sponsored'
         end
-      end
-
-      def no_fee?
-        course.fee_international.blank? && course.fee_uk_eu.blank?
       end
 
       def accredited_provider

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -505,6 +505,11 @@ class CourseDecorator < ApplicationDecorator
     )
   end
 
+  def no_fee?
+    object.teacher_degree_apprenticeship? ||
+      (fee_international.blank? && fee_uk_eu.blank?)
+  end
+
   private
 
   def not_on_find

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -506,8 +506,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def no_fee?
-    object.teacher_degree_apprenticeship? ||
-      (fee_international.blank? && fee_uk_eu.blank?)
+    !object.fee?
   end
 
   private

--- a/app/services/publish/courses/assign_tda_attributes_service.rb
+++ b/app/services/publish/courses/assign_tda_attributes_service.rb
@@ -38,7 +38,10 @@ module Publish
           course_enrichment = @course.enrichments.find_or_initialize_draft
           course_enrichment.course_length = '4 years'
         else
-          @course.enrichments.max_by(&:created_at).update(course_length: '4 years')
+          @course
+            .enrichments
+            .max_by(&:created_at)
+            .update(course_length: '4 years', fee_details: nil, fee_international: nil, fee_uk_eu: nil)
         end
       end
     end

--- a/spec/components/find/courses/sumary_component/view_preview.rb
+++ b/spec/components/find/courses/sumary_component/view_preview.rb
@@ -67,6 +67,10 @@ module Find
             has_bursary
           end
 
+          def teacher_degree_apprenticeship?
+            true
+          end
+
           def enrichment_attribute(params)
             send(params)
           end

--- a/spec/components/find/courses/sumary_component/view_preview.rb
+++ b/spec/components/find/courses/sumary_component/view_preview.rb
@@ -67,7 +67,7 @@ module Find
             has_bursary
           end
 
-          def teacher_degree_apprenticeship?
+          def fee?
             true
           end
 

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -23,6 +23,16 @@ module Find
           )
         end
 
+        context 'when teacher degree apprenticeship courses has incorrectly fees' do
+          it 'does not render fees' do
+            course = create(:course, :published_teacher_degree_apprenticeship, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
+
+            result = render_inline(described_class.new(course))
+            expect(result.text).not_to include('£9,250')
+            expect(result.text).not_to include('Course fee')
+          end
+        end
+
         context 'applications open date has not passed' do
           it "renders the 'Date you can apply from'" do
             course = build(

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -23,7 +23,7 @@ module Find
           )
         end
 
-        context 'when teacher degree apprenticeship courses has incorrectly fees' do
+        context 'when teacher degree apprenticeship course has incorrect fees' do
           it 'does not render fees' do
             course = create(:course, :published_teacher_degree_apprenticeship, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -8,7 +8,7 @@ module Find
       describe View do
         it 'renders sub sections' do
           provider = build(:provider).decorate
-          course = create(:course, :draft_enrichment, applications_open_from: Time.zone.tomorrow, provider:).decorate
+          course = create(:course, :fee, :draft_enrichment, applications_open_from: Time.zone.tomorrow, provider:).decorate
 
           result = render_inline(described_class.new(course))
           expect(result.text).to include(
@@ -25,7 +25,7 @@ module Find
 
         context 'when teacher degree apprenticeship course has incorrect fees' do
           it 'does not render fees' do
-            course = create(:course, :published_teacher_degree_apprenticeship, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
+            course = create(:course, :apprenticeship, :published_teacher_degree_apprenticeship, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 
             result = render_inline(described_class.new(course))
             expect(result.text).not_to include('£9,250')
@@ -138,7 +138,7 @@ module Find
 
         context 'when there are UK fees' do
           it 'renders the uk fees' do
-            course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
+            course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 
             result = render_inline(described_class.new(course))
             expect(result.text).to include('£9,250 for UK citizens')
@@ -148,7 +148,7 @@ module Find
 
         context 'when there are international fees' do
           it 'renders the international fees' do
-            course = create(:course, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
+            course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
 
             result = render_inline(described_class.new(course))
             expect(result.text).to include('£14,000 for Non-UK citizens')
@@ -157,7 +157,7 @@ module Find
 
         context 'when there are uk fees but no international fees' do
           it 'renders the uk fees and not the internation fee label' do
-            course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250, fee_international: nil)]).decorate
+            course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_uk_eu: 9250, fee_international: nil)]).decorate
 
             result = render_inline(described_class.new(course))
 
@@ -168,7 +168,7 @@ module Find
 
         context 'when there are international fees but no uk fees' do
           it 'renders the international fees but not the uk fee label' do
-            course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: 14_000)]).decorate
+            course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: 14_000)]).decorate
 
             result = render_inline(described_class.new(course))
 
@@ -179,7 +179,7 @@ module Find
 
         context 'when there are no fees' do
           it 'does not render the row' do
-            course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]).decorate
+            course = create(:course, :salary, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]).decorate
 
             result = render_inline(described_class.new(course))
 

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -116,7 +116,7 @@ module Find
       end
     end
 
-    context 'when teacher degree apprenticeship courses has incorrectly fees' do
+    context 'when teacher degree apprenticeship course has incorrect fees' do
       it 'does not render fees' do
         course = create(:course, :published_teacher_degree_apprenticeship, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -118,7 +118,7 @@ module Find
 
     context 'when teacher degree apprenticeship course has incorrect fees' do
       it 'does not render fees' do
-        course = create(:course, :published_teacher_degree_apprenticeship, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
+        course = create(:course, :apprenticeship, :published_teacher_degree_apprenticeship, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 
         result = render_inline(described_class.new(course:, results_view:))
         expect(result.text).not_to include('£9,250')
@@ -128,7 +128,7 @@ module Find
 
     context 'when there are UK fees' do
       it 'renders the uk fees' do
-        course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
+        course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 
         result = render_inline(described_class.new(course:, results_view:))
         expect(result.text).to include('£9,250 for UK citizens')
@@ -138,7 +138,7 @@ module Find
 
     context 'when there are international fees' do
       it 'renders the international fees' do
-        course = create(:course, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
+        course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
 
         result = render_inline(described_class.new(course:, results_view:))
         expect(result.text).to include('£14,000 for Non-UK citizens')
@@ -147,7 +147,7 @@ module Find
 
     context 'when there are uk fees but no international fees' do
       it 'renders the uk fees and not the internation fee label' do
-        course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250, fee_international: nil)]).decorate
+        course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_uk_eu: 9250, fee_international: nil)]).decorate
 
         result = render_inline(described_class.new(course:, results_view:))
 
@@ -158,7 +158,7 @@ module Find
 
     context 'when there are international fees but no uk fees' do
       it 'renders the international fees but not the uk fee label' do
-        course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: 14_000)]).decorate
+        course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: 14_000)]).decorate
 
         result = render_inline(described_class.new(course:, results_view:))
 
@@ -169,7 +169,7 @@ module Find
 
     context 'when there are no fees' do
       it 'does not render the row' do
-        course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]).decorate
+        course = create(:course, :salary, enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]).decorate
 
         result = render_inline(described_class.new(course:, results_view:))
 

--- a/spec/components/find/results/search_result_component_spec.rb
+++ b/spec/components/find/results/search_result_component_spec.rb
@@ -116,6 +116,16 @@ module Find
       end
     end
 
+    context 'when teacher degree apprenticeship courses has incorrectly fees' do
+      it 'does not render fees' do
+        course = create(:course, :published_teacher_degree_apprenticeship, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
+
+        result = render_inline(described_class.new(course:, results_view:))
+        expect(result.text).not_to include('£9,250')
+        expect(result.text).not_to include('Course fee')
+      end
+    end
+
     context 'when there are UK fees' do
       it 'renders the uk fees' do
         course = create(:course, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -224,6 +224,61 @@ describe CourseDecorator do
   #   end
   # end
 
+  describe '#no_fee?' do
+    context 'when it is a teacher degree apprenticeship with incorrect fees' do
+      let(:course) do
+        create(
+          :course,
+          :published_teacher_degree_apprenticeship,
+          enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]
+        ).decorate
+      end
+
+      it 'returns true' do
+        expect(decorated_course.no_fee?).to be true
+      end
+    end
+
+    context 'when both fees are blank' do
+      let(:course) do
+        create(
+          :course,
+          enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]
+        ).decorate
+      end
+
+      it 'returns true' do
+        expect(decorated_course.no_fee?).to be true
+      end
+    end
+
+    context 'when at least one fee is present' do
+      let(:course) do
+        create(
+          :course,
+          enrichments: [create(:course_enrichment, fee_uk_eu: 1000, fee_international: nil)]
+        ).decorate
+      end
+
+      it 'returns false' do
+        expect(decorated_course.no_fee?).to be false
+      end
+    end
+
+    context 'when all fees are present' do
+      let(:course) do
+        create(
+          :course,
+          enrichments: [create(:course_enrichment, fee_uk_eu: 1000, fee_international: 1000)]
+        ).decorate
+      end
+
+      it 'returns false' do
+        expect(decorated_course.no_fee?).to be false
+      end
+    end
+  end
+
   describe '#subject_present?' do
     it 'returns true when the subject id exists' do
       expect(decorated_course.subject_present?(english)).to be(true)

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -225,38 +225,11 @@ describe CourseDecorator do
   # end
 
   describe '#no_fee?' do
-    context 'when it is a teacher degree apprenticeship with incorrect fees' do
+    context 'when course funding is fee' do
       let(:course) do
         create(
           :course,
-          :published_teacher_degree_apprenticeship,
-          enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]
-        ).decorate
-      end
-
-      it 'returns true' do
-        expect(decorated_course.no_fee?).to be true
-      end
-    end
-
-    context 'when both fees are blank' do
-      let(:course) do
-        create(
-          :course,
-          enrichments: [create(:course_enrichment, fee_uk_eu: nil, fee_international: nil)]
-        ).decorate
-      end
-
-      it 'returns true' do
-        expect(decorated_course.no_fee?).to be true
-      end
-    end
-
-    context 'when at least one fee is present' do
-      let(:course) do
-        create(
-          :course,
-          enrichments: [create(:course_enrichment, fee_uk_eu: 1000, fee_international: nil)]
+          :fee
         ).decorate
       end
 
@@ -265,16 +238,29 @@ describe CourseDecorator do
       end
     end
 
-    context 'when all fees are present' do
+    context 'when course funding is salary' do
       let(:course) do
         create(
           :course,
-          enrichments: [create(:course_enrichment, fee_uk_eu: 1000, fee_international: 1000)]
+          :salary
         ).decorate
       end
 
-      it 'returns false' do
-        expect(decorated_course.no_fee?).to be false
+      it 'returns true' do
+        expect(decorated_course.no_fee?).to be true
+      end
+    end
+
+    context 'when course funding is apprenticeship' do
+      let(:course) do
+        create(
+          :course,
+          :apprenticeship
+        ).decorate
+      end
+
+      it 'returns true' do
+        expect(decorated_course.no_fee?).to be true
       end
     end
   end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -193,6 +193,18 @@ FactoryBot.define do
       end
     end
 
+    trait :fee do
+      funding { 'fee' }
+    end
+
+    trait :salary do
+      funding { 'salary' }
+    end
+
+    trait :apprenticeship do
+      funding { 'apprenticeship' }
+    end
+
     trait :salary_type_based do
       program_type { %i[pg_teaching_apprenticeship school_direct_salaried_training_programme].sample }
     end

--- a/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
+++ b/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
@@ -3,19 +3,54 @@
 require 'rails_helper'
 
 RSpec.describe Publish::Courses::AssignTdaAttributesService do
-  let(:course) { create(:course, study_mode: 'part_time', funding_type: 'fee', can_sponsor_skilled_worker_visa: true, can_sponsor_student_visa: true) }
+  subject(:service) { described_class.new(course) }
+
+  let(:course) do
+    create(
+      :course,
+      study_mode: 'part_time',
+      funding_type: 'fee',
+      can_sponsor_skilled_worker_visa: true,
+      can_sponsor_student_visa: true
+    )
+  end
 
   describe '#call' do
-    it 'updates the course attributes and returns true' do
-      expect(described_class.new(course).call).to be_truthy
-      expect(course.study_mode).to eq('full_time')
-      expect(course.funding_type).to eq('apprenticeship')
-      expect(course.can_sponsor_skilled_worker_visa).to be(false)
-      expect(course.can_sponsor_student_visa).to be(false)
-      expect(course.additional_degree_subject_requirements).to be(false)
-      expect(course.degree_subject_requirements).to be_nil
-      expect(course.degree_grade).to eq('not_required')
-      expect(course.degree_type).to eq('undergraduate')
+    context 'when course does not have enrichments' do
+      it 'updates the course attributes and returns true' do
+        expect(service.call).to be_truthy
+        expect(course.study_mode).to eq('full_time')
+        expect(course.funding_type).to eq('apprenticeship')
+        expect(course.can_sponsor_skilled_worker_visa).to be(false)
+        expect(course.can_sponsor_student_visa).to be(false)
+        expect(course.additional_degree_subject_requirements).to be(false)
+        expect(course.degree_subject_requirements).to be_nil
+        expect(course.degree_grade).to eq('not_required')
+        expect(course.degree_type).to eq('undergraduate')
+      end
+    end
+
+    context 'when course is postgraduate and contain fees' do
+      let!(:enrichment) do
+        build(
+          :course_enrichment,
+          :initial_draft,
+          fee_uk_eu: 9200,
+          fee_international: 9000,
+          fee_details: 'Some details'
+        ).tap do |course_enrichment|
+          course.enrichments << course_enrichment
+        end
+      end
+
+      it 'updates fee details to nil' do
+        expect(service.call).to be_truthy
+        expect(course.degree_type).to eq('undergraduate')
+        enrichment.reload
+        expect(enrichment.fee_uk_eu).to be_nil
+        expect(enrichment.fee_details).to be_nil
+        expect(enrichment.fee_international).to be_nil
+      end
     end
   end
 end

--- a/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
+++ b/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
@@ -11,11 +11,14 @@ RSpec.describe Publish::Courses::AssignTdaAttributesService do
       study_mode: 'part_time',
       funding_type: 'fee',
       can_sponsor_skilled_worker_visa: true,
-      can_sponsor_student_visa: true
+      can_sponsor_student_visa: true,
+      degree_type:
     )
   end
 
   describe '#call' do
+    let(:degree_type) { 'undergraduate' }
+
     context 'when course does not have enrichments' do
       it 'updates the course attributes and returns true' do
         expect(service.call).to be_truthy
@@ -31,6 +34,7 @@ RSpec.describe Publish::Courses::AssignTdaAttributesService do
     end
 
     context 'when course is postgraduate and contain fees' do
+      let(:degree_type) { 'postgraduate' }
       let!(:enrichment) do
         build(
           :course_enrichment,


### PR DESCRIPTION
## Context

Found one TDA course on QA/Production with fees on it.

TDA courses shouldn't have fees. This bug happens when the user switch from postgraduate to undergraduate courses.

On Find the fee shouldn’t be displayed as the course fee is only for fee funding courses.

The potential reason of this bug is when changing Non TDA to TDA course might have set the fee and not being erased when the course is changed to TDA

## Changes proposed in this pull request

Erase fees if course is changed from Non TDA to TDA courses. If the user change back they will have to enter fees again.

## Guidance to review

1. Create a postgraduate courses
2. Enter fees
3. Switch to a TDA course (basic details -> qualifications)
4. Check if the fees are visible (or in the database)