### PR TITLE
Enable ActiveJob in skylight

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,7 @@ module ManageCoursesBackend
     config.skylight.environments += Settings.skylight.enable ? [Rails.env] : []
     config.skylight.logger = SemanticLogger[Skylight]
     config.skylight.log_level = :fatal
+    config.skylight.probes += ['active_job']
     config.skylight.native_log_level = :fatal
 
     config.view_component.preview_paths = [Rails.root.join('spec/components')]


### PR DESCRIPTION
## Context

Sidekiq needs to be explicitly enabled in Skylight.

  https://www.skylight.io/support/background-jobs#using-skylightyml
  https://www.skylight.io/support/background-jobs#enabling-frameworks

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Enable our Application Performance Monitoring tool to collect data on our background jobs

## Guidance to review

[Link to the review process](https://www.skylight.io/app/applications/P29Oy7glIJ6w/recent/5m/endpoints) (might disappear by the time you see this)

![image](https://github.com/user-attachments/assets/a01fc2f0-0eb6-4f6a-b841-59bc53bc30c8)

