### PR TITLE
Rename Publish::PublishController to Publish::ApplicationController

### DIFF
--- a/app/controllers/publish/application_controller.rb
+++ b/app/controllers/publish/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class PublishController < ApplicationController
+  class ApplicationController < ::ApplicationController
     include SuccessMessage
 
     layout 'publish'

--- a/app/controllers/publish/courses/a_level_requirements/a_level_requirements_controller.rb
+++ b/app/controllers/publish/courses/a_level_requirements/a_level_requirements_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Courses
     module ALevelRequirements
-      class ALevelRequirementsController < PublishController
+      class ALevelRequirementsController < ApplicationController
         before_action :assign_course, :verify_teacher_degree_apprenticeship_course
 
         def new

--- a/app/controllers/publish/courses/about_this_course_controller.rb
+++ b/app/controllers/publish/courses/about_this_course_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class AboutThisCourseController < PublishController
+    class AboutThisCourseController < ApplicationController
       include GotoPreview
       include CopyCourseContent
 

--- a/app/controllers/publish/courses/accredited_provider_controller.rb
+++ b/app/controllers/publish/courses/accredited_provider_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class AccreditedProviderController < PublishController
+    class AccreditedProviderController < ApplicationController
       include CourseBasicDetailConcern
       before_action :build_course, only: %i[edit update]
       before_action :build_course_params, only: :continue

--- a/app/controllers/publish/courses/age_range_controller.rb
+++ b/app/controllers/publish/courses/age_range_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class AgeRangeController < PublishController
+    class AgeRangeController < ApplicationController
       include CourseBasicDetailConcern
       decorates_assigned :course
 

--- a/app/controllers/publish/courses/application_status_controller.rb
+++ b/app/controllers/publish/courses/application_status_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class ApplicationStatusController < PublishController
+    class ApplicationStatusController < ApplicationController
       def new
         course
       end

--- a/app/controllers/publish/courses/applications_open_controller.rb
+++ b/app/controllers/publish/courses/applications_open_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class ApplicationsOpenController < PublishController
+    class ApplicationsOpenController < ApplicationController
       before_action :build_recruitment_cycle
       before_action :build_course_params, only: %i[update continue]
       include CourseBasicDetailConcern

--- a/app/controllers/publish/courses/base_funding_type_controller.rb
+++ b/app/controllers/publish/courses/base_funding_type_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class BaseFundingTypeController < PublishController
+    class BaseFundingTypeController < ApplicationController
       include SuccessMessage
       include GotoPreview
 

--- a/app/controllers/publish/courses/degrees/grade_controller.rb
+++ b/app/controllers/publish/courses/degrees/grade_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Courses
     module Degrees
-      class GradeController < PublishController
+      class GradeController < ApplicationController
         include GotoPreview
 
         def edit

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Courses
     module Degrees
-      class StartController < PublishController
+      class StartController < ApplicationController
         include GotoPreview
 
         def edit

--- a/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Courses
     module Degrees
-      class SubjectRequirementsController < PublishController
+      class SubjectRequirementsController < ApplicationController
         include CopyCourseContent
         include GotoPreview
 

--- a/app/controllers/publish/courses/deletions_controller.rb
+++ b/app/controllers/publish/courses/deletions_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class DeletionsController < PublishController
+    class DeletionsController < ApplicationController
       before_action :redirect_to_courses, if: -> { course&.is_published? }
 
       def edit

--- a/app/controllers/publish/courses/draft_rollover_controller.rb
+++ b/app/controllers/publish/courses/draft_rollover_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class DraftRolloverController < PublishController
+    class DraftRolloverController < ApplicationController
       before_action :redirect_to_courses, if: -> { course.is_published? }
 
       def edit

--- a/app/controllers/publish/courses/engineers_teach_physics_controller.rb
+++ b/app/controllers/publish/courses/engineers_teach_physics_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class EngineersTeachPhysicsController < PublishController
+    class EngineersTeachPhysicsController < ApplicationController
       decorates_assigned :course
       include CourseBasicDetailConcern
 

--- a/app/controllers/publish/courses/fees_and_financial_support_controller.rb
+++ b/app/controllers/publish/courses/fees_and_financial_support_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class FeesAndFinancialSupportController < PublishController
+    class FeesAndFinancialSupportController < ApplicationController
       include CopyCourseContent
       before_action :authorise_with_pundit
 

