### PR TITLE
Foundation for the pre filter work: add qualification filter and further education filter

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -20,7 +20,9 @@ module Find
           :can_sponsor_visa,
           :send_courses,
           :applications_open,
-          study_types: []
+          :further_education,
+          study_types: [],
+          qualifications: []
         )
       end
 

--- a/app/forms/search_courses_form.rb
+++ b/app/forms/search_courses_form.rb
@@ -7,6 +7,8 @@ class SearchCoursesForm < ApplicationForm
   attribute :send_courses, :boolean
   attribute :applications_open, :boolean
   attribute :study_types
+  attribute :qualifications
+  attribute :further_education, :boolean
 
   def search_params
     attributes.symbolize_keys.compact

--- a/app/services/courses_query.rb
+++ b/app/services/courses_query.rb
@@ -25,6 +25,8 @@ class CoursesQuery
   def call
     @scope = visa_sponsorship_scope
     @scope = study_modes_scope
+    @scope = qualifications_scope
+    @scope = further_education_scope
     @scope = applications_open_scope
     @scope = special_education_needs_scope
     @scope = @scope.distinct
@@ -63,6 +65,29 @@ class CoursesQuery
     else
       @scope
     end
+  end
+
+  def qualifications_scope
+    return @scope if params[:qualifications].blank?
+
+    @applied_scopes[:qualifications_scope] = params[:qualifications]
+
+    case params[:qualifications]
+    when ['qts']
+      @scope.where(qualification: [Course.qualifications[:qts]])
+    when ['qts_with_pgce_or_pgde'], ['qts_with_pgce']
+      @scope.where(qualification: [Course.qualifications[:pgce_with_qts], Course.qualifications[:pgde_with_qts]])
+    else
+      @scope
+    end
+  end
+
+  def further_education_scope
+    return @scope if params[:further_education].blank?
+
+    @applied_scopes[:further_education] = params[:further_education]
+
+    @scope.where(level: Course.levels[:further_education])
   end
 
   def applications_open_scope

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -12,7 +12,7 @@
       </div>
 
       <div class="app-filter__content">
-        <%= form.submit "Apply filters", name: nil, class: "govuk-button", data: { qa: "apply-filters" } %>
+        <%= form.govuk_submit "Apply filters" %>
 
         <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
           <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.can_sponsor_visa"), size: "s" } %>

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -23,6 +23,15 @@
           <%= form.govuk_check_box :study_types, "part_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.part_time"), size: "s" }, include_hidden: false %>
         <% end %>
 
