### PR TITLE
Fix intermittent spec

### DIFF
--- a/spec/features/publish/searching_for_a_school_spec.rb
+++ b/spec/features/publish/searching_for_a_school_spec.rb
@@ -42,7 +42,7 @@ feature 'Searching for a school from the GIAS list' do
   end
 
   def and_there_are_schools_in_the_database
-    @school = create(:gias_school, name: 'Bernard')
+    @school = create(:gias_school, name: 'Bernard', urn: '466415', postcode: 'NW1 5WS', town: 'Damonmouth')
     @school_two = create(:gias_school, name: 'School Two')
     @school_three = create(:gias_school, name: 'School Three')
   end


### PR DESCRIPTION
## Problem

A test keeps failing intermittently on CI.

```
Failures:
  1) Searching for a school from the GIAS list i can search for a school by query
     Failure/Error: expect(page).to have_no_content @school.name
       expected not to find text "Bernard" in "Cookies on Publish teacher training courses\nWe use some essential cookies to make this service work.\nWe’d also like to use analytics cookies so we can understand how you use the service and make improvements.\nAccept analytics cookies Reject analytics cookies View cookies\nSkip to main content\nGOV.UK Publish teacher training courses\nSign out (Micheline Stokes)\nTest This is a new service – your feedback will help us to improve it.\nCourses Schools Study sites Users Accredited providers Organisation details\nBack\nAdd school 3 results found for ‘sch’\nChange your search if the school you’re looking for is not listed.\nSchool\nBernard\nSchulistburgh, U7 2NJ\nSchool Three\nSouth Frank, SE4 0JY\nSchool Two\nCathleenland, S7 1RL\nContinue\nCancel\nGet support\nEmail: becomingateacher@digital.education.gov.uk We respond within 5 working days, or one working day for more urgent queries Teacher Training Courses API documentation\nSupport links\nHow to use this service Accessibility Cookies Privacy Terms and conditions Service performance\n&copy Crown copyright"
     # /usr/local/bundle/gems/super_diff-0.12.1/lib/super_diff/rspec/monkey_patches.rb:45:in `handle_failure'
     # ./spec/features/publish/searching_for_a_school_spec.rb:69:in `then_i_should_see_a_radio_list'
     # ./spec/features/publish/searching_for_a_school_spec.rb:21:in `block (2 levels) in <main>'
     # ./spec/rails_helper.rb:71:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in `cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in `block (2 levels) in cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in `cleaning'
     # ./spec/rails_helper.rb:70:in `block (2 levels) in <top (required)>'
     # ./spec/support/features/rollover/can_edit_current_and_next_cycle.rb:19:in `block (2 levels) in <top (required)>'
     # ./spec/support/authentication/mode/magic_link.rb:20:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
Finished in 1 minute 22.46 seconds (files took 9.02 seconds to load)
71 examples, 1 failure
Failed examples:
rspec ./spec/features/publish/searching_for_a_school_spec.rb:11 # Searching for a school from the GIAS list i can search for a school by query
```

## Current spec

The spec was adding the term "sch" on the school search to search only GiasSchools that are "Schools" - "sch*".

But the spec was failing because it was including "Bernard" school.

## Investigation

In our search functionality, the searchable_vector_value method was intermittently including terms like "Schaeferbury" due to Faker which led to unexpected results.

Specifically, searches with inputs such as "sch" would return records that weren’t intended to match, as these additional terms were being added inconsistently.

Example of the data failing spec:

```ruby
@school = create(:gias_school, name: 'Bernard')

# In some spec sometimes it could create terms with "sch"
@school.attributes
=> {"id"=>1,
 "urn"=>"504234",
 "name"=>"Bernard",
 "town"=>"Schaeferbury",
 "postcode"=>"UX5 4LF",
 "searchable"=>"'4lf':5 '504234':1 'bernard':2,3 'schaeferbury':7 'ux5':4 'ux54lf':6"
}
```

So when searching for "sch" the term was in the searchable vector because of the town field. Hence why was intermitent.

This was caused by certain fields in searchable_vector_value sometimes including extra data based on variations in the data source, leading to inconsistency in the search vector values.

## Solution

To ensure consistent and accurate search results,
I updated the factory to avoid searchable_vector_value method to the add unwanted terms to test the search.

This way, all values passed to TO_TSVECTOR exclude extraneous terms like "Sch."

Now, only the relevant values are indexed, avoiding any unintentional matches.
