### PR TITLE
Foundation work implement location search and radius filter

### DIFF
--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -2,7 +2,7 @@
 
 module Courses
   class SummaryCardComponent < ViewComponent::Base
-    attr_reader :course, :location, :visa_sponsorship, :available_placements_count, :minimum_distance_to_search_location
+    attr_reader :course, :location, :visa_sponsorship, :available_placements_count
 
     def initialize(course:, location: nil, visa_sponsorship: nil)
       @course = course
@@ -35,7 +35,7 @@ module Courses
         t(
           '.location_value.distance',
           school_term:,
-          distance: content_tag(:span, pluralize(course.minimum_distance_to_search_location, 'mile'), class: 'govuk-!-font-weight-bold'),
+          distance: content_tag(:span, pluralize(course.minimum_distance_to_search_location.ceil(2), 'mile'), class: 'govuk-!-font-weight-bold'),
           location: content_tag(:span, sanitize(@location), class: 'govuk-!-font-weight-bold')
         ).html_safe
       else

--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -8,9 +8,9 @@ module Find
         @search_params = @search_courses_form.search_params
 
         @courses = ::Courses::Query.call(params: @search_params)
-        @courses_count = @courses.count
+        @courses_count = @courses.unscope(:order, :group).distinct.count(:id)
 
-        @pagy, @results = pagy(@courses)
+        @pagy, @results = pagy(@courses, count: @courses_count)
       end
 
       private
@@ -23,6 +23,10 @@ module Find
           :level,
           :funding,
           :age_group,
+          :location,
+          :latitude,
+          :longitude,
+          :radius,
           subjects: [],
           study_types: [],
           qualifications: [],

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -12,6 +12,10 @@ module Courses
     attribute :qualifications
     attribute :level
     attribute :funding
+    attribute :location
+    attribute :longitude
+    attribute :latitude
+    attribute :radius
 
     attribute :age_group
     attribute :qualification

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -130,10 +130,10 @@ module Courses
     def location_scope
       return @scope.distinct if params[:latitude].blank? || params[:longitude].blank?
 
-      radius_in_miles = (params[:radius] || DEFAULT_RADIUS_IN_MILES).to_f
+      radius_in_miles = Float(params[:radius] || DEFAULT_RADIUS_IN_MILES)
       radius_in_meters = radius_in_miles * 1609.34
-      latitude = params[:latitude].to_f
-      longitude = params[:longitude].to_f
+      latitude = Float(params[:latitude])
+      longitude = Float(params[:longitude])
 
       @applied_scopes[:location] = {
         latitude: latitude,

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :location, class: Struct.new(:latitude, :longitude, keyword_init: true) do
+    latitude { 0.0 }
+    longitude { 0.0 }
+
+    trait :bristol do
+      latitude { 51.4545 }
+      longitude { -2.5879 }
+    end
+
+    trait :cambridge do
+      latitude { 52.2053 }
+      longitude { 0.1218 }
+    end
+
+    trait :canary_wharf do
+      latitude { 51.5045 }
+      longitude { -0.0243 }
+    end
+
+    trait :cardiff do
+      latitude { 51.4816 }
+      longitude { -3.1791 }
+    end
+
+    trait :crawley do
+      latitude { 51.1091 }
+      longitude { -0.1872 }
+    end
+
+    trait :edinburgh do
+      latitude { 55.9533 }
+      longitude { -3.1883 }
+    end
+
+    trait :farnborough do
+      latitude { 51.2903 }
+      longitude { -0.7501 }
+    end
+
+    trait :guildford do
+      latitude { 51.2362 }
+      longitude { -0.5704 }
+    end
+
+    trait :lewisham do
+      latitude { 51.4539 }
+      longitude { -0.016 }
+    end
+
+    trait :london do
+      latitude { 51.5074 }
+      longitude { -0.1278 }
+    end
+
+    trait :manchester do
+      latitude { 53.4808 }
+      longitude { -2.2426 }
+    end
+
+    trait :norwich do
+      latitude { 52.6309 }
+      longitude { 1.2974 }
+    end
+
+    trait :oxford do
+      latitude { 51.7548 }
+      longitude { -1.2544 }
+    end
+
+    trait :reading do
+      latitude { 51.4543 }
+      longitude { -0.9781 }
+    end
+
+    trait :watford do
+      latitude { 51.6553 }
+      longitude { -0.3960 }
+    end
+
+    trait :wimbledon do
+      latitude { 51.4230 }
+      longitude { -0.2195 }
+    end
+
+    trait :woking do
+      latitude { 51.3200 }
+      longitude { -0.5582 }
+    end
+  end
+end

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -89,8 +89,16 @@ RSpec.describe Courses::SearchForm do
     context 'when funding is provided' do
       let(:form) { described_class.new(funding: %w[fee salary]) }
 
-      it 'returns the correct search params with study_types as an array' do
+      it 'returns the correct search params with funding as an array' do
         expect(form.search_params).to eq({ funding: %w[fee salary] })
+      end
+    end
+
+    context 'when location is provided' do
+      let(:form) { described_class.new(location: 'London NW9, UK', latitude: 51.53328, longitude: -0.1734435, radius: 10) }
+
+      it 'returns the correct search params with location details' do
+        expect(form.search_params).to eq(location: 'London NW9, UK', latitude: 51.53328, longitude: -0.1734435, radius: 10)
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,6 +67,15 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
     DatabaseCleaner.strategy = :transaction
+
+    postgis_table_count = ActiveRecord::Base.connection.execute(
+      'SELECT COUNT(*) FROM spatial_ref_sys;'
+    ).field_values('count').flatten.first.to_i
+
+    if postgis_table_count.zero?
+      ActiveRecord::Base.connection.execute('DROP EXTENSION IF EXISTS postgis CASCADE;')
+      ActiveRecord::Base.connection.execute('CREATE EXTENSION IF NOT EXISTS postgis;')
+    end
   end
 
   # start the transaction strategy as examples are run

--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe Courses::Query do
   describe '.call' do
     subject(:results) { described_class.call(params:) }
 
+    let(:test_search_result_wrapper_klass) do
+      Class.new(SimpleDelegator) do
+        attr_reader :minimum_distance_to_search_location
+
+        def initialize(course, minimum_distance_to_search_location:)
+          super(course)
+          @minimum_distance_to_search_location = minimum_distance_to_search_location
+        end
+      end
+    end
+
     context 'when no filters or sorting are applied' do
       let!(:findable_course) { create(:course, :with_full_time_sites) }
       let!(:another_course) { create(:course, :with_full_time_sites) }
@@ -292,6 +303,357 @@ RSpec.describe Courses::Query do
             [fee_course, salaried_course, apprenticeship_course],
             attribute_names: %w[funding]
           )
