### PR TITLE
V2 results - Add all courses, pagination and card title

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -5,7 +5,11 @@ module Find
     class ResultsController < Find::ApplicationController
       before_action :enforce_basic_auth
 
-      def index; end
+      def index
+        @courses = CoursesQuery.call
+
+        @pagy, @results = pagy(@courses)
+      end
 
       def enforce_basic_auth
         authenticate_or_request_with_http_basic do |username, password|

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -16,10 +16,6 @@ class CourseDecorator < ApplicationDecorator
     object.study_site_ids.compact_blank
   end
 
-  def name_and_code
-    "#{object.name} (#{object.course_code})"
-  end
-
   def modern_languages_other_id
     '24'
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -886,6 +886,10 @@ class Course < ApplicationRecord
     current_published_enrichment.present?
   end
 
+  def name_and_code
+    "#{name} (#{course_code})"
+  end
+
   private
 
   def update_vac_status(study_mode, site_status)

--- a/app/services/courses_query.rb
+++ b/app/services/courses_query.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CoursesQuery
+  def self.call(params = {})
+    new(params:).call
+  end
+
+  attr_reader :scope
+
+  def initialize(params:)
+    @params = params
+    @scope = RecruitmentCycle
+             .current
+             .courses
+             .joins(:site_statuses)
+             .where(
+               site_statuses: {
+                 status: SiteStatus.statuses[:running],
+                 publish: SiteStatus.publishes[:published]
+               }
+             )
+  end
+
+  def call
+    @scope.distinct
+  end
+end

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -1,0 +1,34 @@
+<div class="app-filter-layout">
+  <div class="app-filter-layout__filter">
+    <div class="app-filter__header">
+      <h2 class="govuk-heading-m">Filters</h2>
+
+      <div class="app-filter__content">
+      </div>
+    </div>
+  </div>
+  <div class="app-filter-layout__content">
+    <ul class="app-search-results">
+      <% @results.each do |course| %>
+        <li class="app-search-results__item" data-qa="course">
+          <%= govuk_summary_card(
+            classes: ["course-summary-card"],
+            title: govuk_link_to(
+              find_course_path(
+                provider_code: course.provider_code,
+                course_code: course.course_code
+              ),
+              class: 'govuk-link govuk-!-font-size-24',
+              data: { qa: 'course__link' }
+            ) do
+              content_tag(:span, course.provider.provider_name, class: 'app-search-result__provider-name', data: { qa: 'course__provider_name' }) +
+              content_tag(:span, course.name_and_code, class: 'app-search-result__course-name', data: { qa: 'course__name' })
+            end
+          ) %>
+        </li>
+      <% end %>
+    </ul>
+
+    <%= govuk_pagination(pagy: @pagy) %>
+  </div>
+</div>

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -18,11 +18,11 @@
                 provider_code: course.provider_code,
                 course_code: course.course_code
               ),
-              class: 'govuk-link govuk-!-font-size-24',
-              data: { qa: 'course__link' }
+              class: "govuk-link govuk-!-font-size-24",
+              data: { qa: "course__link" }
             ) do
-              content_tag(:span, course.provider.provider_name, class: 'app-search-result__provider-name', data: { qa: 'course__provider_name' }) +
-              content_tag(:span, course.name_and_code, class: 'app-search-result__course-name', data: { qa: 'course__name' })
+              content_tag(:span, course.provider.provider_name, class: "app-search-result__provider-name", data: { qa: "course__provider_name" }) +
+              content_tag(:span, course.name_and_code, class: "app-search-result__course-name", data: { qa: "course__name" })
             end
           ) %>
         </li>

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -53,10 +53,6 @@ describe CourseDecorator do
 
   let(:decorated_course) { course.decorate }
 
-  it 'returns the course name and code in brackets' do
-    expect(decorated_course.name_and_code).to eq('Mathematics (A1)')
-  end
-
   it 'returns a list of subjects in alphabetical order' do
     expect(decorated_course.sorted_subjects).to eq('English<br>Mathematics')
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -25,6 +25,12 @@ describe Course do
   it { is_expected.to delegate_method(:provider_name).to(:provider).allow_nil }
   it { is_expected.to delegate_method(:provider_code).to(:provider).allow_nil }
 
+  describe '#name_and_code' do
+    it 'returns the course name and code in brackets' do
+      expect(course.name_and_code).to eq('Biology (3X9F)')
+    end
+  end
+
   describe '#campaign_name' do
     it 'assigns the campaign' do
       course.engineers_teach_physics!

--- a/spec/services/courses_query_spec.rb
+++ b/spec/services/courses_query_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CoursesQuery do
+  let!(:findable_course) do
+    create(:course, :with_full_time_sites)
+  end
+  let!(:another_course) do
+    create(:course, :with_full_time_sites)
+  end
+  let!(:non_findable_course) do
+    create(:course)
+  end
+
+  describe '.call' do
+    context 'when no filters or sorting are applied' do
+      it 'returns all findable courses' do
+        result = described_class.call({})
+        expect(result).to contain_exactly(findable_course, another_course)
+      end
+    end
+  end
+end

--- a/spec/services/courses_query_spec.rb
+++ b/spec/services/courses_query_spec.rb
@@ -3,21 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe CoursesQuery do
-  let!(:findable_course) do
-    create(:course, :with_full_time_sites)
-  end
-  let!(:another_course) do
-    create(:course, :with_full_time_sites)
-  end
-  let!(:non_findable_course) do
-    create(:course)
-  end
-
   describe '.call' do
+    subject(:results) { described_class.call(query) }
+
     context 'when no filters or sorting are applied' do
+      let!(:findable_course) { create(:course, :with_full_time_sites) }
+      let!(:another_course) { create(:course, :with_full_time_sites) }
+      let!(:non_findable_course) { create(:course) }
+
+      let(:query) { {} }
+
       it 'returns all findable courses' do
-        result = described_class.call({})
-        expect(result).to contain_exactly(findable_course, another_course)
+        expect(results).to contain_exactly(findable_course, another_course)
       end
     end
   end


### PR DESCRIPTION
## Context

Start to populate the `/v2/results`

This PR adds all courses and paginate all courses. And add only the course title (provider name, course name and code) to the summary card (for now).

## Changes proposed in this pull request

![screencapture-find-localhost-v2-results-2024-12-03-10_04_26](https://github.com/user-attachments/assets/dc577dcb-f157-4b15-a34e-a2a59830eed5)

## Guidance to review

1. Access the review app /v2/results 
2. See all courses paginated

## What comes next?

Next I will start to implement the filters, one by one and later add the no course scenario along side with the content of amount of courses listed.
