### PR TITLE
Run migration with callbacks to update updated_at

### DIFF
--- a/app/services/publish/accredited_provider_updater.rb
+++ b/app/services/publish/accredited_provider_updater.rb
@@ -17,17 +17,20 @@ module Publish
     end
 
     def update_provider_and_courses
-      update_provider && update_courses
+      ActiveRecord::Base.transaction do
+        update_provider
+        update_courses
+      end
     end
 
     def update_provider
-      provider.update_columns(accrediting_provider: 'not_an_accredited_provider',
-                              accrediting_provider_enrichments: new_accrediting_provider_enrichments)
+      provider.update!(accrediting_provider: 'not_an_accredited_provider',
+                       accrediting_provider_enrichments: new_accrediting_provider_enrichments)
     end
 
     def update_courses
       courses = provider.courses
-      courses.update_all(accredited_provider_code: new_accredited_provider.provider_code)
+      courses.each { |c| c.update!(accredited_provider_code: new_accredited_provider.provider_code) }
     end
 
     private

--- a/spec/services/publish/accredited_provider_updater_spec.rb
+++ b/spec/services/publish/accredited_provider_updater_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe Publish::AccreditedProviderUpdater do
   describe '#update_provider' do
     let!(:new_accredited_provider) { create(:provider, provider_code: new_accredited_provider_code, recruitment_cycle:) }
 
+    describe 'updates the providers updated_at' do
+      let(:updated_at) { 1.week.ago.change(sec: 0) }
+      let!(:provider) do
+        create(:provider, :accredited_provider,
+               provider_code:,
+               recruitment_cycle:,
+               accrediting_provider_enrichments: nil,
+               updated_at:)
+      end
+
+      it "updates the course's Accrediting Provider" do
+        expect { subject.update_provider }.to change { provider.reload.updated_at }.from(updated_at).to(be_within(1.minute).of(Time.zone.now))
+      end
+    end
+
     context 'when Provider is an Accredited Provider' do
       let!(:provider) do
         create(:provider, :accredited_provider,
@@ -79,13 +94,23 @@ RSpec.describe Publish::AccreditedProviderUpdater do
     let!(:provider) { create(:provider, provider_code:, recruitment_cycle:) }
     let!(:new_accredited_provider) { create(:provider, provider_code: new_accredited_provider_code, recruitment_cycle:) }
 
+    describe 'updates the courses updated_at' do
+      let(:updated_at) { 1.week.ago.change(sec: 0) }
+      let!(:course) { create(:course, provider:, accredited_provider_code: nil, updated_at:) }
+
+      it "updates the course's Accrediting Provider" do
+        expect { subject.update_courses }.to change { course.reload.updated_at }.from(updated_at).to(be_within(1.minute).of(Time.zone.now))
+      end
+    end
+
     context 'when the course does not have an Accredited Provider' do
-      let!(:course) { create(:course, provider:, accredited_provider_code: nil) }
+      let!(:course) { create(:course, provider:, accredited_provider_code: nil, updated_at: 1.week.ago) }
 
       it "updates the course's Accrediting Provider" do
         subject.update_courses
 
         expect(course.reload.accredited_provider_code).to eq(new_accredited_provider_code)
+        expect(course.reload.updated_at).to be_within(1.minute).of(Time.zone.now)
       end
     end
 


### PR DESCRIPTION
## Context

  Amendment to an existing data migration.

  We want the updated_at to change so the incremental sync in apply will pick up
  the changes


## Changes proposed in this pull request

 Use the `update` methods to update providers and courses. This will update the `updated_at` column and schedule the models for updating in the TTAPI.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
