### PR TITLE
Replace #accredited_provider with #accredited on provider

### DIFF
--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -50,7 +50,7 @@ class AddCourseButton < ViewComponent::Base
   end
 
   def accredited_provider_not_present?
-    return false if provider.accredited_provider?
+    return false if provider.accredited?
 
     !accredited_provider_present?
   end
@@ -60,7 +60,7 @@ class AddCourseButton < ViewComponent::Base
   end
 
   def accredited_provider?
-    provider.accredited_provider?
+    provider.accredited?
   end
 
   def incomplete_section_article(section)

--- a/app/components/providers/provider_list/view.html.erb
+++ b/app/components/providers/provider_list/view.html.erb
@@ -23,7 +23,7 @@
         row.with_action(text: "Change", href: edit_support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider), visually_hidden_text: "accredited provider")
       end
 
-      if @provider.accredited_provider?
+      if @provider.accredited?
         component.with_row(html_attributes: { data: { qa: "ap-number-row" } }) do |row|
           row.with_key { "Accredited provider number" }
           row.with_value { value_provided?(@provider.accredited_provider_number.to_s) }

--- a/app/components/providers/provider_list/view.rb
+++ b/app/components/providers/provider_list/view.rb
@@ -16,7 +16,7 @@ module Providers
       end
 
       def formatted_accrediting_provider
-        @provider.accredited_provider? ? 'Yes' : 'No'
+        @provider.accredited? ? 'Yes' : 'No'
       end
     end
   end

--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -72,7 +72,7 @@ module API
           @providers = @providers.with_region_codes(region_codes) if region_codes.present?
           @providers = @providers.with_can_sponsor_skilled_worker_visa(true) if can_sponsor_skilled_worker_visa?
           @providers = @providers.with_can_sponsor_student_visa(true) if can_sponsor_student_visa?
-          @providers = @providers.accredited_provider if is_accredited_body?
+          @providers = @providers.accredited if is_accredited_body?
           @providers = @providers.unscope(where: :discarded_at).discarded if discarded?
           @providers = if sort_by_provider_ascending?
                          @providers.by_name_ascending

--- a/app/forms/support/update_provider_form.rb
+++ b/app/forms/support/update_provider_form.rb
@@ -26,7 +26,7 @@ module Support
     end
 
     def remove_accredited_provider_number
-      return unless @provider.accrediting_provider_changed?(to: 'not_an_accredited_provider')
+      return unless @provider.accredited_changed?(to: false)
 
       @provider.accredited_provider_number = nil
     end

--- a/app/helpers/navigation_bar_helper.rb
+++ b/app/helpers/navigation_bar_helper.rb
@@ -19,9 +19,9 @@ module NavigationBarHelper
   end
 
   def partnership_link(provider)
-    if Settings.features.provider_partnerships && !provider.accredited_provider?
+    if Settings.features.provider_partnerships && !provider.accredited?
       { name: t('navigation_bar.accredited_partnerships'), url: publish_provider_recruitment_cycle_accredited_partnerships_path(provider.provider_code, provider.recruitment_cycle_year) }
-    elsif provider.accredited_provider?
+    elsif provider.accredited?
       { name: t('navigation_bar.training_partners'), url: publish_provider_recruitment_cycle_training_providers_path(provider.provider_code, provider.recruitment_cycle_year) }
     else
       { name: t('navigation_bar.accredited_provider'), url: publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, provider.recruitment_cycle_year) }

--- a/app/lib/user_notification_preferences.rb
+++ b/app/lib/user_notification_preferences.rb
@@ -46,7 +46,7 @@ class UserNotificationPreferences
   private
 
   def user_accredited_provider_codes
-    user.providers.accredited_provider.in_current_cycle.distinct.pluck(:provider_code)
+    user.providers.accredited.in_current_cycle.distinct.pluck(:provider_code)
   end
 
   def user_notifications

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -678,7 +678,7 @@ class Course < ApplicationRecord
   end
 
   def is_uni_or_scitt?
-    provider.accredited_provider?
+    provider.accredited?
   end
 
   def is_school_direct?
@@ -686,7 +686,7 @@ class Course < ApplicationRecord
   end
 
   def self_accredited?
