### PR TITLE
Enable API course description changes in QA

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -28,6 +28,7 @@ basic_auth:
 
 features:
   send_request_data_to_bigquery: true
+  api_summary_content_change: true
 
 find_valid_referers:
   - https://qa.find-teacher-training-courses.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -14,3 +14,5 @@ authentication:
   secret: secret
   mode: persona
 
+features:
+  api_summary_content_change: true


### PR DESCRIPTION
## Context

Now that the PGDE/PGCE changes are live (see https://github.com/DFE-Digital/publish-teacher-training/pull/4645 ) we can enable the feature in QA in order to ask Apply and Register to test their sync on QA.

## Changes proposed in this pull request

Enable the API content changes in QA for Register & Apply team.

After merging this PR, you can request any course in the QA API and the summary attributes will be changed from:

1. "PGCE with QTS" into "QTS with PGCE ..." 
2. "PGDE with QTS" into "QTS with PGDE ..."
