### PR TITLE
Perf: Better response times from api/public/v1/courses

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -7,13 +7,23 @@ module API
         def index
           render jsonapi: paginate(courses),
                  include: include_param,
-                 meta: { count: courses.count('course.id') },
+                 meta: { count: cached_course_count },
                  class: API::Public::V1::SerializerService.call
         rescue ActiveRecord::StatementInvalid
           render json: { status: 400, message: 'Invalid changed_since value, the format should be an ISO8601 UTC timestamp, for example: `2019-01-01T12:01:00Z`' }.to_json, status: :bad_request
         end
 
         private
+
+        def cached_course_count
+          if params[:no_cache]
+            courses.count('course.id')
+          else
+            Rails.cache.fetch('api_course_count', expires_in: 5.minutes) do
+              courses.count('course.id')
+            end
+          end
+        end
 
         def courses
           @courses ||= APICourseSearchService.call(

--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -18,12 +18,8 @@ module API
         def cached_course_count
           year = permitted_params[:recruitment_cycle_year] || RecruitmentCycle.current.year
 
-          if permitted_params[:no_cache]
+          Rails.cache.fetch("api_course_count_#{year}", expires_in: 5.minutes) do
             courses.count('course.id')
-          else
-            Rails.cache.fetch("api_course_count_#{year}", expires_in: 5.minutes) do
-              courses.count('course.id')
-            end
           end
         end
 
@@ -40,7 +36,7 @@ module API
         end
 
         def permitted_params
-          params.permit('page', 'no_cache', 'sort', 'per_page', 'courses', 'recruitment_cycle_year', 'include', 'filter' => %w[updated_since funding_type])
+          params.permit('page', 'sort', 'per_page', 'courses', 'recruitment_cycle_year', 'include', 'filter' => %w[updated_since funding_type])
         end
       end
     end

--- a/app/lib/required_qualifications_summary.rb
+++ b/app/lib/required_qualifications_summary.rb
@@ -8,7 +8,12 @@ class RequiredQualificationsSummary
   end
 
   def extract
-    legacy_qualifications_attribute = course.latest_published_enrichment&.required_qualifications
+    # This performance improvement saves ~100 database queries in the courses api endpoint
+    legacy_qualifications_attribute = if course.enrichments.loaded?
+                                        course.enrichments.max_by(&:created_at)&.required_qualifications
+                                      else
+                                        course.latest_published_enrichment&.required_qualifications
+                                      end
     return legacy_qualifications_attribute if legacy_qualifications_attribute.present?
 
     generate_summary_text

--- a/app/lib/required_qualifications_summary.rb
+++ b/app/lib/required_qualifications_summary.rb
@@ -8,7 +8,6 @@ class RequiredQualificationsSummary
   end
 
   def extract
-    # This performance improvement saves ~100 database queries in the courses api endpoint
     legacy_qualifications_attribute = if course.enrichments.loaded?
                                         course.enrichments.max_by(&:created_at)&.required_qualifications
                                       else

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -594,7 +594,7 @@ class Course < ApplicationRecord
   end
 
   def last_published_at
-    return enrichments.max_by(&:last_published_timestamp_utc)&.last_published_timestamp_utc if enrichments.loaded?
+    return enrichments.select(&:last_published_timestamp_utc).max_by(&:last_published_timestamp_utc)&.last_published_timestamp_utc if enrichments.loaded?
 
     enrichments.maximum(:last_published_timestamp_utc)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -594,6 +594,8 @@ class Course < ApplicationRecord
   end
 
   def last_published_at
+    return enrichments.max_by(&:last_published_timestamp_utc)&.last_published_timestamp_utc if enrichments.loaded?
+
     enrichments.maximum(:last_published_timestamp_utc)
   end
 

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -138,7 +138,7 @@ module API
         end
 
         attribute :subject_codes do
-          @object.subjects.pluck(:subject_code).compact
+          @object.subjects.map(&:subject_code).compact
         end
 
         attribute :required_qualifications do

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe API::Public::V1::CoursesController do
 
           it 'delegates to the CourseSearchService' do
             expect(CourseSearchService).to have_received(:call).with(
-              hash_including(filter: ActionController::Parameters.new(funding_type: 'salary'))
+              hash_including(filter: ActionController::Parameters.new(funding_type: 'salary').permit!)
             )
           end
         end

--- a/spec/lib/required_qualifications_summary_spec.rb
+++ b/spec/lib/required_qualifications_summary_spec.rb
@@ -60,6 +60,18 @@ describe RequiredQualificationsSummary do
       end
     end
 
+    context 'when the course enrichments are not loaded' do
+      let(:enrichment) { build(:course_enrichment, :published, required_qualifications: 'GCSE Computer Science') }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it 'returns the expected value' do
+        course.reload
+        expect(course.enrichments.loaded?).to be_falsey
+        summary = described_class.new(course).extract
+        expect(summary).to eq 'GCSE Computer Science'
+      end
+    end
+
     context 'when required_qualifications enrichment attribute is blank' do
       it 'assembles a whole summary based on course attributes' do
         course = create(:course, :primary)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3157,6 +3157,38 @@ describe Course do
     end
   end
 
+  describe '#last_published_at' do
+    context 'with an unpublished course' do
+      let(:course) { create(:course, study_mode: :part_time, enrichments: [create(:course_enrichment)]) }
+
+      it 'returns nil' do
+        expect(course.last_published_at).to be_nil
+      end
+    end
+
+    context 'with a twice published course' do
+      let(:course) do
+        create(:course, study_mode: :part_time, enrichments:
+          [
+            create(:course_enrichment, :published, last_published_timestamp_utc: '1/1/2024'),
+            create(:course_enrichment, :published, last_published_timestamp_utc: '1/1/2023')
+          ])
+      end
+
+      it 'selects the enrichment with the latest date' do
+        expect(course.last_published_at).to eq('1/1/2024')
+      end
+
+      context 'when the enrichments are not loaded' do
+        it 'selects the enrichment with the latest date' do
+          course.reload
+          expect(course.enrichments.loaded?).to be_falsey
+          expect(course.last_published_at).to eq('1/1/2024')
+        end
+      end
+    end
+  end
+
   describe 'funding_type and program_type' do
     context 'setting the funding to apprenticeship' do
       it 'sets the funding to apprenticeship and program_type to pg_teaching_apprenticeship' do


### PR DESCRIPTION
## Context

Counting the number of courses in a recruitment cycle is very expensive. We do this on every request to the courses endpoint.

### This is an "agonising" endpoint in Skylight

![image](https://github.com/user-attachments/assets/774703d7-e379-44f1-bd29-5cb0bbb0114a)


## Loadtesting the change
The tests were run with Siege.

[Siege documentation](https://linux.die.net/man/1/siege) 

All tests were run against review apps. The review apps all had 1 replica with 512MiB memory.

### Before changes

```
inulty-dfe ~/Code/publish-teacher-training ( perf-api-providers) $ siege -c 10 -t 1m -if app/controllers/api/loadtest-urls-other-branch.txt

{       "transactions":                           91,
        "availability":                       100.00,
        "elapsed_time":                        59.50,
        "data_transferred":                    19.95,
        "response_time":                        5.97,
        "transaction_rate":                     1.53,
        "throughput":                           0.34,
        "concurrency":                          9.13,
        "successful_transactions":                31,
        "failed_transactions":                     0,
        "longest_transaction":                 19.52,
        "shortest_transaction":                 0.97
}71
}
```

### With just `loaded?` changes

```
inulty-dfe ~/Code/publish-teacher-training ( perf-api-providers) $ siege -c 10 -t 1m -if app/controllers/api/loadtest-urls-no-cache.txt

{       "transactions":                           75,
        "availability":                       100.00,
        "elapsed_time":                        59.49,
        "data_transferred":                    26.39,
        "response_time":                        7.16,
        "transaction_rate":                     1.26,
        "throughput":                           0.44,
        "concurrency":                          9.03,
        "successful_transactions":                45,
        "failed_transactions":                     0,
        "longest_transaction":                 19.76,
        "shortest_transaction":                 1.11
}
```

### With count query cached and `loaded?` changes

```
inulty-dfe ~/Code/publish-teacher-training ( perf-api-providers) $ siege -c 10 -t 1m -if app/controllers/api/loadtest-urls.txt

{       "transactions":                           94,
        "availability":                       100.00,
        "elapsed_time":                        59.86,
        "data_transferred":                    51.11,
        "response_time":                        6.07,
        "transaction_rate":                     1.57,
        "throughput":                           0.85,
        "concurrency":                          9.53,
        "successful_transactions":                84,
        "failed_transactions":                     0,
        "longest_transaction":                 13.18,
        "shortest_transaction":                 1.90
}
```


### Result

|Operation|Original|No cache changes|Cache changes|
|---|---|---|---|
| throughput |  0.34 | 0.44 | 0.85
| successful_transactions| 31 | 45 | 84 |
| data_transferred | 19.95 | 26.39 | 51.11|

### The URLs
The URLs used were variations on this list.
I added `no_cache` for the "no cache" test run.
I changed the PR number for the "original" test run.

![image](https://github.com/user-attachments/assets/c1cb08ad-c1b6-4ed2-9a67-41d2057682c7)



## Changes proposed in this pull request

- Use `loaded?` to avoid making requests to the database when we already have records in memory.
- Cache the course record count per recruitment cycle for a period of time.
- The `filter` field is not used in the cache key because it is ignored in the query. The API does not filter courses.

## Guidance to review

- How long should the course count be cached? I would suggest 1 day.

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