-    provider.accredited_provider?
+    provider.accredited?
   end
 
   def to_s

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -102,6 +102,7 @@ class Provider < ApplicationRecord
     accredited_courses.includes(:provider).where(provider: { recruitment_cycle: })
   end
 
+  scope :accredited, -> { where(accredited: true) }
   scope :by_provider_code, lambda { |provider_code|
     where('lower(provider_code) = ?', provider_code.to_s.downcase).first!
   }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -287,6 +287,10 @@ class Provider < ApplicationRecord
     ).select('provider.*, COALESCE(a.courses_count, 0) AS included_accredited_courses_count')
   end
 
+  def self.accrediteds
+    %w[accredited_provider not_an_accredited_provider]
+  end
+
   def courses_count
     has_attribute?('included_courses_count') ? included_courses_count : courses.size
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -10,7 +10,7 @@ class Provider < ApplicationRecord
   include PgSearch::Model
   include VectorSearchable
 
-  before_save :update_searchable, if: :accredited_provider?
+  before_save :update_searchable, if: :accredited?
   before_create :set_defaults
 
   after_save :update_courses_program_type, if: :provider_type_previously_changed?
@@ -18,13 +18,6 @@ class Provider < ApplicationRecord
   has_associated_audits
   audited except: :changed_at
 
-  # NOTE: `provider_type` &  `accrediting_provider`
-  # The `unknown` & `invalid_value` provider types can be removed
-  # Once the underlying the data discreptives has been amended.
-  # Validation can be added to enforce compliance.
-  # The `scitt` & `university` provider types can be used to denote
-  # that they are an `accredited_provider` for accrediting providers
-  # therefore `lead_school` is a `not_an_accredited_provider`.
   enum :provider_type, {
     scitt: 'B',
     lead_school: 'Y',
@@ -81,7 +74,6 @@ class Provider < ApplicationRecord
   end
 
   alias accrediting_providers accredited_providers
-  alias accredited? accredited_provider?
 
   delegate :year, to: :recruitment_cycle, prefix: true
 
@@ -178,11 +170,11 @@ class Provider < ApplicationRecord
 
   validate :add_enrichment_errors
 
-  validates :accredited_provider_number, accredited_provider_number_format: true, if: :accredited_provider?
+  validates :accredited_provider_number, accredited_provider_number_format: true, if: :accredited?
 
   validate :accredited_provider_type
   def accredited_provider_type
-    return unless accredited_provider?
+    return unless accredited?
 
     errors.add(:accrediting_provider, :invalid_provider_type) unless provider_type.to_s.in?(%w[scitt university])
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -24,11 +24,6 @@ class Provider < ApplicationRecord
     university: 'O'
   }
 
-  enum :accrediting_provider, {
-    accredited_provider: 'Y',
-    not_an_accredited_provider: 'N'
-  }
-
   belongs_to :recruitment_cycle
 
   has_and_belongs_to_many :organisations, join_table: :organisation_provider

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
   def associated_with_accredited_provider?
     providers
       .in_current_cycle
-      .accredited_provider
+      .accredited
       .count
       .positive?
   end

--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -27,7 +27,7 @@ module API
                    :selectable_school
 
         attribute :accredited_body do
-          @object.accredited_provider?
+          @object.accredited?
         end
 
         attribute :changed_at do

--- a/app/services/accredited_providers/search_service.rb
+++ b/app/services/accredited_providers/search_service.rb
@@ -23,7 +23,7 @@ module AccreditedProviders
     attr_reader :query, :limit, :recruitment_cycle_year
 
     def providers
-      providers = RecruitmentCycle.find_by(year: recruitment_cycle_year).providers.accredited_provider
+      providers = RecruitmentCycle.find_by(year: recruitment_cycle_year).providers.accredited
       providers = providers.accredited_provider_search(query) if query
       providers = providers.limit(limit) if limit
       providers.reorder(:provider_name)

--- a/app/services/provider_reporting_service.rb
+++ b/app/services/provider_reporting_service.rb
@@ -28,7 +28,7 @@ class ProviderReportingService
           open: @open_providers.count,
           closed: @closed_providers.count
         },
-        accredited_provider: { **group_by_count(:accrediting_provider) },
+        accredited_provider: { **group_by_count(:accredited) },
         provider_type: { **group_by_count(:provider_type) },
         region_code: { **group_by_count(:region_code) }
       }
