### PR TITLE
Add Data migration to create ProviderPartnerships from enrichments

### DIFF
--- a/db/data/20250124165440_migrate_provider_partnerships_from_enrichments.rb
+++ b/db/data/20250124165440_migrate_provider_partnerships_from_enrichments.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class MigrateProviderPartnershipsFromEnrichments < ActiveRecord::Migration[8.0]
+  def up
+    Provider.where.not(accrediting_provider_enrichments: nil).find_each do |training_provider|
+      training_provider.accrediting_provider_enrichments.each do |enrichment|
+        accredited_provider = Provider.find_by(recruitment_cycle_id: training_provider.recruitment_cycle_id, provider_code: enrichment.UcasProviderCode)
+
+        created = training_provider.accredited_partnerships.create(accredited_provider:, description: enrichment.Description)
+        Rails.logger.warn("Partnership could not be created #{training_provider.recruitment_cycle_id}:#{accredited_provider.id}:#{training_provider.id}") unless created
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Context

Now we have the `provider_partnerships` table we need a data migration to backfill the `provider_partnerships` table with the existing `AccreditingProviderEnrichment`s


## Changes proposed in this pull request

## Providers with enrichments
There are 7237 provider records with enrichments
```ruby
Provider.where.not(accrediting_provider_enrichments: nil).count
# => 7237
```

2705 of them are empty.
```ruby
Provider.where.not(accrediting_provider_enrichments: nil).count { |p| p.accrediting_provider_enrichments.empty? }
=> 2705
```

## Quality of existing Enrichments

84 enrichments either don't have a provider code at all or the provider doesn't exist in the database.
```ruby
Provider.where.not(accrediting_provider_enrichments: nil).find_each do |provider|
  provider.accrediting_provider_enrichments.each do |enrichment|
no_provider_exists += 1 unless Provider.exists?(recruitment_cycle:provider.recruitment_cycle, provider_code: enrichment.UcasProviderCode)
  end
end
=> 84
```
307 enrichments cannot be created as ProviderPartnerships becuase the partnership is invalid.

1. The Training provider is accredited
2. The accredited provider is unaccredited
3. Duplicated partnership

```ruby
12987=>[{:reason=>3, :obj=>{:training_provider=>["must not be accredited"]}}],
 20661=>[{:reason=>3, :obj=>{:accredited_provider=>["Accredited provider must be accredited"]}}],
 21014=>[{:reason=>3, :obj=>{:accredited_provider=>["Accredited provider must be accredited"]}}],
 18810=>[{:reason=>3, :obj=>{:training_provider=>["must not be accredited"]}}],
 16353=>[{:reason=>0}],
 20906=>[{:reason=>3, :obj=>{:accredited_provider=>["Accredited provider must be accredited"]}}, {:reason=>3, :obj=>{:accredited_provider=>["Accredited provider must be accredited"]}}],
 16262=>[{:reason=>3, :obj=>{:training_provider=>["must not be accredited"]}}],
 18813=>[{:reason=>3, :obj=>{:training_provider=>["must not be accredited"]}}],
 16166=>[{:reason=>0}],
 19682=>[{:reason=>3, :obj=>{:accredited_provider=>["Accredited provider must be accredited"]}}],
 16709=>[{:reason=>3, :obj=>{:training_provider=>["must not be accredited"]}}],
 16474=>[{:reason=>3, :obj=>{:training_provider=>["must not be accredited"]}}],
 16303=>[{:reason=>3, :obj=>{:training_provider=>["must not be accredited"]}}, {:reason=>3, :obj=>{:training_provider=>["must not be accredited"]}}],
 15903=>[{:reason=>0}],
```


## Guidance to review

Are we confident enough to go ahead with this migration?


## Trello
https://trello.com/c/F7uLdysB/395-datamigration-create-providerpartnerships-from-accreditedproviderenrichments
