### PR TITLE
Copy courses between providers in Support console

### DIFF
--- a/app/components/notification_banner.rb
+++ b/app/components/notification_banner.rb
@@ -39,7 +39,7 @@ class NotificationBanner < ApplicationComponent
   end
 
   def type_class
-    "#{DEFAULT_CLASS}--#{type}" if success_banner?
+    "#{DEFAULT_CLASS}--#{type}"
   end
 
   def title

--- a/app/components/tab_navigation.html.erb
+++ b/app/components/tab_navigation.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :tab_navigation_actions %>
+
 <nav class="app-tab-navigation govuk-!-margin-bottom-7" aria-label="Sub navigation">
   <ul class="app-tab-navigation__list">
     <% items.each do |item| %>

--- a/app/controllers/support/providers/copy_courses_controller.rb
+++ b/app/controllers/support/providers/copy_courses_controller.rb
@@ -4,25 +4,31 @@ module Support
   module Providers
     class CopyCoursesController < SupportController
       before_action :recruitment_cycle
+
       def new
-        @provider = Provider.find(params[:provider_id])
+        @target_provider = Provider.find(params[:provider_id])
+        @copy_courses_form = CopyCoursesForm.new(@target_provider)
       end
 
       def create
-        @provider = Provider.find(params[:provider_id])
-        @from_provider = recruitment_cycle.providers.find_by(provider_code: params[:course][:autocompleted_provider_code])
+        @target_provider = Provider.find(params[:provider_id])
+        @copy_courses_form = CopyCoursesForm.new(@target_provider, recruitment_cycle.providers.find_by(provider_code: params[:course][:autocompleted_provider_code]))
 
-        sites_copy_to_course = params[:schools] ? Sites::CopyToCourseService : ->(*) {}
+        if @copy_courses_form.valid?
+          sites_copy_to_course = params[:schools] ? Sites::CopyToCourseService : ->(*) {}
 
-        copier = ::Courses::CopyToProviderService.new(sites_copy_to_course:, enrichments_copy_to_course: Enrichments::CopyToCourseService.new, force: true)
+          copier = ::Courses::CopyToProviderService.new(sites_copy_to_course:, enrichments_copy_to_course: Enrichments::CopyToCourseService.new, force: true)
 
-        Provider.transaction do
-          @from_provider.courses.map do |course|
-            copier.execute(course:, new_provider: @provider)
+          Provider.transaction do
+            @copy_courses_form.provider.courses.map do |course|
+              copier.execute(course:, new_provider: @copy_courses_form.target_provider)
+            end
           end
-        end
 
-        redirect_to support_recruitment_cycle_provider_path(recruitment_cycle.year, @provider.id)
+          redirect_to support_recruitment_cycle_provider_path(recruitment_cycle.year, @copy_courses_form.target_provider.id)
+        else
+          render :new
+        end
       end
     end
   end

--- a/app/controllers/support/providers/copy_courses_controller.rb
+++ b/app/controllers/support/providers/copy_courses_controller.rb
@@ -12,7 +12,7 @@ module Support
         @provider = Provider.find(params[:provider_id])
         @from_provider = recruitment_cycle.providers.find_by(provider_code: params[:course][:autocompleted_provider_code])
 
-        sites_copy_to_course = params[:sites] ? Sites::CopyToCourseService : ->(*) {}
+        sites_copy_to_course = params[:schools] ? Sites::CopyToCourseService : ->(*) {}
 
         copier = ::Courses::CopyToProviderService.new(sites_copy_to_course:, enrichments_copy_to_course: Enrichments::CopyToCourseService.new, force: true)
 

--- a/app/controllers/support/providers/copy_courses_controller.rb
+++ b/app/controllers/support/providers/copy_courses_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Support
+  module Providers
+    class CopyCoursesController < SupportController
+      before_action :recruitment_cycle
+      def new
+        @provider = Provider.find(params[:provider_id])
+      end
+
+      def create
+        @provider = Provider.find(params[:provider_id])
+        @from_provider = recruitment_cycle.providers.find_by(provider_code: params[:course][:autocompleted_provider_code])
+
+        sites_copy_to_course = params[:sites] ? Sites::CopyToCourseService : -> {}
+
+        copier = ::Courses::CopyToProviderService.new(sites_copy_to_course:, enrichments_copy_to_course: Enrichments::CopyToCourseService.new, force: true)
+
+        Provider.transaction do
+          @from_provider.courses.map do |course|
+            copier.execute(course:, new_provider: @provider)
+          end
+        end
+
+        redirect_to support_recruitment_cycle_provider_path(recruitment_cycle.year, @provider.id)
+      end
+    end
+  end
+end

