### PR TITLE
Use old financial support field only for 2024 courses and previous cycles only

### DIFF
--- a/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
+++ b/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
@@ -18,9 +18,4 @@
       <%= render partial: "shared/courses/financial_support/loan" %>
     <% end %>
   <% end %>
-
-  <% if financial_support.present? && !course.recruitment_cycle.after_2024? %>
-    <h3 data-qa="course__financial_support_details" class="govuk-heading-m">Financial support from the training provider</h3>
-    <%= markdown(financial_support) %>
-  <% end %>
 </div>

--- a/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
+++ b/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
@@ -19,7 +19,7 @@
     <% end %>
   <% end %>
 
-  <% if financial_support.present? %>
+  <% if financial_support.present? && !course.recruitment_cycle.after_2024? %>
     <h3 data-qa="course__financial_support_details" class="govuk-heading-m">Financial support from the training provider</h3>
     <%= markdown(financial_support) %>
   <% end %>

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -71,8 +71,4 @@ class RecruitmentCycle < ApplicationRecord
   def after_2021?
     year.to_i >= 2022
   end
-
-  def after_2024?
-    year.to_i > 2024
-  end
 end

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -77,16 +77,6 @@
       action_visually_hidden_text: t("publish.providers.courses.description_content.fee_details_hidden_text")
     ) %>
 
-    <% if course.financial_support.present? && !@provider.recruitment_cycle.after_2024? %>
-      <% enrichment_summary(
-        summary_list,
-        :course,
-        t("publish.providers.courses.description_content.financial_support_you_offer_label"),
-        value_provided?(markdown(course.financial_support)),
-        %w[financial_support]
-      ) %>
-    <% end %>
-
     <% summary_list.with_row(html_attributes: { data: { qa: "course__financial_incentives" } }) do |row| %>
       <% row.with_key { t("publish.providers.courses.description_content.financial_incentive_details_label") } %>
       <% row.with_value { course.financial_incentive_details } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -482,7 +482,6 @@ en:
           fee_for_international_students_label: Fee for international students
           fee_details_label: Fees and financial support (optional)
           fee_details_hidden_text: fees and financial support
-          financial_support_you_offer_label: Financial support you offer
           financial_incentive_details_label: Financial support from the government
           salary_label: Salary
           requirements_heading: Requirements and eligibility

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -277,8 +277,6 @@ feature 'Viewing a findable course' do
 
     expect(find_course_show_page.bursary_amount).to have_content('a bursary of £4,000')
 
-    expect(find_course_show_page.financial_support_details).to have_content('Financial support from the training provider')
-
     expect(find_course_show_page.required_qualifications).to have_no_content(
       @course.latest_published_enrichment.required_qualifications
     )

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -259,10 +259,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
 
     expect(publish_course_preview_page).not_to have_salary_details
 
-    expect(publish_course_preview_page.financial_support_details).to have_content(
-      'Financial support from the training provider'
-    )
-
     expect(publish_course_preview_page).to have_content(
       'Training with disabilities'
     )

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -49,26 +49,6 @@ describe RecruitmentCycle do
     end
   end
 
-  describe '#after_2024?', :aggregate_failures do
-    context 'when cycle year is 2024' do
-      before { allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2024) }
-
-      it 'returns false' do
-        expect(current_cycle).not_to be_after_2024
-        expect(next_cycle).to be_after_2024
-      end
-    end
-
-    context 'when cycle year is 2025' do
-      before { allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025) }
-
-      it 'returns true' do
-        expect(current_cycle).to be_after_2024
-        expect(next_cycle).to be_after_2024
-      end
-    end
-  end
-
   context 'when there are multiple cycles' do
     let!(:third_cycle) do
       current_cycle


### PR DESCRIPTION
## Context

Provider raised a support ticket about financial support duplication, Reading the code I understood this field is only for "< 2025 courses"

Support ticket: 

https://trello.com/c/7pXkBeQ8/309-fees-and-financial-support-info-duplicated