### PR TITLE
Reorder contents section on course pages

### DIFF
--- a/app/components/find/courses/about_schools_component/view.rb
+++ b/app/components/find/courses/about_schools_component/view.rb
@@ -21,9 +21,7 @@ module Find
         end
 
         def render?
-          published_how_school_placements_work.present? ||
-            study_sites.any? ||
-            site_statuses.map(&:site).uniq.many? || preview?(params)
+          @course.training_locations? || preview?(params)
         end
 
         def placements_url

--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m"><%= t(".heading") %> </h2>
 <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
-  <% if course.training_locations? %>
+  <% if course.training_locations? || preview? %>
     <li><%= govuk_link_to t(".where_you_will_train"), "#training-locations" %></li>
   <% end %>
   <% if salaried? %>

--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -1,14 +1,14 @@
 <h2 class="govuk-heading-m"><%= t(".heading") %> </h2>
 <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
-  <% if about_course.present? || preview? %>
-    <li><%= govuk_link_to t(".course_details"), "#section-about" %></li>
+  <% if course.training_locations? %>
+    <li><%= govuk_link_to t(".where_you_will_train"), "#training-locations" %></li>
   <% end %>
   <% if salaried? %>
     <li><%= govuk_link_to t(".salary"), "#section-salary" %></li>
   <% end %>
   <li><%= govuk_link_to t(".fees_and_financial_support"), "#section-financial-support" %></li>
-  <% if how_school_placements_work.present? || program_type == "higher_education_programme" || program_type == "scitt_programme" || preview? %>
-    <li><%= govuk_link_to t(".where_you_will_train"), "#training-locations" %></li>
+  <% if about_course.present? || preview? %>
+    <li><%= govuk_link_to t(".course_details"), "#section-about" %></li>
   <% end %>
   <% if interview_process.present? %>
     <li><%= govuk_link_to t(".interview_process"), "#section-interviews" %></li>

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -509,6 +509,12 @@ class CourseDecorator < ApplicationDecorator
     !object.fee?
   end
 
+  def training_locations?
+    published_how_school_placements_work.present? ||
+      study_sites.any? ||
+      site_statuses.map(&:site).uniq.many?
+  end
+
   private
 
   def not_on_find

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -35,9 +35,7 @@
 
     <%= render Find::Courses::ContentsComponent::View.new(@course) %>
 
-    <% if @course.published_about_course.present? %>
-      <%= render partial: "find/courses/about_course", locals: { course: @course } %>
-    <% end %>
+    <%= render Find::Courses::AboutSchoolsComponent::View.new(@course, preview: preview?(params)) %>
 
     <% if @course.salaried? %>
       <%= render partial: "find/courses/salary", locals: { course: @course } %>
@@ -45,7 +43,9 @@
 
     <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
 
-    <%= render Find::Courses::AboutSchoolsComponent::View.new(@course, preview: preview?(params)) %>
+    <% if @course.published_about_course.present? %>
+      <%= render partial: "find/courses/about_course", locals: { course: @course } %>
+    <% end %>
 
     <% if @course.published_interview_process.present? %>
       <%= render partial: "find/courses/interview_process", locals: { course: @course } %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -107,7 +107,7 @@ en:
           equivalency_tests: Equivalency tests
       contents_component:
         view:
-          course_details: Course details
+          course_details: About the course
           where_you_will_train: Where you will train
           training_with_disabilities: Training with disabilities
           fees_and_financial_support: Fees and financial support
@@ -128,7 +128,7 @@ en:
           a_levels: A levels
           above_or_equivalent_qualification: or above, or equivalent qualification
       about_course:
-        heading: Course details
+        heading: About the course
       qualifications_summary_component:
         view:
           tda_with_qts: Teacher degree apprenticeship (TDA) with QTS

--- a/spec/components/find/courses/contents_component/view_preview.rb
+++ b/spec/components/find/courses/contents_component/view_preview.rb
@@ -25,6 +25,10 @@ module Find
           include ActiveModel::Model
           attr_accessor(:provider, :about_course, :how_school_placements_work, :placements_heading, :about_accrediting_provider, :salaried, :interview_process, :application_status_open)
 
+          def training_locations?
+            true
+          end
+
           def has_bursary?
             has_bursary
           end

--- a/spec/components/find/courses/contents_component/view_spec.rb
+++ b/spec/components/find/courses/contents_component/view_spec.rb
@@ -51,6 +51,18 @@ describe Find::Courses::ContentsComponent::View, type: :component do
     end
   end
 
+  context 'when previewing the course' do
+    it 'renders the schools section link' do
+      course = build(:course).decorate
+      component = described_class.new(course)
+      allow_any_instance_of(ActionController::Base).to receive(:params).and_return(action: 'preview')
+
+      result = render_inline(component)
+
+      expect(result.text).to include('Where you will train')
+    end
+  end
+
   context 'when the course is open' do
     it 'does render the apply link' do
       provider = build(:provider)

--- a/spec/components/find/courses/contents_component/view_spec.rb
+++ b/spec/components/find/courses/contents_component/view_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe Find::Courses::ContentsComponent::View, type: :component do
-  context 'when the program type is higher_education_programme' do
+  context 'when the course has details about school placements' do
     it 'renders the schools section link' do
       provider = build(:provider)
 
-      course = build(
+      course = create(
         :course,
         provider:,
-        program_type: 'higher_education_programme'
+        enrichments: [build(:course_enrichment, :published, how_school_placements_work: 'test')]
       ).decorate
 
       result = render_inline(described_class.new(course))
@@ -19,14 +19,14 @@ describe Find::Courses::ContentsComponent::View, type: :component do
     end
   end
 
-  context 'when the program type is scitt_programme' do
+  context 'when the course has study sites' do
     it 'renders the schools section link' do
       provider = build(:provider)
 
       course = build(
         :course,
         provider:,
-        program_type: 'scitt_programme'
+        study_sites: [Site.new]
       ).decorate
 
       result = render_inline(described_class.new(course))
@@ -35,18 +35,19 @@ describe Find::Courses::ContentsComponent::View, type: :component do
     end
   end
 
-  context 'when the program type neither one of higher education or scitt_progamme' do
-    it 'does not render the school section link' do
+  context 'when the course has many site statuses' do
+    it 'renders the schools section link' do
       provider = build(:provider)
 
-      course = build(
+      course = create(
         :course,
-        provider:
+        provider:,
+        site_statuses: [build(:site_status), build(:site_status)]
       ).decorate
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).not_to include('Where you will train')
+      expect(result.text).to include('Where you will train')
     end
   end
 


### PR DESCRIPTION
## Context

Currently, the order of the course page is problematic for candidates, as they have to skip over some sections to get to key information they need to narrow down courses before delving into the detail. [See example of the live site](https://trello.com/1/cards/66df067eb52d058bd38651e4/attachments/66df073ffef4da0a1a4afd68/download/find-teacher-training-courses.service.gov.uk_course_2FR_X558.png).

## Changes

* Update “Course details” title Update “Course details” to “About the course”
* Reorder of the contents section and the content
* Make sure contents section has the same equivalent check on render the content as well.

## Updated order

The order of the sections on the course page and in the contents list should be as follows:

Where you will train
Fees and financial support
About the course
Interview process
Training with disabilities
Support and advice
Apply

* Salary section should be before Fees and financial support if the course is salaried

