### PR TITLE
Add accredited provider number / id to Support Provider list

### DIFF
--- a/app/views/support/providers/_list.html.erb
+++ b/app/views/support/providers/_list.html.erb
@@ -4,6 +4,7 @@
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">Provider code</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">Accredited Provider?</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Accredited Provider Number</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">UKPRN</th>
     </tr>
   </thead>
@@ -34,6 +35,11 @@
           </span>
         </td>
 
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.accredited_provider_id %>
+          </span>
+        </td>
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <%= provider.ukprn %>

--- a/app/views/support/providers/_list.html.erb
+++ b/app/views/support/providers/_list.html.erb
@@ -3,7 +3,6 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">Provider code</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Accredited Provider?</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">Accredited Provider Number</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-third">UKPRN</th>
     </tr>
@@ -27,19 +26,16 @@
 
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <% if  provider.accrediting_provider_before_type_cast == "Y" %>
-              ☑️
-            <% else %>
-              ✖️
+            <% if provider.accrediting_provider_before_type_cast == "Y" %>
+               <% if provider.accredited_provider_id.present? %>
+                  <%= govuk_tag(text: provider.accredited_provider_id, colour: "green") %>
+               <% else %>
+                  <%= govuk_tag(text: "Fill me in", colour: "yellow") %>
+               <% end %>
             <% end %>
           </span>
         </td>
 
-        <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= provider.accredited_provider_id %>
-          </span>
-        </td>
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <%= provider.ukprn %>


### PR DESCRIPTION
## Context

  It is useful for our team to see which accredited providers are
  missing an accredited provider number


## Changes proposed in this pull request

Show a providers' accredited Provider number in the support console.

## Guidance to review

[Review App Support Console](https://publish-review-4688.test.teacherservices.cloud/support/2025/providers)
