### PR TITLE
Add sorting to the new results page

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -31,6 +31,7 @@ module Find
           :latitude,
           :longitude,
           :radius,
+          :order,
           :age_group,
           :degree_required,
           :university_degree_status,

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -19,6 +19,7 @@ module Courses
     attribute :longitude
     attribute :latitude
     attribute :radius
+    attribute :order
 
     attribute :age_group
     attribute :qualification
@@ -59,6 +60,29 @@ module Courses
 
     def primary_subjects
       Subject.where(type: 'PrimarySubject').order(:subject_name)
+    end
+
+    OrderingOption = Struct.new(:id, :name, keyword_init: true)
+
+    def ordering_options
+      [
+        OrderingOption.new(
+          id: 'course_name_ascending',
+          name: I18n.t('helpers.label.courses_search_form.ordering.options.course_name_ascending')
+        ),
+        OrderingOption.new(
+          id: 'course_name_descending',
+          name: I18n.t('helpers.label.courses_search_form.ordering.options.course_name_descending')
+        ),
+        OrderingOption.new(
+          id: 'provider_name_ascending',
+          name: I18n.t('helpers.label.courses_search_form.ordering.options.provider_name_ascending')
+        ),
+        OrderingOption.new(
+          id: 'provider_name_descending',
+          name: I18n.t('helpers.label.courses_search_form.ordering.options.provider_name_descending')
+        )
+      ]
     end
 
     private

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -4,94 +4,115 @@
   <%= t(".page_title", count: @courses_count, formatted_count: number_with_delimiter(@courses_count)) %>
 </h1>
 
-<div class="app-filter-toggle"></div>
+<%= form_with model: @search_courses_form, scope: "", url: find_v2_results_path, method: :get do |form| %>
+  <div class="app-filter-toggle"></div>
 
