### PR TITLE
Change content about the service in relation to placement locations

### DIFF
--- a/app/components/publish/providers/school_placements/explainer_component.html.erb
+++ b/app/components/publish/providers/school_placements/explainer_component.html.erb
@@ -12,5 +12,5 @@
 </div>
 
 <p class="govuk-body">
-  Add placement schools here, then attach them to any of your courses from the ‘Basic details’ tab on each course page.
+  Add placement schools here, then attach them to any of your courses from the ‘Basic details’ tab on each course page. You can choose whether to show or hide the placements from candidates in Organisation details.
 <p>

--- a/app/views/pages/add_schools_and_study_sites.html.erb
+++ b/app/views/pages/add_schools_and_study_sites.html.erb
@@ -40,6 +40,8 @@
 
     <p class="govuk-body">You can add all potential schools and study sites to your account and then link them to each course that you publish.</p>
 
+    <p class="govuk-body">If you do not want candidate to see a list of placement school locations, or select a preference when they apply, you can hide them in Organisation details.</p>
+
     <h2 id="adding-a-school" class="govuk-heading-m">Adding a school</h2>
 
     <p class="govuk-body"> To add details about a school, go to the ‘Schools’ tab.</p>

--- a/spec/components/publish/providers/school_placements/explainer_component_spec.rb
+++ b/spec/components/publish/providers/school_placements/explainer_component_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe Publish::Providers::SchoolPlacements::ExplainerComponent, type: :
     expect(page).to have_text('Add the schools you can offer placements in. A placement school is where candidates will go to get classroom experience.', normalize_ws: true)
     expect(page).to have_text('Your courses will not appear in candidate’s location searches if you do not add placement schools to them.', normalize_ws: true)
     expect(page).to have_link('Find out more about why you should add school placement locations', href: 'https://www.publish-teacher-training-courses.service.gov.uk/how-to-use-this-service/add-schools-and-study-sites')
-    expect(page).to have_text('Add placement schools here, then attach them to any of your courses from the ‘Basic details’ tab on each course page.', normalize_ws: true)
+    expect(page).to have_text('Add placement schools here, then attach them to any of your courses from the ‘Basic details’ tab on each course page. You can choose whether to show or hide the placements from candidates in Organisation details.', normalize_ws: true)
   end
 end


### PR DESCRIPTION
## Context

Now that some training providers can opt to show placement school locations in Find and Apply, we can update the content in Publish to reflect this option to improve awareness.

## Changes

![Find_-_Course_pages_and_Pre-filtering_-_Page_1_(6)](https://github.com/user-attachments/assets/ddb41364-7577-4978-8a7f-f9138f3ab440)

![Find_-_Course_pages_and_Pre-filtering_-_Page_1_(8)](https://github.com/user-attachments/assets/81ffbfa9-f9e1-46e9-ae6a-8cf2a8e22ef8)
