### PR TITLE
Remove www2 route redirection

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,6 @@ Rails.application.routes.draw do
     get '/', to: redirect('/docs/')
   end
 
-  constraints(host: /www2\./) do
-    match '/(*path)' => redirect { |_, req| "#{Settings.base_url}#{req.fullpath}" }, via: %i[get post put]
-  end
-
   constraints(FindConstraint.new) do
     draw(:find)
   end


### PR DESCRIPTION
## Context

The `www2` host is no longer resolved within our DNS routes. We can safely drop this routing constraint/redirection.

The `www2` host was used as a preview host for the new publish application: https://github.com/DFE-Digital/publish-teacher-training/pull/2655

## Changes proposed in this pull request

- Drop the `www2` route group.

## Guidance to review

- Try visiting https://www2.publish-teacher-training-courses.service.gov.uk/, it should fail. This means we can safely drop the host constraint and routes within the group.
