### PR TITLE
Validate `accredited_provider_number` on update too

### DIFF
--- a/app/forms/support/update_provider_form.rb
+++ b/app/forms/support/update_provider_form.rb
@@ -2,21 +2,31 @@
 
 module Support
   class UpdateProviderForm
-    attr_reader :provider
+    delegate :valid?, to: :provider
 
     def initialize(provider, attributes:)
       @provider = provider
       @attributes = attributes
+      assign_attributes
     end
 
     def save
-      @provider.assign_attributes(@attributes)
+      return false unless provider.valid?
+
+      provider.save!
+    end
+
+    private
+
+    attr_reader :provider, :attributes
+
+    def assign_attributes
+      @provider.assign_attributes(attributes)
       remove_accredited_provider_number
-      @provider.save
     end
 
     def remove_accredited_provider_number
-      return unless @provider.accrediting_provider_change&.[](1) == 'not_an_accredited_provider'
+      return unless @provider.accrediting_provider_changed?(to: 'not_an_accredited_provider')
 
       @provider.accredited_provider_number = nil
     end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -170,6 +170,13 @@ class Provider < ApplicationRecord
 
   validates :accredited_provider_number, accredited_provider_number_format: true, if: :accredited_provider?
 
+  validate :accredited_provider_type
+  def accredited_provider_type
+    return unless accredited_provider?
+
+    errors.add(:accrediting_provider, :invalid_provider_type) unless provider_type.to_s.in?(%w[scitt university])
+  end
+
   acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 
   before_discard do

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -168,7 +168,7 @@ class Provider < ApplicationRecord
 
   validate :add_enrichment_errors
 
-  validates :accredited_provider_number, accredited_provider_number_format: { allow_blank: true }, on: :update, if: :accredited_provider?
+  validates :accredited_provider_number, accredited_provider_number_format: true, if: :accredited_provider?
 
   acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -33,7 +33,8 @@ module Providers
         provider_name: @provider_name,
         provider_code: @provider_code,
         provider_type: @provider_type,
-        accrediting_provider: @is_accredited_provider ? 'accredited_provider' : 'not_an_accredited_provider'
+        accrediting_provider: @is_accredited_provider ? 'accredited_provider' : 'not_an_accredited_provider',
+        accredited_provider_number: @is_accredited_provider && generate_accredited_provider_number(@provider_type)
       }.merge(DEFAULT_PROVIDER_ATTRIBUTES))
 
       organisation = Organisation.new(name: @provider_name)
@@ -68,6 +69,11 @@ module Providers
 
     def attempting_to_make_lead_school_accredited_provider?
       errors << "Provider #{@provider_name} (#{@provider_code}) cannot be both a lead school and an accredited provider." if @provider_type == 'lead_school' && @is_accredited_provider
+    end
+
+    def generate_accredited_provider_number(provider_type)
+      classifier = provider_type == 'scitt' ? 5000 : 1000
+      rand(100..999) + classifier
     end
   end
 end

--- a/app/validators/accredited_provider_number_format_validator.rb
+++ b/app/validators/accredited_provider_number_format_validator.rb
@@ -3,9 +3,9 @@
 class AccreditedProviderNumberFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if record.scitt?
-      record.errors.add(attribute, :format) unless value.to_s.match?(/\A5\d{3}\Z/)
+      record.errors.add(attribute, :scitt_format) unless value.to_s.match?(/\A5\d{3}\Z/)
     elsif record.university?
-      record.errors.add(attribute, :format) unless value.to_s.match?(/\A1\d{3}\Z/)
+      record.errors.add(attribute, :university_format) unless value.to_s.match?(/\A1\d{3}\Z/)
     end
   end
 end

--- a/app/validators/accredited_provider_number_format_validator.rb
+++ b/app/validators/accredited_provider_number_format_validator.rb
@@ -2,11 +2,7 @@
 
 class AccreditedProviderNumberFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if options[:allow_blank] && value.blank?
-
-    if record.lead_school?
-      record.errors.add(:provider_type, :format)
-    elsif record.scitt?
+    if record.scitt?
       record.errors.add(attribute, :format) unless value.to_s.match?(/\A5\d{3}\Z/)
     elsif record.university?
       record.errors.add(attribute, :format) unless value.to_s.match?(/\A1\d{3}\Z/)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -906,7 +906,8 @@ en:
               contains_eight_numbers_starting_with_one: Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678
             accredited_provider_number:
               blank: Enter the accredited provider number
