### PR TITLE
[2415] Update `funding_type` to `funding`

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -83,7 +83,7 @@ class CourseDecorator < ApplicationDecorator
       'salary' => 'Salary',
       'apprenticeship' => 'Teaching apprenticeship - with salary',
       'fee' => 'Fee - no salary'
-    }[object.funding_type]
+    }[object.funding]
   end
 
   def subject_name
@@ -150,11 +150,11 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def salaried?
-    object.funding_type == 'salary' || object.funding_type == 'apprenticeship'
+    object.funding == 'salary' || object.funding == 'apprenticeship'
   end
 
   def apprenticeship?
-    object.funding_type.to_s == 'apprenticeship'
+    object.funding.to_s == 'apprenticeship'
   end
 
   def apprenticeship
@@ -324,7 +324,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def has_fees?
-    object.funding_type.match?(/fee/)
+    object.funding.match?(/fee/)
   end
 
   def is_further_education?

--- a/app/mailers/course_publish_email_mailer.rb
+++ b/app/mailers/course_publish_email_mailer.rb
@@ -11,7 +11,7 @@ class CoursePublishEmailMailer < GovukNotifyRails::Mailer
       course_name: course.name,
       course_code: course.course_code,
       course_description: course.description,
-      course_funding_type: course.funding_type,
+      course_funding_type: course.funding,
       create_course_datetime: gov_uk_format(course.created_at),
       course_url: create_course_url(course)
     )

--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -17,7 +17,7 @@ class CourseUpdateEmailMailer < GovukNotifyRails::Mailer
       course_name: set_course_name(course, attribute_name, original_value),
       course_code: course.course_code,
       course_description: course.description,
-      course_funding_type: course.funding_type,
+      course_funding_type: course.funding,
       attribute_changed: I18n.t("course.update_email.#{attribute_name}"),
       attribute_change_datetime: gov_uk_format(course.updated_at),
       course_url: create_course_url(course),

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -747,7 +747,7 @@ class Course < ApplicationRecord
   end
 
   def training_route
-    TRAINING_ROUTE_MAP.fetch([degree_type, funding_type], 'unknown_training_route')
+    TRAINING_ROUTE_MAP.fetch([degree_type, funding], 'unknown_training_route')
   end
 
   def ensure_site_statuses_match_study_mode

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -385,7 +385,7 @@ class Provider < ApplicationRecord
 
   def update_courses_program_type
     courses.each do |course|
-      Courses::AssignProgramTypeService.new.execute(course.funding_type, course)
+      Courses::AssignProgramTypeService.new.execute(course.funding, course)
       course.save
     end
   end

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -30,7 +30,6 @@ module API
                    :bursary_amount,
                    :bursary_requirements,
                    :created_at,
-                   :funding_type,
                    :gcse_subjects_required,
                    :level,
                    :name,
@@ -140,6 +139,10 @@ module API
 
         attribute :required_qualifications do
           @object.required_qualifications
+        end
+
+        attribute :funding_type do
+          @object.funding
         end
 
         enrichment_attribute :about_course

--- a/spec/components/find/courses/sumary_component/view_preview.rb
+++ b/spec/components/find/courses/sumary_component/view_preview.rb
@@ -35,7 +35,7 @@ module Find
                          applications_open_from: Time.zone.now,
                          start_date: Time.zone.now,
                          qualification: 'pgce',
-                         funding_type: 'salaried',
+                         funding: 'salaried',
                          subjects: nil,
                          level: :secondary)
         end
@@ -51,7 +51,7 @@ module Find
                          applications_open_from: Time.zone.now,
                          start_date: Time.zone.now,
                          qualification: 'pgce',
-                         funding_type: 'salaried',
+                         funding: 'salaried',
                          subjects: nil,
                          level: :primary,
                          can_sponsor_student_visa: true)
@@ -59,7 +59,7 @@ module Find
 
         class FakeCourse
           include ActiveModel::Model
-          attr_accessor(:provider, :accrediting_provider, :course_code, :has_bursary, :age_range_in_years, :course_length, :applications_open_from, :start_date, :qualification, :funding_type, :subjects, :level, :can_sponsor_student_visa, :fee_uk_eu, :fee_international)
+          attr_accessor(:provider, :accrediting_provider, :course_code, :has_bursary, :age_range_in_years, :course_length, :applications_open_from, :start_date, :qualification, :funding, :subjects, :level, :can_sponsor_student_visa, :fee_uk_eu, :fee_international)
 
           delegate :provider_name, :provider_code, to: :provider, allow_nil: true
 