+        <%= form.govuk_check_boxes_fieldset :qualifications, legend: { text: t("helpers.legend.courses_query_filters.qualifications_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+          <%= form.govuk_check_box :qualifications, "qts", label: { text: t("helpers.label.courses_query_filters.qualification_options.qts"), size: "s" }, include_hidden: false %>
+          <%= form.govuk_check_box :qualifications, "qts_with_pgce_or_pgde", label: { text: t("helpers.label.courses_query_filters.qualification_options.qts_with_pgce_or_pgde"), size: "s" }, include_hidden: false %>
+        <% end %>
+
+        <%= form.govuk_check_boxes_fieldset :further_education, legend: { text: t("helpers.legend.courses_query_filters.further_education_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.further_education"), class: "govuk-!-font-size-16" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+          <%= form.govuk_check_box :further_education, "true", label: { text: t("helpers.label.courses_query_filters.further_education"), size: "s" }, multiple: false %>
+        <% end %>
+
         <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
           <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.special_education_needs"), size: "s" } %>
         <% end %>

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -7,31 +7,29 @@
 <div class="app-filter-layout">
   <div class="app-filter-layout__filter">
     <%= form_with model: @search_courses_form, scope: "", url: find_v2_results_path, class: "app-filter", method: :get do |form| %>
+      <div class="app-filter__header">
+        <h2 class="govuk-heading-m">Filters</h2>
+      </div>
+
       <div class="app-filter__content">
-        <div class="app-filter__header">
-          <h2 class="govuk-heading-m">Filters</h2>
-        </div>
+        <%= form.submit "Apply filters", name: nil, class: "govuk-button", data: { qa: "apply-filters" } %>
 
-        <div class="app-filter__content">
-          <%= form.submit "Apply filters", name: nil, class: "govuk-button", data: { qa: "apply-filters" } %>
+        <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+          <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.can_sponsor_visa"), size: "s" } %>
+        <% end %>
 
-          <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false do %>
-            <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.can_sponsor_visa"), size: "s" } %>
-          <% end %>
+        <%= form.govuk_check_boxes_fieldset :study_types, legend: { text: t("helpers.legend.courses_query_filters.study_type_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+          <%= form.govuk_check_box :study_types, "full_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.full_time"), size: "s" }, include_hidden: false %>
+          <%= form.govuk_check_box :study_types, "part_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.part_time"), size: "s" }, include_hidden: false %>
+        <% end %>
 
-          <%= form.govuk_check_boxes_fieldset :study_types, legend: { text: t("helpers.legend.courses_query_filters.study_type_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false do %>
-            <%= form.govuk_check_box :study_types, "full_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.full_time"), size: "s" }, include_hidden: false %>
-            <%= form.govuk_check_box :study_types, "part_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.part_time"), size: "s" }, include_hidden: false %>
-          <% end %>
+        <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+          <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.special_education_needs"), size: "s" } %>
+        <% end %>
 
-          <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false do %>
-            <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.special_education_needs"), size: "s" } %>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :applications_open, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.applications_open_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false do %>
-            <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.applications_open"), size: "s" } %>
-          <% end %>
-        </div>
+        <%= form.govuk_check_boxes_fieldset :applications_open, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.applications_open_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+          <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.applications_open"), size: "s" } %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -46,7 +46,7 @@
   <div class="app-filter-layout__content">
     <ul class="app-search-results">
       <% @results.each do |course| %>
-        <li class="app-search-results__item" data-qa="course">
+        <li class="app-search-results__item">
           <%= govuk_summary_card(
             classes: ["course-summary-card"],
             title: govuk_link_to(
@@ -54,11 +54,10 @@
                 provider_code: course.provider_code,
                 course_code: course.course_code
               ),
-              class: "govuk-link govuk-!-font-size-24",
-              data: { qa: "course__link" }
+              class: "govuk-link govuk-!-font-size-24"
             ) do
-              content_tag(:span, course.provider.provider_name, class: "app-search-result__provider-name", data: { qa: "course__provider_name" }) +
-              content_tag(:span, course.name_and_code, class: "app-search-result__course-name", data: { qa: "course__name" })
+              content_tag(:span, course.provider.provider_name, class: "app-search-result__provider-name") +
+              content_tag(:span, course.name_and_code, class: "app-search-result__course-name")
             end
           ) %>
         </li>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -314,8 +314,13 @@ en:
       courses_query_filters:
         can_sponsor_visa_html: Visa sponsorship<span class="govuk-visually-hidden"> filter</span>
         study_type_html: Study type<span class="govuk-visually-hidden"> filter</span>
+        qualifications_html: Qualification awarded<span class="govuk-visually-hidden"> filter</span>
+        further_education_html: Further education<span class="govuk-visually-hidden"> filter</span>
         special_education_needs_html: Special educational needs<span class="govuk-visually-hidden"> filter</span>
         applications_open_html: Applications open<span class="govuk-visually-hidden"> filter</span>
+    hint:
+      courses_query_filters:
+        further_education: (ages 16 and over)
     label:
       courses_query_filters:
         can_sponsor_visa: Only show courses with visa sponsorship
@@ -324,6 +329,10 @@ en:
         study_type_options:
           full_time: Full time (12 months)
           part_time: Part time (18 to 24 months)
+        qualification_options:
+          qts: QTS only
+          qts_with_pgce_or_pgde: QTS with PGCE or PGDE
+        further_education: Only show further education courses
   activemodel:
     errors:
       models:

--- a/spec/features/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_enabled_spec.rb
@@ -110,9 +110,9 @@ feature 'V2 results - enabled' do
   end
 
   def given_there_are_courses_containing_all_levels
