### PR TITLE
Users should not see any providers without explicit association

### DIFF
--- a/app/components/persona.html.erb
+++ b/app/components/persona.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag("/auth/developer/callback") do %>
+<%= form_tag("/auth/developer/callback", method: :get) do %>
   <%= hidden_field_tag "email", email_address %>
   <%= hidden_field_tag "first_name", first_name %>
   <%= hidden_field_tag "last_name", last_name %>

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -101,7 +101,7 @@ module Publish
     private
 
     def provider
-      @provider ||= recruitment_cycle.providers.find_by!(provider_code: params[:provider_code] || params[:code])
+      @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code] || params[:code])
     end
 
     def providers

--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -9,6 +9,9 @@ module Publish
     before_action :check_interrupt_redirects
     before_action :clear_previous_cycle_year_in_session, unless: -> { FeatureService.enabled?('rollover.can_edit_current_and_next_cycles') }
 
+    # Protect every action of a provider
+    before_action { authorize provider, :show? if provider }
+
     after_action :verify_authorized
 
     # DFE Analytics namespace

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -45,7 +45,7 @@ if AuthenticationService.magic_link?
   get '/auth/dfe/signout', to: 'sessions#destroy'
 elsif AuthenticationService.persona?
   get '/personas', to: 'personas#index'
-  post '/auth/developer/callback', to: 'sessions#callback'
+  get '/auth/developer/callback', to: 'sessions#callback'
   get '/auth/developer/signout', to: 'sessions#destroy'
 else
   get '/auth/dfe/callback', to: 'sessions#callback'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,4 @@
+base_url: http://www.publish-test.com
 govuk_notify:
   api_key: cafe-cafecafe-cafe-cafe-cafe-cafecafecafe-cafecafe-cafe-cafe-cafe-cafecafecafe
 system_authentication_token: "Ge32"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -49,7 +49,7 @@ describe SessionsController do
   describe '#callback' do
     let(:request_callback) do
       request.env['omniauth.auth'] = user_exists_in_dfe_sign_in(user:)
-      post :callback
+      get :callback
     end
 
     context 'existing database user' do

--- a/spec/features/publish/editing_notification_preference_spec.rb
+++ b/spec/features/publish/editing_notification_preference_spec.rb
@@ -33,7 +33,7 @@ feature 'Opting into notifications', { can_edit_current_and_next_cycles: false }
   end
 
   def when_i_visit_accredited_provider_page
-    publish_provider_courses_index_page.load(id: accrediting_provider.provider_code)
+    publish_provider_courses_index_page.load(provider_code: accrediting_provider.provider_code, recruitment_cycle_year: accrediting_provider.recruitment_cycle.year)
   end
 
   def and_i_click_on_notifications_link

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -419,7 +419,9 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def next_cycle_provider
-    create(:provider, :next_recruitment_cycle, courses: [build(:course, enrichments: [course_enrichments_published])])
+    create(:provider, :next_recruitment_cycle, provider_code: current_user.providers.first.provider_code, courses: [build(:course, enrichments: [course_enrichments_published])]) do |provider|
+      current_user.providers << provider
+    end
   end
 
   def then_i_should_see_the_status_scheduled

--- a/spec/requests/publish/authorization_spec.rb
+++ b/spec/requests/publish/authorization_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Provider authorization spec' do
+  include DfESignInUserHelper
+
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
+  let(:provider) { create(:provider, recruitment_cycle:, provider_code: 'A14') }
+  let(:another_provider) { create(:provider) }
+  let!(:user) { create(:user, providers: [provider]) }
+
+  before { host! URI(Settings.base_url).host }
+
+  describe 'GET /publish/organisations' do
+    describe 'when authenticated' do
+      it 'redirects twice to the first valid providers courses' do
+        get '/auth/dfe/callback', headers: { 'omniauth.auth' => user_exists_in_dfe_sign_in(user:) }
+        get publish_root_path
+        expect(response).to redirect_to('/publish/organisations/A14')
+        follow_redirect!
+        expect(response).to redirect_to('/publish/organisations/A14/2025/courses')
+        follow_redirect!
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'GET /publish/organisations/:provider_code/:recruitment_cycle_year' do
+    describe 'when the current_user is not authorized to see the provider code' do
+      it 'returns 403' do
+        get '/auth/dfe/callback', headers: { 'omniauth.auth' => user_exists_in_dfe_sign_in(user:) }
+        get publish_provider_recruitment_cycle_courses_path(provider_code: another_provider.provider_code, recruitment_cycle_year: another_provider.recruitment_cycle.year)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR fixes a bug that allowed any provider user to visit the courses pages (and more ) of any provider in the system. 
We've added an `authorize provider` call to a before action in the parent PublishController which authorizes all requests to any action in that controller.

Some of the tests had to be changed so that the user perfroming the action under test had an explicit association with the provider they are interacting with in the test.

## Changes proposed in this pull request

![image](https://github.com/user-attachments/assets/9607eac6-f6b4-4fb2-a7c2-731f572f223b)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->



## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated added to the Azure KeyVault
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Attach PR to Trello card
