### PR TITLE
Replace instances of PGDE with QTS / change API course summary

### DIFF
--- a/app/components/find/courses/qualifications_summary_component/view.html.erb
+++ b/app/components/find/courses/qualifications_summary_component/view.html.erb
@@ -20,7 +20,7 @@
 <% when "pgde_with_qts" %>
   <%= govuk_details(summary_text:) do %>
     <p class="govuk-body">
-      A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
+      Qualified teacher status (QTS) with a postgraduate diploma in education (PGDE) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
     </p>
     <p class="govuk-body">
       It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.

--- a/app/components/find/courses/qualifications_summary_component/view.html.erb
+++ b/app/components/find/courses/qualifications_summary_component/view.html.erb
@@ -1,6 +1,6 @@
-<% case find_outcome %>
-<% when "QTS" %>
-  <%= govuk_details(summary_text: "QTS") do %>
+<% case course.qualification %>
+<% when 'qts' %>
+  <%= govuk_details(summary_text:) do %>
     <p class="govuk-body">
       Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
     </p>
@@ -8,8 +8,8 @@
       It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.
     </p>
   <% end %>
-<% when "QTS with PGCE" %>
-  <%= govuk_details(summary_text: "QTS with PGCE") do %>
+<% when "pgce_with_qts" %>
+  <%= govuk_details(summary_text:) do %>
     <p class="govuk-body">
      You need qualified teacher status (QTS) to teach in state schools in England. QTS may also allow you to teach in other parts of the UK.
     </p>
@@ -17,8 +17,8 @@
       This course also offers a postgraduate certificate in education (PGCE). PGCE courses can include credits that count towards a master’s degree.
     </p>
   <% end %>
-<% when "PGDE with QTS" %>
-  <%= govuk_details(summary_text: "PGDE with QTS") do %>
+<% when "pgde_with_qts" %>
+  <%= govuk_details(summary_text:) do %>
     <p class="govuk-body">
       A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
     </p>
@@ -29,8 +29,8 @@
       Many PGDE courses include credits towards a Master’s degree.
     </p>
   <% end %>
-<% when "PGCE" %>
-  <%= govuk_details(summary_text: "PGCE") do %>
+<% when "pgce" %>
+  <%= govuk_details(summary_text:) do %>
     <p class="govuk-body">
       A postgraduate certificate in education (PGCE) is an academic qualification in education.
     </p>
@@ -41,8 +41,8 @@
       This course does not lead to qualified teacher status (QTS).
     </p>
   <% end %>
-<% when "PGDE" %>
-  <%= govuk_details(summary_text: "PGDE") do %>
+<% when "pgde" %>
+  <%= govuk_details(summary_text:) do %>
     <p class="govuk-body">
       A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).
     </p>
@@ -53,7 +53,7 @@
       This course does not lead to qualified teacher status (QTS).
     </p>
   <% end %>
