### PR TITLE
Update filter default: uncheck Study type & Qualifications checkboxes

### DIFF
--- a/app/views/find/result_filters/_qualifications_filter.html.erb
+++ b/app/views/find/result_filters/_qualifications_filter.html.erb
@@ -11,7 +11,7 @@
           class: "govuk-checkboxes__input",
           multiple: true,
           data: { qa: "qts_only" },
-          checked: @filters_view.qts_only_checked? || @filters_view.qualification_params_nil?
+          checked: @filters_view.qts_only_checked?
         },
         "qts",
         false
@@ -28,7 +28,7 @@
           class: "govuk-checkboxes__input",
           multiple: true,
           data: { qa: "pgde_pgce_with_qts" },
-          checked: @filters_view.pgde_pgce_with_qts_checked? || @filters_view.qualification_params_nil?
+          checked: @filters_view.pgde_pgce_with_qts_checked?
         },
         "pgce_with_qts",
         false
@@ -45,7 +45,7 @@
           class: "govuk-checkboxes__input",
           multiple: true,
           data: { qa: "other" },
-          checked: @filters_view.other_checked? || @filters_view.qualification_params_nil?
+          checked: @filters_view.other_checked?
         },
         ["pgce pgde"],
         false

--- a/app/views/find/result_filters/_study_type_filter.html.erb
+++ b/app/views/find/result_filters/_study_type_filter.html.erb
@@ -10,7 +10,7 @@
           class: "govuk-checkboxes__input",
           multiple: true,
           data: { qa: "full_time" },
-          checked: @filters_view.full_time_checked? || @filters_view.default_study_types_to_true
+          checked: @filters_view.full_time_checked?
         },
         "full_time",
         nil
@@ -27,7 +27,7 @@
           class: "govuk-checkboxes__input",
           multiple: true,
           data: { qa: "part_time" },
-          checked: @filters_view.part_time_checked? || @filters_view.default_study_types_to_true
+          checked: @filters_view.part_time_checked?
         },
         "part_time",
         nil

--- a/spec/features/find/result_page_filters/applications_open_spec.rb
+++ b/spec/features/find/result_page_filters/applications_open_spec.rb
@@ -34,7 +34,13 @@ RSpec.feature 'Results page new application open filter' do
   def and_the_applications_open_query_parameters_are_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('study_type[]=full_time&study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=show_all_courses&applications_open=false')
