### PR TITLE
Enable provider partnerships

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,7 +79,7 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
-  provider_partnerships: false
+  provider_partnerships: true
   api_summary_content_change: true
   send_request_data_to_bigquery: false
   rollover:


### PR DESCRIPTION
## Context

Enable the Provider Partnerships feature in production.

This feature upgrades the associations between Training providers and accredited Providers in our system.

Before this change, An accredited provider partnership existed on a column called `accrediting_provider_enrichments` on the Training provider. Now there is a join table called `provider_partnerships` that maintains the relationships in a normalised structure.



## Changes proposed in this pull request

Enable a feature flag

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/5vwjxjUn/402-enable-provider-partnerships-feature-flag-in-production