--- a/spec/controllers/publish/courses/outcome_controller_spec.rb
+++ b/spec/controllers/publish/courses/outcome_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Publish::Courses::OutcomeController do
 
         course.reload
 
-        expect(course.funding_type).to eq('apprenticeship')
+        expect(course.funding).to eq('apprenticeship')
         expect(course.can_sponsor_skilled_worker_visa).to be(false)
         expect(course.can_sponsor_student_visa).to be(false)
         expect(course.additional_degree_subject_requirements).to be(false)

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -55,7 +55,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
         and_the_degree_type_is_postgraduate
         and_the_back_link_points_to_the_outcome_page
         and_i_choose_the_fee_paying
-        and_the_back_link_points_to_the_funding_type_page
+        and_the_back_link_points_to_the_funding_page
         and_i_choose_part_time
         and_the_back_link_points_to_the_study_mode_page
 
@@ -189,7 +189,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_there_is_a_qts_course_i_want_to_edit
-    given_a_course_exists(:resulting_in_qts, study_mode: 'part_time', funding_type: 'fee', can_sponsor_skilled_worker_visa: true)
+    given_a_course_exists(:resulting_in_qts, study_mode: 'part_time', funding: 'fee', can_sponsor_skilled_worker_visa: true)
   end
 
   def and_the_degree_type_is_undergraduate
@@ -204,7 +204,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     course.reload
     expect(course.undergraduate_degree_type?).to be(true)
     expect(course.full_time?).to be(true)
-    expect(course.funding_type == 'apprenticeship').to be(true)
+    expect(course.funding == 'apprenticeship').to be(true)
     expect(course.can_sponsor_skilled_worker_visa).to be false
     expect(course.can_sponsor_student_visa).to be false
   end
@@ -212,7 +212,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   def then_i_see_the_correct_attributes_in_the_database_for_fee_paying
     course.reload
     expect(course.part_time?).to be(true)
-    expect(course.funding_type == 'fee').to be(true)
+    expect(course.funding == 'fee').to be(true)
     expect(course.can_sponsor_skilled_worker_visa).to be(false)
     expect(course.can_sponsor_student_visa).to be(true)
   end
@@ -225,7 +225,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   def then_i_see_the_correct_attributes_in_the_database_for_salaried
     course.reload
     expect(course.study_mode == 'part_time').to be(true)
-    expect(course.funding_type == 'salary').to be(true)
+    expect(course.funding == 'salary').to be(true)
     expect(course.can_sponsor_skilled_worker_visa).to be(true)
     expect(course.can_sponsor_student_visa).to be(false)
 

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -55,7 +55,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
         and_the_degree_type_is_postgraduate
         and_the_back_link_points_to_the_outcome_page
         and_i_choose_the_fee_paying
-        and_the_back_link_points_to_the_funding_page
+        and_the_back_link_points_to_the_funding_type_page
         and_i_choose_part_time
         and_the_back_link_points_to_the_study_mode_page
 

--- a/spec/features/publish/courses/editing_funding_type_spec.rb
+++ b/spec/features/publish/courses/editing_funding_type_spec.rb
@@ -119,7 +119,7 @@ feature 'Editing funding type', { can_edit_current_and_next_cycles: false } do
 
   def then_the_course_should_should_still_be_fee_paying
     course.reload
-    expect(course.funding_type).to eq('fee')
+    expect(course.funding).to eq('fee')
   end
 
   def then_the_previously_updated_skilled_worker_visa_should_be_false
@@ -134,7 +134,7 @@ feature 'Editing funding type', { can_edit_current_and_next_cycles: false } do
 
   def then_the_course_should_should_still_be_salaried
     course.reload
-    expect(course.funding_type).to eq('salary')
+    expect(course.funding).to eq('salary')
   end
 
   def when_i_update_funding_type_back_to_salaried_and_skilled_worker_to_sponsored
