### PR TITLE
Stop pre-loading accredited course list associations

### DIFF
--- a/app/controllers/publish/training_providers/course_exports_controller.rb
+++ b/app/controllers/publish/training_providers/course_exports_controller.rb
@@ -16,11 +16,11 @@ module Publish
       private
 
       def courses
-        @courses ||= provider.current_accredited_courses.includes(:enrichments, :sites, :site_statuses)
+        @courses ||= provider.current_accredited_courses
       end
 
       def data_export
-        @data_export ||= Exports::AccreditedCourseList.new(courses)
+        @data_export ||= Exports::AccreditedCourseList.new(courses:)
       end
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -116,7 +116,7 @@ class Course < ApplicationRecord
   after_validation :remove_unnecessary_enrichments_validation_message
   before_save :set_applications_open_from
 
-  after_save :update_program_type!, if: :saved_change_to_funding?
+  before_save :update_program_type!, if: :will_save_change_to_funding?
 
   belongs_to :provider
 

--- a/app/services/exports/accredited_course_list.rb
+++ b/app/services/exports/accredited_course_list.rb
@@ -4,14 +4,42 @@ require 'csv'
 
 module Exports
   class AccreditedCourseList
-    def initialize(courses)
-      @data_for_export = format_courses(courses)
+    CSV_HEADERS = [
+      'Provider code',
+      'Provider',
+      'Course code',
+      'Course',
+      'Study mode',
+      'Programme type',
+      'Qualification',
+      'Status',
+      'View on Find',
+      'Applications open from',
+      'Campus Codes'
+    ].freeze
+
+    def initialize(courses:)
+      @courses = courses
     end
 
     def data
-      CSV.generate(headers: data_for_export.first.keys, write_headers: true) do |csv|
-        data_for_export.each do |course_csv_row|
-          csv << course_csv_row
+      CSV.generate(headers: CSV_HEADERS, write_headers: true) do |csv|
+        courses.find_each do |course|
+          decorated_course = course.decorate
+
+          csv << [
+            decorated_course.provider.provider_code,
+            decorated_course.provider.provider_name,
+            decorated_course.course_code,
+            decorated_course.name,
+            decorated_course.study_mode&.humanize,
+            decorated_course.program_type&.humanize,
+            decorated_course.outcome,
+            decorated_course.content_status&.to_s&.humanize,
+            decorated_course.find_url,
+            I18n.l(decorated_course.applications_open_from&.to_date),
+            decorated_course.sites&.map(&:code)&.join(' ')
+          ]
         end
       end
     end
@@ -22,30 +50,6 @@ module Exports
 
     private
 
-    attr_reader :data_for_export
-
-    def format_courses(courses)
-      courses
-        .map(&:decorate)
-        .flat_map do |c|
-        base_data = {
-          'Provider code' => c.provider.provider_code,
-          'Provider' => c.provider.provider_name,
-          'Course code' => c.course_code,
-          'Course' => c.name,
-          'Study mode' => c.study_mode&.humanize,
-          'Programme type' => c.program_type&.humanize,
-          'Qualification' => c.outcome,
-          'Status' => c.content_status&.to_s&.humanize,
-          'View on Find' => c.find_url,
-          'Applications open from' => I18n.l(c.applications_open_from&.to_date)
-        }
-        if c.sites
-          base_data.merge({ 'Campus Codes' => c.sites.pluck(:code).join(' ') })
-        else
-          base_data
-        end
-      end
-    end
+    attr_reader :courses
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -165,18 +165,22 @@ FactoryBot.define do
 
     trait :with_higher_education do
       program_type { :higher_education_programme }
+      funding { :fee }
     end
 
     trait :with_school_direct do
       program_type { :school_direct_training_programme }
+      funding { :fee }
     end
 
     trait :with_scitt do
       program_type { :scitt_programme }
+      funding { :fee }
     end
 
     trait :with_apprenticeship do
       program_type { :pg_teaching_apprenticeship }