-<% when "Teacher degree apprenticeship with QTS" %>
+<% when "undergraduate_degree_with_qts" %>
   <%= govuk_details(summary_text: t(".tda_with_qts")) do %>
     <p class="govuk-body">
       <%= t(

--- a/app/components/find/courses/qualifications_summary_component/view.rb
+++ b/app/components/find/courses/qualifications_summary_component/view.rb
@@ -7,11 +7,13 @@ module Find
         include ApplicationHelper
         include ::ViewHelper
 
-        attr_reader :find_outcome
+        attr_reader :course
+        delegate :find_outcome, to: :course
+        alias_method :summary_text, :find_outcome
 
-        def initialize(find_outcome)
+        def initialize(course:)
           super
-          @find_outcome = find_outcome
+          @course = course
         end
       end
     end

--- a/app/components/find/courses/qualifications_summary_component/view.rb
+++ b/app/components/find/courses/qualifications_summary_component/view.rb
@@ -8,8 +8,9 @@ module Find
         include ::ViewHelper
 
         attr_reader :course
+
         delegate :find_outcome, to: :course
-        alias_method :summary_text, :find_outcome
+        alias summary_text find_outcome
 
         def initialize(course:)
           super

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -38,7 +38,7 @@
   <% summary_list.with_row do |row| %>
     <% row.with_key(text: t(".qualification")) %>
     <% row.with_value do %>
-      <%= render Find::Courses::QualificationsSummaryComponent::View.new(find_outcome) %>
+      <%= render Find::Courses::QualificationsSummaryComponent::View.new(course:) %>
     <% end %>
   <% end %>
 

--- a/app/models/concerns/with_qualifications.rb
+++ b/app/models/concerns/with_qualifications.rb
@@ -79,6 +79,12 @@ module WithQualifications
       I18n.t("qualifications.description.#{qualification}")
     end
 
+    def qualifications_summary
+      return '' unless qualifications
+
+      I18n.t("qualifications.summary.#{qualification}")
+    end
+
     def full_qualification_descriptions
       return '' unless full_qualifications
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -516,9 +516,18 @@ class Course < ApplicationRecord
   def description
     return qualifications_description if teacher_degree_apprenticeship?
 
-    study_mode_string = (full_time_or_part_time? ? ', ' : ' ') +
-                        study_mode_description
     qualifications_description + study_mode_string + program_type_description
+  end
+
+  def summary
+    return qualifications_summary if teacher_degree_apprenticeship?
+
+    qualifications_summary + study_mode_string + program_type_description
+  end
+
+  def study_mode_string
+    (full_time_or_part_time? ? ', ' : ' ') +
+      study_mode_description
   end
 
   def extended_qualification_descriptions
@@ -1027,7 +1036,7 @@ class Course < ApplicationRecord
     if qualification.blank?
       errors.add(:qualification, :blank)
     else
-      errors.add(:qualification, "^#{qualifications_description} is not valid for a #{level.to_s.humanize.downcase} course") unless qualification.in?(qualification_options)
+      errors.add(:qualification, "^#{qualifications_summary} is not valid for a #{level.to_s.humanize.downcase} course") unless qualification.in?(qualification_options)
     end
   end
 

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -130,7 +130,11 @@ module API
         end
 
         attribute :summary do
-          @object.description
+          if FeatureService.enabled?(:api_summary_content_change)
+            @object.summary
+          else
+            @object.description
+          end
         end
 
         attribute :subject_codes do

--- a/app/views/publish/courses/_course_table_row.html.erb
+++ b/app/views/publish/courses/_course_table_row.html.erb
@@ -9,7 +9,7 @@
         <%= course.name_and_code %><br>
       </span>
     <% end %>
-    <span class="govuk-body-s"><%= course.description %></span>
+    <span class="govuk-body-s"><%= course.summary %></span>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__status">
     <%= course.status_tag %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,13 @@ en:
     description: Description
     basic_details: Basic details
   qualifications:
+    summary:
+      qts: QTS
+      undergraduate_degree_with_qts: Teacher degree apprenticeship with QTS
+      pgce_with_qts: QTS with PGCE
+      pgde_with_qts: QTS with PGDE
+      pgce: PGCE
+      pgde: PGDE
     description:
       qts: QTS
       undergraduate_degree_with_qts: Teacher degree apprenticeship with QTS

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,7 +181,7 @@ en:
         help: "Postgraduate diploma in education"
       pgde_with_qts:
         label: "QTS with PGDE"
-        help: "Postgraduate diploma in education with qualified teacher status"
+        help: "Qualified teacher status with a postgraduate diploma in education"
     age_range_in_years:
       other:
         label: "Another age range"
@@ -1298,7 +1298,7 @@ en:
         help: "Postgraduate diploma in education"
       pgde_with_qts:
         label: "QTS with PGDE"
-        help: "Postgraduate diploma in education with qualified teacher status"
+        help: "Qualified teacher status with a postgraduate diploma in education"
       undergraduate_degree_with_qts:
         label: "Teacher degree apprenticeship (TDA) with QTS"
         help: "Teacher degree apprenticeship with qualified teacher status"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,7 +173,7 @@ en:
         label: "PGDE only (without QTS)"
         help: "Postgraduate diploma in education"
       pgde_with_qts:
-        label: "PGDE with QTS"
+        label: "QTS with PGDE"
         help: "Postgraduate diploma in education with qualified teacher status"
     age_range_in_years:
       other:
@@ -422,7 +422,7 @@ en:
         qts: "QTS"
         pgce_with_qts: "QTS with PGCE"
         pgce: "PGCE"
-        pgde_with_qts: "PGDE with QTS"
+        pgde_with_qts: "QTS with PGDE"
         pgde: "PGDE"
       entry_requirements:
         must_have_qualification_at_application_time: "Must have the GCSE"
@@ -1290,7 +1290,7 @@ en:
         label: "PGDE only (without QTS)"
         help: "Postgraduate diploma in education"
       pgde_with_qts:
-        label: "PGDE with QTS"
+        label: "QTS with PGDE"
         help: "Postgraduate diploma in education with qualified teacher status"
       undergraduate_degree_with_qts:
         label: "Teacher degree apprenticeship (TDA) with QTS"

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -282,7 +282,7 @@ en:
         pgce_with_qts:
           html: <abbr title='Qualified teacher status'>QTS</abbr> with <abbr title='Postgraduate certificate in education'>PGCE</abbr>
         pgde_with_qts:
-          html: <abbr title='Postgraduate diploma in education'>PGDE</abbr> with <abbr title='Qualified teacher status'>QTS</abbr>
+          html: <abbr title='Qualified teacher status'>QTS</abbr> with <abbr title='Postgraduate diploma in education'>PGDE</abbr>
         pgce:
           html: <abbr title='Postgraduate certificate in education'>PGCE</abbr> without <abbr title='Qualified teacher status'>QTS</abbr>
         pgde:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -27,7 +27,7 @@ en:
       pgce: "PGCE"
       pgce_with_qts: "QTS with PGCE"
       pgde: "PGDE"
-      pgde_with_qts: "PGDE with QTS"
+      pgde_with_qts: "QTS with PGDE"
       undergraduate_degree_with_qts: Teacher degree apprenticeship with QTS
     location_filter:
       errors:

--- a/spec/components/find/courses/qualifications_summary_component/view_preview.rb
+++ b/spec/components/find/courses/qualifications_summary_component/view_preview.rb
@@ -5,23 +5,28 @@ module Find
     module QualificationsSummaryComponent
       class ViewPreview < ViewComponent::Preview
         def qts
-          render Find::Courses::QualificationsSummaryComponent::View.new('QTS')
+          course = Course.new(qualification: 'qts').decorate
+          render Find::Courses::QualificationsSummaryComponent::View.new(course:)
         end
 
         def pgce_with_qts
-          render Find::Courses::QualificationsSummaryComponent::View.new('PGCE with QTS')
+          course = Course.new(qualification: 'pgce_with_qts').decorate
+          render Find::Courses::QualificationsSummaryComponent::View.new(course:)
         end
 
         def pgde_with_qts
-          render Find::Courses::QualificationsSummaryComponent::View.new('PGDE with QTS')
+          course = Course.new(qualification: 'pgde_with_qts').decorate
+          render Find::Courses::QualificationsSummaryComponent::View.new(course:)
         end
 
         def pgce
-          render Find::Courses::QualificationsSummaryComponent::View.new('PGCE')
+          course = Course.new(qualification: 'pgce').decorate
+          render Find::Courses::QualificationsSummaryComponent::View.new(course:)
         end
 
         def pgde
-          render Find::Courses::QualificationsSummaryComponent::View.new('PGDE')
+          course = Course.new(qualification: 'pgde').decorate
+          render Find::Courses::QualificationsSummaryComponent::View.new(course:)
         end
       end
     end

--- a/spec/components/find/courses/qualifications_summary_component/view_spec.rb
+++ b/spec/components/find/courses/qualifications_summary_component/view_spec.rb
@@ -29,7 +29,7 @@ describe Find::Courses::QualificationsSummaryComponent::View, type: :component d
       result = render_inline(described_class.new(course:))
 
       expect(result.text).to include('QTS with PGDE')
-      expect(result.text).to include('A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England')
+      expect(result.text).to include('Qualified teacher status (QTS) with a postgraduate diploma in education (PGDE) will allow you to teach in state schools in England')
     end
   end
 

--- a/spec/components/find/courses/qualifications_summary_component/view_spec.rb
+++ b/spec/components/find/courses/qualifications_summary_component/view_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 describe Find::Courses::QualificationsSummaryComponent::View, type: :component do
   context 'QTS qualification' do
     it 'renders correct text' do
-      result = render_inline(described_class.new('QTS'))
+      course = build(:course, :resulting_in_qts).decorate
+      result = render_inline(described_class.new(course:))
 
       expect(result.text).to include('Qualified teacher status (QTS) allows you to teach in state schools in England')
     end
@@ -13,8 +14,10 @@ describe Find::Courses::QualificationsSummaryComponent::View, type: :component d
 
   context 'PGCE with QTS qualification' do
     it 'renders correct text' do
-      result = render_inline(described_class.new('QTS with PGCE'))
+      course = build(:course, :resulting_in_pgce_with_qts).decorate
+      result = render_inline(described_class.new(course:))
 
+      expect(result.text).to include('QTS with PGCE')
       expect(result.text).to include('You need qualified teacher status (QTS) to teach in state schools in England. QTS may also allow you to teach in other parts of the UK.')
       expect(result.text).to include('This course also offers a postgraduate certificate in education (PGCE)')
     end
@@ -22,15 +25,18 @@ describe Find::Courses::QualificationsSummaryComponent::View, type: :component d
 
   context 'PGDE with QTS qualification' do
     it 'renders correct text' do
-      result = render_inline(described_class.new('PGDE with QTS'))
+      course = build(:course, :resulting_in_pgde_with_qts).decorate
+      result = render_inline(described_class.new(course:))
 
+      expect(result.text).to include('QTS with PGDE')
       expect(result.text).to include('A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England')
     end
   end
 
   context 'PGCE qualification' do
     it 'renders correct text' do
-      result = render_inline(described_class.new('PGCE'))
+      course = build(:course, :resulting_in_pgce).decorate
+      result = render_inline(described_class.new(course:))
 
       expect(result.text).to include('A postgraduate certificate in education (PGCE) is an academic qualification in education.')
     end
@@ -38,7 +44,8 @@ describe Find::Courses::QualificationsSummaryComponent::View, type: :component d
 
   context 'PGDE qualification' do
     it 'renders correct text' do
-      result = render_inline(described_class.new('PGDE'))
+      course = build(:course, :resulting_in_pgde).decorate
+      result = render_inline(described_class.new(course:))
 
       expect(result.text).to include('A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).')
     end
@@ -46,8 +53,10 @@ describe Find::Courses::QualificationsSummaryComponent::View, type: :component d
 
   context 'Teacher degree apprenticeship with QTS' do
     it 'renders correct text' do
-      result = render_inline(described_class.new('Teacher degree apprenticeship with QTS'))
+      course = build(:course, :resulting_in_undergraduate_degree_with_qts).decorate
+      result = render_inline(described_class.new(course:))
 
+      expect(result.text).to include('Teacher degree apprenticeship (TDA) with QTS')
       expect(result.text).to include('On a teacher degree apprenticeship you’ll work in a school and earn a salary while getting a bachelor’s degree and qualified teacher status (QTS). Find out more about teacher degree apprenticeships')
     end
   end

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -141,7 +141,7 @@ feature 'Editing course outcome', { can_edit_current_and_next_cycles: false } do
   end
 
   def then_i_am_shown_the_correct_qts_options
-    expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('QTS', 'QTS with PGCE', 'PGDE with QTS', 'Teacher degree apprenticeship (TDA) with QTS')
+    expect(publish_courses_outcome_edit_page.qualification_names).to contain_exactly('QTS', 'QTS with PGCE', 'QTS with PGDE', 'Teacher degree apprenticeship (TDA) with QTS')
   end
 
   def then_i_am_shown_the_correct_non_qts_options

--- a/spec/services/course_attribute_formatter_service_spec.rb
+++ b/spec/services/course_attribute_formatter_service_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe CourseAttributeFormatterService do
 
     context 'pgde_with_qts' do
       let(:value) { 'pgde_with_qts' }
-      let(:expected_value) { 'PGDE with QTS' }
+      let(:expected_value) { 'QTS with PGDE' }
 
       it { is_expected.to eq(expected_value) }
     end


### PR DESCRIPTION
## Context

There is inconsistency of terminology between GiT and Find. GiT use “QTS with PGDE” (which is more clear/intuitive) whereas Find uses “PGDE with QTS”.

## Changes

This PR replaces all instances of `PGDE with QTS` to `QTS with PGDE`. 

## Coordination between other teams

It was decided by Apply and Find teach leads to change the API content of the course description to the expected ones 

1. PGCE with QTS becomes QTS with PGCE
2. PGDE with QTS becomes QTS with PGDE

In order to coordinate this change with this other team this PR:

1. Changes everything in the UI
2. Uses a feature flag for the `course.summary` field in the API.

So this is the plan to deploy this:

- [x] Merge the feature flag PR 
- [ ] Merge the code that uses the feature flag (This one!)
- [ ] Turn on the feature flag on QA when having a session with Register & Apply ([PR](https://github.com/DFE-Digital/publish-teacher-training/pull/4652))
- [ ] Have the Register & Apply sign off that everything worked
- [ ] Turn on the feature flag on Production ([PR](https://github.com/DFE-Digital/publish-teacher-training/pull/4653)) and also deploy the API docs change here about the content change on API on the history/updates section.
- [ ] Cleanup the feature flag (PR to be added here)