### PR TITLE
Add course summary card to the new results page

### DIFF
--- a/app/components/courses/summary_card_component.html.erb
+++ b/app/components/courses/summary_card_component.html.erb
@@ -1,0 +1,42 @@
+<li class="app-search-results__item">
+  <%= govuk_summary_card(classes: ["course-summary-card"], title:) do |card| %>
+    <%= card.with_summary_list(actions: false, classes: ["govuk-summary-list--no-border"]) do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: location_key) %>
+        <% row.with_value(text: location_value) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: fee_key) %>
+        <% row.with_value(text: fee_value) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: length_key) %>
+        <% row.with_value(text: length_value) %>
+      <% end %>
+
+      <% if show_age_group_row? %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key(text: age_group_key) %>
+          <% row.with_value(text: age_group_value) %>
+        <% end %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: qualification_key) %>
+        <% row.with_value(text: qualification_value) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: degree_requirements_key) %>
+        <% row.with_value(text: degree_requirements_value) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key(text: visa_sponsorship_key) %>
+        <% row.with_value(text: visa_sponsorship_value) %>
+      <% end %>
+    <% end %>
+  <% end %>
+</li>

--- a/app/components/courses/summary_card_component.html.erb
+++ b/app/components/courses/summary_card_component.html.erb
@@ -3,12 +3,24 @@
     <%= card.with_summary_list(actions: false, classes: ["govuk-summary-list--no-border"]) do |summary_list| %>
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: location_key) %>
-        <% row.with_value(text: location_value) %>
+        <% row.with_value do %>
+          <%= location_value %>
+
+          <% if location_hint.present? %>
+            <div class="govuk-hint govuk-!-font-size-16"><%= location_hint %></div>
+          <% end %>
+        <% end %>
       <% end %>
 
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: fee_key) %>
-        <% row.with_value(text: fee_value) %>
+        <% row.with_value do %>
+          <%= fee_value %>
+
+          <% if fee_hint.present? %>
+            <div class="govuk-hint govuk-!-font-size-16"><%= fee_hint %></div>
+          <% end %>
+        <% end %>
       <% end %>
 
       <% summary_list.with_row do |row| %>
@@ -30,7 +42,13 @@
 
       <% summary_list.with_row do |row| %>
         <% row.with_key(text: degree_requirements_key) %>
-        <% row.with_value(text: degree_requirements_value) %>
+        <% row.with_value do %>
+          <%= degree_requirements_value %>
+
+          <% if degree_requirements_hint.present? %>
+            <%= degree_requirements_hint %>
+          <% end %>
+        <% end %>
       <% end %>
 
       <% summary_list.with_row do |row| %>

--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+module Courses
+  class SummaryCardComponent < ViewComponent::Base
+    attr_reader :course, :search_params, :available_placements_count, :minimum_distance_to_search_location
+
+    def initialize(course:, search_params:)
+      @course = course
+      @search_params = search_params
+      @available_placements_count = course.available_placements_count
+
+      super
+    end
+
+    def title
+      govuk_link_to(find_course_path(provider_code: course.provider_code, course_code: course.course_code), class: 'govuk-link govuk-!-font-size-24') do
+        safe_join(
+          [
+            content_tag(:span, course.provider_name, class: 'app-search-result__provider-name'),
+            content_tag(:span, course.name_and_code, class: 'app-search-result__course-name')
+          ]
+        )
+      end
+    end
+
+    def location_key
+      t(".location_key.#{course.funding}", count: @available_placements_count)
+    end
+
+    def location_value
+      return t('.location_value.not_listed') if @available_placements_count.zero?
+
+      if search_by_location?
+        safe_join(
+          [
+            t(
+              '.location_value.distance',
+              school_term:,
+              distance: content_tag(:span, pluralize(course.minimum_distance_to_search_location, 'mile'), class: 'govuk-!-font-weight-bold'),
+              location: content_tag(:span, sanitize(@search_params[:location]), class: 'govuk-!-font-weight-bold')
+            ).html_safe,
+            content_tag(
+              :div,
+              t(
+                '.location_value.distance_hint_html',
+                school_term:,
+                count: @available_placements_count
+              ),
+              class: 'govuk-hint govuk-!-font-size-16'
+            )
+          ]
+        )
+      else
+        t(
+          '.location_value.potential_schools',
+          count: @available_placements_count,
+          school_term:
+        )
+      end
+    end
+
+    def fee_key
+      t('.fee_key')
+    end
+
+    def fee_value
+      case course.funding
+      when 'salary', 'apprenticeship'
+        t(".fee_value.#{course.funding}")
+      else
+        [
+          fee_content,
+          fee_hint
+        ].join.html_safe
+      end
+    end
+
+    def length_key
+      t('.length_key')
+    end
+
+    def length_value
+      course_length = course.enrichment_attribute(:course_length).to_s
+      translated_course_length = t(".length_value.#{course_length}", default: course_length)
+
+      [translated_course_length, course.study_mode.humanize.downcase].join(' - ')
+    end
+
+    def show_age_group_row?
+      course.age_range_in_years.present?
+    end
+
+    def age_group_key
+      t('.age_group_key')
+    end
+
+    def age_group_value
+      "#{course.level.humanize} - #{course.age_range_in_years.humanize}"
+    end
+
+    def qualification_key
+      t('.qualification_key')
+    end
+
+    def qualification_value
+      t(".qualification_value.#{course.qualification}_html")
+    end
+
+    def degree_requirements_key
+      t('.degree_requirements_key')
+    end
+
+    def degree_requirements_value
+      content = t(".degree_requirements_value.#{course.degree_type}.#{course.degree_grade}")
+      hint = t(".degree_requirements_hint.#{course.degree_grade}.html") unless course.undergraduate_degree_type?
+
+      [
+        content,
+        hint
+      ].join.html_safe
+    end
+
+    def visa_sponsorship_key
+      t('.visa_sponsorship_key')
+    end
+
+    def visa_sponsorship_value
+      t(".visa_sponsorship_value.#{course.visa_sponsorship}")
+    end
+
+    private
+
+    def school_term
+      t(".location_value.school_term.#{course.funding}", default: t('.location_value.school_term.default'))
+    end
+
+    def search_by_location?
+      @search_params[:location].present?
+    end
+
+    def fee_content
+      fees = [uk_fees, international_fees].compact_blank
+
+      safe_join(fees, tag.br)
+    end
+
+    def uk_fees(fee_uk = course.enrichment_attribute(:fee_uk_eu))
+      t('.fee_value.fee.uk_fees_html', value: content_tag(:b, number_to_currency(fee_uk.to_f)))
+    end
+
+    def international_fees(fee_international = course.enrichment_attribute(:fee_international))
+      return if fee_international.blank?
+
+      t('.fee_value.fee.international_fees_html', value: content_tag(:b, number_to_currency(fee_international.to_f)))
+    end
+
+    def fee_hint
+      return nil if hide_fee_hint?
+
+      if financial_incentive.bursary_amount.present? && financial_incentive.scholarship.present?
+        t(
+          '.fee_value.fee.hint.bursaries_and_scholarship_html',
+          bursary_amount: number_to_currency(financial_incentive.bursary_amount),
+          scholarship_amount: number_to_currency(financial_incentive.scholarship)
+        )
+      elsif financial_incentive.bursary_amount.present?
+        t(
+          '.fee_value.fee.hint.bursaries_only_html',
+          bursary_amount: number_to_currency(financial_incentive.bursary_amount)
+        )
+      elsif financial_incentive.scholarship.present?
+        t(
+          '.fee_value.fee.hint.scholarship_only_html',
+          scholarship_amount: number_to_currency(financial_incentive.scholarship)
+        )
+      end
+    end
+
+    def hide_fee_hint?
+      !bursary_and_scholarship_flag_active_or_preview? || (search_by_visa_sponsorship? && (!physics? && !languages?)) || financial_incentive.blank?
+    end
+
+    def search_by_visa_sponsorship?
+      @search_params[:can_sponsor_visa].present?
+    end
+
+    PHYSICS_SUBJECT = 'Physics'
+
+    def physics?
+      main_subject&.subject_name == PHYSICS_SUBJECT
+    end
+
+    LANGUAGE_SUBJECTS = [
+      'Ancient Greek',
+      'Ancient Hebrew',
+      'English',
+      'English as a second or other language',
+      'French',
+      'German',
+      'Italian',
+      'Japanese',
+      'Latin',
+      'Mandarin',
+      'Modern Languages',
+      'Modern languages (other)',
+      'Russian',
+      'Spanish'
+    ].freeze
+
+    def languages?
+      main_subject&.subject_name.in?(LANGUAGE_SUBJECTS)
+    end
+
+    def financial_incentive
+      @financial_incentive ||= main_subject&.financial_incentive
+    end
+
+    def main_subject
+      @main_subject ||= Subject.find_by(id: course.master_subject_id)
+    end
+
+    def bursary_and_scholarship_flag_active_or_preview?
+      FeatureFlag.active?(:bursaries_and_scholarships_announced)
+    end
+  end
+end

