### PR TITLE
Add musl to Gemfile.lock PLATFORMS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -742,6 +742,7 @@ PLATFORMS
   arm64-darwin
   x86_64-darwin
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   aasm


### PR DESCRIPTION
## Context

We need to run `bundle lock --add-platform x86_64-linux-musl` to keep the musl build of nokogiri in the Gemfile.lock file
https://nokogiri.org/tutorials/installing_nokogiri.html#supported-platforms


## Changes proposed in this pull request

Permanently add `x86_64-linux-musl` platform to our Gemfile

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
