### PR TITLE
Remove the cloudfront-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,10 +151,6 @@ gem 'blazer'
 
 gem 'dfe-wizard', require: 'dfe/wizard', github: 'DFE-Digital/dfe-wizard', tag: 'v0.1.1'
 
-group :production, :qa, :sandbox, :staging do
-  gem 'cloudfront-rails'
-end
-
 group :development, :test do
   # Prettyprint in console
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,8 +191,6 @@ GEM
     chartkick (5.1.0)
     childprocess (5.0.0)
     choice (0.2.0)
-    cloudfront-rails (0.4.0)
-      railties (> 4.0)
     coderay (1.1.3)
     colorize (1.1.0)
     concurrent-ruby (1.3.4)
@@ -760,7 +758,6 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 2.15)
-  cloudfront-rails
   colorize
   config
   cssbundling-rails (~> 1.4)


### PR DESCRIPTION
## Context

We have no need for this gem since moving onto Azure.

## Changes proposed in this pull request

- Remove the `cloudfront-rails` gem.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
