### PR TITLE
Add @publish-and-find CODEOWNERS to cover entire repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @publish-and-find


### PR DESCRIPTION
## Context

We want to automatically include all @DFE-Digital/publish-and-find developers in all PR reviewers.

By adding a CODEOWNERS file, we can automatically set code owners as reviewers.

We require, at minimum, a single review from anyone in the team.

## Changes proposed in this pull request

- Add `.github/CODEOWNERS` file.

## Guidance to review

Nothing in particular.
