### PR TITLE
Change further education filter

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -18,11 +18,13 @@ module Find
           :can_sponsor_visa,
           :send_courses,
           :applications_open,
-          :further_education,
+          :level,
           :funding,
+          :age_group,
           subjects: [],
           study_types: [],
           qualifications: [],
+          qualification: [],
           funding: []
         )
       end

--- a/app/forms/search_courses_form.rb
+++ b/app/forms/search_courses_form.rb
@@ -9,11 +9,24 @@ class SearchCoursesForm < ApplicationForm
   attribute :applications_open, :boolean
   attribute :study_types
   attribute :qualifications
-  attribute :further_education, :boolean
+  attribute :level
   attribute :funding
 
+  attribute :age_group
+  attribute :qualification
+
   def search_params
-    attributes.symbolize_keys.compact
+    attributes
+      .symbolize_keys
+      .then { |params| params.except(*old_parameters) }
+      .then { |params| transform_old_parameters(params) }
+      .compact
+  end
+
+  def level
+    return 'further_education' if old_further_education_parameters?
+
+    super
   end
 
   def secondary_subjects
@@ -21,5 +34,21 @@ class SearchCoursesForm < ApplicationForm
       .where(type: %w[SecondarySubject ModernLanguagesSubject])
       .where.not(subject_name: ['Modern Languages'])
       .order(:subject_name)
+  end
+
+  private
+
+  def transform_old_parameters(params)
+    params.tap do
+      params[:level] = level
+    end
+  end
+
+  def old_further_education_parameters?
+    age_group == 'further_education' || qualification == ['pgce pgde']
+  end
+
+  def old_parameters
+    %i[age_group qualification]
   end
 end

--- a/app/services/courses_query.rb
+++ b/app/services/courses_query.rb
@@ -93,9 +93,9 @@ class CoursesQuery
   end
 
   def further_education_scope
-    return @scope if params[:further_education].blank?
+    return @scope if params[:level] != 'further_education'
 
-    @applied_scopes[:further_education] = params[:further_education]
+    @applied_scopes[:level] = params[:level]
 
     @scope.where(level: Course.levels[:further_education])
   end

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -39,7 +39,7 @@
         <% end %>
 
         <%= form.govuk_check_boxes_fieldset :further_education, legend: { text: t("helpers.legend.courses_query_filters.further_education_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.further_education"), class: "govuk-!-font-size-16" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_check_box :further_education, "true", label: { text: t("helpers.label.courses_query_filters.further_education"), size: "s" }, multiple: false %>
+          <%= form.govuk_check_box :level, "further_education", label: { text: t("helpers.label.courses_query_filters.further_education"), size: "s" }, multiple: false %>
         <% end %>
 
         <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -335,7 +335,7 @@ en:
         qualification_options:
           qts: QTS only
           qts_with_pgce_or_pgde: QTS with PGCE or PGDE
-        further_education: Only show further education courses
+        further_education: Further education courses
         funding_options:
           fee: Fee - no salary
           salary: Salary

--- a/spec/forms/search_courses_form_spec.rb
+++ b/spec/forms/search_courses_form_spec.rb
@@ -60,6 +60,32 @@ RSpec.describe SearchCoursesForm do
       end
     end
 
+    context 'when further education is provided' do
+      context 'when new level params' do
+        let(:form) { described_class.new(level: 'further_education') }
+
+        it 'returns level search params' do
+          expect(form.search_params).to eq({ level: 'further_education' })
+        end
+      end
+
+      context 'when old age group params is used' do
+        let(:form) { described_class.new(age_group: 'further_education') }
+
+        it 'returns level search params' do
+          expect(form.search_params).to eq({ level: 'further_education' })
+        end
+      end
+
+      context 'when old qualification params is used as string' do
+        let(:form) { described_class.new(qualification: ['pgce pgde']) }
+
+        it 'returns level search params' do
+          expect(form.search_params).to eq({ level: 'further_education' })
+        end
+      end
+    end
+
     context 'when funding is provided' do
       let(:form) { described_class.new(funding: %w[fee salary]) }
 

--- a/spec/services/courses_query_spec.rb
+++ b/spec/services/courses_query_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe CoursesQuery do
       let!(:regular_course) do
         create(:course, :with_full_time_sites, level: 'secondary')
       end
-      let(:params) { { further_education: 'true' } }
+      let(:params) { { level: 'further_education' } }
 
       it 'returns courses for further education only' do
         expect(results).to match_collection(

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -51,13 +51,32 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     and_i_see_that_there_are_two_courses_found
   end
 
-  scenario 'when I filter by further education only courses' do
-    given_there_are_courses_containing_all_levels
-    when_i_visit_the_find_results_page
-    and_i_filter_by_further_education_courses
-    then_i_see_only_further_education__courses
-    and_the_further_education_filter_is_checked
-    and_i_see_that_there_is_one_course_found
+  context 'when I filter by further education only courses' do
+    before do
+      given_there_are_courses_containing_all_levels
+    end
+
+    scenario 'when I filter by further education only courses' do
+      when_i_visit_the_find_results_page
+      and_i_filter_by_further_education_courses
+      then_i_see_only_further_education__courses
+      and_the_further_education_filter_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
+
+    scenario 'when I filter by the old age group further education parameter' do
+      when_i_visit_the_find_results_page_using_the_old_age_group_parameter
+      then_i_see_only_further_education__courses
+      and_the_further_education_filter_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
+
+    scenario 'when I filter by the old pgce pgde further education parameter' do
+      when_i_visit_the_find_results_page_using_the_old_pgce_pgde_parameter
+      then_i_see_only_further_education__courses
+      and_the_further_education_filter_is_checked
+      and_i_see_that_there_is_one_course_found
+    end
   end
 
   scenario 'when I filter by applications open' do
@@ -247,6 +266,14 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
 
   def when_i_visit_the_find_results_page_passing_mathematics_in_the_params
     visit(find_v2_results_path(subjects: ['G1']))
+  end
+
+  def when_i_visit_the_find_results_page_using_the_old_age_group_parameter
+    visit(find_v2_results_path(age_group: 'further_education'))
+  end
+
+  def when_i_visit_the_find_results_page_using_the_old_pgce_pgde_parameter
+    visit(find_v2_results_path(qualification: ['pgce pgde']))
   end
 
   def and_i_search_for_the_mathematics_option

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   end
 
   def and_i_filter_by_further_education_courses
-    check 'Only show further education courses', visible: :all
+    check 'Further education courses', visible: :all
     and_i_apply_the_filters
   end
 
@@ -413,7 +413,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   end
 
   def and_the_further_education_filter_is_checked
-    expect(page).to have_checked_field('Only show further education courses', visible: :all)
+    expect(page).to have_checked_field('Further education courses', visible: :all)
   end
 
   def then_i_see_only_courses_with_special_education_needs


### PR DESCRIPTION
## Context

This PR changes the further education filter:

1. Use `level` as parameter (to map the data modelling)
2. Makes compatible with "old" parameters (the current live version that soon will be replaced):
     - "age_group" parameter is used when user answer the second question and chooses "Further education"
     - "qualification" as "pgce pgde" parameter is used when user answer the qualification "further education" filter 

## Changes proposed in this pull request

Also changed the content of the filter as the trello card: 

## Guidance to review

1. Visit /v2/results page
2. Does the further education filter works?
3. Go to live site and answer the second question and go to results page. Copy the parameters and paste into `/v2/results?...." 
4. Does the further education filter works?
5. Go to live site and filter the qualification to further education. Copy the parameters and paste into `/v2/results?...." 
6. Does the further education filter works?
