### PR TITLE
Remove the Teacher degree apprenticeship feature flag from Find & Publish

### DIFF
--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -29,10 +29,6 @@ module Find
       'find'
     end
 
-    def teacher_degree_apprenticeship_active?
-      Settings.current_recruitment_cycle_year.to_i > 2024 && FeatureService.enabled?(:teacher_degree_apprenticeship)
-    end
-
     private
 
     def provider

--- a/app/controllers/find/search/subjects_controller.rb
+++ b/app/controllers/find/search/subjects_controller.rb
@@ -25,11 +25,7 @@ module Find
       private
 
       def next_page
-        if teacher_degree_apprenticeship_active?
-          find_university_degree_status_path(filter_params[:find_subjects_form])
-        else
-          find_visa_status_path(filter_params[:find_subjects_form])
-        end
+        find_university_degree_status_path(filter_params[:find_subjects_form])
       end
 
       def sanitised_subject_codes

--- a/app/controllers/find/search/university_degree_status_controller.rb
+++ b/app/controllers/find/search/university_degree_status_controller.rb
@@ -27,13 +27,6 @@ module Find
 
       def back_path
         find_subjects_path(backlink_query_parameters)
-
-        # investigate
-#        if params[:age_group] == 'further_education' || (params[:find_visa_status_form] && params[:find_visa_status_form][:age_group] == 'further_education')
-#          find_age_groups_path(backlink_query_parameters)
-#        else
-#          find_subjects_path(backlink_query_parameters)
-#        end
       end
       helper_method :back_path
     end

--- a/app/controllers/find/search/university_degree_status_controller.rb
+++ b/app/controllers/find/search/university_degree_status_controller.rb
@@ -27,6 +27,13 @@ module Find
 
       def back_path
         find_subjects_path(backlink_query_parameters)
+
+        # investigate
+#        if params[:age_group] == 'further_education' || (params[:find_visa_status_form] && params[:find_visa_status_form][:age_group] == 'further_education')
+#          find_age_groups_path(backlink_query_parameters)
+#        else
+#          find_subjects_path(backlink_query_parameters)
+#        end
       end
       helper_method :back_path
     end

--- a/app/controllers/find/search/visa_status_controller.rb
+++ b/app/controllers/find/search/visa_status_controller.rb
@@ -55,13 +55,7 @@ module Find
       def form_name = :find_visa_status_form
 
       def back_path
-        return find_university_degree_status_path(backlink_query_parameters) if teacher_degree_apprenticeship_active?
-
-        if params[:age_group] == 'further_education' || (params[:find_visa_status_form] && params[:find_visa_status_form][:age_group] == 'further_education')
-          find_age_groups_path(backlink_query_parameters)
-        else
-          find_subjects_path(backlink_query_parameters)
-        end
+        find_university_degree_status_path(backlink_query_parameters)
       end
       helper_method :back_path
     end

--- a/app/controllers/find/search/visa_status_controller.rb
+++ b/app/controllers/find/search/visa_status_controller.rb
@@ -55,7 +55,11 @@ module Find
       def form_name = :find_visa_status_form
 
       def back_path
-        find_university_degree_status_path(backlink_query_parameters)
+        if params[:age_group] == 'further_education' || (params[:find_visa_status_form] && params[:find_visa_status_form][:age_group] == 'further_education')
+          find_age_groups_path(backlink_query_parameters)
+        else
+          find_university_degree_status_path(backlink_query_parameters)
+        end
       end
       helper_method :back_path
     end

--- a/app/models/concerns/courses/edit_options/qualification_concern.rb
+++ b/app/models/concerns/courses/edit_options/qualification_concern.rb
@@ -21,6 +21,7 @@ module Courses
           qts_list
         end
 
+        # investigate
         def non_tda_published?
           !teacher_degree_apprenticeship? && is_published?
         end