+        end
+      end
+    end
+
+    shared_examples 'location search results' do |radius:|
+      it "returns courses within a #{radius} mile radius" do
+        params = { latitude: london.latitude, longitude: london.longitude, radius: }
+
+        expect(described_class.call(params:)).to match_collection(
+          expected,
+          attribute_names: %w[name minimum_distance_to_search_location]
+        )
+      end
+    end
+
+    context 'when searching by location applying radius filter' do
+      let(:london) { build(:location, :london) }
+      let(:canary_wharf) { build(:location, :canary_wharf) }
+      let(:lewisham) { build(:location, :lewisham) }
+      let(:manchester) { build(:location, :manchester) }
+      let(:cambridge) { build(:location, :cambridge) }
+      let(:bristol) { build(:location, :bristol) }
+      let(:cardiff) { build(:location, :cardiff) }
+      let(:watford) { build(:location, :watford) }
+      let(:woking) { build(:location, :woking) }
+      let(:guildford) { build(:location, :guildford) }
+      let(:oxford) { build(:location, :oxford) }
+      let(:edinburgh) { build(:location, :edinburgh) }
+
+      let!(:course_london_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Mathematics (London)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: london.latitude, longitude: london.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 0.0
+        )
+      end
+
+      let!(:course_canary_wharf_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Science (Canary Wharf)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: canary_wharf.latitude, longitude: canary_wharf.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 4.46
+        )
+      end
+
+      let!(:course_lewisham_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Science (Lewisham)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: lewisham.latitude, longitude: lewisham.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 6.07
+        )
+      end
+
+      let!(:course_romford_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Science (Romford)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: 51.5807, longitude: 0.185)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 14.36
+        )
+      end
+
+      let!(:course_watford_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Music (Watford)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: watford.latitude, longitude: watford.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 15.4
+        )
+      end
+
+      let!(:course_woking_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Engineering (Woking)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: woking.latitude, longitude: woking.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 22.62
+        )
+      end
+
+      let!(:course_guildford_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Art (Guildford)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: guildford.latitude, longitude: guildford.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 26.75
+        )
+      end
+
+      let!(:course_cambridge_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Chemistry (Cambridge)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: cambridge.latitude, longitude: cambridge.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 49.38
+        )
+      end
+
+      let!(:course_oxford_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Biology (Oxford)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: oxford.latitude, longitude: oxford.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 51.25
+        )
+      end
+
+      let!(:course_bristol_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'English (Bristol)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: bristol.latitude, longitude: bristol.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 105.92
+        )
+      end
+
+      let!(:course_cardiff_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Citizenship (Cardiff)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: cardiff.latitude, longitude: cardiff.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 131.26
+        )
+      end
+
+      let!(:course_manchester_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Biology (Manchester)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: manchester.latitude, longitude: manchester.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 162.79
+        )
+      end
+
+      let!(:course_edinburgh_result) do
+        test_search_result_wrapper_klass.new(
+          create(
+            :course,
+            name: 'Physics (Edinburgh)',
+            site_statuses: [
+              create(
+                :site_status,
+                :findable,
+                site: create(:site, latitude: edinburgh.latitude, longitude: edinburgh.longitude)
+              )
+            ]
+          ),
+          minimum_distance_to_search_location: 331.6
+        )
+      end
+
+      it_behaves_like 'location search results', radius: 1 do
+        let(:expected) { [course_london_result] }
+      end
+
+      it_behaves_like 'location search results', radius: 5 do
+        let(:expected) { [course_london_result, course_canary_wharf_result] }
+      end
+
+      it_behaves_like 'location search results', radius: 10 do
+        let(:expected) do
+          [
+            course_london_result,
+            course_canary_wharf_result,
+            course_lewisham_result
+          ]
+        end
+      end
+
+      it_behaves_like 'location search results', radius: 15 do
+        let(:expected) do
+          [
+            course_london_result,
+            course_canary_wharf_result,
+            course_lewisham_result,
+            course_romford_result
+          ]
+        end
+      end
+
+      it_behaves_like 'location search results', radius: 20 do
+        let(:expected) do
+          [
+            course_london_result,
+            course_canary_wharf_result,
+            course_lewisham_result,
+            course_romford_result,
+            course_watford_result
+          ]
+        end
+      end
+
+      it_behaves_like 'location search results', radius: 25 do
+        let(:expected) do
+          [
+            course_london_result,
+            course_canary_wharf_result,
+            course_lewisham_result,
+            course_romford_result,
+            course_watford_result,
+            course_woking_result
+          ]
+        end
+      end
+
+      it_behaves_like 'location search results', radius: 50 do
+        let(:expected) do
+          [
+            course_london_result,
+            course_canary_wharf_result,
+            course_lewisham_result,
+            course_romford_result,
+            course_watford_result,
+            course_woking_result,
+            course_guildford_result,
+            course_cambridge_result
+          ]
+        end
+      end
+
+      it_behaves_like 'location search results', radius: 100 do
+        let(:expected) do
+          [
+            course_london_result,
+            course_canary_wharf_result,
+            course_lewisham_result,
+            course_romford_result,
+            course_watford_result,
+            course_woking_result,
+            course_guildford_result,
+            course_cambridge_result,
+            course_oxford_result
+          ]
+        end
+      end
+
+      it_behaves_like 'location search results', radius: 200 do
+        let(:expected) do
+          [
+            course_london_result,
+            course_canary_wharf_result,
+            course_lewisham_result,
+            course_romford_result,
+            course_watford_result,
+            course_woking_result,
+            course_guildford_result,
+            course_cambridge_result,
+            course_oxford_result,
+            course_bristol_result,
+            course_cardiff_result,
+            course_manchester_result
+          ]
         end
       end
     end