--- a/app/controllers/publish/courses/funding_type_controller.rb
+++ b/app/controllers/publish/courses/funding_type_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class FundingTypeController < PublishController
+    class FundingTypeController < ApplicationController
       include CourseBasicDetailConcern
 
       def continue

--- a/app/controllers/publish/courses/gcse_requirements_controller.rb
+++ b/app/controllers/publish/courses/gcse_requirements_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class GcseRequirementsController < PublishController
+    class GcseRequirementsController < ApplicationController
       include CopyCourseContent
       include GotoPreview
 

--- a/app/controllers/publish/courses/interview_process_controller.rb
+++ b/app/controllers/publish/courses/interview_process_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class InterviewProcessController < PublishController
+    class InterviewProcessController < ApplicationController
       include CopyCourseContent
       before_action :authorise_with_pundit
 

--- a/app/controllers/publish/courses/length_controller.rb
+++ b/app/controllers/publish/courses/length_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class LengthController < PublishController
+    class LengthController < ApplicationController
       before_action :redirect_if_not_editable
 
       def edit

--- a/app/controllers/publish/courses/level_controller.rb
+++ b/app/controllers/publish/courses/level_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class LevelController < PublishController
+    class LevelController < ApplicationController
       include CourseBasicDetailConcern
 
       private

--- a/app/controllers/publish/courses/modern_languages_controller.rb
+++ b/app/controllers/publish/courses/modern_languages_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class ModernLanguagesController < PublishController
+    class ModernLanguagesController < ApplicationController
       decorates_assigned :course
       before_action :build_course, only: %i[edit update]
       before_action :build_course_params, only: [:continue]

--- a/app/controllers/publish/courses/outcome_controller.rb
+++ b/app/controllers/publish/courses/outcome_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class OutcomeController < PublishController
+    class OutcomeController < ApplicationController
       include CourseBasicDetailConcern
 
       def continue

--- a/app/controllers/publish/courses/providers_controller.rb
+++ b/app/controllers/publish/courses/providers_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class ProvidersController < PublishController
+    class ProvidersController < ApplicationController
       include CourseBasicDetailConcern
 
       before_action :build_course, only: %i[show]

--- a/app/controllers/publish/courses/school_placements_controller.rb
+++ b/app/controllers/publish/courses/school_placements_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class SchoolPlacementsController < PublishController
+    class SchoolPlacementsController < ApplicationController
       include CopyCourseContent
       include GotoPreview
 

--- a/app/controllers/publish/courses/schools_controller.rb
+++ b/app/controllers/publish/courses/schools_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class SchoolsController < PublishController
+    class SchoolsController < ApplicationController
       include CourseBasicDetailConcern
 
       def continue

--- a/app/controllers/publish/courses/start_date_controller.rb
+++ b/app/controllers/publish/courses/start_date_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class StartDateController < PublishController
+    class StartDateController < ApplicationController
       include CourseBasicDetailConcern
 
       private

--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class StudyModeController < PublishController
+    class StudyModeController < ApplicationController
       include CourseBasicDetailConcern
 
       def continue

--- a/app/controllers/publish/courses/study_sites_controller.rb
+++ b/app/controllers/publish/courses/study_sites_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class StudySitesController < PublishController
+    class StudySitesController < ApplicationController
       include CourseBasicDetailConcern
 
       def continue

--- a/app/controllers/publish/courses/subjects_controller.rb
+++ b/app/controllers/publish/courses/subjects_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class SubjectsController < PublishController
+    class SubjectsController < ApplicationController
       decorates_assigned :course
       before_action :build_course, only: %i[edit update]
       before_action :build_course_params, :campaign_name_check, only: [:continue]

--- a/app/controllers/publish/courses/training_with_disabilities_controller.rb
+++ b/app/controllers/publish/courses/training_with_disabilities_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class TrainingWithDisabilitiesController < PublishController
+    class TrainingWithDisabilitiesController < ApplicationController
       include CourseBasicDetailConcern
       before_action :build_course, only: %i[show]
 

--- a/app/controllers/publish/courses/visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/visa_sponsorship_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class VisaSponsorshipController < PublishController
+    class VisaSponsorshipController < ApplicationController
       include CourseBasicDetailConcern
 
       def new

