### PR TITLE
Clear the accredited_provider_number when removing provider accreditation

### DIFF
--- a/app/components/providers/provider_list/view.html.erb
+++ b/app/components/providers/provider_list/view.html.erb
@@ -24,7 +24,7 @@
       end
 
       if @provider.accredited_provider?
-        component.with_row do |row|
+        component.with_row(html_attributes: { data: { qa: 'ap-number-row' } }) do |row|
           row.with_key { "Accredited provider number" }
           row.with_value { value_provided?(@provider.accredited_provider_number.to_s) }
           row.with_action(text: "Change", href: edit_support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider), visually_hidden_text: "accredited provider id")

--- a/app/components/providers/provider_list/view.html.erb
+++ b/app/components/providers/provider_list/view.html.erb
@@ -24,7 +24,7 @@
       end
 
       if @provider.accredited_provider?
-        component.with_row(html_attributes: { data: { qa: 'ap-number-row' } }) do |row|
+        component.with_row(html_attributes: { data: { qa: "ap-number-row" } }) do |row|
           row.with_key { "Accredited provider number" }
           row.with_value { value_provided?(@provider.accredited_provider_number.to_s) }
           row.with_action(text: "Change", href: edit_support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider), visually_hidden_text: "accredited provider id")

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -18,7 +18,7 @@ module Support
 
     def update
       provider.assign_attributes(update_provider_params)
-      provider.accredited_provider_number = nil if provider.accrediting_provider_change[1] == 'not_an_accredited_provider'
+      provider.accredited_provider_number = nil if provider.accrediting_provider_change&.[](1) == 'not_an_accredited_provider'
       if provider.save
         redirect_to support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider), flash: { success: t('support.flash.updated', resource: 'Provider') }
       else

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -17,7 +17,9 @@ module Support
     end
 
     def update
-      if provider.update(update_provider_params)
+      provider.assign_attributes(update_provider_params)
+      provider.accredited_provider_number = nil if provider.accrediting_provider_change[1] == 'not_an_accredited_provider'
+      if provider.save
         redirect_to support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider), flash: { success: t('support.flash.updated', resource: 'Provider') }
       else
         render :edit
@@ -52,7 +54,8 @@ module Support
                                        :provider_type,
                                        :ukprn,
                                        :urn,
-                                       :accrediting_provider, :accredited_provider_number)
+                                       :accrediting_provider,
+                                       :accredited_provider_number)
     end
 
     def create_provider_params

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -17,9 +17,8 @@ module Support
     end
 
     def update
-      provider.assign_attributes(update_provider_params)
-      provider.accredited_provider_number = nil if provider.accrediting_provider_change&.[](1) == 'not_an_accredited_provider'
-      if provider.save
+      update_form = UpdateProviderForm.new(provider, attributes: update_provider_params)
+      if update_form.save
         redirect_to support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider), flash: { success: t('support.flash.updated', resource: 'Provider') }
       else
         render :edit

--- a/app/forms/support/update_provider_form.rb
+++ b/app/forms/support/update_provider_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Support
+  class UpdateProviderForm
+    attr_reader :provider
+
+    def initialize(provider, attributes:)
+      @provider = provider
+      @attributes = attributes
+    end
+
+    def save
+      @provider.assign_attributes(@attributes)
+      remove_accredited_provider_number
+      @provider.save
+    end
+
+    def remove_accredited_provider_number
+      return unless @provider.accrediting_provider_change&.[](1) == 'not_an_accredited_provider'
+
+      @provider.accredited_provider_number = nil
+    end
+  end
+end

--- a/spec/forms/support/update_provider_form_spec.rb
+++ b/spec/forms/support/update_provider_form_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Support
+  describe UpdateProviderForm, type: :model do
+    let(:provider) { create(:provider, :accredited_provider) }
+    let(:update_provider_form) { described_class.new(provider, attributes:) }
+    let(:attributes) { attributes_for(:provider, :accredited_provider) }
+
+    subject { update_provider_form }
+
+    describe '#save' do
+      context 'provider is changed from accredited_provider to not accredited_provider' do
+        let(:attributes) { { accrediting_provider: 'not_an_accredited_provider' } }
+
+        it 'removes the accredited_provider_number' do
+          expect { subject.save }.to change(provider.reload, :accredited_provider_number).from(provider.accredited_provider_number).to(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/support/update_provider_spec.rb
+++ b/spec/system/support/update_provider_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+RSpec.describe 'Removing accredited status from provider', service: :publish do
+  include DfESignInUserHelper
+  let(:provider) { create(:provider, :accredited_provider, provider_name: 'Pro Vider') }
+  let(:user) { create(:user, :admin, providers: [provider]) }
+
+  before do
+    sign_in_system_test(user:)
+  end
+
+  it 'accredited provider number is cleared' do
+    visit "/support/#{RecruitmentCycle.current.year}/providers"
+
+    click_on 'Pro Vider'
+    expect(page).to have_current_path("/support/#{RecruitmentCycle.current.year}/providers/#{provider.id}")
+
+    within '[data-qa="ap-number-row"]' do
+      expect(page.find('.govuk-summary-list__value').text).to eq(provider.accredited_provider_number.to_s)
+      click_on('Change')
+    end
+    page.find_by_id('provider-accrediting-provider-not-an-accredited-provider-field', visible: false).click
+
+    click_on 'Update organisation details'
+    expect(page).to have_current_path("/support/#{RecruitmentCycle.current.year}/providers/#{provider.id}")
+    expect(provider.reload.accredited_provider_number).to be_blank
+  end
+end


### PR DESCRIPTION
## Context

  Only Accredited providers should have an `accredited_provider_number`

## Changes proposed in this pull request

Add simple UpdateProviderForm
It accepts attributes and uses `ActiveRecord::Base#assign_attributes` to assign the attributes. Not much needs to be tested here.
It removes the `accredited_provider_number` if the attribute assignment changes `accrediting_provider` to `'not_an_accredited_provider'`

## Guidance to review

The main point in the video below is that the Accredited provider number is not there when we change the provider back to an Accredited provider.

[Screencast from 29-11-24 15:09:10.webm](https://github.com/user-attachments/assets/0fcfd11e-f4b2-4faa-a8f1-b4f47061c121)



Pick it apart and recommend changes