@@ -153,14 +153,14 @@ feature 'Editing funding type', { can_edit_current_and_next_cycles: false } do
 
   def and_the_course_should_have_updated_to_salaried_and_sponsor_skilled_worker_visa
     course.reload
-    expect(course.funding_type).to eq('salary')
+    expect(course.funding).to eq('salary')
     expect(course.can_sponsor_skilled_worker_visa).to be(true)
     expect(course.can_sponsor_student_visa).to be(false)
   end
 
   def and_the_course_should_have_updated_to_fee_and_sponsor_student_visa
     course.reload
-    expect(course.funding_type).to eq('fee')
+    expect(course.funding).to eq('fee')
     expect(course.can_sponsor_skilled_worker_visa).to be(false)
     expect(course.can_sponsor_student_visa).to be(true)
   end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -417,7 +417,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def and_the_tda_defaults_are_saved
     expect(course.program_type).to eq('teacher_degree_apprenticeship')
-    expect(course.funding_type).to eq('apprenticeship')
+    expect(course.funding).to eq('apprenticeship')
     expect(course.can_sponsor_student_visa?).to be false
     expect(course.can_sponsor_skilled_worker_visa?).to be false
     expect(course.additional_degree_subject_requirements).to be false
@@ -598,7 +598,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   def then_i_see_the_correct_attributes_in_the_database_for_fee_paying
     course.reload
     expect(course.part_time?).to be(true)
-    expect(course.funding_type == 'fee').to be(true)
+    expect(course.funding == 'fee').to be(true)
     expect(course.can_sponsor_skilled_worker_visa).to be(false)
     expect(course.can_sponsor_student_visa).to be(true)
   end
@@ -606,7 +606,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   def then_i_see_the_correct_attributes_in_the_database_for_salaried
     course.reload
     expect(course.study_mode == 'part_time').to be(true)
-    expect(course.funding_type == 'salary').to be(true)
+    expect(course.funding == 'salary').to be(true)
     expect(course.can_sponsor_skilled_worker_visa).to be(true)
     expect(course.can_sponsor_student_visa).to be(false)
   end

--- a/spec/mailers/course_publish_email_mailer_spec.rb
+++ b/spec/mailers/course_publish_email_mailer_spec.rb
@@ -38,7 +38,7 @@ describe CoursePublishEmailMailer do
     end
 
     it 'includes the course funding type in the personalisation' do
-      expect(mail.govuk_notify_personalisation[:course_funding_type]).to eq(course.funding_type)
+      expect(mail.govuk_notify_personalisation[:course_funding_type]).to eq(course.funding)
     end
 
     it 'includes the datetime for the creation in the personalisation' do

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -57,7 +57,7 @@ describe CourseUpdateEmailMailer do
     end
 
     it 'includes the course funding type in the personalisation' do
-      expect(mail.govuk_notify_personalisation[:course_funding_type]).to eq(course.funding_type)
+      expect(mail.govuk_notify_personalisation[:course_funding_type]).to eq(course.funding)
     end
 
     it 'includes the updated detail in the personalisation' do

--- a/spec/models/course/assign_program_type_spec.rb
+++ b/spec/models/course/assign_program_type_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'AssignProgramType' do
         it 'keeps the teacher_degree_apprenticeship program type' do
           provider = create(:provider)
           course = create(:course, :with_teacher_degree_apprenticeship, provider:)
-          service.execute(course.funding_type, course)
+          service.execute(course.funding, course)
           expect(course.program_type).to eq('teacher_degree_apprenticeship')
         end
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3109,7 +3109,6 @@ describe Course do
         course = described_class.new(program_type: :higher_education_salaried_programme, funding: 'fee')
         expect(course.program_type).to eq('higher_education_salaried_programme')
         expect(course.funding).to eq('fee')
-        expect(course.funding_type).to eq('fee')
       end
     end
 
@@ -3118,7 +3117,6 @@ describe Course do
         course = build(:course, :with_school_direct, funding: 'salary')
         expect(course.program_type).to eq('school_direct_training_programme')
         expect(course.funding).to eq('salary')
-        expect(course.funding_type).to eq('salary')
       end
     end
 
@@ -3127,7 +3125,6 @@ describe Course do
         course = build(:course, :with_school_direct, funding: 'fee')
         expect(course.program_type).to eq('school_direct_training_programme')
         expect(course.funding).to eq('fee')