--- a/app/models/concerns/courses/edit_options/qualification_concern.rb
+++ b/app/models/concerns/courses/edit_options/qualification_concern.rb
@@ -16,7 +16,7 @@ module Courses
         def qualifications_with_qts
           qts_list = Course.qualifications.keys.grep(/qts/)
 
-          qts_list -= %w[undergraduate_degree_with_qts] if !tda_active? || non_tda_published?
+          qts_list -= %w[undergraduate_degree_with_qts] if non_tda_published?
 
           qts_list
         end

--- a/app/models/concerns/courses/edit_options/qualification_concern.rb
+++ b/app/models/concerns/courses/edit_options/qualification_concern.rb
@@ -21,7 +21,6 @@ module Courses
           qts_list
         end
 
-        # investigate
         def non_tda_published?
           !teacher_degree_apprenticeship? && is_published?
         end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -120,7 +120,6 @@ class Course < ApplicationRecord
 
   belongs_to :provider
 
-  delegate :tda_active?, to: :provider, allow_nil: true
   delegate :provider_name, :provider_code, to: :provider, allow_nil: true
 
   belongs_to :accrediting_provider,

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -377,10 +377,6 @@ class Provider < ApplicationRecord
     Provider.joins(:recruitment_cycle).where(recruitment_cycle: { year: Settings.current_recruitment_cycle_year.succ.to_s }).find_by(provider_code:)
   end
 
-  def tda_active?
-    recruitment_cycle_year.to_i > 2024 && FeatureService.enabled?(:teacher_degree_apprenticeship)
-  end
-
   private
 
   def update_courses_program_type

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -89,7 +89,6 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
-  teacher_degree_apprenticeship: true
   send_request_data_to_bigquery: false
   rollover:
     # Normally a short period of time between rollover and the next cycle

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -9,9 +9,6 @@ environment:
   label: "development"
   name: "development"
 
-features:
-  teacher_degree_apprenticeship: true
-
 find_valid_referers:
   - http://localhost:3001
 

--- a/spec/controllers/publish/courses/outcome_controller_spec.rb
+++ b/spec/controllers/publish/courses/outcome_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Publish::Courses::OutcomeController do
   before do
     allow(controller).to receive(:authenticate).and_return(true)
     controller.instance_variable_set(:@current_user, user)
-    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   describe '#edit' do

--- a/spec/features/find/search/across_england/further_education_spec.rb
+++ b/spec/features/find/search/across_england/further_education_spec.rb
@@ -18,6 +18,7 @@ feature 'Searching across England' do
     when_i_select_the_further_education_radio_button
     and_i_click_continue
     then_i_should_see_the_visa_status_page
+    and_the_back_link_points_to_age_group_page
 
     when_i_select_my_visa_status
     and_i_click_find_courses
@@ -81,5 +82,21 @@ feature 'Searching across England' do
     find_results_page.courses.first.then do |first_course|
       expect(first_course.course_name.text).to include(@further_education_course.name)
     end
+  end
+
+  def and_the_back_link_points_to_age_group_page
+    further_education_subject_code = 41
+    expect(page.find_link(text: 'Back')[:href]).to eq(
+      find_age_groups_path(
+        age_group: 'further_education',
+        applications_open: true,
+        has_vacancies: true,
+        l: 2,
+        qualification: ['qts', 'pgce_with_qts', 'pgce pgde'],
+        send_courses: false,
+        study_type: %w[full_time part_time],
+        subjects: [further_education_subject_code]
+      )
+    )
   end
 end

--- a/spec/features/find/search/undergraduate/course_results_spec.rb
+++ b/spec/features/find/search/undergraduate/course_results_spec.rb
@@ -13,7 +13,6 @@ feature 'Questions and results for undergraduate courses' do
 
   scenario 'with the TDA feature active and searching for secondary courses' do
     given_i_have_courses
-    and_the_tda_feature_flag_is_active
     when_i_visit_the_start_page
     and_i_select_the_across_england_radio_button
     and_i_click_continue
