### PR TITLE
Improve navigation - Add browsing accordion

### DIFF
--- a/app/assets/stylesheets/find/components/_callout.scss
+++ b/app/assets/stylesheets/find/components/_callout.scss
@@ -4,7 +4,8 @@
   border-left-width: govuk-spacing(1);
 
   &.app-callout--pink {
-    border-left-color: govuk-colour("pink")
+    border-left-color: govuk-colour("pink");
+    margin-top: 0px;
   }
 
   @include govuk-media-query($from: tablet) {

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -12,6 +12,19 @@ class Subject < ApplicationRecord
 
   scope :active, -> { where.not(type: 'DiscontinuedSubject') }
   scope :primary, -> { where(type: 'PrimarySubject').order(:subject_name) }
+  scope :secondary, lambda {
+    where(type: %w[SecondarySubject ModernLanguagesSubject])
+      .where.not(subject_name: ['Modern Languages'])
+      .order(:subject_name)
+  }
+
+  def self.primary_subject_codes
+    primary.pluck(:subject_code)
+  end
+
+  def self.secondary_subject_codes_with_incentives
+    secondary.includes(:financial_incentive).pluck(:subject_code)
+  end
 
   def secondary_subject?
     type == 'SecondarySubject'

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -136,6 +136,38 @@
       </div>
     </div>
   </div>
+
+  <div class="govuk-grid-row govuk-!-margin-top-6">
+    <div class="govuk-grid-column-full">
+      <%= govuk_accordion(html_attributes: { class: "accordion-without-controls" }) do |accordion| %>
+        <%= accordion.with_section(heading_text: content_tag(:h3, t("find.search.tda.title"), class: "govuk-heading-m")) do %>
+          <p class="govuk-body"><%= t("find.search.tda.degree") %></p>
+          <p class="govuk-body"><%= govuk_link_to(t("find.search.tda.browse_tda_courses"), find_v2_results_path({ minimum_degree_required: "no_degree_required" })) %></p>
+          <p class="govuk-body"><%= t("find.search.learn_about") %> <%= govuk_link_to(t("find.search.tda.teacher_degree_apprenticeships"), t("find.get_into_teaching.url_tda")) %></p>
+        <% end %>
+
+        <%= accordion.with_section(heading_text: content_tag(:h3, t("find.search.send.title"), class: "govuk-heading-m")) do %>
+          <p class="govuk-body"><%= t("find.search.send.send_specialism") %></p>
+          <p class="govuk-body"><%= govuk_link_to(t("find.search.send.browse_primary_send"), find_v2_results_path({ send_courses: true, subjects: Subject.primary_subject_codes })) %></p>
+          <p class="govuk-body"><%= govuk_link_to(t("find.search.send.browse_secondary_send"), find_v2_results_path({ send_courses: true, subjects: Subject.secondary_subject_codes_with_incentives })) %></p>
+          <p class="govuk-body"><%= t("find.search.learn_about") %> <%= govuk_link_to(t("find.search.send.teaching_pupils"), t("find.get_into_teaching.url_send")) %></p>
+        <% end %>
+
+        <%= accordion.with_section(heading_text: content_tag(:h3, t("find.search.other_stages.title"), class: "govuk-heading-m")) do %>
+          <h4 class="govuk-heading-s"><%= t("find.search.other_stages.nursery.title") %></h4>
+
+          <p class="govuk-body"><%= t("find.search.other_stages.nursery.help") %></p>
+          <p class="govuk-body"><%= t("find.search.learn_about") %> <%= govuk_link_to(t("find.search.other_stages.nursery.route_to_early_years"), t("find.get_into_teaching.early_years")) %></p>
+
+          <h4 class="govuk-heading-s"><%= t("find.search.other_stages.further_ed.title") %></h4>
+
+          <p class="govuk-body"><%= t("find.search.other_stages.further_ed.teach_young_people") %></p>
+          <p class="govuk-body"><%= govuk_link_to(t("find.search.other_stages.further_ed.browse_further_ed"), find_v2_results_path({ level: "further_education" })) %></p>
+          <p class="govuk-body"><%= t("find.search.learn_about") %> <%= govuk_link_to(t("find.search.other_stages.further_ed.teaching_further_ed"), t("find.get_into_teaching.further_ed")) %></p>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -189,6 +189,29 @@ en:
       get_help_and_support_link_text: contact Get Into Teaching
       get_help_and_support_html: |
         If you're thinking about teaching or are ready to apply, %{link} for free support.
+      learn_about: Learn about
+      tda:
+        title: Teacher degree apprenticeships (TDA)
+        degree: Teach primary or secondary if you do not have a degree and are not studying for one.
+        browse_tda_courses: Browse teacher degree apprenticeship courses.
+        teacher_degree_apprenticeships: teacher degree apprenticeships.
+      send:
+        title: Special educational needs and disabilities (SEND)
+        send_specialism: All initial teacher training courses cover teaching pupils with SEND, but some courses have a SEND specialism.
+        browse_primary_send: Browse primary courses with a SEND specialism.
+        browse_secondary_send: Browse secondary courses with a SEND specialism.
+        teaching_pupils: teaching pupils with special educational needs and disabilities.
+      other_stages:
+        title: Teaching other stages
+        nursery:
+          title: Nursery or pre-school
+          help: Help young children under 5 years old to develop by becoming an early years teacher.
+          route_to_early_years: the routes to become an early years teacher.
+        further_ed:
+          title: Further education
+          teach_young_people: Teach young people and adults over 16 who are not studying for a degree.
+          browse_further_ed: Browse further education courses.
+          teaching_further_ed: teaching in further education.
     subjects:
       primary_title: Primary courses with subject specialisms
       secondary_title: Which secondary subjects do you want to teach?
@@ -385,8 +408,11 @@ en:
       train_to_be_a_teacher: Find out about the different ways to train to be a teacher (opens in a new tab)
       url_train_to_be_a_teacher: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
       url_tda: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/teacher-degree-apprenticeships
+      further_ed: https://getintoteaching.education.gov.uk/life-as-a-teacher/age-groups-and-specialisms/further-education-teachers
+      early_years: https://getintoteaching.education.gov.uk/life-as-a-teacher/age-groups-and-specialisms/early-years-teachers
       url_engineers_teach_physics: https://getintoteaching.education.gov.uk/subjects/engineers-teach-physics
       url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
+      url_send: https://getintoteaching.education.gov.uk/life-as-a-teacher/age-groups-and-specialisms/special-educational-needs
       url_ways_to_train_no_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
       url_ways_to_train_experienced_teacher: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/assessment-only-route-to-qts
       url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -21,4 +21,31 @@ describe Subject do
   it 'returns all primary subjects' do
     expect(described_class.primary.pluck(:type)).to include('PrimarySubject')
   end
+
+  it 'returns all secondary subjects' do
+    expect(described_class.secondary.pluck(:type)).to include('SecondarySubject')
+    expect(described_class.secondary.pluck(:type)).to include('ModernLanguagesSubject')
+    expect(described_class.secondary.pluck(:type)).not_to include('Modern Languages')
+  end
+
+  context 'when returning subject codes' do
+    before do
+      FinancialIncentive.delete_all
+      described_class.delete_all
+
+      find_or_create(:primary_subject, :primary_with_english, subject_code: '00')
+      find_or_create(:primary_subject, :primary, subject_code: '01')
+
+      find_or_create(:modern_languages_subject, subject_name: 'Modern languages (other)', subject_code: '101')
+      find_or_create(:secondary_subject, :ancient_greek, subject_code: '102')
+    end
+
+    it 'returns all primary_subject_codes' do
+      expect(described_class.primary_subject_codes).to match_array(%w[00 01])
+    end
+
+    it 'returns all secondary_subject_codes_with_incentives' do
+      expect(described_class.secondary_subject_codes_with_incentives).to match_array(%w[101 102])
+    end
+  end
 end


### PR DESCRIPTION
## Context

Research has shown that candidates are frustrated with the current journey, as they have to go through multiple pages to get to the results of a list of courses to choose from.

This ticket is to add new subject and location fields to the homepage to allow candidates to search by subject and location in order to get to results in one step.

## Changes proposed in this pull request

Add accordion and 3 sections showing new content and links

## Guidance to review

- Visit the homepage and view the content and design match

<img width="1185" alt="Screenshot 2025-02-06 at 12 05 10" src="https://github.com/user-attachments/assets/1b849d9a-4eef-4947-a60b-c8c6bbe7fed4" />