@@ -42,14 +42,15 @@ class ProviderReportingService
   def group_by_count(column)
     open = @open_providers.group(column).count
     closed = @closed_providers.group(column).count
+    column_name = column.to_s.pluralize
 
     {
-      open: Provider.send(column.to_s.pluralize).map do |key, _value|
+      open: Provider.send(column_name).map do |key, _value|
               x = {}
               x[key.to_sym] = open[key] || 0
               x
             end.reduce({}, :merge),
-      closed: Provider.send(column.to_s.pluralize).map do |key, _value|
+      closed: Provider.send(column_name).map do |key, _value|
                 x = {}
                 x[key.to_sym] = closed[key] || 0
                 x

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -33,7 +33,7 @@ module Providers
         provider_name: @provider_name,
         provider_code: @provider_code,
         provider_type: @provider_type,
-        accrediting_provider: @is_accredited_provider ? 'accredited_provider' : 'not_an_accredited_provider',
+        accredited: @is_accredited_provider,
         accredited_provider_number: @is_accredited_provider && generate_accredited_provider_number(@provider_type)
       }.merge(DEFAULT_PROVIDER_ATTRIBUTES))
 

--- a/app/services/publish/accredited_providers/search_service.rb
+++ b/app/services/publish/accredited_providers/search_service.rb
@@ -23,7 +23,7 @@ module Publish
       attr_reader :query, :limit
 
       def providers
-        providers = RecruitmentCycle.current.providers.accredited_provider
+        providers = RecruitmentCycle.current.providers.accredited
         providers = providers.accredited_provider_search(query) if query
         providers = providers.limit(limit) if limit
         providers.reorder(:provider_name)

--- a/app/services/support/filter.rb
+++ b/app/services/support/filter.rb
@@ -57,7 +57,7 @@ module Support
     def provider_accredited_type(records, accredited_provider)
       return records unless accredited_provider == 'on'
 
-      records.accredited_provider
+      records.accredited
     end
 
     def filter_records

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -152,7 +152,7 @@
        end
      end
 
-     unless @provider.accredited_provider?
+     unless @provider.accredited?
        summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row|
          row.with_key { "Accredited provider" }
          row.with_value { course.accrediting_provider&.provider_name }

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -151,7 +151,7 @@
           <% end %>
         <% end %>
 
-        <% unless @provider.accredited_provider? || course.is_further_education? %>
+        <% unless @provider.accredited? || course.is_further_education? %>
           <% summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row| %>
             <% row.with_key { "Accredited provider" } %>
             <% row.with_value { course.accrediting_provider.provider_name } %>

--- a/app/views/publish/recruitment_cycles/_courses_accredited_provider.html.erb
+++ b/app/views/publish/recruitment_cycles/_courses_accredited_provider.html.erb
@@ -1,4 +1,4 @@
-<% if @provider.accredited_provider? %>
+<% if @provider.accredited? %>
   <h2 class="govuk-heading-m">
     <%= govuk_link_to "Courses as an accredited provider", publish_provider_recruitment_cycle_training_providers_path(@provider.provider_code, year), data: { qa: "courses-as-an-accredited-body" } %>
   </h2>

--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -15,7 +15,7 @@
   { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: support_recruitment_cycle_provider_accredited_providers_path(@provider.recruitment_cycle_year, @provider) }] unless @provider.accredited_provider?)
+  *([{ name: "Accredited providers", url: support_recruitment_cycle_provider_accredited_providers_path(@provider.recruitment_cycle_year, @provider) }] unless @provider.accredited?)
 ]) %>
 
 <%= govuk_link_to "Copy Courses", new_support_recruitment_cycle_provider_copy_course_path(@recruitment_cycle.year, @provider), class: "govuk-button" %>

--- a/app/views/support/providers/accredited_partnerships/index.html.erb
+++ b/app/views/support/providers/accredited_partnerships/index.html.erb
@@ -15,7 +15,7 @@
   { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited_provider?)
+  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
 ]) %>
 
 <%= govuk_button_link_to(t(".add"), search_support_recruitment_cycle_provider_accredited_providers_path) %>

--- a/app/views/support/providers/accredited_providers/index.html.erb
+++ b/app/views/support/providers/accredited_providers/index.html.erb
@@ -15,7 +15,7 @@
   { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited_provider?)
