### PR TITLE
Feature flags must be available even if Find is down

### DIFF
--- a/app/controllers/find/feature_flags_controller.rb
+++ b/app/controllers/find/feature_flags_controller.rb
@@ -4,6 +4,7 @@ module Find
   class FeatureFlagsController < ApplicationController
     before_action :enforce_basic_auth
     skip_before_action :redirect_to_maintenance_page_if_flag_is_active
+    skip_before_action :redirect_to_cycle_has_ended_if_find_is_down
 
     def index; end
 

--- a/spec/requests/find/feature_flags_spec.rb
+++ b/spec/requests/find/feature_flags_spec.rb
@@ -19,5 +19,17 @@ module Find
 
       expect(response).to have_http_status(:ok)
     end
+
+    context 'when the cycle has ended' do
+      before do
+        allow(CycleTimetable).to receive(:find_down?).and_return(true)
+      end
+
+      it 'responds with 200 without basic auth' do
+        get '/feature-flags', headers: { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'password') }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

We have a redirect that comes into effect before we re-open Find. This redirect prevents us from reaching the Feature Flags on Find. We need to reach the feature flags to turn off bursary information

## Changes proposed in this pull request

Skip the redirect on the feature flags controller

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
