### PR TITLE
Foundation for the pre filter work add Funding filter

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -21,6 +21,7 @@ module Find
           :send_courses,
           :applications_open,
           :further_education,
+          :funding,
           study_types: [],
           qualifications: [],
           funding: []

--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -22,7 +22,8 @@ module Find
           :applications_open,
           :further_education,
           study_types: [],
-          qualifications: []
+          qualifications: [],
+          funding: []
         )
       end
 

--- a/app/forms/search_courses_form.rb
+++ b/app/forms/search_courses_form.rb
@@ -9,6 +9,7 @@ class SearchCoursesForm < ApplicationForm
   attribute :study_types
   attribute :qualifications
   attribute :further_education, :boolean
+  attribute :funding
 
   def search_params
     attributes.symbolize_keys.compact

--- a/app/services/courses_query.rb
+++ b/app/services/courses_query.rb
@@ -29,6 +29,7 @@ class CoursesQuery
     @scope = further_education_scope
     @scope = applications_open_scope
     @scope = special_education_needs_scope
+    @scope = funding_scope
     @scope = @scope.distinct
 
     log_query_info
@@ -104,6 +105,14 @@ class CoursesQuery
     @applied_scopes[:send_courses] = params[:send_courses]
 
     @scope.where(is_send: true)
+  end
+
+  def funding_scope
+    return @scope if params[:funding].blank?
+
+    @applied_scopes[:funding] = params[:funding]
+
+    @scope.where(funding: params[:funding])
   end
 
   private

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -36,6 +36,12 @@
           <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.special_education_needs"), size: "s" } %>
         <% end %>
 
