### PR TITLE
Remove the stackprof gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ gem 'jsonb_accessor'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'sentry-sidekiq'
-gem 'stackprof'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -691,7 +691,6 @@ GEM
     skylight (6.0.4)
       activesupport (>= 5.2.0)
     smart_properties (1.17.0)
-    stackprof (0.2.26)
     stringio (3.1.2)
     super_diff (0.14.0)
       attr_extras (>= 6.2.4)
@@ -843,7 +842,6 @@ DEPENDENCIES
   simplecov (< 0.23)
   site_prism (~> 5.0)
   skylight
-  stackprof
   super_diff
   table_print
   terminal-table


### PR DESCRIPTION
## Context

We want to profile our application within Skylight, not Sentry, due to cost constraints.

## Changes proposed in this pull request

- Remove the `stackprof` gem.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