-        expect(course.funding_type).to eq('fee')
       end
     end
 
@@ -3136,7 +3133,6 @@ describe Course do
         course = build(:course, :with_school_direct, funding: 'apprenticeship')
         expect(course.program_type).to eq('school_direct_training_programme')
         expect(course.funding).to eq('apprenticeship')
-        expect(course.funding_type).to eq('apprenticeship')
       end
     end
 
@@ -3145,7 +3141,6 @@ describe Course do
         course = build(:course, :with_apprenticeship, funding: 'fee')
         expect(course.program_type).to eq('pg_teaching_apprenticeship')
         expect(course.funding).to eq('fee')
-        expect(course.funding_type).to eq('fee')
       end
     end
   end
@@ -3189,7 +3184,7 @@ describe Course do
       it 'sets the funding to apprenticeship and program_type to pg_teaching_apprenticeship' do
         course = build(:course, funding: 'apprenticeship')
 
-        expect(course.funding_type).to eq('apprenticeship')
+        expect(course.funding).to eq('apprenticeship')
         expect(course.program_type).to eq('pg_teaching_apprenticeship')
       end
     end
@@ -3200,27 +3195,27 @@ describe Course do
           provider = build(:provider, provider_type: 'scitt')
           course = create(:course, provider:, funding: 'salary')
 
-          expect(course.funding_type).to eq('salary')
+          expect(course.funding).to eq('salary')
           expect(course.program_type).to eq('scitt_salaried_programme')
         end
       end
 
       context 'when the provider is a University' do
-        it 'sets the funding_type to salary and the program_type to higher_education_salaried_programme' do
+        it 'sets the funding to salary and the program_type to higher_education_salaried_programme' do
           provider = build(:provider, provider_type: 'university')
           course = create(:course, provider:, funding: 'salary')
 
-          expect(course.funding_type).to eq('salary')
+          expect(course.funding).to eq('salary')
           expect(course.program_type).to eq('higher_education_salaried_programme')
         end
       end
 
       context 'when the provider is a Lead School' do
-        it 'sets the funding_type to salary and the program_type to school_direct_salaried_training_programme' do
+        it 'sets the funding to salary and the program_type to school_direct_salaried_training_programme' do
           provider = build(:provider, provider_type: 'lead_school')
           course = create(:course, provider:, funding: 'salary')
 
-          expect(course.funding_type).to eq('salary')
+          expect(course.funding).to eq('salary')
           expect(course.program_type).to eq('school_direct_salaried_training_programme')
         end
       end
@@ -3315,33 +3310,33 @@ describe Course do
       end
     end
 
-    context 'setting the funding_type to fee' do
+    context 'setting the funding to fee' do
       context 'when the provider is not self accredited' do
-        it 'sets the funding_type to salary and the program_type to school_direct_training_programme' do
+        it 'sets the funding to salary and the program_type to school_direct_training_programme' do
           provider = build(:provider, accrediting_provider: :not_an_accredited_provider)
           course = create(:course, provider:, funding: 'fee')
 
-          expect(course.funding_type).to eq('fee')
+          expect(course.funding).to eq('fee')
           expect(course.program_type).to eq('school_direct_training_programme')
         end
       end
 
       context 'when the provider is self accredited and a SCITT' do
-        it 'sets the funding_type to salary and the program_type to scitt_programme' do
+        it 'sets the funding to salary and the program_type to scitt_programme' do
           provider = build(:provider, accrediting_provider: :accredited_provider, provider_type: 'scitt')
           course = create(:course, provider:, funding: 'fee')
 
-          expect(course.funding_type).to eq('fee')
+          expect(course.funding).to eq('fee')
           expect(course.program_type).to eq('scitt_programme')
         end
       end
 
       context 'when the provider is self accredited and not a SCITT' do
-        it 'sets the funding_type to salary and the program_type to higher_education_programme' do
+        it 'sets the funding to salary and the program_type to higher_education_programme' do
           provider = build(:provider, accrediting_provider: :accredited_provider, provider_type: 'university')
           course = create(:course, provider:, funding: 'fee')
 
-          expect(course.funding_type).to eq('fee')
+          expect(course.funding).to eq('fee')
           expect(course.program_type).to eq('higher_education_programme')
         end
       end