+  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
 ]) %>
 
 <%= govuk_button_link_to("Add accredited provider", search_support_recruitment_cycle_provider_accredited_providers_path) %>

--- a/app/views/support/providers/edit.html.erb
+++ b/app/views/support/providers/edit.html.erb
@@ -33,13 +33,13 @@
     <%= t("links.ukprn_html") %>
   </p>
 
-  <%= f.govuk_radio_buttons_fieldset :accrediting_provider, legend: { text: "Is the organisation an accredited provider?", size: "s" } do %>
-    <%= f.govuk_radio_button :accrediting_provider, :accredited_provider, label: { text: "Yes", size: "s" } do %>
+  <%= f.govuk_radio_buttons_fieldset :accredited, legend: { text: "Is the organisation an accredited provider?", size: "s" } do %>
+    <%= f.govuk_radio_button :accredited, true, label: { text: "Yes", size: "s" } do %>
       <%= f.govuk_text_field :accredited_provider_number,
         label: { text: "Accredited provider number" },
         width: 10 %>
     <% end %>
-    <%= f.govuk_radio_button :accrediting_provider, :not_an_accredited_provider, label: { text: "No", size: "s" } %>
+    <%= f.govuk_radio_button :accredited, false, label: { text: "No", size: "s" } %>
   <% end %>
 
   <%= f.govuk_radio_buttons_fieldset :provider_type, legend: { text: "Provider type", size: "s" } do %>

--- a/app/views/support/providers/onboarding/checks/show.html.erb
+++ b/app/views/support/providers/onboarding/checks/show.html.erb
@@ -31,11 +31,11 @@
 
             component.with_row do |row|
               row.with_key { "Is the organisation an accredited provider?" }
-              row.with_value { @provider_form.accredited_provider? ? "Yes" : "No" }
+              row.with_value { @provider_form.accredited? ? "Yes" : "No" }
               row.with_action(text: "Change", href: new_support_recruitment_cycle_providers_onboarding_path(goto_confirmation: true), visually_hidden_text: "accredited provider")
             end
 
-            if @provider_form.accredited_provider?
+            if @provider_form.accredited?
               component.with_row do |row|
                 row.with_key { "Accredited provider number" }
                 row.with_value { @provider_form.accredited_provider_number }

--- a/app/views/support/providers/onboardings/new.html.erb
+++ b/app/views/support/providers/onboardings/new.html.erb
@@ -23,15 +23,15 @@
         <%= t("links.ukprn_html") %>
       </p>
 
-      <%= f.govuk_radio_buttons_fieldset(:accredited_provider, legend: { text: "Is the organisation an accredited provider?", size: "s" }) do %>
-        <%= f.govuk_radio_button :accredited_provider, :accredited_provider, label: { text: "Yes" }, link_errors: true  do %>
+      <%= f.govuk_radio_buttons_fieldset(:accredited, legend: { text: "Is the organisation an accredited provider?", size: "s" }) do %>
+        <%= f.govuk_radio_button :accredited, "1", label: { text: "Yes" }, link_errors: true  do %>
           <%= f.govuk_text_field :accredited_provider_number,
                                 width: 10,
                                 label: { text: "Accredited provider number" },
                                 autocomplete: :disabled %>
 
           <% end %>
-          <%= f.govuk_radio_button :accredited_provider, :not_an_accredited_provider, label: { text: "No" }, link_errors: true %>
+          <%= f.govuk_radio_button :accredited, "0", label: { text: "No" }, link_errors: true %>
         <% end %>
 
         <%= f.govuk_radio_buttons_fieldset(:provider_type, legend: { text: "Provider type", size: "s" }) do %>

--- a/app/views/support/providers/show.html.erb
+++ b/app/views/support/providers/show.html.erb
@@ -15,7 +15,7 @@
   { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited_provider?)
+  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
 ]) %>
 
 <%= render Providers::ProviderList::View.new(provider: @provider) %>

--- a/app/views/support/providers/users/index.html.erb
+++ b/app/views/support/providers/users/index.html.erb
@@ -15,7 +15,7 @@
   { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited_provider?)
+  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
 ]) %>
 
 <%= govuk_button_link_to t("components.page_titles.support.providers.users.new"), new_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider) %>

