### PR TITLE
PART 1 - Add secondary filter to the v2 results page 

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -22,6 +22,7 @@ module Find
           :applications_open,
           :further_education,
           :funding,
+          subjects: [],
           study_types: [],
           qualifications: [],
           funding: []

--- a/app/forms/search_courses_form.rb
+++ b/app/forms/search_courses_form.rb
@@ -4,6 +4,7 @@ class SearchCoursesForm < ApplicationForm
   include ActiveModel::Attributes
 
   attribute :can_sponsor_visa, :boolean
+  attribute :subjects
   attribute :send_courses, :boolean
   attribute :applications_open, :boolean
   attribute :study_types
@@ -13,5 +14,12 @@ class SearchCoursesForm < ApplicationForm
 
   def search_params
     attributes.symbolize_keys.compact
+  end
+
+  def secondary_subjects
+    Subject
+      .where(type: %w[SecondarySubject ModernLanguagesSubject])
+      .where.not(subject_name: ['Modern Languages'])
+      .order(:subject_name)
   end
 end

--- a/app/services/courses_query.rb
+++ b/app/services/courses_query.rb
@@ -24,6 +24,7 @@ class CoursesQuery
 
   def call
     @scope = visa_sponsorship_scope
+    @scope = subjects_scope
     @scope = study_modes_scope
     @scope = qualifications_scope
     @scope = further_education_scope
@@ -51,6 +52,14 @@ class CoursesQuery
           can_sponsor_skilled_worker_visa: true
         )
       )
+  end
+
+  def subjects_scope
+    return @scope if params[:subjects].blank?
+
+    @applied_scopes[:subjects] = params[:subjects]
+
+    @scope.joins(:subjects).where(subjects: { subject_code: params[:subjects] })
   end
 
   def study_modes_scope

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -18,6 +18,10 @@
           <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.can_sponsor_visa"), size: "s" } %>
         <% end %>
 
+        <%= form.govuk_check_boxes_fieldset :subjects, legend: { text: t("helpers.legend.courses_query_filters.secondary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.secondary"), class: "govuk-!-font-size-16" }, class: "app-filter__group", hidden: false, multiple: false, form_group: { class: "app-filter__group" } do %>
+          <%= form.govuk_collection_check_boxes :subjects, form.object.secondary_subjects, :subject_code, :subject_name, legend: nil, include_hidden: false, small: true %>
+        <% end %>
+
         <%= form.govuk_check_boxes_fieldset :study_types, legend: { text: t("helpers.legend.courses_query_filters.study_type_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
           <%= form.govuk_check_box :study_types, "full_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.full_time"), size: "s" }, include_hidden: false %>
           <%= form.govuk_check_box :study_types, "part_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.part_time"), size: "s" }, include_hidden: false %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -313,6 +313,7 @@ en:
     legend:
       courses_query_filters:
         can_sponsor_visa_html: Visa sponsorship<span class="govuk-visually-hidden"> filter</span>
+        secondary_html: Secondary<span class="govuk-visually-hidden"> filter</span>
         study_type_html: Study type<span class="govuk-visually-hidden"> filter</span>
         qualifications_html: Qualification awarded<span class="govuk-visually-hidden"> filter</span>
         further_education_html: Further education<span class="govuk-visually-hidden"> filter</span>
@@ -322,6 +323,7 @@ en:
     hint:
       courses_query_filters:
         further_education: (ages 16 and over)
+        secondary: (ages 11 to 18)
     label:
       courses_query_filters:
         can_sponsor_visa: Only show courses with visa sponsorship

--- a/spec/features/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/features/find/v2/results/search_results_enabled_spec.rb
@@ -126,6 +126,37 @@ feature 'V2 results - enabled' do
     end
   end
 
+  context 'when filter by secondary subjects' do
+    before do
+      given_there_are_courses_with_secondary_subjects
+    end
+
+    scenario 'filter by specific secondary subjects' do
+      when_i_visit_the_find_results_page
+      and_i_filter_by_mathematics
+      then_i_see_only_mathematics_courses
+      and_the_mathematics_secondary_option_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
+
+    scenario 'filter by many secondary subjects' do
+      when_i_visit_the_find_results_page
+      and_i_filter_by_mathematics
+      and_i_filter_by_chemistry
+      then_i_see_mathematics_and_chemistry_courses
+      and_the_mathematics_secondary_option_is_checked
+      and_the_chemistry_secondary_option_is_checked
+      and_i_see_that_there_are_two_courses_found
+    end
+
+    scenario 'passing subjects on the parameters' do
+      when_i_visit_the_find_results_page_passing_mathematics_in_the_params
+      then_i_see_only_mathematics_courses
+      and_the_mathematics_secondary_option_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
+  end
+
   scenario 'when no results' do
     when_i_visit_the_find_results_page
     then_i_see_no_courses_found
