### PR TITLE
Publish a 2024 Course

### DIFF
--- a/db/data/20241024085622_publish_2024_course.rb
+++ b/db/data/20241024085622_publish_2024_course.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Publish2024Course < ActiveRecord::Migration[7.2]
+  def up
+    current_user = User.find_by!(email: 'david4.young@education.gov.uk')
+    course = Course.find_by!(uuid: 'b8da2ddd-d7c8-440e-ba21-67eab7eeba53')
+
+
+    # Code extracted from
+    # https://github.com/DFE-Digital/publish-teacher-training/blob/adbc010be7e3457a986fae93bcfead66a7aa0ef9/app/controllers/publish/courses_controller.rb#L133
+    Course.transaction do
+      course.publish_sites
+      course.publish_enrichment(current_user)
+      course.application_status_open!
+      # NotificationService::CoursePublished.call(course: @course)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20241024085622_publish_2024_course.rb
+++ b/db/data/20241024085622_publish_2024_course.rb
@@ -5,7 +5,6 @@ class Publish2024Course < ActiveRecord::Migration[7.2]
     current_user = User.find_by!(email: 'david4.young@education.gov.uk')
     course = Course.find_by!(uuid: 'b8da2ddd-d7c8-440e-ba21-67eab7eeba53')
 
-
     # Code extracted from
     # https://github.com/DFE-Digital/publish-teacher-training/blob/adbc010be7e3457a986fae93bcfead66a7aa0ef9/app/controllers/publish/courses_controller.rb#L133
     Course.transaction do


### PR DESCRIPTION
## Context

Register team are having problems importing an Application from Apply due to the Course not being visible on Publish API.
As a fix we want to publish the Course in question. To do this openly it has been put into a Data Migration

## Changes proposed in this pull request

Data Migration publishes a specific course

## Guidance to review

- N/A

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
