### PR TITLE
Replace content on school placements page

### DIFF
--- a/app/controllers/find/placements_controller.rb
+++ b/app/controllers/find/placements_controller.rb
@@ -2,7 +2,7 @@
 
 module Find
   class PlacementsController < ApplicationController
-    before_action -> { render_not_found if provider.nil? }
+    before_action -> { render_not_found if provider.nil? || provider.selectable_school.blank? }
 
     def index
       @course = provider.courses.includes(

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -2,13 +2,8 @@
   <%= t(".heading", provider_name: course.provider_name) %>
 </h1>
 
-<%= govuk_warning_text(text: t(".warning")) %>
-
-<p class="govuk-body">
-  <%= t(".will_place_you", provider_name: course.provider_name) %>
-</p>
-
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>
+<p class="govuk-body"><%= t(".schools_you_can_choose") %></p>
 
 <ul class="govuk-list govuk-list--spaced" id="course_school_placements">
   <% course.preview_site_statuses.each do |site_status| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,9 +31,8 @@ en:
         heading: Contact %{provider_name}
       placements:
         heading: School placements at %{provider_name}
-        warning: You can’t pick which schools you will be in.
-        will_place_you: '%{provider_name} will place you in different schools you can travel to during your training.'
-        schools_to_be_placed: 'The schools you could be placed in are:'
+        schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
+        schools_you_can_choose: 'The schools you can choose from are:'
       school_placements_advice:
         view:
           heading: How school placements work

--- a/spec/controllers/find/placements_controller_spec.rb
+++ b/spec/controllers/find/placements_controller_spec.rb
@@ -20,6 +20,20 @@ module Find
         end
       end
 
+      context 'when provider sets school_placement as not selectable' do
+        it 'renders the not found page' do
+          provider = create(:provider, selectable_school: false)
+          course = create(:course, :published, provider:)
+
+          get :index, params: {
+            provider_code: provider.provider_code,
+            course_code: course.course_code
+          }
+
+          expect(response).to render_template('errors/not_found')
+        end
+      end
+
       context 'when course is not published' do
         it 'renders the not found page' do
           provider = create(:provider)
@@ -31,6 +45,20 @@ module Find
           }
 
           expect(response).to render_template('errors/not_found')
+        end
+      end
+
+      context 'when course is published and school placement is selectable' do
+        it 'respond successfully' do
+          provider = create(:provider, selectable_school: true)
+          course = create(:course, :published, provider:)
+
+          get :index, params: {
+            provider_code: provider.provider_code,
+            course_code: course.course_code
+          }
+
+          expect(response).to have_http_status(:success)
         end
       end
     end

--- a/spec/features/find/search/viewing_a_course_spec.rb
+++ b/spec/features/find/search/viewing_a_course_spec.rb
@@ -380,6 +380,9 @@ feature 'Viewing a findable course' do
   alias_method :and_i_click, :when_i_click
 
   def then_i_should_be_on_the_school_placements_page
+    expect(page).to have_content(
+      'You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.'
+    )
     @course.site_statuses.new_or_running.map(&:site).uniq.each do |site|
       expect(find_course_show_page).to have_content(smart_quotes(site.decorate.full_address))
     end


### PR DESCRIPTION
## Context

The school placements page is only shown for courses which have chosen to show placement locations (selectable_school_on). 
These providers want candidates to be able to choose a placement location, which means [the existing content is wrong](https://trello.com/1/cards/66e05f6b535a2312652618f9/attachments/66e05fbe6de03ba9a1c982fa/download/find-teacher-training-courses.service.gov.uk_course_G70_G615_placements_(1).png).

This PR is about the change of this content.
And make sure the couses which you can't select a school, can't render the `/placements` page.

## Changes proposed in this pull request

**Before**

![find-teacher-training-courses service gov uk_course_G70_G615_placements_(1)](https://github.com/user-attachments/assets/623c0c69-bdf0-4c70-8925-f39b095afd98)

**After**

![screencapture-find-review-4604-test-teacherservices-cloud-course-2LR-2KBG-placements-2024-10-18-10_04_29](https://github.com/user-attachments/assets/20c253df-2c66-4660-a5b4-62bd09fc8e05)

## Guidance to review

1. No links to school placements page should show if the provider didn't enable the setting to select a school placement
2. And if you try to go manually to any /placements for the courses on step 1, you should a not found page
3. For the ones that are enable the content is show as expected - see [review example](https://find-review-4604.test.teacherservices.cloud/course/2LR/2KBG/placements)
