### PR TITLE
Rename SupportController to Support::ApplicationController

### DIFF
--- a/app/controllers/support/application_controller.rb
+++ b/app/controllers/support/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class SupportController < ApplicationController
+  class ApplicationController < ::ApplicationController
     layout 'support'
     before_action :check_user_is_admin
 

--- a/app/controllers/support/contact_details_controller.rb
+++ b/app/controllers/support/contact_details_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class ContactDetailsController < SupportController
+  class ContactDetailsController < ApplicationController
     def edit
       @provider_contact_form = ContactDetailsForm.new(provider)
     end

--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class CoursesController < SupportController
+  class CoursesController < ApplicationController
     def index
       @pagy, @courses = pagy(provider.courses.order(:name))
       render layout: 'provider_record'

--- a/app/controllers/support/data_exports_controller.rb
+++ b/app/controllers/support/data_exports_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class DataExportsController < SupportController
+  class DataExportsController < ApplicationController
     def index
       @data_exports = DataExports::DataExport.all
     end

--- a/app/controllers/support/providers/accredited_provider_search_controller.rb
+++ b/app/controllers/support/providers/accredited_provider_search_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   module Providers
-    class AccreditedProviderSearchController < SupportController
+    class AccreditedProviderSearchController < ApplicationController
       helper_method :query, :search_result_title_component
 
       def new

--- a/app/controllers/support/providers/accredited_providers/checks_controller.rb
+++ b/app/controllers/support/providers/accredited_providers/checks_controller.rb
@@ -3,7 +3,7 @@
 module Support
   module Providers
     module AccreditedProviders
-      class ChecksController < SupportController
+      class ChecksController < ApplicationController
         include ClearStashable
 
         def show

--- a/app/controllers/support/providers/accredited_providers_controller.rb
+++ b/app/controllers/support/providers/accredited_providers_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   module Providers
-    class AccreditedProvidersController < SupportController
+    class AccreditedProvidersController < ApplicationController
       include ClearStashable
 
       helper_method :accredited_provider_id

--- a/app/controllers/support/providers/copy_courses_controller.rb
+++ b/app/controllers/support/providers/copy_courses_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   module Providers
-    class CopyCoursesController < SupportController
+    class CopyCoursesController < ApplicationController
       before_action :recruitment_cycle
 
       def new

--- a/app/controllers/support/providers/onboarding/checks_controller.rb
+++ b/app/controllers/support/providers/onboarding/checks_controller.rb
@@ -3,7 +3,7 @@
 module Support
   module Providers
     module Onboarding
-      class ChecksController < SupportController
+      class ChecksController < ApplicationController
         def show
           provider_form
           provider_contact_form

--- a/app/controllers/support/providers/onboarding/contacts_controller.rb
+++ b/app/controllers/support/providers/onboarding/contacts_controller.rb
@@ -3,7 +3,7 @@
 module Support
   module Providers
     module Onboarding
-      class ContactsController < SupportController
+      class ContactsController < ApplicationController
         include GotoConfirmationHelper
 
         def new

--- a/app/controllers/support/providers/onboardings_controller.rb
+++ b/app/controllers/support/providers/onboardings_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   module Providers
-    class OnboardingsController < SupportController
+    class OnboardingsController < ApplicationController
       include GotoConfirmationHelper
 
       def new

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -3,7 +3,7 @@
 module Support
   module Providers
     module Schools
-      class CheckMultipleController < SupportController
+      class CheckMultipleController < ApplicationController
         include SuccessMessage
 
         def show

--- a/app/controllers/support/providers/schools/multiple_controller.rb
+++ b/app/controllers/support/providers/schools/multiple_controller.rb
@@ -3,7 +3,7 @@
 module Support
   module Providers
     module Schools
-      class MultipleController < SupportController
+      class MultipleController < ApplicationController
         def new
           @raw_csv_schools_form = RawCSVSchoolsForm.new(provider)
         end

--- a/app/controllers/support/providers/schools/new_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/new_multiple_controller.rb
@@ -3,7 +3,7 @@
 module Support
   module Providers
     module Schools
-      class NewMultipleController < SupportController
+      class NewMultipleController < ApplicationController
         def show
           site
           max