--- a/spec/support/matchers/match_collection.rb
+++ b/spec/support/matchers/match_collection.rb
@@ -37,6 +37,7 @@ RSpec::Matchers.define :match_collection do |expected_collection, attribute_name
       attribute_names.each_with_object({}) do |attr, hash|
         value = item.public_send(attr) if item.respond_to?(attr)
         hash[attr] = value
+        hash[attr] = value.round(2) if value.is_a? Float
       end.merge(id: item.id)
     end
   end


### PR DESCRIPTION
## Context

For the new results page, we need to enhance the location search functionality:

Allow users to search for courses within a specific radius of a given location.
Sort the results by courses with the nearest available placements.

We are replacing the current search mechanism with PostGIS for geolocation searches, which offers improved performance and accuracy.

* Users can search for courses by location within a specified radius.
* If no radius is provided, a default radius is applied.
* Results are sorted by courses with the nearest placements.
* The implementation uses PostGIS for geolocation calculations.

## Things won't be done on this PR

* The site latitude and longitude geometry ST_MakePointM(float x, float y, float m) could be store in the Database but this will be done in a further iteration.
* This is only the backend, the interface will be done in a separate card and separate PR.

## Guidance to review

1. Visit the review and pass the latitude, longitude and location params: https://find-review-4852.test.teacherservices.cloud/v2/results?latitude=51.5345978&location=Some+Rd%2C+London+NW9%2C+UK&longitude=-0.1676324
