### PR TITLE
Revert removing `personal_qualities` and `other_requirements` from rollover script

### DIFF
--- a/app/services/enrichments/copy_to_course_service.rb
+++ b/app/services/enrichments/copy_to_course_service.rb
@@ -4,8 +4,6 @@ module Enrichments
   class CopyToCourseService
     def execute(enrichment:, new_course:)
       new_enrichment = enrichment.dup
-      new_enrichment.personal_qualities = nil
-      new_enrichment.other_requirements = nil
       new_enrichment.last_published_timestamp_utc = nil
       new_enrichment.rolled_over!
       new_course.enrichments << new_enrichment

--- a/spec/services/enrichments/copy_to_course_service_spec.rb
+++ b/spec/services/enrichments/copy_to_course_service_spec.rb
@@ -27,8 +27,6 @@ describe Enrichments::CopyToCourseService do
 
     its(:about_course) { is_expected.to eq published_enrichment.about_course }
     its(:last_published_timestamp_utc) { is_expected.to be_nil }
-    its(:other_requirements) { is_expected.to be_nil }
-    its(:personal_qualities) { is_expected.to be_nil }
     it { is_expected.to be_rolled_over }
   end
 end


### PR DESCRIPTION
## Context

We added this to the rollover script in #4347 to remove all the `personal_qualities` and `other_requirements` from all of the courses since we no longer surface the information.

Now that all courses have had this information erased, we should remove this from the rollover script as it is unnecessary and could confuse people in the future.