### PR TITLE
Split skylight metrics for review apps out per review app

### DIFF
--- a/app/components/phase_banner.rb
+++ b/app/components/phase_banner.rb
@@ -7,7 +7,7 @@ class PhaseBanner < ViewComponent::Base
   end
 
   def environment_label
-    Settings.environment.label.capitalize
+    Settings.environment.label
   end
 
   def environment_colour

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -7,3 +7,5 @@ ignored_endpoints:
   - HeartbeatController#sha
 deploy:
   git_sha: <%= ENV["COMMIT_SHA"] %>
+review:
+  env: <%= ENV["APP_NAME_SUFFIX"] %>

--- a/terraform/aks/locals.tf
+++ b/terraform/aks/locals.tf
@@ -9,7 +9,7 @@ locals {
     REDIS_CACHE_URL  = module.redis_cache.url
     REDIS_WORKER_URL = module.redis_worker.url
   }
-  app_env_values = yamldecode(file(var.app_config_file))[var.app_environment]
+  app_env_values = merge(yamldecode(file(var.app_config_file))[var.app_environment], { APP_NAME_SUFFIX = local.app_name_suffix })
   infra_secrets  = yamldecode(module.secrets.map[var.key_vault_infra_secret_name])
 
   statuscake_additional_hostnames = var.additional_hostnames != null ? tolist([for hostname in var.additional_hostnames : format("https://%s/ping", hostname)]) : null


### PR DESCRIPTION
## Context

We can send our Skylight metrics for review apps out into separate environments. In the case that we want to understand the performance of a review app, we will be able to distinguish between each review app and its metrics.

## Changes proposed in this pull request

- Send review app metrics to Skylight per PR number.

## Guidance to review

- See https://www.skylight.io/app/applications/2qpKL45hvoni/recent/5m/endpoints for example.
