### PR TITLE
Add Pagy to just the results page

### DIFF
--- a/app/components/find/results/results_component.html.erb
+++ b/app/components/find/results/results_component.html.erb
@@ -32,6 +32,6 @@
       </ul>
     <% end %>
 
-    <%= paginate(courses) %>
+    <%= govuk_pagination(pagy: @pagy) %>
   </div>
 </div>

--- a/app/components/find/results/results_component.rb
+++ b/app/components/find/results/results_component.rb
@@ -5,12 +5,13 @@ module Find
     class ResultsComponent < ViewComponent::Base
       include ::ViewHelper
 
-      attr_reader :results, :courses
+      attr_reader :results, :courses, :pagy
 
-      def initialize(results:, courses:)
+      def initialize(results:, courses:, pagy:)
         super
         @results = results
         @courses = courses
+        @pagy = pagy
       end
     end
   end

--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -2,6 +2,7 @@
 
 module Find
   class ApplicationController < ActionController::Base
+    include Pagy::Backend
     include DfE::Analytics::Requests
 
     layout 'find_layout'

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -11,11 +11,11 @@ module Find
 
       @results_view = ResultsView.new(query_parameters: matched_params)
       @filters_view = ResultFilters::FiltersView.new(params: matched_params)
-      @courses = @results_view.courses.page params[:page]
+      @pagy, @courses = pagy(@results_view.courses)
       @number_of_courses_string = @results_view.number_of_courses_string
 
       track_search_results(number_of_results: @results_view.course_count,
-                           course_codes: @courses.pluck(:course_code).uniq)
+                           course_codes: @results_view.courses.pluck(:course_code).uniq)
     end
 
     private

--- a/app/views/find/results/index.html.erb
+++ b/app/views/find/results/index.html.erb
@@ -2,5 +2,6 @@
 
 <%= render Find::Results::ResultsComponent.new(
   results: @results_view,
-  courses: @courses
+  courses: @courses,
+  pagy: @pagy
 ) %>

--- a/spec/components/find/results/results_component_spec.rb
+++ b/spec/components/find/results/results_component_spec.rb
@@ -25,11 +25,12 @@ module Find
         )
       end
 
-      let(:courses) { ::Course.all.page(1) }
+      let(:courses) { ::Course.all }
+      let(:pagy) { Pagy.new(count: courses.count, page: 1) }
 
       it 'renders a "No courses found" message when there are no results' do
         component = render_inline(
-          described_class.new(results: results_view, courses:)
+          described_class.new(results: results_view, courses:, pagy:)
         )
 
         expect(component.text).to include('No courses found')
@@ -37,7 +38,7 @@ module Find
 
       it 'renders the inset text' do
         component = render_inline(
-          described_class.new(results: results_view, courses:)
+          described_class.new(results: results_view, courses:, pagy:)
         )
         expect(component.text).to include('event near you')
       end
@@ -57,7 +58,8 @@ module Find
         )
       end
 
-      let(:courses) { ::Course.all.page(1) }
+      let(:courses) { ::Course.all }
+      let(:pagy) { Pagy.new(count: courses.count, page: 1) }
 
       before do
         create_list(:course, 10, :with_2_full_time_sites)
@@ -67,7 +69,7 @@ module Find
         allow(Results::SearchResultComponent).to receive(:new).and_return(plain: '')
 
         component = render_inline(
-          described_class.new(results: results_view, courses:)
+          described_class.new(results: results_view, courses:, pagy:)
         )
 
         courses.each do |course|
@@ -83,7 +85,7 @@ module Find
 
       it 'renders the inset text' do
         component = render_inline(
-          described_class.new(results: results_view, courses:)
+          described_class.new(results: results_view, courses:, pagy:)
         )
 
         courses.each do |course|


### PR DESCRIPTION
## Context

Original PR to replace Kaminari with Pagy : https://github.com/DFE-Digital/publish-teacher-training/pull/4651

Due to the issue we had the other week with queries taking 30 seconds or more, we identified where the issue was coming from and have resolved this. This change just isolates the issue into one PR to allow us to add the Pagy to the various pages individually to make rollback easier if issues arise. 

