### PR TITLE
Bump dfe-wizard from v0.1.0 to v0.1.1 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,7 +155,7 @@ gem 'colorize'
 # for running SQL queries
 gem 'blazer'
 
-gem 'dfe-wizard', require: 'dfe/wizard', github: 'DFE-Digital/dfe-wizard', tag: 'v0.1.0'
+gem 'dfe-wizard', require: 'dfe/wizard', github: 'DFE-Digital/dfe-wizard', tag: 'v0.1.1'
 
 group :production, :qa, :sandbox, :staging do
   gem 'cloudfront-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,10 +18,10 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-wizard.git
-  revision: 2968ba3310680071948df98eca11d3a6dbe49a6c
-  tag: v0.1.0
+  revision: 859236dacbede69359d6df1b2965dd6fbcb8b9d6
+  tag: v0.1.1
   specs:
-    dfe-wizard (0.1.0)
+    dfe-wizard (0.1.1)
       activemodel
       activesupport
 
@@ -782,6 +782,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/components/a_level_row_component.html.erb
+++ b/app/components/a_level_row_component.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--error") do %>
     <% a_level_errors.each do |a_level_error| %>
       <p class="govuk-heading-s app-inset-text__title">
-        <%= t("course.#{wizard_step(a_level_error)}.heading") %>
+        <%= t("course.a_level_steps/#{wizard_step(a_level_error)}.heading") %>
       </p>
       <p class="govuk-body">
       <%= govuk_link_to(

--- a/app/components/a_level_row_component.rb
+++ b/app/components/a_level_row_component.rb
@@ -28,11 +28,11 @@ class ALevelRowComponent < ViewComponent::Base
   end
 
   def pending_a_level_summary_content
-    I18n.t("course.consider_pending_a_level.row.#{@course.accept_pending_a_level?}") unless @course.accept_pending_a_level.nil?
+    I18n.t("course.a_level_steps/consider_pending_a_level.row.#{@course.accept_pending_a_level?}") unless @course.accept_pending_a_level.nil?
   end
 
   def a_level_equivalency_summary_content
-    I18n.t("course.a_level_equivalencies.row.#{@course.accept_a_level_equivalency?}") unless @course.accept_a_level_equivalency.nil?
+    I18n.t("course.a_level_steps/a_level_equivalencies.row.#{@course.accept_a_level_equivalency?}") unless @course.accept_a_level_equivalency.nil?
   end
 
   def has_errors?

--- a/app/components/a_level_subject_requirement_row_component.rb
+++ b/app/components/a_level_subject_requirement_row_component.rb
@@ -77,9 +77,9 @@ class ALevelSubjectRequirementRowComponent < ViewComponent::Base
 
   def grade_hint
     if minimum_grade?
-      "#{I18n.t('course.a_level_equivalencies.or_above')} #{I18n.t('course.a_level_equivalencies.suffix')}"
+      "#{I18n.t('course.a_level_steps/a_level_equivalencies.or_above')} #{I18n.t('course.a_level_steps/a_level_equivalencies.suffix')}"
     else
-      I18n.t('course.a_level_equivalencies.suffix')
+      I18n.t('course.a_level_steps/a_level_equivalencies.suffix')
     end
   end
 

--- a/app/wizards/a_level_steps/a_level_equivalencies.rb
+++ b/app/wizards/a_level_steps/a_level_equivalencies.rb
@@ -29,7 +29,7 @@ module ALevelSteps
       excess_words = word_count - MAXIMUM_ADDITIONAL_A_LEVEL_EQUIVALENCY_WORDS
 
       I18n.t(
-        'activemodel.errors.models.a_level_equivalencies.attributes.additional_a_level_equivalencies.too_long',
+        'activemodel.errors.models.a_level_steps/a_level_equivalencies.attributes.additional_a_level_equivalencies.too_long',
         maximum: MAXIMUM_ADDITIONAL_A_LEVEL_EQUIVALENCY_WORDS,
         count: excess_words
       )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -321,7 +321,7 @@ en:
     max_grade: "Grade A*"
   helpers:
     legend:
-      what_a_level_is_required:
+      a_level_steps/what_a_level_is_required:
         subject: Subject
       add_a_level_to_a_list:
         add_another_a_level: Do you want to add another A level or equivalent qualification?
@@ -330,7 +330,6 @@ en:
     label:
       what_a_level_is_required:
         other_subject: Subjects
-        other_subject_prompt: Choose subject
         minimum_grade_required: Minimum grade required (optional)
         subject_options:
           any_subject: Any subject
@@ -345,6 +344,8 @@ en:
           any_modern_foreign_language: Any %{count_in_words} modern foreign languages
           any_humanities_subject: Any %{count_in_words} humanities subjects
           any_science_subject: Any %{count_in_words} science subjects
+      a_level_steps/what_a_level_is_required:
+        other_subject_prompt: Choose subject
       add_a_level_to_a_list:
         add_another_a_level_options:
           "yes": "Yes"
@@ -371,20 +372,20 @@ en:
       open: "Course opened"
       closed: "Course closed"
     add_course: "Add course"
-    what_a_level_is_required:
+    a_level_steps/what_a_level_is_required:
       heading: What A level or equivalent qualification is required?
       success_message: You have added a required A level or equivalent qualification
-    add_a_level_to_a_list:
+    a_level_steps/add_a_level_to_a_list:
       heading: Required A levels or equivalent qualifications
-    remove_a_level_subject_confirmation:
+    a_level_steps/remove_a_level_subject_confirmation:
       heading: Are you sure you want to remove %{subject}?
-    consider_pending_a_level:
+    a_level_steps/consider_pending_a_level:
       heading: Will you consider candidates with pending A levels?
       hint: These are candidates who expect to have the qualification before the beginning of the course. You can give them an offer, on the condition that they pass their A levels.
       row:
         "true": "Candidates with pending A levels will be considered."
         "false": "Candidates with pending A levels will not be considered."
-    a_level_equivalencies:
+    a_level_steps/a_level_equivalencies:
       heading: Will you consider candidates who need to take an equivalency test for their A levels?
       submit: Update A levels
       hint: For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay
@@ -934,7 +935,7 @@ en:
             description:
               blank: Enter details about the accredited provider
               too_long: Description about the accredited provider must be 100 words or fewer
-        what_a_level_is_required:
+        a_level_steps/what_a_level_is_required:
           attributes:
             subject:
               blank: Select a subject
@@ -944,19 +945,19 @@ en:
               chars_count:
                 one: Grade must be %{maximum} characters or less. You have %{count} character too many.
                 other: Grade must be %{maximum} characters or less. You have %{count} characters too many.
-        add_a_level_to_a_list:
+        a_level_steps/add_a_level_to_a_list:
           attributes:
             add_another_a_level:
               blank: Select if you want to add another A level or equivalent qualification
-        remove_a_level_subject_confirmation:
+        a_level_steps/remove_a_level_subject_confirmation:
           attributes:
             confirmation:
               blank: Select if you want to remove %{subject}
-        consider_pending_a_level:
+        a_level_steps/consider_pending_a_level:
           attributes:
             pending_a_level:
               blank: Select if you will consider candidates with pending A levels
-        a_level_equivalencies:
+        a_level_steps/a_level_equivalencies:
           attributes:
             accept_a_level_equivalency:
               blank: Select if you will consider candidates who need to take equivalency tests

--- a/spec/components/a_level_row_component_spec.rb
+++ b/spec/components/a_level_row_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ALevelRowComponent do
     component = described_class.new(course: course.decorate)
     rendered_component = render_inline(component)
 
-    expect(rendered_component.text).to include(I18n.t('course.consider_pending_a_level.row.true'))
+    expect(rendered_component.text).to include(I18n.t('course.a_level_steps/consider_pending_a_level.row.true'))
   end
 
   it 'renders the pending a level summary content for non-acceptance when course does not accept pending a levels' do
@@ -37,7 +37,7 @@ RSpec.describe ALevelRowComponent do
     component = described_class.new(course: course.decorate)
     rendered_component = render_inline(component)
 
-    expect(rendered_component.text).to include(I18n.t('course.consider_pending_a_level.row.false'))
+    expect(rendered_component.text).to include(I18n.t('course.a_level_steps/consider_pending_a_level.row.false'))
   end
 
   it 'renders the a level equivalency summary content for acceptance when course accepts a level equivalencies' do
@@ -45,7 +45,7 @@ RSpec.describe ALevelRowComponent do
     component = described_class.new(course: course.decorate)
     rendered_component = render_inline(component)
 
-    expect(rendered_component.text).to include(I18n.t('course.a_level_equivalencies.row.true'))
+    expect(rendered_component.text).to include(I18n.t('course.a_level_steps/a_level_equivalencies.row.true'))
   end
 
   it 'renders the a level equivalency summary content for non-acceptance when course does not accept a level equivalencies' do
@@ -53,7 +53,7 @@ RSpec.describe ALevelRowComponent do
     component = described_class.new(course: course.decorate)
     rendered_component = render_inline(component)
 
-    expect(rendered_component.text).to include(I18n.t('course.a_level_equivalencies.row.false'))
+    expect(rendered_component.text).to include(I18n.t('course.a_level_steps/a_level_equivalencies.row.false'))
   end
 
   it 'renders the additional a level equivalencies content when present' do
@@ -123,7 +123,7 @@ RSpec.describe ALevelRowComponent do
       let(:attributes) { {  accept_a_level_equivalency: nil } }
 
       it 'renders the error message for accept_a_level_equivalency' do
-        expect(rendered_component).to have_text(I18n.t("course.#{component.wizard_step(:accept_a_level_equivalency)}.heading"))
+        expect(rendered_component).to have_text(I18n.t("course.a_level_steps/#{component.wizard_step(:accept_a_level_equivalency)}.heading"))
         expect(rendered_component).to have_link(
           component.errors[:accept_a_level_equivalency].first,
           href: publish_provider_recruitment_cycle_course_a_levels_a_level_equivalencies_path(
@@ -140,7 +140,7 @@ RSpec.describe ALevelRowComponent do
       let(:attributes) { { a_level_subject_requirements: [] } }
 
       it 'renders the error message for a_level_subject_requirements' do
-        expect(rendered_component).to have_text(I18n.t("course.#{component.wizard_step(:a_level_subject_requirements)}.heading"))
+        expect(rendered_component).to have_text(I18n.t("course.a_level_steps/#{component.wizard_step(:a_level_subject_requirements)}.heading"))
         expect(rendered_component).to have_link(
           component.errors[:a_level_subject_requirements].first,
           href: publish_provider_recruitment_cycle_course_a_levels_what_a_level_is_required_path(
@@ -157,7 +157,7 @@ RSpec.describe ALevelRowComponent do
       let(:attributes) { { accept_pending_a_level: nil } }
 
       it 'renders the error message for accept_pending_a_level' do
-        expect(rendered_component).to have_text(I18n.t("course.#{component.wizard_step(:accept_pending_a_level)}.heading"))
+        expect(rendered_component).to have_text(I18n.t("course.a_level_steps/#{component.wizard_step(:accept_pending_a_level)}.heading"))
         expect(rendered_component).to have_link(
           component.errors[:accept_pending_a_level].first,
           href: publish_provider_recruitment_cycle_course_a_levels_consider_pending_a_level_path(


### PR DESCRIPTION
## Context

Bump dfe-wizard from v0.1.0 to v0.1.1 

## Changes proposed in this pull request

Bump dfe-wizard from v0.1.0 to v0.1.1  and fix the translations for the a level flow

## Guidance to review

- Sign into publish
- Add a new course
- A levels
- When selecting Requirements and eligibility
- You should see all the translations as normal

<img width="908" alt="Screenshot 2024-10-15 at 17 04 54" src="https://github.com/user-attachments/assets/f5536d25-8cd5-42f8-95fe-cac64e9c0ce8">