@@ -58,7 +57,6 @@ feature 'Questions and results for undergraduate courses' do
 
   scenario 'with the TDA feature active and searching primary courses' do
     given_i_have_courses
-    and_the_tda_feature_flag_is_active
     when_i_visit_the_start_page
     and_i_select_the_across_england_radio_button
     and_i_click_continue
@@ -89,8 +87,6 @@ feature 'Questions and results for undergraduate courses' do
 
   scenario 'with the TDA feature active and searching for further education courses' do
     given_i_have_courses
-    and_the_tda_feature_flag_is_active
-
     when_i_visit_the_start_page
     and_i_select_the_across_england_radio_button
     and_i_click_continue
@@ -104,7 +100,6 @@ feature 'Questions and results for undergraduate courses' do
 
   scenario 'with the TDA feature active and searching for postgraduate courses' do
     given_i_have_courses
-    and_the_tda_feature_flag_is_active
     when_i_visit_the_start_page
     and_i_select_the_across_england_radio_button
     and_i_click_continue
@@ -128,7 +123,6 @@ feature 'Questions and results for undergraduate courses' do
 
   scenario 'with the TDA feature active and searching by location' do
     given_i_have_courses_in_different_locations
-    and_the_tda_feature_flag_is_active
     when_i_visit_the_start_page
     and_i_choose_to_find_courses_by_location
     and_i_add_a_location
@@ -167,7 +161,6 @@ feature 'Questions and results for undergraduate courses' do
   end
 
   scenario 'when there are no results' do
-    given_the_tda_feature_flag_is_active
     when_i_visit_the_start_page
     and_i_choose_to_find_courses_by_location
     and_i_add_a_location
@@ -230,10 +223,6 @@ feature 'Questions and results for undergraduate courses' do
         )
       ]
     )
-  end
-
-  def and_the_tda_feature_flag_is_active
-    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   def when_i_visit_the_start_page
@@ -487,6 +476,4 @@ feature 'Questions and results for undergraduate courses' do
       'Find out more about teacher degree apprenticeship (TDA) courses.'
     )
   end
-
-  alias_method :given_the_tda_feature_flag_is_active, :and_the_tda_feature_flag_is_active
 end

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_current_and_next_cycles: false } do
   scenario 'adding a level requirements' do
     given_i_am_authenticated_as_a_provider_user
-    and_the_tda_feature_flag_is_active
     and_i_have_a_teacher_degree_apprenticeship_course
 
     when_i_visit_the_course_description_tab
@@ -149,10 +148,6 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
     )
 
     given_i_am_authenticated(user: @user)
-  end
-
-  def and_the_tda_feature_flag_is_active
-    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   def and_i_have_a_teacher_degree_apprenticeship_course

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -155,7 +155,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
   end
 
   def when_i_visit_the_course_description_tab
-    publish_provider_courses_show_page.load(provider_code: @provider.provider_code, recruitment_cycle_year: 2025, course_code: @course.course_code)
+    publish_provider_courses_show_page.load(provider_code: @provider.provider_code, recruitment_cycle_year:, course_code: @course.course_code)
   end
 
   def then_i_see_a_levels_row
@@ -180,7 +180,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code
       )
     )
@@ -190,7 +190,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
     expect(page.find_link(text: 'Back')[:href]).to eq(
       publish_provider_recruitment_cycle_course_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code
       )
     )
@@ -217,7 +217,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_a_levels_what_a_level_is_required_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code
       ),
       ignore_query: true
@@ -255,7 +255,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_a_levels_add_a_level_to_a_list_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code
       ),
       ignore_query: true
@@ -441,7 +441,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_a_levels_what_a_level_is_required_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code,
         uuid: @course.reload.a_level_subject_requirements.first['uuid']
       )
@@ -452,7 +452,7 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_a_levels_remove_a_level_subject_confirmation_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code,
         uuid: @course.reload.a_level_subject_requirements.first['uuid']
       )
