### PR TITLE
Rename partnership concepts

### DIFF
--- a/app/components/accredited_provider_component.html.erb
+++ b/app/components/accredited_provider_component.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_summary_card(title: provider_name) do |card|
       card.with_action { govuk_link_to("Remove", remove_path, class: "app-link--destructive govuk-!-font-weight-regular", data: { qa: "remove-link" }) }
-      card.with_summary_list(rows: [{ key: { text: "About the accredited provider" },
+      card.with_summary_list(rows: [{ key: { text: "About the accredited partner" },
                                       value: { text: markdown(about_accredited_provider) },
                                       actions: [{ href: change_about_accredited_provider_path }] }])
     end %>

--- a/app/controllers/publish/courses/accredited_provider_controller.rb
+++ b/app/controllers/publish/courses/accredited_provider_controller.rb
@@ -127,7 +127,7 @@ module Publish
         if other_selected_with_no_autocompleted_code?(code) && query.length < 2
           errors = { accredited_provider: ['Accredited provider search too short, enter 2 or more characters'] }
         elsif code.blank?
-          errors = { accredited_provider_code: ['Select an accredited provider'] }
+          errors = { accredited_provider_code: ['Select a ratifying partner'] }
         end
 
         errors

--- a/app/controllers/publish/courses/accredited_provider_controller.rb
+++ b/app/controllers/publish/courses/accredited_provider_controller.rb
@@ -65,7 +65,7 @@ module Publish
         if update_params[:accredited_provider_code] == 'other'
           redirect_to_provider_search
         elsif @course.update(update_params)
-          course_updated_message('Accredited provider')
+          course_updated_message('Ratifying partner')
           redirect_to_update_successful
         else
           @errors = @course.errors.messages

--- a/app/controllers/publish/providers/accredited_providers/checks_controller.rb
+++ b/app/controllers/publish/providers/accredited_providers/checks_controller.rb
@@ -10,7 +10,7 @@ module Publish
 
         def update
           accredited_provider_form.save!
-          redirect_to publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year), flash: { success: 'Accredited provider added' }
+          redirect_to publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year), flash: { success: 'Accredited partner added' }
         end
 
         private

--- a/app/controllers/support/providers/accredited_providers/checks_controller.rb
+++ b/app/controllers/support/providers/accredited_providers/checks_controller.rb
@@ -15,7 +15,7 @@ module Support
 
           redirect_to support_recruitment_cycle_provider_accredited_providers_path(
             recruitment_cycle.year, provider.id
-          ), flash: { success: 'Accredited provider added' }
+          ), flash: { success: 'Accredited partner added' }
         end
 
         private

--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -14,7 +14,7 @@ module NavigationBarHelper
       { name: t('navigation_bar.study_sites'), url: publish_provider_recruitment_cycle_study_sites_path(provider.provider_code, provider.recruitment_cycle_year) },
       { name: t('navigation_bar.users'), url: publish_provider_users_path(provider_code: provider.provider_code), additional_url: request_access_publish_provider_path(provider.provider_code) },
       *([name: t('navigation_bar.training_partners'), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year)] if provider.accredited_provider?),
-      *([name: t('navigation_bar.accredited_provider'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)] unless provider.accredited_provider?),
+      *([name: t('navigation_bar.accredited_partnerships'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year)] unless provider.accredited_provider?),
       { name: t('navigation_bar.organisation_details'), url: details_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year) }
     ]
   end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -160,7 +160,7 @@
            row.with_action
          elsif !course.accrediting_provider.nil?
            row.with_action(href: accredited_provider_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                           visually_hidden_text: "ratifying provider")
+                           visually_hidden_text: "ratifying partner")
          elsif @provider.accredited_providers.any?
            row.with_value do
              "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Select an accredited partner', accredited_provider_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code))}</div>".html_safe

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -154,20 +154,20 @@
 
      unless @provider.accredited_provider?
        summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row|
-         row.with_key { "Accredited provider" }
+         row.with_key { "Ratifying provider" }
          row.with_value { course.accrediting_provider&.provider_name }
          if course.is_published? || course.is_withdrawn?
            row.with_action
          elsif !course.accrediting_provider.nil?
            row.with_action(href: accredited_provider_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-                           visually_hidden_text: "accredited provider")
+                           visually_hidden_text: "ratifying provider")
          elsif @provider.accredited_providers.any?
            row.with_value do
-             "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Select an accredited provider', accredited_provider_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code))}</div>".html_safe
+             "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Select an accredited partner', accredited_provider_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code))}</div>".html_safe
            end
          else
            row.with_value do
-             "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Add at least one accredited provider', publish_provider_recruitment_cycle_accredited_providers_path(@course.provider_code, @course.recruitment_cycle_year))}</div>".html_safe
+             "<div class=\"govuk-inset-text app-inset-text--narrow-border app-inset-text--important\">#{govuk_link_to('Add at least one accredited partner', publish_provider_recruitment_cycle_accredited_providers_path(@course.provider_code, @course.recruitment_cycle_year))}</div>".html_safe
            end
          end
        end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -153,8 +153,8 @@
      end
 
      unless @provider.accredited_provider?
-       summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row|
-         row.with_key { "Ratifying provider" }
+       summary_list.with_row(html_attributes: { data: { qa: "course__ratifying_partner" } }) do |row|
+         row.with_key { "Ratifying partner" }
          row.with_value { course.accrediting_provider&.provider_name }
          if course.is_published? || course.is_withdrawn?
            row.with_action

--- a/app/views/publish/courses/accredited_provider/_provider_suggestion.html.erb
+++ b/app/views/publish/courses/accredited_provider/_provider_suggestion.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-radios__item" data-qa="course__accredited_provider_option">
+<div class="govuk-radios__item" data-qa="course__ratifying_partner_option">
   <%= form.radio_button :accredited_provider_code,
     provider_suggestion[:provider_code],
     checked: provider_suggestion[:provider_code] == @course.accrediting_provider&.provider_code,

