### PR TITLE
Add `Settings.features.provider_partnerships` feature flag

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,6 +79,7 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
+  provider_partnerships: false
   api_summary_content_change: true
   send_request_data_to_bigquery: false
   v2_results: false


### PR DESCRIPTION
## Context

  This feature flag will be used to enable / disable routes and toggle the
  return values of certain methods so we can merge the updated provider
  partnerships code incrementally while maintaining the current
  behaviour.

  In test files we can have functional tests test the existing behaviour
  and the new implementation by switching on the feature flag
  for example:

    allow(Setttings.features).to receive(:provider_partnerships).and_return(true)


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