## Changes proposed in this pull request
In `app/controllers/find/results_controller.rb` we identified the query which caused the issue was when we passed the `@courses` to `track_search_results ` method. We now dont pass the pagy version of `@courses` and instead pass `@results_view.courses`. This resolved the issue and after some testing does not cause the delay in the query


Pagy query 
```
SELECT DISTINCT
    "course"."name" AS alias_0,
    "provider"."provider_name" AS alias_1,
    "course"."course_code" AS alias_2,
    "course"."id"
FROM
    "course"
INNER JOIN
    "provider" ON "provider"."id" = "course"."provider_id"
LEFT OUTER JOIN
    "recruitment_cycle" ON "recruitment_cycle"."id" = "provider"."recruitment_cycle_id"
LEFT OUTER JOIN
    "provider_ucas_preference" ON "provider_ucas_preference"."provider_id" = "provider"."id"
LEFT OUTER JOIN
    "course_enrichment" ON "course_enrichment"."course_id" = "course"."id"
LEFT OUTER JOIN
    "course_subject" ON "course_subject"."course_id" = "course"."id"
LEFT OUTER JOIN
    "subject" ON "subject"."id" = "course_subject"."subject_id"
LEFT OUTER JOIN
    "financial_incentive" ON "financial_incentive"."subject_id" = "subject"."id"
LEFT OUTER JOIN
    "subject" AS "subject_course_subject" ON "subject_course_subject"."id" = "course_subject"."subject_id"
LEFT OUTER JOIN
    "course_site" ON "course_site"."course_id" = "course"."id"
LEFT OUTER JOIN
    "site" ON "site"."id" = "course_site"."site_id"
WHERE
    "course"."id" IN (
        SELECT
            "course"."id"
        FROM
            "course"
        INNER JOIN
            "provider" ON "course"."provider_id" = "provider"."id"
        INNER JOIN
            "course_site" ON "course_site"."course_id" = "course"."id"
        INNER JOIN
            "course_subject" ON "course_subject"."course_id" = "course"."id"
        INNER JOIN
            "subject" ON "subject"."id" = "course_subject"."subject_id"
        WHERE
            "provider"."recruitment_cycle_id" = $1
            AND "provider"."discarded_at" IS NULL
            AND "course"."discarded_at" IS NULL
            AND "course_site"."status" = $2
            AND "course_site"."publish" = $3
            AND "course"."program_type" != $4
            AND "course"."qualification" IN ($5, $6, $7)
            AND "course"."application_status" = $8
            AND "course"."study_mode" IN ($9, $10, $11)
            AND "subject"."subject_code" = $12
    )
ORDER BY
    "course"."name" ASC,
    "provider"."provider_name" ASC,
    "course"."course_code" ASC
LIMIT $13 OFFSET $14;
```


Kaminari query

```

SELECT "course".*
FROM "course"
INNER JOIN "provider" ON "provider"."id" = "course"."provider_id"
WHERE "course"."id" IN (
    SELECT "course"."id"
    FROM "course"
    INNER JOIN "provider" ON "course"."provider_id" = "provider"."id"
    INNER JOIN "course_site" ON "course_site"."course_id" = "course"."id"
    INNER JOIN "course_subject" ON "course_subject"."course_id" = "course"."id"
    INNER JOIN "subject" ON "subject"."id" = "course_subject"."subject_id"
    WHERE "provider"."recruitment_cycle_id" = $1
      AND "provider"."discarded_at" IS NULL
      AND "course"."discarded_at" IS NULL
      AND "course_site"."status" = $2
      AND "course_site"."publish" = $3
      AND "course"."program_type" != $4
      AND "course"."qualification" IN ($5, $6, $7)
      AND "course"."application_status" = $8
      AND "course"."study_mode" IN ($9, $10, $11)
      AND "subject"."subject_code" = $12
)
ORDER BY "course"."name" ASC,
         "provider"."provider_name" ASC,
         "course"."course_code" ASC
LIMIT $13 OFFSET $14;
```

## Guidance to review
**This change compared to the old PR drops it down from an average of 37 seconds to around 1 second. Fixing the issue**

