### PR TITLE
Normalize provider names

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -64,6 +64,8 @@ class Provider < ApplicationRecord
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
 
+  normalizes :provider_name, with: ->(value) { value.gsub(/\s+/, ' ').strip }
+
   def accredited_providers
     recruitment_cycle.providers.where(provider_code: accredited_provider_codes)
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -108,6 +108,10 @@ describe Provider do
     end
   end
 
+  describe 'normalizations' do
+    it { is_expected.to normalize(:provider_name).from('  ACME  SCITT  ').to('ACME SCITT') }
+  end
+
   describe 'organisation' do
     it 'returns the only organisation a provider has' do
       expect(subject.organisation).to eq subject.organisations.first


### PR DESCRIPTION
## Context

Provider names should not not contain multiple spaces.

## Changes proposed in this pull request

- Normalize `Provider#provider_name` to de-dup whitespaces and strip excess ones.

## Guidance to review

- Should we add a data migration to clean up existing records?
