### PR TITLE
Unset Publish errors controller layout to default 'application'

### DIFF
--- a/app/controllers/publish/errors_controller.rb
+++ b/app/controllers/publish/errors_controller.rb
@@ -5,7 +5,5 @@ module Publish
     skip_before_action :authenticate
 
     include Errorable
-
-    layout 'publish'
   end
 end


### PR DESCRIPTION
## Context

When merging the Publish layout into plain "application", https://github.com/DFE-Digital/publish-teacher-training/pull/4831, a "publish" layout reference was missed.

## Changes proposed in this pull request

- Remove the explicit `layout 'publish'` call and fallback to the default `application` layout.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
