### PR TITLE
table_print and terminal-table are not used in the app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,12 +50,6 @@ gem 'jwt'
 # Formalise config settings with support for env vars
 gem 'config'
 
-# Build pretty tables in the terminal
-#   table_print handles ActiveRecord objects and collections really nicely
-gem 'table_print'
-#   terminal-table is a bit more flexible allowing us to use a headers column
-gem 'terminal-table'
-
 # For querying third party APIs
 gem 'faraday'
 gem 'faraday-net_http_persistent', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -699,9 +699,6 @@ GEM
       attr_required (>= 0.0.5)
       faraday (~> 2.0)
       faraday-follow_redirects
-    table_print (1.5.7)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.2)
     timecop (0.9.10)
     timeout (0.4.3)
@@ -840,8 +837,6 @@ DEPENDENCIES
   site_prism (~> 5.0)
   skylight
   super_diff
-  table_print
-  terminal-table
   timecop
   tzinfo-data
   uk_postcode


### PR DESCRIPTION
## Context

table_print and terminal-table are not used in the app

[Commit where they were added](https://github.com/DFE-Digital/publish-teacher-training/commit/6d73a4a04a32c3cb82a9e6a5d1c5ae5657dc6f3f)

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
