### PR TITLE
Find results on location on large areas

### DIFF
--- a/app/controllers/find/search/locations_controller.rb
+++ b/app/controllers/find/search/locations_controller.rb
@@ -59,7 +59,7 @@ module Find
 
       def get_params_for_selected_option(all_params)
         if location_option_selected?
-          all_params.except('provider.provider_name').merge(radius: ResultsView::MILES)
+          all_params.except('provider.provider_name').reverse_merge(radius: ResultsView::MILES)
         elsif across_england_option_selected?
           all_params.except(:latitude, :longitude, :radius, :loc, :lq, 'provider.provider_name', :sortby)
         elsif provider_option_selected?

--- a/app/forms/find/location_filter_form.rb
+++ b/app/forms/find/location_filter_form.rb
@@ -5,6 +5,7 @@ module Find
     NO_OPTION = nil
     LOCATION_OPTION = '1'
     PROVIDER_OPTION = '3'
+    RADIUS_FOR_LARGE_AREA_LOCATION = 50
 
     attr_reader :params, :errors
 
@@ -55,7 +56,10 @@ module Find
         loc: results.address,
         lq: location_query,
         c: country(results)
-      }
+      }.tap do |params|
+        # Set large radius for large search areas
+        params[:radius] = RADIUS_FOR_LARGE_AREA_LOCATION if large_area?(results)
+      end
     end
 
     def selected_option
@@ -79,6 +83,10 @@ module Find
       countries = [DEVOLVED_NATIONS, 'England'].flatten
 
       countries.each { |country| return country if flattened_results.include?(country) }
+    end
+
+    def large_area?(results)
+      results.data['types'].include?('administrative_area_level_2')
     end
   end
 end

--- a/spec/features/find/search/location_options_spec.rb
+++ b/spec/features/find/search/location_options_spec.rb
@@ -16,11 +16,23 @@ feature 'Searching by location' do
     then_i_should_see_a_missing_location_validation_error
   end
 
-  scenario 'persists the correct location options in the url' do
-    when_i_enter_a_location
+  scenario 'when searchng a small area persists the correct location options in the url' do
+    when_i_enter_a_1d_location
+
     and_i_click_continue
     then_i_should_see_the_age_groups_form
-    and_the_correct_age_group_form_page_url_and_query_params_are_present
+    and_the_correct_age_group_form_page_url_and_query_params_are_present_for_small_area
+
+    when_i_click_back
+    then_i_should_see_the_start_page
+    and_the_location_radio_button_is_selected
+  end
+
+  scenario 'when searchng a large area persists the correct location options in the url' do
+    when_i_enter_a_2d_location
+    and_i_click_continue
+    then_i_should_see_the_age_groups_form
+    and_the_correct_age_group_form_page_url_and_query_params_are_present_for_large_area
 
     when_i_click_back
     then_i_should_see_the_start_page
@@ -51,18 +63,29 @@ feature 'Searching by location' do
     expect(page).to have_content('Enter a city, town or postcode')
   end
 
-  def when_i_enter_a_location
-    find_courses_by_location_or_training_provider_page.location.set('Yorkshire')
+  def when_i_enter_a_1d_location
+    find_courses_by_location_or_training_provider_page.location.set('Station Rise')
+  end
+
+  def when_i_enter_a_2d_location
+    find_courses_by_location_or_training_provider_page.location.set('Cornwall')
   end
 
   def then_i_should_see_the_age_groups_form
     expect(page).to have_content(I18n.t('find.age_groups.title'))
   end
 
-  def and_the_correct_age_group_form_page_url_and_query_params_are_present
+  def and_the_correct_age_group_form_page_url_and_query_params_are_present_for_large_area
     URI(current_url).then do |uri|
       expect(uri.path).to eq('/age-groups')
