### PR TITLE
Add content on A levels to include equivalent qualifications

### DIFF
--- a/app/components/a_level_row_component.html.erb
+++ b/app/components/a_level_row_component.html.erb
@@ -16,6 +16,10 @@
   <% Array(@course.a_level_subject_requirements).map do |a_level_subject_requirement| %>
     <p class="govuk-body">
       <%= a_level_subject_row_content(a_level_subject_requirement.with_indifferent_access) %>
+      <br>
+      <span class="govuk-hint govuk-!-font-size-16">
+        <%= or_equivalent_message(a_level_subject_requirement.with_indifferent_access) %>
+      </span>
     </p>
   <% end %>
 

--- a/app/components/a_level_row_component.rb
+++ b/app/components/a_level_row_component.rb
@@ -20,12 +20,11 @@ class ALevelRowComponent < ViewComponent::Base
   end
 
   def a_level_subject_row_content(a_level_subject_requirement)
-    a_level_subject_requirement_row_component = ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement)
+    ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement).row_value_with_hint
+  end
 
-    a_level_subject_requirement_row_component.add_equivalency_suffix(
-      course:,
-      row_value: a_level_subject_requirement_row_component.row_value
-    )
+  def or_equivalent_message(a_level_subject_requirement)
+    ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement).grade_hint
   end
 
   def pending_a_level_summary_content

--- a/app/components/a_level_subject_requirement_row_component.rb
+++ b/app/components/a_level_subject_requirement_row_component.rb
@@ -21,6 +21,14 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
     "#{plural_subject_name(count:)}#{grade}"
   end
 
+  def row_value_with_hint
+    "#{subject_name}#{grade(short_description: true)}"
+  end
+
+  def plural_row_value_with_hint(count:)
+    "#{plural_subject_name(count:)}#{grade(short_description: true)}"
+  end
+
   def subject_name
     if other_subject?
       other_subject
@@ -37,30 +45,41 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
     end
   end
 
-  def grade
+  def grade(short_description: false)
     return '' if minimum_grade.blank?
 
-    if MINIMUM_GRADES.include?(minimum_grade)
-      " - #{I18n.t('a_level_grades.minimum_grade', minimum_grade:)}"
-    elsif minimum_grade == MAX_GRADE
-      " - #{I18n.t('a_level_grades.max_grade')}"
+    " - #{grade_description(short_description:)}"
+  end
+
+  def grade_description(short_description:)
+    return I18n.t('a_level_grades.max_grade').to_s if max_grade?
+
+    if minimum_grade? && short_description.present?
+      I18n.t('a_level_grades.minimum_grade', minimum_grade:).to_s
+    elsif minimum_grade? && short_description.blank?
+      I18n.t('a_level_grades.minimum_grade_or_above', minimum_grade:).to_s
     else
-      " - #{minimum_grade}"
+      minimum_grade.to_s
     end
+  end
+
+  def minimum_grade?
+    MINIMUM_GRADES.include?(minimum_grade)
+  end
+
+  def max_grade?
+    minimum_grade == MAX_GRADE
   end
 
   def other_subject?
     subject == 'other_subject'
   end
 
-  def add_equivalency_suffix(course:, row_value:)
-    if course.accept_a_level_equivalency?
-      [
-        row_value,
-        I18n.t('course.a_level_equivalencies.suffix')
-      ].join(', ')
+  def grade_hint
+    if minimum_grade?
+      "#{I18n.t('course.a_level_equivalencies.or_above')} #{I18n.t('course.a_level_equivalencies.suffix')}"
     else
-      row_value
+      I18n.t('course.a_level_equivalencies.suffix')
     end
   end
 

--- a/app/components/find/courses/a_level_component/grouped_a_level_subject_requirements.rb
+++ b/app/components/find/courses/a_level_component/grouped_a_level_subject_requirements.rb
@@ -16,9 +16,9 @@ module Find
             component = ALevelSubjectRequirementRowComponent.new(a_level_subject_requirement)
 
             if count > 1
-              component.add_equivalency_suffix(course:, row_value: component.plural_row_value(count:))
+              [component.plural_row_value_with_hint(count:), component.grade_hint]
             else
-              component.add_equivalency_suffix(course:, row_value: component.row_value)
+              [component.row_value_with_hint, component.grade_hint]
             end
           end
         end