--- a/app/views/publish/courses/accredited_provider/edit.html.erb
+++ b/app/views/publish/courses/accredited_provider/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("Accredited provider – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Ratifying provider – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -10,7 +10,7 @@
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
     <h1 class="govuk-fieldset__heading">
       <%= render CaptionText.new(text: course.name_and_code) %>
-      Accredited provider
+      Ratifying provider
     </h1>
   </legend>
 
@@ -25,9 +25,9 @@
         </div>
 
         <div class="govuk-button-group">
-          <%= form.submit "Update accredited provider", class: "govuk-button govuk-!-margin-top-5", data: { qa: "course__save" } %>
+          <%= form.submit "Update ratifying provider", class: "govuk-button govuk-!-margin-top-5", data: { qa: "course__save" } %>
           <%= govuk_link_to(
-            "Add accredited provider",
+            "Add accredited partner",
             search_publish_provider_recruitment_cycle_accredited_providers_path(course.provider_code, course.recruitment_cycle_year),
             class: "govuk-!-margin-bottom-6 govuk-!-margin-top-5",
             data: { qa: "course__add" }

--- a/app/views/publish/courses/accredited_provider/edit.html.erb
+++ b/app/views/publish/courses/accredited_provider/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("Ratifying provider – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Ratifying partner – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
@@ -10,7 +10,7 @@
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
     <h1 class="govuk-fieldset__heading">
       <%= render CaptionText.new(text: course.name_and_code) %>
-      Ratifying provider
+      Ratifying partner
     </h1>
   </legend>
 
@@ -20,7 +20,7 @@
                     url: accredited_provider_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                     method: :put do |form| %>
 
-        <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__accredited_provider">
+        <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__ratifying_partner">
           <%= render partial: "provider_suggestion", collection: @provider.accredited_bodies, locals: { form: } %>
         </div>
 

--- a/app/views/publish/courses/accredited_provider/edit.html.erb
+++ b/app/views/publish/courses/accredited_provider/edit.html.erb
@@ -25,7 +25,7 @@
         </div>
 
         <div class="govuk-button-group">
-          <%= form.submit "Update ratifying provider", class: "govuk-button govuk-!-margin-top-5", data: { qa: "course__save" } %>
+          <%= form.submit "Update ratifying partner", class: "govuk-button govuk-!-margin-top-5", data: { qa: "course__save" } %>
           <%= govuk_link_to(
             "Add accredited partner",
             search_publish_provider_recruitment_cycle_accredited_providers_path(course.provider_code, course.recruitment_cycle_year),

--- a/app/views/publish/courses/accredited_provider/new.html.erb
+++ b/app/views/publish/courses/accredited_provider/new.html.erb
@@ -9,17 +9,17 @@
   <div class="govuk-grid-column-full">
   <%= form_with url: continue_publish_provider_recruitment_cycle_courses_accredited_provider_path(@provider.provider_code, @provider.recruitment_cycle_year), method: :get do |form| %>
     <%= render "publish/courses/new_fields_holder", form:, except_keys: [:accredited_provider_code] do |fields| %>
-      <%= render "publish/shared/error_wrapper", error_keys: [:accredited_provider_code], data_qa: "course__accredited_provider" do %>
+      <%= render "publish/shared/error_wrapper", error_keys: [:accredited_provider_code], data_qa: "course__ratifying_partner" do %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
             <%= render CaptionText.new(text: t("course.add_course")) %>
-            Ratifying provider
+            Ratifying partner
           </h1>
         </legend>
         <%= render "publish/shared/error_messages", error_keys: [:accredited_provider_code] %>
 
-        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_provider">
+        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__ratifying_partner">
           <% if @provider.accredited_bodies.length > 0 %>
             <%= render partial: "provider_suggestion", collection: @provider.accredited_bodies.sort_by { |k| k[:provider_name] }, locals: { form: fields } %>
           <% else %>

--- a/app/views/publish/courses/accredited_provider/new.html.erb
+++ b/app/views/publish/courses/accredited_provider/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("Ratifying provider – #{course.name_and_code}", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Ratifying partner – #{course.name_and_code}", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>

--- a/app/views/publish/courses/accredited_provider/new.html.erb
+++ b/app/views/publish/courses/accredited_provider/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("Accredited provider – #{course.name_and_code}", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Ratifying provider – #{course.name_and_code}", @errors && @errors.any?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
@@ -14,7 +14,7 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
             <%= render CaptionText.new(text: t("course.add_course")) %>
-            Accredited provider
+            Ratifying provider
           </h1>
         </legend>
         <%= render "publish/shared/error_messages", error_keys: [:accredited_provider_code] %>

--- a/app/views/publish/courses/accredited_provider/search.html.erb
+++ b/app/views/publish/courses/accredited_provider/search.html.erb
@@ -21,7 +21,7 @@
       <% if @provider_suggestions.any? %>
         <p class="govuk-body">We found these providers which matched your search:</p>
 
-        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_provider">
+        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__ratifying_partner">
           <%= render partial: "provider_suggestion", collection: @provider_suggestions, locals: { form: } %>
           <div class="govuk-radios__divider">or</div>
 

--- a/app/views/publish/courses/accredited_provider/search.html.erb
+++ b/app/views/publish/courses/accredited_provider/search.html.erb
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Pick an accredited provider
+      Pick an accredited partner
     </h1>
 
     <p class="govuk-body">You searched for ‘<%= @query %>’.</p>

--- a/app/views/publish/courses/accredited_provider/search_new.html.erb
+++ b/app/views/publish/courses/accredited_provider/search_new.html.erb
@@ -25,7 +25,7 @@
       <% if @provider_suggestions.any? %>
         <p class="govuk-body">We found these providers which matched your search:</p>
 
-        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_provider">
+        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__ratifying_partner">
           <%= render partial: "provider_suggestion", collection: @provider_suggestions, locals: { form: } %>
           <div class="govuk-radios__divider">or</div>
 

--- a/app/views/publish/courses/accredited_provider/search_new.html.erb
+++ b/app/views/publish/courses/accredited_provider/search_new.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Pick an accredited provider
+      Pick an accredited partner
     </h1>
 
     <p class="govuk-body">You searched for ‘<%= @query %>’.</p>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -158,7 +158,7 @@
             <% if @provider.accredited_bodies.length > 1 %>
               <% row.with_action(
                 href: new_publish_provider_recruitment_cycle_courses_accredited_provider_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
-                visually_hidden_text: "ratifying provider"
+                visually_hidden_text: "ratifying partner"
               ) %>
             <% else %>
               <% row.with_action %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -153,12 +153,12 @@
 
         <% unless @provider.accredited_provider? || course.is_further_education? %>
           <% summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row| %>
-            <% row.with_key { "Accredited provider" } %>
+            <% row.with_key { "Ratifying provider" } %>
             <% row.with_value { course.accrediting_provider.provider_name } %>
             <% if @provider.accredited_bodies.length > 1 %>
               <% row.with_action(
                 href: new_publish_provider_recruitment_cycle_courses_accredited_provider_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
-                visually_hidden_text: "accredited provider"
+                visually_hidden_text: "ratifying provider"
               ) %>
             <% else %>
               <% row.with_action %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -152,8 +152,8 @@
         <% end %>
 
         <% unless @provider.accredited_provider? || course.is_further_education? %>
-          <% summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row| %>
-            <% row.with_key { "Ratifying provider" } %>
+          <% summary_list.with_row(html_attributes: { data: { qa: "course__ratifying_partner" } }) do |row| %>
+            <% row.with_key { "Ratifying partner" } %>
             <% row.with_value { course.accrediting_provider.provider_name } %>
             <% if @provider.accredited_bodies.length > 1 %>
               <% row.with_action(

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -14,7 +14,7 @@
 <% @courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
   <section data-qa="courses__table-section">
     <h2 class="govuk-heading-m">
-      <span class="govuk-caption-m">Ratifying provider</span>
+      <span class="govuk-caption-m">Ratifying partner</span>
       <%= accrediting_provider %>
     </h2>
 

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -14,7 +14,7 @@
 <% @courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
   <section data-qa="courses__table-section">
     <h2 class="govuk-heading-m">
-      <span class="govuk-caption-m">Accredited provider</span>
+      <span class="govuk-caption-m">Ratifying provider</span>
       <%= accrediting_provider %>
     </h2>
 

--- a/app/views/publish/providers/accredited_provider_search/results.html.erb
+++ b/app/views/publish/providers/accredited_provider_search/results.html.erb
@@ -19,7 +19,7 @@
         <%= render search_result_title_component %>
 
         <% unless @accredited_provider_search.providers.empty? %>
-          <%= f.govuk_radio_buttons_fieldset(:provider_id, legend: { text: "Accredited provider", size: "m" }) do %>
+          <%= f.govuk_radio_buttons_fieldset(:provider_id, legend: { text: "Accredited partner", size: "m" }) do %>
             <% @accredited_provider_search.providers.each_with_index do |provider, index| %>
               <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code }, link_errors: index.zero? %>
             <% end %>

--- a/app/views/publish/providers/accredited_providers/_can_remove.html.erb
+++ b/app/views/publish/providers/accredited_providers/_can_remove.html.erb
@@ -11,7 +11,7 @@
         <%= t("publish.providers.accredited_providers.delete.title") %>
     </h1>
 
-    <%= govuk_button_to "Remove accredited provider",
+    <%= govuk_button_to "Remove accredited partner",
                         delete_publish_provider_recruitment_cycle_accredited_provider_path,
         method: :delete,
         class: "govuk-button--warning" %>

--- a/app/views/publish/providers/accredited_providers/_cannot_remove.html.erb
+++ b/app/views/publish/providers/accredited_providers/_cannot_remove.html.erb
@@ -18,7 +18,7 @@
     </p>
 
     <p class="govuk-body">
-      If you need to change an ratifying provider for a course which is published, please contact us at
+      If you need to change an ratifying partner for a course which is published, please contact us at
       <%= bat_contact_mail_to %>.
     </p>
 

--- a/app/views/publish/providers/accredited_providers/_cannot_remove.html.erb
+++ b/app/views/publish/providers/accredited_providers/_cannot_remove.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "You cannot remove this accredited provider" %>
+<% content_for :page_title, "You cannot remove this accredited partner" %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_recruitment_cycle_accredited_providers_path) %>
@@ -8,17 +8,17 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
      <span class="govuk-caption-l"><%= @accredited_provider.provider_name %></span>
-      You cannot remove this accredited provider
+      You cannot remove this accredited partner
     </h1>
 
     <p class="govuk-body">
       <%= @accredited_provider.provider_name %> is an
-      accredited provider for courses run by <%= @provider.provider_name %>. At least one of these courses is
+      ratifying partner for courses run by <%= @provider.provider_name %>. At least one of these courses is
       currently published on Find.
     </p>
 
     <p class="govuk-body">
-      If you need to change an accredited provider for a course which is published, please contact us at
+      If you need to change an ratifying provider for a course which is published, please contact us at
       <%= bat_contact_mail_to %>.
     </p>
 

--- a/app/views/publish/providers/accredited_providers/checks/show.html.erb
+++ b/app/views/publish/providers/accredited_providers/checks/show.html.erb
@@ -18,15 +18,15 @@
 
       <%= render GovukComponent::SummaryListComponent.new do |component|
             component.with_row do |row|
-              row.with_key { "Accredited provider" }
+              row.with_key { "Accredited partner" }
               row.with_value { @accredited_provider_form.provider_name }
-              row.with_action(text: "Change", href: search_publish_provider_recruitment_cycle_accredited_providers_path(goto_confirmation: true), visually_hidden_text: "accredited provider name")
+              row.with_action(text: "Change", href: search_publish_provider_recruitment_cycle_accredited_providers_path(goto_confirmation: true), visually_hidden_text: "accredited partner name")
             end
 
             component.with_row do |row|
-              row.with_key { "About the accredited provider" }
+              row.with_key { "About the accredited partner" }
               row.with_value { markdown @accredited_provider_form.description }
-              row.with_action(text: "Change", href: new_publish_provider_recruitment_cycle_accredited_provider_path(goto_confirmation: true), visually_hidden_text: "accredited provider description")
+              row.with_action(text: "Change", href: new_publish_provider_recruitment_cycle_accredited_provider_path(goto_confirmation: true), visually_hidden_text: "accredited partner description")
             end
           end %>
 

--- a/app/views/publish/providers/accredited_providers/edit.html.erb
+++ b/app/views/publish/providers/accredited_providers/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("About the accredited provider - #{@accredited_provider.provider_name}", @accredited_provider_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("About the accredited partnership - #{@accredited_provider.provider_name}", @accredited_provider_form.errors.present?) %>
 
  <%= form_with(
         model: @accredited_provider_form,

--- a/app/views/publish/providers/accredited_providers/index.html.erb
+++ b/app/views/publish/providers/accredited_providers/index.html.erb
@@ -1,12 +1,12 @@
-<% content_for :page_title, title_with_error_prefix("Accredited providers", nil) %>
+<% content_for :page_title, title_with_error_prefix("Accredited partners", nil) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Accredited providers
+      Accredited partners
     </h1>
 
-    <%= govuk_button_link_to("Add accredited provider", search_publish_provider_recruitment_cycle_accredited_providers_path(
+    <%= govuk_button_link_to("Add accredited partner", search_publish_provider_recruitment_cycle_accredited_providers_path(
       provider_code: @provider.provider_code,
       recruitment_cycle_year: @provider.recruitment_cycle_year
     )) %>
@@ -16,7 +16,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if @provider.accredited_bodies.none? %>
-        <p class="govuk-body">There are no accredited providers for <%= @provider.provider_name %>.</p>
+        <p class="govuk-body">There are no accredited partners for <%= @provider.provider_name %>.</p>
     <% else %>
       <% @provider.accredited_bodies.each do |accredited_body| %>
         <%= render AccreditedProviderComponent.new(provider_name: accredited_body[:provider_name], remove_path: delete_publish_provider_recruitment_cycle_accredited_provider_path(accredited_provider_code: accredited_body[:provider_code]), about_accredited_provider: accredited_body[:description], change_about_accredited_provider_path: edit_publish_provider_recruitment_cycle_accredited_provider_path(accredited_provider_code: accredited_body[:provider_code])) %>

--- a/app/views/publish/providers/accredited_providers/new.html.erb
+++ b/app/views/publish/providers/accredited_providers/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("About the accredited provider - Add accredited provider - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("About the accredited partnership - Add accredited partner - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
 
  <%= form_with(
         model: @accredited_provider_form,

--- a/app/views/publish/providers/training_providers/index.html.erb
+++ b/app/views/publish/providers/training_providers/index.html.erb
@@ -35,7 +35,7 @@
     <aside class="govuk-grid-column-one-third">
       <div class="app-status-box" data-qa="download-section">
         <h2 class="govuk-heading-m">Download</h2>
-        <p class="govuk-body">Export all the courses you’re the ratifying provider for.</p>
+        <p class="govuk-body">Export all the courses you’re the ratifying partner for.</p>
         <p class="govuk-body">
           <%= govuk_link_to(
             "Download as a CSV file",

--- a/app/views/publish/providers/training_providers/index.html.erb
+++ b/app/views/publish/providers/training_providers/index.html.erb
@@ -35,7 +35,7 @@
     <aside class="govuk-grid-column-one-third">
       <div class="app-status-box" data-qa="download-section">
         <h2 class="govuk-heading-m">Download</h2>
-        <p class="govuk-body">Export all the courses you’re the accredited provider for.</p>
+        <p class="govuk-body">Export all the courses you’re the ratifying provider for.</p>
         <p class="govuk-body">
           <%= govuk_link_to(
             "Download as a CSV file",

--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -8,7 +8,7 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Course name and code</th>
       <th scope="col" class="govuk-table__header">Status</th>
-      <th scope="col" class="govuk-table__header">Ratifying Provider</th>
+      <th scope="col" class="govuk-table__header">Ratifying partner</th>
       <th scope="col" class="govuk-table__header"></th>
     </tr>
   </thead>

--- a/app/views/support/providers/accredited_providers/_can_remove.html.erb
+++ b/app/views/support/providers/accredited_providers/_can_remove.html.erb
@@ -10,7 +10,7 @@
         <%= t("support.providers.accredited_providers.delete.title") %>
     </h1>
 
-    <%= govuk_button_to "Remove accredited provider",
+    <%= govuk_button_to "Remove accredited partner",
                         delete_support_recruitment_cycle_provider_accredited_provider_path,
         method: :delete,
         class: "govuk-button--warning" %>

--- a/app/views/support/providers/accredited_providers/_cannot_remove.html.erb
+++ b/app/views/support/providers/accredited_providers/_cannot_remove.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "You cannot remove this accredited provider" %>
+<% content_for :page_title, "You cannot remove this accredited partner" %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(support_recruitment_cycle_provider_accredited_providers_path) %>
 <% end %>
@@ -7,12 +7,12 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
      <span class="govuk-caption-l"><%= @accredited_provider.provider_name %></span>
-      You cannot remove this accredited provider
+      You cannot remove this accredited partner
     </h1>
 
     <p class="govuk-body">
       <%= @accredited_provider.provider_name %> is an
-      accredited provider for courses run by <%= @provider.provider_name %>. At least one of these courses is
+      ratifying partner for courses run by <%= @provider.provider_name %>. At least one of these courses is
       currently published on Find.
     </p>
 

--- a/app/views/support/providers/accredited_providers/checks/show.html.erb
+++ b/app/views/support/providers/accredited_providers/checks/show.html.erb
@@ -18,15 +18,15 @@
 
       <%= render GovukComponent::SummaryListComponent.new do |component|
             component.with_row do |row|
-              row.with_key { "Accredited provider" }
+              row.with_key { "Accredited partner" }
               row.with_value { @accredited_provider_form.provider_name }
-              row.with_action(text: "Change", href: search_support_recruitment_cycle_provider_accredited_providers_path(goto_confirmation: true), visually_hidden_text: "accredited provider name")
+              row.with_action(text: "Change", href: search_support_recruitment_cycle_provider_accredited_providers_path(goto_confirmation: true), visually_hidden_text: "accredited partner name")
             end
 
             component.with_row do |row|
-              row.with_key { "About the accredited provider" }
+              row.with_key { "About the accredited partner" }
               row.with_value { @accredited_provider_form.description }
-              row.with_action(text: "Change", href: new_support_recruitment_cycle_provider_accredited_provider_path(goto_confirmation: true), visually_hidden_text: "accredited provider description")
+              row.with_action(text: "Change", href: new_support_recruitment_cycle_provider_accredited_provider_path(goto_confirmation: true), visually_hidden_text: "accredited partner description")
             end
           end %>
 

--- a/app/views/support/providers/accredited_providers/edit.html.erb
+++ b/app/views/support/providers/accredited_providers/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("About the accredited provider - Edit accredited provider - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("About the accredited partnership - Edit accredited partner - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support/providers/accredited_providers/index.html.erb
+++ b/app/views/support/providers/accredited_providers/index.html.erb
@@ -1,9 +1,9 @@
 <%= render PageTitle.new(title: "support.providers.accredited_providers.index") %>
 
-<%= govuk_button_link_to("Add accredited provider", search_support_recruitment_cycle_provider_accredited_providers_path) %>
+<%= govuk_button_link_to("Add accredited partner", search_support_recruitment_cycle_provider_accredited_providers_path) %>
 
 <% if @accredited_providers.none? %>
-  <p class="govuk-body">There are no accredited providers for <%= @provider.provider_name %>.</p>
+  <p class="govuk-body">There are no accredited partners for <%= @provider.provider_name %>.</p>
 <% else %>
   <% @accredited_providers.each do |accredited_provider| %>
     <%= render AccreditedProviderComponent.new(

--- a/app/views/support/providers/accredited_providers/new.html.erb
+++ b/app/views/support/providers/accredited_providers/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("About the accredited provider - Add accredited provider - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("About the accredited partnership - Add accredited partner - #{@provider.name_and_code}", @accredited_provider_form.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,7 +130,7 @@ en:
     users: "Users"
     training_partners: "Training partners"
     organisation_details: "Organisation details"
-    accredited_provider: "Accredited providers"
+    accredited_provider: "Accredited partnerships"
   secondary_navigation:
     description: Description
     basic_details: Basic details
@@ -279,7 +279,7 @@ en:
             show: "User overview"
             delete: "Are you sure you want to remove this user?"
           accredited_providers:
-            index: Accredited providers
+            index: Accredited partnerships
           onboardings:
             new: "Organisation details"
           onboarding:
@@ -334,7 +334,7 @@ en:
         train_with_us:
           text: "Enter details about the training provider"
         about_accrediting_provider:
-          text: "Enter details about the accredited provider"
+          text: "Enter details about the ratifying provider"
   value_not_entered: "Not entered"
   a_level_grades:
     minimum_grade: Grade %{minimum_grade}
@@ -650,26 +650,26 @@ en:
           cannot_find: *cannot_find
       accredited_providers:
         new:
-          title: About the accredited provider
-          hint: Tell candidates about the accredited provider. You could mention their academic specialities and achievements.
-          caption: &add_accredited_provider Add accredited provider
+          title: About the accredited partnership
+          hint: Tell candidates about the accredited partner. You could mention their academic specialities and achievements.
+          caption: &add_accredited_partner Add accredited partner
         edit:
-          title: About the accredited provider
-          hint: Tell candidates about the accredited provider. You could mention their academic specialities and achievements.
-          updated: About the accredited provider updated
+          title: About the accredited partnership
+          hint: Tell candidates about the accredited partner. You could mention their academic specialities and achievements.
+          updated: About the accredited partner updated
         delete:
-          title: Are you sure you want to remove this accredited provider?
-          remove: Remove accredited provider
-          updated: Accredited provider removed
+          title: Are you sure you want to remove this accredited partner?
+          remove: Remove accredited partner
+          updated: Accredited partner removed
         checks:
           show:
-            title:  *add_accredited_provider
-            caption: *add_accredited_provider
-            add: *add_accredited_provider
+            title:  *add_accredited_partner
+            caption: *add_accredited_partner
+            add: *add_accredited_partner
       accredited_provider_search:
         new:
           title: &accredited_provider_title Enter a provider name, UKPRN or postcode
-          caption: *add_accredited_provider
+          caption: *add_accredited_partner
   search_result_title_component:
     add_school: *add_school
     many_results_html: Showing the first %{results_limit} results. %{link} if the %{search_resource} you’re looking for is not listed.
@@ -710,25 +710,25 @@ en:
       accredited_provider_search:
         new:
           title: *accredited_provider_title
-          caption: &accredited_provider_caption "Add accredited provider - %{provider_name} (%{code})"
+          caption: &accredited_provider_caption "Add accredited partner - %{provider_name} (%{code})"
       accredited_providers:
         new:
-          title: About the accredited provider
-          hint: Tell candidates about the accredited provider. You could mention their academic specialities and achievements.
-          caption: "Add accredited provider - %{provider_name} (%{code})"
+          title: About the accredited partner
+          hint: Tell candidates about the accredited partner. You could mention their academic specialities and achievements.
+          caption: "Add accredited partner - %{provider_name} (%{code})"
         edit:
-          title: About the accredited provider
-          hint: Tell candidates about the accredited provider. You could mention their academic specialities and achievements.
+          title: About the accredited partner
+          hint: Tell candidates about the accredited partner. You could mention their academic specialities and achievements.
           caption: "%{provider_name}"
-          updated: About the accredited provider updated
+          updated: About the accredited partner updated
         delete:
-          title: Are you sure you want to remove this accredited provider?
-          remove: Remove accredited provider
-          updated: Accredited provider removed
+          title: Are you sure you want to remove this accredited partner?
+          remove: Remove accredited partner
+          updated: Accredited partner removed
         checks:
           show:
             caption: *accredited_provider_caption
-            add: Add accredited provider
+            add: Add accredited partner
       provider_type:
         lead_school: "School"
         scitt: "School centred initial teacher training (SCITT)"
@@ -828,9 +828,9 @@ en:
             applications_open_from:
               blank: "Select an applications open date"
             accrediting_provider:
-              blank: "Select an accredited provider"
-              is_not_accredited: "Update the accredited provider"
-              does_not_exist_in_cycle: "The accredited provider %{accredited_provider_code} does not exist in this cycle"
+              blank: "Select an accredited partner"
+              is_not_accredited: "Update the ratifying provider"
+              does_not_exist_in_cycle: "The accredited partner %{accredited_provider_code} does not exist in this cycle"
             is_send:
               inclusion: Select if this course has a special educational needs and disability (SEND) specialism
             a_level_subject_requirements:
@@ -950,8 +950,8 @@ en:
         accredited_provider_form:
           attributes:
             description:
-              blank: Enter details about the accredited provider
-              too_long: Description about the accredited provider must be 100 words or fewer
+              blank: Enter details about the accredited partner
+              too_long: Description about the accredited partnership must be 100 words or fewer
         a_level_steps/what_a_level_is_required:
           attributes:
             subject:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -334,7 +334,7 @@ en:
         train_with_us:
           text: "Enter details about the training provider"
         about_accrediting_provider:
-          text: "Enter details about the ratifying provider"
+          text: "Enter details about the ratifying partner"
   value_not_entered: "Not entered"
   a_level_grades:
     minimum_grade: Grade %{minimum_grade}
@@ -829,7 +829,7 @@ en:
               blank: "Select an applications open date"
             accrediting_provider:
               blank: "Select an accredited partner"
-              is_not_accredited: "Update the ratifying provider"
+              is_not_accredited: "Update the ratifying partner"
               does_not_exist_in_cycle: "The accredited partner %{accredited_provider_code} does not exist in this cycle"
             is_send:
               inclusion: Select if this course has a special educational needs and disability (SEND) specialism

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -828,7 +828,7 @@ en:
             applications_open_from:
               blank: "Select an applications open date"
             accrediting_provider:
-              blank: "Select an accredited partner"
+              blank: "Select a ratifying partner"
               is_not_accredited: "Update the ratifying partner"
               does_not_exist_in_cycle: "The accredited partner %{accredited_provider_code} does not exist in this cycle"
             is_send:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,7 +130,7 @@ en:
     users: "Users"
     training_partners: "Training partners"
     organisation_details: "Organisation details"
-    accredited_provider: "Accredited partnerships"
+    accredited_partnerships: "Accredited partnerships"
   secondary_navigation:
     description: Description
     basic_details: Basic details

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,7 +79,7 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
-  provider_partnerships: false
+  provider_partnerships: true
   api_summary_content_change: true
   send_request_data_to_bigquery: false
   v2_results: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,7 +79,7 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
-  provider_partnerships: true
+  provider_partnerships: false
   api_summary_content_change: true
   send_request_data_to_bigquery: false
   v2_results: false

--- a/spec/components/accredited_provider_component_spec.rb
+++ b/spec/components/accredited_provider_component_spec.rb
@@ -17,7 +17,7 @@ describe AccreditedProviderComponent do
   end
 
   it 'renders the about_accredited_provider key' do
-    expect(component).to have_css '.govuk-summary-list__key', text: 'About the accredited provider'
+    expect(component).to have_css '.govuk-summary-list__key', text: 'About the accredited partner'
   end
 
   it 'renders the about_accredited_provider change link' do

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -52,7 +52,7 @@ module CoursePreview
       include_examples 'course with missing information', :train_with_disability, 'Enter details about training with disabilities and other needs'
 
       include_examples 'course with missing information', :train_with_us, 'Enter details about the training provider'
-      include_examples 'course with missing information', :about_accrediting_provider, 'Enter details about the accredited provider'
+      include_examples 'course with missing information', :about_accrediting_provider, 'Enter details about the ratifying provider'
     end
   end
 end

--- a/spec/components/course_preview/missing_information_component_spec.rb
+++ b/spec/components/course_preview/missing_information_component_spec.rb
@@ -52,7 +52,7 @@ module CoursePreview
       include_examples 'course with missing information', :train_with_disability, 'Enter details about training with disabilities and other needs'
 
       include_examples 'course with missing information', :train_with_us, 'Enter details about the training provider'
-      include_examples 'course with missing information', :about_accrediting_provider, 'Enter details about the ratifying provider'
+      include_examples 'course with missing information', :about_accrediting_provider, 'Enter details about the ratifying partner'
     end
   end
 end

--- a/spec/features/publish/accredited_provider_spec.rb
+++ b/spec/features/publish/accredited_provider_spec.rb
@@ -59,7 +59,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
 
     when_i_select_the_provider
     and_i_continue_without_entering_a_description
-    then_i_should_see_an_error_message('Enter details about the accredited provider')
+    then_i_should_see_an_error_message('Enter details about the accredited partner')
 
     when_i_input_some_information
     then_i_should_see_the_information_i_added
@@ -73,13 +73,13 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
 
   scenario 'back links behaviour' do
     given_i_am_on_the_confirm_page
-    when_i_click_the_change_link_for('accredited provider name')
+    when_i_click_the_change_link_for('accredited partner name')
     then_i_should_be_taken_to_the_accredited_provider_search_page
 
     when_i_click_the_back_link
     then_i_should_be_taken_back_to_the_confirm_page
 
-    when_i_click_the_change_link_for('accredited provider description')
+    when_i_click_the_change_link_for('accredited partner description')
     then_i_should_be_taken_to_the_accredited_provider_description_page
 
     when_i_click_the_back_link
@@ -89,11 +89,11 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   private
 
   def and_i_click_remove_ap
-    click_link_or_button 'Remove accredited provider'
+    click_link_or_button 'Remove accredited partner'
   end
 
   def then_i_should_see_the_cannot_remove_ap_text
-    expect(page).to have_css('h1', text: 'You cannot remove this accredited provider')
+    expect(page).to have_css('h1', text: 'You cannot remove this accredited partner')
   end
 
   def and_i_click_remove
@@ -157,15 +157,15 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def and_i_should_see_a_success_message
-    expect(page).to have_content('Accredited provider added')
+    expect(page).to have_content('Accredited partner added')
   end
 
   def and_i_see_the_success_message
-    expect(page).to have_content('About the accredited provider updated')
+    expect(page).to have_content('About the accredited partner updated')
   end
 
   def and_i_see_the_remove_success_message
-    expect(page).to have_content('Accredited provider removed')
+    expect(page).to have_content('Accredited partner removed')
   end
 
   def then_i_should_be_taken_to_the_index_page
@@ -174,7 +174,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
 
   def when_i_confirm_the_changes
     expect do
-      click_link_or_button 'Add accredited provider'
+      click_link_or_button 'Add accredited partner'
     end.to have_enqueued_email(Users::OrganisationMailer, :added_as_an_organisation_to_training_partner)
   end
 
@@ -189,12 +189,12 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   alias_method :then_i_should_see_the_description, :then_i_should_see_the_information_i_added
 
   def when_i_input_some_information
-    fill_in 'About the accredited provider', with: 'This is a description'
+    fill_in 'About the accredited partner', with: 'This is a description'
     click_continue
   end
 
   def when_i_input_some_different_information
-    fill_in 'About the accredited provider', with: 'updates to the AP description'
+    fill_in 'About the accredited partner', with: 'updates to the AP description'
     click_link_or_button 'Update description'
   end
 
@@ -244,15 +244,15 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def when_i_click_add_accredited_provider
-    click_link_or_button 'Add accredited provider'
+    click_link_or_button 'Add accredited partner'
   end
 
   def then_i_see_the_correct_text_for_no_accredited_providers
-    expect(page).to have_text("There are no accredited providers for #{@provider.provider_name}")
+    expect(page).to have_text("There are no accredited partners for #{@provider.provider_name}")
   end
 
   def when_i_click_on_the_accredited_provider_tab
-    click_link_or_button 'Accredited provider'
+    click_link_or_button 'Accredited partner'
   end
 
   alias_method :and_i_click_on_the_accredited_provider_tab, :when_i_click_on_the_accredited_provider_tab
@@ -277,7 +277,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   alias_method :and_i_continue_without_entering_a_description, :click_continue
 
   def and_my_provider_has_accrediting_providers
-    course = build(:course, accrediting_provider: build(:provider, :accredited_provider, provider_name: 'Accrediting provider name'))
+    course = build(:course, accrediting_provider: build(:provider, :accredited_provider, provider_name: 'Accrediting partner name'))
 
     @provider.courses << course
     @provider.update(
@@ -288,6 +288,6 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def then_i_should_see_the_accredited_provider_name_displayed
-    expect(page).to have_css('h2', text: 'Accrediting provider name')
+    expect(page).to have_css('h2', text: 'Accrediting partner name')
   end
 end

--- a/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
@@ -104,7 +104,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
-    expect(publish_provider_courses_show_page.error_messages).to include('Update the accredited provider')
+    expect(publish_provider_courses_show_page.error_messages).to include('Update the ratifying provider')
   end
 
   def then_i_should_see_an_error_message_for_the_accrediting_provider
@@ -142,7 +142,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def then_i_see_that_the_accredited_provider_has_been_added
-    expect(page).to have_content('Accredited provider added')
+    expect(page).to have_content('Ratifying partner added')
   end
 
   def and_i_click_the_publish_button
@@ -150,13 +150,13 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def when_i_click_the_select_accredited_provider_error_message_link
-    page.click_link_or_button('Select an accredited provider')
+    page.click_link_or_button('Select an ratifying partner')
   end
 
   def and_i_choose_the_new_accredited_provider
     choose accredited_provider.provider_name
-    page.click_link_or_button('Update accredited provider')
-    expect(page).to have_content('Accredited provider updated')
+    page.click_link_or_button('Update ratifying partner')
+    expect(page).to have_content('Ratifying partner updated')
   end
 
   def and_an_accredited_provider_exists

--- a/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_accredited_provider_when_publishing_a_course_spec.rb
@@ -7,8 +7,8 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
     given_i_am_authenticated_as_a_provider_user
   end
 
-  scenario 'Add accrediting provider to provider and provider has no accrediting providers, change accrediting provider of course then publish' do
-    and_the_provider_has_no_accredited_provider
+  scenario 'Add ratifying provider to training provider and provider has no accredited partner, change ratifying provider of course then publish' do
+    and_the_provider_has_no_accredited_partners
     and_there_is_a_draft_course_with_an_unaccredited_provider
 
     # Publising is invalid
@@ -68,7 +68,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
     provider.update!(accrediting_provider_enrichments: [enrichment])
   end
 
-  def and_the_provider_has_no_accredited_provider
+  def and_the_provider_has_no_accredited_partners
     expect(provider.accredited_providers).to be_empty
   end
 
@@ -104,11 +104,11 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
-    expect(publish_provider_courses_show_page.error_messages).to include('Update the ratifying provider')
+    expect(publish_provider_courses_show_page.error_messages).to include('Update the ratifying partner')
   end
 
   def then_i_should_see_an_error_message_for_the_accrediting_provider
-    expect(publish_provider_courses_show_page.error_messages).to include('Select an accredited provider')
+    expect(publish_provider_courses_show_page.error_messages).to include('Select a ratifying partner')
   end
 
   def when_i_click_the_error_message_link
@@ -142,7 +142,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def then_i_see_that_the_accredited_provider_has_been_added
-    expect(page).to have_content('Ratifying partner added')
+    expect(page).to have_content('Accredited partner added')
   end
 
   def and_i_click_the_publish_button
@@ -150,7 +150,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def when_i_click_the_select_accredited_provider_error_message_link
-    page.click_link_or_button('Select an ratifying partner')
+    page.click_link_or_button('Select a ratifying partner')
   end
 
   def and_i_choose_the_new_accredited_provider

--- a/spec/features/publish/courses/add_ratifying_partner_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_ratifying_partner_when_publishing_a_course_spec.rb
@@ -132,13 +132,13 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
   end
 
   def and_i_fill_in_the_accredited_provider_form
-    publish_courses_new_accredited_provider_page.about_section_input.set('About course')
+    publish_courses_new_ratifying_partner_page.about_section_input.set('About course')
 
-    publish_courses_new_accredited_provider_page.submit.click
+    publish_courses_new_ratifying_partner_page.submit.click
   end
 
   def and_i_confirm_creation_of_the_accredited_provider
-    publish_courses_new_accredited_provider_page.submit.click
+    publish_courses_new_ratifying_partner_page.submit.click
   end
 
   def then_i_see_that_the_accredited_provider_has_been_added

--- a/spec/features/publish/courses/add_ratifying_partner_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_ratifying_partner_when_publishing_a_course_spec.rb
@@ -14,7 +14,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
     # Publising is invalid
     when_i_visit_the_course_page
     and_i_click_the_publish_button
-    then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
+    then_i_should_see_an_error_message_that_ratifying_provider_is_not_accredited
 
     # Add accrediting provider to provider
     when_i_click_the_error_message_link
@@ -28,11 +28,11 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
     # Publishing is invalid
     when_i_visit_the_course_page
     and_i_click_the_publish_button
-    then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
+    then_i_should_see_an_error_message_that_ratifying_provider_is_not_accredited
 
     # Clicking error message allows user to select accrediting provider
     when_i_click_the_error_message_link
-    and_i_choose_the_new_accredited_provider
+    and_i_choose_the_new_accredited_partner
     and_i_click_the_publish_button
     then_i_should_see_a_success_message
   end
@@ -49,7 +49,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
 
     # Clicking error message allows user to select accrediting provider
     when_i_click_the_select_accredited_provider_error_message_link
-    and_i_choose_the_new_accredited_provider
+    and_i_choose_the_new_accredited_partner
     and_i_click_the_publish_button
     then_i_should_see_a_success_message
   end
@@ -103,7 +103,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
     expect(page).to have_content('Your course has been published.')
   end
 
-  def then_i_should_see_an_error_message_that_accredited_provider_is_not_accredited
+  def then_i_should_see_an_error_message_that_ratifying_provider_is_not_accredited
     expect(publish_provider_courses_show_page.error_messages).to include('Update the ratifying partner')
   end
 
@@ -153,7 +153,7 @@ feature 'Publishing a course when course accrediting provider is invalid', { can
     page.click_link_or_button('Select a ratifying partner')
   end
 
-  def and_i_choose_the_new_accredited_provider
+  def and_i_choose_the_new_accredited_partner
     choose accredited_provider.provider_name
     page.click_link_or_button('Update ratifying partner')
     expect(page).to have_content('Ratifying partner updated')

--- a/spec/features/publish/courses/adding_an_accredited_provider_to_an_unpublished_course_spec.rb
+++ b/spec/features/publish/courses/adding_an_accredited_provider_to_an_unpublished_course_spec.rb
@@ -2,44 +2,44 @@
 
 require 'rails_helper'
 
-feature 'unpublished course without accredited provider', { can_edit_current_and_next_cycles: false } do
-  scenario 'adding and changing an accredited provider' do
+feature 'unpublished course without ratifying provider', { can_edit_current_and_next_cycles: false } do
+  scenario 'adding and changing an ratifying provider' do
     given_i_am_authenticated_as_a_provider_user
-    and_i_visit_the_course_details_page_of_a_course_without_an_accredited_provider
+    and_i_visit_the_course_details_page_of_a_course_without_an_ratifying_provider
     and_i_click_the_add_accredited_provider_link
-    and_i_create_a_new_accredited_provider
+    and_i_create_a_new_accredited_partnership
     and_i_revisit_the_course_details_page
-    when_i_click_select_an_accredited_provider
-    and_i_choose_the_new_accredited_provider
+    when_i_click_select_an_accredited_partner
+    and_i_choose_the_new_ratifying_provider
     then_i_should_see_the_success_message
 
-    given_i_click_change_accredited_provider
-    and_i_click_update_accredited_provider
+    given_i_click_change_ratifying_partner
+    and_i_click_update_ratifying_provider
     then_i_should_see_the_success_message
   end
 
-  def given_i_click_change_accredited_provider
-    click_link_or_button 'Change accredited provider'
+  def given_i_click_change_ratifying_partner
+    click_link_or_button 'Change ratifying partner'
   end
 
   def then_i_should_see_the_success_message
-    expect(page).to have_text('Accredited provider updated')
+    expect(page).to have_text('Ratifying partner updated')
   end
 
-  def and_i_click_update_accredited_provider
-    click_link_or_button 'Update accredited provider'
+  def and_i_click_update_ratifying_provider
+    click_link_or_button 'Update ratifying partner'
   end
 
-  def and_i_choose_the_new_accredited_provider
+  def and_i_choose_the_new_ratifying_provider
     choose @accredited_provider.provider_name
-    and_i_click_update_accredited_provider
+    and_i_click_update_ratifying_provider
   end
 
-  def when_i_click_select_an_accredited_provider
-    click_link_or_button 'Select an accredited provider'
+  def when_i_click_select_an_accredited_partner
+    click_link_or_button 'Select an accredited partner'
   end
 
-  def and_i_create_a_new_accredited_provider
+  def and_i_create_a_new_accredited_partnership
     and_there_is_an_accredited_provider_in_the_database
     and_i_click_add_accredited_provider_link
     and_i_search_for_an_accredited_provider_with_a_valid_query
@@ -54,7 +54,7 @@ feature 'unpublished course without accredited provider', { can_edit_current_and
   end
 
   def and_i_input_some_information
-    fill_in 'About the accredited provider', with: 'This is a description'
+    fill_in 'About the accredited partner', with: 'This is a description'
     click_continue
   end
 
@@ -76,15 +76,15 @@ feature 'unpublished course without accredited provider', { can_edit_current_and
   end
 
   def and_i_click_the_add_accredited_provider_link
-    click_link_or_button 'Add at least one accredited provider'
+    click_link_or_button 'Add at least one accredited partner'
   end
 
   def and_i_click_add_accredited_provider_link
-    click_link_or_button 'Add accredited provider'
+    click_link_or_button 'Add accredited partner'
   end
 
   def and_i_click_add_accredited_provider_button
-    click_link_or_button 'Add accredited provider'
+    click_link_or_button 'Add accredited partner'
   end
 
   def given_i_am_authenticated_as_a_provider_user
@@ -98,13 +98,13 @@ feature 'unpublished course without accredited provider', { can_edit_current_and
     )
   end
 
-  def and_i_visit_the_course_details_page_of_a_course_without_an_accredited_provider
+  def and_i_visit_the_course_details_page_of_a_course_without_an_ratifying_provider
     publish_provider_courses_details_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code
     )
   end
 
-  alias_method :and_i_revisit_the_course_details_page, :and_i_visit_the_course_details_page_of_a_course_without_an_accredited_provider
+  alias_method :and_i_revisit_the_course_details_page, :and_i_visit_the_course_details_page_of_a_course_without_an_ratifying_provider
 
   def provider
     @current_user.providers.first

--- a/spec/features/publish/courses/new_accredited_provider_spec.rb
+++ b/spec/features/publish/courses/new_accredited_provider_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 feature 'selection accredited_bodies', { can_edit_current_and_next_cycles: false } do
   before do
     given_i_am_authenticated_as_a_provider_user
-    when_i_visit_the_new_accredited_providers_page
+    when_i_visit_the_new_ratifying_partner_page
   end
 
   scenario 'selecting multiple accredited_bodies' do
-    when_i_select_an_accredited_provider
+    when_i_select_a_ratifying_partner
     and_i_click_continue
     then_i_am_met_with_the_applications_open_page
   end
@@ -33,16 +33,16 @@ feature 'selection accredited_bodies', { can_edit_current_and_next_cycles: false
     given_i_am_authenticated(user: @user)
   end
 
-  def when_i_visit_the_new_accredited_providers_page
-    publish_courses_new_accredited_provider_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: accredited_provider_params)
+  def when_i_visit_the_new_ratifying_partner_page
+    publish_courses_new_ratifying_partner_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: accredited_provider_params)
   end
 
-  def when_i_select_an_accredited_provider
-    publish_courses_new_accredited_provider_page.find("#course_accredited_provider_code_#{@accredited_provider_code.downcase}").click
+  def when_i_select_a_ratifying_partner
+    publish_courses_new_ratifying_partner_page.find("#course_accredited_provider_code_#{@accredited_provider_code.downcase}").click
   end
 
   def and_i_click_continue
-    publish_courses_new_accredited_provider_page.continue.click
+    publish_courses_new_ratifying_partner_page.continue.click
   end
 
   def provider
@@ -56,6 +56,6 @@ feature 'selection accredited_bodies', { can_edit_current_and_next_cycles: false
 
   def then_i_am_met_with_errors
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content('Select an accredited provider')
+    expect(page).to have_content('Select a ratifying partner')
   end
 end

--- a/spec/features/publish/courses/new_schools_spec.rb
+++ b/spec/features/publish/courses/new_schools_spec.rb
@@ -12,7 +12,7 @@ feature 'selection schools', { can_edit_current_and_next_cycles: false } do
   scenario 'selecting multiple schools' do
     when_i_select_a_school
     and_i_click_continue
-    then_i_am_met_with_the_accredited_provider_page
+    then_i_am_met_with_the_ratifying_partner_page
   end
 
   scenario 'invalid entries' do
@@ -48,9 +48,9 @@ feature 'selection schools', { can_edit_current_and_next_cycles: false } do
     @provider ||= @user.providers.first
   end
 
-  def then_i_am_met_with_the_accredited_provider_page
+  def then_i_am_met_with_the_ratifying_partner_page
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/accredited-provider/new", ignore_query: true)
-    expect(page).to have_content('Ratifying provider')
+    expect(page).to have_content('Ratifying partner')
   end
 
   def then_i_am_met_with_errors

--- a/spec/features/publish/courses/new_schools_spec.rb
+++ b/spec/features/publish/courses/new_schools_spec.rb
@@ -50,7 +50,7 @@ feature 'selection schools', { can_edit_current_and_next_cycles: false } do
 
   def then_i_am_met_with_the_accredited_provider_page
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/accredited-provider/new", ignore_query: true)
-    expect(page).to have_content('Accredited provider')
+    expect(page).to have_content('Ratifying provider')
   end
 
   def then_i_am_met_with_errors

--- a/spec/features/publish/ratifying_partner_spec.rb
+++ b/spec/features/publish/ratifying_partner_spec.rb
@@ -2,26 +2,26 @@
 
 require 'rails_helper'
 
-feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } do
+feature 'Ratifying partner flow', { can_edit_current_and_next_cycles: false } do
   before do
     given_i_am_a_lead_school_provider_user
     and_i_visit_the_root_path
-    when_i_click_on_the_accredited_provider_tab
+    when_i_click_on_the_accredited_partners_tab
   end
 
-  scenario 'i can view the accredited providers tab when there are none' do
-    then_i_see_the_correct_text_for_no_accredited_providers
+  scenario 'i can view the accredited partnerships tab when there are none' do
+    then_i_see_the_correct_text_for_no_accredited_partners
   end
 
-  scenario 'i can view accredited providers on the index page' do
-    and_my_provider_has_accrediting_providers
-    and_i_click_on_the_accredited_provider_tab
-    then_i_should_see_the_accredited_provider_name_displayed
+  scenario 'i can view accredited partners on the index page' do
+    and_my_provider_has_accrediting_partners
+    and_i_click_on_the_accredited_partners_tab
+    then_i_should_see_the_accredited_partners_name_displayed
   end
 
-  scenario 'i can edit accredited providers on the index page' do
-    and_my_provider_has_accrediting_providers
-    and_i_click_on_the_accredited_provider_tab
+  scenario 'i can edit accredited partners on the index page' do
+    and_my_provider_has_accrediting_partners
+    and_i_click_on_the_accredited_partners_tab
     and_i_click_change
 
     when_i_input_some_different_information
@@ -29,24 +29,24 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     and_i_see_the_success_message
   end
 
-  scenario 'i cannot delete accredited providers if they are attached to a course' do
-    and_my_provider_has_accrediting_providers
-    and_i_click_on_the_accredited_provider_tab
+  scenario 'i cannot delete accredited partners if they are attached to a course' do
+    and_my_provider_has_accrediting_partners
+    and_i_click_on_the_accredited_partners_tab
     and_i_click_remove
     then_i_should_see_the_cannot_remove_ap_text
   end
 
-  scenario 'i can delete accredited providers if they are not attached to a course' do
-    and_i_create_a_new_accredited_provider
+  scenario 'i can delete accredited partners if they are not attached to a course' do
+    and_i_create_a_new_accredited_partner
     and_i_click_remove
     and_i_click_remove_ap
     and_i_see_the_remove_success_message
     then_i_should_be_taken_to_the_index_page
   end
 
-  scenario 'i can search for an accredited provider when they are searchable' do
+  scenario 'i can search for an accredited partners when they are searchable' do
     given_there_are_accredited_providers_in_the_database_with_users
-    when_i_click_add_accredited_provider
+    when_i_click_add_accredited_partner
     and_i_search_with_an_invalid_query
     then_i_should_see_an_error_message
 
@@ -68,7 +68,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     then_i_should_be_taken_to_the_index_page
     and_the_accredited_provider_is_saved_to_the_database
     and_i_should_see_a_success_message
-    and_i_should_see_the_accredited_providers
+    and_i_should_see_the_accredited_partners
   end
 
   scenario 'back links behaviour' do
@@ -100,9 +100,9 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     click_link_or_button 'Remove'
   end
 
-  def and_i_create_a_new_accredited_provider
+  def and_i_create_a_new_accredited_partner
     given_there_are_accredited_providers_in_the_database_with_users
-    when_i_click_add_accredited_provider
+    when_i_click_add_accredited_partner
     when_i_search_for_an_accredited_provider_with_a_valid_query
     when_i_select_the_provider
     when_i_input_some_information
@@ -113,7 +113,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     click_link_or_button('Change')
   end
 
-  def and_i_should_see_the_accredited_providers
+  def and_i_should_see_the_accredited_partners
     expect(page).to have_css('.govuk-summary-card', count: 1)
     expect(page).to have_content(@accredited_provider.provider_name)
   end
@@ -150,7 +150,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
 
   def given_i_am_on_the_confirm_page
     given_there_are_accredited_providers_in_the_database_with_users
-    when_i_click_add_accredited_provider
+    when_i_click_add_accredited_partner
     when_i_search_for_an_accredited_provider_with_a_valid_query
     when_i_select_the_provider
     when_i_input_some_information
@@ -243,19 +243,19 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     click_continue
   end
 
-  def when_i_click_add_accredited_provider
+  def when_i_click_add_accredited_partner
     click_link_or_button 'Add accredited partner'
   end
 
-  def then_i_see_the_correct_text_for_no_accredited_providers
+  def then_i_see_the_correct_text_for_no_accredited_partners
     expect(page).to have_text("There are no accredited partners for #{@provider.provider_name}")
   end
 
-  def when_i_click_on_the_accredited_provider_tab
+  def when_i_click_on_the_accredited_partners_tab
     click_link_or_button 'Accredited partner'
   end
 
-  alias_method :and_i_click_on_the_accredited_provider_tab, :when_i_click_on_the_accredited_provider_tab
+  alias_method :and_i_click_on_the_accredited_partners_tab, :when_i_click_on_the_accredited_partners_tab
 
   def and_i_visit_the_root_path
     visit root_path
@@ -276,7 +276,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
 
   alias_method :and_i_continue_without_entering_a_description, :click_continue
 
-  def and_my_provider_has_accrediting_providers
+  def and_my_provider_has_accrediting_partners
     course = build(:course, accrediting_provider: build(:provider, :accredited_provider, provider_name: 'Accrediting partner name'))
 
     @provider.courses << course
@@ -287,7 +287,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
     )
   end
 
-  def then_i_should_see_the_accredited_provider_name_displayed
+  def then_i_should_see_the_accredited_partners_name_displayed
     expect(page).to have_css('h2', text: 'Accrediting partner name')
   end
 end

--- a/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/support/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -22,7 +22,7 @@ feature 'Searching for an accredited provider' do
 
     when_i_select_the_provider
     and_i_continue_without_entering_a_description
-    then_i_should_see_an_error_message('Enter details about the accredited provider')
+    then_i_should_see_an_error_message('Enter details about the accredited partner')
 
     when_i_enter_a_description
     and_i_confirm_the_changes
@@ -33,13 +33,13 @@ feature 'Searching for an accredited provider' do
 
   scenario 'back links behaviour' do
     when_i_am_on_the_confirm_page
-    and_i_click_the_change_link_for('accredited provider name')
+    and_i_click_the_change_link_for('accredited partner name')
     then_i_should_be_taken_to_the_accredited_provider_search_page
     when_i_click_the_back_link
     then_i_should_be_taken_back_to_the_confirm_page
 
     when_i_am_on_the_confirm_page
-    and_i_click_the_change_link_for('accredited provider description')
+    and_i_click_the_change_link_for('accredited partner description')
     then_i_should_be_taken_to_the_accredited_provider_description_page
     when_i_click_the_back_link
     then_i_should_be_taken_back_to_the_confirm_page
@@ -109,18 +109,18 @@ feature 'Searching for an accredited provider' do
   end
 
   def when_i_enter_a_description
-    fill_in 'About the accredited provider', with: 'This is a description'
+    fill_in 'About the accredited partner', with: 'This is a description'
     click_continue
   end
 
   def and_i_confirm_the_changes
     expect do
-      click_link_or_button 'Add accredited provider'
+      click_link_or_button 'Add accredited partner'
     end.to have_enqueued_email(Users::OrganisationMailer, :added_as_an_organisation_to_training_partner)
   end
 
   def and_i_should_see_a_success_message
-    expect(page).to have_content('Accredited provider added')
+    expect(page).to have_content('Accredited partner added')
   end
 
   def and_i_should_see_the_accredited_providers

--- a/spec/features/support/providers/accredited_providers_spec.rb
+++ b/spec/features/support/providers/accredited_providers_spec.rb
@@ -62,15 +62,15 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   def and_i_see_the_remove_success_message; end
 
   def and_i_click_remove_ap
-    click_link_or_button 'Remove accredited provider'
+    click_link_or_button 'Remove accredited partner'
   end
 
   def and_i_confirm_the_changes
-    click_link_or_button 'Add accredited provider'
+    click_link_or_button 'Add accredited partner'
   end
 
   def when_i_input_new_information
-    fill_in 'About the accredited provider', with: 'New AP description'
+    fill_in 'About the accredited partner', with: 'New AP description'
     click_link_or_button 'Continue'
   end
 
@@ -89,7 +89,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def and_i_click_add_accredited_provider
-    click_link_or_button 'Add accredited provider'
+    click_link_or_button 'Add accredited partner'
   end
 
   def and_i_click_remove
@@ -97,7 +97,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def then_i_should_see_the_cannot_remove_text
-    expect(page).to have_css('h1', text: 'You cannot remove this accredited provider')
+    expect(page).to have_css('h1', text: 'You cannot remove this accredited partner')
   end
 
   def given_i_am_authenticated_as_an_admin_user
@@ -134,7 +134,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def and_i_see_the_success_message
-    expect(page).to have_content('About the accredited provider updated')
+    expect(page).to have_content('About the accredited partner updated')
   end
 
   def then_i_should_see_the_updated_description
@@ -142,12 +142,12 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def when_i_input_updated_description
-    fill_in 'About the accredited provider', with: 'update the AP description'
+    fill_in 'About the accredited partner', with: 'update the AP description'
     click_link_or_button 'Update description'
   end
 
   def then_i_see_the_correct_text_for_no_accredited_providers
-    expect(page).to have_text("There are no accredited providers for #{@provider.provider_name}")
+    expect(page).to have_text("There are no accredited partners for #{@provider.provider_name}")
   end
 
   def and_i_click_on_the_accredited_provider_tab
@@ -155,7 +155,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   end
 
   def and_my_provider_has_accrediting_providers
-    course = build(:course, accrediting_provider: build(:provider, :accredited_provider, provider_name: 'Accrediting provider name'))
+    course = build(:course, accrediting_provider: build(:provider, :accredited_provider, provider_name: 'Accrediting partner name'))
 
     @provider.courses << course
     @provider.update(
@@ -168,7 +168,7 @@ feature 'Accredited provider flow', { can_edit_current_and_next_cycles: false } 
   def then_i_should_see_the_accredited_provider_name_displayed
     expect(page).to have_css(
       'h2.govuk-summary-card__title a.govuk-link',
-      text: 'Accrediting provider name'
+      text: 'Accrediting partner name'
     )
   end
 end

--- a/spec/helpers/navigation_bar_helper_spec.rb
+++ b/spec/helpers/navigation_bar_helper_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe NavigationBarHelper do
       helper.navigation_items(provider)
     end
 
-    let(:accredited_provider_item) { subject.find { |item| item[:name] == 'Accredited providers' } }
+    let(:accredited_partnerships_item) { subject.find { |item| item[:name] == 'Accredited partnerships' } }
 
     context 'when provider is an accredited provider' do
       let(:provider) { create(:provider, :accredited_provider) }
 
       it 'does not include accredited_provider in items' do
-        expect(accredited_provider_item).to be_nil
+        expect(accredited_partnerships_item).to be_nil
       end
     end
 
@@ -22,11 +22,11 @@ RSpec.describe NavigationBarHelper do
       let(:provider) { create(:provider) }
 
       it 'includes accredited_provider in items' do
-        expect(accredited_provider_item).not_to be_nil
+        expect(accredited_partnerships_item).not_to be_nil
       end
 
       it 'includes the correct link to accredited providers' do
-        expect(accredited_provider_item[:url]).to eq publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle.year)
+        expect(accredited_partnerships_item[:url]).to eq publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle.year)
       end
     end
   end

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -15,7 +15,7 @@ describe '#publishable?' do
     expect(course).not_to be_publishable
     expect(course.errors.messages).to eq(
       { sites: ['^Select at least one school'],
-        accrediting_provider: ['Select an accredited provider'],
+        accrediting_provider: ['Select an accredited partner'],
         about_course: ['^Enter information about this course'],
         how_school_placements_work: ['^Enter details about how placements work'],
         course_length: ['^Enter a course length'],
@@ -24,7 +24,7 @@ describe '#publishable?' do
     )
   end
 
-  context 'when associated accredited provider is no longer accredited' do
+  context 'when associated accredited partner is no longer accredited' do
     let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
     let(:primary_with_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
     let(:course) do

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -15,7 +15,7 @@ describe '#publishable?' do
     expect(course).not_to be_publishable
     expect(course.errors.messages).to eq(
       { sites: ['^Select at least one school'],
-        accrediting_provider: ['Select an accredited partner'],
+        accrediting_provider: ['Select a ratifying partner'],
         about_course: ['^Enter information about this course'],
         how_school_placements_work: ['^Enter details about how placements work'],
         course_length: ['^Enter a course length'],

--- a/spec/support/page_objects/find/course_show.rb
+++ b/spec/support/page_objects/find/course_show.rb
@@ -8,7 +8,7 @@ module PageObjects
       element :page_heading, '.govuk-heading-xl'
       element :sub_title, '[data-qa=course__provider_name]'
       element :extended_qualification_descriptions, '[data-qa=course__extended_qualification_descriptions]'
-      element :accredited_provider, '[data-qa=course__accredited_provider]'
+      element :accredited_provider, '[data-qa=course__ratifying_partner]'
       element :provider_website, '[data-qa=course__provider_website]'
       element :vacancies, '[data-qa=course__vacancies]'
       element :about_course, '[data-qa=course__about_course]'

--- a/spec/support/page_objects/publish/course_confirmation.rb
+++ b/spec/support/page_objects/publish/course_confirmation.rb
@@ -24,7 +24,7 @@ module PageObjects
         section :study_mode, SummaryList, '[data-qa=course__study_mode]'
         section :schools, SummaryList, '[data-qa=course__schools]'
         section :study_sites, SummaryList, '[data-qa=course__study_sites]'
-        section :accredited_provider, SummaryList, '[data-qa=course__accredited_provider]'
+        section :accredited_provider, SummaryList, '[data-qa=course__ratifying_partner]'
         section :applications_open, SummaryList, '[data-qa=course__applications_open]'
         section :start_date, SummaryList, '[data-qa=course__start_date]'
         section :name, SummaryList, '[data-qa=course__name]'

--- a/spec/support/page_objects/publish/course_preview.rb
+++ b/spec/support/page_objects/publish/course_preview.rb
@@ -7,7 +7,7 @@ module PageObjects
 
       element :sub_title, '[data-qa=course__provider_name]'
       element :description, '[data-qa=course__description]'
-      element :accredited_provider, '[data-qa=course__accredited_provider]'
+      element :accredited_provider, '[data-qa=course__ratifying_partner]'
       element :provider_website, '[data-qa=course__provider_website]'
       element :vacancies, '[data-qa=course__vacancies]'
       element :about_course, '[data-qa=course__about_course]'

--- a/spec/support/page_objects/publish/courses/accredited_providers.rb
+++ b/spec/support/page_objects/publish/courses/accredited_providers.rb
@@ -6,7 +6,7 @@ module PageObjects
       class AccreditedProviders < PageObjects::Base
         set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/accredited-provider'
 
-        elements :suggested_accredited_bodies, '[data-qa="course__accredited_provider_option"]'
+        elements :suggested_accredited_bodies, '[data-qa="course__ratifying_partner_option"]'
         element :add_new_link, '[data-qa="course__add"]'
 
         element :update_button, 'input[type=submit]'

--- a/spec/support/page_objects/publish/courses/new_accredited_provider.rb
+++ b/spec/support/page_objects/publish/courses/new_accredited_provider.rb
@@ -6,7 +6,7 @@ module PageObjects
       class NewAccreditedProvider < PageObjects::Base
         set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/accredited-provider/new{?query*}'
 
-        elements :suggested_accredited_bodies, '[data-qa="course__accredited_provider_option"]'
+        elements :suggested_accredited_bodies, '[data-qa="course__ratifying_partner_option"]'
 
         element :continue, '[data-qa="course__save"]'
         element :about_section_input, 'textarea'

--- a/spec/support/page_objects/publish/courses/new_ratifying_partner.rb
+++ b/spec/support/page_objects/publish/courses/new_ratifying_partner.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Publish
     module Courses
-      class NewAccreditedProvider < PageObjects::Base
+      class NewRatifyingPartner < PageObjects::Base
         set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/accredited-provider/new{?query*}'
 
         elements :suggested_accredited_bodies, '[data-qa="course__ratifying_partner_option"]'

--- a/spec/support/page_objects/publish/provider_courses_details.rb
+++ b/spec/support/page_objects/publish/provider_courses_details.rb
@@ -19,7 +19,7 @@ module PageObjects
       section :funding, Sections::SummaryList, '[data-qa="course__funding"]'
       section :study_mode, Sections::SummaryList, '[data-qa="course__study_mode"]'
       section :schools, Sections::SummaryList, '[data-qa="course__schools"]'
-      section :accredited_provider, Sections::SummaryList, '[data-qa="course__accredited_provider"]'
+      section :accredited_provider, Sections::SummaryList, '[data-qa="course__ratifying_partner"]'
       section :applications_open, Sections::SummaryList, '[data-qa="course__applications_open"]'
       section :start_date, Sections::SummaryList, '[data-qa="course__start_date"]'
       section :contact_support_link, Sections::SummaryList, '[data-qa="course__contact_support_link"]'


### PR DESCRIPTION
## Context

|Label| Meaning|
|---|----|
|Providers| All providers|
|Training provider| A provider that runs ITT training courses|
|Accredited provider|A provider that is accredited by DfE|
|Training partner|The training provider in a provider partnership association|
|Accredited partner|The accredited provider in a provider partnership association|
|Ratifying partner|The Accredited partner that ratifies the course of a Training partner|


The wording in specs still needs to be changed.
For example

```
  scenario 'i can edit accredited providers on the index page' do
```

Needs to change to `accredited partners`. This is WIP until all the wording is updated.

## Changes proposed in this pull request

Update all the UI labels and text to accurately convey the concepts above.

## Guidance to review

`Accredited partners` V `Accredited partnerships`
