### PR TITLE
Represent the same postgis version as production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "6379:6379"
 
   db:
-    image: postgis/postgis:14-3.5-alpine
+    image: postgis/postgis:14-3.2-alpine
     # To preserve data between runs of docker compose, we mount a folder from the host machine.
     volumes:
       - dbdata:/var/lib/postgresql/data

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -56,5 +56,5 @@ module "postgres" {
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_maintenance_window       = var.postgres_azure_maintenance_window
   server_version                 = "14"
-  server_docker_image            = "postgis/postgis:14-3.5"
+  server_docker_image            = "postgis/postgis:14-3.2"
 }


### PR DESCRIPTION
## Context

Azure postgis version is 3.2.3 - let's represent the same version on CI and review apps.

Azure postgres is fixed
https://learn.microsoft.com/en-us/azure/postgresql/extensions/concepts-extensions-versions#postgis

although they do mention update via

 https://learn.microsoft.com/en-us/azure/postgresql/extensions/how-to-allow-extensions?tabs=allow-extensions-portal%2Cload-libraries-portal#update-extensions

So it may not update more than 3.2.3 for pg 14, so fixing the version in CI and in review apps

## Guidance on review

1. Does it work on the review app? 
    - Run in the review db: `SELECT postgis_full_version();` (e.g `ActiveRecord::Base.connection.execute("SELECT postgis_full_version();").values`) 
    - It should return the 3.2.3
    - run `SELECT *  FROM spatial_ref_sys LIMIT 10;`
    - run `SELECT * FROM geometry_columns  LIMIT 10;`
2. Does terraform includes postgis? 