+        <%= form.govuk_check_boxes_fieldset :funding, legend: { text: t("helpers.legend.courses_query_filters.funding_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+          <%= form.govuk_check_box :funding, "fee", label: { text: t("helpers.label.courses_query_filters.funding_options.fee"), size: "s" }, include_hidden: false %>
+          <%= form.govuk_check_box :funding, "salary", label: { text: t("helpers.label.courses_query_filters.funding_options.salary"), size: "s" }, include_hidden: false %>
+          <%= form.govuk_check_box :funding, "apprenticeship", label: { text: t("helpers.label.courses_query_filters.funding_options.apprenticeship"), size: "s" }, include_hidden: false %>
+        <% end %>
+
         <%= form.govuk_check_boxes_fieldset :applications_open, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.applications_open_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
           <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.applications_open"), size: "s" } %>
         <% end %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -317,6 +317,7 @@ en:
         qualifications_html: Qualification awarded<span class="govuk-visually-hidden"> filter</span>
         further_education_html: Further education<span class="govuk-visually-hidden"> filter</span>
         special_education_needs_html: Special educational needs<span class="govuk-visually-hidden"> filter</span>
+        funding_html: Fee or salary<span class="govuk-visually-hidden"> filter</span>
         applications_open_html: Applications open<span class="govuk-visually-hidden"> filter</span>
     hint:
       courses_query_filters:
@@ -333,6 +334,10 @@ en:
           qts: QTS only
           qts_with_pgce_or_pgde: QTS with PGCE or PGDE
         further_education: Only show further education courses
+        funding_options:
+          fee: Fee - no salary
+          salary: Salary
+          apprenticeship: Teaching apprenticeship - with salary
   activemodel:
     errors:
       models:

--- a/spec/features/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_enabled_spec.rb
@@ -79,31 +79,44 @@ feature 'V2 results - enabled' do
     and_the_special_education_needs_filter_is_checked
   end
 
-  scenario 'when I filter by salaried' do
-    given_there_are_courses_with_all_funding_types
-    when_i_visit_the_find_results_page
-    and_i_filter_by_salaried_courses
-    then_i_see_only_salaried_courses
-    and_the_salary_filter_is_checked
-    and_i_see_that_there_is_one_course_found
-  end
+  context 'when filter by funding type' do
+    before do
+      given_there_are_courses_with_all_funding_types
+    end
 
-  scenario 'when I filter by fee' do
-    given_there_are_courses_with_all_funding_types
-    when_i_visit_the_find_results_page
-    and_i_filter_by_fee_courses
-    then_i_see_only_fee_courses
-    and_the_fee_filter_is_checked
-    and_i_see_that_there_is_one_course_found
-  end
+    scenario 'when I filter by salaried' do
+      when_i_visit_the_find_results_page
+      and_i_filter_by_salaried_courses
+      then_i_see_only_salaried_courses
+      and_the_salary_filter_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
 
-  scenario 'when I filter by apprenticeship' do
-    given_there_are_courses_with_all_funding_types
-    when_i_visit_the_find_results_page
-    and_i_filter_by_apprenticeship_courses
-    then_i_see_only_apprenticeship_courses
-    and_the_apprenticeship_filter_is_checked
-    and_i_see_that_there_is_one_course_found
+    scenario 'when I filter by fee' do
+      when_i_visit_the_find_results_page
+      and_i_filter_by_fee_courses
+      then_i_see_only_fee_courses
+      and_the_fee_filter_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
+
+    scenario 'when I filter by fee and salaried' do
+      when_i_visit_the_find_results_page
+      and_i_filter_by_fee_courses
+      and_i_filter_by_salaried_courses
+      then_i_see_fee_and_salaried_courses
+      and_the_fee_filter_is_checked
+      and_the_salary_filter_is_checked
+      and_i_see_that_there_are_two_courses_found
+    end
+
+    scenario 'when I filter by apprenticeship' do
+      when_i_visit_the_find_results_page
+      and_i_filter_by_apprenticeship_courses
+      then_i_see_only_apprenticeship_courses
+      and_the_apprenticeship_filter_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
   end
 
   scenario 'when no results' do
@@ -327,6 +340,12 @@ feature 'V2 results - enabled' do
   def then_i_see_only_fee_courses
     expect(page).to have_content('Biology (S872)')
     expect(page).to have_no_content('Chemistry (K592)')
+    expect(page).to have_no_content('Computing (L364)')
+  end
+
+  def then_i_see_fee_and_salaried_courses
+    expect(page).to have_content('Biology (S872)')
+    expect(page).to have_content('Chemistry (K592)')
     expect(page).to have_no_content('Computing (L364)')
   end
 

--- a/spec/features/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_enabled_spec.rb
@@ -110,6 +110,13 @@ feature 'V2 results - enabled' do
       and_i_see_that_there_are_two_courses_found
     end
 
+    scenario 'when I use the old funding parameter' do
+      when_i_visit_the_find_results_page_using_old_salary_parameter
+      then_i_see_only_salaried_courses
+      and_the_salary_filter_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
+
     scenario 'when I filter by apprenticeship' do
       when_i_visit_the_find_results_page
       and_i_filter_by_apprenticeship_courses
@@ -189,6 +196,10 @@ feature 'V2 results - enabled' do
 
   def when_i_visit_the_find_results_page
     visit find_v2_results_path
+  end
+
+  def when_i_visit_the_find_results_page_using_old_salary_parameter
+    visit(find_v2_results_path(funding: 'salary'))
   end
 
   def and_i_filter_by_courses_that_sponsor_visa

--- a/spec/features/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_enabled_spec.rb
@@ -79,6 +79,33 @@ feature 'V2 results - enabled' do
     and_the_special_education_needs_filter_is_checked
   end
 
+  scenario 'when I filter by salaried' do
+    given_there_are_courses_with_all_funding_types
+    when_i_visit_the_find_results_page
+    and_i_filter_by_salaried_courses
+    then_i_see_only_salaried_courses
+    and_the_salary_filter_is_checked
+    and_i_see_that_there_is_one_course_found
+  end
+
+  scenario 'when I filter by fee' do
+    given_there_are_courses_with_all_funding_types
+    when_i_visit_the_find_results_page
+    and_i_filter_by_fee_courses
+    then_i_see_only_fee_courses
+    and_the_fee_filter_is_checked
+    and_i_see_that_there_is_one_course_found
+  end
+
+  scenario 'when I filter by apprenticeship' do
+    given_there_are_courses_with_all_funding_types
+    when_i_visit_the_find_results_page
+    and_i_filter_by_apprenticeship_courses
+    then_i_see_only_apprenticeship_courses
+    and_the_apprenticeship_filter_is_checked
+    and_i_see_that_there_is_one_course_found
+  end
+
   scenario 'when no results' do
     when_i_visit_the_find_results_page
     then_i_see_no_courses_found
@@ -130,6 +157,12 @@ feature 'V2 results - enabled' do
     create(:course, :with_full_time_sites, :with_special_education_needs, name: 'Biology SEND', course_code: 'S872')
     create(:course, :with_full_time_sites, :with_special_education_needs, name: 'Chemistry SEND', course_code: 'K592')
     create(:course, :with_full_time_sites, :with_special_education_needs, name: 'Computing SEND', course_code: 'L364')
+  end
+
+  def given_there_are_courses_with_all_funding_types
+    create(:course, :with_full_time_sites, :fee_type_based, name: 'Biology', course_code: 'S872')
+    create(:course, :with_full_time_sites, :with_salary, name: 'Chemistry', course_code: 'K592')
+    create(:course, :with_full_time_sites, :with_apprenticeship, name: 'Computing', course_code: 'L364')
   end
 
   def and_there_are_courses_that_with_no_special_education_needs
@@ -190,6 +223,21 @@ feature 'V2 results - enabled' do
 
   def and_i_filter_by_courses_with_special_education_needs
     check 'Only show courses with a SEND specialism'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_salaried_courses
+    check 'Salary'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_fee_courses
+    check 'Fee - no salary'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_apprenticeship_courses
+    check 'Teaching apprenticeship - with salary'
     and_i_apply_the_filters
   end
 
@@ -270,8 +318,26 @@ feature 'V2 results - enabled' do
     expect(page).to have_no_content('Physics (3CXN)')
   end
 
+  def then_i_see_only_salaried_courses
+    expect(page).to have_content('Chemistry (K592)')
+    expect(page).to have_no_content('Biology (S872)')
+    expect(page).to have_no_content('Computing (L364)')
+  end
+
+  def then_i_see_only_fee_courses
+    expect(page).to have_content('Biology (S872)')
+    expect(page).to have_no_content('Chemistry (K592)')
+    expect(page).to have_no_content('Computing (L364)')
+  end
+
+  def then_i_see_only_apprenticeship_courses
+    expect(page).to have_content('Computing (L364)')
+    expect(page).to have_no_content('Chemistry (K592)')
+    expect(page).to have_no_content('Biology (S872)')
+  end
+
   def then_i_see_only_courses_that_are_open_for_applications
-    expect(page).to have_content('Biology (S872')
+    expect(page).to have_content('Biology (S872)')
     expect(page).to have_content('Chemistry (K592)')
     expect(page).to have_content('Computing (L364)')
     expect(page).to have_no_content('Dance (C115)')
@@ -288,6 +354,18 @@ feature 'V2 results - enabled' do
 
   def and_the_special_education_needs_filter_is_checked
     expect(page).to have_checked_field('Only show courses with a SEND specialism')
+  end
+
+  def and_the_fee_filter_is_checked
+    expect(page).to have_checked_field('Fee - no salary')
+  end
+
+  def and_the_salary_filter_is_checked
+    expect(page).to have_checked_field('Salary')
+  end
+
+  def and_the_apprenticeship_filter_is_checked
+    expect(page).to have_checked_field('Teaching apprenticeship - with salary')
   end
 
   def and_i_apply_the_filters

--- a/spec/forms/search_courses_form_spec.rb
+++ b/spec/forms/search_courses_form_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe SearchCoursesForm do
       end
     end
 
+    context 'when funding is provided' do
+      let(:form) { described_class.new(funding: %w[fee salary]) }
+
+      it 'returns the correct search params with study_types as an array' do
+        expect(form.search_params).to eq({ funding: %w[fee salary] })
+      end
+    end
+
     context 'when no attributes are set' do
       let(:form) { described_class.new }
 

--- a/spec/services/courses_query_spec.rb
+++ b/spec/services/courses_query_spec.rb
@@ -196,5 +196,72 @@ RSpec.describe CoursesQuery do
         )
       end
     end
+
+    context 'when filter by funding' do
+      let!(:fee_course) do
+        create(:course, :with_full_time_sites, funding: 'fee')
+      end
+      let!(:salaried_course) do
+        create(:course, :with_full_time_sites, funding: 'salary')
+      end
+      let!(:apprenticeship_course) do
+        create(:course, :with_full_time_sites, funding: 'apprenticeship')
+      end
+
+      context 'when filter by fee' do
+        let(:params) { { funding: ['fee'] } }
+
+        it 'returns courses with fees only' do
+          expect(results).to match_collection(
+            [fee_course],
+            attribute_names: %w[funding]
+          )
+        end
+      end
+
+      context 'when filter by salary' do
+        let(:params) { { funding: ['salary'] } }
+
+        it 'returns courses with salary' do
+          expect(results).to match_collection(
+            [salaried_course],
+            attribute_names: %w[funding]
+          )
+        end
+      end
+
+      context 'when filter by apprenticeship' do
+        let(:params) { { funding: ['apprenticeship'] } }
+
+        it 'returns courses with apprenticeship' do
+          expect(results).to match_collection(
+            [apprenticeship_course],
+            attribute_names: %w[funding]
+          )
+        end
+      end
+
+      context 'when filter by two funding types' do
+        let(:params) { { funding: %w[fee salary] } }
+
+        it 'returns courses with the expected funding types' do
+          expect(results).to match_collection(
+            [fee_course, salaried_course],
+            attribute_names: %w[funding]
+          )
+        end
+      end
+
+      context 'when filter by all funding types' do
+        let(:params) { { funding: %w[fee salary apprenticeship] } }
+
+        it 'returns all courses' do
+          expect(results).to match_collection(
+            [fee_course, salaried_course, apprenticeship_course],
+            attribute_names: %w[funding]
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/services/courses_query_spec.rb
+++ b/spec/services/courses_query_spec.rb
@@ -241,6 +241,17 @@ RSpec.describe CoursesQuery do
         end
       end
 
+      context 'when filter by salary in the old search parameter' do
+        let(:params) { { funding: 'salary' } }
+
+        it 'returns courses with salary' do
+          expect(results).to match_collection(
+            [salaried_course],
+            attribute_names: %w[funding]
+          )
+        end
+      end
+
       context 'when filter by two funding types' do
         let(:params) { { funding: %w[fee salary] } }
 


### PR DESCRIPTION
## Context

This PR adds the funding type filter on the v2 results page

## Caveats

For backwards compatibility the funding is string on the live site (v1 results page). This PR adds an array but also accept the funding as string for compatibility.

## Changes proposed in this pull request

<img width="260" alt="Screenshot 2024-12-16 at 11 37 57" src="https://github.com/user-attachments/assets/18df6c2b-25ba-4505-a4e3-b7c7a93a970a" />

## Guidance to review

1. Visit /v2/results
2. Does it work with all three checkboxes? Choosing one, two, three, zero?