@@ -502,5 +502,9 @@ feature 'Adding A levels to a teacher degree apprenticeship course', { can_edit_
         @course.course_code
       )
     )
+  end
+
+  def recruitment_cycle_year
+    RecruitmentCycle.current.year
   end
 end

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -35,7 +35,6 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   context 'TDA course' do
     scenario 'changing the outcome from non TDA to TDA' do
       given_i_am_authenticated_as_a_provider_user
-      and_the_tda_feature_flag_is_active
       and_there_is_a_qts_course_i_want_to_edit
       when_i_visit_the_course_outcome_page
       and_i_choose_undergraduate_degree_with_qts
@@ -47,7 +46,6 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     context 'fee course' do
       scenario 'changing the outcome from TDA to non TDA' do
         given_i_am_authenticated_as_a_provider_user
-        and_the_tda_feature_flag_is_active
         and_there_is_a_tda_course_i_want_to_edit
         when_i_visit_the_course_outcome_page
         and_the_degree_type_is_undergraduate
@@ -76,7 +74,6 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     context 'salaried course' do
       scenario 'changing the outcome from TDA to non TDA' do
         given_i_am_authenticated_as_a_provider_user
-        and_the_tda_feature_flag_is_active
         and_there_is_a_tda_course_i_want_to_edit
         when_i_visit_the_course_outcome_page
         and_the_degree_type_is_undergraduate
@@ -176,16 +173,8 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
     and_i_update
   end
 
-  def and_the_tda_feature_flag_is_active
-    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
-  end
-
   def provider
     @current_user.providers.first
-  end
-
-  def and_the_tda_feature_flag_is_active
-    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   def and_there_is_a_qts_course_i_want_to_edit

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -229,7 +229,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   def and_the_back_link_points_to_the_outcome_page
     expect(URI.parse(find_link('Back')[:href]).path).to eq(outcome_publish_provider_recruitment_cycle_course_path(
                                                              provider_code: provider.provider_code,
-                                                             recruitment_cycle_year: 2025,
+                                                             recruitment_cycle_year:,
                                                              code: course.course_code
                                                            ))
   end
@@ -237,7 +237,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   def and_the_back_link_points_to_the_funding_type_page
     expect(URI.parse(find_link('Back')[:href]).path).to eq(funding_type_publish_provider_recruitment_cycle_course_path(
                                                              provider_code: provider.provider_code,
-                                                             recruitment_cycle_year: 2025,
+                                                             recruitment_cycle_year:,
                                                              code: course.course_code
                                                            ))
   end
@@ -245,7 +245,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   def and_the_back_link_points_to_the_study_mode_page
     expect(URI.parse(find_link('Back')[:href]).path).to eq(full_part_time_publish_provider_recruitment_cycle_course_path(
                                                              provider_code: provider.provider_code,
-                                                             recruitment_cycle_year: 2025,
+                                                             recruitment_cycle_year:,
                                                              code: course.course_code
                                                            ))
   end
@@ -257,7 +257,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   def then_i_am_on_the_study_mode_page
     expect(page).to have_current_path(full_part_time_publish_provider_recruitment_cycle_course_path(
                                         provider_code: provider.provider_code,
-                                        recruitment_cycle_year: 2025,
+                                        recruitment_cycle_year:,
                                         code: course.course_code,
                                         previous_tda_course: true
                                       ))
@@ -266,10 +266,14 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   def then_i_am_on_the_funding_type_page
     expect(page).to have_current_path(funding_type_publish_provider_recruitment_cycle_course_path(
                                         provider_code: provider.provider_code,
-                                        recruitment_cycle_year: 2025,
+                                        recruitment_cycle_year:,
                                         code: course.course_code,
                                         previous_tda_course: true
                                       ))
