### PR TITLE
Improve navigation - Update Browse primary courses page

### DIFF
--- a/app/controllers/find/v2/subjects_controller.rb
+++ b/app/controllers/find/v2/subjects_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Find
+  module V2
+    class SubjectsController < Find::ApplicationController
+      def primary
+        @form = Find::V2::Subjects::PrimarySubjectsForm.new(subject_params)
+        @primary_subject_options = Subject.primary
+      end
+
+      def submit
+        @form = Find::V2::Subjects::PrimarySubjectsForm.new(subject_params)
+
+        if @form.valid?
+          redirect_to find_v2_results_path({ subjects: @form.subjects })
+        else
+          @primary_subject_options = Subject.primary
+          render :primary
+        end
+      end
+
+      private
+
+      def subject_params
+        params.fetch(:find_v2_subjects_primary_subjects_form, {}).permit(subjects: [])
+      end
+    end
+  end
+end

--- a/app/forms/find/v2/subjects/primary_subjects_form.rb
+++ b/app/forms/find/v2/subjects/primary_subjects_form.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Find
+  module V2
+    module Subjects
+      class PrimarySubjectsForm
+        include ActiveModel::Model
+
+        attr_accessor :subjects
+
+        validates :subjects, presence: true
+
+        def initialize(params = {})
+          @subjects = Array(params[:subjects]).compact_blank
+        end
+      end
+    end
+  end
+end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -11,6 +11,7 @@ class Subject < ApplicationRecord
   }
 
   scope :active, -> { where.not(type: 'DiscontinuedSubject') }
+  scope :primary, -> { where(type: 'PrimarySubject').order(:subject_name) }
 
   def secondary_subject?
     type == 'SecondarySubject'

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -125,7 +125,7 @@
     <div class="govuk-grid-column-one-half">
       <div class="quick-link-card">
         <h2 class="govuk-heading-m"><%= t("find.search.primary") %></h2>
-        <p class="govuk-body"><%= govuk_link_to(t("find.search.browse_primary"), find_track_click_path(utm_content: "primary-quick-link", url: "/subjects?age_group=primary&l=2")) %></p>
+        <p class="govuk-body"><%= govuk_link_to(t("find.search.browse_primary"), find_track_click_path(utm_content: "primary-quick-link", url: find_primary_url)) %></p>
       </div>
     </div>
 

--- a/app/views/find/v2/subjects/primary.html.erb
+++ b/app/views/find/v2/subjects/primary.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, title_with_error_prefix(I18n.t(".find.v2.subjects.primary.page_title"), @form.errors.present?) %>
+
+<%= form_with model: @form, url: find_submit_primary_path, method: :post do |f| %>
+  <%= f.govuk_error_summary link_base_errors_to: :subjects %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= I18n.t(".find.v2.subjects.primary.page_title") %></h1>
+
+      <%= f.govuk_collection_check_boxes :subjects, @primary_subject_options, :subject_code, :subject_name, legend: { hidden: true } %>
+
+      <%= f.govuk_submit I18n.t(".find.v2.subjects.primary.find_courses_button") %>
+
+      <%= render Shared::AdviceComponent::View.new(title: t(".how_primary_specialism_works")) do %>
+        <p class="govuk-body"><%= I18n.t(".find.v2.subjects.primary.how_primary_specialism_works_para_one") %></p>
+        <p class="govuk-body"><%= I18n.t(".find.v2.subjects.primary.how_primary_specialism_works_para_two") %></p>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -431,6 +431,14 @@ en:
             zero: "No courses found"
             one: "1 course found"
             other: "%{formatted_count} courses found"
+      subjects:
+        primary:
+          page_title: Browse primary courses
+          find_courses_button: Find primary courses
+          how_primary_specialism_works: How primary specialisms work
+          how_primary_specialism_works_para_one: As a trainee primary teacher you’ll learn to teach all subjects across the national curriculum.
+          how_primary_specialism_works_para_two: Some courses also enable you to develop your knowledge of a particular subject. This means that when you're a teacher, you might be able to influence the way this subject is taught in your school. For example, you might mentor your colleagues to teach that subject better.
+
   helpers:
     legend:
       courses_search_form:
@@ -505,3 +513,5 @@ en:
             subjects:
               primary_subject: "Select at least one primary subject you want to teach"
               secondary_subject: "Select at least one secondary subject you want to teach"
