### PR TITLE
Add link to View Component previews in Support

### DIFF
--- a/app/controllers/component_previews_controller.rb
+++ b/app/controllers/component_previews_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class ComponentPreviewsController < ViewComponentsController
-  include Authentication
-  helper_method :current_user
-end

--- a/app/controllers/support/component_previews_controller.rb
+++ b/app/controllers/support/component_previews_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Support
+  class ComponentPreviewsController < ViewComponentsController
+    include Authentication
+    helper_method :current_user
+  end
+end

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -29,6 +29,12 @@
     ) %>
 
     <div class="govuk-width-container">
+
+      <% content_for :before_content do %>
+        <%= govuk_back_link_to(publish_support_view_component_previews_path) unless content_for?(:before_content) %>
+      <% end %>
+
+      <%= content_for :before_content %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= yield %>
       </main>

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,6 @@
 <%= render TabNavigation.new(items: [
 { name: "Providers", url: support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
 { name: "Users", url: support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) },
-{ name: "Find - Feature Flags", url: x_find_url(find_feature_flags_path) }
+{ name: "Find - Feature Flags", url: x_find_url(find_feature_flags_path) },
+{ name: "View Component Previews", url: publish_support_view_component_previews_path }
 ]) %>

--- a/app/views/view_components/index.html.erb
+++ b/app/views/view_components/index.html.erb
@@ -5,6 +5,9 @@
   These act as larger building blocks used to build pages specific to the Find and Publish services leveraging the <%= govuk_link_to("GOV.UK Design System", "https://design-system.service.gov.uk/") %> and the <%= govuk_link_to("GOV.UK components gem", "https://github.com/DFE-Digital/govuk-components") %>
 </p>
 
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_recruitment_cycles_path) %>
+<% end %>
 <% @previews.each do |preview| %>
   <h2 class="govuk-heading-m"><%= link_to preview.preview_name.titleize, preview_view_component_path(preview.preview_name) %></h2>
   <ul class="govuk-list">

--- a/app/views/view_components/previews.html.erb
+++ b/app/views/view_components/previews.html.erb
@@ -1,7 +1,0 @@
-<h2 class="govuk-heading-m"><%= @preview.preview_name.titleize %></h2>
-
-<ul class="govuk-list">
-  <% @preview.examples.each do |example| %>
-    <li><%= govuk_link_to example, preview_view_component_path("#{@preview.preview_name}/#{example}") %></li>
-  <% end %>
-</ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,9 +59,9 @@ module ManageCoursesBackend
     config.skylight.native_log_level = :fatal
 
     config.view_component.preview_paths = [Rails.root.join('spec/components')]
-    config.view_component.preview_route = '/view_components'
+    config.view_component.preview_route = '/support/view_components'
     config.view_component.default_preview_layout = 'component_preview'
-    config.view_component.preview_controller = 'ComponentPreviewsController'
+    config.view_component.preview_controller = 'Support::ComponentPreviewsController'
     config.view_component.show_previews = !Rails.env.production_aks?
 
     config.analytics = config_for(:analytics)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,4 +23,8 @@ Rails.application.routes.draw do
     draw(:support)
     draw(:api)
   end
+
+  direct :publish_support_view_component_previews, path_only: true do
+    Rails.application.config.view_component.preview_route
+  end
 end


### PR DESCRIPTION
## Context

Good to have a link to the View Component Previews so everyone can access them.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

![image](https://github.com/user-attachments/assets/c3f33550-e46a-41e4-87fc-c1fa9ff3eee3)

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