-              format: Enter a valid accredited provider number - it must be 4 digits starting with a 1 or a 5
+              university_format: Enter a valid University accredited provider number - it must be 4 digits starting with a 1
+              scitt_format: Enter a valid SCITT accredited provider number - it must be 4 digits starting with a 5
         organisation:
           attributes:
             name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -877,6 +877,9 @@ en:
             provider_type:
               blank: "Provider type can't be blank"
               format: Accredited provider cannot be a school
+            accrediting_provider:
+              format: '%{message}'
+              invalid_provider_type: 'Accredited provider must not have Provider type school'
             email:
               blank: "^Enter email address"
             website:

--- a/spec/components/providers/provider_list/view_spec.rb
+++ b/spec/components/providers/provider_list/view_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Providers::ProviderList::View do
-  let(:scitt_provider) { create(:provider, provider_type: 'scitt', accrediting_provider: 'accredited_provider') }
-  let(:lead_school_provider) { create(:provider, provider_type: 'lead_school', accrediting_provider: 'not_an_accredited_provider') }
-  let(:university_provider) { create(:provider, provider_type: 'university', accrediting_provider: 'accredited_provider') }
+  let(:scitt_provider) { create(:accredited_provider, :scitt) }
+  let(:lead_school_provider) { create(:provider) }
+  let(:university_provider) { create(:accredited_provider, :university) }
 
   describe '#formatted_accrediting_provider' do
     context 'provider is an accredited provider and scitt' do

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe API::Public::V1::ProvidersController do
       context 'with filter' do
         let(:provider2) do
           Timecop.freeze(Time.zone.today + 1) do
