### PR TITLE
Update miscellaneous development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,10 @@
 !/log/.keep
 !/tmp/.keep
 
-#Ignore .env file
+#Ignore .env files
 .env
+.env.local
+.env.*.local
 
 .byebug_history
 .node-version

--- a/bin/setup
+++ b/bin/setup
@@ -19,24 +19,6 @@ FileUtils.chdir APP_ROOT do
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
-  puts "\n== Copying development settings file =="
-  if Gem.win_platform?
-    puts "ATTENTION WINDOWS USER!".red
-    puts
-    puts "Copy #{"config/settings/development.yml".yellow} to #{"config/settings/development.local.yml".yellow} and edit it:",
-      "Replace #{"'secret: secret'".blue} with #{"'mode: persona'".blue}"
-    puts
-  else
-    system! "sed 's/secret: secret/mode: persona/' config/settings/development.yml > config/settings/development.local.yml"
-  end
-
-  puts "\n== Install process manager foreman =="
-  system! "gem install foreman"
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
-  # end
-
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,11 +36,6 @@ authentication:
   # mode: magic_link  # when dfe_signin is down
   # mode: persona     # none critical systems, ie localhost
 
-cookies:
-  consent:
-    name: _consented_to_analytics_cookies
-    expire_after_days: 182
-
 current_recruitment_cycle_year: 2025
 next_cycle_open_date: 2025-10-1 # TBC
 
@@ -81,9 +76,6 @@ google:
     dataset: replaceme
     api_json_key: "{}"
     table_name: events
-
-google_tag_manager:
-  tracking_id: change_me
 
 feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,10 +1,14 @@
 authentication:
   secret: secret
+  mode: persona
+
 mcbg:
   redis_password:
+
 system_authentication_token: "Ge32"
 log_level: debug
 gcp_api_key: please_change_me
+
 environment:
   label: "development"
   name: "development"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
-version: '3.4'
-volumes:
-  dbdata:
 services:
-
   redis:
     image: redis
+    ports:
+      - "6379:6379"
 
   db:
     image: postgres:14-alpine
     # To preserve data between runs of docker compose, we mount a folder from the host machine.
     volumes:
-     - dbdata:/var/lib/postgresql/data
+      - dbdata:/var/lib/postgresql/data
     environment:
-    - POSTGRES_PASSWORD=developmentpassword
+      - POSTGRES_PASSWORD=developmentpassword
+    ports:
+      - "5432:5432"
 
   web:
     build:
@@ -51,3 +51,6 @@ services:
       - DB_PASSWORD=developmentpassword
       - SETTINGS__APPLICATION=teacher-training-api-bg
       - REDIS_WORKER_URL=redis://redis:6379
+
+volumes:
+  dbdata:


### PR DESCRIPTION
## Context

Some minor cleanup.

## Changes proposed in this pull request

- Add `.env.local` and `.env.*.local` to `.gitignore`.
  - The recommendation is to use `.env.development.local` for local ENV vars - namely to avoid any clash with other environments or in the very rare case that this file is added to git, it doesn't effect production - Unlike `.env` would.
- Update local default authentication mode to `persona`.
- Expose ports of `docker-compose.yml` services.

## Guidance to review

- Does this break any of your workflows?