-      expect(uri.query).to eq('c=England&l=1&latitude=51.4524877&loc=AA+Teamworks+W+Yorks+SCITT%2C+School+Street%2C+Greetland%2C+Halifax%2C+West+Yorkshire+HX4+8JB&longitude=-0.1204749&lq=Yorkshire&radius=10&sortby=distance')
+      expect(uri.query).to eq('c=England&l=1&latitude=50.5036299&loc=Cornwall%2C+UK&longitude=-4.6524982&lq=Cornwall&radius=50&sortby=distance')
+    end
+  end
+
+  def and_the_correct_age_group_form_page_url_and_query_params_are_present_for_small_area
+    URI(current_url).then do |uri|
+      expect(uri.path).to eq('/age-groups')
+      expect(uri.query).to eq('c=England&l=1&latitude=53.83365879999999&loc=Station+Rise%2C+Ricall%2C+York+YO19+2C%2C+UK&longitude=-1.0564076&lq=Station+Rise&radius=10&sortby=distance')
     end
   end
 

--- a/spec/fixtures/files/google/geocode/cornwall.json
+++ b/spec/fixtures/files/google/geocode/cornwall.json
@@ -1,0 +1,66 @@
+{
+  "results": [
+    {
+      "address_components": [
+        {
+          "long_name": "Cornwall",
+          "short_name": "Cornwall",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "England",
+          "short_name": "England",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United Kingdom",
+          "short_name": "GB",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "Cornwall, UK",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 50.9312716,
+            "lng": -4.1663819
+          },
+          "southwest": {
+            "lat": 49.9588004,
+            "lng": -5.74689
+          }
+        },
+        "location": {
+          "lat": 50.5036299,
+          "lng": -4.6524982
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 50.9312716,
+            "lng": -4.1663819
+          },
+          "southwest": {
+            "lat": 49.9588004,
+            "lng": -5.74689
+          }
+        }
+      },
+      "place_id": "ChIJyQ4nv_C3akgRcUVL2YU8Qm4",
+      "types": [
+        "administrative_area_level_2",
+        "political"
+      ]
+    }
+  ],
+  "status": "OK"
+}

--- a/spec/fixtures/files/google/geocode/london.json
+++ b/spec/fixtures/files/google/geocode/london.json
@@ -1,0 +1,81 @@
+{
+  "results": [
+    {
+      "address_components": [
+        {
+          "long_name": "London",
+          "short_name": "London",
+          "types": [
+            "locality",
+            "political"
+          ]
+        },
+        {
+          "long_name": "London",
+          "short_name": "London",
+          "types": [
+            "postal_town"
+          ]
+        },
+        {
+          "long_name": "Greater London",
+          "short_name": "Greater London",
+          "types": [
+            "administrative_area_level_2",
+            "political"
+          ]
+        },
+        {
+          "long_name": "England",
+          "short_name": "England",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ]
+        },
+        {
+          "long_name": "United Kingdom",
+          "short_name": "GB",
+          "types": [
+            "country",
+            "political"
+          ]
+        }
+      ],
+      "formatted_address": "London, UK",
+      "geometry": {
+        "bounds": {
+          "northeast": {
+            "lat": 51.6723432,
+            "lng": 0.148271
+          },
+          "southwest": {
+            "lat": 51.38494009999999,
+            "lng": -0.3514683
+          }
+        },
+        "location": {
+          "lat": 51.5072178,
+          "lng": -0.1275862
+        },
+        "location_type": "APPROXIMATE",
+        "viewport": {
+          "northeast": {
+            "lat": 51.6723432,
+            "lng": 0.148271
+          },
+          "southwest": {
+            "lat": 51.38494009999999,
+            "lng": -0.3514683
+          }
+        }
+      },
+      "place_id": "ChIJdd4hrwug2EcRmSrV3Vo6llI",
+      "types": [
+        "locality",
+        "political"
+      ]
+    }
+  ],
+  "status": "OK"
+}

--- a/spec/forms/find/location_filter_form_spec.rb
+++ b/spec/forms/find/location_filter_form_spec.rb
@@ -6,6 +6,49 @@ module Find
   describe LocationFilterForm, type: :model do
     subject { described_class.new(params) }
 
