### PR TITLE
Add safe navigation to data migration

### DIFF
--- a/lib/update_ratifying_provider_for_course.rb
+++ b/lib/update_ratifying_provider_for_course.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
 class UpdateRatifyingProviderForCourse
-  # PROVIDERS = %w[5W1 1BJ 24H 4R4 2a5].freeze
-  # TARGET_PROVIDER = '3A1'
-
   def initialize(training_provider_code:, target_ratifying_provider_code:)
     @training_provider = RecruitmentCycle.current.providers.find_by(provider_code: training_provider_code)
     @target_ratifying_provider_code = target_ratifying_provider_code
   end
 
   def call
-    @training_provider.courses.each do |course|
+    @training_provider&.courses&.each do |course|
       course.update!(accredited_provider_code: @target_ratifying_provider_code)
     end
   end

--- a/spec/lib/update_ratifying_provider_for_course_spec.rb
+++ b/spec/lib/update_ratifying_provider_for_course_spec.rb
@@ -11,4 +11,10 @@ RSpec.describe UpdateRatifyingProviderForCourse do
     described_class.new(training_provider_code: provider.provider_code, target_ratifying_provider_code: target_ratifying_provider.provider_code).call
     expect(provider.courses.reload.first.accrediting_provider).to eq(target_ratifying_provider)
   end
+
+  it 'no errors when a provider cannot be found' do
+    expect do
+      described_class.new(training_provider_code: 'P11', target_ratifying_provider_code: target_ratifying_provider.provider_code).call
+    end.not_to raise_error
+  end
 end


### PR DESCRIPTION
## Context

A data migration is failing in Sandbox environment.
This PR adds safe navigation to the code to prevent an exception being raised.

## Changes proposed in this pull request

Add safe navigation to data migration to stop errors 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