--- a/app/components/find/courses/a_level_component/view.html.erb
+++ b/app/components/find/courses/a_level_component/view.html.erb
@@ -1,13 +1,17 @@
-<% a_level_subject_requirements.each do |a_level_subject_requirement| %>
+<% a_level_subject_requirements.each do |a_level_subject_requirement, or_equivalent_message| %>
   <p class="govuk-body">
     <%= a_level_subject_requirement %>
-  </p>
-
-  <% unless course.accept_pending_a_level.nil? %>
+    <br>
     <span class="govuk-hint govuk-!-font-size-16">
-      <%= pending_a_level_summary_content %>
+      <%= or_equivalent_message %>
     </span>
-  <% end %>
+  </p>
+<% end %>
+
+<% unless course.accept_pending_a_level.nil? %>
+  <span class="govuk-hint govuk-!-font-size-16">
+    <%= pending_a_level_summary_content %>
+  </span>
 <% end %>
 
 <% if course.any_a_levels? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,7 +316,8 @@ en:
           text: "Enter details about the accredited provider"
   value_not_entered: "Not entered"
   a_level_grades:
-    minimum_grade: Grade %{minimum_grade} or above
+    minimum_grade: Grade %{minimum_grade}
+    minimum_grade_or_above: Grade %{minimum_grade} or above
     max_grade: "Grade A*"
   helpers:
     legend:
@@ -387,6 +388,7 @@ en:
       heading: Will you consider candidates who need to take an equivalency test for their A levels?
       submit: Update A levels
       hint: For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay
+      or_above: or above
       suffix: or equivalent qualification
       row:
         "true": "Equivalency tests will be considered."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,7 +323,7 @@ en:
       what_a_level_is_required:
         subject: Subject
       add_a_level_to_a_list:
-        add_another_a_level: Do you want to add another A level?
+        add_another_a_level: Do you want to add another A level or equivalent qualification?
       find_university_degree_status_form:
         university_degree_status: Do you have a university degree?
     label:
@@ -371,10 +371,10 @@ en:
       closed: "Course closed"
     add_course: "Add course"
     what_a_level_is_required:
-      heading: What A level is required?
-      success_message: You have added a required A level
+      heading: What A level or equivalent qualification is required?
+      success_message: You have added a required A level or equivalent qualification
     add_a_level_to_a_list:
-      heading: Required A levels
+      heading: Required A levels or equivalent qualifications
     remove_a_level_subject_confirmation:
       heading: Are you sure you want to remove %{subject}?
     consider_pending_a_level:
@@ -946,7 +946,7 @@ en:
         add_a_level_to_a_list:
           attributes:
             add_another_a_level:
-              blank: Select if you want to add another A level
+              blank: Select if you want to add another A level or equivalent qualification
         remove_a_level_subject_confirmation:
           attributes:
             confirmation:

--- a/spec/components/a_level_row_component_spec.rb
+++ b/spec/components/a_level_row_component_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe ALevelRowComponent do
     component = described_class.new(course: course.decorate)
     rendered_component = render_inline(component)
 
-    expect(rendered_component.text).to include('Math - Grade A or above')
+    expect(
+      rendered_component.text.gsub(/\r?\n/, ' ').squeeze(' ').strip
+    ).to include('Math - Grade A or above')
   end
 
   it 'renders the pending a level summary content for acceptance when course accepts pending a levels' do

--- a/spec/components/find/courses/a_level_component/grouped_a_level_subject_requirements_spec.rb
+++ b/spec/components/find/courses/a_level_component/grouped_a_level_subject_requirements_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       it 'renders the correct content' do
         expect(grouped_a_level_subject_requirements).to eq(
           [
-            'Any subject',
-            'Any STEM subject',
-            'Any modern foreign language - Grade A or above',
-            'Geography'
+            ['Any subject', 'or equivalent qualification'],
+            ['Any STEM subject', 'or equivalent qualification'],
+            ['Any modern foreign language - Grade A', 'or above or equivalent qualification'],
+            ['Geography', 'or equivalent qualification']
           ]
         )
       end
@@ -43,7 +43,7 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
 
       it 'renders the correct content' do
         expect(grouped_a_level_subject_requirements).to eq(
-          ['Any two STEM subjects']
+          [['Any two STEM subjects', 'or equivalent qualification']]
         )
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
 
       it 'renders the correct content' do
         expect(grouped_a_level_subject_requirements).to eq(
-          ['Any two STEM subjects - Grade B or above']
+          [['Any two STEM subjects - Grade B', 'or above or equivalent qualification']]
         )
       end
     end
@@ -72,7 +72,9 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       end
 
       it 'renders the correct content' do