--- a/app/controllers/support/providers/schools_check_controller.rb
+++ b/app/controllers/support/providers/schools_check_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   module Providers
-    class SchoolsCheckController < SupportController
+    class SchoolsCheckController < ApplicationController
       before_action :new_form
 
       def show; end

--- a/app/controllers/support/providers/users_check_controller.rb
+++ b/app/controllers/support/providers/users_check_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   module Providers
-    class UsersCheckController < SupportController
+    class UsersCheckController < ApplicationController
       def show
         provider
         @user_form = UserForm.new(current_user, user)
@@ -13,8 +13,8 @@ module Support
         return unless @user_form.save!
 
         UserAssociationsService::Create.call(user: @user_form.model, provider:) if @user_form.model.providers.exclude?(provider)
-        redirect_to support_recruitment_cycle_provider_users_path
-        flash[:success] = 'User added'
+
+        redirect_to support_recruitment_cycle_provider_users_path, flash: { success: 'User added' }
       end
 
       private

--- a/app/controllers/support/providers/users_controller.rb
+++ b/app/controllers/support/providers/users_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   module Providers
-    class UsersController < SupportController
+    class UsersController < ApplicationController
       def index
         @pagy, @users = pagy(provider.users.order(:last_name))
         render layout: 'provider_record'

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class ProvidersController < SupportController
+  class ProvidersController < ApplicationController
     def index
       [ProviderForm.new(current_user, recruitment_cycle:), ProviderContactForm.new(current_user)].each(&:clear_stash) if flash.key?(:success)
       @pagy, @providers = pagy(filtered_providers)

--- a/app/controllers/support/recruitment_cycle_controller.rb
+++ b/app/controllers/support/recruitment_cycle_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class RecruitmentCycleController < SupportController
+  class RecruitmentCycleController < ApplicationController
     def index
       redirect_to support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year) unless FeatureService.enabled?('rollover.can_edit_current_and_next_cycles')
     end

--- a/app/controllers/support/revert_withdrawal_controller.rb
+++ b/app/controllers/support/revert_withdrawal_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class RevertWithdrawalController < SupportController
+  class RevertWithdrawalController < ApplicationController
     def edit
       provider
       course

--- a/app/controllers/support/schools_controller.rb
+++ b/app/controllers/support/schools_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class SchoolsController < SupportController
+  class SchoolsController < ApplicationController
     before_action :build_site, only: %i[index new create]
     before_action :new_form, only: %i[index new]
     before_action :reset_csv_schools_forms, only: %i[index]

--- a/app/controllers/support/user_permissions_controller.rb
+++ b/app/controllers/support/user_permissions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class UserPermissionsController < SupportController
+  class UserPermissionsController < ApplicationController
     def destroy
       user.remove_access_to(provider)
 

--- a/app/controllers/support/users/providers_controller.rb
+++ b/app/controllers/support/users/providers_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   module Users
-    class ProvidersController < SupportController
+    class ProvidersController < ApplicationController
       def show
         user
         @pagy, @providers = pagy(providers.order(:provider_name))

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Support
-  class UsersController < SupportController
+  class UsersController < ApplicationController
     def index
       recruitment_cycle
       @pagy, @users = pagy(filtered_users)

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -5,7 +5,7 @@ module LayoutHelper
   # Adapted from the nestive gem: https://github.com/rwz/nestive/blob/master/lib/nestive/layout_helper.rb#L84
   def extends_layout(layout, ...)
     layout = layout.to_s
-    layout = "layouts/#{layout}" unless layout.include?('/')
+    layout = "layouts/#{layout}" unless layout.start_with?('/')
     view_flow.get(:layout).replace(capture(...).to_s)
 
     render(template: layout)


### PR DESCRIPTION
## Context

We want to conventionalise base class naming conventions. For example:

- Base models should be named `ApplicationRecord`.
- Base controllers should be named `ApplicationController`.
- Base mailers should be named `ApplicationMailer`.

Each namespace should have a base class implementation. For example:

- `Find::ApplicationController < ::ApplicationController` and `Support::ApplicationController < ::ApplicationController`.

## Changes proposed in this pull request

- Rename `Support::SupportController` to `Support::ApplicationController`

## Guidance to review

- 
