### PR TITLE
Remove access_request table

### DIFF
--- a/db/migrate/20250116123350_remove_access_requests_if_table_exists.rb
+++ b/db/migrate/20250116123350_remove_access_requests_if_table_exists.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RemoveAccessRequestsIfTableExists < ActiveRecord::Migration[8.0]
+  def change
+    drop_table :access_request, if_exists: true do |t|
+      t.text 'email_address'
+      t.text 'first_name'
+      t.text 'last_name'
+      t.text 'organisation'
+      t.text 'reason'
+      t.datetime 'request_date_utc', precision: nil, null: false
+      t.integer 'requester_id'
+      t.integer 'status', null: false
+      t.text 'requester_email'
+      t.datetime 'discarded_at', precision: nil
+      t.index ['discarded_at'], name: 'index_access_request_on_discarded_at'
+      t.index ['requester_id'], name: 'IX_access_request_requester_id'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_19_142038) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_16_123350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"


### PR DESCRIPTION
## Context

Their is an `access_request` table in the production database which is missing from other environments. It is unused. We can remove it.

## Changes proposed in this pull request

- Add a migration to drop the table if it exists.

## Guidance to review

Pull down the backup and run this migration. Your schema should be unchanged.