+        find/v2/subjects/primary_subjects_form:
+          blank: "Select at least one type of primary course"

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -21,6 +21,10 @@ namespace :find, path: '/' do
   get '/course/:provider_code/:course_code/provider/website', to: 'courses#provider_website', as: :provider_website
 
   get '/v2/results', to: 'v2/results#index', as: 'v2_results', constraints: ->(_request) { Settings.features.v2_results.present? }
+
+  get '/v2/primary', to: 'v2/subjects#primary', as: 'primary', constraints: ->(_request) { Settings.features.v2_results.present? }
+  post '/v2/primary', to: 'v2/subjects#submit', as: 'submit_primary', constraints: ->(_request) { Settings.features.v2_results.present? }
+
   get '/results', to: 'results#index', as: 'results'
   get '/location-suggestions', to: 'location_suggestions#index'
   get '/cycle-has-ended', to: 'pages#cycle_has_ended', as: 'cycle_has_ended'

--- a/spec/forms/find/v2/subjects/primary_subjects_form_spec.rb
+++ b/spec/forms/find/v2/subjects/primary_subjects_form_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Find
+  module V2
+    module Subjects
+      describe PrimarySubjectsForm do
+        describe 'validation' do
+          subject { described_class.new(params) }
+
+          context 'when no primary subject is selected' do
+            let(:params) { {} }
+
+            it 'is not valid' do
+              expect(subject.valid?).to be(false)
+              expect(subject.errors[:subjects]).to include('Select at least one type of primary course')
+            end
+          end
+
+          context 'when primary subjects are selected' do
+            let(:params) { { subjects: %w[01 02] } }
+
+            it 'is valid' do
+              expect(subject.valid?).to be(true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -17,4 +17,8 @@ describe Subject do
   it 'returns all active subjects' do
     expect(described_class.active.pluck(:type)).not_to include('DiscontinuedSubject')
   end
+
+  it 'returns all primary subjects' do
+    expect(described_class.primary.pluck(:type)).to include('PrimarySubject')
+  end
 end

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -284,6 +284,19 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     then_i_see_no_courses_found
   end
 
+  context 'when viewing results via the primary subjects quick link' do
+    before do
+      visit find_root_path
+      and_there_are_courses_with_primary_subjects
+    end
+
+    scenario 'filter by primary subjects' do
+      click_link_or_button 'Browse primary courses'
+      when_i_select_primary_courses
+      then_i_see_only_primary_specific_courses
+    end
+  end
+
   def given_there_are_courses_that_sponsor_visa
     create(:course, :with_full_time_sites, :can_sponsor_skilled_worker_visa, name: 'Biology', course_code: 'S872')
     create(:course, :with_full_time_sites, :can_sponsor_student_visa, name: 'Chemistry', course_code: 'K592')
@@ -437,6 +450,11 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   def when_i_filter_by_primary
     check 'Primary', visible: :all
     and_i_apply_the_filters
+  end
+
+  def when_i_select_primary_courses
+    check 'Primary', visible: :all
+    click_link_or_button 'Find primary courses', match: :first
   end
 
   def when_i_filter_by_primary_with_science_too


### PR DESCRIPTION
## Context
Prototype: https://find-review-4453.test.teacherservices.cloud/subjects?age_group=primary
Ticket: https://trello.com/c/lolKTP1k/307-improve-navigation-update-browse-primary-courses-page

The basis of this ticket is to pretty much change some content, however Dan, Tomas and I have agreed we want to simplify the code for this. So we have gone with a v2 line for this work which will rework what we currently have to become easier to maintain and extend.

This PR creates a `SubjectsController` which will be responsible for the primary and secondary subject rendering (Only primary for this ticket, subjects is in an upcoming ticket), I also added a `PrimarySubjectsForm` which just ensures an option is checked before processing to the new v2 results page.

## Changes proposed in this pull request

- Update the `Browse primary courses` quick link to take the user to the new `v2/primary` route instead of the old route
- Update the content
- Add form validation

## Guidance to review
No errors:
<img width="1728" alt="Screenshot 2025-02-03 at 18 59 26" src="https://github.com/user-attachments/assets/a5eb32fc-68aa-4507-a6c5-b46d7c749f1d" />

With errors: 
<img width="1728" alt="Screenshot 2025-02-03 at 19 00 03" src="https://github.com/user-attachments/assets/eacc1883-e354-4f4f-90a5-fc7f82b2a1a5" />
