### PR TITLE
Remove checklist from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,17 +9,3 @@
 ## Guidance to review
 
 <!-- How could someone else check this work? Which parts do you want more feedback on? -->
-
-## Things to check
-
-- [ ] This code does not rely on migrations in the same Pull Request
-- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
-- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
-- [ ] API release notes have been updated if necessary
-- [ ] Required environment variables have been updated added to the Azure KeyVault
-- [ ] Inform data insights team due to database changes
-- [ ] Make sure all information from the Trello card is in here
-- [ ] Rebased main
-- [ ] Cleaned commit history
-- [ ] Tested by running locally
-- [ ] Attach PR to Trello card

--- a/guides/development-workflow.md
+++ b/guides/development-workflow.md
@@ -1,0 +1,62 @@
+# Development Workflow
+
+## Pull Request conventions
+
+### Branch naming
+
+- Branch names should be descriptive and follow the format `<author initials>/<change summary>`.
+
+  e.g.
+
+  ```
+  dd/update-readme
+  gs/fix-broken-link
+  im/add-search-filters
+  td/create-reports
+  ```
+
+  The prefixes are to prevent conflicts between developers working on the same feature and developers forking off from each other's branches.
+
+### PR Title
+
+- The PR title should describe the change in a single line.
+
+- The PR title should be less than or equal to 72 characters long, if possible. This is a guideline, not a strict rule.
+
+### PR Description
+
+- The PR description should provide the motivation and context behind the changes made.
+
+- The PR description should detail considerations made during development - Which alternatives were considered (if any) and why did you decide to go with the current approach?
+
+- The PR description should include screenshots or videos for visual changes.
+
+- The PR description should call out any areas that you would like specific feedback on.
+
+- If there is an accompanying Trello card, ensure that it is linked in the PR description or comments.
+
+### General guidance
+
+- Developers should attempt to create small iterative PRs.
+  - Features may be broken down into smaller PRs to assist with PR reviews and encourage iterative development.
+  - If a feature is not ready for usage, it should be hidden behind a environment variable.
+    - TODO: We need to update terraform to allow developers to set environment variables in config.
+  - If a feautre needs to be turned on or off, it should be hidden behind a feature flag.
+
+### Things to check before marking a PR as ready for review
+
+- Renaming and removing database columns requires multi-step PRs:
+
+  As requests may come in while a database migration is happening, we need to ensure database changes and code changes are de-coupled.
+
+  **Removing columns**
+
+  1. Update the code to stop using the column. Add the attributes to the model's `ignored_columns` array.
+  2. Remove the column from the database.
+  3. Remove the attributes from the model's `ignored_columns` array.
+
+- Renaming tables requires a data-migration to update polymorhic association `_type` columns.
+
+- If the API is being change, ensure that the changelog is updated alongside.
+
+- If you are making any database changes, check in with the Data & Insights team to ensure that you are not breaking anything on the analytics side.


### PR DESCRIPTION
## Context

The PR checklist is often ignored due to its stagnant nature. Let's remove it from the PR template to ensure PR descriptions only contain significant information.

Additionally, let's move the PR checklist into developer docs about PR guidelines.

## Changes proposed in this pull request

- [x] Remove checklist from PR template.
- [x] Add developer onboarding documentation containing PR guidelines.

## Guidance to review

- Review [the Development Workflow documentation](https://github.com/DFE-Digital/publish-teacher-training/blob/dd/remove-checklist-from-pr-template/guides/development-workflow.md).