+  end
+
+  def recruitment_cycle_year
+    RecruitmentCycle.current.year
   end
 
   alias_method :and_i_choose_to_sponsor_a_skilled_worker_visa, :and_i_choose_to_sponsor_a_student_visa

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_next_cycles do
   scenario 'creating a degree awarding course from school direct provider' do
     given_i_am_authenticated_as_a_school_direct_provider_user
-    and_the_tda_feature_flag_is_active
     when_i_visit_the_courses_page
     and_i_click_on_add_course
     and_i_choose_a_secondary_course
@@ -91,7 +90,6 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   scenario 'when choosing primary course' do
     given_i_am_authenticated_as_a_school_direct_provider_user
-    and_the_tda_feature_flag_is_active
     when_i_visit_the_courses_page
     and_i_click_on_add_course
     and_i_choose_a_primary_course
@@ -131,7 +129,6 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   scenario 'do not show teacher degree apprenticeship for further education' do
     given_i_am_authenticated_as_a_school_direct_provider_user
-    and_the_tda_feature_flag_is_active
     when_i_visit_the_courses_page
     and_i_click_on_add_course
     and_i_choose_a_further_education_course
@@ -141,7 +138,6 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   scenario 'back links when choosing a teacher degree apprenticeship' do
     given_i_am_authenticated_as_a_school_direct_provider_user
-    and_the_tda_feature_flag_is_active
     when_i_visit_the_courses_page
     and_i_click_on_add_course
     and_i_choose_a_primary_course
@@ -244,10 +240,6 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     given_i_am_authenticated(
       user: @user
     )
-  end
-
-  def and_the_tda_feature_flag_is_active
-    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   def when_i_visit_the_courses_page
@@ -546,7 +538,6 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
 
   def given_i_am_on_the_check_answers_page_of_a_new_tda_course
     given_i_am_authenticated_as_a_school_direct_provider_user
-    and_the_tda_feature_flag_is_active
     and_i_visit_the_courses_page
     and_i_click_on_add_course
     and_i_choose_a_secondary_course

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -303,7 +303,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def then_i_am_on_the_qualifications_page
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_outcome_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_outcome_path(provider_code: provider.provider_code, recruitment_cycle_year:), ignore_query: true)
   end
 
   def and_i_do_not_see_the_degree_awarding_option
@@ -318,11 +318,11 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def then_i_am_on_the_choose_schools_page
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year:), ignore_query: true)
   end
 
   def and_the_back_link_points_to_outcome_page
