### PR TITLE
Add selenium / system_test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -197,6 +197,8 @@ group :development, :test do
   # Test framework
   gem 'rspec-rails', '7.1.0'
 
+  gem 'selenium-webdriver'
+
   # Make diffs of Ruby objects much more readable
   gem 'super_diff'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -636,10 +636,17 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubypants (0.7.1)
+    rubyzip (2.3.2)
     safely_block (0.4.1)
     schema_to_scaffold (0.8.2)
       activesupport (~> 7)
     securerandom (0.3.2)
+    selenium-webdriver (4.26.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_logger (4.16.0)
       concurrent-ruby (~> 1.0)
     sentry-rails (5.21.0)
@@ -729,6 +736,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.0)
+    websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -827,6 +835,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   rubypants
   schema_to_scaffold
+  selenium-webdriver
   sentry-rails
   sentry-ruby
   sentry-sidekiq

--- a/app/lib/publish_constraint.rb
+++ b/app/lib/publish_constraint.rb
@@ -2,6 +2,6 @@
 
 class PublishConstraint
   def matches?(request)
-    Settings.base_url&.include?(request.host) || Settings.publish_api_url&.include?(request.host) || request.host.include?('publish-teacher-training-pr') || request.host.include?('publish-review')
+    Settings.base_url&.include?(request.host) || Settings.publish_api_url&.include?(request.host) || request.host.include?('publish-teacher-training-pr') || request.host.include?('publish-review') || request.host.include?('publish-test')
   end
 end

--- a/config/rubocop/style.yml
+++ b/config/rubocop/style.yml
@@ -35,3 +35,8 @@ Style/SafeNavigationChainLength:
     - app/services/courses/content_status_service.rb
     - app/services/courses/creation_service.rb
     - app/views/publish/shared/_error_wrapper.html.erb
+
+Style/IfUnlessModifier:
+  Enabled: true
+  Exclude:
+    - spec/support/system_test_config.rb

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,9 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'capybara/rspec'
+require 'capybara/rails'
+require 'selenium/webdriver'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Pull in all the files in spec/support automatically.
@@ -58,6 +61,7 @@ RSpec.configure do |config|
   config.include RequestHelpers, type: :controller
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include ActiveJob::TestHelper, type: :request
 
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
   config.before(:suite) do
@@ -102,12 +106,6 @@ RSpec.configure do |config|
     config.before { Bullet.start_request }
     config.after  { Bullet.end_request }
   end
-
-  config.before(:each, type: :system) do
-    driven_by(:rack_test)
-  end
-
-  config.include ActiveJob::TestHelper, type: :request
 
   ActiveJob::Base.queue_adapter = :test
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,8 @@ if ENV.fetch('COVERAGE', false)
   end
 end
 
+WebMock.disable_net_connect!(allow_localhost: true)
+
 # Pull in all the files in spec/support automatically.
 Dir['./spec/support/**/*.rb'].each { |file| require file }
 

--- a/spec/support/dfe_sign_in_user_helper.rb
+++ b/spec/support/dfe_sign_in_user_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module DfESignInUserHelper
+  def sign_in_system_test(user:)
+    user_exists_in_dfe_sign_in(user:)
+    visit sign_in_path
+    click_on 'Sign in using DfE Sign-in'
+  end
+
   def user_exists_in_dfe_sign_in(user:)
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       fake_dfe_sign_in_auth_hash(

--- a/spec/support/system_test_config.rb
+++ b/spec/support/system_test_config.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Use different Capybara ports when running tests in parallel
+if ENV['TEST_ENV_NUMBER']
+  Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
+end
+
+# Cannot use puma, we may need to upgrade rackup > 3
+Capybara.server = :webrick
+Capybara.javascript_driver = :selenium_chrome_headless
+
+RSpec.configure do |config|
+  screen_size = [1400, 1400]
+
+  config.before(:each, type: :system) do
+    service = self.class.metadata[:service]
+
+    Capybara.app_host = "http://www.#{service}-test.lvh.me"
+    driven_by :rack_test
+  end
+
+  config.before(:each, :js, type: :system) do
+    driven_by :selenium, using: :headless_chrome, screen_size:
+  end
+
+  config.before(:each, :js_browser, type: :system) do
+    driven_by :selenium, using: :chrome, screen_size:
+  end
+end

--- a/spec/system/find/load_the_service_spec.rb
+++ b/spec/system/find/load_the_service_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Find - Root path', service: :find do
+  include DfESignInUserHelper
+
+  it 'shows the find page' do
+    visit '/'
+    expect(page).to have_content('Find courses by location or by training provider')
+  end
+end

--- a/spec/system/publish/load_the_service_spec.rb
+++ b/spec/system/publish/load_the_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Publish - Courses page', service: :publish do
+  include DfESignInUserHelper
+
+  let(:provider) { create(:provider, provider_name: 'System Provider') }
+  let(:course) { create(:course, provider:, name: 'System Course') }
+  let(:user) { create(:user, providers: [provider]) }
+
+  before do
+    sign_in_system_test(user:)
+    course
+  end
+
+  it 'shows the publish courses page' do
+    visit '/publish/organisations'
+    expect(page).to have_content('Sign out')
+    expect(page).to have_content(course.name)
+  end
+end

--- a/spec/system/support/load_the_service_spec.rb
+++ b/spec/system/support/load_the_service_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Support', service: :publish do
+  include DfESignInUserHelper
+
+  let(:provider) { create(:provider, provider_name: 'System Provider') }
+  let(:user) { create(:user, :admin, providers: [provider]) }
+
+  before do
+    sign_in_system_test(user:)
+  end
+
+  it 'shows the support page' do
+    visit '/publish/organisations'
+    click_on('Support console')
+    expect(page).to have_current_path(%r{/support})
+    expect(page).to have_content('System Provider')
+  end
+end


### PR DESCRIPTION
## Context

- Bundle selenium-webdriver to enable system tests to launch in the browser.
- Add starter tests for each service.

### Issues
Cannot yet run javascript tests in CI. Have not yet figured out how the chromedriver gets automatically installed by Selenium Manager.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

How can we get js tests running in CI?