-            create(:provider,
+            create(:accredited_provider,
                    :university,
                    provider_code: '2AT',
                    provider_name: 'Second',

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -242,6 +242,7 @@ FactoryBot.define do
       with_gcse_equivalency
     end
 
+    # Assumes a self accredited training provider
     trait :unpublished do
       transient do
         identifier { 'unpublished' }
@@ -249,7 +250,7 @@ FactoryBot.define do
 
       name { "#{identifier} course name" }
 
-      provider { find_or_create :provider, :published_scitt }
+      provider { find_or_create :accredited_provider, :published_scitt }
       sites { build_list(:site, 1, provider:) }
     end
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -43,13 +43,11 @@ FactoryBot.define do
 
     trait :university do
       provider_type { :university }
-      accrediting_provider { 'Y' }
       urn { nil }
     end
 
     trait :scitt do
       provider_type { :scitt }
-      accrediting_provider { 'Y' }
       urn { nil }
     end
 
@@ -96,6 +94,19 @@ FactoryBot.define do
       end
 
       provider_name { "#{identifier} provider name" }
+    end
+
+    factory :accredited_provider do
+      provider_type { :university }
+      accrediting_provider { 'Y' }
+      accredited_provider_number do
+        if provider_type == :scitt
+          Faker::Number.within(range: 5000..5999)
+        else
+          Faker::Number.within(range: 1000..1999)
+        end
+      end
+      urn { nil }
     end
   end
 end

--- a/spec/features/publish/courses/2024_itt_provider_market_reform/publishing_a_course_as_an_accredited_provider_spec.rb
+++ b/spec/features/publish/courses/2024_itt_provider_market_reform/publishing_a_course_as_an_accredited_provider_spec.rb
@@ -47,7 +47,7 @@ feature 'Publishing a course when course when accrediting_provider is nil', { ca
   end
 
   def and_the_provider_is_accredited
-    provider.update(accrediting_provider: 'accredited_provider')
+    provider.update(accrediting_provider: 'accredited_provider', accredited_provider_number: '5432', provider_type: 'scitt')
   end
 
   def provider

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -214,10 +214,10 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   end
 
   def given_i_am_authenticated_as_a_school_direct_provider_user
-    @user = create(:user, providers: [build(:provider, provider_type: 'lead_school', sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
+    @user = create(:user, providers: [build(:provider, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])])
     @provider = @user.providers.first
-    create(:provider, :accredited_provider, provider_code: '1BJ')
-    @accredited_provider = create(:provider, :accredited_provider, provider_code: '1BK')
+    create(:accredited_provider, provider_code: '1BJ')
+    @accredited_provider = create(:accredited_provider, provider_code: '1BK')
     @provider.accrediting_provider_enrichments = []
     @provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
       {
@@ -234,7 +234,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
     @user = create(
       :user,
       providers: [
-        create(:provider, :scitt, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
+        create(:accredited_provider, :scitt, sites: [build(:site), build(:site)], study_sites: [build(:site, :study_site), build(:site, :study_site)])
       ]
     )
     given_i_am_authenticated(

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3339,7 +3339,7 @@ describe Course do
 
       context 'when the provider is self accredited and a SCITT' do
         it 'sets the funding to salary and the program_type to scitt_programme' do
-          provider = build(:provider, accrediting_provider: :accredited_provider, provider_type: 'scitt')
+          provider = build(:accredited_provider, :scitt)
           course = create(:course, provider:, funding: 'fee')
 
           expect(course.funding).to eq('fee')
@@ -3349,7 +3349,7 @@ describe Course do
 
       context 'when the provider is self accredited and not a SCITT' do
         it 'sets the funding to salary and the program_type to higher_education_programme' do
-          provider = build(:provider, accrediting_provider: :accredited_provider, provider_type: 'university')
+          provider = build(:accredited_provider, :university)
           course = create(:course, provider:, funding: 'fee')
 
           expect(course.funding).to eq('fee')

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -112,7 +112,7 @@ describe Provider do
 
       it 'accredited provider without accredited_provider_number is invalid' do
         expect(accredited_provider).not_to be_valid
-        expect(accredited_provider.errors.full_messages).to include('Accredited provider number Enter a valid accredited provider number - it must be 4 digits starting with a 1 or a 5')
+        expect(accredited_provider.errors.messages[:accredited_provider_number]).to include('Enter a valid University accredited provider number - it must be 4 digits starting with a 1')
       end
     end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -106,6 +106,15 @@ describe Provider do
         expect(valid_provider).to be_valid
       end
     end
+
+    describe 'accredited_provider_number is required for accredited provider' do
+      let(:accredited_provider) { build(:provider, :accredited_provider, accredited_provider_number: nil) }
+
+      it 'accredited provider without accredited_provider_number is invalid' do
+        expect(accredited_provider).not_to be_valid
+        expect(accredited_provider.errors.full_messages).to include('Accredited provider number Enter a valid accredited provider number - it must be 4 digits starting with a 1 or a 5')
+      end
+    end
   end
 
   describe 'normalizations' do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -115,6 +115,15 @@ describe Provider do
         expect(accredited_provider.errors.full_messages).to include('Accredited provider number Enter a valid accredited provider number - it must be 4 digits starting with a 1 or a 5')
       end
     end
+
+    describe 'a lead school can not be an accredited provider' do
+      let(:provider) { build(:provider, provider_type: 'lead_school', accrediting_provider: 'Y') }
+
+      it 'is invalid' do
+        expect(provider).not_to be_valid
+        expect(provider.errors[:accrediting_provider]).to include('Accredited provider must not have Provider type school')
+      end
+    end
   end
 
   describe 'normalizations' do
@@ -348,7 +357,7 @@ describe Provider do
   describe '#accrediting_providers' do
     let(:provider) { create(:provider, accrediting_provider: 'N', accrediting_provider_enrichments:) }
 
-    let(:accrediting_provider) { create(:provider, accrediting_provider: 'Y') }
+    let(:accrediting_provider) { create(:accredited_provider) }
     let(:accredited_provider) { accrediting_provider }
     let!(:course1) { create(:course, accrediting_provider:, provider:) }
     let!(:course2) { create(:course, accrediting_provider:, provider:) }

--- a/spec/validators/accredited_provider_number_format_validator_spec.rb
+++ b/spec/validators/accredited_provider_number_format_validator_spec.rb
@@ -34,6 +34,7 @@ describe AccreditedProviderNumberFormatValidator do
 
       it 'is not valid' do
         expect(model).not_to be_valid
+        expect(model.errors.messages[:accredited_provider_number]).to include('Enter a valid University accredited provider number - it must be 4 digits starting with a 1')
       end
     end
 
@@ -42,6 +43,7 @@ describe AccreditedProviderNumberFormatValidator do
 
       it 'is not valid' do
         expect(model).not_to be_valid
+        expect(model.errors.messages[:accredited_provider_number]).to include('Enter a valid University accredited provider number - it must be 4 digits starting with a 1')
       end
     end
   end
@@ -52,6 +54,7 @@ describe AccreditedProviderNumberFormatValidator do
     context 'with a number starting with 1' do
       it 'is not valid' do
         expect(model).not_to be_valid
+        expect(model.errors.messages[:accredited_provider_number]).to include('Enter a valid SCITT accredited provider number - it must be 4 digits starting with a 5')
       end
     end
 
@@ -60,6 +63,7 @@ describe AccreditedProviderNumberFormatValidator do
 
       it 'is not valid' do
         expect(model).not_to be_valid
+        expect(model.errors.messages[:accredited_provider_number]).to include('Enter a valid SCITT accredited provider number - it must be 4 digits starting with a 5')
       end
     end
 

--- a/spec/validators/accredited_provider_number_format_validator_spec.rb
+++ b/spec/validators/accredited_provider_number_format_validator_spec.rb
@@ -11,7 +11,7 @@ class AccreditedProviderNumberFormatValidatorTest
 end
 
 describe AccreditedProviderNumberFormatValidator do
-  let(:accredited_provider) { create(:provider, :accredited_provider, :university) }
+  let(:accredited_provider) { create(:accredited_provider, :university) }
   let(:accredited_provider_number) { 1234 }
 
   let(:model) do
@@ -20,56 +20,65 @@ describe AccreditedProviderNumberFormatValidator do
     model
   end
 
-  describe 'university validation' do
-    context 'with a valid id starting with 1' do
-      it 'does not add an error' do
+  describe 'accredited university validation' do
+    let(:accredited_provider) { create(:accredited_provider, :university) }
+
+    context 'with a 4 digit number starting with 1' do
+      it 'is valid' do
         expect(model).to be_valid
       end
     end
 
-    context 'with a valid id starting with 5' do
+    context 'with a 5 digit number starting with 1' do
+      let(:accredited_provider_number) { 12_345 }
+
+      it 'is not valid' do
+        expect(model).not_to be_valid
+      end
+    end
+
+    context 'with a number starting with 5' do
       let(:accredited_provider_number) { 5432 }
 
-      it 'does not add an error' do
+      it 'is not valid' do
         expect(model).not_to be_valid
       end
     end
   end
 
-  describe 'scitt validation' do
-    let(:accredited_provider) { create(:provider, :accredited_provider, :scitt) }
+  describe 'accredited scitt validation' do
+    let(:accredited_provider) { create(:accredited_provider, :scitt) }
 
-    context 'with a valid id starting with 1' do
-      it 'does add an error' do
+    context 'with a number starting with 1' do
+      it 'is not valid' do
         expect(model).not_to be_valid
       end
     end
 
-    context 'with a valid id starting with 5' do
+    context 'with a 5 digit number starting with 5' do
+      let(:accredited_provider_number) { 54_321 }
+
+      it 'is not valid' do
+        expect(model).not_to be_valid
+      end
+    end
+
+    context 'with a number starting with 5' do
       let(:accredited_provider_number) { 5432 }
 
-      it 'does not add an error' do
+      it 'is valid' do
         expect(model).to be_valid
       end
     end
   end
 
   describe 'lead school validation' do
-    let(:accredited_provider) { create(:provider, :accredited_provider, :lead_school) }
+    let(:accredited_provider) { create(:provider, accredited_provider_number: nil) }
 
-    context 'with a valid id starting with 1' do
-      it 'adds provider_type error' do
+    context 'without an accredited_provider_number' do
+      it 'adds no errors' do
         model.valid?
-        expect(model.errors.attribute_names).to eq([:provider_type])
-      end
-    end
-
-    context 'with a valid id starting with 5' do
-      let(:accredited_provider_number) { 5432 }
-
-      it 'adds provider_type error' do
-        model.valid?
-        expect(model.errors.attribute_names).to eq([:provider_type])
+        expect(model.errors).to be_empty
       end
     end
   end


### PR DESCRIPTION
## Context

The presence of an `accredited_provider_number` is validated when a provider is being onboarded but not when an existing provider is promoted from a Lead partner to an Accredited Provider

## Changes proposed in this pull request

- Accredited provider cannot be a school
- Accredited provider number must be present when saving an Accredited provider.
- University accredited providers number format starts with a 1
- SCITT accredited providers number format starts with a 5
- Add specific Accredited provider number error messages for SCITT and University
- Update `scitt` and `university` provider factory traits - they are not automatically accredited providers anymore


## Guidance to review

Any tips on the form would be useful. How do we want to use forms going forward?


[Screencast from 06-12-24 15:20:51.webm](https://github.com/user-attachments/assets/ba73cd2a-144a-46ba-8bcd-8c25f7042c55)
