### PR TITLE
Skip authorization on /publish/providers/suggest

### DIFF
--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -18,6 +18,8 @@ module Publish
     end
 
     def suggest
+      skip_authorization
+
       @provider_list = providers
                        .provider_search(params[:query])
                        .limit(10)

--- a/spec/requests/publish/providers_controller_spec.rb
+++ b/spec/requests/publish/providers_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Publish::ProvidersController' do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user, :with_provider) }
+
+  describe '/publish/providers/suggest' do
+    context 'when the user is authenticated' do
+      it 'is successful' do
+        login_user(user)
+        get '/publish/providers/suggest'
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the user is not authenticated' do
+      it 'is successful' do
+        get '/publish/providers/suggest'
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+end

--- a/spec/support/authentication/mode/request_specs_dfe_signin.rb
+++ b/spec/support/authentication/mode/request_specs_dfe_signin.rb
@@ -3,7 +3,7 @@
 # PublishConstraint requires the server domain matches the request host to match routes
 # Settings.base_url&.include?(request.host)
 RSpec.configure do |config|
-  config.before type: :request do
+  config.before namespace: :publish, type: :request do
     host! URI(Settings.base_url).host
   end
 end

--- a/spec/support/authentication/mode/request_specs_dfe_signin.rb
+++ b/spec/support/authentication/mode/request_specs_dfe_signin.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# PublishConstraint requires the server domain matches the request host to match routes
+# Settings.base_url&.include?(request.host)
+RSpec.configure do |config|
+  config.before type: :request do
+    host! URI(Settings.base_url).host
+  end
+end

--- a/spec/support/derived_metadata.rb
+++ b/spec/support/derived_metadata.rb
@@ -27,4 +27,12 @@ RSpec.configure do |config|
 
     metadata[:with_publish_constraint] = true
   end
+
+  config.define_derived_metadata(file_path: Regexp.new('/spec/requests/find')) do |metadata|
+    metadata[:namespace] = :find
+  end
+
+  config.define_derived_metadata(file_path: Regexp.new('/spec/requests/publish')) do |metadata|
+    metadata[:namespace] = :publish
+  end
 end

--- a/spec/support/dfe_sign_in_user_helper.rb
+++ b/spec/support/dfe_sign_in_user_helper.rb
@@ -12,6 +12,11 @@ module DfESignInUserHelper
     )
   end
 
+  # Helper to login user for request specs
+  def login_user(user)
+    get '/auth/dfe/callback', headers: { 'omniauth.auth' => user_exists_in_dfe_sign_in(user:) }
+  end
+
   private
 
   def fake_dfe_sign_in_auth_hash(email:, sign_in_user_id:, first_name:, last_name:)


### PR DESCRIPTION
## Context

Bug fix. I mistakenly removed call to authorize without explicitly skipping the authorization.

We have an after_action call back that asserts that some authorization was done, unless we explicitly skip it.

## Changes proposed in this pull request

- Add some request spec helpers for authentication
- Add before action to all request specs setting the apps host so it can be reached


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
