### PR TITLE
Remove `not_set` from the `funding` enum

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -55,7 +55,6 @@ class Course < ApplicationRecord
   }, suffix: :degree_type
 
   enum :funding, {
-    not_set: 'not_set',
     fee: 'fee',
     salary: 'salary',
     apprenticeship: 'apprenticeship'


### PR DESCRIPTION
## Context

A migration to remove the default value for funding was removed in #4551. 

Funding values should never be `not_set` any more and therefore we should remove it from the enum.

## Changes proposed in this pull request

Remove `not_set` from the `funding` enum

## Guidance to review

🗑️ 

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