-    expect(publish_courses_new_outcome_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_outcome_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
+    expect(publish_courses_new_outcome_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_outcome_path(provider_code: provider.provider_code, recruitment_cycle_year:))
   end
 
   def when_i_choose_the_school
@@ -331,7 +331,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def then_the_back_link_points_to_the_school_page
-    expect(publish_courses_new_study_sites_page.back_link[:href]).to include(back_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
+    expect(publish_courses_new_study_sites_page.back_link[:href]).to include(back_publish_provider_recruitment_cycle_courses_schools_path(provider_code: provider.provider_code, recruitment_cycle_year:))
   end
 
   def and_i_choose_the_study_site
@@ -340,15 +340,15 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def and_the_back_link_points_to_the_study_site_page
-    expect(publish_courses_new_applications_open_page.back_link[:href]).to include(back_publish_provider_recruitment_cycle_courses_study_sites_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
+    expect(publish_courses_new_applications_open_page.back_link[:href]).to include(back_publish_provider_recruitment_cycle_courses_study_sites_path(provider_code: provider.provider_code, recruitment_cycle_year:))
   end
 
   def then_i_am_on_the_add_applications_open_date_page
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year:), ignore_query: true)
   end
 
   def and_the_back_link_points_to_applications_open_date_page
-    expect(publish_courses_new_start_date_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
+    expect(publish_courses_new_start_date_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_applications_open_path(provider_code: provider.provider_code, recruitment_cycle_year:))
   end
 
   def when_i_choose_the_applications_open_date
@@ -362,11 +362,11 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def and_the_back_link_points_to_start_date_page
-    expect(publish_course_confirmation_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_start_date_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025))
+    expect(publish_course_confirmation_page.back_link[:href]).to include(new_publish_provider_recruitment_cycle_courses_start_date_path(provider_code: provider.provider_code, recruitment_cycle_year:))
   end
 
   def then_i_am_on_the_check_your_answers_page
-    expect(page).to have_current_path(confirmation_publish_provider_recruitment_cycle_courses_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    expect(page).to have_current_path(confirmation_publish_provider_recruitment_cycle_courses_path(provider_code: provider.provider_code, recruitment_cycle_year:), ignore_query: true)
   end
 
   def and_i_can_not_change_funding_type
@@ -605,28 +605,28 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   def and_the_back_link_points_to_the_confirm_page
     expect(URI.parse(find_link('Back')[:href]).path).to eq(confirmation_publish_provider_recruitment_cycle_courses_path(
                                                              provider_code: provider.provider_code,
-                                                             recruitment_cycle_year: 2025
+                                                             recruitment_cycle_year:
                                                            ))
   end
 
   def and_the_back_link_points_to_the_qualification_page
     expect(URI.parse(find_link('Back')[:href]).path).to eq(new_publish_provider_recruitment_cycle_courses_outcome_path(
                                                              provider_code: provider.provider_code,
-                                                             recruitment_cycle_year: 2025
+                                                             recruitment_cycle_year:
                                                            ))
   end
 
   def and_the_back_link_points_to_the_funding_type_page
     expect(URI.parse(find_link('Back')[:href]).path).to eq(new_publish_provider_recruitment_cycle_courses_funding_type_path(
                                                              provider_code: provider.provider_code,
-                                                             recruitment_cycle_year: 2025
+                                                             recruitment_cycle_year:
                                                            ))
   end
 
   def and_the_back_link_points_to_the_study_mode_page
     expect(URI.parse(find_link('Back')[:href]).path).to eq(new_publish_provider_recruitment_cycle_courses_study_mode_path(
                                                              provider_code: provider.provider_code,
-                                                             recruitment_cycle_year: 2025
+                                                             recruitment_cycle_year:
                                                            ))
   end
 
@@ -635,11 +635,11 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def then_i_am_on_the_study_mode_page
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_study_mode_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_study_mode_path(provider_code: provider.provider_code, recruitment_cycle_year:), ignore_query: true)
   end
 
   def then_i_am_on_the_funding_type_page
-    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_funding_type_path(provider_code: provider.provider_code, recruitment_cycle_year: 2025), ignore_query: true)
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_courses_funding_type_path(provider_code: provider.provider_code, recruitment_cycle_year:), ignore_query: true)
   end
 
   def and_i_add_a_level_requirements
@@ -652,6 +652,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     and_i_click_continue
     choose 'Yes'
     click_on 'Update A levels'
+  end
+
+  def recruitment_cycle_year
+    RecruitmentCycle.current.year
   end
 
   alias_method :and_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship, :then_i_do_not_see_the_change_links_for_study_mode_funding_type_and_visa_sponsorship

--- a/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
+++ b/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
@@ -137,7 +137,7 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code
       )
     )
@@ -209,7 +209,7 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_a_levels_what_a_level_is_required_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code,
         display_errors: true
       )
@@ -281,9 +281,13 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
     expect(page.find_link(text: 'Back')[:href]).to eq(
       publish_provider_recruitment_cycle_course_path(
         @provider.provider_code,
-        2025,
+        recruitment_cycle_year,
         @course.course_code
       )
     )
+  end
+
+  def recruitment_cycle_year
+    RecruitmentCycle.current.year
   end
 end

--- a/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
+++ b/spec/features/publish/courses/publishing_a_teacher_degree_apprenticeship_course_with_validation_errors_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false } do
   before do
     given_i_am_authenticated_as_a_provider_user