-<div class="app-filter-layout">
-  <div class="app-filter-layout__filter">
-    <%= form_with model: @search_courses_form, scope: "", url: find_v2_results_path, class: "app-filter", method: :get do |form| %>
-      <div class="app-filter__header">
-        <h2 class="govuk-heading-m">Filters</h2>
-      </div>
-
-      <div class="app-filter__content">
-        <%= form.govuk_submit "Apply filters" %>
-
-        <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.can_sponsor_visa"), size: "s" } %>
-        <% end %>
-
-        <%= form.govuk_check_boxes_fieldset :primary_subjects, legend: { text: t("helpers.legend.courses_query_filters.primary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.primary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group" } do %>
-          <div class="scrollable-filter">
-            <% form.object.primary_subjects.each do |subject| %>
-              <%= form.govuk_check_box :subjects,
-              subject.subject_code,
-              label: { text: subject.subject_name } %>
-            <% end %>
-          </div>
-        <% end %>
-
-        <%= form.govuk_check_boxes_fieldset :secondary_subjects, legend: { text: t("helpers.legend.courses_query_filters.secondary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.secondary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group", data: { controller: "filter-search" } } do %>
-          <div class="filter-search scrollable-filter" data-filter-search-target="optionsList">
-            <% form.object.secondary_subjects.each do |subject| %>
-              <%= form.govuk_check_box :subjects,
-              subject.subject_code,
-              label: { text: subject.subject_name } %>
-            <% end %>
-          </div>
-        <% end %>
-
-        <%= form.govuk_check_boxes_fieldset :study_types, legend: { text: t("helpers.legend.courses_query_filters.study_type_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_check_box :study_types, "full_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.full_time"), size: "s" }, include_hidden: false %>
-          <%= form.govuk_check_box :study_types, "part_time", label: { text: t("helpers.label.courses_query_filters.study_type_options.part_time"), size: "s" }, include_hidden: false %>
-        <% end %>
-
-        <%= form.govuk_check_boxes_fieldset :qualifications, legend: { text: t("helpers.legend.courses_query_filters.qualifications_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_check_box :qualifications, "qts", label: { text: t("helpers.label.courses_query_filters.qualification_options.qts"), size: "s" }, include_hidden: false %>
-          <%= form.govuk_check_box :qualifications, "qts_with_pgce_or_pgde", label: { text: t("helpers.label.courses_query_filters.qualification_options.qts_with_pgce_or_pgde"), size: "s" }, include_hidden: false %>
-        <% end %>
-
-        <%= form.govuk_check_boxes_fieldset :further_education, legend: { text: t("helpers.legend.courses_query_filters.further_education_html"), size: "s" }, hint: { text: t("helpers.hint.courses_query_filters.further_education"), class: "govuk-!-font-size-16" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_check_box :level, "further_education", label: { text: t("helpers.label.courses_query_filters.further_education"), size: "s" }, multiple: false %>
-        <% end %>
-
-        <%= form.govuk_radio_buttons_fieldset :minimum_degree_required, legend: { text: t("helpers.legend.courses_query_filters.minimum_degree_required_html"), size: "s" }, class: "app-filter__group govuk-radios--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_radio_button :minimum_degree_required, "two_one", label: { text: t("helpers.label.courses_query_filters.minimum_degree_required_options.two_one"), size: "s" } %>
-          <%= form.govuk_radio_button :minimum_degree_required, "two_two", label: { text: t("helpers.label.courses_query_filters.minimum_degree_required_options.two_two"), size: "s" } %>
-          <%= form.govuk_radio_button :minimum_degree_required, "third_class", label: { text: t("helpers.label.courses_query_filters.minimum_degree_required_options.third_class"), size: "s" } %>
-          <%= form.govuk_radio_button :minimum_degree_required, "pass", label: { text: t("helpers.label.courses_query_filters.minimum_degree_required_options.pass"), size: "s" } %>
-          <%= form.govuk_radio_button :minimum_degree_required, "no_degree_required", label: { text: t("helpers.label.courses_query_filters.minimum_degree_required_options.no_degree_required"), size: "s" } %>
-        <% end %>
-
-        <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.special_education_needs"), size: "s" } %>
-        <% end %>
-
-        <%= form.govuk_check_boxes_fieldset :funding, legend: { text: t("helpers.legend.courses_query_filters.funding_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_check_box :funding, "fee", label: { text: t("helpers.label.courses_query_filters.funding_options.fee"), size: "s" }, include_hidden: false %>
-          <%= form.govuk_check_box :funding, "salary", label: { text: t("helpers.label.courses_query_filters.funding_options.salary"), size: "s" }, include_hidden: false %>
-          <%= form.govuk_check_box :funding, "apprenticeship", label: { text: t("helpers.label.courses_query_filters.funding_options.apprenticeship"), size: "s" }, include_hidden: false %>
-        <% end %>
-
-        <%= form.govuk_check_boxes_fieldset :applications_open, multiple: false, legend: { text: t("helpers.legend.courses_query_filters.applications_open_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
-          <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t("helpers.label.courses_query_filters.applications_open"), size: "s" } %>
-        <% end %>
-
-        <div class="govuk-!-margin-top-4">
-          <%= form.govuk_submit "Apply filters" %>
+  <div class="app-filter-layout">
+    <div class="app-filter-layout__filter app-filter">
+        <div class="app-filter__header">
+          <h2 class="govuk-heading-m">Filters</h2>
         </div>
+
+        <div class="app-filter__content">
+          <%= form.govuk_submit "Apply filters" %>
+
+          <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_search_form.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+            <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.can_sponsor_visa"), size: "s" } %>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :primary_subjects, legend: { text: t("helpers.legend.courses_search_form.primary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.primary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group" } do %>
+            <div class="scrollable-filter">
+              <% form.object.primary_subjects.each do |subject| %>
+                <%= form.govuk_check_box :subjects,
+                subject.subject_code,
+                label: { text: subject.subject_name } %>
+              <% end %>
+            </div>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :secondary_subjects, legend: { text: t("helpers.legend.courses_search_form.secondary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.secondary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group", data: { controller: "filter-search" } } do %>
+            <div class="filter-search scrollable-filter" data-filter-search-target="optionsList">
+              <% form.object.secondary_subjects.each do |subject| %>
+                <%= form.govuk_check_box :subjects,
+                subject.subject_code,
+                label: { text: subject.subject_name } %>
+              <% end %>
+            </div>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :study_types, legend: { text: t("helpers.legend.courses_search_form.study_type_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+            <%= form.govuk_check_box :study_types, "full_time", label: { text: t("helpers.label.courses_search_form.study_type_options.full_time"), size: "s" }, include_hidden: false %>
+            <%= form.govuk_check_box :study_types, "part_time", label: { text: t("helpers.label.courses_search_form.study_type_options.part_time"), size: "s" }, include_hidden: false %>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :qualifications, legend: { text: t("helpers.legend.courses_search_form.qualifications_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+            <%= form.govuk_check_box :qualifications, "qts", label: { text: t("helpers.label.courses_search_form.qualification_options.qts"), size: "s" }, include_hidden: false %>
+            <%= form.govuk_check_box :qualifications, "qts_with_pgce_or_pgde", label: { text: t("helpers.label.courses_search_form.qualification_options.qts_with_pgce_or_pgde"), size: "s" }, include_hidden: false %>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :further_education, legend: { text: t("helpers.legend.courses_search_form.further_education_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.further_education"), class: "govuk-!-font-size-16" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+            <%= form.govuk_check_box :level, "further_education", label: { text: t("helpers.label.courses_search_form.further_education"), size: "s" }, multiple: false %>
+          <% end %>
+
+          <%= form.govuk_radio_buttons_fieldset :minimum_degree_required, legend: { text: t("helpers.legend.courses_search_form.minimum_degree_required_html"), size: "s" }, class: "app-filter__group govuk-radios--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+            <%= form.govuk_radio_button :minimum_degree_required, "two_one", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.two_one"), size: "s" } %>
+            <%= form.govuk_radio_button :minimum_degree_required, "two_two", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.two_two"), size: "s" } %>
+            <%= form.govuk_radio_button :minimum_degree_required, "third_class", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.third_class"), size: "s" } %>
+            <%= form.govuk_radio_button :minimum_degree_required, "pass", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.pass"), size: "s" } %>
+            <%= form.govuk_radio_button :minimum_degree_required, "no_degree_required", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.no_degree_required"), size: "s" } %>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_search_form.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+            <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.special_education_needs"), size: "s" } %>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :funding, legend: { text: t("helpers.legend.courses_search_form.funding_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+            <%= form.govuk_check_box :funding, "fee", label: { text: t("helpers.label.courses_search_form.funding_options.fee"), size: "s" }, include_hidden: false %>
+            <%= form.govuk_check_box :funding, "salary", label: { text: t("helpers.label.courses_search_form.funding_options.salary"), size: "s" }, include_hidden: false %>
+            <%= form.govuk_check_box :funding, "apprenticeship", label: { text: t("helpers.label.courses_search_form.funding_options.apprenticeship"), size: "s" }, include_hidden: false %>
+          <% end %>
+
+          <%= form.govuk_check_boxes_fieldset :applications_open, multiple: false, legend: { text: t("helpers.legend.courses_search_form.applications_open_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+            <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.applications_open"), size: "s" } %>
+          <% end %>
+
+          <div class="govuk-!-margin-top-4">
+            <%= form.govuk_submit t("helpers.submit.courses_search_form.filters") %>
+          </div>
+        </div>
+    </div>
+
+    <% if @results.present? %>
+      <div class="app-filter-layout__content">
+        <div class="app-search-results-header">
+          <div class="app-search-results-header__sort">
+            <% if @search_params[:location].present? %>
+              <p class="govuk-body">
+                <%= I18n.t("helpers.label.courses_search_form.ordering.location") %>
+              </p>
+            <% else %>
+              <%= form.govuk_collection_select(
+                  :order,
+                  form.object.ordering_options,
+                  :id,
+                  :name,
+                  label: { text: t("helpers.label.courses_search_form.ordering.non_location"), class: "govuk-!-display-inline-block" },
+                  role: "listbox", form_group: {}
+                ) %>
+
+              <%= form.govuk_submit t("helpers.submit.courses_search_form.order", class: "govuk-!-display-inline-block") %>
+            <% end %>
+          </div>
+        </div>
+
+        <ul class="app-search-results">
+          <% @results.each do |course| %>
+            <%= render Courses::SummaryCardComponent.new(course:, location: @search_params[:location], visa_sponsorship: @search_params[:can_sponsor_visa]) %>
+          <% end %>
+        </ul>
+
+        <%= govuk_pagination(pagy: @pagy) %>
       </div>
     <% end %>
   </div>
-
-  <% if @results.present? %>
-    <div class="app-filter-layout__content">
-      <ul class="app-search-results">
-        <% @results.each do |course| %>
-          <%= render Courses::SummaryCardComponent.new(course:, location: @search_params[:location], visa_sponsorship: @search_params[:can_sponsor_visa]) %>
-        <% end %>
-      </ul>
-
-      <%= govuk_pagination(pagy: @pagy) %>
-    </div>
-  <% end %>
-</div>
+<% end %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -403,7 +403,7 @@ en:
             other: "%{formatted_count} courses found"
   helpers:
     legend:
-      courses_query_filters:
+      courses_search_form:
         can_sponsor_visa_html: Visa sponsorship<span class="govuk-visually-hidden"> filter</span>
         primary_html: Primary<span class="govuk-visually-hidden"> filter</span>
         secondary_html: Secondary<span class="govuk-visually-hidden"> filter</span>
@@ -415,12 +415,17 @@ en:
         funding_html: Fee or salary<span class="govuk-visually-hidden"> filter</span>
         applications_open_html: Applications open<span class="govuk-visually-hidden"> filter</span>
     hint:
-      courses_query_filters:
+      courses_search_form:
         primary: (ages 3 to 11)
         further_education: (ages 16 and over)
         secondary: (ages 11 to 18)
+    submit:
+      courses_search_form:
+        filters: Apply filters
+        search: Search
+        order: Sort
     label:
-      courses_query_filters:
+      courses_search_form:
         can_sponsor_visa: Only show courses with visa sponsorship
         special_education_needs: Only show courses with a SEND specialism
         applications_open: Only show courses open for applications
@@ -441,6 +446,14 @@ en:
           fee: Fee - no salary
           salary: Salary
           apprenticeship: Teaching apprenticeship - with salary
+        ordering:
+          location: Sorted by distance
+          non_location: Sorted by
+          options:
+            course_name_ascending: Course name (A-Z)
+            course_name_descending: Course name (Z-A)
+            provider_name_ascending: Training provider (A-Z)
+            provider_name_descending: Training provider (Z-A)
   activemodel:
     errors:
       models:

--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -31,16 +31,16 @@ RSpec.describe Courses::Query do
 
     context 'when filter for visa sponsorship' do
       let!(:course_that_sponsor_visa) do
-        create(:course, :with_full_time_sites, :can_sponsor_skilled_worker_visa)
+        create(:course, :with_full_time_sites, :can_sponsor_skilled_worker_visa, name: 'Art and design')
       end
       let!(:another_course_that_sponsor_visa) do
-        create(:course, :with_full_time_sites, :can_sponsor_student_visa)
+        create(:course, :with_full_time_sites, :can_sponsor_student_visa, name: 'Biology')
       end
       let!(:another_course_that_sponsor_all_visas) do
-        create(:course, :with_full_time_sites, :can_sponsor_student_visa, :can_sponsor_skilled_worker_visa)
+        create(:course, :with_full_time_sites, :can_sponsor_student_visa, :can_sponsor_skilled_worker_visa, name: 'Computing')
       end
       let!(:course_that_does_not_sponsor_visa) do
-        create(:course, :with_full_time_sites, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: false)
+        create(:course, :with_full_time_sites, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: false, name: 'Drama')
       end
 
       let(:params) { { can_sponsor_visa: 'true' } }
@@ -132,16 +132,16 @@ RSpec.describe Courses::Query do
 
     context 'when filter by qualifications' do
       let!(:qts_course) do
-        create(:course, :with_full_time_sites, qualification: 'qts')
+        create(:course, :with_full_time_sites, qualification: 'qts', name: 'Art and design')
       end
       let!(:pgce_with_qts_course) do
-        create(:course, :with_full_time_sites, qualification: 'pgce_with_qts')
+        create(:course, :with_full_time_sites, qualification: 'pgce_with_qts', name: 'Biology')
       end
       let!(:pgde_with_qts_course) do
-        create(:course, :with_full_time_sites, qualification: 'pgde_with_qts')
+        create(:course, :with_full_time_sites, qualification: 'pgde_with_qts', name: 'Computing')
       end
       let!(:course_without_qts) do
-        create(:course, :with_full_time_sites, qualification: 'undergraduate_degree_with_qts')
+        create(:course, :with_full_time_sites, qualification: 'undergraduate_degree_with_qts', name: 'Drama')
       end
 
       context 'when filter by qts' do
@@ -231,19 +231,19 @@ RSpec.describe Courses::Query do
 
     context 'when filter by degree grade requirements' do
       let!(:requires_two_one_course) do
-        create(:course, :published_postgraduate, degree_grade: 'two_one')
+        create(:course, :published_postgraduate, degree_grade: 'two_one', name: 'Art and design')
       end
       let!(:requires_two_two_course) do
-        create(:course, :published_postgraduate, degree_grade: 'two_two')
+        create(:course, :published_postgraduate, degree_grade: 'two_two', name: 'Biology')
       end
       let!(:requires_third_class_course) do
-        create(:course, :published_postgraduate, degree_grade: 'third_class')
+        create(:course, :published_postgraduate, degree_grade: 'third_class', name: 'Computing')
       end
       let!(:requires_pass_degree) do
-        create(:course, :published_postgraduate, degree_grade: 'not_required')
+        create(:course, :published_postgraduate, degree_grade: 'not_required', name: 'Drama')
       end
       let!(:undergraduate_does_not_require_degree_course) do
-        create(:course, :published_teacher_degree_apprenticeship, degree_grade: 'not_required')
+        create(:course, :published_teacher_degree_apprenticeship, degree_grade: 'not_required', name: 'Mathematics')
       end
 
       context 'when filter by two_one' do
@@ -304,13 +304,13 @@ RSpec.describe Courses::Query do
 
     context 'when filter by funding' do
       let!(:fee_course) do
-        create(:course, :with_full_time_sites, funding: 'fee')
+        create(:course, :with_full_time_sites, funding: 'fee', name: 'Art and design')
       end
       let!(:salaried_course) do
-        create(:course, :with_full_time_sites, funding: 'salary')
+        create(:course, :with_full_time_sites, funding: 'salary', name: 'Biology')
       end
       let!(:apprenticeship_course) do
-        create(:course, :with_full_time_sites, funding: 'apprenticeship')
+        create(:course, :with_full_time_sites, funding: 'apprenticeship', name: 'Computing')
       end
 
       context 'when filter by fee' do
@@ -385,19 +385,28 @@ RSpec.describe Courses::Query do
         create(:provider, provider_name: 'Warwick University')
       end
       let!(:warwick_courses) do
-        create_list(:course, 2, :with_full_time_sites, provider: warwick_provider)
+        [
+          create(:course, :with_full_time_sites, provider: warwick_provider, name: 'Biology'),
+          create(:course, :with_full_time_sites, provider: warwick_provider, name: 'Computing')
+        ]
       end
       let!(:niot_provider) do
         create(:provider, provider_name: 'NIoT')
       end
       let!(:niot_accredited_courses) do
-        create_list(:course, 2, :with_full_time_sites, accredited_provider_code: niot_provider.provider_code)
+        [
+          create(:course, :with_full_time_sites, accredited_provider_code: niot_provider.provider_code, name: 'Biology'),
+          create(:course, :with_full_time_sites, accredited_provider_code: niot_provider.provider_code, name: 'Computing')
+        ]
       end
       let!(:essex_provider) do
         create(:provider, provider_name: 'Essex University')
       end
       let!(:essex_courses) do
-        create_list(:course, 2, :with_full_time_sites, provider: essex_provider)
+        [
+          create(:course, :with_full_time_sites, provider: essex_provider, name: 'Biology'),
+          create(:course, :with_full_time_sites, provider: essex_provider, name: 'Computing')
+        ]
       end
 
       context 'when searching by provider name for the self ratified provider' do
@@ -522,12 +531,14 @@ RSpec.describe Courses::Query do
       let(:guildford) { build(:location, :guildford) }
       let(:oxford) { build(:location, :oxford) }
       let(:edinburgh) { build(:location, :edinburgh) }
+      let(:london_provider) { create(:provider, provider_name: 'London university') }
 
       let!(:course_london_result) do
         test_search_result_wrapper_klass.new(
           create(
             :course,
             name: 'Mathematics (London)',
+            provider: london_provider,
             site_statuses: [
               create(
                 :site_status,
@@ -545,6 +556,7 @@ RSpec.describe Courses::Query do
           create(
             :course,
             name: 'Science (Canary Wharf)',
+            provider: london_provider,
             site_statuses: [
               create(
                 :site_status,
@@ -847,6 +859,52 @@ RSpec.describe Courses::Query do
           ]
         end
       end
+
+      context 'when latitude and longitude are given' do
+        it 'always order by distance and ignores the order param' do
+          %w[
+            course_name_ascending
+            course_name_descending
+            provider_name_ascending
+            provider_name_descending
+          ].each do |order|
+            results = described_class.call(
+              params: {
+                latitude: london.latitude,
+                longitude: london.longitude,
+                radius: 10,
+                order:
+              }
+            )
+            expect(results).to match_collection(
+              [
+                course_london_result,
+                course_canary_wharf_result,
+                course_lewisham_result
+              ],
+              attribute_names: %w[name minimum_distance_to_search_location]
+            )
+          end
+        end
+
+        it 'always order by distance when search by provider' do
+          results = described_class.call(
+            params: {
+              latitude: london.latitude,
+              longitude: london.longitude,
+              radius: 10,
+              provider_code: course_london_result.provider_code
+            }
+          )
+          expect(results).to match_collection(
+            [
+              course_london_result,
+              course_canary_wharf_result
+            ],
+            attribute_names: %w[name minimum_distance_to_search_location]
+          )
+        end
+      end
     end
 
     describe 'SQL injection tests for location search' do
@@ -893,6 +951,123 @@ RSpec.describe Courses::Query do
         expect { described_class.call(params: params) }.to raise_error(
           ArgumentError, "invalid value for Float(): \"#{malicious_radius}\""
         )
+      end
+    end
+
+    context 'when ordering' do
+      let(:niot_provider) { create(:provider, provider_name: 'Niot University') }
+      let(:essex_provider) { create(:provider, provider_name: 'Essex University') }
+      let(:oxford_provider) { create(:provider, provider_name: 'Oxford University') }
+      let(:manchester_provider) { create(:provider, provider_name: 'Manchester University') }
+
+      let!(:biology) do
+        create(:course, :with_full_time_sites, name: 'Biology', provider: niot_provider)
+      end
+      let!(:chemistry) do
+        create(:course, :with_full_time_sites, name: 'Chemistry', provider: essex_provider)
+      end
+      let!(:mathematics) do
+        create(:course, :with_full_time_sites, name: 'Mathematics', provider: oxford_provider)
+      end
+      let!(:art_and_design) do
+        create(:course, :with_full_time_sites, name: 'Art and Design', provider: manchester_provider)
+      end
+
+      context 'when ordering by course name ascending' do
+        let(:params) { { order: 'course_name_ascending' } }
+
+        it 'returns courses ordered by course name ascending' do
+          expect(results).to match_collection(
+            [
+              art_and_design,
+              biology,
+              chemistry,
+              mathematics
+            ],
+            attribute_names: %w[name]
+          )
+        end
+      end
+
+      context 'when ordering by course name descending' do
+        let(:params) { { order: 'course_name_descending' } }
+
+        it 'returns courses ordered by course name descending' do
+          expect(results).to match_collection(
+            [
+              mathematics,
+              chemistry,
+              biology,
+              art_and_design
+            ],
+            attribute_names: %w[name]
+          )
+        end
+      end
+
+      context 'when ordering by provider name ascending' do
+        let(:params) { { order: 'provider_name_ascending' } }
+
+        it 'returns courses ordered by provider name ascending' do
+          expect(results).to match_collection(
+            [
+              essex_provider.courses,
+              manchester_provider.courses,
+              niot_provider.courses,
+              oxford_provider.courses
+            ].flatten,
+            attribute_names: %w[name provider_name]
+          )
+        end
+      end
+
+      context 'when ordering by provider name descending' do
+        let(:params) { { order: 'provider_name_descending' } }
+
+        it 'returns courses ordered by provider name descending' do
+          expect(results).to match_collection(
+            [
+              oxford_provider.courses,
+              niot_provider.courses,
+              manchester_provider.courses,
+              essex_provider.courses
+            ].flatten,
+            attribute_names: %w[name]
+          )
+        end
+      end
+
+      context 'when searching by provider name' do
+        let(:provider) { create(:provider, provider_name: 'Manchester University') }
+        let!(:manchester_computing_course) do
+          create(:course, :with_full_time_sites, name: 'Computing', provider:)
+        end
+        let!(:manchester_biology_course) do
+          create(:course, :with_full_time_sites, name: 'Biology', provider:)
+        end
+        let!(:manchester_science_course) do
+          create(:course, :with_full_time_sites, name: 'Science', provider:)
+        end
+        let!(:manchester_primary_course) do
+          create(:course, :with_full_time_sites, name: 'Primary', provider:)
+        end
+        let!(:manchester_art_and_design_course) do
+          create(:course, :with_full_time_sites, name: 'Art and design', provider:)
+        end
+        let(:params) { { provider_code: provider.provider_code } }
+
+        it 'order courses by ascending order' do
+          expect(results).to match_collection(
+            [
+              manchester_art_and_design_course,
+              manchester_biology_course,
+              manchester_computing_course,
+              manchester_primary_course,
+              manchester_science_course
+            ],
+            attribute_names: %w[id name provider_name]
+          )
+        end
       end
     end
   end

--- a/spec/system/find/v2/results/search_results_ordering_spec.rb
+++ b/spec/system/find/v2/results/search_results_ordering_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'V2 results ordering', :js, service: :find do
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+    allow(Settings.features).to receive_messages(v2_results: true)
+  end
+
+  context 'when sorting the results' do
+    before { given_there_are_published_courses }
+
+    scenario 'sorting by course name' do
+      when_i_visit_the_find_results_page
+      then_the_courses_are_ordered_by_course_name_ascending
+
+      when_i_click_on_the_second_page
+      then_i_see_the_remaining_courses_ordered_by_course_name_ascending
+
+      when_i_visit_the_find_results_page
+      and_i_sort_courses_from_z_to_a
+      then_the_courses_are_ordered_by_course_name_descending
+
+      when_i_click_on_the_second_page
+      then_i_see_the_remaining_courses_ordered_by_course_name_descending
+
+      when_i_visit_the_find_results_page
+      and_i_sort_courses_from_a_to_z
+      then_the_courses_are_ordered_by_course_name_ascending
+
+      when_i_click_on_the_second_page
+      then_i_see_the_remaining_courses_ordered_by_course_name_ascending
+    end
+
+    scenario 'sorting by provider name' do
+      when_i_visit_the_find_results_page
+
+      and_i_sort_providers_from_a_to_z
+      then_the_courses_are_ordered_by_provider_name_ascending
+
+      and_i_sort_providers_from_z_to_a
+      then_the_courses_are_ordered_by_provider_name_descending
+    end
+
+    def given_there_are_published_courses
+      warwick_provider = create(:provider, provider_name: 'Warwick University')
+      niot_provider = create(:provider, provider_name: 'NIoT')
+      essex_provider = create(:provider, provider_name: 'Essex University')
+      cambridge_provider = create(:provider, provider_name: 'Cambridge University')
+      oxford_provider = create(:provider, provider_name: 'Oxford University')
+
+      create(:course, :with_full_time_sites, provider: warwick_provider, name: 'Computing', course_code: '23TT')
+      create(:course, :with_full_time_sites, provider: warwick_provider, name: 'Art and Design', course_code: 'X100')
+      create(:course, :with_full_time_sites, provider: warwick_provider, name: 'Drama', course_code: 'AB21')
+      create(:course, :with_full_time_sites, provider: warwick_provider, name: 'Chemistry', course_code: 'X121')
+
+      create(:course, :with_full_time_sites, provider: niot_provider, name: 'Economics', course_code: '23TX')
+      create(:course, :with_full_time_sites, provider: niot_provider, name: 'Psychology', course_code: '23X7')
+      create(:course, :with_full_time_sites, provider: niot_provider, name: 'History', course_code: '23X8')
+
+      create(:course, :with_full_time_sites, provider: essex_provider, name: 'Mathematics', course_code: '23X9')
+      create(:course, :with_full_time_sites, provider: essex_provider, name: 'Physics', course_code: '23XB')
+      create(:course, :with_full_time_sites, provider: essex_provider, name: 'Art and Design', course_code: '23XC')
+
+      create(:course, :with_full_time_sites, provider: cambridge_provider, name: 'Music', course_code: '23XD')
+      create(:course, :with_full_time_sites, provider: cambridge_provider, name: 'Dance', course_code: '23XF')
+
+      create(:course, :with_full_time_sites, provider: oxford_provider, name: 'Geography', course_code: '23XJ')
+      create(:course, :with_full_time_sites, provider: oxford_provider, name: 'English', course_code: '23XK')
+      create(:course, :with_full_time_sites, provider: oxford_provider, name: 'Philosophy', course_code: 'T3XK')
+    end
+
+    def when_i_visit_the_find_results_page
+      visit find_v2_results_path
+    end
+
+    def when_i_click_on_the_second_page
+      click_link_or_button '2'
+    end
+
+    def then_i_see_the_remaining_courses_ordered_by_course_name_ascending
+      expect(result_titles).to eq(
+        [
+          'Essex University Mathematics (23X9)',
+          'Cambridge University Music (23XD)',
+          'Oxford University Philosophy (T3XK)',
+          'Essex University Physics (23XB)',
+          'NIoT Psychology (23X7)'
+        ]
+      )
+    end
+
+    def then_i_see_the_remaining_courses_ordered_by_course_name_descending
+      expect(result_titles).to eq(
+        [
+          'Cambridge University Dance (23XF)',
+          'Warwick University Computing (23TT)',
+          'Warwick University Chemistry (X121)',
+          'Essex University Art and Design (23XC)',
+          'Warwick University Art and Design (X100)'
+        ]
+      )
+    end
+
+    def and_i_sort_courses_from_z_to_a
+      select 'Course name (Z-A)', from: 'Sorted by'
+      click_link_or_button 'Sort'
+    end
+
+    def and_i_sort_courses_from_a_to_z
+      select 'Course name (A-Z)', from: 'Sorted by'
+      click_link_or_button 'Sort'
+    end
+
+    def and_i_sort_providers_from_a_to_z
+      select 'Training provider (A-Z)', from: 'Sorted by'
+      click_link_or_button 'Sort'
+    end
+
+    def and_i_sort_providers_from_z_to_a
+      select 'Training provider (Z-A)', from: 'Sorted by'
+      click_link_or_button 'Sort'
+    end
+
+    def then_the_courses_are_ordered_by_course_name_ascending
+      expect(result_titles).to eq(
+        [
+          'Essex University Art and Design (23XC)',
+          'Warwick University Art and Design (X100)',
+          'Warwick University Chemistry (X121)',
+          'Warwick University Computing (23TT)',
+          'Cambridge University Dance (23XF)',
+          'Warwick University Drama (AB21)',
+          'NIoT Economics (23TX)',
+          'Oxford University English (23XK)',
+          'Oxford University Geography (23XJ)',
+          'NIoT History (23X8)'
+        ]
+      )
+    end
+
+    def then_the_courses_are_ordered_by_course_name_descending
+      expect(result_titles).to eq(
+        [
+          'NIoT Psychology (23X7)',
+          'Essex University Physics (23XB)',
+          'Oxford University Philosophy (T3XK)',
+          'Cambridge University Music (23XD)',
+          'Essex University Mathematics (23X9)',
+          'NIoT History (23X8)',
+          'Oxford University Geography (23XJ)',
+          'Oxford University English (23XK)',
+          'NIoT Economics (23TX)',
+          'Warwick University Drama (AB21)'
+        ]
+      )
+    end
+
+    def then_the_courses_are_ordered_by_provider_name_ascending
+      expect(result_titles).to eq(
+        [
+          'Cambridge University Dance (23XF)',
+          'Cambridge University Music (23XD)',
+          'Essex University Art and Design (23XC)',
+          'Essex University Mathematics (23X9)',
+          'Essex University Physics (23XB)',
+          'NIoT Economics (23TX)',
+          'NIoT History (23X8)',
+          'NIoT Psychology (23X7)',
+          'Oxford University English (23XK)',
+          'Oxford University Geography (23XJ)'
+        ]
+      )
+    end
+
+    def then_the_courses_are_ordered_by_provider_name_descending
+      expect(result_titles).to eq(
+        [
+          'Warwick University Art and Design (X100)',
+          'Warwick University Chemistry (X121)',
+          'Warwick University Computing (23TT)',
+          'Warwick University Drama (AB21)',
+          'Oxford University English (23XK)',
+          'Oxford University Geography (23XJ)',
+          'Oxford University Philosophy (T3XK)',
+          'NIoT Economics (23TX)',
+          'NIoT History (23X8)',
+          'NIoT Psychology (23X7)'
+        ]
+      )
+    end
+
+    private
+
+    def result_titles
+      page.all('.govuk-summary-card__title').map { |element| element.text.split("\n").join(' ') }
+    end
+  end
+end


### PR DESCRIPTION
## Context

Following the same pattern
described on
https://becoming-a-teacher.design-history.education.gov.uk/find-teacher-training/sorting-by-course-name-in-the-search-results/

## Changes proposed in this pull request

To add here later

## Guidance to review

To add here later