-        expect(grouped_a_level_subject_requirements).to eq(['Any two modern foreign languages'])
+        expect(grouped_a_level_subject_requirements).to eq(
+          [['Any two modern foreign languages', 'or equivalent qualification']]
+        )
       end
     end
 
@@ -87,8 +89,8 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       it 'renders the correct content' do
         expect(grouped_a_level_subject_requirements).to eq(
           [
-            'Any modern foreign language - Grade A or above',
-            'Any modern foreign language - Grade B or above'
+            ['Any modern foreign language - Grade A', 'or above or equivalent qualification'],
+            ['Any modern foreign language - Grade B', 'or above or equivalent qualification']
           ]
         )
       end
@@ -107,7 +109,7 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       it 'renders the correct content' do
         expect(grouped_a_level_subject_requirements).to eq(
           [
-            'Any two modern foreign languages - Grade A or above, or equivalent qualification'
+            ['Any two modern foreign languages - Grade A', 'or above or equivalent qualification']
           ]
         )
       end
@@ -122,7 +124,11 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       end
 
       it 'renders the correct content' do
-        expect(grouped_a_level_subject_requirements).to eq(%w[Geography])
+        expect(grouped_a_level_subject_requirements).to eq(
+          [
+            ['Geography', 'or equivalent qualification']
+          ]
+        )
       end
     end
 
@@ -138,7 +144,7 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       it 'renders the subject with equivalency' do
         expect(grouped_a_level_subject_requirements).to eq(
           [
-            'Any two modern foreign languages - Grade A or above, or equivalent qualification'
+            ['Any two modern foreign languages - Grade A', 'or above or equivalent qualification']
           ]
         )
       end
@@ -156,7 +162,7 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       it 'renders the subject with equivalency' do
         expect(grouped_a_level_subject_requirements).to eq(
           [
-            'Any two modern foreign languages, or equivalent qualification'
+            ['Any two modern foreign languages', 'or equivalent qualification']
           ]
         )
       end
@@ -168,7 +174,7 @@ RSpec.describe Find::Courses::ALevelComponent::GroupedALevelSubjectRequirements 
       it 'renders the subject with equivalency' do
         expect(grouped_a_level_subject_requirements).to eq(
           [
-            'Any subject - Grade A or above, or equivalent qualification'
+            ['Any subject - Grade A', 'or above or equivalent qualification']
           ]
         )
       end

--- a/spec/components/find/courses/a_level_component/view_spec.rb
+++ b/spec/components/find/courses/a_level_component/view_spec.rb
@@ -3,7 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Find::Courses::ALevelComponent::View, type: :component do
-  subject(:result) { render_inline(described_class.new(course:)).text }
+  subject(:result) do
+    render_inline(
+      described_class.new(course:)
+    ).text.gsub(/\r?\n/, ' ').squeeze(' ').strip
+  end
 
   let(:course) { create(:course, a_level_subject_requirements:).decorate }
   let(:a_level_subject_requirements) { [] }
@@ -96,7 +100,7 @@ RSpec.describe Find::Courses::ALevelComponent::View, type: :component do
 
     it 'renders the correct content' do
       expect(result).to include(
-        'Any two modern foreign languages - Grade A or above, or equivalent qualification'
+        'Any two modern foreign languages - Grade A or above or equivalent qualification'
       )
     end
   end
@@ -140,7 +144,7 @@ RSpec.describe Find::Courses::ALevelComponent::View, type: :component do
     end
 
     it 'renders the subject with equivalency' do
-      expect(result).to include('Any subject - Grade A or above, or equivalent qualification')
+      expect(result).to include('Any subject - Grade A or above or equivalent qualification')
     end
   end
 

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -26,7 +26,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
 
     it 'renders A levels and GCSEs only and ignores degrees' do
       expected_text = <<~TEXT
-        Entry requirements A levels Any subject - Grade A or above, or equivalent qualification We’ll consider candidates with pending A levels. Equivalency tests We’ll consider candidates who need to take A level equivalency tests. Some text GCSEs Grade 4 (C) in English, maths and science or above, or equivalent qualification We will not consider candidates with pending GCSEs. Equivalency tests We will not consider candidates who need to take a GCSE equivalency test.
+        Entry requirements A levels Any subject - Grade A or above or equivalent qualification We’ll consider candidates with pending A levels. Equivalency tests We’ll consider candidates who need to take A level equivalency tests. Some text GCSEs Grade 4 (C) in English, maths and science or above, or equivalent qualification We will not consider candidates with pending GCSEs. Equivalency tests We will not consider candidates who need to take a GCSE equivalency test.
       TEXT
 
       expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to include(expected_text.strip)

