### PR TITLE
Revert "Bump mock_redis from 0.46.0 to 0.48.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,7 +406,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.2)
-    mock_redis (0.48.1)
+    mock_redis (0.46.0)
     msgpack (1.7.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)


### PR DESCRIPTION
This reverts commit 4a90fe8832492e85b0ef2406b9041a210446e9ab.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