--- a/app/controllers/publish/courses/withdrawals_controller.rb
+++ b/app/controllers/publish/courses/withdrawals_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Courses
-    class WithdrawalsController < PublishController
+    class WithdrawalsController < ApplicationController
       before_action :redirect_to_courses, if: :course_withdrawn?
       before_action :redirect_to_courses, unless: -> { course.is_published? }
 

--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class CoursesController < PublishController
+  class CoursesController < ApplicationController
     include ApplyRedirect
 
     decorates_assigned :course

--- a/app/controllers/publish/notifications_controller.rb
+++ b/app/controllers/publish/notifications_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class NotificationsController < PublishController
+  class NotificationsController < ApplicationController
     skip_before_action :check_interrupt_redirects
     skip_before_action :authorize_provider
 

--- a/app/controllers/publish/providers/accredited_provider_search_controller.rb
+++ b/app/controllers/publish/providers/accredited_provider_search_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class AccreditedProviderSearchController < PublishController
+    class AccreditedProviderSearchController < ApplicationController
       helper_method :query, :search_result_title_component
 
       def new

--- a/app/controllers/publish/providers/accredited_providers/checks_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers/checks_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Providers
     module AccreditedProviders
-      class ChecksController < PublishController
+      class ChecksController < ApplicationController
         def show
           accredited_provider_form
         end

--- a/app/controllers/publish/providers/accredited_providers_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class AccreditedProvidersController < PublishController
+    class AccreditedProvidersController < ApplicationController
       helper_method :accredited_provider_id
 
       def index; end

--- a/app/controllers/publish/providers/contacts_controller.rb
+++ b/app/controllers/publish/providers/contacts_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class ContactsController < PublishController
+    class ContactsController < ApplicationController
       def edit
         authorize(provider, :edit?)
 

--- a/app/controllers/publish/providers/school_placements_controller.rb
+++ b/app/controllers/publish/providers/school_placements_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class SchoolPlacementsController < PublishController
+    class SchoolPlacementsController < ApplicationController
       def edit
         authorize(provider, :edit?)
 

--- a/app/controllers/publish/providers/school_search_controller.rb
+++ b/app/controllers/publish/providers/school_search_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class SchoolSearchController < PublishController
+    class SchoolSearchController < ApplicationController
       helper_method :query, :search_result_title_component
 
       before_action :authorize_provider

--- a/app/controllers/publish/providers/schools_check_controller.rb
+++ b/app/controllers/publish/providers/schools_check_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class SchoolsCheckController < PublishController
+    class SchoolsCheckController < ApplicationController
       before_action :new_form
 
       def show; end

--- a/app/controllers/publish/providers/schools_controller.rb
+++ b/app/controllers/publish/providers/schools_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class SchoolsController < PublishController
+    class SchoolsController < ApplicationController
       before_action :site, only: %i[show delete]
 
       def index

--- a/app/controllers/publish/providers/skilled_worker_visa_controller.rb
+++ b/app/controllers/publish/providers/skilled_worker_visa_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class SkilledWorkerVisaController < PublishController
+    class SkilledWorkerVisaController < ApplicationController
       def edit
         authorize(provider, :edit?)
 

--- a/app/controllers/publish/providers/student_visa_controller.rb
+++ b/app/controllers/publish/providers/student_visa_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class StudentVisaController < PublishController
+    class StudentVisaController < ApplicationController
       def edit
         authorize(provider, :edit?)
 

--- a/app/controllers/publish/providers/study_site_search_controller.rb
+++ b/app/controllers/publish/providers/study_site_search_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class StudySiteSearchController < PublishController
+    class StudySiteSearchController < ApplicationController
       helper_method :query, :search_result_title_component
 
       before_action :authorize_provider

--- a/app/controllers/publish/providers/study_sites_check_controller.rb
+++ b/app/controllers/publish/providers/study_sites_check_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class StudySitesCheckController < PublishController
+    class StudySitesCheckController < ApplicationController
       before_action :new_form
 
       def show; end

--- a/app/controllers/publish/providers/study_sites_controller.rb
+++ b/app/controllers/publish/providers/study_sites_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class StudySitesController < PublishController
+    class StudySitesController < ApplicationController
       before_action :site, only: %i[show delete]
       before_action :build_study_site, only: %i[new create]
 