+      funding { :apprenticeship }
     end
 
     trait :with_teacher_degree_apprenticeship do
@@ -186,6 +190,7 @@ FactoryBot.define do
 
     trait :with_salary do
       program_type { :school_direct_salaried_training_programme }
+      funding { :salary }
     end
 
     trait :fee_type_based do
@@ -193,6 +198,7 @@ FactoryBot.define do
         %i[higher_education_programme school_direct_training_programme
            scitt_programme].sample
       end
+      funding { :fee }
     end
 
     trait :fee do
@@ -209,6 +215,7 @@ FactoryBot.define do
 
     trait :salary_type_based do
       program_type { %i[pg_teaching_apprenticeship school_direct_salaried_training_programme].sample }
+      funding { :salary }
     end
 
     trait :non_salary_type_based do

--- a/spec/features/find/result_page_filters/salary_spec.rb
+++ b/spec/features/find/result_page_filters/salary_spec.rb
@@ -26,49 +26,56 @@ RSpec.feature 'Funding filter' do
       :secondary,
       :open,
       site_statuses:,
-      program_type: :higher_education_programme
+      program_type: :higher_education_programme,
+      funding: :fee
     )
     @course_scitt_salaried_programme = create(
       :course,
       :secondary,
       :open,
       site_statuses:,
-      program_type: :scitt_salaried_programme
+      program_type: :scitt_salaried_programme,
+      funding: :salary
     )
     @course_higher_education_salaried_programme = create(
       :course,
       :secondary,
       :open,
       site_statuses:,
-      program_type: :higher_education_salaried_programme
+      program_type: :higher_education_salaried_programme,
+      funding: :salary
     )
     @course_school_direct_training_programme = create(
       :course,
       :secondary,
       :open,
       site_statuses:,
-      program_type: :school_direct_training_programme
+      program_type: :school_direct_training_programme,
+      funding: :fee
     )
     @course_school_direct_salaried_training_programme = create(
       :course,
       :secondary,
       :open,
       site_statuses:,
-      program_type: :school_direct_salaried_training_programme
+      program_type: :school_direct_salaried_training_programme,
+      funding: :salary
     )
     @course_scitt_programme = create(
       :course,
       :secondary,
       :open,
       site_statuses:,
-      program_type: :scitt_programme
+      program_type: :scitt_programme,
+      funding: :fee
     )
     @course_pg_teaching_apprenticeship = create(
       :course,
       :secondary,
       :open,
       site_statuses:,
-      program_type: :pg_teaching_apprenticeship
+      program_type: :pg_teaching_apprenticeship,
+      funding: :apprenticeship
     )
   end
 

--- a/spec/features/publish/courses/editing_course_length_spec.rb
+++ b/spec/features/publish/courses/editing_course_length_spec.rb
@@ -67,7 +67,7 @@ feature 'Editing course length' do
   end
 
   def and_there_is_an_uneditable_course
-    given_a_course_exists(program_type: 'TDA')
+    given_a_course_exists(program_type: 'TDA', funding: :apprenticeship)
   end
 
   def and_there_is_a_course_i_want_to_edit(course_length)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1170,28 +1170,28 @@ describe Course do
       subject { described_class.with_salary }
 
       let!(:course_higher_education_programme) do
-        create(:course, program_type: :higher_education_programme)
+        create(:course, program_type: :higher_education_programme, funding: :fee)
       end
 
       let!(:course_scitt_salaried_programme) do
-        create(:course, program_type: :scitt_salaried_programme)
+        create(:course, program_type: :scitt_salaried_programme, funding: :salary)
       end
 
       let!(:course_higher_education_salaried_programme) do
-        create(:course, program_type: :higher_education_salaried_programme)
+        create(:course, program_type: :higher_education_salaried_programme, funding: :salary)
       end
 
       let!(:course_school_direct_training_programme) do
-        create(:course, program_type: :school_direct_training_programme)
+        create(:course, program_type: :school_direct_training_programme, funding: :fee)
       end
 
       let!(:course_school_direct_salaried_training_programme) do
