### PR TITLE
Show Financial support banner on all pages

### DIFF
--- a/app/views/find/search/subjects/_secondary_subjects.html.erb
+++ b/app/views/find/search/subjects/_secondary_subjects.html.erb
@@ -1,5 +1,3 @@
-<%= render Find::FinancialIncentivesBannerComponent.new %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= f.govuk_collection_check_boxes :subjects, secondary_subject_options,

--- a/app/views/layouts/find_layout.html.erb
+++ b/app/views/layouts/find_layout.html.erb
@@ -54,6 +54,7 @@
 
         <%= render Find::MaintenanceBannerComponent.new %>
         <%= render Find::DeadlineBannerComponent.new(flash_empty: flash.reject { |flash| flash[0] == "start_wizard" }.empty?) unless request.url.include?("/results/filter/subject") %>
+        <%= render Find::FinancialIncentivesBannerComponent.new %>
 
         <%= yield %>
       </main>


### PR DESCRIPTION
## Context

We have been asked to persist the Financial support banner on all pages

## Changes proposed in this pull request

- Move the banner to the main layout page

## Guidance to review

- Visit Find 
- Click through multiple pages to see the banner

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
