### PR TITLE
Enhancements to the selectable school content

### DIFF
--- a/app/views/publish/providers/school_placements/edit.html.erb
+++ b/app/views/publish/providers/school_placements/edit.html.erb
@@ -21,8 +21,11 @@
         <%= page_title %>
       </h1>
 
-      <%= f.govuk_radio_buttons_fieldset(:selectable_school,
-                                         legend: { text: t(".selectable_school_label") }) do %>
+      <%= f.govuk_radio_buttons_fieldset(
+            :selectable_school,
+            legend: { text: t(".selectable_school_label") },
+            hint: { text: t(".selectable_school_hint") }
+          ) do %>
         <%= f.govuk_radio_button :selectable_school, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :selectable_school, false, label: { text: "No" } %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -472,7 +472,7 @@ en:
         school_placements: School placements
         contact_details: Contact details
         visa_sponsorship: Visa sponsorship
-        selectable_school_label: Let candidates choose preferred schools
+        selectable_school_label: Show locations and allow candidates to select a preferred school
       courses:
         accredited_provider:
           show:
@@ -564,7 +564,8 @@ en:
         edit:
           page_title: How placements work - %{course_name_and_code}
           submit_button: Update how placements work
-          selectable_school_label: Let candidates select their preferred schools when applying
+          selectable_school_label: Do you want to show placement schools to candidates?
+          selectable_school_hint: Candidates will see a list of placement schools on your course pages and be able to select a preference when they apply
           guidance_text_html:
             <p class="govuk-body">Give candidates information about the schools they will be training in</p>
             <p class="govuk-body">Tell them:</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -565,7 +565,7 @@ en:
           page_title: How placements work - %{course_name_and_code}
           submit_button: Update how placements work
           selectable_school_label: Do you want to show placement schools to candidates?
-          selectable_school_hint: Candidates will see a list of placement schools on your course pages and be able to select a preference when they apply
+          selectable_school_hint: Candidates will see a list of placement schools on your course pages and be able to select a preference when they apply.
           guidance_text_html:
             <p class="govuk-body">Give candidates information about the schools they will be training in</p>
             <p class="govuk-body">Tell them:</p>


### PR DESCRIPTION
## Context

We implemented radio buttons in Publish to allow providers to select whether they want to display school locations to candidates in Find and allow them to select a placement in Apply.

To get this functionality in by the start of the cycle we used holding content. 

This PR is to make some small changes to make the content more descriptive of what the buttons do.

## Guidance to review

1. E.g Visit https://publish-review-4691.test.teacherservices.cloud/publish/organisations/4A3/2025/details
2. E.g Visit https://publish-review-4691.test.teacherservices.cloud/publish/organisations/4A3/2025/school_placements
3. Does the content looks as expected in the trello card?
