### PR TITLE
Remove webrick initializer

### DIFF
--- a/config/initializers/webrick.rb
+++ b/config/initializers/webrick.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require 'webrick'
-
-WEBrick::HTTPRequest.const_set('MAX_URI_LENGTH', 2083 * 2)


### PR DESCRIPTION
## Context

Since the server is now using Puma by default, we no longer need this initializer.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


