### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,30 @@
 # Find & Publish Teacher Training
 
+[![View performance data on Skylight](https://badges.skylight.io/status/OSMheTARjT6C.svg)](https://oss.skylight.io/app/applications/OSMheTARjT6C)
+
 This repo is home to three services:
 
 - A service for candidates to [find teacher training](https://find-teacher-training-courses.service.gov.uk)
 - A service for providers to [publish teacher training courses](https://www.publish-teacher-training-courses.service.gov.uk)
-- An API to retrieve data on [teacher training courses](https://api.publish-teacher-training-courses.service.gov.uk/)
-
-## Status
-
-![Build](https://github.com/DFE-Digital/publish-teacher-training/workflows/Build/badge.svg)
-[![View performance data on Skylight](https://badges.skylight.io/status/NXAwzyZjkp2m.svg?token=JaYZey50Y8gfC00RvzkcrDz5OP-SwiBSTtbhkMw1KIs)](https://www.skylight.io/app/applications/NXAwzyZjkp2m)
-
-## Table of Contents
-
-- [Environments](#environments)
-- [Guides](#guides)
-- [License](#license)
+- An API to retrieve data on [teacher training courses](https://api.publish-teacher-training-courses.service.gov.uk)
 
 ## Environments
 
 ### Find
 
-| Name        | URL                                                                    | Description
-| ----------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------
-| Production  | [www](https://find-teacher-training-courses.service.gov.uk)   | Public site
-| Staging     | [staging](https://staging.find-teacher-training-courses.service.gov.uk)| For internal use by DfE to test deploys
-| QA          | [qa](https://qa.find-teacher-training-courses.service.gov.uk)     | For internal use by DfE for testing. Automatically deployed from main
+| Name        | URL                                                                     | Description
+| ----------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------
+| Production  | [www](https://find-teacher-training-courses.service.gov.uk)             | Public site
+| Staging     | [staging](https://staging.find-teacher-training-courses.service.gov.uk) | For internal use by DfE to test deploys
+| QA          | [qa](https://qa.find-teacher-training-courses.service.gov.uk)           | For internal use by DfE for testing. Automatically deployed from main
 
 ### Publish
 
-| Name        | URL                                                                | Description
-| ----------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------
-| Production  | [www](https://www.publish-teacher-training-courses.service.gov.uk) | Public site
+| Name        | URL                                                                        | Description
+| ----------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------
+| Production  | [www](https://www.publish-teacher-training-courses.service.gov.uk)         | Public site
 | Staging     | [staging](https://staging.publish-teacher-training-courses.service.gov.uk) | For internal use by DfE to test deploys
-| QA          | [qa](https://qa.publish-teacher-training-courses.service.gov.uk)  | For internal use by DfE for testing. Automatically deployed from main
+| QA          | [qa](https://qa.publish-teacher-training-courses.service.gov.uk)           | For internal use by DfE for testing. Automatically deployed from main
 
 ## Guides
 
@@ -53,7 +44,3 @@ This repo is home to three services:
 - [Support Playbook](/guides/support_playbook.md)
 - [AKS Module Information](/guides/aks_modules.md)
 - [AKS Cheatsheet](/guides/aks-cheatsheet.md)
-
-## License
-
-[MIT Licence](LICENCE)


### PR DESCRIPTION
## Context

The "build" badge in broken on the README.md page. It doesn't necessarily provide any value to us, so we should remove it.

The Skylight badge is a requirement for their OSS program.

## Changes proposed in this pull request

- Remove the "build" badge.
- Update the Skylight badge to point to the `production_aks` environment.
- Remove the LICENSE link as the repository shows important information in the right sidebar.

  ![CleanShot 2024-10-28 at 11 07 52@2x](https://github.com/user-attachments/assets/2cc816b0-ac31-4ea0-9b7f-b95762e32be4)


## Guidance to review

- Review the updated [README](https://github.com/DFE-Digital/publish-teacher-training/blob/dd/update-readme-status-badges/README.md) content.