### PR TITLE
Undiscard the course when publishing

### DIFF
--- a/app/services/courses/publish_service.rb
+++ b/app/services/courses/publish_service.rb
@@ -26,6 +26,7 @@ module Courses
 
     def publish_course
       Course.transaction do
+        course.undiscard
         course.publish_sites
         course.publish_enrichment(user)
         course.application_status_open!

--- a/spec/services/courses/publish_service_spec.rb
+++ b/spec/services/courses/publish_service_spec.rb
@@ -29,6 +29,17 @@ RSpec.describe Courses::PublishService do
     end
   end
 
+  describe 'when the course is discarded' do
+    let(:course) { create(:course, :publishable, uuid:, discarded_at: 1.minute.ago) }
+
+    it 'the course is undiscarded and published' do
+      allow(Course).to receive(:find_by).with({ uuid: uuid }).and_return(course)
+      subject.call
+      expect(course.reload).to be_published
+      expect(course.reload).to be_undiscarded
+    end
+  end
+
   describe 'publishing the course fails' do
     it 'the course is unpublished' do
       allow(Course).to receive(:find_by).with({ uuid: uuid }).and_return(course)


### PR DESCRIPTION


## Context

  Courses may be #published? and still not appear in the API. When we
  publish a course, we should expect it to appear in the API.
  When publishing a course we should undiscard the course if it has been
  discarded

## Changes proposed in this pull request

PunlishService will undiscard a course in the process of publishing it.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
