### PR TITLE
[2199] Monitor apex ssl certificates

### DIFF
--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -45,7 +45,8 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 }
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
-  version = "2.32.0"
+  version     = "2.32.0"
+  constraints = "2.32.0"
   hashes = [
     "h1:Cj3RHyw3wE3AkNlCtSNrZfjFNkShvaZR0K/K3pJlYJU=",
     "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
@@ -64,21 +65,21 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version = "3.6.2"
+  version = "3.6.3"
   hashes = [
-    "h1:R5qdQjKzOU16TziCN1vR3Exr/B+8WGK80glLTT4ZCPk=",
-    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
-    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
-    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
-    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
-    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
-    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
-    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
-    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
-    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
-    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
   ]
 }
 

--- a/terraform/aks/statuscake.tf
+++ b/terraform/aks/statuscake.tf
@@ -4,7 +4,7 @@ module "statuscake" {
   source = "./vendor/modules/aks//monitoring/statuscake"
 
   uptime_urls = compact(concat([module.web_application["main"].probe_url], local.statuscake_additional_hostnames))
-  ssl_urls    = compact([var.external_url])
+  ssl_urls    = var.apex_urls
 
   contact_groups = var.statuscake_contact_groups
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -40,14 +40,9 @@ variable "enable_monitoring" {
 
 variable "enable_logit" { default = false }
 
-variable "external_url" {
-  default     = null
-  description = "Healthcheck URL for StatusCake monitoring"
-}
-
 variable "statuscake_contact_groups" {
-  type    = list(number)
-  default = []
+  type        = list(number)
+  default     = []
   description = "Contact group IDs for receiving StatusCake alerts"
 }
 
@@ -135,3 +130,9 @@ variable "use_db_setup_command" {
 }
 
 variable "postgres_azure_maintenance_window" { default = null }
+
+variable "apex_urls" {
+  description = "List of URLs with DNS zones apex domain for SSL certificate monitoring"
+  type        = list(string)
+  default     = []
+}

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -27,12 +27,16 @@
   "enable_monitoring": true,
   "enable_logit": true,
   "statuscake_contact_groups": [324594, 282453],
-  "external_url": "https://find-teacher-training-courses.service.gov.uk/ping",
   "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
   "postgres_enable_high_availability": true,
   "postgres_azure_maintenance_window": {
     "day_of_week": 0,
     "start_hour": 3,
     "start_minute": 0
-  }
+  },
+  "apex_urls": [
+    "https://find-teacher-training-courses.service.gov.uk",
+    "https://find-postgraduate-teacher-training.service.gov.uk",
+    "https://publish-teacher-training-courses.service.gov.uk"
+  ]
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
@@ -35,7 +35,10 @@
       "environment_short": "pd",
       "origin_hostname": "publish-production.teacherservices.cloud",
       "null_host_header": true,
-      "redirect_rules": []
+      "redirect_rules": [{
+        "from-domain": "www",
+        "to-domain": "find-teacher-training-courses.service.gov.uk"
+      }]
     }
   }
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
@@ -13,7 +13,11 @@
       "environment_short": "pd",
       "environment_tag": "pd",
       "origin_hostname": "publish-production.teacherservices.cloud",
-      "null_host_header": true
+      "null_host_header": true,
+      "redirect_rules": [{
+        "from-domain": "apex",
+        "to-domain": "www.publish-teacher-training-courses.service.gov.uk"
+      }]
     }
   }
 }


### PR DESCRIPTION
## Context
Monitor apex domain certificates so they can be renewed before they expire

## Changes proposed in this pull request
Monitor SSL certificate of:
- find-teacher-training-courses.service.gov.uk
- find-postgraduate-teacher-training.service.gov.uk
- publish-teacher-training-courses.service.gov.uk

Add 2 domain redirects to catch all potential web traffic:
- Redirect publish-teacher-training-courses.service.gov.uk to www.publish-teacher-training-courses.service.gov.uk
- Redirect www.find-teacher-training-courses.service.gov.uk to find-teacher-training-courses.service.gov.uk

## Guidance to review
- make staging deploy-plan (No change)
- make production deploy-plan CONFIRM_PRODUCTION=yes
- make find production domains-plan CONFIRM_PRODUCTION=yes
- make publish production domains-plan CONFIRM_PRODUCTION=yes

## After merging
Run terraform for production domains