### PR TITLE
Remove references to accredited provider in `AboutYourOrganisationForm`

### DIFF
--- a/app/forms/publish/about_your_organisation_form.rb
+++ b/app/forms/publish/about_your_organisation_form.rb
@@ -10,8 +10,6 @@ module Publish
     validates :train_with_us, words_count: { maximum: 250, message: 'Reduce the word count for training with you' }
     validates :train_with_disability, words_count: { maximum: 250, message: 'Reduce the word count for training with disabilities and other needs' }
 
-    validate :add_enrichment_errors
-
     def initialize(model, params: {}, redirect_params: {}, course_code: nil)
       super(model, params:)
       @redirect_params = redirect_params
@@ -21,17 +19,10 @@ module Publish
     FIELDS = %i[
       train_with_us
       train_with_disability
-      accrediting_provider_enrichments
     ].freeze
 
     attr_accessor(*FIELDS)
     attr_reader :redirect_params, :course_code
-
-    def accredited_bodies
-      @accredited_bodies ||= provider.accredited_bodies.map do |ab|
-        accredited_provider(**ab)
-      end
-    end
 
     def update_success_path
       case redirection_key
@@ -76,48 +67,12 @@ module Publish
       public_send(attribute) != provider.public_send(attribute)
     end
 
-    def accredited_provider(provider_name:, provider_code:, description:)
-      AccreditedProvider.new(
-        provider_name:,
-        provider_code:,
-        description: params_description(provider_code) || description
-      )
-    end
-
-    def params_description(provider_code)
-      params[:accredited_bodies].to_h { |i| [i[:provider_code], i[:description]] }[provider_code] if params&.dig(:accredited_bodies).present?
-    end
-
-    def accrediting_provider_enrichments
-      accredited_bodies.map do |accredited_provider|
-        {
-          UcasProviderCode: accredited_provider.provider_code,
-          Description: accredited_provider.description
-        }
-      end
-    end
-
     def compute_fields
       provider.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end
 
     def new_attributes
-      params.except(:accredited_bodies).merge(accrediting_provider_enrichments:)
-    end
-
-    def add_enrichment_errors
-      accredited_bodies&.each_with_index do |accredited_provider, _index|
-        errors.add :accredited_bodies, accredited_provider.errors[:description].first if accredited_provider.invalid?
-      end
-    end
-
-    class AccreditedProvider
-      include ActiveModel::Model
-      validates :description, words_count: { maximum: 100, message: lambda do |object, _data|
-        "Reduce the word count for #{object.provider_name}"
-      end }
-
-      attr_accessor :provider_name, :provider_code, :description
+      params
     end
 
     def redirection_key

--- a/spec/forms/publish/about_your_organisation_form_spec.rb
+++ b/spec/forms/publish/about_your_organisation_form_spec.rb
@@ -13,15 +13,7 @@ module Publish
     end
     let(:train_with_us) { 'train_with_us' }
     let(:train_with_disability) { 'train_with_disability' }
-    let(:provider) do
-      create(
-        :provider,
-        accrediting_provider_enrichments: [
-          { UcasProviderCode: accredited_provider.provider_code }
-        ]
-      )
-    end
-    let(:accredited_provider) { create(:provider, :accredited_provider) }
+    let(:provider) { create(:provider) }
     let(:redirect_params) { { 'goto_preview' => 'true' } }
     let(:course_code) { create(:course) }
 
@@ -47,17 +39,6 @@ module Publish
           expect(subject.valid?).to be_falsey
           expect(subject.errors[:train_with_disability]).to include('Reduce the word count for training with disabilities and other needs')
         end
-      end
-    end
-
-    describe '#accredited_bodies' do
-      it 'returns an array of accredited_providers' do
-        expect(subject.accredited_bodies).to include(
-          have_attributes(
-            provider_name: accredited_provider.provider_name,
-            provider_code: accredited_provider.provider_code
-          )
-        )
       end
     end
 


### PR DESCRIPTION
## Context

Currently, the `AboutYourOrganisationForm` has a lot of logic around accepting arguments relating to Accredited bodies. This appears to be functionality that may have been used in the past but is not longer relevant.

## Changes proposed in this pull request

Delete code that serves no pupose anymore.

## Guidance to review

|What|Image|
|---|---|
|Show|![image](https://github.com/user-attachments/assets/ff6b85ac-72f6-443b-8f68-4d65b826d9e4)|
|Form (1)|![image](https://github.com/user-attachments/assets/475c575f-2758-40b4-9a95-b309239e4781)|
|Form (2)|![image](https://github.com/user-attachments/assets/6344d200-6a95-4afd-bcc6-ec227caa3743)|

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
