### PR TITLE
Add routing constraint to switch routes on a feature flag

### DIFF
--- a/app/lib/constraints/partnership_feature.rb
+++ b/app/lib/constraints/partnership_feature.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Constraints
+  class PartnershipFeature
+    def initialize(setting)
+      @setting = setting
+    end
+
+    def matches?(_request)
+      if @setting == :on
+        Settings.features.provider_partnerships
+      else
+        !Settings.features.provider_partnerships
+      end
+    end
+  end
+end

--- a/spec/lib/constraints/partnership_feature_spec.rb
+++ b/spec/lib/constraints/partnership_feature_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Constraints
+  RSpec.describe PartnershipFeature do
+    describe 'when the feature is on' do
+      before do
+        allow(Settings.features).to receive(:provider_partnerships).and_return(true)
+      end
+
+      context 'when we pass :on' do
+        let(:constraint) { described_class.new(:on) }
+
+        it 'matches' do
+          expect(constraint.matches?(nil)).to be_truthy
+        end
+      end
+
+      context 'when we pass :off' do
+        let(:constraint) { described_class.new(:off) }
+
+        it 'does not match' do
+          expect(constraint.matches?(nil)).to be_falsey
+        end
+      end
+    end
+
+    describe 'when the feature is off' do
+      before do
+        allow(Settings.features).to receive(:provider_partnerships).and_return(false)
+      end
+
+      context 'when we pass :on' do
+        let(:constraint) { described_class.new(:on) }
+
+        it 'does not match' do
+          expect(constraint.matches?(nil)).to be_falsey
+        end
+      end
+
+      context 'when we pass :off' do
+        let(:constraint) { described_class.new(:off) }
+
+        it 'matches' do
+          expect(constraint.matches?(nil)).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Part of the work to move from `AccreditedProviderEnrichments` to `ProviderPartnership`

## Changes proposed in this pull request

  Toggling the provider_partnerships feature flag will be used to make
  available sets of routes in the applicaiton


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/NUdxv9XW/377-add-routing-constraint-to-enable-provider-partnerships-urls-based-on-feature-flag