### PR TITLE
Add single-quotes lint changes to git blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf # https://github.com/DFE-Digital/publish-teacher-training/commit/fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf


### PR DESCRIPTION
## Context

We have a handful of formatting-only commits that remove the git blame context from a line of code. This makes it less convenient to fetch the context around a change.

GitHub provides a way to ignore certain commits from git blame: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view

## Changes proposed in this pull request

- Add fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf to the `.git-blame-ignore-revs` file.

## Guidance to review

Visit the `Gemfile` file on [main](https://github.com/DFE-Digital/publish-teacher-training/blob/main/Gemfile) vs in [this branch](https://github.com/DFE-Digital/publish-teacher-training/blob/dd/add-git-blame-ignore-revs-file/Gemfile) in GitHub. The blame will differ.