-    create(:course, :with_full_time_sites, level: 'primary', name: 'Biology', course_code: 'S872')
-    create(:course, :with_full_time_sites, level: 'secondary', name: 'Chemistry', course_code: 'K592')
-    create(:course, :with_full_time_sites, level: 'further_education', name: 'Further education', course_code: 'K594')
+    create(:course, :with_full_time_sites, :primary, name: 'Biology', course_code: 'S872')
+    create(:course, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592')
+    create(:course, :with_full_time_sites, :further_education, name: 'Further education', course_code: 'K594')
   end
 
   def given_there_are_courses_open_for_applications

--- a/spec/features/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_enabled_spec.rb
@@ -34,6 +34,33 @@ feature 'V2 results - enabled' do
     and_the_full_time_filter_is_checked
   end
 
+  scenario 'when I filter by QTS-only courses' do
+    given_there_are_courses_containing_all_qualifications
+    when_i_visit_the_find_results_page
+    and_i_filter_by_qts_only_courses
+    then_i_see_only_qts_only_courses
+    and_the_qts_only_filter_is_checked
+    and_i_see_that_there_is_one_course_found
+  end
+
+  scenario 'when I filter by QTS with PGCE' do
+    given_there_are_courses_containing_all_qualifications
+    when_i_visit_the_find_results_page
+    and_i_filter_by_qts_with_pgce_or_pgde_courses
+    then_i_see_only_qts_with_pgce_or_pgde_courses
+    and_the_qts_with_pgce_or_pgde_filter_is_checked
+    and_i_see_that_there_are_two_courses_found
+  end
+
+  scenario 'when I filter by further education only courses' do
+    given_there_are_courses_containing_all_levels
+    when_i_visit_the_find_results_page
+    and_i_filter_by_further_education_courses
+    then_i_see_only_further_education__courses
+    and_the_further_education_filter_is_checked
+    and_i_see_that_there_is_one_course_found
+  end
+
   scenario 'when I filter by applications open' do
     given_there_are_courses_open_for_applications
     and_there_are_courses_that_are_closed_for_applications
@@ -71,6 +98,21 @@ feature 'V2 results - enabled' do
     create(:course, :with_full_time_sites, study_mode: 'full_time', name: 'Biology', course_code: 'S872')
     create(:course, :with_part_time_sites, study_mode: 'part_time', name: 'Chemistry', course_code: 'K592')
     create(:course, :with_full_time_or_part_time_sites, study_mode: 'full_time_or_part_time', name: 'Computing', course_code: 'L364')
+  end
+
+  def given_there_are_courses_containing_all_qualifications
+    create(:course, :with_full_time_sites, qualification: 'qts', name: 'Biology', course_code: 'S872')
+    create(:course, :with_full_time_sites, qualification: 'pgce_with_qts', name: 'Chemistry', course_code: 'K592')
+    create(:course, :with_full_time_sites, qualification: 'pgde_with_qts', name: 'Computing', course_code: 'L364')
+    create(:course, :with_full_time_sites, qualification: 'pgce', name: 'Dance', course_code: 'C115')
+    create(:course, :with_full_time_sites, qualification: 'pgde', name: 'Physics', course_code: '3CXN')
+    create(:course, :with_full_time_sites, qualification: 'undergraduate_degree_with_qts', name: 'Mathemathics', course_code: '4RTU')
+  end
+
+  def given_there_are_courses_containing_all_levels
+    create(:course, :with_full_time_sites, level: 'primary', name: 'Biology', course_code: 'S872')
+    create(:course, :with_full_time_sites, level: 'secondary', name: 'Chemistry', course_code: 'K592')
+    create(:course, :with_full_time_sites, level: 'further_education', name: 'Further education', course_code: 'K594')
   end
 
   def given_there_are_courses_open_for_applications
@@ -126,8 +168,23 @@ feature 'V2 results - enabled' do
     and_i_apply_the_filters
   end
 
+  def and_i_filter_by_qts_only_courses
+    check 'QTS only'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_qts_with_pgce_or_pgde_courses
+    check 'QTS with PGCE or PGDE'
+    and_i_apply_the_filters
+  end
+
   def and_i_filter_by_courses_open_for_applications
     check 'Only show courses open for applications'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_further_education_courses
+    check 'Only show further education courses'
     and_i_apply_the_filters
   end
 
@@ -169,6 +226,42 @@ feature 'V2 results - enabled' do
     expect(page).to have_content('Chemistry (K592)')
   end
 
+  def then_i_see_only_qts_only_courses
+    expect(page).to have_content('Biology (S872)')
+    expect(page).to have_no_content('Chemistry (K592)')
+    expect(page).to have_no_content('Computing (L364)')
+    expect(page).to have_no_content('Dance (C115)')
+    expect(page).to have_no_content('Physics (3CXN)')
+    expect(page).to have_no_content('Mathemathics (4RTU)')
+  end
+
+  def and_the_qts_only_filter_is_checked
+    expect(page).to have_checked_field('QTS only')
+  end
+
+  def then_i_see_only_qts_with_pgce_or_pgde_courses
+    expect(page).to have_content('Chemistry (K592)')
+    expect(page).to have_content('Computing (L364)')
+    expect(page).to have_no_content('Biology (S872)')
+    expect(page).to have_no_content('Dance (C115)')
+    expect(page).to have_no_content('Physics (3CXN)')
+    expect(page).to have_no_content('Mathemathics (4RTU)')
+  end
+
+  def and_the_qts_with_pgce_or_pgde_filter_is_checked
+    expect(page).to have_checked_field('QTS with PGCE or PGDE')
+  end
+
+  def then_i_see_only_further_education__courses
+    expect(page).to have_content('Further education (K594)')
+    expect(page).to have_no_content('Biology (S872)')
+    expect(page).to have_no_content('Chemistry (K592)')
+  end
+
+  def and_the_further_education_filter_is_checked
+    expect(page).to have_checked_field('Only show further education courses')
+  end
+
   def then_i_see_only_courses_with_special_education_needs
     expect(page).to have_content('Biology SEND (S872')
     expect(page).to have_content('Chemistry SEND (K592)')
@@ -199,6 +292,16 @@ feature 'V2 results - enabled' do
 
   def and_i_apply_the_filters
     click_link_or_button 'Apply filters'
+  end
+
+  def and_i_see_that_there_is_one_course_found
+    expect(page).to have_content('1 course found')
+    expect(page).to have_title('1 course found')
+  end
+
+  def and_i_see_that_there_are_two_courses_found
+    expect(page).to have_content('2 courses found')
+    expect(page).to have_title('2 courses found')
   end
 
   def and_i_see_that_there_are_three_courses_are_found

--- a/spec/services/courses_query_spec.rb
+++ b/spec/services/courses_query_spec.rb
@@ -98,6 +98,71 @@ RSpec.describe CoursesQuery do
       end
     end
 
+    context 'when filter by qualifications' do
+      let!(:qts_course) do
+        create(:course, :with_full_time_sites, qualification: 'qts')
+      end
+      let!(:pgce_with_qts_course) do
+        create(:course, :with_full_time_sites, qualification: 'pgce_with_qts')
+      end
+      let!(:pgde_with_qts_course) do
+        create(:course, :with_full_time_sites, qualification: 'pgde_with_qts')
+      end
+      let!(:course_without_qts) do
+        create(:course, :with_full_time_sites, qualification: 'undergraduate_degree_with_qts')
+      end
+
+      context 'when filter by qts' do
+        let(:params) { { qualifications: ['qts'] } }
+
+        it 'returns courses with qts qualification only' do
+          expect(results).to match_collection(
+            [qts_course],
+            attribute_names: %w[qualification]
+          )
+        end
+      end
+
+      context 'when filter by qts with pgce or pgde' do
+        let(:params) { { qualifications: ['qts_with_pgce_or_pgde'] } }
+
+        it 'returns courses with qts and pgce/pgde qualifications' do
+          expect(results).to match_collection(
+            [pgce_with_qts_course, pgde_with_qts_course],
+            attribute_names: %w[qualification]
+          )
+        end
+      end
+
+      context 'when filter by qts with pgce (for backwards compatibility)' do
+        let(:params) { { qualifications: ['qts_with_pgce'] } }
+
+        it 'returns courses with qts and pgce/pgde qualifications' do
+          expect(results).to match_collection(
+            [pgce_with_qts_course, pgde_with_qts_course],
+            attribute_names: %w[qualification]
+          )
+        end
+      end
+    end
+
+    context 'when filter for further education' do
+      let!(:further_education_course) do
+        create(:course, :with_full_time_sites, level: 'further_education')
+      end
+      let!(:regular_course) do
+        create(:course, :with_full_time_sites, level: 'secondary')
+      end
+      let(:params) { { further_education: 'true' } }
+
+      it 'returns courses for further education only' do
+        expect(results).to match_collection(
+          [further_education_course],
+          attribute_names: %w[level]
+        )
+      end
+    end
+
     context 'when filter for applications open' do
       let!(:course_opened) do
         create(:course, :with_full_time_sites, :open)


### PR DESCRIPTION
## Context

This PR adds the "Qualification" and "Further education" filter to the new search results that we will replace the live one in the future.

## Caveats

In production if you go to the live page and select "Across England" and "Further education" the parameter will be "age_group: further_education" and if you apply the filter "Further education (PGCE or PGDE without QTS)" the parameter will be: "qualification[]: pgce_pgde".

I changed to just: further_education=true (I might change to level=further_education when primary and secondary are added).

## Changes proposed in this pull request

<img width="245" alt="Screenshot 2024-12-16 at 07 18 02" src="https://github.com/user-attachments/assets/bbd72ed3-3250-439a-9145-a0d0d4769f81" />

## Guidance to review

1. Visit /v2/results
2. Does each filter (qualifications and further education) work as expected?