+    describe 'large_area' do
+      let(:params) { { lq: 'Cornwall', l: '1' } }
+
+      it 'merges a default radius of 50 when user searches a large area' do
+        stub_request(:get, 'https://maps.googleapis.com/maps/api/geocode/json?address=Cornwall&components=country:UK&key=replace_me&language=en&sensor=false')
+          .to_return(status: 200, headers: {}, body: file_fixture('google/geocode/cornwall.json').read)
+
+        subject.valid?
+
+        expect(subject.params).to eq(
+          { lq: 'Cornwall',
+            l: '1',
+            latitude: 50.5036299,
+            longitude: -4.6524982,
+            loc: 'Cornwall, UK',
+            c: 'England',
+            radius: 50 }
+        )
+      end
+    end
+
+    describe 'non large_area' do
+      let(:params) { { lq: 'London', l: '1' } }
+
+      it 'does not merge a radius for searches on small areas' do
+        stub_request(:get, 'https://maps.googleapis.com/maps/api/geocode/json?address=London&components=country:UK&key=replace_me&language=en&sensor=false')
+          .to_return(status: 200, headers: {}, body: file_fixture('google/geocode/london.json').read)
+
+        subject.valid?
+
+        expect(subject.params).to eq(
+          {
+            lq: 'London',
+            l: '1',
+            latitude: 51.5072178,
+            longitude: -0.1275862,
+            loc: 'London, UK',
+            c: 'England'
+          }
+        )
+      end
+    end
+
     describe 'validations' do
       before { subject.valid? }
 

--- a/spec/support/geocoder_helper.rb
+++ b/spec/support/geocoder_helper.rb
@@ -53,8 +53,32 @@ module GeocoderHelper
           'state' => 'England',
           'country' => 'United Kingdom',
           'country_code' => 'UK',
-          'address_components' => [{ long_name: 'England' }]
+          'address_components' => [{ long_name: 'England' }],
+          'types' => %w[
+            locality
+            political
+          ]
         }
+      ]
+    )
+
+    Geocoder::Lookup::Test.add_stub(
+      'Cornwall',
+      [
+        {
+          'coordinates' => [50.5036299, -4.6524982],
+          'address' => 'Cornwall, UK',
+          'state' => 'England',
+          'state_code' => 'England',
+          'country' => 'United Kingdom',
+          'country_code' => 'UK',
+          'address_components' => [{ long_name: 'England' }],
+          'types' => %w[
+            administrative_area_level_2
+            political
+          ]
+        }
+
       ]
     )
 
@@ -68,7 +92,11 @@ module GeocoderHelper
           'state_code' => 'England',
           'country' => 'United Kingdom',
           'country_code' => 'UK',
-          'address_components' => [{ long_name: 'England' }]
+          'address_components' => [{ long_name: 'England' }],
+          'types' => %w[
+            locality
+            political
+          ]
         }
       ]
     )
@@ -83,7 +111,11 @@ module GeocoderHelper
           'state_code' => 'England',
           'country' => 'United Kingdom',
           'country_code' => 'UK',
-          'address_components' => [{ long_name: 'England' }]
+          'address_components' => [{ long_name: 'England' }],
+          'types' => %w[
+            locality
+            political
+          ]
         }
       ]
     )


### PR DESCRIPTION
## Context

When people search for courses near Cornwall, we give them a 10 mile radius by default.
When people search Cornwall, they expect to see all the courses run in Cornwall, not just ones within 10 miles of the "centre" of Cornwall.

## Changes proposed in this pull request

If a user searches for a large area like Cornwall, our Geocoding API identifies Cornwall as an `administrative_area_level_2`. Using this information, we can change the default radius of the search from the default 10 mile radius to 50 mile radius.

This will include almost all courses run in Cornwall.

## Edge Cases

Some places are not `administrative_area_level_2`, but instead are `colloquial_areas`

We've identified these `colloquial_areas`
 - Yorkshire
 - Buckinghamshire

There are likely more. We can include these location types in a further change if we decide it's a good idea

## Trello
https://trello.com/c/GzY6DstC/431-bug-find-results-on-location-on-large-areas

## Guidance to review


