### PR TITLE
Change ratifying provider for courses

### DIFF
--- a/db/data/20250114155946_update_ratifying_provider.rb
+++ b/db/data/20250114155946_update_ratifying_provider.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class UpdateRatifyingProvider < ActiveRecord::Migration[8.0]
+  PROVIDERS = %w[5W1 1BJ 24H 4R4 3A7].freeze
+  TARGET_PROVIDER = '3A1'
+
+  def up
+    PROVIDERS.each do |training_provider_code|
+      UpdateRatifyingProviderForCourse.new(training_provider_code:, target_ratifying_provider_code: TARGET_PROVIDER).call
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/update_ratifying_provider_for_course.rb
+++ b/lib/update_ratifying_provider_for_course.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UpdateRatifyingProviderForCourse
+  # PROVIDERS = %w[5W1 1BJ 24H 4R4 2a5].freeze
+  # TARGET_PROVIDER = '3A1'
+
+  def initialize(training_provider_code:, target_ratifying_provider_code:)
+    @training_provider = RecruitmentCycle.current.providers.find_by(provider_code: training_provider_code)
+    @target_ratifying_provider_code = target_ratifying_provider_code
+  end
+
+  def call
+    @training_provider.courses.each do |course|
+      course.update!(accredited_provider_code: @target_ratifying_provider_code)
+    end
+  end
+end

--- a/spec/lib/update_ratifying_provider_for_course_spec.rb
+++ b/spec/lib/update_ratifying_provider_for_course_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe UpdateRatifyingProviderForCourse do
+  let(:current_ratifying_provider) { create(:accredited_provider) }
+  let(:target_ratifying_provider) { create(:accredited_provider) }
+  let!(:provider) { create(:provider, courses: [create(:course, accrediting_provider: current_ratifying_provider)]) }
+
+  it 'changes the ratifying provider from current to target' do
+    described_class.new(training_provider_code: provider.provider_code, target_ratifying_provider_code: target_ratifying_provider.provider_code).call
+    expect(provider.courses.reload.first.accrediting_provider).to eq(target_ratifying_provider)
+  end
+end


### PR DESCRIPTION
## Context

Support Request

## Changes proposed in this pull request

Update the ratifying provider for all courses of a given set of training providers in the current recruitment cycle.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/wTPmCvLG/479-update-accrediting-provider-for-hubs
