### PR TITLE
Remove local SSL configurations

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,36 +41,4 @@ pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 
-listen_port = ENV.fetch('PORT', 3001)
-
-if env == 'development' && Settings.use_ssl
-  config_dir = Pathname.pwd.join('config', 'localhost', 'https')
-  config_dir.mkpath unless config_dir.exist?
-  cert = config_dir.join('localhost.crt')
-  key = config_dir.join('localhost.key')
-
-  unless File.exist?(cert) && File.exist?(key)
-    def generate_root_cert(root_key)
-      root_ca = OpenSSL::X509::Certificate.new
-      root_ca.version = 2 # cf. RFC 5280 - to make it a "v3" certificate
-      root_ca.serial = rand(100_000) # randomized for local development to prevent SEC_ERROR_REUSED_ISSUER_AND_SERIAL errors in firefox after a git-clean
-      root_ca.subject = OpenSSL::X509::Name.parse '/C=GB/L=London/O=DfE/CN=localhost'
-      root_ca.issuer = root_ca.subject # root CA's are "self-signed"
-      root_ca.public_key = root_key.public_key
-      root_ca.not_before = Time.zone.now
-      root_ca.not_after = root_ca.not_before + (2 * 365 * 24 * 60 * 60) # 2 years validity
-      root_ca.sign(root_key, OpenSSL::Digest.new('SHA256'))
-      root_ca
-    end
-
-    root_key = OpenSSL::PKey::RSA.new(2048)
-    File.write(key, root_key, mode: 'wb')
-
-    root_cert = generate_root_cert(root_key)
-    File.write(cert, root_cert, mode: 'wb')
-  end
-
-  ssl_bind '0.0.0.0', listen_port, cert:, key:, verify_mode: 'none'
-else
-  port listen_port
-end
+port ENV.fetch('PORT', 3001)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,8 +23,6 @@ dfe_signin:
   # The URL support users are directed to in order to find a user by email
   user_search_url: https://test-support.signin.education.gov.uk/users
 
-use_ssl: false
-
 authentication:
   algorithm: HS256
   # Set this in the env! The below ensures that we are un-authenticatable if we

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -18,4 +18,3 @@ find_valid_referers:
 
 base_url: https://publish.localhost
 find_url: https://find.localhost
-use_ssl: true


### PR DESCRIPTION
## Context

We don't need to setup SSL on our local machines. If we needed to test SSL locally, we can use a secure tunnelling service.

## Changes proposed in this pull request

- Remove all `use_ssl` references.
- Remove SSL config in `config/puma.rb`.

## Guidance to review

Try running `rails s` and `bundle exec puma` locally. Both should work.
