### PR TITLE
Add primary subjects filter

### DIFF
--- a/app/forms/search_courses_form.rb
+++ b/app/forms/search_courses_form.rb
@@ -36,6 +36,10 @@ class SearchCoursesForm < ApplicationForm
       .order(:subject_name)
   end
 
+  def primary_subjects
+    Subject.where(type: 'PrimarySubject').order(:subject_name)
+  end
+
   private
 
   def transform_old_parameters(params)

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -18,15 +18,25 @@
           <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.can_sponsor_visa"), size: "s" } %>
         <% end %>
 
-        <%= form.govuk_check_boxes_fieldset :subjects, legend: { text: t("helpers.legend.courses_query_filters.secondary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.secondary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group", data: { controller: "filter-search" } } do %>
-            <div class="filter-search scrollable-filter" data-filter-search-target="optionsList">
-              <% form.object.secondary_subjects.each do |subject| %>
-                <%= form.govuk_check_box :subjects,
-                subject.subject_code,
-                label: { text: subject.subject_name } %>
-              <% end %>
-            </div>
-          <% end %>
+        <%= form.govuk_check_boxes_fieldset :primary_subjects, legend: { text: t("helpers.legend.courses_query_filters.primary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.primary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group" } do %>
+          <div class="scrollable-filter">
+            <% form.object.primary_subjects.each do |subject| %>
+              <%= form.govuk_check_box :subjects,
+              subject.subject_code,
+              label: { text: subject.subject_name } %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <%= form.govuk_check_boxes_fieldset :secondary_subjects, legend: { text: t("helpers.legend.courses_query_filters.secondary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.secondary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group", data: { controller: "filter-search" } } do %>
+          <div class="filter-search scrollable-filter" data-filter-search-target="optionsList">
+            <% form.object.secondary_subjects.each do |subject| %>
+              <%= form.govuk_check_box :subjects,
+              subject.subject_code,
+              label: { text: subject.subject_name } %>
+            <% end %>
+          </div>
+        <% end %>
 
         <%= form.govuk_check_boxes_fieldset :study_types, legend: { text: t("helpers.legend.courses_query_filters.study_type_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
           <%= form.govuk_check_box :study_types, "full_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.full_time"), size: "s" }, include_hidden: false %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -313,6 +313,7 @@ en:
     legend:
       courses_query_filters:
         can_sponsor_visa_html: Visa sponsorship<span class="govuk-visually-hidden"> filter</span>
+        primary_html: Primary<span class="govuk-visually-hidden"> filter</span>
         secondary_html: Secondary<span class="govuk-visually-hidden"> filter</span>
         study_type_html: Study type<span class="govuk-visually-hidden"> filter</span>
         qualifications_html: Qualification awarded<span class="govuk-visually-hidden"> filter</span>
@@ -322,6 +323,7 @@ en:
         applications_open_html: Applications open<span class="govuk-visually-hidden"> filter</span>
     hint:
       courses_query_filters:
+        primary: (ages 3 to 11)
         further_education: (ages 16 and over)
         secondary: (ages 11 to 18)
     label:

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -144,13 +144,27 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     end
   end
 
-  context 'when filter by secondary subjects' do
+  context 'when filter by subjects' do
     before do
       given_there_are_courses_with_secondary_subjects
+      and_there_are_courses_with_primary_subjects
+      when_i_visit_the_find_results_page
+    end
+
+    scenario 'filter by specific primary subjects' do
+      when_i_filter_by_primary
+      then_i_see_only_primary_specific_courses
+      and_the_primary_option_is_checked
+      and_i_see_that_there_is_one_course_found
+
+      when_i_filter_by_primary_with_science_too
+      then_i_see_primary_and_primary_with_science_courses
+      and_the_primary_option_is_checked
+      and_the_primary_with_science_option_is_checked
+      and_i_see_that_there_are_two_courses_found
     end
 
     scenario 'filter by specific secondary subjects' do
-      when_i_visit_the_find_results_page
       and_i_search_for_the_mathematics_option
       then_i_can_only_see_the_mathematics_option
       when_i_clear_my_search_for_secondary_options
@@ -168,7 +182,6 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     end
 
     scenario 'filter by many secondary subjects' do
-      when_i_visit_the_find_results_page
       and_i_filter_by_mathematics
       and_i_filter_by_chemistry
       then_i_see_mathematics_and_chemistry_courses
@@ -207,6 +220,13 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     create(:course, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592', subjects: [find_or_create(:secondary_subject, :chemistry)])
     create(:course, :with_full_time_sites, :secondary, name: 'Computing', course_code: 'L364', subjects: [find_or_create(:secondary_subject, :computing)])
     create(:course, :with_full_time_sites, :secondary, name: 'Mathematics', course_code: '4RTU', subjects: [find_or_create(:secondary_subject, :mathematics)])
+  end
+
+  def and_there_are_courses_with_primary_subjects
+    create(:course, :with_full_time_sites, :primary, name: 'Primary', course_code: 'S872', subjects: [find_or_create(:primary_subject, :primary)])
+    create(:course, :with_full_time_sites, :primary, name: 'Primary with english', course_code: 'K592', subjects: [find_or_create(:primary_subject, :primary_with_english)])
+    create(:course, :with_full_time_sites, :primary, name: 'Primary with mathematics', course_code: 'L364', subjects: [find_or_create(:primary_subject, :primary_with_mathematics)])
+    create(:course, :with_full_time_sites, :primary, name: 'Primary with science', course_code: '4RTU', subjects: [find_or_create(:primary_subject, :primary_with_science)])
   end
 
   def given_there_are_courses_containing_all_qualifications
@@ -305,6 +325,16 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     and_i_apply_the_filters
   end
 
+  def when_i_filter_by_primary
+    check 'Primary', visible: :all
+    and_i_apply_the_filters
+  end
+
+  def when_i_filter_by_primary_with_science_too
+    check 'Primary with science', visible: :all
+    and_i_apply_the_filters
+  end
+
   def when_i_filter_by_mathematics
     check 'Mathematics', visible: :all
     and_i_apply_the_filters
@@ -372,6 +402,28 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   def and_i_filter_by_apprenticeship_courses
     check 'Teaching apprenticeship - with salary', visible: :all
     and_i_apply_the_filters
+  end
+
+  def then_i_see_only_primary_specific_courses
+    expect(results).to have_content('Primary (S872)')
+    expect(results).to have_no_content('Primary with english')
+    expect(results).to have_no_content('Primary with mathematics')
+    expect(results).to have_no_content('Primary with science')
+  end
+
+  def then_i_see_primary_and_primary_with_science_courses
+    expect(results).to have_content('Primary (S872)')
+    expect(results).to have_content('Primary with science')
+    expect(results).to have_no_content('Primary with english')
+    expect(results).to have_no_content('Primary with mathematics')
+  end
+
+  def and_the_primary_option_is_checked
+    expect(page).to have_checked_field('Primary', visible: :all)
+  end
+
+  def and_the_primary_with_science_option_is_checked
+    expect(page).to have_checked_field('Primary with science', visible: :all)
   end
 
   def then_i_see_only_courses_that_sponsor_visa


### PR DESCRIPTION
## Context

This PR adds the primary filter to the `/v2/results` page.

## Changes proposed in this pull request

<img width="326" alt="Screenshot 2025-01-02 at 08 27 33" src="https://github.com/user-attachments/assets/b2d4b6c7-39f2-4530-a1f8-3e08c2035b40" />


## Guidance to review

1. Visit /v2/results page
2. Does the primary filter work as expected?
3. Does also work with secondary filter?

