### PR TITLE
Skip verify_authorized for Publish::ErrorsController

### DIFF
--- a/app/controllers/publish/errors_controller.rb
+++ b/app/controllers/publish/errors_controller.rb
@@ -3,6 +3,7 @@
 module Publish
   class ErrorsController < ApplicationController
     skip_before_action :authenticate
+    skip_after_action :verify_authorized
 
     include Errorable
   end


### PR DESCRIPTION
## Context

We have a recurring error happening in some environments.

https://dfe-teacher-services.sentry.io/issues/6234856794

## Changes proposed in this pull request

- Skip the `verify_authorized` after action callback in the `Publish::ErrorsController`.

## Guidance to review

Visit the following pages:

| Environment | URL                                                               |
| ----------- | ----------------------------------------------------------------- |
| QA          | https://qa.publish-teacher-training-courses.service.gov.uk/onetwo |
| Review      | https://publish-review-4881.test.teacherservices.cloud/onetwo     |
