### PR TITLE
Add new results page to create our new search mechanism

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -3,7 +3,15 @@
 module Find
   module V2
     class ResultsController < Find::ApplicationController
+      before_action :enforce_basic_auth
+
       def index; end
+
+      def enforce_basic_auth
+        authenticate_or_request_with_http_basic do |username, password|
+          BasicAuthenticable.authenticate(username, password)
+        end
+      end
     end
   end
 end

--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Find
+  module V2
+    class ResultsController < Find::ApplicationController
+      def index; end
+    end
+  end
+end

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -17,6 +17,8 @@ namespace :find, path: '/' do
   get '/course/:provider_code/:course_code/apply', to: 'courses#apply', as: :apply
   get '/course/:provider_code/:course_code/git/:git_path', to: 'courses#git_redirect', as: :get_into_teaching_redirect
   get '/course/:provider_code/:course_code/provider/website', to: 'courses#provider_website', as: :provider_website
+
+  get '/v2/results', to: 'v2/results#index', as: 'v2_results', constraints: ->(_request) { Settings.features.v2_results.present? }
   get '/results', to: 'results#index', as: 'results'
   get '/location-suggestions', to: 'location_suggestions#index'
   get '/cycle-has-ended', to: 'pages#cycle_has_ended', as: 'cycle_has_ended'

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -18,7 +18,7 @@ namespace :find, path: '/' do
   get '/course/:provider_code/:course_code/git/:git_path', to: 'courses#git_redirect', as: :get_into_teaching_redirect
   get '/course/:provider_code/:course_code/provider/website', to: 'courses#provider_website', as: :provider_website
 
-  get '/v2/results', to: 'v2/results#index', as: 'v2_results', constraints: ->(_request) { Settings.features.v2_results.present? }
+  get '/v2/results', to: 'v2/results#index', as: 'v2_results'
   get '/results', to: 'results#index', as: 'results'
   get '/location-suggestions', to: 'location_suggestions#index'
   get '/cycle-has-ended', to: 'pages#cycle_has_ended', as: 'cycle_has_ended'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,6 +81,7 @@ feedback:
 features:
   api_summary_content_change: false
   send_request_data_to_bigquery: false
+  v2_results: false
   rollover:
     # Normally a short period of time between rollover and the next cycle
     # actually starting when it would be set to false

--- a/spec/features/find/v2/results/search_results_disabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_disabled_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-feature 'V2 results - feature flag disabled' do
+feature 'V2 results - disabled' do
   before do
     allow(Settings.features).to receive_messages(v2_results: false)
   end

--- a/spec/features/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_enabled_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-feature 'V2 results - feature flag enabled' do
+feature 'V2 results - enabled' do
   before do
     allow(Settings.features).to receive_messages(v2_results: true)
   end

--- a/spec/features/find/v2/results/search_results_feature_flag_disabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_feature_flag_disabled_spec.rb
@@ -9,14 +9,14 @@ feature 'V2 results - feature flag disabled' do
 
   scenario 'when I visit the results page' do
     when_i_visit_the_find_results_page
-    then_i_see_not_found
+    then_i_see_not_authorised
   end
 
   def when_i_visit_the_find_results_page
     visit find_v2_results_path
   end
 
-  def then_i_see_not_found
-    expect(page.status_code).to eq(404)
+  def then_i_see_not_authorised
+    expect(page.status_code).to eq(401)
   end
 end

--- a/spec/features/find/v2/results/search_results_feature_flag_disabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_feature_flag_disabled_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'V2 results - feature flag disabled' do
+  before do
+    allow(Settings.features).to receive_messages(v2_results: false)
+  end
+
+  scenario 'when I visit the results page' do
+    when_i_visit_the_find_results_page
+    then_i_see_not_found
+  end
+
+  def when_i_visit_the_find_results_page
+    visit find_v2_results_path
+  end
+
+  def then_i_see_not_found
+    expect(page.status_code).to eq(404)
+  end
+end

--- a/spec/features/find/v2/results/search_results_feature_flag_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_feature_flag_enabled_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'V2 results - feature flag enabled' do
+  before do
+    allow(Settings.features).to receive_messages(v2_results: true)
+  end
+
+  scenario 'when I visit the results page' do
+    when_i_visit_the_find_results_page
+    then_the_page_is_load_successfully
+  end
+
+  def when_i_visit_the_find_results_page
+    visit find_v2_results_path
+  end
+
+  def then_the_page_is_load_successfully
+    expect(page.status_code).to eq(200)
+  end
+end

--- a/spec/features/find/v2/results/search_results_feature_flag_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_feature_flag_enabled_spec.rb
@@ -8,8 +8,13 @@ feature 'V2 results - feature flag enabled' do
   end
 
   scenario 'when I visit the results page' do
+    given_i_am_authenticated
     when_i_visit_the_find_results_page
     then_the_page_is_load_successfully
+  end
+
+  def given_i_am_authenticated
+    page.driver.browser.authorize 'admin', 'password'
   end
 
   def when_i_visit_the_find_results_page


### PR DESCRIPTION
## Context

The goal of this PR is to create a second results page (behind a feature flag) that we can start to consolidate the good foundation for the search engine intelligence.

A new course results page is added
For now we won’t display any courses or anything (to be done in the next cards) This page is behind a feature flag


## Changes proposed in this pull request

Add an empty controller and view behind a feature flag for now.

## Guidance to review

1. Is the `V2` naming good? (If not, please provide suggestions)

The tests are remporarily until the next card where will show all courses paginated.
Then later down the line we will add one filter at a time with sorting coming last.
[Any doubt check the outcome card and its checklist](https://trello.com/c/hoQqU8XQ/256-outcome-improve-course-search-engine-by-setup-a-good-foundation-for-the-pre-filter-work)
