### PR TITLE
Add data migration to nullify unaccredited provider number

### DIFF
--- a/db/data/20250124164607_remove_accredited_provider_number.rb
+++ b/db/data/20250124164607_remove_accredited_provider_number.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveAccreditedProviderNumber < ActiveRecord::Migration[8.0]
+  def up
+    Provider.where.not(accredited: true).update_all(accredited_provider_number: nil)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Context

  No Lead Partner should have an accredited_provider_number value
We have updated the support interface now so that when we change an accredited provider to unaccredited then we remove the `accredited_provider_number`.

There are still some unaccredited providers with accredited provider numbers.

112 to be precise
![image](https://github.com/user-attachments/assets/d552a882-b589-46ef-a83d-5443b527991e)



## Changes proposed in this pull request

Delete the `Provider#accredited_provider_number` from all unaccredited providers

## Guidance to review

![image](https://github.com/user-attachments/assets/a8ae6cfc-c6fb-459f-8ae2-063676e1effc)

## Trello

https://trello.com/c/Rl1xNeFS/274-datamigration-remove-accredited-provider-number-from-all-non-accredited-providers