### PR TITLE
[610] Add visa sponsorship application deadline attribute to course object

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -153,6 +153,12 @@ module API
           @object.funding
         end
 
+        attribute :visa_sponsorship_application_deadline_at do
+          # A date_time attribute is required for Apply to block candidates who require visa sponsorship from applying to
+          # courses with early deadlines. The value is nil until the UI is built to collect the data. (4/2/2025)
+          nil
+        end
+
         enrichment_attribute :about_course
         enrichment_attribute :course_length
         enrichment_attribute :fee_details

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -402,7 +402,8 @@ RSpec.describe API::Public::V1::CoursesController do
                 campaign_name
                 application_status
                 training_route
-                degree_type]
+                degree_type
+                visa_sponsorship_application_deadline_at]
           end
 
           before do

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:application_status) }
   it { is_expected.to have_attribute(:training_route) }
   it { is_expected.to have_attribute(:degree_type) }
+  it { is_expected.to have_attribute(:visa_sponsorship_application_deadline_at).with_value(nil) }
 
   context 'when bursary amount is present' do
     let(:course) { create(:course, :with_accrediting_provider, :secondary, enrichments: [enrichment], subjects: [find_or_create(:secondary_subject, :classics)]) }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -491,6 +491,13 @@
               "example": "00"
             }
           },
+          "visa_sponsorship_application_deadline_at": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time",
+            "description": "The application deadline for candidates who require visa sponsorship.",
+            "example": "2019-06-13T10:44:31Z"
+          },
           "degree_grade": {
             "type": "string",
             "nullable": true,

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -334,6 +334,12 @@ properties:
     items:
       type: string
       example: "00"
+  visa_sponsorship_application_deadline_at:
+    type: string
+    nullable: true
+    format: date-time
+    description: "The application deadline for candidates who require visa sponsorship."
+    example: "2025-06-13T10:44:31Z"
   degree_grade:
     type: string
     nullable: true


### PR DESCRIPTION
## Context

[Trello card on the Apply / Manage board](https://trello.com/c/cgxezeG7)

We want to enable providers to add early deadlines for candidates who require visa sponsorship (on courses that sponsor visas).  The [outcome card](https://trello.com/c/AyrMu8s3) is also on the Apply / Manage board.

## Changes proposed in this pull request

This is just an enabling task to allow work to move forward on the Apply side. There are future tickets written / planned for the rest of the work on the publish side (@dp-daly and @dcyoung-dev are working on this together, I believe)

## Guidance to review

- You can see the new field in the API response in the review app https://publish-review-4887.test.teacherservices.cloud/api/public/v1/recruitment_cycles/2025/courses
- have a look at the [revised api documentation here](https://publish-review-4887.test.teacherservices.cloud/docs/api-reference.html#schema-courseattributes)

