### PR TITLE
Add shortcuts to Publish from Support

### DIFF
--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -8,48 +8,40 @@
 <% end %>
 
 <div class="govuk-caption-l"><%= Provider.human_attribute_name(@provider.provider_type) %></div>
-<h1 class="govuk-heading-l"><%= @provider.name_and_code %></h1>
+<h1 class="govuk-heading-l">
+  <%= govuk_link_to @provider.name_and_code, publish_provider_path(@provider.provider_code), no_visited_state: true %>
+</h1>
 
-<%= render TabNavigation.new(items: [
-  { name: "Details", url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: support_recruitment_cycle_provider_accredited_providers_path(@provider.recruitment_cycle_year, @provider) }] unless @provider.accredited?)
-]) %>
+<%= render "support/providers/navigation" %>
 
 <%= govuk_link_to "Copy Courses", new_support_recruitment_cycle_provider_copy_course_path(@recruitment_cycle.year, @provider), class: "govuk-button" %>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Course name and code</th>
-      <th scope="col" class="govuk-table__header">Status</th>
-      <th scope="col" class="govuk-table__header">Ratifying Provider</th>
-      <th scope="col" class="govuk-table__header"></th>
-    </tr>
-  </thead>
+<%= govuk_table do |table| %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell text: "Course name and code" %>
+      <% row.with_cell text: "Status" %>
+      <% row.with_cell text: "Ratifying Provider" %>
+      <% row.with_cell %>
+    <% end %>
+  <% end %>
 
-  <tbody class="govuk-table__body">
+  <% table.with_body do |body| %>
     <% @courses.each do |course| %>
-      <tr class="govuk-table__row course-row">
-        <td class="govuk-table__cell name">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.name %> (<%= course.course_code %>)</span>
-        </td>
-        <td class="govuk-table__cell status">
-          <%= course.decorate.status_tag %>
-        </td>
-        <td class="govuk-table__cell">
+      <% body.with_row classes: ["course-row"] do |row| %>
+        <% row.with_cell text: govuk_link_to(course.name_and_code, publish_provider_recruitment_cycle_course_url(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code)), classes: ["name"] %>
+        <% row.with_cell text: course.decorate.status_tag, classes: ["status"] %>
+
+        <% row.with_cell do %>
           <% if course.accrediting_provider %>
             <%= govuk_link_to(course.accrediting_provider.provider_name, support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, course.accrediting_provider)) %>
           <% end %>
-        </td>
-        <td class="govuk-table__cell change">
-          <%= govuk_link_to "Change", edit_support_recruitment_cycle_provider_course_url(@provider.recruitment_cycle_year, @provider, course) %>
-        </td>
-      </tr>
+        <% end %>
+
+        <% row.with_cell text: govuk_link_to("Change", edit_support_recruitment_cycle_provider_course_url(@provider.recruitment_cycle_year, @provider, course)), classes: ["change"] %>
+      <% end %>
     <% end %>
-  </tbody>
-</table>
+  <% end %>
+<% end %>
 
 <%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/support/providers/_navigation.html.erb
