### PR TITLE
Increase max uri length

### DIFF
--- a/config/initializers/webrick.rb
+++ b/config/initializers/webrick.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'webrick'
+
+WEBrick::HTTPRequest.const_set('MAX_URI_LENGTH', 2083 * 2)


### PR DESCRIPTION
## Context

Long URLs, due to selecting _many/all_ secondary subjects breaks the web application due to default security constraints.

The default maximum length is 2083 characters long.

## Changes proposed in this pull request

- Double the maximum URI length to 4166.

## Guidance to review

- Visit the following url before and after:
  - http://find.localhost:3000/results?age_group=secondary&applications_open=true&can_sponsor_visa=false&has_vacancies=true&l=2&subjects%5B%5D=A1&subjects%5B%5D=A2&subjects%5B%5D=W1&subjects%5B%5D=C1&subjects%5B%5D=08&subjects%5B%5D=F1&subjects%5B%5D=09&subjects%5B%5D=Q8&subjects%5B%5D=P3&subjects%5B%5D=11&subjects%5B%5D=12&subjects%5B%5D=DT&subjects%5B%5D=13&subjects%5B%5D=L1&subjects%5B%5D=Q3&subjects%5B%5D=15&subjects%5B%5D=F8&subjects%5B%5D=17&subjects%5B%5D=L5&subjects%5B%5D=V1&subjects%5B%5D=18&subjects%5B%5D=19&subjects%5B%5D=A0&subjects%5B%5D=20&subjects%5B%5D=G1&subjects%5B%5D=24&subjects%5B%5D=W3&subjects%5B%5D=P1&subjects%5B%5D=C6&subjects%5B%5D=C7&subjects%5B%5D=F3&subjects%5B%5D=C8&subjects%5B%5D=V6&subjects%5B%5D=21&subjects%5B%5D=F0&subjects%5B%5D=14&subjects%5B%5D=22&university_degree_status=true&visa_status=false
