### PR TITLE
Add more provider and course information to support lists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -210,7 +210,7 @@ group :development, :test do
   gem 'fakefs', require: 'fakefs/safe'
   gem 'faker'
 
-  gem 'dotenv-rails'
+  gem 'dotenv'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,9 +228,6 @@ GEM
     docile (1.4.0)
     domain_name (0.6.20240107)
     dotenv (3.1.4)
-    dotenv-rails (3.1.4)
-      dotenv (= 3.1.4)
-      railties (>= 6.1)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -766,7 +763,7 @@ DEPENDENCIES
   dfe-analytics!
   dfe-wizard!
   discard
-  dotenv-rails
+  dotenv
   draper
   dry-container
   erb_lint

--- a/app/views/layouts/provider_record.html.erb
+++ b/app/views/layouts/provider_record.html.erb
@@ -8,6 +8,7 @@
     ) %>
   <% end %>
 
+  <div class="govuk-caption-l"><%= Provider.human_attribute_name(@provider.provider_type) %></div>
   <h1 class="govuk-heading-l"><%= @provider.name_and_code %></h1>
 
   <%= render TabNavigation.new(items: [

--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -5,6 +5,7 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Course name and code</th>
       <th scope="col" class="govuk-table__header">Status</th>
+      <th scope="col" class="govuk-table__header">Ratifying Provider</th>
       <th scope="col" class="govuk-table__header"></th>
     </tr>
   </thead>
@@ -15,8 +16,13 @@
         <td class="govuk-table__cell name">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.name %> (<%= course.course_code %>)</span>
         </td>
-           <td class="govuk-table__cell status">
+        <td class="govuk-table__cell status">
           <%= course.decorate.status_tag %>
+        </td>
+        <td class="govuk-table__cell">
+          <% if course.accrediting_provider %>
+            <%= govuk_link_to(course.accrediting_provider.provider_name, support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, course.accrediting_provider)) %>
+          <% end %>
         </td>
         <td class="govuk-table__cell change">
           <%= govuk_link_to "Change", edit_support_recruitment_cycle_provider_course_url(@provider.recruitment_cycle_year, @provider, course) %>

--- a/app/views/support/providers/_list.html.erb
+++ b/app/views/support/providers/_list.html.erb
@@ -12,9 +12,10 @@
     <% @providers.each do |provider| %>
       <tr class="govuk-table__row qa-provider_row">
         <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+          <div class="govuk-!-display-block govuk-!-margin-bottom-1">
             <%= govuk_link_to provider.provider_name, support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider) %>
-          </span>
+            <div class="govuk-caption-m"><%= Provider.human_attribute_name(provider.provider_type) %></div>
+          </div>
         </td>
 
         <td class="govuk-table__cell">

--- a/spec/features/support/providers/providers_filter_spec.rb
+++ b/spec/features/support/providers/providers_filter_spec.rb
@@ -78,7 +78,8 @@ feature 'View filtered providers' do
 
   def then_i_see_the_providers_filtered_by_accredited_provider
     expect(support_provider_index_page.providers.size).to eq(1)
-    expect(support_provider_index_page.providers.first.text).to have_content('Accredited school A03')
+    expect(support_provider_index_page.providers.first.text).to have_content('Accredited school')
+    expect(support_provider_index_page.providers.first.text).to have_content('A03')
   end
 
   def when_i_filter_by_provider
@@ -100,16 +101,20 @@ feature 'View filtered providers' do
 
   def then_i_see_providers_filtered_by_provider_name
     expect(support_provider_index_page.providers.size).to eq(1)
-    expect(support_provider_index_page.providers.first.text).to have_content('Really big school A01')
+    expect(support_provider_index_page.providers.first.text).to have_content('Really big school')
+    expect(support_provider_index_page.providers.first.text).to have_content('A01')
   end
 
   alias_method :then_i_see_the_providers_filtered_by_provider_code_and_course_code, :then_i_see_providers_filtered_by_provider_name
 
   def then_i_see_the_providers_filtered_by_course_code
     expect(support_provider_index_page.providers.size).to eq(3)
-    expect(support_provider_index_page.providers[0].text).to have_content('Accredited school A03')
-    expect(support_provider_index_page.providers[1].text).to have_content('Really big school A01')
-    expect(support_provider_index_page.providers[2].text).to have_content('Slightly smaller school A02')
+    expect(support_provider_index_page.providers[0].text).to have_content('Accredited school')
+    expect(support_provider_index_page.providers[0].text).to have_content('A03')
+    expect(support_provider_index_page.providers[1].text).to have_content('Really big school')
+    expect(support_provider_index_page.providers[1].text).to have_content('A01')
+    expect(support_provider_index_page.providers[2].text).to have_content('Slightly smaller school')
+    expect(support_provider_index_page.providers[2].text).to have_content('A02')
   end
 
   def when_i_remove_the_provider_filter


### PR DESCRIPTION
## Context

As we are currently trying to sort out provider relationships, namely the accredited providers associated with courses and therefore lead partners, we want to add visual assistance to our support console.

This should act as visual aid when discussing these topics.

## Changes proposed in this pull request

- Surface provider type on provider details support pages.
- Surface provider type on provider list.
- Surface ratifying provider on provider course list support pages.

## Guidance to review

- Visit the review app.