@@ -3421,7 +3416,7 @@ describe Course do
       expect(course.training_route).to eq('fee_funded_initial_teacher_training')
     end
 
-    it 'returns unknown_training_route for unknown degree_type and funding_type combination' do
+    it 'returns unknown_training_route for unknown degree_type and funding combination' do
       course = build(:course, funding: 'fee', degree_type: 'undergraduate')
       expect(course.training_route).to eq('unknown_training_route')
     end

--- a/spec/services/courses/assign_subjects_service_spec.rb
+++ b/spec/services/courses/assign_subjects_service_spec.rb
@@ -147,7 +147,7 @@ describe Courses::AssignSubjectsService do
     end
 
     it 'sets further_education_fields' do
-      expect(subject.funding_type).to eq('fee')
+      expect(subject.funding).to eq('fee')
       expect(subject.english).to eq('not_required')
       expect(subject.maths).to eq('not_required')
       expect(subject.science).to eq('not_required')

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -31,7 +31,7 @@ describe Courses::CreationService do
 
     it 'creates the teacher degree apprenticeship course' do
       expect(subject.program_type).to eq('teacher_degree_apprenticeship')
-      expect(subject.funding_type).to eq('apprenticeship')
+      expect(subject.funding).to eq('apprenticeship')
       expect(subject.can_sponsor_student_visa?).to be false
       expect(subject.can_sponsor_skilled_worker_visa?).to be false
       expect(subject.additional_degree_subject_requirements).to be(false)
@@ -215,7 +215,7 @@ describe Courses::CreationService do
       expect(subject.course_code).to be_nil
       expect(subject.name).to eq('Further education (SEND)')
       expect(subject.errors).to be_empty
-      expect(subject.funding_type).to eq('fee')
+      expect(subject.funding).to eq('fee')
       expect(subject.english).to eq('not_required')
       expect(subject.maths).to eq('not_required')
       expect(subject.science).to eq('not_required')
@@ -240,7 +240,7 @@ describe Courses::CreationService do
         expect(subject.course_code).not_to eq('D0CK')
         expect(subject.name).to eq('Further education (SEND)')
         expect(subject.errors).to be_empty
-        expect(subject.funding_type).to eq('fee')
+        expect(subject.funding).to eq('fee')
         expect(subject.english).to eq('not_required')
         expect(subject.maths).to eq('not_required')
         expect(subject.science).to eq('not_required')

--- a/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
+++ b/spec/services/publish/courses/assign_tda_attributes_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Publish::Courses::AssignTdaAttributesService do
     create(
       :course,
       study_mode: 'part_time',
-      funding_type: 'fee',
+      funding: 'fee',
       can_sponsor_skilled_worker_visa: true,
       can_sponsor_student_visa: true,
       degree_type:
@@ -23,7 +23,7 @@ RSpec.describe Publish::Courses::AssignTdaAttributesService do
       it 'updates the course attributes and returns true' do
         expect(service.call).to be_truthy
         expect(course.study_mode).to eq('full_time')
-        expect(course.funding_type).to eq('apprenticeship')
+        expect(course.funding).to eq('apprenticeship')
         expect(course.can_sponsor_skilled_worker_visa).to be(false)
         expect(course.can_sponsor_student_visa).to be(false)
         expect(course.additional_degree_subject_requirements).to be(false)


### PR DESCRIPTION
## Context

We have added a deprecation warning to `funding_type` and re-directed people to the database backed version (`funding`) instead.

We want to update our code to use the `funding` instead of `funding_type` so that it is cleaner and it doesn’t cause confusion in the future.

We are aiming for the low hanging fruits here, so if there are any that are particular difficult, this will be out of scope.

## Changes proposed in this pull request

- We have updated `funding_type` to `funding` in the codebase (all or at least most)

- We receive less (or no) deprecation warnings relating to `funding_type`

## Guidance to review

Have a click around and ensure all functionality continues to work. Especially functionality related to funding, e.g creating a course, changing funding, changing to a TDA course etc.

`funding_type` is still coming through on the API

<img width="514" alt="image" src="https://github.com/user-attachments/assets/6e709ff8-aaa5-42d2-988b-556175d1d027">


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated added to the Azure KeyVault
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Attach PR to Trello card
