### PR TITLE
Add storage account for sanitised backups

### DIFF
--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/eppo/environment" {
   constraints = "1.3.5"
   hashes = [
     "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
+    "h1:pceowuRAKcjLd+g4noIJdX6CBIWavlM4BvRTsGfH0uQ=",
     "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
     "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
     "zh:12ca5162286b80b7f46bd013ae2007641132d201af12bc6adb872f9a0ff85b7a",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.116.0"
   hashes = [
     "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
+    "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.32.0"
   constraints = "2.32.0"
   hashes = [
+    "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
     "h1:Cj3RHyw3wE3AkNlCtSNrZfjFNkShvaZR0K/K3pJlYJU=",
     "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
     "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
@@ -68,6 +71,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [
     "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
     "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
@@ -87,6 +91,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.2.2"
   constraints = "2.2.2"
   hashes = [
+    "h1:nVaJkDBk4sv0yWFzg3p+yeJGzE8mB4KJv3Q6/UgU164=",
     "h1:wFoZJfmNvG6XTf65NLai67geSHqYV1Tilx7OITrHilE=",
     "zh:0916313344c579d6e05d70f88129a10fe48f7dabe0e61cad17874d6c496f288d",
     "zh:0d491ff72c2eda6482855033ca2146c5ace1663d07cb3da7253b59ed2e2ec6f4",

--- a/terraform/aks/storage.tf
+++ b/terraform/aks/storage.tf
@@ -1,0 +1,58 @@
+locals {
+  uploads_default_storage_account_name = "${var.azure_resource_prefix}${var.service_short}dbbkpsan${var.config_short}sa"
+}
+
+
+resource "azurerm_storage_account" "sanitised_uploads" {
+  count                             = var.enable_sanitised_storage ? 1 : 0
+
+  name                              = local.uploads_default_storage_account_name
+  resource_group_name               = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
+  location                          = "UK South"
+  account_replication_type          = "LRS"
+  account_tier                      = "Standard"
+  account_kind                      = "StorageV2"
+  min_tls_version                   = "TLS1_2"
+  infrastructure_encryption_enabled = true
+  allow_nested_items_to_be_public   = false
+  cross_tenant_replication_enabled  = false
+
+  blob_properties {
+
+    container_delete_retention_policy {
+      days = 7
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_storage_management_policy" "backup" {
+  count = var.enable_sanitised_storage ? 1 : 0
+
+  storage_account_id = azurerm_storage_account.sanitised_uploads[0].id
+
+  rule {
+    name    = "DeleteAfter7Days"
+    enabled = true
+    filters {
+      blob_types = ["blockBlob"]
+    }
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 7
+      }
+    }
+  }
+}
+
+
+resource "azurerm_storage_container" "sanitised_uploads" {
+  count                 = var.enable_sanitised_storage ? 1 : 0
+
+  name                  = "database-backup"
+  storage_account_name  = azurerm_storage_account.sanitised_uploads[0].name
+  container_access_type = "private"
+}

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -136,3 +136,14 @@ variable "apex_urls" {
   type        = list(string)
   default     = []
 }
+
+variable "enable_sanitised_storage" {
+  description = "Enable sanitised storage account"
+  type        = bool
+  default     = false
+}
+
+variable "uploads_storage_account_name" {
+  type    = string
+  default = null
+}

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -38,5 +38,6 @@
     "https://find-teacher-training-courses.service.gov.uk",
     "https://find-postgraduate-teacher-training.service.gov.uk",
     "https://publish-teacher-training-courses.service.gov.uk"
-  ]
+  ],
+  "enable_sanitised_storage": true
 }


### PR DESCRIPTION
## Context
There is a requirement to create a storage account to store sanitised backups

## Trello
https://trello.com/c/FWUebqgi

## Changes proposed in this pull request
Creates a storage account

## Guidance to review
Check the azure storage account in azure console