--- a/app/views/support/schools/index.html.erb
+++ b/app/views/support/schools/index.html.erb
@@ -15,7 +15,7 @@
   { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
   { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited_provider?)
+  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
 ]) %>
 
 <%= govuk_link_to("Add school", new_support_recruitment_cycle_provider_school_path, class: "govuk-button govuk-!-margin-bottom-3") %>

--- a/db/data/20250110100810_backfill_accredited_on_provider.rb
+++ b/db/data/20250110100810_backfill_accredited_on_provider.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BackfillAccreditedOnProvider < ActiveRecord::Migration[7.2]
+  def up
+    Provider.update_all("accredited = CASE WHEN accrediting_provider = 'Y' THEN TRUE ELSE FALSE END")
+  end
+
+  def down
+    Provider.update_all(accredited: false)
+  end
+end

--- a/spec/components/add_course_button_preview.rb
+++ b/spec/components/add_course_button_preview.rb
@@ -45,7 +45,7 @@ class AddCourseButtonPreview < ViewComponent::Preview
       Settings.current_recruitment_cycle_year
     end
 
-    def accredited_provider?
+    def accredited?
       false
     end
   end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -541,7 +541,7 @@ RSpec.describe API::Public::V1::ProvidersController do
             'train_with_disability' => provider.train_with_disability,
             'train_with_us' => provider.train_with_us,
             'website' => provider.website,
-            'accredited_body' => provider.accredited_provider?,
+            'accredited_body' => provider.accredited?,
             'changed_at' => provider.changed_at.iso8601,
             'city' => provider.town,
             'county' => provider.address4,

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     urn { Faker::Number.number(digits: [5, 6].sample) }
     ukprn { Faker::Number.within(range: 10_000_000..19_999_999) }
     accrediting_provider { 'N' }
+    accredited { false }
     region_code { 'london' }
     association :recruitment_cycle, strategy: :find_or_create
 
@@ -54,6 +55,7 @@ FactoryBot.define do
     trait :accredited_provider do
       provider_type { :university }
       accrediting_provider { 'Y' }
+      accredited { true }
       accredited_provider_number { Faker::Number.within(range: 1000..1999) }
       urn { nil }
     end
@@ -99,6 +101,7 @@ FactoryBot.define do
     factory :accredited_provider do
       provider_type { :university }
       accrediting_provider { 'Y' }
+      accredited { true }
       accredited_provider_number do
         if provider_type == :scitt
           Faker::Number.within(range: 5000..5999)

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :provider do
     provider_name { "ACME SCITT#{rand(1_000_000)}" }
 
-    sequence(:provider_code) { |n| format('A%02d', n % 100) }
+    sequence(:provider_code) { |n| format("#{('A'..'Z').to_a.sample}%02d", n % 100) }
 
     trait :with_anonymised_data do
       sequence(:provider_code) do |n|

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :provider do
     provider_name { "ACME SCITT#{rand(1_000_000)}" }
 
-    sequence(:provider_code) { |n| format('A%02d', n) }
+    sequence(:provider_code) { |n| format('A%02d', n % 100) }
 
     trait :with_anonymised_data do
       sequence(:provider_code) do |n|
@@ -25,7 +25,6 @@ FactoryBot.define do
     provider_type { :lead_school }
     urn { Faker::Number.number(digits: [5, 6].sample) }
     ukprn { Faker::Number.within(range: 10_000_000..19_999_999) }
-    accrediting_provider { 'N' }
     accredited { false }
     region_code { 'london' }
     association :recruitment_cycle, strategy: :find_or_create
@@ -54,7 +53,6 @@ FactoryBot.define do
 
     trait :accredited_provider do
       provider_type { :university }
-      accrediting_provider { 'Y' }
       accredited { true }
       accredited_provider_number { Faker::Number.within(range: 1000..1999) }
       urn { nil }
@@ -100,7 +98,6 @@ FactoryBot.define do
 
     factory :accredited_provider do
       provider_type { :university }
-      accrediting_provider { 'Y' }
       accredited { true }
       accredited_provider_number do
         if provider_type == :scitt