+
+      expected_params = {
+        'degree_required' => 'show_all_courses',
+        'applications_open' => 'false'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 end

--- a/spec/features/find/result_page_filters/degree_required_spec.rb
+++ b/spec/features/find/result_page_filters/degree_required_spec.rb
@@ -59,21 +59,39 @@ RSpec.feature 'Degree required filter' do
   def and_the_two_two_degree_query_parameters_are_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('study_type[]=full_time&study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=two_two&applications_open=true')
+
+      expected_params = {
+        'degree_required' => 'two_two',
+        'applications_open' => 'true'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 
   def and_the_third_degree_query_parameters_are_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('study_type[]=full_time&study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=third_class&applications_open=true')
+
+      expected_params = {
+        'degree_required' => 'third_class',
+        'applications_open' => 'true'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 
   def and_the_pass_degree_query_parameters_are_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('study_type[]=full_time&study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=not_required&applications_open=true')
+
+      expected_params = {
+        'degree_required' => 'not_required',
+        'applications_open' => 'true'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 end

--- a/spec/features/find/result_page_filters/salary_spec.rb
+++ b/spec/features/find/result_page_filters/salary_spec.rb
@@ -99,7 +99,14 @@ RSpec.feature 'Funding filter' do
   def and_the_salary_query_parameter_is_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('study_type[]=full_time&study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=show_all_courses&funding=salary&applications_open=true')
+
+      expected_params = {
+        'degree_required' => 'show_all_courses',
+        'funding' => 'salary',
+        'applications_open' => 'true'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 

--- a/spec/features/find/result_page_filters/send_spec.rb
+++ b/spec/features/find/result_page_filters/send_spec.rb
@@ -33,7 +33,14 @@ RSpec.feature 'SEND filter' do
   def and_the_send_query_parameter_is_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('study_type[]=full_time&study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=show_all_courses&send_courses=true&applications_open=true')
+
+      expected_params = {
+        'degree_required' => 'show_all_courses',
+        'send_courses' => 'true',
+        'applications_open' => 'true'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 end

--- a/spec/features/find/result_page_filters/study_type_spec.rb
+++ b/spec/features/find/result_page_filters/study_type_spec.rb
@@ -10,6 +10,10 @@ RSpec.feature 'Study type filter' do
 
   scenario 'Candidate applies study type filters on results page' do
     when_i_visit_the_find_results_page
+    then_i_see_both_study_type_checkboxes_are_not_selected
+
+    when_i_select_all_study_types
+    and_apply_the_filters
     then_i_see_both_study_type_checkboxes_are_selected
 
     when_i_unselect_the_part_time_study_checkbox
@@ -31,8 +35,18 @@ RSpec.feature 'Study type filter' do
     expect(find_results_page.study_type.full_time).to be_checked
   end
 
+  def then_i_see_both_study_type_checkboxes_are_not_selected
+    expect(find_results_page.study_type.part_time).not_to be_checked
+    expect(find_results_page.study_type.full_time).not_to be_checked
+  end
+
   def when_i_unselect_the_part_time_study_checkbox
     uncheck('Part time (18 to 24 months)')
+  end
+
+  def when_i_select_all_study_types
+    check 'Full time (12 months)'
+    check 'Part time (18 to 24 months)'
   end
 
   def then_i_see_that_the_full_time_study_checkbox_is_still_selected
@@ -46,7 +60,14 @@ RSpec.feature 'Study type filter' do
   def and_the_full_time_study_query_parameters_are_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('study_type[]=full_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=show_all_courses&applications_open=true')
+
+      expected_params = {
+        'study_type' => ['full_time'],
+        'degree_required' => 'show_all_courses',
+        'applications_open' => 'true'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 
@@ -69,7 +90,14 @@ RSpec.feature 'Study type filter' do
   def and_the_part_time_study_query_parameters_are_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=show_all_courses&applications_open=true')
+
+      expected_params = {
+        'study_type' => ['part_time'],
+        'degree_required' => 'show_all_courses',
+        'applications_open' => 'true'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 end

--- a/spec/features/find/result_page_filters/visa_spec.rb
+++ b/spec/features/find/result_page_filters/visa_spec.rb
@@ -33,7 +33,14 @@ RSpec.feature 'Visa filter' do
   def and_the_visa_query_parameter_is_retained
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/results')
-      expect(uri.query).to eq('can_sponsor_visa=true&study_type[]=full_time&study_type[]=part_time&qualification[]=qts&qualification[]=pgce_with_qts&qualification[]=pgce+pgde&degree_required=show_all_courses&applications_open=true')
+
+      expected_params = {
+        'can_sponsor_visa' => 'true',
+        'degree_required' => 'show_all_courses',
+        'applications_open' => 'true'
+      }
+
+      expect(query_params(uri)).to eq(expected_params)
     end
   end
 end

--- a/spec/support/filters_feature_specs_helper.rb
+++ b/spec/support/filters_feature_specs_helper.rb
@@ -9,4 +9,8 @@ module FiltersFeatureSpecsHelper
   def and_apply_the_filters
     find_results_page.apply_filters_button.click
   end
+
+  def query_params(uri)
+    ActionDispatch::Request.new({ 'QUERY_STRING' => uri.query }).query_parameters
+  end
 end


### PR DESCRIPTION
## Context

Currently the default view of filters has the ‘Study type’ and ‘Qualifications’ checkboxes checked to indicate that they are all selected.

We want to change this to all the checkboxes being unchecked by default, still to indicate that they are all selected.


## Changes proposed in this pull request

*Before*
<img width="252" alt="Screenshot 2024-11-15 at 12 05 15" src="https://github.com/user-attachments/assets/66dee4c1-1f96-441e-8cc4-007e1117a202">

*After*
<img width="272" alt="Screenshot 2024-11-15 at 12 05 33" src="https://github.com/user-attachments/assets/fb202832-8259-4590-acdc-f323916bc599">

## Guidance to review

1. Do a Find search
2. Study type and qualification filters should be unchecked by default
3. Select all study types and qualfications
4. Study type and qualification filters should be checked
5. Now filter by specific study type or qualification
6. Does the filters still continuing to work as expected?
