### PR TITLE
Partially disable semantic logger in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,4 +82,9 @@ Rails.application.configure do
   config.authentication_token = ENV.fetch('AUTHENTICATION_TOKEN', 'bats')
 
   config.x.read_only_database_url = "postgres://localhost/#{ENV.fetch('DB_DATABASE', 'manage_courses_backend_development')}"
+
+  config.rails_semantic_logger.semantic   = false
+  config.rails_semantic_logger.started    = true
+  config.rails_semantic_logger.processing = true
+  config.rails_semantic_logger.rendered   = true
 end


### PR DESCRIPTION
## Context

Disable partially the semantic logger in development in order to be as close as we can from Rails default in development.

## Changes proposed in this pull request

Following semantic logger documentation and comment on the issue: https://github.com/reidmorrison/rails_semantic_logger/issues/213

There is no way to disable entirely rails semantic logger without the `require: false` as the issue above described. I opt-in for the solution proposed in the issue above.

The image below are from the docs: https://logger.rocketjob.io/rails.html

<img width="1177" alt="Screenshot 2024-11-21 at 12 30 32" src="https://github.com/user-attachments/assets/1f6550bc-6fcf-41c7-9669-aefce1648e19">

## Guidance to review

1. The review app logs in JSON?
2. If you pull locally the logs are near to the Rails default as we can?
