### PR TITLE
Td/foundation work applications open and send filter

### DIFF
--- a/app/services/courses_query.rb
+++ b/app/services/courses_query.rb
@@ -24,6 +24,8 @@ class CoursesQuery
 
   def call
     @scope = visa_sponsorship_scope
+    @scope = applications_open_scope
+    @scope = special_education_needs_scope
     @scope = @scope.distinct
 
     log_query_info
@@ -45,6 +47,22 @@ class CoursesQuery
           can_sponsor_skilled_worker_visa: true
         )
       )
+  end
+
+  def applications_open_scope
+    return @scope if params[:applications_open].blank?
+
+    @applied_scopes[:applications_open] = params[:applications_open]
+
+    @scope.where(application_status: Course.application_statuses[:open])
+  end
+
+  def special_education_needs_scope
+    return @scope if params[:send_courses].blank?
+
+    @applied_scopes[:send_courses] = params[:send_courses]
+
+    @scope.where(is_send: true)
   end
 
   private

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -9,8 +9,16 @@
         <div class="app-filter__content">
           <%= form.submit "Apply filters", name: nil, class: "govuk-button", data: { qa: "apply-filters" } %>
 
-          <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.course_search_form.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", data: { qa: "filters__visa" }, hidden: false do %>
-            <%= form.govuk_check_box :can_sponsor_visa, "true", name: "can_sponsor_visa", label: { text: t("helpers.label.course_search_form.can_sponsor_visa"), size: "s" }, checked: params[:can_sponsor_visa].present? %>
+          <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false do %>
+            <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.can_sponsor_visa"), size: "s" }, checked: params[:can_sponsor_visa].present? %>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false do %>
+            <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.special_education_needs"), size: "s" }, checked: params[:send_courses].present? %>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :applications_open, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.applications_open_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false do %>
+            <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.applications_open"), size: "s" }, checked: params[:applications_open].present? %>
           <% end %>
         </div>
       </div>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -304,11 +304,15 @@ en:
           other: '%{count} miles'
   helpers:
     legend:
-      course_search_form:
+      courses_query_filters:
         can_sponsor_visa_html: Visa sponsorship<span class="govuk-visually-hidden"> filter</span>
+        special_education_needs_html: Special educational needs<span class="govuk-visually-hidden"> filter</span>
+        applications_open_html: Applications open<span class="govuk-visually-hidden"> filter</span>
     label:
-      course_search_form:
+      courses_query_filters:
         can_sponsor_visa: Only show courses with visa sponsorship
+        special_education_needs: Only show courses with a SEND specialism
+        applications_open: Only show courses open for applications
   activemodel:
     errors:
       models:

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -325,5 +325,9 @@ FactoryBot.define do
       with_full_time_sites
       resulting_in_pgce_with_qts
     end
+
+    trait :with_special_education_needs do
+      is_send { true }
+    end
   end
 end

--- a/spec/features/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_enabled_spec.rb
@@ -18,6 +18,24 @@ feature 'V2 results - enabled' do
     and_the_visa_sponsorship_filter_is_checked
   end
 
+  scenario 'when I filter by applications open' do
+    given_there_are_courses_open_for_applications
+    and_there_are_courses_that_are_closed_for_applications
+    when_i_visit_the_find_results_page
+    and_i_filter_by_courses_open_for_applications
+    then_i_see_only_courses_that_are_open_for_applications
+    and_the_open_for_application_filter_is_checked
+  end
+
+  scenario 'when I filter by special educational needs' do
+    given_there_are_courses_with_special_education_needs
+    and_there_are_courses_that_with_no_special_education_needs
+    when_i_visit_the_find_results_page
+    and_i_filter_by_courses_with_special_education_needs
+    then_i_see_only_courses_with_special_education_needs
+    and_the_special_education_needs_filter_is_checked
+  end
+
   def given_i_am_authenticated
     page.driver.browser.authorize 'admin', 'password'
   end
@@ -26,6 +44,28 @@ feature 'V2 results - enabled' do
     create(:course, :with_full_time_sites, :can_sponsor_skilled_worker_visa, name: 'Biology', course_code: 'S872')
     create(:course, :with_full_time_sites, :can_sponsor_student_visa, name: 'Chemistry', course_code: 'K592')
     create(:course, :with_full_time_sites, :can_sponsor_student_visa, :can_sponsor_skilled_worker_visa, name: 'Computing', course_code: 'L364')
