### PR TITLE
Add Feature flag switches on Provider accredited_bodies

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -73,7 +73,11 @@ class Provider < ApplicationRecord
   normalizes :provider_name, with: ->(value) { value.gsub(/\s+/, ' ').strip }
 
   def accredited_providers
-    recruitment_cycle.providers.where(provider_code: accredited_provider_codes)
+    if Settings.features.provider_partnerships
+      accredited_partners
+    else
+      recruitment_cycle.providers.where(provider_code: accredited_provider_codes)
+    end
   end
 
   alias accrediting_providers accredited_providers
@@ -339,6 +343,8 @@ class Provider < ApplicationRecord
   end
 
   def accredited_bodies
+    return accredited_partners if Settings.features.provider_partnerships
+
     accrediting_provider_enrichments&.filter_map do |accrediting_provider_enrichment|
       provider_code = accrediting_provider_enrichment.UcasProviderCode
 


### PR DESCRIPTION
## Context

Part of the work to move from `AccreditedProviderEnrichments` to `ProviderPartnership`

## Changes proposed in this pull request

  #accredited_bodies is the main way the we retreive a providers'
  accredited partnerships with enrichments.

  #accredited_providers returns the providers that are associated 
  with the training provider through their enrichments association.

  By adding a feature flag switch here we can choose whether to activate
  the new partnership association or the existing enrichment
  association.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