-        create(:course, program_type: :school_direct_salaried_training_programme)
+        create(:course, program_type: :school_direct_salaried_training_programme, funding: :salary)
       end
 
-      let!(:course_scitt_programme) { create(:course, program_type: :scitt_programme) }
+      let!(:course_scitt_programme) { create(:course, program_type: :scitt_programme, funding: :fee) }
       let!(:course_pg_teaching_apprenticeship) do
-        create(:course, program_type: :pg_teaching_apprenticeship)
+        create(:course, program_type: :pg_teaching_apprenticeship, funding: :apprenticeship)
       end
 
       it 'only returns salaried training programme' do

--- a/spec/services/exports/accredited_course_list_spec.rb
+++ b/spec/services/exports/accredited_course_list_spec.rb
@@ -5,39 +5,40 @@ require 'rails_helper'
 module Exports
   describe AccreditedCourseList do
     let(:course) do
-      CourseDecorator.new(
-        create(
-          :course,
-          site_statuses: [create(:site_status, :full_time_vacancies, :findable)],
-          enrichments: [build(:course_enrichment, :published)]
-        )
+      create(
+        :course,
+        site_statuses: [create(:site_status, :full_time_vacancies, :findable)],
+        enrichments: [build(:course_enrichment, :published)]
       )
     end
 
-    subject { described_class.new([course]) }
+    let(:decorated_course) { CourseDecorator.new(course) }
+
+    subject { described_class.new(courses: Course.where(id: course)) }
 
     describe '#data' do
       let(:expected_output) do
         {
-          'Provider code' => course.provider.provider_code,
-          'Provider' => course.provider.provider_name,
-          'Course code' => course.course_code,
-          'Course' => course.name,
-          'Study mode' => course.study_mode&.humanize,
-          'Programme type' => course.program_type&.humanize,
-          'Qualification' => course.outcome,
-          'Status' => course.content_status&.to_s&.humanize,
-          'View on Find' => course.find_url,
-          'Applications open from' => I18n.l(course.applications_open_from&.to_date)
+          'Provider code' => decorated_course.provider.provider_code,
+          'Provider' => decorated_course.provider.provider_name,
+          'Course code' => decorated_course.course_code,
+          'Course' => decorated_course.name,
+          'Study mode' => decorated_course.study_mode&.humanize,
+          'Programme type' => decorated_course.program_type&.humanize,
+          'Qualification' => decorated_course.outcome,
+          'Status' => decorated_course.content_status&.to_s&.humanize,
+          'View on Find' => decorated_course.find_url,
+          'Applications open from' => I18n.l(decorated_course.applications_open_from&.to_date),
+          'Campus Codes' => decorated_course.sites&.map(&:code)&.join(' ')
         }
       end
 
       it 'sets the correct headers' do
-        expect(subject.data).to include(expected_output.keys.join(','))
+        expect(subject.data.lines[0].strip).to eq(expected_output.keys.join(','))
       end
 
       it 'sets the correct row values' do
-        expect(subject.data).to include(expected_output.values.join(','))
+        expect(subject.data.lines[1].strip).to eq(expected_output.values.join(','))
       end
     end
   end


### PR DESCRIPTION
## Context

The accredited provider's download of all courses they ratify times out for some providers. We need to investigate the cause and how to fix it.

## Changes proposed in this pull request

- Remove `.includes` call when loading the accredited course list. More information in commit message: [137a46e](https://github.com/DFE-Digital/publish-teacher-training/pull/4708/commits/137a46e4adb8a4724f23d41e8620c6795009197e)
- Change the program type re-assignment based on fee to run before a database write occurs. (Whilst testing the `spec/services/exports/accredited_course_list_spec.rb` spec, it would fail _`course.program_type == course.program_type`_. This is because one of the instances was taken from the database, one ran the after_save callback.

## Guidance to review

- Visit http://publish.localhost:3000/publish/organisations/C58/2025/training-providers and download the CSV on the side. It should take around 3-5 seconds.