--- a/app/controllers/publish/providers/training_providers/course_exports_controller.rb
+++ b/app/controllers/publish/providers/training_providers/course_exports_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Providers
     module TrainingProviders
-      class CourseExportsController < PublishController
+      class CourseExportsController < ApplicationController
         def index
           authorize(provider, :can_list_training_providers?)
 

--- a/app/controllers/publish/providers/training_providers/courses_controller.rb
+++ b/app/controllers/publish/providers/training_providers/courses_controller.rb
@@ -3,7 +3,7 @@
 module Publish
   module Providers
     module TrainingProviders
-      class CoursesController < PublishController
+      class CoursesController < ApplicationController
         def index
           authorize(provider, :index?)
 

--- a/app/controllers/publish/providers/training_providers_controller.rb
+++ b/app/controllers/publish/providers/training_providers_controller.rb
@@ -2,7 +2,7 @@
 
 module Publish
   module Providers
-    class TrainingProvidersController < PublishController
+    class TrainingProvidersController < ApplicationController
       def index
         authorize(provider, :can_list_training_providers?)
 

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class ProvidersController < PublishController
+  class ProvidersController < ApplicationController
     include RecruitmentCycleHelper
     include GotoPreview
     rescue_from ActiveRecord::RecordNotFound, with: :render_not_found

--- a/app/controllers/publish/recruitment_cycles_controller.rb
+++ b/app/controllers/publish/recruitment_cycles_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class RecruitmentCyclesController < PublishController
+  class RecruitmentCyclesController < ApplicationController
     def show
       @recruitment_cycle = RecruitmentCycle.find_by(year: params[:year])
       @provider ||= recruitment_cycle.providers.find_by!(provider_code: params[:provider_code] || params[:code])

--- a/app/controllers/publish/terms_controller.rb
+++ b/app/controllers/publish/terms_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class TermsController < ApplicationController
+  class TermsController < ::ApplicationController
     def edit
       @accept_terms_form = Interruption::AcceptTermsForm.new(current_user)
     end

--- a/app/controllers/publish/users_check_controller.rb
+++ b/app/controllers/publish/users_check_controller.rb
@@ -11,8 +11,7 @@ module Publish
       return unless @user_form.save!
 
       UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
-      redirect_to publish_provider_users_path(params[:provider_code])
-      flash[:success] = 'User added'
+      redirect_to publish_provider_users_path(params[:provider_code]), flash: { success: 'User added' }
     end
 
     private

--- a/app/controllers/publish/users_check_controller.rb
+++ b/app/controllers/publish/users_check_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class UsersCheckController < PublishController
+  class UsersCheckController < ApplicationController
     def show
       @user_form = UserForm.new(current_user, user)
     end

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class UsersController < PublishController
+  class UsersController < ApplicationController
     def index
       @pagy, @users = pagy(provider.users.in_name_order)
     end

--- a/app/controllers/publish/users_edit_check_controller.rb
+++ b/app/controllers/publish/users_edit_check_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Publish
-  class UsersEditCheckController < PublishController
+  class UsersEditCheckController < ApplicationController
     def show
       @user_form = UserForm.new(current_user, user)
     end

--- a/app/controllers/publish/users_edit_check_controller.rb
+++ b/app/controllers/publish/users_edit_check_controller.rb
@@ -11,8 +11,7 @@ module Publish
       return unless @user_form.save!
 
       UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
-      redirect_to publish_provider_user_path(id: params[:user_id])
-      flash[:success] = 'User updated'
+      redirect_to publish_provider_user_path(id: params[:user_id]), flash: { success: 'User updated' }
     end
 
     private


### PR DESCRIPTION
## Context

Following the convention of each namespace having their own `[Namespace]::ApplicationController`, we want to add a `Publish::ApplicationController`.

## Changes proposed in this pull request

- Update `PublishController` references to `Publish::ApplicationController`.
- Update `ApplicationController` references within the Publish namespace to `::ApplicationController`.

## Guidance to review

The `Publish::ApplicationController` adds a lot of logic that should not be shared 100% throughout all publish controllers. We will clean up this logic in a future PR that distinguishes pages nested under a recruitment cycle or provider out from generic publish controllers.
