### PR TITLE
Set Find errors controller layout to 'find'

### DIFF
--- a/app/controllers/find/errors_controller.rb
+++ b/app/controllers/find/errors_controller.rb
@@ -4,6 +4,6 @@ module Find
   class ErrorsController < ApplicationController
     include Errorable
 
-    layout 'find_layout'
+    layout 'find'
   end
 end


### PR DESCRIPTION
## Context

When renaming the Find layout in https://github.com/DFE-Digital/publish-teacher-training/pull/4831, a `find_layout` reference was missed.

## Changes proposed in this pull request

- Rename remaining `find_layout` reference to `find`.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