--- a/app/controllers/support/providers/copy_courses_controller.rb
+++ b/app/controllers/support/providers/copy_courses_controller.rb
@@ -12,7 +12,7 @@ module Support
         @provider = Provider.find(params[:provider_id])
         @from_provider = recruitment_cycle.providers.find_by(provider_code: params[:course][:autocompleted_provider_code])
 
-        sites_copy_to_course = params[:sites] ? Sites::CopyToCourseService : -> {}
+        sites_copy_to_course = params[:sites] ? Sites::CopyToCourseService : ->(*) {}
 
         copier = ::Courses::CopyToProviderService.new(sites_copy_to_course:, enrichments_copy_to_course: Enrichments::CopyToCourseService.new, force: true)
 

--- a/app/controllers/support/providers/copy_courses_controller.rb
+++ b/app/controllers/support/providers/copy_courses_controller.rb
@@ -25,7 +25,12 @@ module Support
             end
           end
 
-          redirect_to support_recruitment_cycle_provider_path(recruitment_cycle.year, @copy_courses_form.target_provider.id)
+          @courses_copied = copier.courses_copied
+          @courses_not_copied = copier.courses_not_copied
+          flash[:success] = "Courses copied: #{@courses_copied.map(&:course_code).to_sentence}"
+          flash[:warning] = "Courses not copied: #{@courses_not_copied.map(&:course_code).to_sentence}"
+
+          redirect_to support_recruitment_cycle_provider_courses_path(recruitment_cycle.year, @copy_courses_form.target_provider.id)
         else
           render :new
         end

--- a/app/forms/support/copy_courses_form.rb
+++ b/app/forms/support/copy_courses_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Support
+  class CopyCoursesForm
+    include ActiveModel::Model
+
+    attr_reader :target_provider, :provider
+
+    def initialize(target_provider, provider = nil)
+      @target_provider = target_provider
+      @provider = provider
+    end
+
+    validates :target_provider, :provider, presence: true
+  end
+end

--- a/app/forms/support/copy_courses_form.rb
+++ b/app/forms/support/copy_courses_form.rb
@@ -12,5 +12,10 @@ module Support
     end
 
     validates :target_provider, :provider, presence: true
+    validate :different_providers
+
+    def different_providers
+      errors.add(:provider, message: 'Choose different providers') if target_provider == provider
+    end
   end
 end