+  end
+
+  def given_there_are_courses_open_for_applications
+    create(:course, :with_full_time_sites, :open, name: 'Biology', course_code: 'S872')
+    create(:course, :with_full_time_sites, :open, name: 'Chemistry', course_code: 'K592')
+    create(:course, :with_full_time_sites, :open, name: 'Computing', course_code: 'L364')
+  end
+
+  def and_there_are_courses_that_are_closed_for_applications
+    create(:course, :with_full_time_sites, :closed, name: 'Dance', course_code: 'C115')
+    create(:course, :with_full_time_sites, :closed, name: 'Physics', course_code: '3CXN')
+  end
+
+  def given_there_are_courses_with_special_education_needs
+    create(:course, :with_full_time_sites, :with_special_education_needs, name: 'Biology SEND', course_code: 'S872')
+    create(:course, :with_full_time_sites, :with_special_education_needs, name: 'Chemistry SEND', course_code: 'K592')
+    create(:course, :with_full_time_sites, :with_special_education_needs, name: 'Computing SEND', course_code: 'L364')
+  end
+
+  def and_there_are_courses_that_with_no_special_education_needs
+    create(:course, :with_full_time_sites, is_send: false, can_sponsor_student_visa: false, name: 'Dance', course_code: 'C115')
+    create(:course, :with_full_time_sites, is_send: false, name: 'Physics', course_code: '3CXN')
   end
 
   def and_there_are_courses_that_do_not_sponsor_visa
@@ -38,7 +78,17 @@ feature 'V2 results - enabled' do
 
   def and_i_filter_by_courses_that_sponsor_visa
     check 'Only show courses with visa sponsorship'
-    click_link_or_button 'Apply filters'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_courses_open_for_applications
+    check 'Only show courses open for applications'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_courses_with_special_education_needs
+    check 'Only show courses with a SEND specialism'
+    and_i_apply_the_filters
   end
 
   def then_i_see_only_courses_that_sponsor_visa
@@ -48,7 +98,35 @@ feature 'V2 results - enabled' do
     expect(page).to have_no_content('Dance (C115)')
   end
 
+  def then_i_see_only_courses_with_special_education_needs
+    expect(page).to have_content('Biology SEND (S872')
+    expect(page).to have_content('Chemistry SEND (K592)')
+    expect(page).to have_content('Computing SEND (L364)')
+    expect(page).to have_no_content('Dance (C115)')
+    expect(page).to have_no_content('Physics (3CXN)')
+  end
+
+  def then_i_see_only_courses_that_are_open_for_applications
+    expect(page).to have_content('Biology (S872')
+    expect(page).to have_content('Chemistry (K592)')
+    expect(page).to have_content('Computing (L364)')
+    expect(page).to have_no_content('Dance (C115)')
+    expect(page).to have_no_content('Physics (3CXN)')
+  end
+
   def and_the_visa_sponsorship_filter_is_checked
     expect(page).to have_checked_field('Only show courses with visa sponsorship')
+  end
+
+  def and_the_open_for_application_filter_is_checked
+    expect(page).to have_checked_field('Only show courses open for applications')
+  end
+
+  def and_the_special_education_needs_filter_is_checked
+    expect(page).to have_checked_field('Only show courses with a SEND specialism')
+  end
+
+  def and_i_apply_the_filters
+    click_link_or_button 'Apply filters'
   end
 end

--- a/spec/services/courses_query_spec.rb
+++ b/spec/services/courses_query_spec.rb
@@ -41,5 +41,39 @@ RSpec.describe CoursesQuery do
         )
       end
     end
+
+    context 'when filter for applications open' do
+      let!(:course_opened) do
+        create(:course, :with_full_time_sites, :open)
+      end
+      let!(:course_closed) do
+        create(:course, :with_full_time_sites, :closed)
+      end
+      let(:params) { { applications_open: 'true' } }
+
+      it 'returns courses that sponsor visa' do
+        expect(results).to match_collection(
+          [course_opened],
+          attribute_names: %w[application_status]
+        )
+      end
+    end
+
+    context 'when filter for special education needs' do
+      let!(:course_with_special_education_needs) do
+        create(:course, :with_full_time_sites, :with_special_education_needs)
+      end
+      let!(:course_with_no_special_education_needs) do
+        create(:course, :with_full_time_sites, is_send: false)
+      end
+      let(:params) { { send_courses: 'true' } }
+
+      it 'returns courses that sponsor visa' do
+        expect(results).to match_collection(
+          [course_with_special_education_needs],
+          attribute_names: %w[is_send]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

This PR adds the two filters to `/v2/results`:

* Applications open
* SEND (Special education needs)

Some caveats:

* In the v1 (live Find as it is now), courses with the status "open" show up in search results—even if they won’t actually accept applications until a future date. While you can add it to your application, Apply stops you from submitting it until then.
* Applications open on this PR will search by application status as it is on v1 (live) search. But will be reviewed before we changed to use the v2 on results. I've asked the team and the team is aware of the problem.

The SEND filter is behaving same as v1 and no issues.

## Changes proposed in this pull request

![screencapture-find-localhost-v2-results-2024-12-10-15_06_09](https://github.com/user-attachments/assets/2566c9b9-78ee-495c-82c5-f8c2d5c5e63d)
![screencapture-find-localhost-v2-results-2024-12-10-15_06_25](https://github.com/user-attachments/assets/2f8695c8-253b-45cb-b966-b9498a69f50b)

## Guidance to review

1. Visit /v2/results
2. Does it works as expected?