-    and_the_tda_feature_flag_is_active
   end
 
   scenario 'The error links target the correct pages' do
@@ -80,10 +79,6 @@ feature 'Publishing courses errors', { can_edit_current_and_next_cycles: false }
     )
 
     given_i_am_authenticated(user: @user)
-  end
-
-  def and_the_tda_feature_flag_is_active
-    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   def and_there_is_an_invalid_tda_course_i_want_to_publish

--- a/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
+++ b/spec/features/publish/preview_teacher_degree_apprenticeship_course_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 feature 'Course show', { can_edit_current_and_next_cycles: false } do
   scenario 'when viewing a teacher degree apprenticeship course' do
     given_i_am_authenticated_as_a_provider_user
-    and_the_tda_feature_flag_is_active
     and_i_have_a_teacher_degree_apprenticeship_course
 
     when_i_visit_the_course_page
@@ -30,10 +29,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     )
 
     given_i_am_authenticated(user: @user)
-  end
-
-  def and_the_tda_feature_flag_is_active
-    allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
   end
 
   def and_i_have_a_teacher_degree_apprenticeship_course

--- a/spec/models/concerns/courses/edit_options/qualification_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/qualification_concern_spec.rb
@@ -8,8 +8,6 @@ describe Courses::EditOptions::QualificationConcern do
       include Courses::EditOptions::QualificationConcern
       attr_accessor :level
 
-      def tda_active?; end
-
       def teacher_degree_apprenticeship?; end
 
       def is_published?; end
@@ -44,10 +42,6 @@ describe Courses::EditOptions::QualificationConcern do
 
   context 'for a teacher degree apprenticeship course' do
     let(:level_value) { 'secondary' }
-
-    before do
-      allow(example_model).to receive(:tda_active?).and_return true
-    end
 
     it 'returns a teacher degree apprenticeship' do
       expect(example_model.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts undergraduate_degree_with_qts])

--- a/spec/models/concerns/courses/edit_options/qualification_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/qualification_concern_spec.rb
@@ -24,7 +24,7 @@ describe Courses::EditOptions::QualificationConcern do
     let(:level_value) { 'primary' }
 
     it 'returns only QTS options for users to choose between' do
-      expect(example_model.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts])
+      expect(example_model.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts undergraduate_degree_with_qts])
       expect(example_model.qualification_options).to all(include('qts'))
     end
   end
@@ -37,14 +37,6 @@ describe Courses::EditOptions::QualificationConcern do
       example_model.qualification_options.each do |q|
         expect(q).not_to include('qts')
       end
-    end
-  end
-
-  context 'for a teacher degree apprenticeship course' do
-    let(:level_value) { 'secondary' }
-
-    it 'returns a teacher degree apprenticeship' do
-      expect(example_model.qualification_options).to eq(%w[qts pgce_with_qts pgde_with_qts undergraduate_degree_with_qts])
     end
   end
 end

--- a/spec/models/concerns/courses/edit_options_spec.rb
+++ b/spec/models/concerns/courses/edit_options_spec.rb
@@ -75,7 +75,7 @@ describe 'Course with edit options' do
   end
 
   describe 'qualifications' do
-    let(:provider) { create(:provider, recruitment_cycle: create(:recruitment_cycle, year: 2025)) }
+    let(:provider) { create(:provider) }
     let(:course) { create(:course, provider:, level: 'primary', subjects: [subjects]) }
 
     context "for a course that's not further education" do

--- a/spec/models/concerns/courses/edit_options_spec.rb
+++ b/spec/models/concerns/courses/edit_options_spec.rb
@@ -99,32 +99,8 @@ describe 'Course with edit options' do
       end
     end
 