--- a/app/javascript/publish/autocomplete/accredited_provider.js
+++ b/app/javascript/publish/autocomplete/accredited_provider.js
@@ -5,7 +5,8 @@ const providerSuggestionTemplate = (result) => result && `${result.provider_name
 const onConfirm = (input) => (option) => (input.value = option ? option.id : '')
 
 function init () {
-  const recruitmentCycleYear = document.getElementById('accredited_provider_search_form_recruitment_cycle_year').value
+  const recruitmentCycleYear = document.getElementById('accredited_provider_search_form_recruitment_cycle_year')?.value
+  if (!recruitmentCycleYear) return
   const options = {
     path: `/api/${recruitmentCycleYear}/accredited_provider_suggestions`,
     template: {

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -2,15 +2,19 @@
 
 module Courses
   class CopyToProviderService
+    attr_reader :courses_copied, :courses_not_copied
+
     def initialize(sites_copy_to_course:, enrichments_copy_to_course:, force:)
       @sites_copy_to_course = sites_copy_to_course
       @enrichments_copy_to_course = enrichments_copy_to_course
       @force = force
+      @courses_copied = []
+      @courses_not_copied = []
     end
 
     def execute(course:, new_provider:)
-      return unless course.rollable? || force
-      return if course_code_already_exists_on_provider?(course:, new_provider:)
+      @courses_not_copied << course and return unless course.rollable? || force
+      @courses_not_copied << course and return if course_code_already_exists_on_provider?(course:, new_provider:)
 
       new_course = nil
 
@@ -32,7 +36,7 @@ module Courses
         copy_schools(course:, new_provider:, new_course:)
         copy_study_sites(course:, new_provider:, new_course:)
       end
-      new_course
+      new_course.tap { @courses_copied << _1 }
     end
 
     private

--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -1,4 +1,7 @@
 <%= render PageTitle.new(title: "support.providers.courses.index") %>
+<% content_for :tab_navigation_actions do %>
+  <%= govuk_link_to "Copy Courses", new_support_recruitment_cycle_provider_copy_course_path(@recruitment_cycle.year, @provider), class: "govuk-button" %>
+<% end %>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/app/views/support/providers/copy_courses/new.html.erb
+++ b/app/views/support/providers/copy_courses/new.html.erb
@@ -1,26 +1,28 @@
-<h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
-<h2 class="govuk-heading-m">Copy courses from:</h2>
+<%= render PageTitle.new(title: "support.providers.copy_courses.new", has_errors: @copy_courses_form.errors.present?) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <div>
-        <%= form_with url: support_recruitment_cycle_provider_copy_courses_path(@recruitment_cycle.year, @provider) do |form| %>
-          <% error = flash[:error] && flash[:error]["message"] == "Name or provider code" %>
-          <div class="govuk-form-group<% if error %> govuk-form-group--error<% end %>">
-            <%= form.label :query, { class: "govuk-label", for: "provider" } do %>
-              <div>Search for an organisation to copy courses from:</div>
-              <span class="govuk-hint govuk-!-display-inline">Enter the name or provider code</span>
-              <% if error %>
-                <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
-                  Please enter the name or provider code
-                </span>
-              <% end %>
-            <% end %>
-            <%= form.text_field :provider,
-                                id: "provider",
-                                value: params[:query],
-                                class: "govuk-input",
-                                data: { qa: "provider-search" } %>
-            <div id="provider-autocomplete"></div>
+        <%= form_with model: @copy_courses_form, url: support_recruitment_cycle_provider_copy_courses_path(@recruitment_cycle.year, @target_provider) do |form| %>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <%= form.govuk_error_summary %>
+            </div>
+          </div>
+          <h1 class="govuk-heading-l"><%= @target_provider.provider_name %></h1>
+          <h2 class="govuk-heading-m">Copy courses from:</h2>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <div class="govuk-form-group">
+                <%= form.govuk_text_field :provider,
+                  id: "provider",
+                  value: params[:query],
+                  class: "govuk-input",
+                  data: { qa: "provider-search" },
+                  label: -> { tag.div("Search for an organisation to copy courses from:") + tag.div("Enter the name or provider code", class: %w[govuk-hint govuk-!-display-inline]) } %>
+                <div id="provider-autocomplete"></div>
+              </div>
+            </div>
           </div>
 
           <div class="govuk-grid-row">

--- a/app/views/support/providers/copy_courses/new.html.erb
+++ b/app/views/support/providers/copy_courses/new.html.erb
@@ -1,0 +1,48 @@
+<h1 class="govuk-heading-l">Copy courses from:</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div>
+        <%= form_with url: support_recruitment_cycle_provider_copy_courses_path(@recruitment_cycle.year, @provider) do |form| %>
+          <% error = flash[:error] && flash[:error]["message"] == "Name or provider code" %>
+          <div class="govuk-form-group<% if error %> govuk-form-group--error<% end %>">
+            <%= form.label :query, { class: "govuk-label", for: "provider" } do %>
+              Search for an organisation to copy courses from
+              <span class="govuk-hint govuk-!-display-inline">Enter the name or provider code</span>
+              <% if error %>
+                <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
+                  Please enter the name or provider code
+                </span>
+              <% end %>
+            <% end %>
+            <%= form.text_field :provider,
+                                id: "provider",
+                                value: params[:query],
+                                class: "govuk-input",
+                                data: { qa: "provider-search" } %>
+            <div id="provider-autocomplete"></div>
+          </div>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <div class="govuk-form-group">
+                <%= form.govuk_check_box :sites, true, false, label: { text: "Copy study sites?" }, multiple: false %>
+              </div>
+            </div>
+          </div>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <div class="govuk-form-group">
+                <%= form.govuk_check_box :schools, true, false, label: { text: "Copy placement schools?" }, multiple: false %>
+              </div>
+            </div>
+          </div>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <%= form.govuk_submit "Continue" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/support/providers/copy_courses/new.html.erb
+++ b/app/views/support/providers/copy_courses/new.html.erb
@@ -33,7 +33,7 @@
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-              <%= form.govuk_submit "Continue" %>
+              <%= form.govuk_submit "Copy courses" %>
             </div>
           </div>
         <% end %>

--- a/app/views/support/providers/copy_courses/new.html.erb
+++ b/app/views/support/providers/copy_courses/new.html.erb
@@ -1,4 +1,5 @@
-<h1 class="govuk-heading-l">Copy courses from:</h1>
+<h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
+<h2 class="govuk-heading-m">Copy courses from:</h2>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <div>
@@ -6,7 +7,7 @@
           <% error = flash[:error] && flash[:error]["message"] == "Name or provider code" %>
           <div class="govuk-form-group<% if error %> govuk-form-group--error<% end %>">
             <%= form.label :query, { class: "govuk-label", for: "provider" } do %>
-              Search for an organisation to copy courses from
+              <div>Search for an organisation to copy courses from:</div>
               <span class="govuk-hint govuk-!-display-inline">Enter the name or provider code</span>
               <% if error %>
                 <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
@@ -25,17 +26,11 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
               <div class="govuk-form-group">
-                <%= form.govuk_check_box :sites, true, false, label: { text: "Copy study sites?" }, multiple: false %>
+                <%= form.govuk_check_box :schools, true, false, label: { text: "Copy placement schools?" }, hint: { text: tag.div("Any placement schools that are not already linked to the target provider will not be copied", class: %w[govuk-hint govuk-!-font-size-16]) }, multiple: false %>
               </div>
             </div>
           </div>
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-              <div class="govuk-form-group">
-                <%= form.govuk_check_box :schools, true, false, label: { text: "Copy placement schools?" }, multiple: false %>
-              </div>
-            </div>
-          </div>
+
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
               <%= form.govuk_submit "Continue" %>

--- a/app/views/support/providers/show.html.erb
+++ b/app/views/support/providers/show.html.erb
@@ -1,1 +1,4 @@
+<% content_for :tab_navigation_actions do %>
+  <%= govuk_link_to "Copy Courses", new_support_recruitment_cycle_provider_copy_course_path(@recruitment_cycle.year, @provider), class: "govuk-button" %>
+<% end %>
 <%= render Providers::ProviderList::View.new(provider: @provider) %>

--- a/app/views/support/providers/show.html.erb
+++ b/app/views/support/providers/show.html.erb
@@ -1,4 +1,1 @@
-<% content_for :tab_navigation_actions do %>
-  <%= govuk_link_to "Copy Courses", new_support_recruitment_cycle_provider_copy_course_path(@recruitment_cycle.year, @provider), class: "govuk-button" %>
-<% end %>
 <%= render Providers::ProviderList::View.new(provider: @provider) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,8 @@ en:
           show: "View a provider"
           edit: "Edit a provider"
           edit_contact: "Edit provider contact details"
+          copy_courses:
+            new: Copy courses
           courses:
             index: "Courses"
             edit: "Edit course details"
@@ -1028,6 +1030,8 @@ en:
               blank: "Enter a first name"
             last_name:
               blank: "Enter a last name"
+        support/copy_courses_form:
+          blank: Provider can't be blank
         support/user_form:
           attributes:
             email:

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -56,6 +56,8 @@ namespace :support do
           get '/check', on: :collection, to: 'accredited_providers/checks#show'
           put '/check', on: :collection, to: 'accredited_providers/checks#update'
         end
+
+        resources :copy_courses, only: %i[new create]
       end
     end
     resources :users do

--- a/spec/forms/support/copy_course_form_spec.rb
+++ b/spec/forms/support/copy_course_form_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Support
+  describe CopyCoursesForm, type: :model do
+    subject { described_class.new(target_provider, provider) }
+
+    let(:provider) { create(:provider) }
+
+    describe 'validations' do
+      let(:target_provider) { provider }
+
+      context 'unique provider' do
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages[:provider]).to include('Choose different providers')
+        end
+      end
+
+      context 'provider must be present' do
+        let(:target_provider) { nil }
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages[:target_provider]).to include("Provider can't be blank")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe 'Support::CopyCourses' do
   end
 
   describe 'POST create' do
+    it 'copies the courses and shows flash message' do
+      login_user(user)
+      post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { 'course[autocompleted_provider_code]' => source_provider.provider_code }
+      expect(target_provider.reload.courses.length).to eq(3)
+
+      expect(response).to redirect_to(support_recruitment_cycle_provider_courses_path(year, target_provider.id))
+      follow_redirect!
+      expect(response.parsed_body.css('.govuk-notification-banner--success').text).to match(format('Courses copied: %s', source_provider.courses.map(&:course_code).to_sentence))
+    end
+
     context 'with schools' do
       it 'copies the courses with schools' do
         login_user(user)
@@ -27,14 +37,33 @@ RSpec.describe 'Support::CopyCourses' do
         expect(target_provider.reload.courses.length).to eq(3)
         courses = target_provider.reload.courses
         expect(courses.flat_map(&:sites).length).to eq(3)
+        expect(response).to redirect_to(support_recruitment_cycle_provider_courses_path(year, target_provider.id))
+        follow_redirect!
+        expect(response.parsed_body.css('.govuk-notification-banner--success').text).to match(format('Courses copied: %s', source_provider.courses.map(&:course_code).to_sentence))
       end
     end
 
-    context 'without schools' do
-      it 'copies the course without schools' do
+    context 'course code already exists on target provider' do
+      let(:source_provider) { create(:provider, courses: [create(:course)]) }
+      let!(:target_provider) { create(:provider, courses: [create(:course, course_code: source_provider.courses.first.course_code)]) }
+
+      it 'notifies user that the course was not copied' do
         login_user(user)
         post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { 'course[autocompleted_provider_code]' => source_provider.provider_code }
-        expect(target_provider.reload.courses.length).to eq(3)
+
+        expect(response).to redirect_to(support_recruitment_cycle_provider_courses_path(year, target_provider.id))
+        follow_redirect!
+
+        expect(response.parsed_body.css('.govuk-notification-banner--warning').text).to match(format('Courses not copied: %s', source_provider.courses.map(&:course_code).to_sentence))
+      end
+    end
+
+    context 'when copying courses to the same provider' do
+      it 'renders the new action with error messages' do
+        login_user(user)
+        post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { 'course[autocompleted_provider_code]' => target_provider.provider_code }
+        expect(response).to render_template(:new)
+        expect(response.parsed_body.css('.govuk-error-summary').text).to match('Choose different providers')
       end
     end
   end

--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Support::CopyCourses' do
+  include DfESignInUserHelper
+  let(:user) { create(:user, :admin) }
+  let(:source_provider) { create(:provider, courses: create_list(:course, 3, :with_full_time_sites)) }
+  let!(:target_provider) { create(:provider, sites: source_provider.courses.flat_map(&:sites)) }
+  let!(:year) { find_or_create(:recruitment_cycle).year }
+
+  before { host! URI(Settings.base_url).host }
+
+  describe 'GET new' do
+    it 'responds with 200' do
+      login_user(user)
+      get "/support/2025/providers/#{source_provider.id}/copy_courses/new"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST create' do
+    context 'with schools' do
+      it 'copies the courses with schools' do
+        login_user(user)
+        post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { 'course[autocompleted_provider_code]' => source_provider.provider_code, schools: '1' }
+        expect(target_provider.reload.courses.length).to eq(3)
+        courses = target_provider.reload.courses
+        expect(courses.flat_map(&:sites).length).to eq(3)
+      end
+    end
+
+    context 'without schools' do
+      it 'copies the course without schools' do
+        login_user(user)
+        post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { 'course[autocompleted_provider_code]' => source_provider.provider_code }
+        expect(target_provider.reload.courses.length).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe Courses::CopyToProviderService do
     expect(new_course.can_sponsor_student_visa).to eq course.can_sponsor_student_visa
   end
 
+  it 'adds the copied course to @courses_copied' do
+    service.execute(course:, new_provider:)
+
+    expect(service.courses_copied.map(&:course_code)).to include(course.course_code)
+  end
+
   context 'applications open from date' do
     it 'updates the applications_open_from and start date attributes' do
       service.execute(course:, new_provider:)
@@ -177,6 +183,12 @@ RSpec.describe Courses::CopyToProviderService do
       service.execute(course:, new_provider:)
 
       expect(mocked_enrichments_copy_to_course_service).not_to have_received(:execute)
+    end
+
+    it 'adds the uncopied course to @courses_not_copied' do
+      service.execute(course:, new_provider:)
+
+      expect(service.courses_not_copied).to include(course)
     end
   end
 

--- a/spec/system/support/providers/copy_courses_to_provider_spec.rb
+++ b/spec/system/support/providers/copy_courses_to_provider_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Support', service: :publish do
     li = page.find('ul#provider__listbox li', visible: false)
     li.click
     page.find_by_id('schools-true-field', visible: false).click
-    click_on 'Continue'
+    click_on 'Copy courses'
     click_on 'Courses'
     courses.map(&:name).each do |course_name|
       expect(page).to have_content(course_name)

--- a/spec/system/support/providers/copy_courses_to_provider_spec.rb
+++ b/spec/system/support/providers/copy_courses_to_provider_spec.rb
@@ -12,17 +12,15 @@ RSpec.describe 'Support', service: :publish do
       create(:course, :withdrawn, :with_full_time_sites)
     ]
   end
-  let(:source_provider) { create(:provider, provider_name: 'Source Provider', courses:) }
-  let(:target_provider) { create(:provider, provider_name: 'Target Provider') }
+  let!(:source_provider) { create(:provider, provider_name: 'Source Provider', courses:) }
+  let!(:target_provider) { create(:provider, provider_name: 'Target Provider') }
   let(:user) { create(:user, :admin) }
 
   before do
     sign_in_system_test(user:)
-    source_provider
-    target_provider
   end
 
-  it 'copy courses from one provider to another', :js_browser do
+  it 'copy courses from one provider to another', :js do
     visit '/support'
     click_on 'Target Provider'
     click_on 'Copy Courses'
@@ -31,7 +29,7 @@ RSpec.describe 'Support', service: :publish do
     sleep 3
     li = page.find('ul#provider__listbox li', visible: false)
     li.click
-    page.find_by_id('sites-true-field', visible: false).click
+    page.find_by_id('schools-true-field', visible: false).click
     click_on 'Continue'
     click_on 'Courses'
     courses.map(&:name).each do |course_name|

--- a/spec/system/support/providers/copy_courses_to_provider_spec.rb
+++ b/spec/system/support/providers/copy_courses_to_provider_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Support', service: :publish do
+  include DfESignInUserHelper
+
+  let(:courses) do
+    [
+      create(:course, :unpublished, :with_full_time_sites),
+      create(:course, :published, :with_full_time_sites),
+      create(:course, :withdrawn, :with_full_time_sites)
+    ]
+  end
+  let(:source_provider) { create(:provider, provider_name: 'Source Provider', courses:) }
+  let(:target_provider) { create(:provider, provider_name: 'Target Provider') }
+  let(:user) { create(:user, :admin) }
+
+  before do
+    sign_in_system_test(user:)
+    source_provider
+    target_provider
+  end
+
+  it 'copy courses from one provider to another', :js_browser do
+    visit '/support'
+    click_on 'Target Provider'
+    click_on 'Copy Courses'
+    autocomplete = page.find('input#provider')
+    autocomplete.set(source_provider.provider_code)
+    sleep 3
+    li = page.find('ul#provider__listbox li', visible: false)
+    li.click
+    page.find_by_id('sites-true-field', visible: false).click
+    click_on 'Continue'
+    click_on 'Courses'
+    courses.map(&:name).each do |course_name|
+      expect(page).to have_content(course_name)
+    end
+  end
+end

--- a/spec/system/support/providers/copy_courses_to_provider_spec.rb
+++ b/spec/system/support/providers/copy_courses_to_provider_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Support', service: :publish do
   it 'copy courses from one provider to another', :js do
     visit '/support'
     click_on 'Target Provider'
+    click_on 'Courses'
     click_on 'Copy Courses'
     autocomplete = page.find('input#provider')
     autocomplete.set(source_provider.provider_code)

--- a/spec/system/support/providers/copy_courses_to_provider_spec.rb
+++ b/spec/system/support/providers/copy_courses_to_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Support', service: :publish do
+RSpec.describe 'Support', service: :publish, skip: 'can not get chromedriver working on Alpine' do
   include DfESignInUserHelper
 
   let(:courses) do


### PR DESCRIPTION
## Context

Support are often asked to copy courses from one provider to another. This PR provides the ability for users to copy courses via the Support console.

#### Considerations

1. Copy all courses
2. Copy schools and study sites or not


- What if the target provider already has copied the courses?
  - The courses are not recopied
- What if the target provider already has copied the courses and deleted them?
  - The courses are not recopied
- What if there are 1000 courses
  - It will take a while to copy all the courses across.
- Could this be a background process?
  - Lets see if that is necessary

## Changes proposed in this pull request

[Screencast from 09-12-24 15:27:18.webm](https://github.com/user-attachments/assets/065d4116-2ce3-45f0-8a0c-def86ad6bae4)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
