### PR TITLE
Handle publish providers 404

### DIFF
--- a/app/controllers/publish/notifications_controller.rb
+++ b/app/controllers/publish/notifications_controller.rb
@@ -3,6 +3,7 @@
 module Publish
   class NotificationsController < PublishController
     skip_before_action :check_interrupt_redirects
+    skip_before_action :authorize_provider
 
     def index
       authorize(current_user, :index?)

--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -10,7 +10,7 @@ module Publish
     before_action :clear_previous_cycle_year_in_session, unless: -> { FeatureService.enabled?('rollover.can_edit_current_and_next_cycles') }
 
     # Protect every action of a provider
-    before_action { authorize provider, :show? if provider }
+    before_action :authorize_provider
 
     after_action :verify_authorized
 
@@ -22,7 +22,7 @@ module Publish
     private
 
     def provider
-      @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code] || params[:code])
+      @provider ||= recruitment_cycle.providers.find_by!(provider_code: provider_code_param)
     end
 
     def recruitment_cycle
@@ -50,6 +50,14 @@ module Publish
       return if session[:cycle_year].to_i == Settings.current_recruitment_cycle_year
 
       session[:cycle_year] = nil
+    end
+
+    def authorize_provider
+      authorize provider, :show? if provider_code_param.present?
+    end
+
+    def provider_code_param
+      params[:provider_code] || params[:code]
     end
   end
 end

--- a/spec/requests/publish/authorization_spec.rb
+++ b/spec/requests/publish/authorization_spec.rb
@@ -13,7 +13,7 @@ describe 'Provider authorization spec' do
   before { host! URI(Settings.base_url).host }
 
   describe 'GET /publish/organisations' do
-    describe 'when authenticated' do
+    describe 'when authenticated user has one provider' do
       it 'redirects twice to the first valid providers courses' do
         get '/auth/dfe/callback', headers: { 'omniauth.auth' => user_exists_in_dfe_sign_in(user:) }
         get publish_root_path
@@ -21,6 +21,16 @@ describe 'Provider authorization spec' do
         follow_redirect!
         expect(response).to redirect_to('/publish/organisations/A14/2025/courses')
         follow_redirect!
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'when authenticated user has two providers' do
+      it 'renders the providers index' do
+        user.providers << another_provider
+
+        get '/auth/dfe/callback', headers: { 'omniauth.auth' => user_exists_in_dfe_sign_in(user:) }
+        get publish_root_path
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/requests/publish/providers_controller_spec.rb
+++ b/spec/requests/publish/providers_controller_spec.rb
@@ -23,4 +23,59 @@ describe 'Publish::ProvidersController' do
       end
     end
   end
+
+  describe '/publish/providers/{authorized_provider_code}' do
+    let(:provider) { user.providers.first }
+
+    context 'when the user is authenticated' do
+      it 'is redirect to courses page of the users first provider' do
+        login_user(user)
+        get "/publish/organisations/#{provider.provider_code}"
+        expect(response).to redirect_to("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses")
+      end
+    end
+
+    context 'when the user is not authenticated' do
+      it 'is redirect to sign-in path' do
+        get "/publish/organisations/#{provider.provider_code}"
+        expect(response).to redirect_to('/sign-in')
+      end
+    end
+  end
+
+  describe '/publish/providers/{unauthorized_provider_code}' do
+    let(:other_provider) { create(:provider) }
+
+    context 'when the user is authenticated' do
+      it 'is forbidden' do
+        login_user(user)
+        get "/publish/organisations/#{other_provider.provider_code}"
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when the user is not authenticated' do
+      it 'is redirect to sign-in path' do
+        get "/publish/organisations/#{other_provider.provider_code}"
+        expect(response).to redirect_to('/sign-in')
+      end
+    end
+  end
+
+  describe '/publish/providers/{invalid_provider_code}' do
+    context 'when the user is authenticated' do
+      it 'is not found' do
+        login_user(user)
+        get '/publish/organisations/ZZZ'
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the user is not authenticated' do
+      it 'is redirect to sign-in path' do
+        get '/publish/organisations/ZZZ'
+        expect(response).to redirect_to('/sign-in')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

#### User hits a collection endpoint
 - do not try to authorize a provider instance.

#### User requests a provider they are authorized for
 - return a 200

#### User requests a provider they are not authorized for
 - return a 403

#### User requests a provider that does not exist
 - return a 404

### Description

We added a `before_action` in the `PublishController` to enable an allow list for provider authorization. This means that by default we try to protect all actions by authorizing the user making the request.

Not all actions will need to instantiate a provider and will not send a `provider_code_param` (collection actions) so we need to ignore the authorization call for those actions.

We removed the exception raising version of the provider find method because we were calling it with nil. Now that we are avoiding that, we can raise an exception when the param does not find a record in the database. (404)

If a user passes a provider code that they are not authorized for, we retreive it from the database and then attempt to authorize the user. In this case we return a 403 (forbidden) correctly.

This will try to instantiate a provider and then assert authorization for the current user on that provider.

## Changes proposed in this pull request

Only try to authorize a user on a provider when a provider parameter is passed.

## Guidance to review

More work is required to tidy up the `PublishController` inheritance.
