### PR TITLE
Bug fix: Updating and filtering accredited providers in support console

### DIFF
--- a/app/components/filters/provider_attributes/view.html.erb
+++ b/app/components/filters/provider_attributes/view.html.erb
@@ -9,8 +9,8 @@
 <div class="govuk-form-group">
   <div class="govuk-checkboxes">
     <div class="govuk-checkboxes__item">
-      <%= check_box_tag "accrediting_provider", nil, class: "govuk-checkboxes__input", checked: filters[:accrediting_provider] == "on" %>
-      <%= label_tag "accrediting_provider", t("components.filter.providers.accrediting_provider"), class: "govuk-label govuk-checkboxes__label govuk-label--s" %>
+      <%= check_box_tag "accredited", nil, class: "govuk-checkboxes__input", checked: filters[:accredited] == "on" %>
+      <%= label_tag "accredited", t("components.filter.providers.accredited"), class: "govuk-label govuk-checkboxes__label govuk-label--s" %>
     </div>
   </div>
 </div>

--- a/app/components/paginated_filter.rb
+++ b/app/components/paginated_filter.rb
@@ -19,7 +19,7 @@ class PaginatedFilter < ViewComponent::Base
   def allowed_search_params_keys
     {
       User: %i[text_search user_type],
-      Provider: %i[provider_search course_search accrediting_provider provider_type]
+      Provider: %i[provider_search course_search accredited provider_type]
     }[collection.klass.name.to_sym]
   end
 end

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -47,7 +47,7 @@ module Support
                                        :provider_type,
                                        :ukprn,
                                        :urn,
-                                       :accrediting_provider,
+                                       :accredited,
                                        :accredited_provider_number)
     end
 

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -35,7 +35,7 @@ module Support
     end
 
     def filter_params
-      @filter_params ||= params.except(:commit, :recruitment_cycle_year).permit(:provider_search, :course_search, :page, :accrediting_provider, provider_type: %i[scitt university lead_school])
+      @filter_params ||= params.except(:commit, :recruitment_cycle_year).permit(:provider_search, :course_search, :page, :accredited, provider_type: %i[scitt university lead_school])
     end
 
     def provider

--- a/app/services/support/filter.rb
+++ b/app/services/support/filter.rb
@@ -66,7 +66,7 @@ module Support
       filtered_records = text_search(filtered_records, filter_params[:text_search]) if filtered_records.respond_to?(:search)
       filtered_records = provider_search(filtered_records, filter_params[:provider_search]) if filtered_records.respond_to?(:provider_search)
       filtered_records = provider_type(filtered_records, filter_params[:provider_type])
-      filtered_records = provider_accredited_type(filtered_records, filter_params[:accrediting_provider])
+      filtered_records = provider_accredited_type(filtered_records, filter_params[:accredited])
       filtered_records = course_search(filtered_records, filter_params[:course_search]) if filtered_records.respond_to?(:course_search)
       filtered_records = user_type(filtered_records, filter_params[:user_type]) if filtered_records.respond_to?(:admins)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,7 +304,7 @@ en:
       providers:
         provider_search: "Provider name, code or UKPRN"
         course_search: "Course code"
-        accrediting_provider: "Accredited providers"
+        accredited: "Accredited providers"
         provider_type: "Provider Type"
         scitt: "SCITT"
         university: "University"

--- a/spec/system/support/remove_accredited_status_from_accredited_provider_spec.rb
+++ b/spec/system/support/remove_accredited_status_from_accredited_provider_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Support::UpdateProviders', service: :publish do
+  include DfESignInUserHelper
+  before do
+    driven_by(:rack_test)
+    sign_in_system_test(user:)
+  end
+
+  let(:user) { create(:user, :admin, providers: [provider]) }
+  let(:accredited_provider) { create(:accredited_provider, provider_name: 'MyAccredited') }
+  let!(:providers) { [provider, accredited_provider] }
+
+  it 'Remove accredited status from accredited provider' do
+    visit "/support/#{RecruitmentCycle.current.year}/providers"
+
+    expect(page).to have_content('MyAccredited')
+    click_on accredited_provider.provider_name
+    expect(page).to have_css(:h1, text: accredited_provider.provider_name)
+
+    expect(page).to have_content('Is the organisation an accredited provider?Yes')
+    expect(page).to have_content('Accredited provider number')
+    click_on 'Change accredited provider'
+    within_fieldset('Is the organisation an accredited provider?') do
+      choose 'No', disabled: false
+    end
+    click_on 'Update organisation details'
+    expect(page).to have_content('Provider successfully updated')
+    expect(page).to have_content('Is the organisation an accredited provider?No')
+    expect(page).to have_no_content('Accredited provider number')
+  end
+end

--- a/spec/system/support/support_filter_providers_spec.rb
+++ b/spec/system/support/support_filter_providers_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Support::FilterProviders', service: :publish do
+  include DfESignInUserHelper
+  before do
+    driven_by(:rack_test)
+    sign_in_system_test(user:)
+  end
+
+  let(:user) { create(:user, :admin, providers: [provider]) }
+  let(:provider) { create(:provider, provider_name: 'MyProvider') }
+  let(:accredited_provider) { create(:accredited_provider, provider_name: 'MyAccredited') }
+  let!(:providers) { [provider, accredited_provider] }
+
+  it 'filters accredited providers' do
+    visit "/support/#{RecruitmentCycle.current.year}/providers"
+
+    expect(page).to have_content('MyAccredited')
+    expect(page).to have_content('MyProvider')
+    check 'Accredited providers'
+    click_on 'Apply filters'
+    expect(page).to have_no_content('MyProvider')
+  end
+end


### PR DESCRIPTION
## Context

I noticed a bug I introduced when changing `Provider#accrediting_provider` to `Provider#accredited`


## Changes proposed in this pull request

1. Editing Accredited status of a provider in support console works correctly now
2. Updated the param names and properties from `accrediting_provider` to `accredited` to match the model property in the filtering code

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/7wmekQgP/399-bug-accredited-provider-update-and-filter-bug