### PR TITLE
Add feature flag for the API summary content change

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -89,6 +89,7 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
+  api_summary_content_change: false
   send_request_data_to_bigquery: false
   rollover:
     # Normally a short period of time between rollover and the next cycle


### PR DESCRIPTION
## Context

There is inconsistency of terminology between GiT and Find. GiT use “QTS with PGDE” (which is more clear/intuitive) whereas Find uses “PGDE with QTS”. 

It was decided by Apply and Find teach leads to change the API content of the course description to the expected ones (PGCE with QTS becomes QTS with PGCE and PGDE with QTS becomes QTS with PGDE).

This is a simple PR that just adds the feature flag.

Will be `false` as default in all environments.

## Plan

1. Merge the feature flag PR (this PR!)
2. Merge the code that uses the feature flag (#4645 )
3. Turn on the feature flag on QA when having a session with Register & Apply (needs a PR and deployment) 
4. Have the Register & Apply sign off that everything worked 
5. Turn on the feature flag on Production (needs a deployment) and also deploy the API docs change here about the content change on API on the history/updates section.
