### PR TITLE
Show ActiveRecord object attributes in console except production

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -3,7 +3,13 @@
 module PublishConsole
   def start
     show_warning_message_about_environments
+    set_attributes_for_inspect
     super
+  end
+
+  # https://api.rubyonrails.org/classes/ActiveRecord/Core.html#method-i-inspect
+  def set_attributes_for_inspect
+    ActiveRecord::Base.attributes_for_inspect = :all unless Rails.env.production_aks?
   end
 
   def show_warning_message_about_environments


### PR DESCRIPTION
## Context

When working in the console it's useful to have ActiveRecord objects printed with all their attribute values.
Rails by default will not print the attributes apart from the id anymore.

This change will restore the printing of all attributes on all objects unless the environment is production.

(If you really want to see the attributes in production, just run 

```ruby
ActiveRecord::Base.attributes_for_inspect = :all

# or

SomeModel.attributes_for_inspect = :all
```
To change it back to the default

```ruby
ActiveRecord::Base.attributes_for_inspect = [:id]

# or

SomeModel.attributes_for_inspect = [:id]
```
## Changes proposed in this pull request

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/260bace4-c768-464a-8dee-25aff225e546)|![image](https://github.com/user-attachments/assets/83861987-114e-43f0-93f0-8f3d080c5f61)|


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