--- a/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
+++ b/spec/components/find/courses/teacher_degree_apprenticeship_entry_requirements/view_spec.rb
@@ -22,7 +22,7 @@ describe Find::Courses::TeacherDegreeApprenticeshipEntryRequirements::View do
 
     it 'renders A levels and GCSEs only and ignores degrees' do
       expected_text = <<~TEXT
-        Any subject - Grade A or above, or equivalent qualification We’ll consider candidates with pending A levels. Equivalency tests We’ll consider candidates who need to take A level equivalency tests. Some text about A level equivalencies
+        Any subject - Grade A or above or equivalent qualification We’ll consider candidates with pending A levels. Equivalency tests We’ll consider candidates who need to take A level equivalency tests. Some text about A level equivalencies
       TEXT
 
       expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to include(expected_text.strip)

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -401,10 +401,10 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
   end
 
   def and_i_see_the_a_level_requirements_for_the_course
-    expect(page).to have_content('Any subject - Grade C or above, or equivalent')
-    expect(page).to have_content('Any STEM subject - Grade C or above, or equivalent')
-    expect(page).to have_content('Any humanities subject, or equivalent')
-    expect(page).to have_content('Mathematics, or equivalent')
+    expect(page).to have_content('Any subject - Grade C or above or equivalent')
+    expect(page).to have_content('Any STEM subject - Grade C or above or equivalent')
+    expect(page).to have_content('Any humanities subject or equivalent')
+    expect(page).to have_content('Mathematics or equivalent')
     expect(page).to have_content('Candidates with pending A levels will not be considered.')
     expect(page).to have_content('Equivalency tests will be considered.')
     expect(page).to have_content('Some additional A level equivalencies text')

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -271,7 +271,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
 
   def then_i_see_an_error_message_for_the_add_a_level_to_a_list_page
     and_i_see_there_is_a_problem
-    expect(page).to have_content('Select if you want to add another A level').twice
+    expect(page).to have_content('Select if you want to add another A level or equivalent qualification').twice
   end
 
   def and_i_see_there_is_a_problem
@@ -311,7 +311,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
 
   def and_i_do_not_see_the_option_to_add_more_a_level_subjects
     expect(page).to have_no_css('fieldset.govuk-fieldset')
-    expect(page).to have_no_css('legend', text: 'Do you want to add another A level?')
+    expect(page).to have_no_css('legend', text: 'Do you want to add another A level or equivalent qualification?')
   end
 
   def then_i_am_on_the_add_another_a_level_subject_page
@@ -327,7 +327,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
   alias_method :and_i_am_on_the_add_another_a_level_subject_page, :then_i_am_on_the_add_another_a_level_subject_page
 
   def and_i_see_the_success_message_that_i_added_an_a_level
-    expect(page).to have_content('You have added a required A level')
+    expect(page).to have_content('You have added a required A level or equivalent qualification')
   end
 
   def then_i_am_on_the_consider_pending_a_level_page

--- a/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
+++ b/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
@@ -181,7 +181,7 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
 
   def then_i_see_a_level_subject_is_required
     and_i_see_that_i_need_to_enter_a_level_requirements
-    expect(page).to have_content('What A level is required?')
+    expect(page).to have_content('What A level or equivalent qualification is required?')
   end
 
   def and_i_see_that_i_need_to_enter_a_level_requirements

--- a/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
+++ b/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
@@ -73,8 +73,8 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
   def then_i_see_the_a_level_requirements_content
     expect(page).to have_content('A levels')
-    expect(page).to have_content('Any subject - Grade A or above, or equivalent qualification')
-    expect(page).to have_content('Any two modern foreign languages - Grade A*, or equivalent qualification')
+    expect(page).to have_content('Any subject - Grade A or above or equivalent qualification')
+    expect(page).to have_content('Any two modern foreign languages - Grade A* or equivalent qualification')
     expect(page).to have_content('We’ll consider candidates with pending A levels.')
     expect(page).to have_content('We’ll consider candidates who need to take A level equivalency tests.')
     expect(page).to have_content('Some additional text about A level equivalencies')


### PR DESCRIPTION
## Context

We received feedback from a provider that they cannot add a TDA course, as they want the A level requirements to be more flexible to include equivalent qualifications, such as level 3 qualifications.

## Changes proposed in this pull request

See trello card for the prints

## Guidance to review

1. Create TDA course and many A level variations (Grade A, Grade A*, custom grade).
2. See card for the content changes for the variations