-    context 'when TDA is active' do
-      before do
-        allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
-      end
-
-      it 'includes undergraduate_degree_with_qts' do
-        expect(course.qualification_options).to include('undergraduate_degree_with_qts')
-      end
-    end
-
-    context 'when TDA is not active' do
-      before do
-        allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(false)
-      end
-
-      it 'does not include undergraduate_degree_with_qts' do
-        expect(course.qualification_options).not_to include('undergraduate_degree_with_qts')
-      end
-    end
-
     context 'when the course is non-TDA and published' do
       let(:course) { create(:course, :resulting_in_qts, :published) }
-
-      before do
-        allow(Settings.features).to receive(:teacher_degree_apprenticeship).and_return(true)
-      end
 
       it 'does not include undergraduate_degree_with_qts' do
         expect(course.qualification_options).not_to include('undergraduate_degree_with_qts')

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -54,62 +54,6 @@ describe Provider do
     end
   end
 
-  describe '#tda_active?' do
-    let(:provider) { create(:provider) }
-
-    before do
-      allow(provider).to receive(:recruitment_cycle_year).and_return(recruitment_cycle_year)
-    end
-
-    context 'when recruitment cycle year is after 2024 and TDA is active' do
-      let(:recruitment_cycle_year) { 2025 }
-
-      before do
-        allow(FeatureService).to receive(:enabled?).with(:teacher_degree_apprenticeship).and_return(true)
-      end
-
-      it 'returns true' do
-        expect(provider.tda_active?).to be true
-      end
-    end
-
-    context 'when recruitment cycle year is 2024 or before and TDA is active' do
-      let(:recruitment_cycle_year) { 2024 }
-
-      before do
-        allow(FeatureService).to receive(:enabled?).with(:teacher_degree_apprenticeship).and_return(true)
-      end
-
-      it 'returns false' do
-        expect(provider.tda_active?).to be false
-      end
-    end
-
-    context 'when recruitment cycle year is after 2024 and TDA is not active' do
-      let(:recruitment_cycle_year) { 2025 }
-
-      before do
-        allow(FeatureService).to receive(:enabled?).with(:teacher_degree_apprenticeship).and_return(false)
-      end
-
-      it 'returns false' do
-        expect(provider.tda_active?).to be false
-      end
-    end
-
-    context 'when recruitment cycle year is 2024 or before and TDA is not active' do
-      let(:recruitment_cycle_year) { 2024 }
-
-      before do
-        allow(FeatureService).to receive(:enabled?).with(:teacher_degree_apprenticeship).and_return(false)
-      end
-
-      it 'returns false' do
-        expect(provider.tda_active?).to be false
-      end
-    end
-  end
-
   describe 'validations' do
     describe 'urn validations' do
       context 'when provider_type is lead_school' do


### PR DESCRIPTION
## Context

Once the TDA work is live for a while and we are in the 2025 cycle, we should remove the feature flag and TDA checks.

## Changes proposed in this pull request

Remove all feature flag checks for Find and Publish for teacher degree apprenticeship feature.

This means that:

1. The option "Teacher degree apprenticeship" on qualifications page in Publish will be shown always
2. The question "Do you have a university degree" in Find will be shown always

## Guidance to review

1. Is the feature flag checks got removed?
3. Is the feature flag active? `FeatureService.enabled?(:teacher_degree_apprenticeship)` should be `false`
4. Can you create a teacher degree apprenticeship?  - it should allow to create TDA courses no matter if the feature is active or not. ([one example](https://publish-review-4597.test.teacherservices.cloud/publish/organisations/4A3/2025/courses/outcome/new?course%5Bage_range_in_years%5D=14_to_19&course%5Bcampaign_name%5D=&course%5Bis_send%5D=true&course%5Blevel%5D=secondary&course%5Bmaster_subject_id%5D=8&course%5Bsubjects_ids%5D%5B%5D=8&course%5Bsubordinate_subject_id%5D=))
5. Does the question "Do you have a university degree" always show in Find no matter if the feature flag exists or not? ([one example](https://find-review-4597.test.teacherservices.cloud/university-degree-status?age_group=secondary&l=2&subjects%5B%5D=&subjects%5B%5D=A1))

