### PR TITLE
Make sure we can remove sites when there are no kept courses

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -52,7 +52,7 @@ class Site < ApplicationRecord
   delegate :after_2021?, to: :recruitment_cycle, allow_nil: true, prefix: :recruitment_cycle
 
   def has_no_course?
-    Course.includes(:sites).where(sites: { id: }).none?
+    Course.kept.includes(:sites).where(sites: { id: }).none?
   end
 
   def geocode_site

--- a/spec/features/publish/managing_schools_spec.rb
+++ b/spec/features/publish/managing_schools_spec.rb
@@ -67,12 +67,25 @@ feature "Managing a provider's schools", { can_edit_current_and_next_cycles: fal
       and_the_school_is_deleted
     end
 
-    scenario 'with associcated course' do
+    scenario 'with associated course' do
       given_there_is_an_associated_course
       when_i_visit_the_publish_school_show_page
       and_i_click_remove_school_link
       then_i_am_on_the_school_delete_page
       and_i_cannot_delete_the_school
+    end
+
+    scenario 'with discarded associated course' do
+      given_there_is_an_associated_course
+      and_i_delete_the_course
+      when_i_visit_the_publish_school_show_page
+      and_i_click_remove_school_link
+      then_i_am_on_the_school_delete_page
+      and_i_am_able_to_remove_the_school
+
+      when_i_click_remove_school_button
+      then_i_am_on_the_index_page
+      and_the_school_is_deleted
     end
   end
 
@@ -130,13 +143,28 @@ feature "Managing a provider's schools", { can_edit_current_and_next_cycles: fal
     @course.sites << @site
   end
 
+  def and_i_delete_the_course
+    visit delete_publish_provider_recruitment_cycle_course_path(
+      provider_code: @course.provider.provider_code,
+      recruitment_cycle_year: @course.recruitment_cycle.year,
+      code: @course.course_code
+    )
+    fill_in 'Enter the course code to confirm', with: @course.course_code
+    click_link_or_button 'Yes I’m sure – delete this course'
+  end
+
   def and_the_school_is_deleted
     expect(provider.sites.count).to eq 0
+  end
+
+  def and_i_am_able_to_remove_the_school
+    expect(page).to have_content('Remove school')
   end
 
   def and_i_click_remove_school_button
     click_link_or_button 'Remove school'
   end
+  alias_method :when_i_click_remove_school_button, :and_i_click_remove_school_button
 
   def when_i_click_cancel
     click_link_or_button 'Cancel'


### PR DESCRIPTION
## Context

An user raised a support ticket stating that they can’t remove schools.

## Reproducing the bug

1. Create a school for test
2. Create a draft course and attach the school above
3. Delete the draft course
4. Try to delete the school - you can’t!



## Changes proposed in this pull request

It should be possible to delete schools if is not attached to any `kept` course.

## Guidance to review

1. Is there a problem deleting a site associated with a discarded (deleted) course? - I couldn't identify any.
