### PR TITLE
Add a link to the accredited provider on support page

### DIFF
--- a/app/views/support/providers/accredited_providers/index.html.erb
+++ b/app/views/support/providers/accredited_providers/index.html.erb
@@ -2,18 +2,18 @@
 
 <%= govuk_button_link_to("Add accredited provider", search_support_recruitment_cycle_provider_accredited_providers_path) %>
 
-<% if @provider.accredited_bodies.none? %>
+<% if @accredited_providers.none? %>
   <p class="govuk-body">There are no accredited providers for <%= @provider.provider_name %>.</p>
 <% else %>
-  <% @provider.accredited_bodies.each do |accredited_body| %>
+  <% @accredited_providers.each do |accredited_provider| %>
     <%= render AccreditedProvider.new(
-      provider_name: accredited_body[:provider_name],
+      provider_name: govuk_link_to(accredited_provider.provider_name, support_recruitment_cycle_provider_path(accredited_provider.recruitment_cycle_year, accredited_provider)),
       remove_path: delete_support_recruitment_cycle_provider_accredited_provider_path(
-        accredited_provider_code: accredited_body[:provider_code]
+        accredited_provider_code: accredited_provider.provider_code
       ),
-      about_accredited_provider: accredited_body[:description],
+      about_accredited_provider: @provider.accredited_body(accredited_provider.provider_code)[:description],
       change_about_accredited_provider_path: edit_support_recruitment_cycle_provider_accredited_provider_path(
-        accredited_provider_code: accredited_body[:provider_code]
+        accredited_provider_code: accredited_provider.provider_code
       )
     ) %>
   <% end %>

--- a/spec/features/support/providers/accredited_providers_spec.rb
+++ b/spec/features/support/providers/accredited_providers_spec.rb
@@ -166,6 +166,9 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def then_i_should_see_the_accredited_provider_name_displayed
-    expect(page).to have_css('h2', text: 'Accrediting provider name')
+    expect(page).to have_css(
+      'h2.govuk-summary-card__title a.govuk-link',
+      text: 'Accrediting provider name'
+    )
   end
 end


### PR DESCRIPTION
## Context

When inspecting a training providers accredited providers, there is not link to easily navigate to the accredited provider from that page.

## Changes proposed in this pull request

Add a link to we 

## Guidance to review

1. Enter on one provider (a lead school e.g `support/2025/providers/21176`)
2. Click on accredited providers tab
3. See the links ✌️ 