@@ -145,6 +176,13 @@ feature 'V2 results - enabled' do
     create(:course, :with_full_time_sites, study_mode: 'full_time', name: 'Biology', course_code: 'S872')
     create(:course, :with_part_time_sites, study_mode: 'part_time', name: 'Chemistry', course_code: 'K592')
     create(:course, :with_full_time_or_part_time_sites, study_mode: 'full_time_or_part_time', name: 'Computing', course_code: 'L364')
+  end
+
+  def given_there_are_courses_with_secondary_subjects
+    create(:course, :with_full_time_sites, :secondary, name: 'Biology', course_code: 'S872', subjects: [find_or_create(:secondary_subject, :biology)])
+    create(:course, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592', subjects: [find_or_create(:secondary_subject, :chemistry)])
+    create(:course, :with_full_time_sites, :secondary, name: 'Computing', course_code: 'L364', subjects: [find_or_create(:secondary_subject, :computing)])
+    create(:course, :with_full_time_sites, :secondary, name: 'Mathematics', course_code: '4RTU', subjects: [find_or_create(:secondary_subject, :mathematics)])
   end
 
   def given_there_are_courses_containing_all_qualifications
@@ -202,8 +240,22 @@ feature 'V2 results - enabled' do
     visit(find_v2_results_path(funding: 'salary'))
   end
 
+  def when_i_visit_the_find_results_page_passing_mathematics_in_the_params
+    visit(find_v2_results_path(subjects: ['G1']))
+  end
+
   def and_i_filter_by_courses_that_sponsor_visa
     check 'Only show courses with visa sponsorship'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_mathematics
+    check 'Mathematics'
+    and_i_apply_the_filters
+  end
+
+  def and_i_filter_by_chemistry
+    check 'Chemistry'
     and_i_apply_the_filters
   end
 
@@ -266,16 +318,16 @@ feature 'V2 results - enabled' do
   end
 
   def then_i_see_only_courses_that_sponsor_visa
-    expect(page).to have_content('Biology (S872')
-    expect(page).to have_content('Chemistry (K592)')
-    expect(page).to have_content('Computing (L364)')
-    expect(page).to have_no_content('Dance (C115)')
+    expect(results).to have_content('Biology (S872')
+    expect(results).to have_content('Chemistry (K592)')
+    expect(results).to have_content('Computing (L364)')
+    expect(results).to have_no_content('Dance (C115)')
   end
 
   def then_i_see_only_part_time_courses
-    expect(page).to have_content('Chemistry (K592)')
-    expect(page).to have_content('Computing (L364)')
-    expect(page).to have_no_content('Biology (S872)')
+    expect(results).to have_content('Chemistry (K592)')
+    expect(results).to have_content('Computing (L364)')
+    expect(results).to have_no_content('Biology (S872)')
   end
 
   def and_the_part_time_filter_is_checked
@@ -283,9 +335,9 @@ feature 'V2 results - enabled' do
   end
 
   def then_i_see_only_full_time_courses
-    expect(page).to have_content('Biology (S872)')
-    expect(page).to have_content('Computing (L364)')
-    expect(page).to have_no_content('Chemistry (K592)')
+    expect(results).to have_content('Biology (S872)')
+    expect(results).to have_content('Computing (L364)')
+    expect(results).to have_no_content('Chemistry (K592)')
   end
 
   def and_the_full_time_filter_is_checked
@@ -293,18 +345,18 @@ feature 'V2 results - enabled' do
   end
 
   def then_i_see_all_courses_containing_all_study_types
-    expect(page).to have_content('Biology (S872)')
-    expect(page).to have_content('Computing (L364)')
-    expect(page).to have_content('Chemistry (K592)')
+    expect(results).to have_content('Biology (S872)')
+    expect(results).to have_content('Computing (L364)')
+    expect(results).to have_content('Chemistry (K592)')
   end
 
   def then_i_see_only_qts_only_courses
-    expect(page).to have_content('Biology (S872)')
-    expect(page).to have_no_content('Chemistry (K592)')
-    expect(page).to have_no_content('Computing (L364)')
-    expect(page).to have_no_content('Dance (C115)')
-    expect(page).to have_no_content('Physics (3CXN)')
-    expect(page).to have_no_content('Mathemathics (4RTU)')
+    expect(results).to have_content('Biology (S872)')
+    expect(results).to have_no_content('Chemistry (K592)')
+    expect(results).to have_no_content('Computing (L364)')
+    expect(results).to have_no_content('Dance (C115)')
+    expect(results).to have_no_content('Physics (3CXN)')
+    expect(results).to have_no_content('Mathemathics (4RTU)')
   end
 
   def and_the_qts_only_filter_is_checked
@@ -312,12 +364,12 @@ feature 'V2 results - enabled' do
   end
 
   def then_i_see_only_qts_with_pgce_or_pgde_courses
-    expect(page).to have_content('Chemistry (K592)')
-    expect(page).to have_content('Computing (L364)')
-    expect(page).to have_no_content('Biology (S872)')
-    expect(page).to have_no_content('Dance (C115)')
-    expect(page).to have_no_content('Physics (3CXN)')
-    expect(page).to have_no_content('Mathemathics (4RTU)')
+    expect(results).to have_content('Chemistry (K592)')
+    expect(results).to have_content('Computing (L364)')
+    expect(results).to have_no_content('Biology (S872)')
+    expect(results).to have_no_content('Dance (C115)')
+    expect(results).to have_no_content('Physics (3CXN)')
+    expect(results).to have_no_content('Mathemathics (4RTU)')
   end
 
   def and_the_qts_with_pgce_or_pgde_filter_is_checked
@@ -325,9 +377,9 @@ feature 'V2 results - enabled' do
   end
 
   def then_i_see_only_further_education__courses
-    expect(page).to have_content('Further education (K594)')
-    expect(page).to have_no_content('Biology (S872)')
-    expect(page).to have_no_content('Chemistry (K592)')
+    expect(results).to have_content('Further education (K594)')
+    expect(results).to have_no_content('Biology (S872)')
+    expect(results).to have_no_content('Chemistry (K592)')
   end
 
   def and_the_further_education_filter_is_checked
@@ -335,43 +387,43 @@ feature 'V2 results - enabled' do
   end
 
   def then_i_see_only_courses_with_special_education_needs
-    expect(page).to have_content('Biology SEND (S872')
-    expect(page).to have_content('Chemistry SEND (K592)')
-    expect(page).to have_content('Computing SEND (L364)')
-    expect(page).to have_no_content('Dance (C115)')
-    expect(page).to have_no_content('Physics (3CXN)')
+    expect(results).to have_content('Biology SEND (S872')
+    expect(results).to have_content('Chemistry SEND (K592)')
+    expect(results).to have_content('Computing SEND (L364)')
+    expect(results).to have_no_content('Dance (C115)')
+    expect(results).to have_no_content('Physics (3CXN)')
   end
 
   def then_i_see_only_salaried_courses
-    expect(page).to have_content('Chemistry (K592)')
-    expect(page).to have_no_content('Biology (S872)')
-    expect(page).to have_no_content('Computing (L364)')
+    expect(results).to have_content('Chemistry (K592)')
+    expect(results).to have_no_content('Biology (S872)')
+    expect(results).to have_no_content('Computing (L364)')
   end
 
   def then_i_see_only_fee_courses
-    expect(page).to have_content('Biology (S872)')
-    expect(page).to have_no_content('Chemistry (K592)')
-    expect(page).to have_no_content('Computing (L364)')
+    expect(results).to have_content('Biology (S872)')
+    expect(results).to have_no_content('Chemistry (K592)')
+    expect(results).to have_no_content('Computing (L364)')
   end
 
   def then_i_see_fee_and_salaried_courses
-    expect(page).to have_content('Biology (S872)')
-    expect(page).to have_content('Chemistry (K592)')
-    expect(page).to have_no_content('Computing (L364)')
+    expect(results).to have_content('Biology (S872)')
+    expect(results).to have_content('Chemistry (K592)')
+    expect(results).to have_no_content('Computing (L364)')
   end
 
   def then_i_see_only_apprenticeship_courses
-    expect(page).to have_content('Computing (L364)')
-    expect(page).to have_no_content('Chemistry (K592)')
-    expect(page).to have_no_content('Biology (S872)')
+    expect(results).to have_content('Computing (L364)')
+    expect(results).to have_no_content('Chemistry (K592)')
+    expect(results).to have_no_content('Biology (S872)')
   end
 
   def then_i_see_only_courses_that_are_open_for_applications
-    expect(page).to have_content('Biology (S872)')
-    expect(page).to have_content('Chemistry (K592)')
-    expect(page).to have_content('Computing (L364)')
-    expect(page).to have_no_content('Dance (C115)')
-    expect(page).to have_no_content('Physics (3CXN)')
+    expect(results).to have_content('Biology (S872)')
+    expect(results).to have_content('Chemistry (K592)')
+    expect(results).to have_content('Computing (L364)')
+    expect(results).to have_no_content('Dance (C115)')
+    expect(results).to have_no_content('Physics (3CXN)')
   end
 
   def and_the_visa_sponsorship_filter_is_checked
@@ -417,8 +469,36 @@ feature 'V2 results - enabled' do
     expect(page).to have_title('3 courses found')
   end
 
+  def then_i_see_only_mathematics_courses
+    expect(results).to have_content('Mathematics (4RTU)')
+    expect(results).to have_no_content('Biology')
+    expect(results).to have_no_content('Chemistry')
+    expect(results).to have_no_content('Computing')
+  end
+
+  def then_i_see_mathematics_and_chemistry_courses
+    expect(results).to have_content('Mathematics')
+    expect(results).to have_content('Chemistry')
+    expect(results).to have_no_content('Biology')
+    expect(results).to have_no_content('Computing')
+  end
+
+  def and_the_mathematics_secondary_option_is_checked
+    expect(page).to have_checked_field('Mathematics')
+  end
+
+  def and_the_chemistry_secondary_option_is_checked
+    expect(page).to have_checked_field('Chemistry')
+  end
+
   def then_i_see_no_courses_found
     expect(page).to have_content('No courses found')
     expect(page).to have_title('No courses found')
+  end
+
+  private
+
+  def results
+    page.first('.app-search-results')
   end
 end

--- a/spec/services/courses_query_spec.rb
+++ b/spec/services/courses_query_spec.rb
@@ -42,6 +42,27 @@ RSpec.describe CoursesQuery do
       end
     end
 
+    context 'when filter by secondary subjects' do
+      let!(:biology) do
+        create(:course, :with_full_time_sites, :secondary, name: 'Biology', subjects: [find_or_create(:secondary_subject, :biology)])
+      end
+      let!(:chemistry) do
+        create(:course, :with_full_time_sites, :secondary, name: 'Chemistry', subjects: [find_or_create(:secondary_subject, :chemistry)])
+      end
+      let!(:mathematics) do
+        create(:course, :with_full_time_sites, :secondary, name: 'Mathematics', subjects: [find_or_create(:secondary_subject, :mathematics)])
+      end
+
+      let(:params) { { subjects: %w[C1 F1] } }
+
+      it 'returns specific secondary courses' do
+        expect(results).to match_collection(
+          [biology, chemistry],
+          attribute_names: %w[name]
+        )
+      end
+    end
+
     context 'when filter by study mode' do
       let!(:full_time_course) do
         create(:course, :with_full_time_sites, study_mode: 'full_time', name: 'Biology', course_code: 'S872')


### PR DESCRIPTION
## Context

Add secondary filter to the `/v2/results`.

## Part 1 / Part 2 / 3 considerations

I divided this work in three parts (and will be three PRs):

* Part 1: the filter working - This PR!
* Part 2: Move the /v2/results specs to system specs and divide the filter into different specs - future PR
* Part 3: the "search" JS component within the secondary filter - a future PR!

## Changes proposed in this pull request

<img width="331" alt="Screenshot 2024-12-20 at 17 34 17" src="https://github.com/user-attachments/assets/49ca0626-4cfa-418e-9919-90b48adad6de" />

## Guidance to review

1. Visit /v2/results
2. Check some secondary filters or all of them individually. Does it work?