+++ b/app/views/support/providers/_navigation.html.erb
@@ -1,0 +1,7 @@
+<%= render TabNavigation.new(items: [
+  { name: "Details", url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider) },
+  { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
+  { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
+  { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
+  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
+]) %>

--- a/app/views/support/providers/accredited_partnerships/index.html.erb
+++ b/app/views/support/providers/accredited_partnerships/index.html.erb
@@ -8,15 +8,11 @@
 <% end %>
 
 <div class="govuk-caption-l"><%= Provider.human_attribute_name(@provider.provider_type) %></div>
-<h1 class="govuk-heading-l"><%= @provider.name_and_code %></h1>
+<h1 class="govuk-heading-l">
+  <%= govuk_link_to @provider.name_and_code, publish_provider_path(@provider.provider_code), no_visited_state: true %>
+</h1>
 
-<%= render TabNavigation.new(items: [
-  { name: "Details", url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
-]) %>
+<%= render "support/providers/navigation" %>
 
 <%= govuk_button_link_to(t(".add"), search_support_recruitment_cycle_provider_accredited_providers_path) %>
 

--- a/app/views/support/providers/accredited_providers/index.html.erb
+++ b/app/views/support/providers/accredited_providers/index.html.erb
@@ -8,15 +8,11 @@
 <% end %>
 
 <div class="govuk-caption-l"><%= Provider.human_attribute_name(@provider.provider_type) %></div>
-<h1 class="govuk-heading-l"><%= @provider.name_and_code %></h1>
+<h1 class="govuk-heading-l">
+  <%= govuk_link_to @provider.name_and_code, publish_provider_path(@provider.provider_code), no_visited_state: true %>
+</h1>
 
-<%= render TabNavigation.new(items: [
-  { name: "Details", url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
-]) %>
+<%= render "support/providers/navigation" %>
 
 <%= govuk_button_link_to("Add accredited provider", search_support_recruitment_cycle_provider_accredited_providers_path) %>
 

--- a/app/views/support/providers/show.html.erb
+++ b/app/views/support/providers/show.html.erb
@@ -8,14 +8,10 @@
 <% end %>
 
 <div class="govuk-caption-l"><%= Provider.human_attribute_name(@provider.provider_type) %></div>
-<h1 class="govuk-heading-l"><%= @provider.name_and_code %></h1>
+<h1 class="govuk-heading-l">
+  <%= govuk_link_to @provider.name_and_code, publish_provider_path(@provider.provider_code), no_visited_state: true %>
+</h1>
 
-<%= render TabNavigation.new(items: [
-  { name: "Details", url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
-]) %>
+<%= render "support/providers/navigation" %>
 
 <%= render Providers::ProviderList::View.new(provider: @provider) %>

--- a/app/views/support/providers/users/index.html.erb
+++ b/app/views/support/providers/users/index.html.erb
@@ -8,15 +8,11 @@
 <% end %>
 
 <div class="govuk-caption-l"><%= Provider.human_attribute_name(@provider.provider_type) %></div>
-<h1 class="govuk-heading-l"><%= @provider.name_and_code %></h1>
+<h1 class="govuk-heading-l">
+  <%= govuk_link_to @provider.name_and_code, publish_provider_path(@provider.provider_code), no_visited_state: true %>
+</h1>
 
-<%= render TabNavigation.new(items: [
-  { name: "Details", url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
-]) %>
+<%= render "support/providers/navigation" %>
 
 <%= govuk_button_link_to t("components.page_titles.support.providers.users.new"), new_support_recruitment_cycle_provider_user_path(@provider.recruitment_cycle_year, @provider) %>
 <%= render "provider_user_list", users: @users, provider: @provider %>

--- a/app/views/support/schools/index.html.erb
+++ b/app/views/support/schools/index.html.erb
@@ -8,15 +8,11 @@
 <% end %>
 
 <div class="govuk-caption-l"><%= Provider.human_attribute_name(@provider.provider_type) %></div>
-<h1 class="govuk-heading-l"><%= @provider.name_and_code %></h1>
+<h1 class="govuk-heading-l">
+  <%= govuk_link_to @provider.name_and_code, publish_provider_path(@provider.provider_code), no_visited_state: true %>
+</h1>
 
-<%= render TabNavigation.new(items: [
-  { name: "Details", url: support_recruitment_cycle_provider_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Users", url: support_recruitment_cycle_provider_users_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Courses", url: support_recruitment_cycle_provider_courses_path(@provider.recruitment_cycle_year, @provider) },
-  { name: "Schools", url: support_recruitment_cycle_provider_schools_path(@provider.recruitment_cycle_year, @provider) },
-  *([{ name: "Accredited providers", url: x_accredited_partnerships_navigation_item_link_path(@provider) }] unless @provider.accredited?)
-]) %>
+<%= render "support/providers/navigation" %>
 
 <%= govuk_link_to("Add school", new_support_recruitment_cycle_provider_school_path, class: "govuk-button govuk-!-margin-bottom-3") %>
 


### PR DESCRIPTION
## Context

A lot of support currently requires us to visit the Provider pages from Publish directly. It's a hassle to navigate to a provider or course in Publish from Support.

## Changes proposed in this pull request

- Add links to Publish from Support.

## Guidance to review

### Provider links

- Sign into Support.
- Find a provider.
- Click on the heading, it will take you to the provider on Publish.

### Course links

- Sign into Support.
- Find a provider.
- View their courses.
- Click on "View on Publish", it will take you to the course on Publish.