--- a/spec/features/publish/courses/2024_itt_provider_market_reform/publishing_a_course_as_an_accredited_provider_spec.rb
+++ b/spec/features/publish/courses/2024_itt_provider_market_reform/publishing_a_course_as_an_accredited_provider_spec.rb
@@ -47,7 +47,7 @@ feature 'Publishing a course when course when accrediting_provider is nil', { ca
   end
 
   def and_the_provider_is_accredited
-    provider.update(accrediting_provider: 'accredited_provider', accredited_provider_number: '5432', provider_type: 'scitt')
+    provider.update(accredited: true, accredited_provider_number: '5432', provider_type: 'scitt')
   end
 
   def provider

--- a/spec/forms/support/update_provider_form_spec.rb
+++ b/spec/forms/support/update_provider_form_spec.rb
@@ -12,7 +12,7 @@ module Support
 
     describe '#save' do
       context 'provider is changed from accredited_provider to not accredited_provider' do
-        let(:attributes) { { accrediting_provider: 'not_an_accredited_provider' } }
+        let(:attributes) { { accredited: false } }
 
         it 'removes the accredited_provider_number' do
           expect { subject.save }.to change(provider.reload, :accredited_provider_number).from(provider.accredited_provider_number).to(nil)

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -32,7 +32,7 @@ describe '#publishable?' do
     end
 
     it 'is not publishable' do
-      course.accrediting_provider.not_an_accredited_provider!
+      course.accrediting_provider.update!(accredited: false)
       expect(course).not_to be_publishable
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -117,7 +117,7 @@ describe Provider do
     end
 
     describe 'a lead school can not be an accredited provider' do
-      let(:provider) { build(:provider, provider_type: 'lead_school', accrediting_provider: 'Y') }
+      let(:provider) { build(:provider, provider_type: 'lead_school', accredited: true) }
 
       it 'is invalid' do
         expect(provider).not_to be_valid
@@ -299,11 +299,20 @@ describe Provider do
 
   its(:recruitment_cycle) { is_expected.to eq find(:recruitment_cycle) }
 
-  it 'defines an enum for accrediting_provider' do
-    expect(subject)
-      .to define_enum_for('accrediting_provider')
-      .backed_by_column_of_type(:text)
-      .with_values('accredited_provider' => 'Y', 'not_an_accredited_provider' => 'N')
+  describe '#accredited' do
+    context 'when provider is accredited' do
+      it 'returns true' do
+        provider = build(:accredited_provider)
+        expect(provider).to be_accredited
+      end
+    end
+
+    context 'when provider is not accredited' do
+      it 'returns false' do
+        provider = build(:provider)
+        expect(provider).not_to be_accredited
+      end
+    end
   end
 
   describe 'courses' do
@@ -587,6 +596,15 @@ describe Provider do
   end
 
   describe 'scopes' do
+    describe '.accredited' do
+      let!(:accredited_providers) { create_list(:accredited_provider, 2) }
+      let!(:providers) { create_list(:provider, 2) }
+
+      it 'returns only accredited providers' do
+        expect(described_class.accredited).to match_array(accredited_providers)
+      end
+    end
+
     describe '.with_findable_courses' do
       subject do
         described_class.with_findable_courses
@@ -1020,24 +1038,6 @@ describe Provider do
 
     it 'returns only study sites' do
       expect(provider.study_sites).to match([study_site])
-    end
-  end
-
-  describe '#accredited?' do
-    context 'for an accredited provider' do
-      let(:provider) { create(:provider, :accredited_provider) }
-
-      it 'returns true' do
-        expect(provider).to be_accredited
-      end
-    end
-
-    context 'for an unaccredited provider' do
-      let(:provider) { create(:provider) }
-
-      it 'returns false' do
-        expect(provider).not_to be_accredited
-      end
     end
   end
 

--- a/spec/serializers/api/public/v1/serializable_provider_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_provider_spec.rb
@@ -22,7 +22,7 @@ describe API::Public::V1::SerializableProvider do
   it { is_expected.to have_attribute(:train_with_us).with_value(provider.train_with_us) }
   it { is_expected.to have_attribute(:website).with_value(provider.website) }
 
-  it { is_expected.to have_attribute(:accredited_body).with_value(provider.accredited_provider?) }
+  it { is_expected.to have_attribute(:accredited_body).with_value(provider.accredited?) }
   it { is_expected.to have_attribute(:changed_at).with_value(provider.changed_at.iso8601) }
   it { is_expected.to have_attribute(:city).with_value(provider.town) }
   it { is_expected.to have_attribute(:code).with_value(provider.provider_code) }

--- a/spec/services/csv_imports/fake_providers_import_spec.rb
+++ b/spec/services/csv_imports/fake_providers_import_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CSVImports::FakeProvidersImport do
       expect(created_provider.provider_name).to eq('Provider A')
       expect(created_provider.provider_code).to eq('ABC')
       expect(created_provider.provider_type).to eq('scitt')
-      expect(created_provider).not_to be_accredited_provider
+      expect(created_provider).not_to be_accredited
     end
 
     it 'reports on the created provider' do

--- a/spec/services/provider_reporting_service_spec.rb
+++ b/spec/services/provider_reporting_service_spec.rb
@@ -108,7 +108,7 @@ describe ProviderReportingService do
         expect(open_providers_scope).to receive(:count).and_return(open_providers_count)
 
         expect(open_providers_scope).to receive(:group)
-          .with(:accrediting_provider)
+          .with(:accredited)
           .and_return(open_providers_accrediting_provider_scope)
 
         expect(open_providers_accrediting_provider_scope).to receive(:count)
@@ -143,7 +143,7 @@ describe ProviderReportingService do
 
         expect(closed_providers_scope).to receive(:count).and_return(closed_providers_count)
 
-        expect(closed_providers_scope).to receive(:group).with(:accrediting_provider).and_return(closed_providers_accrediting_provider_scope)
+        expect(closed_providers_scope).to receive(:group).with(:accredited).and_return(closed_providers_accrediting_provider_scope)
         expect(closed_providers_accrediting_provider_scope).to receive(:count).and_return({})
 
         expect(closed_providers_scope).to receive(:group).with(:provider_type).and_return(closed_providers_provider_type_scope)

--- a/spec/services/providers/create_fake_provider_service_spec.rb
+++ b/spec/services/providers/create_fake_provider_service_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Providers::CreateFakeProviderService do
     it 'the created provider is an accredited_provider' do
       service.execute
 
-      expect(Provider.last.accredited_provider?).to be(true)
+      expect(Provider.last.accredited?).to be(true)
     end
   end
 
@@ -62,7 +62,7 @@ RSpec.describe Providers::CreateFakeProviderService do
     it 'the created provider is an accredited_provider' do
       service.execute
 
-      expect(Provider.last.accredited_provider?).to be(false)
+      expect(Provider.last.accredited?).to be(false)
     end
   end
 end

--- a/spec/system/support/update_provider_spec.rb
+++ b/spec/system/support/update_provider_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Removing accredited status from provider', service: :publish do
       expect(page.find('.govuk-summary-list__value').text).to eq(provider.accredited_provider_number.to_s)
       click_on('Change')
     end
-    page.find_by_id('provider-accrediting-provider-not-an-accredited-provider-field', visible: false).click
+    page.find_by_id('provider-accredited-field', visible: false).click
 
     click_on 'Update organisation details'
     expect(page).to have_current_path("/support/#{RecruitmentCycle.current.year}/providers/#{provider.id}")


### PR DESCRIPTION
## Context

Providers are either Training providers or Accredited providers.
We currently use a column `accrediting_provider varchar(1)` to mark a provider as one or the other.
We use a Rails enum on top of this column which gives us more methods.

We get `accrediting_provider` which returns `"accredited_provider"` if the column value is `'Y'` or `"not_an_accredited_provider"` if the column value is `'N'`.
We also get methods 
#`accredited_provider?` which returns true or false.

We would like to simplify this by using a boolean column that returns true or false.

## Changes proposed in this pull request

Every where we use `#accrediting_provider`, `#accredited_provider?`, etc, we can use `#accredited?`

## Guidance to review

The ProviderForm is a bit tricky. We submit a radio button with value `true` or `false`. The value is recieved as a string `'true'` or `'false'`. Both these values are truthy. We need to cast the value to a boolean to use it effectively in the class.
Normally we could pass this straight to an ActiveRecord model and it would be cast before insert but we aren't saving this directly to a db. 

### Data Migration
The PR includes a data migration that updates the `accredited` column based on the value of the `accrediting_provider` column.
This data migration will run as part of the CMD to start the docker container.

## Trello 
https://trello.com/c/tQIpgo0P/367-update-code-to-use-provideraccredited-instead-of-the-provider-enum-accreditingprovider