### PR TITLE
Remove all `Provider#accrediting_provider` code

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -172,7 +172,7 @@ class Provider < ApplicationRecord
   def accredited_provider_type
     return unless accredited?
 
-    errors.add(:accrediting_provider, :invalid_provider_type) unless provider_type.to_s.in?(%w[scitt university])
+    errors.add(:accredited, :invalid_provider_type) unless provider_type.to_s.in?(%w[scitt university])
   end
 
   acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude

--- a/app/services/publish/accredited_provider_updater.rb
+++ b/app/services/publish/accredited_provider_updater.rb
@@ -24,7 +24,7 @@ module Publish
     end
 
     def update_provider
-      provider.update!(accrediting_provider: 'not_an_accredited_provider',
+      provider.update!(accredited: false,
                        accrediting_provider_enrichments: new_accrediting_provider_enrichments)
     end
 

--- a/app/views/support/providers/_list.html.erb
+++ b/app/views/support/providers/_list.html.erb
@@ -26,7 +26,7 @@
 
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <% if provider.accrediting_provider_before_type_cast == "Y" %>
+            <% if provider.accredited? %>
                <% if provider.accredited_provider_number.present? %>
                   <%= govuk_tag(text: provider.accredited_provider_number, colour: "green") %>
                <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -979,7 +979,7 @@ en:
             provider_type:
               blank: "Provider type can't be blank"
               format: Accredited provider cannot be a school
-            accrediting_provider:
+            accredited:
               format: '%{message}'
               invalid_provider_type: 'Accredited provider must not have Provider type school'
             email:

--- a/spec/forms/accredited_provider_form_spec.rb
+++ b/spec/forms/accredited_provider_form_spec.rb
@@ -104,7 +104,7 @@ describe AccreditedProviderForm, type: :model do
         ]
       end
 
-      let(:model) { create(:provider, accrediting_provider: 'N', accrediting_provider_enrichments:) }
+      let(:model) { create(:provider, accrediting_provider_enrichments:) }
 
       it 'updates the provider with the new accredited provider information' do
         subject.save!

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3329,7 +3329,7 @@ describe Course do
     context 'setting the funding to fee' do
       context 'when the provider is not self accredited' do
         it 'sets the funding to salary and the program_type to school_direct_training_programme' do
-          provider = build(:provider, accrediting_provider: :not_an_accredited_provider)
+          provider = build(:provider)
           course = create(:course, provider:, funding: 'fee')
 
           expect(course.funding).to eq('fee')

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -121,7 +121,7 @@ describe Provider do
 
       it 'is invalid' do
         expect(provider).not_to be_valid
-        expect(provider.errors[:accrediting_provider]).to include('Accredited provider must not have Provider type school')
+        expect(provider.errors[:accredited]).to include('Accredited provider must not have Provider type school')
       end
     end
   end
@@ -368,7 +368,7 @@ describe Provider do
       allow(Settings.features).to receive(:provider_partnerships).and_return(true)
     end
 
-    let(:provider) { create(:provider, accrediting_provider: 'N', accrediting_provider_enrichments:) }
+    let(:provider) { create(:provider, accrediting_provider_enrichments:) }
     let!(:partnership) { create(:provider_partnership, training_provider: provider, accredited_provider:) }
 
     let(:accrediting_provider) { create(:accredited_provider) }
@@ -394,7 +394,7 @@ describe Provider do
       allow(Settings.features).to receive(:provider_partnerships).and_return(false)
     end
 
-    let(:provider) { create(:provider, accrediting_provider: 'N', accrediting_provider_enrichments:) }
+    let(:provider) { create(:provider, accrediting_provider_enrichments:) }
 
     let(:accrediting_provider) { create(:accredited_provider) }
     let(:accredited_provider) { accrediting_provider }

--- a/spec/services/publish/accredited_provider_updater_spec.rb
+++ b/spec/services/publish/accredited_provider_updater_spec.rb
@@ -79,14 +79,13 @@ RSpec.describe Publish::AccreditedProviderUpdater do
         create(:provider,
                provider_code:,
                recruitment_cycle:,
-               accrediting_provider: 'not_an_accredited_provider',
                accrediting_provider_enrichments: [{ UcasProviderCode: new_accredited_provider_code, Description: '' }])
       end
 
       it 'updates the provider' do
         subject.update_provider
 
-        expect(provider.reload.accrediting_provider).to eq('not_an_accredited_provider')
+        expect(provider.reload.accredited).to be(false)
         expect(provider.reload.accredited_providers).to include(new_accredited_provider)
         expect(provider.reload.accrediting_provider_enrichments.count).to eq(1)
       end


### PR DESCRIPTION
## Context

We recently replaced the use of `accrediting_provider` with `accredited` on the Provider model.
Some of the code was not updated.
This PR finishes the migration by removing all references to the old column

Any remaining references to `accrediting_provider` should be relevant to the course only.
## Changes proposed in this pull request

Change all places where `Provider#accrediting_provider` is used to determine if a provider is accredited to `Provider#accredited`

## Guidance to review

Has all references correctly been removed?

## Trello
https://trello.com/c/VhkOfHZG/410-remove-all-remaining-references-to-provideraccreditingprovider