### PR TITLE
Revert "Use JSON arguments for Dockerfile CMD"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,4 @@ RUN ls /app/public/ && \
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
 
-CMD ["bundle", "exec", "rails", "db:migrate:with_data_migrations", "&&", "bundle", "exec", "rails", "server", "-b 0.0.0.0"]
+CMD bundle exec rails db:migrate:with_data_migrations && bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
## Context

Our servers seem to be restarting and failing to deploy with this change.

## Changes proposed in this pull request

- Revert commit 1e1a4879578a992aff41cb5ae3d5bd0f3ade6ea7.

## Guidance to review