--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -2,12 +2,13 @@
 
 module Courses
   class SummaryCardComponent < ViewComponent::Base
-    attr_reader :course, :search_params, :available_placements_count, :minimum_distance_to_search_location
+    attr_reader :course, :location, :visa_sponsorship, :available_placements_count, :minimum_distance_to_search_location
 
-    def initialize(course:, search_params:)
+    def initialize(course:, location: nil, visa_sponsorship: nil)
       @course = course
-      @search_params = search_params
       @available_placements_count = course.available_placements_count
+      @location = location
+      @visa_sponsorship = visa_sponsorship
 
       super
     end
@@ -37,7 +38,7 @@ module Courses
               '.location_value.distance',
               school_term:,
               distance: content_tag(:span, pluralize(course.minimum_distance_to_search_location, 'mile'), class: 'govuk-!-font-weight-bold'),
-              location: content_tag(:span, sanitize(@search_params[:location]), class: 'govuk-!-font-weight-bold')
+              location: content_tag(:span, sanitize(@location), class: 'govuk-!-font-weight-bold')
             ).html_safe,
             content_tag(
               :div,
@@ -134,10 +135,6 @@ module Courses
       t(".location_value.school_term.#{course.funding}", default: t('.location_value.school_term.default'))
     end
 
-    def search_by_location?
-      @search_params[:location].present?
-    end
-
     def fee_content
       fees = [uk_fees, international_fees].compact_blank
 
@@ -180,8 +177,12 @@ module Courses
       !bursary_and_scholarship_flag_active_or_preview? || (search_by_visa_sponsorship? && (!physics? && !languages?)) || financial_incentive.blank?
     end
 
+    def search_by_location?
+      @location.present?
+    end
+
     def search_by_visa_sponsorship?
-      @search_params[:can_sponsor_visa].present?
+      @visa_sponsorship.present?
     end
 
     PHYSICS_SUBJECT = 'Physics'

--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -5,7 +5,9 @@ module Find
     class ResultsController < Find::ApplicationController
       def index
         @search_courses_form = ::Courses::SearchForm.new(search_courses_params)
-        @courses = ::Courses::Query.call(params: @search_courses_form.search_params)
+        @search_params = @search_courses_form.search_params
+
+        @courses = ::Courses::Query.call(params: @search_params)
         @courses_count = @courses.count
 
         @pagy, @results = pagy(@courses)

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -79,7 +79,7 @@
     <div class="app-filter-layout__content">
       <ul class="app-search-results">
         <% @results.each do |course| %>
-          <%= render Courses::SummaryCardComponent.new(course:, search_params: @search_params) %>
+          <%= render Courses::SummaryCardComponent.new(course:, location: @search_params[:location], visa_sponsorship: @search_params[:can_sponsor_visa]) %>
         <% end %>
       </ul>
 

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -75,27 +75,15 @@
     <% end %>
   </div>
 
-  <div class="app-filter-layout__content">
-    <ul class="app-search-results">
-      <% @results.each do |course| %>
-        <li class="app-search-results__item">
-          <%= govuk_summary_card(
-            classes: ["course-summary-card"],
-            title: govuk_link_to(
-              find_course_path(
-                provider_code: course.provider_code,
-                course_code: course.course_code
-              ),
-              class: "govuk-link govuk-!-font-size-24"
-            ) do
-              content_tag(:span, course.provider.provider_name, class: "app-search-result__provider-name") +
-              content_tag(:span, course.name_and_code, class: "app-search-result__course-name")
-            end
-          ) %>
-        </li>
-      <% end %>
-    </ul>
+  <% if @results.present? %>
+    <div class="app-filter-layout__content">
+      <ul class="app-search-results">
+        <% @results.each do |course| %>
+          <%= render Courses::SummaryCardComponent.new(course:, search_params: @search_params) %>
+        <% end %>
+      </ul>
 
-    <%= govuk_pagination(pagy: @pagy) %>
-  </div>
+      <%= govuk_pagination(pagy: @pagy) %>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -31,9 +31,9 @@ en:
           uk_fees_html: '%{value} for UK citizens'
           international_fees_html: '%{value} for Non-UK citizens'
           hint:
-            bursaries_and_scholarship_html: '<div><span class="govuk-hint govuk-!-font-size-16">Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available</span></div>'
-            bursaries_only_html: '<div><span class="govuk-hint govuk-!-font-size-16">Bursaries of %{bursary_amount} are available</span></div>'
-            scholarship_only_html: '<div><span class="govuk-hint govuk-!-font-size-16">Scholarships of %{scholarship_amount} are available</span></div>'
+            bursaries_and_scholarship_html: 'Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available'
+            bursaries_only_html: 'Bursaries of %{bursary_amount} are available'
+            scholarship_only_html: 'Scholarships of %{scholarship_amount} are available'
       length_key: Course length
       length_value:
         OneYear: 1 year

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -1,4 +1,88 @@
 en:
+  courses:
+    summary_card_component:
+      location_key:
+        fee:
+          one: Placement schools
+          other: Placement schools
+        salary:
+          one: Employing school
+          other: Employing schools
+        apprenticeship:
+          one: Employing school
+          other: Employing schools
+      location_value:
+        not_listed: Not listed yet
+        school_term:
+          fee: 'placement'
+          default: 'employing'
+        potential_schools:
+          one: '1 potential %{school_term} school'
+          other: '%{count} potential %{school_term} schools'
+        distance: "%{distance} from %{location}"
+        distance_hint_html:
+          one: "Nearest of %{count} potential %{school_term} school"
+          other: "Nearest of %{count} potential %{school_term} schools"
+      fee_key: Fee or salary
+      fee_value:
+        salary: Salary
+        apprenticeship: Salary (apprenticeship)
+        fee:
+          uk_fees_html: '%{value} for UK citizens'
+          international_fees_html: '%{value} for Non-UK citizens'
+          hint:
+            bursaries_and_scholarship_html: '<div><span class="govuk-hint govuk-!-font-size-16">Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available</span></div>'
+            bursaries_only_html: '<div><span class="govuk-hint govuk-!-font-size-16">Bursaries of %{bursary_amount} are available</span></div>'
+            scholarship_only_html: '<div><span class="govuk-hint govuk-!-font-size-16">Scholarships of %{scholarship_amount} are available</span></div>'
+      length_key: Course length
+      length_value:
+        OneYear: 1 year
+        TwoYears: Up to 2 years
+      age_group_key: Age group
+      qualification_key: Qualification awarded
+      qualification_value:
+        qts_html: <abbr title='Qualified teacher status'>QTS</abbr> only
+        pgce_with_qts_html: <abbr title='Qualified teacher status'>QTS</abbr> with <abbr title='Postgraduate certificate in education'>PGCE</abbr>
+        pgde_with_qts_html: <abbr title='Qualified teacher status'>QTS</abbr> with <abbr title='Postgraduate diploma in education'>PGDE</abbr>
+        pgce_html: <abbr title='Postgraduate certificate in education'>PGCE</abbr> without <abbr title='Qualified teacher status'>QTS</abbr>
+        pgde_html: <abbr title='Postgraduate diploma in education'>PGDE</abbr> without <abbr title='Qualified teacher status'>QTS</abbr>
+        undergraduate_degree_with_qts_html: Teacher degree apprenticeship with <abbr title='Qualified teacher status'>QTS</abbr>
+      degree_requirements_key: Degree required
+      degree_requirements_value:
+        postgraduate:
+          two_one: '2:1 bachelor’s degree'
+          two_two: '2:2 bachelor’s degree'
+          third_class: 'Bachelor’s degree'
+          not_required: 'Bachelor’s degree'
+        undergraduate:
+          not_required: No degree required
+      degree_requirements_hint:
+        two_one: &two_one_html
+          html: "<br><span class='govuk-hint govuk-!-font-size-16'>or above or equivalent qualification</span>"
+        two_two:
+          <<: *two_one_html
+        third_class:
+          html:
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16">
+              or equivalent qualification
+            </span>
+            <br>
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16">
+              This should be an honours degree (Third or above), or equivalent
+            </span>
+        not_required:
+          html:
+            <br>
+            <span class="govuk-hint govuk-!-font-size-16">
+              or equivalent qualification
+            </span>
+      visa_sponsorship_key: Visa sponsorship
+      visa_sponsorship_value:
+        no_sponsorship: Visas cannot be sponsored
+        can_sponsor_student_visa: Student visas can be sponsored
+        can_sponsor_skilled_worker_visa: Skilled Worker visas can be sponsored
   find:
     cycles:
       real:

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -1,0 +1,646 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Courses::SummaryCardComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  subject(:summary_card) do
+    render_inline(
+      described_class.new(
+        course:,
+        search_params:
+      )
+    )
+  end
+
+  let(:search_params) { {} }
+
+  describe '#title' do
+    let(:course) do
+      build(
+        :course,
+        name: 'Mathematics',
+        course_code: '37CP',
+        provider: build(:provider, provider_code: 'B1T', provider_name: 'University')
+      )
+    end
+
+    it 'renders the correct link with provider and course name' do
+      expect(summary_card).to have_link('University', href: find_course_path(provider_code: 'B1T', course_code: '37CP'))
+    end
+
+    it 'renders the provider name with the correct class' do
+      expect(summary_card).to have_css('.app-search-result__provider-name', text: 'University')
+    end
+
+    it 'renders the course name and code with the correct class' do
+      expect(summary_card).to have_css('.app-search-result__course-name', text: 'Mathematics (37CP)')
+    end
+  end
+
+  shared_examples 'school location row' do |funding_type, count, expected_output|
+    let(:funding) { funding_type }
+    let(:available_placements_count) { count }
+
+    before { allow(course).to receive(:available_placements_count).and_return(count) }
+
+    it "returns the correct content for #{funding_type} when course has #{count} school(s)" do
+      expect(subject.text).to include(expected_output)
+    end
+  end
+
+  describe 'when displaying location field' do
+    let(:course) do
+      create(
+        :course,
+        funding:
+      )
+    end
+
+    context "when funding is 'fee'" do
+      it_behaves_like 'school location row', :fee, 1, 'Placement school'
+      it_behaves_like 'school location row', :fee, 3, 'Placement schools'
+    end
+
+    context "when funding is 'salary'" do
+      it_behaves_like 'school location row', :salary, 1, 'Employing school'
+      it_behaves_like 'school location row', :salary, 5, 'Employing schools'
+    end
+
+    context "when funding is 'apprenticeship'" do
+      it_behaves_like 'school location row', :apprenticeship, 1, 'Employing school'
+      it_behaves_like 'school location row', :apprenticeship, 7, 'Employing schools'
+    end
+  end
+
+  describe 'displaying location value' do
+    let(:course) do
+      create(
+        :course,
+        funding:
+      )
+    end
+
+    context 'when no placements' do
+      it_behaves_like 'school location row', :fee, 0, 'Not listed yet'
+      it_behaves_like 'school location row', :salary, 0, 'Not listed yet'
+      it_behaves_like 'school location row', :apprenticeship, 0, 'Not listed yet'
+    end
+
+    context 'when there are placements and is not a location search' do
+      it_behaves_like 'school location row', :fee, 1, '1 potential placement school'
+      it_behaves_like 'school location row', :fee, 2, '2 potential placement schools'
+      it_behaves_like 'school location row', :salary, 1, '1 potential employing school'
+      it_behaves_like 'school location row', :salary, 2, '2 potential employing schools'
+      it_behaves_like 'school location row', :apprenticeship, 1, '1 potential employing school'
+      it_behaves_like 'school location row', :apprenticeship, 3, '3 potential employing schools'
+    end
+
+    context 'when search by location' do
+      let(:search_params) { { location: 'London', latitude: 1, longitude: 1 } }
+
+      before do
+        # minimum_distance_to_search_location will be an attribute
+        # in the query SELECT list so we avoid Ruby computation and
+        # recalculation of all sites and its latitude, longitude from a single
+        # location
+        course.define_singleton_method(:minimum_distance_to_search_location) { 0.2 }
+      end
+
+      it_behaves_like 'school location row', :fee, 3, '0.2 miles from London'
+      it_behaves_like 'school location row', :salary, 3, '0.2 miles from London'
+      it_behaves_like 'school location row', :apprenticeship, 3, '0.2 miles from London'
+
+      it_behaves_like 'school location row', :fee, 1, 'Nearest of 1 potential placement school'
+      it_behaves_like 'school location row', :fee, 3, 'Nearest of 3 potential placement schools'
+      it_behaves_like 'school location row', :salary, 1, 'Nearest of 1 potential employing school'
+      it_behaves_like 'school location row', :salary, 3, 'Nearest of 3 potential employing schools'
+      it_behaves_like 'school location row', :apprenticeship, 1, 'Nearest of 1 potential employing school'
+      it_behaves_like 'school location row', :apprenticeship, 3, 'Nearest of 3 potential employing schools'
+
+      context 'sanitize dangerous user input' do
+        let(:funding) { :fee }
+        let(:search_params) do
+          { location: '<script>alert("XSS")</script>', latitude: 1, longitude: 1 }
+        end
+
+        before { allow(course).to receive(:available_placements_count).and_return(2) }
+
+        it 'sanitizes user input by striping html tags' do
+          expect(summary_card.text).to include(
+            '0.2 miles from alert("XSS")Nearest of 2 potential placement schools'
+          )
+        end
+      end
+    end
+  end
+
+  shared_examples 'fee or salary row' do |funding_type, params, expected_output|
+    let(:funding) { funding_type }
+    let(:search_params) { params }
+
+    before { allow(course).to receive(:available_placements_count).and_return(2) }
+
+    it "returns the correct fee or salary row for #{funding_type}" do
+      expect(subject.text).to include(expected_output)
+    end
+  end
+
+  describe 'when displaying fee or salary' do
+    let(:course) do
+      create(
+        :course,
+        funding:
+      )
+    end
+
+    before do
+      FeatureFlag.activate(:bursaries_and_scholarships_announced)
+    end
+
+    context 'when course funding is salary' do
+      let(:funding) { :salary }
+
+      it 'does not show bursaries or scholarship' do
+        expect(summary_card.text).to include('Salary')
+        expect(summary_card.text).not_to include('Bursaries')
+        expect(summary_card.text).not_to include('Scholarships')
+      end
+    end
+
+    context 'when course funding is apprenticeship' do
+      let(:funding) { :apprenticeship }
+
+      it 'does not show bursaries or scholarship' do
+        expect(summary_card.text).to include('Salary (apprenticeship)')
+        expect(summary_card.text).not_to include('Bursaries')
+        expect(summary_card.text).not_to include('Scholarships')
+      end
+    end
+
+    context 'when course funding is fee and user searches for visa sponsorship' do
+      context 'when physics is main subject and has bursaries' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            name: 'Physics with Drama',
+            subjects: [
+              build(:secondary_subject, :physics, bursary_amount: 10_000),
+              build(:secondary_subject, :drama)
+            ],
+            funding:,
+            enrichments: [create(:course_enrichment, fee_uk_eu: 9250, fee_international: 17_900)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£9,250 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£17,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, 'Bursaries of £10,000 are available'
+      end
+
+      context 'when physics is main subject and has scholarship' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            name: 'Physics with Drama',
+            subjects: [
+              build(:secondary_subject, :physics, scholarship: 10_000),
+              build(:secondary_subject, :drama)
+            ],
+            funding:,
+            enrichments: [create(:course_enrichment, fee_uk_eu: 6000, fee_international: 11_000)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,000 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£11,000 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, 'Scholarships of £10,000 are available'
+      end
+
+      context 'when physics is main subject and has bursaries and scholarship' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            name: 'Physics with Drama',
+            subjects: [
+              build(:secondary_subject, :physics, bursary_amount: 9000, scholarship: 10_000),
+              build(:secondary_subject, :drama)
+            ],
+            funding:,
+            enrichments: [create(:course_enrichment, fee_uk_eu: 7000, fee_international: 7000)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£7,000 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£7,000 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, 'Scholarships of £10,000 or bursaries of £9,000 are available'
+      end
+
+      context 'when main subject does not have bursaries and physics is second subject with bursaries' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'Physics with Drama',
+            subjects: [
+              build(:secondary_subject, :drama),
+              build(:secondary_subject, :physics, bursary_amount: 9000, scholarship: 10_000)
+            ],
+            enrichments: [create(:course_enrichment, fee_uk_eu: 8000, fee_international: 8000)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£8,000 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£8,000 for Non-UK citizens'
+
+        it 'does not show bursaries or scholarship' do
+          expect(summary_card.text).not_to include('Bursaries')
+          expect(summary_card.text).not_to include('Scholarships')
+        end
+      end
+
+      context 'when languages is the main subject and offer bursaries and scholarship' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            name: 'English with Drama',
+            subjects: [
+              build(:secondary_subject, :english, bursary_amount: 6000, scholarship: 5000),
+              build(:secondary_subject, :drama)
+            ],
+            funding:,
+            enrichments: [create(:course_enrichment, fee_uk_eu: 10_000, fee_international: nil)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£10,000 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, 'Scholarships of £5,000 or bursaries of £6,000 are available'
+      end
+
+      context 'when languages is the second subject' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'Physics with Drama',
+            subjects: [
+              build(:secondary_subject, :drama),
+              build(:secondary_subject, :physics, bursary_amount: 9000, scholarship: 10_000)
+            ],
+            enrichments: [create(:course_enrichment, fee_uk_eu: 6250, fee_international: 6900)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,250 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,900 for Non-UK citizens'
+
+        it 'does not show bursaries or scholarship' do
+          expect(summary_card.text).not_to include('Bursaries')
+          expect(summary_card.text).not_to include('Scholarships')
+        end
+      end
+
+      context 'when is not physics' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'History with Drama',
+            subjects: [
+              build(:secondary_subject, :history, bursary_amount: 9000, scholarship: 10_000),
+              build(:secondary_subject, :drama)
+            ],
+            enrichments: [create(:course_enrichment, fee_uk_eu: 6250, fee_international: nil)]
+          )
+        end
+        let(:search_params) { { can_sponsor_visa: true } }
+
+        it 'does not show bursaries or scholarship' do
+          expect(summary_card.text).not_to include('Bursaries')
+          expect(summary_card.text).not_to include('Scholarships')
+        end
+      end
+
+      context 'when is not languages' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'Biology with Drama',
+            subjects: [
+              build(:secondary_subject, :biology, bursary_amount: 9000, scholarship: 10_000),
+              build(:secondary_subject, :drama)
+            ]
+          )
+        end
+        let(:search_params) { { can_sponsor_visa: true } }
+
+        it 'does not show bursaries or scholarship' do
+          expect(summary_card.text).not_to include('Bursaries')
+          expect(summary_card.text).not_to include('Scholarships')
+        end
+      end
+    end
+
+    context 'when course funding is fee and user does not search for visa sponsorship' do
+      context 'when main subject offers bursary' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'Dance with Drama',
+            subjects: [
+              build(:secondary_subject, :dance, bursary_amount: 9000),
+              build(:secondary_subject, :drama)
+            ],
+            enrichments: [create(:course_enrichment, fee_uk_eu: 6250, fee_international: 6900)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,250 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, 'Bursaries of £9,000 are available'
+      end
+
+      context 'when main subject offers scholarship' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'Dance with Drama',
+            subjects: [
+              build(:secondary_subject, :dance, scholarship: 9000),
+              build(:secondary_subject, :drama)
+            ],
+            enrichments: [create(:course_enrichment, fee_uk_eu: 6250, fee_international: 6900)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,250 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, 'Scholarships of £9,000 are available'
+      end
+
+      context 'when main subject offers bursaries and scholarship' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'Dance with Drama',
+            subjects: [
+              build(:secondary_subject, :dance, bursary_amount: 7000, scholarship: 9000),
+              build(:secondary_subject, :drama)
+            ],
+            enrichments: [create(:course_enrichment, fee_uk_eu: 7250, fee_international: 6900)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, {}, '£7,250 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, 'Scholarships of £9,000 or bursaries of £7,000 are available'
+      end
+
+      context 'when main subject does not offer bursary or scholarship' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'Dance with Drama',
+            subjects: [
+              build(:secondary_subject, :drama),
+              build(:secondary_subject, :dance, bursary_amount: 7000, scholarship: 9000)
+            ],
+            enrichments: [create(:course_enrichment, fee_uk_eu: 7500, fee_international: 6900)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, {}, '£7,500 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
+
+        it 'does not show bursaries or scholarship' do
+          expect(summary_card.text).not_to include('Bursaries')
+          expect(summary_card.text).not_to include('Scholarships')
+        end
+      end
+
+      context 'when all subjects does not offer bursary or scholarship' do
+        let(:course) do
+          create(
+            :course,
+            :secondary,
+            :fee_type_based,
+            name: 'Dance with Drama',
+            subjects: [
+              build(:secondary_subject, :dance),
+              build(:secondary_subject, :drama)
+            ],
+            enrichments: [create(:course_enrichment, fee_uk_eu: 8500, fee_international: 8500)]
+          )
+        end
+
+        it_behaves_like 'fee or salary row', :fee, {}, '£8,500 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£8,500 for Non-UK citizens'
+
+        it 'does not show bursaries or scholarship' do
+          expect(summary_card.text).not_to include('Bursaries')
+          expect(summary_card.text).not_to include('Scholarships')
+        end
+      end
+    end
+  end
+
+  shared_examples 'course length row' do |course_length, course_study_mode, expected_output|
+    let(:course) do
+      create(:course, study_mode:, enrichments: [build(:course_enrichment, course_length: length)])
+    end
+    let(:length) { course_length }
+    let(:study_mode) { course_study_mode }
+
+    before { allow(course).to receive(:available_placements_count).and_return(2) }
+
+    it "returns the correct course length row for #{course_length} and #{course_study_mode}" do
+      expect(subject.text).to include("Course length#{expected_output}")
+    end
+  end
+
+  describe 'when displaying course length' do
+    context 'when course length is one year' do
+      it_behaves_like 'course length row', 'OneYear', :full_time, '1 year - full time'
+      it_behaves_like 'course length row', 'OneYear', :part_time, '1 year - part time'
+      it_behaves_like 'course length row', 'OneYear', :full_time_or_part_time, '1 year - full time or part time'
+    end
+
+    context 'when course length is two years' do
+      it_behaves_like 'course length row', 'TwoYears', :full_time, 'Up to 2 years - full time'
+      it_behaves_like 'course length row', 'TwoYears', :part_time, 'Up to 2 years - part time'
+      it_behaves_like 'course length row', 'TwoYears', :full_time_or_part_time, 'Up to 2 years - full time or part time'
+    end
+
+    context 'when custom course length' do
+      it_behaves_like 'course length row', '4 years', :full_time, '4 years - full time'
+      it_behaves_like 'course length row', '4 years', :part_time, '4 years - part time'
+      it_behaves_like 'course length row', '4 years', :full_time_or_part_time, '4 years - full time or part time'
+    end
+  end
+
+  shared_examples 'course age group row' do |course_level, course_age_group, expected_output|
+    let(:course) { create(:course, level:, age_range_in_years:) }
+    let(:level) { course_level.downcase }
+    let(:age_range_in_years) { course_age_group }
+
+    before { allow(course).to receive(:available_placements_count).and_return(2) }
+
+    it "returns the correct age group row for #{course_level} and #{course_age_group}" do
+      expect(subject.text).to include("Age group#{expected_output}")
+    end
+  end
+
+  describe 'when displaying age group' do
+    context 'when course is primary' do
+      it_behaves_like 'course age group row', 'Primary', '3_to_11', 'Primary - 3 to 11'
+      it_behaves_like 'course age group row', 'Primary', '3_to_7', 'Primary - 3 to 7'
+      it_behaves_like 'course age group row', 'Primary', '4_to_11', 'Primary - 4 to 11'
+      it_behaves_like 'course age group row', 'Primary', '5_to_11', 'Primary - 5 to 11'
+      it_behaves_like 'course age group row', 'Primary', '5_to_14', 'Primary - 5 to 14'
+      it_behaves_like 'course age group row', 'Primary', '7_to_11', 'Primary - 7 to 11'
+      it_behaves_like 'course age group row', 'Primary', '7_to_14', 'Primary - 7 to 14'
+    end
+
+    context 'when course is secondary' do
+      it_behaves_like 'course age group row', 'Secondary', '5_to_18', 'Secondary - 5 to 18'
+      it_behaves_like 'course age group row', 'Secondary', '7_to_14', 'Secondary - 7 to 14'
+      it_behaves_like 'course age group row', 'Secondary', '9_to_16', 'Secondary - 9 to 16'
+      it_behaves_like 'course age group row', 'Secondary', '11_to_16', 'Secondary - 11 to 16'
+      it_behaves_like 'course age group row', 'Secondary', '11_to_18', 'Secondary - 11 to 18'
+      it_behaves_like 'course age group row', 'Secondary', '11_to_19', 'Secondary - 11 to 19'
+      it_behaves_like 'course age group row', 'Secondary', '13_to_18', 'Secondary - 13 to 18'
+      it_behaves_like 'course age group row', 'Secondary', '14_to_18', 'Secondary - 14 to 18'
+      it_behaves_like 'course age group row', 'Secondary', '14_to_19', 'Secondary - 14 to 19'
+    end
+
+    context 'when course is further education' do
+      let(:course) { create(:course, :further_education, age_range_in_years: nil) }
+
+      it 'does not include age group row' do
+        expect(subject.text).not_to include('Age group')
+      end
+    end
+  end
+
+  shared_examples 'course qualification row' do |course_qualification, expected_output|
+    let(:course) { create(:course, qualification: course_qualification) }
+
+    before { allow(course).to receive(:available_placements_count).and_return(2) }
+
+    it "returns the correct qualification row for #{course_qualification}" do
+      expect(subject.text).to include("Qualification awarded#{expected_output}")
+    end
+  end
+
+  describe 'when displaying qualification' do
+    it_behaves_like 'course qualification row', :qts, 'QTS only'
+    it_behaves_like 'course qualification row', :pgce_with_qts, 'QTS with PGCE'
+    it_behaves_like 'course qualification row', :pgde_with_qts, 'QTS with PGDE'
+    it_behaves_like 'course qualification row', :pgce, 'PGCE without QTS'
+    it_behaves_like 'course qualification row', :pgde, 'PGDE without QTS'
+    it_behaves_like 'course qualification row', :undergraduate_degree_with_qts, 'Teacher degree apprenticeship with QTS'
+  end
+
+  shared_examples 'course degree requirements row' do |course_degree_type, course_degree_grade_required, expected_output|
+    let(:course) { create(:course, degree_type:, degree_grade:) }
+    let(:degree_type) { course_degree_type }
+    let(:degree_grade) { course_degree_grade_required }
+
+    before { allow(course).to receive(:available_placements_count).and_return(2) }
+
+    it "returns the correct degree requirements row for #{course_degree_type} and #{course_degree_grade_required}" do
+      expect(subject.text).to include("Degree required#{expected_output}")
+    end
+  end
+
+  describe 'when displaying course degree requirements' do
+    context 'when course requires 2:1 degree' do
+      it_behaves_like 'course degree requirements row', :postgraduate, 'two_one', '2:1 bachelor’s degreeor above or equivalent qualification'
+    end
+
+    context 'when course requires 2:2 degree' do
+      it_behaves_like 'course degree requirements row', :postgraduate, 'two_two', '2:2 bachelor’s degreeor above or equivalent qualification'
+    end
+
+    context 'when course requires third class degree' do
+      it_behaves_like 'course degree requirements row',
+                      :postgraduate,
+                      'third_class',
+                      'Bachelor’s degree  or equivalent qualification     This should be an honours degree (Third or above), or equivalent'
+    end
+
+    context 'when course requires "Pass" degree' do
+      it_behaves_like 'course degree requirements row', :postgraduate, 'not_required', 'Bachelor’s degree  or equivalent qualification'
+    end
+
+    context 'when course requires no degree' do
+      it_behaves_like 'course degree requirements row', :undergraduate, 'not_required', 'No degree required'
+
+      it 'does not render the hint text' do
+        course = create(:course, degree_type: 'undergraduate', degree_grade: 'not_required')
+        expect(render_inline(described_class.new(course:, search_params: {}))).not_to include('or equivalent qualification')
+      end
+    end
+  end
+
+  shared_examples 'visa sponsorship row' do |funding, visa_sponsorship, expected_text|
+    let(:course) do
+      create(
+        :course,
+        funding:,
+        can_sponsor_student_visa:,
+        can_sponsor_skilled_worker_visa:
+      )
+    end
+    let(:can_sponsor_student_visa) { visa_sponsorship[:can_sponsor_student_visa] }
+    let(:can_sponsor_skilled_worker_visa) { visa_sponsorship[:can_sponsor_skilled_worker_visa] }
+
+    it "displays the correct visa sponsorship text for #{funding} courses with #{visa_sponsorship}" do
+      expect(summary_card.text).to include("Visa sponsorship#{expected_text}")
+    end
+  end
+
+  describe 'when displaying course visa sponsorship' do
+    context 'when the provider sponsor skilled worker visa for a salaried course' do
+      it_behaves_like 'visa sponsorship row', :salary, { can_sponsor_skilled_worker_visa: true }, 'Skilled Worker visas can be sponsored'
+      it_behaves_like 'visa sponsorship row', :apprenticeship, { can_sponsor_skilled_worker_visa: true }, 'Skilled Worker visas can be sponsored'
+    end
+
+    context 'when the provider sponsor skilled worker visa sponsorship for an unsalaried course' do
+      it_behaves_like 'visa sponsorship row', :fee, { can_sponsor_skilled_worker_visa: true }, 'Visas cannot be sponsored'
+    end
+
+    context 'when the provider specifies student visa sponsorship for an salaried course' do
+      it_behaves_like 'visa sponsorship row', :salary, { can_sponsor_student_visa: true }, 'Visas cannot be sponsored'
+      it_behaves_like 'visa sponsorship row', :apprenticeship, { can_sponsor_student_visa: true }, 'Visas cannot be sponsored'
+    end
+
+    context 'when the provider specifies student visa sponsorship for an unsalaried course' do
+      it_behaves_like 'visa sponsorship row', :fee, { can_sponsor_student_visa: true }, 'Student visas can be sponsored'
+    end
+
+    context 'when neither kind of visa is sponsored' do
+      it_behaves_like 'visa sponsorship row', :fee, { can_sponsor_student_visa: false }, 'Visas cannot be sponsored'
+      it_behaves_like 'visa sponsorship row', :salary, { can_sponsor_student_visa: false }, 'Visas cannot be sponsored'
+      it_behaves_like 'visa sponsorship row', :apprenticeship, { can_sponsor_student_visa: false }, 'Visas cannot be sponsored'
+    end
+  end
+end

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -9,12 +9,15 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     render_inline(
       described_class.new(
         course:,
-        search_params:
+        location:,
+        visa_sponsorship:
       )
     )
   end
 
   let(:search_params) { {} }
+  let(:location) { search_params[:location] }
+  let(:visa_sponsorship) { search_params[:can_sponsor_visa] }
 
   describe '#title' do
     let(:course) do
@@ -596,7 +599,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
 
       it 'does not render the hint text' do
         course = create(:course, degree_type: 'undergraduate', degree_grade: 'not_required')
-        expect(render_inline(described_class.new(course:, search_params: {}))).not_to include('or equivalent qualification')
+        expect(render_inline(described_class.new(course:))).not_to include('or equivalent qualification')
       end
     end
   end

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -5,7 +5,11 @@ require 'rails_helper'
 RSpec.describe Courses::SummaryCardComponent, type: :component do
   include Rails.application.routes.url_helpers
 
-  subject(:summary_card) do
+  subject(:summary_card_content) do
+    summary_card.text.gsub(/\r?\n/, ' ').squeeze(' ').strip
+  end
+
+  let(:summary_card) do
     render_inline(
       described_class.new(
         course:,
@@ -14,7 +18,6 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
       )
     )
   end
-
   let(:search_params) { {} }
   let(:location) { search_params[:location] }
   let(:visa_sponsorship) { search_params[:can_sponsor_visa] }
@@ -49,7 +52,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     before { allow(course).to receive(:available_placements_count).and_return(count) }
 
     it "returns the correct content for #{funding_type} when course has #{count} school(s)" do
-      expect(subject.text).to include(expected_output)
+      expect(summary_card_content).to include(expected_output)
     end
   end
 
@@ -131,8 +134,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
         before { allow(course).to receive(:available_placements_count).and_return(2) }
 
         it 'sanitizes user input by striping html tags' do
-          expect(summary_card.text).to include(
-            '0.2 miles from alert("XSS")Nearest of 2 potential placement schools'
+          expect(summary_card_content).to include(
+            '0.2 miles from alert("XSS") Nearest of 2 potential placement schools'
           )
         end
       end
@@ -146,7 +149,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     before { allow(course).to receive(:available_placements_count).and_return(2) }
 
     it "returns the correct fee or salary row for #{funding_type}" do
-      expect(subject.text).to include(expected_output)
+      expect(summary_card_content).to include(expected_output)
     end
   end
 
@@ -166,9 +169,9 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
       let(:funding) { :salary }
 
       it 'does not show bursaries or scholarship' do
-        expect(summary_card.text).to include('Salary')
-        expect(summary_card.text).not_to include('Bursaries')
-        expect(summary_card.text).not_to include('Scholarships')
+        expect(summary_card_content).to include('Salary')
+        expect(summary_card_content).not_to include('Bursaries')
+        expect(summary_card_content).not_to include('Scholarships')
       end
     end
 
@@ -176,9 +179,9 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
       let(:funding) { :apprenticeship }
 
       it 'does not show bursaries or scholarship' do
-        expect(summary_card.text).to include('Salary (apprenticeship)')
-        expect(summary_card.text).not_to include('Bursaries')
-        expect(summary_card.text).not_to include('Scholarships')
+        expect(summary_card_content).to include('Salary (apprenticeship)')
+        expect(summary_card_content).not_to include('Bursaries')
+        expect(summary_card_content).not_to include('Scholarships')
       end
     end
 
@@ -262,8 +265,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
         it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£8,000 for Non-UK citizens'
 
         it 'does not show bursaries or scholarship' do
-          expect(summary_card.text).not_to include('Bursaries')
-          expect(summary_card.text).not_to include('Scholarships')
+          expect(summary_card_content).not_to include('Bursaries')
+          expect(summary_card_content).not_to include('Scholarships')
         end
       end
 
@@ -305,8 +308,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
         it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,900 for Non-UK citizens'
 
         it 'does not show bursaries or scholarship' do
-          expect(summary_card.text).not_to include('Bursaries')
-          expect(summary_card.text).not_to include('Scholarships')
+          expect(summary_card_content).not_to include('Bursaries')
+          expect(summary_card_content).not_to include('Scholarships')
         end
       end
 
@@ -327,8 +330,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
         let(:search_params) { { can_sponsor_visa: true } }
 
         it 'does not show bursaries or scholarship' do
-          expect(summary_card.text).not_to include('Bursaries')
-          expect(summary_card.text).not_to include('Scholarships')
+          expect(summary_card_content).not_to include('Bursaries')
+          expect(summary_card_content).not_to include('Scholarships')
         end
       end
 
@@ -348,8 +351,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
         let(:search_params) { { can_sponsor_visa: true } }
 
         it 'does not show bursaries or scholarship' do
-          expect(summary_card.text).not_to include('Bursaries')
-          expect(summary_card.text).not_to include('Scholarships')
+          expect(summary_card_content).not_to include('Bursaries')
+          expect(summary_card_content).not_to include('Scholarships')
         end
       end
     end
@@ -434,8 +437,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
         it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
 
         it 'does not show bursaries or scholarship' do
-          expect(summary_card.text).not_to include('Bursaries')
-          expect(summary_card.text).not_to include('Scholarships')
+          expect(summary_card_content).not_to include('Bursaries')
+          expect(summary_card_content).not_to include('Scholarships')
         end
       end
 
@@ -458,8 +461,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
         it_behaves_like 'fee or salary row', :fee, {}, '£8,500 for Non-UK citizens'
 
         it 'does not show bursaries or scholarship' do
-          expect(summary_card.text).not_to include('Bursaries')
-          expect(summary_card.text).not_to include('Scholarships')
+          expect(summary_card_content).not_to include('Bursaries')
+          expect(summary_card_content).not_to include('Scholarships')
         end
       end
     end
@@ -475,7 +478,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     before { allow(course).to receive(:available_placements_count).and_return(2) }
 
     it "returns the correct course length row for #{course_length} and #{course_study_mode}" do
-      expect(subject.text).to include("Course length#{expected_output}")
+      expect(summary_card_content).to include("Course length#{expected_output}")
     end
   end
 
@@ -507,7 +510,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     before { allow(course).to receive(:available_placements_count).and_return(2) }
 
     it "returns the correct age group row for #{course_level} and #{course_age_group}" do
-      expect(subject.text).to include("Age group#{expected_output}")
+      expect(summary_card_content).to include("Age group#{expected_output}")
     end
   end
 
@@ -538,7 +541,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
       let(:course) { create(:course, :further_education, age_range_in_years: nil) }
 
       it 'does not include age group row' do
-        expect(subject.text).not_to include('Age group')
+        expect(summary_card_content).not_to include('Age group')
       end
     end
   end
@@ -549,7 +552,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     before { allow(course).to receive(:available_placements_count).and_return(2) }
 
     it "returns the correct qualification row for #{course_qualification}" do
-      expect(subject.text).to include("Qualification awarded#{expected_output}")
+      expect(summary_card_content).to include("Qualification awarded#{expected_output}")
     end
   end
 
@@ -570,28 +573,28 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     before { allow(course).to receive(:available_placements_count).and_return(2) }
 
     it "returns the correct degree requirements row for #{course_degree_type} and #{course_degree_grade_required}" do
-      expect(subject.text).to include("Degree required#{expected_output}")
+      expect(summary_card_content).to include("Degree required #{expected_output}")
     end
   end
 
   describe 'when displaying course degree requirements' do
     context 'when course requires 2:1 degree' do
-      it_behaves_like 'course degree requirements row', :postgraduate, 'two_one', '2:1 bachelor’s degreeor above or equivalent qualification'
+      it_behaves_like 'course degree requirements row', :postgraduate, 'two_one', '2:1 bachelor’s degree or above or equivalent qualification'
     end
 
     context 'when course requires 2:2 degree' do
-      it_behaves_like 'course degree requirements row', :postgraduate, 'two_two', '2:2 bachelor’s degreeor above or equivalent qualification'
+      it_behaves_like 'course degree requirements row', :postgraduate, 'two_two', '2:2 bachelor’s degree or above or equivalent qualification'
     end
 
     context 'when course requires third class degree' do
       it_behaves_like 'course degree requirements row',
                       :postgraduate,
                       'third_class',
-                      'Bachelor’s degree  or equivalent qualification     This should be an honours degree (Third or above), or equivalent'
+                      'Bachelor’s degree or equivalent qualification This should be an honours degree (Third or above), or equivalent'
     end
 
     context 'when course requires "Pass" degree' do
-      it_behaves_like 'course degree requirements row', :postgraduate, 'not_required', 'Bachelor’s degree  or equivalent qualification'
+      it_behaves_like 'course degree requirements row', :postgraduate, 'not_required', 'Bachelor’s degree or equivalent qualification'
     end
 
     context 'when course requires no degree' do
@@ -617,7 +620,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
     let(:can_sponsor_skilled_worker_visa) { visa_sponsorship[:can_sponsor_skilled_worker_visa] }
 
     it "displays the correct visa sponsorship text for #{funding} courses with #{visa_sponsorship}" do
-      expect(summary_card.text).to include("Visa sponsorship#{expected_text}")
+      expect(summary_card_content).to include("Visa sponsorship#{expected_text}")
     end
   end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3437,4 +3437,52 @@ describe Course do
       expect(course.training_route).to eq('unknown_training_route')
     end
   end
+
+  describe '#visa_sponsorship' do
+    context 'when the funding type is fee-based' do
+      let(:course) { build(:course, funding: 'fee', can_sponsor_student_visa:) }
+
+      context 'and the course can sponsor a student visa' do
+        let(:can_sponsor_student_visa) { true }
+
+        it 'returns :can_sponsor_student_visa' do
+          expect(course.visa_sponsorship).to eq(:can_sponsor_student_visa)
+        end
+      end
+
+      context 'and the course cannot sponsor a student visa' do
+        let(:can_sponsor_student_visa) { false }
+
+        it 'returns :no_sponsorship' do
+          expect(course.visa_sponsorship).to eq(:no_sponsorship)
+        end
+      end
+    end
+
+    context 'when the funding type is salary-based or apprenticeship' do
+      let(:course) { build(:course, funding: funding, can_sponsor_skilled_worker_visa:) }
+
+      %w[salary apprenticeship].each do |funding_type|
+        context "and the funding type is #{funding_type}" do
+          let(:funding) { funding_type }
+
+          context 'and the course can sponsor a skilled worker visa' do
+            let(:can_sponsor_skilled_worker_visa) { true }
+
+            it 'returns :can_sponsor_skilled_worker_visa' do
+              expect(course.visa_sponsorship).to eq(:can_sponsor_skilled_worker_visa)
+            end
+          end
+
+          context 'and the course cannot sponsor a skilled worker visa' do
+            let(:can_sponsor_skilled_worker_visa) { false }
+
+            it 'returns :no_sponsorship' do
+              expect(course.visa_sponsorship).to eq(:no_sponsorship)
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Context

This PR adds all the course summary content into the search result.

The goal was:

* Simplify the views and the component and the locales in comparison from the old search result (you can compare with `SearchResultComponent` if you want)

If you wanna see the details of each field please read the commit message.

## Caveats

* There are N+1 queries on this PR - this will be addressed in future PR.