### PR TITLE
Set $govuk-fonts-path and $govuk-images-path to '/'

### DIFF
--- a/app/assets/stylesheets/govuk_style_setup.scss
+++ b/app/assets/stylesheets/govuk_style_setup.scss
@@ -1,5 +1,5 @@
-$govuk-fonts-path: "";
-$govuk-images-path: "";
+$govuk-fonts-path: "/";
+$govuk-images-path: "/";
 
 @import "govuk-frontend/dist/govuk/all";
 @import "@ministryofjustice/frontend/moj/all";


### PR DESCRIPTION
## Context

When re-organising the asset files, it seems the path` set in `govuk_style_setup.scss` are relative to the caller. This made all the font and image paths become prefixed with `/find` or `/publish`.

## Changes proposed in this pull request

- Update `$govuk-fonts-path` and `$govuk-images-path` both to `"/"`;

## Guidance to review

Visit the review app. There should be no console errors.
