### PR TITLE
Bug fix: can change accredited provider description before save

### DIFF
--- a/app/controllers/publish/providers/accredited_partnerships_controller.rb
+++ b/app/controllers/publish/providers/accredited_partnerships_controller.rb
@@ -9,10 +9,11 @@ module Publish
 
       def new
         provider_partnership = provider.accredited_partnerships.build
-        provider_partnership.assign_attributes(accredited_provider_id: params[:accredited_provider_id] || ProviderPartnershipForm.new(current_user, provider).accredited_provider_id)
+        accredited_provider_id = params[:accredited_provider_id] || ProviderPartnershipForm.new(current_user, provider).accredited_provider_id
+        provider_partnership.assign_attributes(accredited_provider_id:)
 
         if provider_partnership.valid?
-          @provider_partnership_form = ProviderPartnershipForm.new(current_user, provider_partnership, params: { accredited_provider_id: params[:accredited_provider_id] })
+          @provider_partnership_form = ProviderPartnershipForm.new(current_user, provider_partnership, params: { accredited_provider_id: })
         else
           redirect_to search_publish_provider_recruitment_cycle_accredited_providers_path(provider.provider_code, RecruitmentCycle.current.year), flash: { error: { message: "#{Provider.find(params[:accredited_provider_id]).name_and_code} partnership already exists" } }
         end
@@ -78,7 +79,7 @@ module Publish
       end
 
       def partnership_params
-        params.require(:provider_partnership_form).permit(:accredited_provider_id, :description)
+        params.expect(provider_partnership_form: %i[accredited_provider_id description])
       end
     end
   end

--- a/spec/features/publish/accredited_partnership_spec.rb
+++ b/spec/features/publish/accredited_partnership_spec.rb
@@ -17,7 +17,7 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
   scenario 'i can view accredited partnerships on the index page' do
     and_my_provider_has_accrediting_providers
     and_i_click_on_the_accredited_provider_tab
-    then_i_should_see_the_accredited_provider_name_displayed
+    then_i_see_the_accredited_provider_name_displayed
   end
 
   scenario 'i can edit accredited partnerships on the index page' do
@@ -25,8 +25,10 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     and_i_click_on_the_accredited_provider_tab
     and_i_click_change
 
-    when_i_input_some_different_information
-    then_i_should_see_the_different_information
+    when_i_enter_a_different_description
+
+    click_link_or_button 'Update description'
+    then_i_see_the_different_description
     and_i_see_the_success_message
   end
 
@@ -35,7 +37,9 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     and_i_click_on_the_accredited_provider_tab
     when_i_click_add_accredited_provider
     when_i_search_for_an_existing_accredited_partner
+    click_continue
     when_i_select_an_existing_partner
+    click_continue
     then_i_see_an_error_that_i_cannot_add_the_provider
   end
 
@@ -43,7 +47,7 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     and_my_provider_has_accrediting_providers
     and_i_click_on_the_accredited_provider_tab
     and_i_click_remove
-    then_i_should_see_the_cannot_remove_ap_text
+    then_i_see_the_cannot_remove_ap_text
   end
 
   scenario 'i can delete accredited providers if they are not attached to a course' do
@@ -51,58 +55,112 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     and_i_click_remove
     and_i_click_remove_ap
     and_i_see_the_remove_success_message
-    then_i_should_be_taken_to_the_index_page
+    then_i_am_taken_to_the_index_page
   end
 
   scenario 'i can create a new provider partnership' do
     given_there_are_accredited_providers_in_the_database_with_users
     when_i_click_add_accredited_provider
     and_i_search_with_an_invalid_query
-    then_i_should_see_an_error_message
+    click_continue
+
+    then_i_see_an_error_message
 
     when_i_search_for_an_accredited_provider_with_a_valid_query
+    click_continue
     then_i_see_the_provider_i_searched_for
 
     when_i_continue_without_selecting_an_accredited_provider
-    and_i_should_see_an_error_message('Select an accredited provider')
-    then_i_should_still_see_the_provider_i_searched_for
+    and_i_see_an_error_message('Select an accredited provider')
+    then_i_still_see_the_provider_i_searched_for
 
     when_i_select_the_provider
+    click_continue
     and_i_continue_without_entering_a_description
-    then_i_should_see_an_error_message('Enter details about the accredited provider')
+    then_i_see_an_error_message('Enter details about the accredited provider')
 
-    when_i_input_some_information
-    then_i_should_see_the_information_i_added
+    when_i_enter_a_description
+    click_continue
+    then_i_see_the_description
 
     when_i_confirm_the_changes
-    then_i_should_be_taken_to_the_index_page
+    then_i_am_taken_to_the_index_page
     and_the_accredited_provider_is_saved_to_the_database
-    and_i_should_see_a_success_message
-    and_i_should_see_the_accredited_providers
+    and_i_see_a_success_message
+    and_i_see_the_accredited_providers
   end
 
   scenario 'back links behaviour' do
     given_i_am_on_the_confirm_page
     when_i_click_the_change_link_for('accredited provider name')
-    then_i_should_be_taken_to_the_accredited_provider_search_page
+    then_i_am_taken_to_the_accredited_provider_search_page
 
     when_i_click_the_back_link
-    then_i_should_be_taken_back_to_the_confirm_page
+    then_i_am_taken_back_to_the_confirm_page
 
     when_i_click_the_change_link_for('accredited provider description')
-    then_i_should_be_taken_to_the_accredited_provider_description_page
+    then_i_am_taken_to_the_accredited_provider_description_page
+    and_i_see_the_correct_description_content
 
     when_i_click_the_back_link
-    then_i_should_be_taken_back_to_the_confirm_page
+    then_i_am_taken_back_to_the_confirm_page
+  end
+
+  scenario 'change links behaviour' do
+    given_i_am_on_the_confirm_page
+    when_i_click_the_change_link_for('accredited provider name')
+    then_i_am_taken_to_the_accredited_provider_search_page
+
+    when_i_search_for_an_accredited_provider_with_a_valid_query
+    click_continue
+    when_i_select_the_provider
+    click_continue
+    then_i_am_on_the_description_page
+
+    when_i_enter_a_description
+    click_continue
+    then_i_am_taken_to_the_confirm_page
+    and_i_see_the_information_to_be_confirmed
+
+    when_i_click_the_change_link_for('accredited provider description')
+    then_i_am_taken_to_the_accredited_provider_description_page
+    and_i_see_the_correct_description_content
+
+    when_i_enter_a_different_description
+    click_continue
+
+    then_i_see_the_different_description
+    when_i_confirm_the_changes
+    then_i_am_taken_to_the_index_page
+    and_the_accredited_provider_is_saved_to_the_database
+    and_i_see_a_success_message
+    and_i_see_the_accredited_providers
   end
 
   private
+
+  def and_i_see_the_information_to_be_confirmed
+    expect(page).to have_content('Check your answers')
+    expect(page).to have_content('Accredited providerUCLChange accredited provider name')
+    expect(page).to have_content('About the accredited provider')
+    expect(page).to have_content('This is a description')
+  end
+
+  def then_i_am_taken_to_the_confirm_page
+    expect(page).to have_current_path(check_publish_provider_recruitment_cycle_accredited_partnerships_path(@provider.provider_code, @provider.recruitment_cycle_year))
+  end
+
+  def and_i_see_the_correct_description_content
+    expect(page).to have_content('This is a description')
+  end
+
+  def when_i_change_the_description; end
 
   def and_i_click_remove_ap
     click_link_or_button 'Remove accredited provider'
   end
 
-  def then_i_should_see_the_cannot_remove_ap_text
+  def then_i_see_the_cannot_remove_ap_text
     expect(page).to have_css('h1', text: 'You cannot remove this accredited provider')
   end
 
@@ -114,8 +172,11 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     given_there_are_accredited_providers_in_the_database_with_users
     when_i_click_add_accredited_provider
     when_i_search_for_an_accredited_provider_with_a_valid_query
+    click_continue
     when_i_select_the_provider
-    when_i_input_some_information
+    click_continue
+    when_i_enter_a_description
+    click_continue
     when_i_confirm_the_changes
   end
 
@@ -123,7 +184,7 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     click_link_or_button('Change')
   end
 
-  def and_i_should_see_the_accredited_providers
+  def and_i_see_the_accredited_providers
     expect(page).to have_css('.govuk-summary-card', count: 1)
     expect(page).to have_content(@accredited_provider.provider_name)
   end
@@ -134,11 +195,15 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     expect(@provider.accredited_partners.first.id).to eq(@accredited_provider.id)
   end
 
-  def then_i_should_be_taken_to_the_accredited_provider_description_page
+  def then_i_am_on_the_description_page
+    expect(page).to have_current_path(new_publish_provider_recruitment_cycle_accredited_partnership_path(@provider.provider_code, @provider.recruitment_cycle_year, accredited_provider_id: @accredited_provider.id))
+  end
+
+  def then_i_am_taken_to_the_accredited_provider_description_page
     expect(page).to have_current_path(new_publish_provider_recruitment_cycle_accredited_partnership_path(@provider.provider_code, @provider.recruitment_cycle_year, goto_confirmation: true))
   end
 
-  def then_i_should_be_taken_back_to_the_confirm_page
+  def then_i_am_taken_back_to_the_confirm_page
     expect(page).to have_current_path(check_publish_provider_recruitment_cycle_accredited_partnerships_path(@provider.provider_code, @provider.recruitment_cycle_year))
   end
 
@@ -146,7 +211,7 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     click_link_or_button 'Back'
   end
 
-  def then_i_should_be_taken_to_the_accredited_provider_search_page
+  def then_i_am_taken_to_the_accredited_provider_search_page
     expect(page).to have_current_path(
       search_publish_provider_recruitment_cycle_accredited_providers_path(@provider.provider_code, @provider.recruitment_cycle_year, goto_confirmation: true)
     )
@@ -162,11 +227,14 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     given_there_are_accredited_providers_in_the_database_with_users
     when_i_click_add_accredited_provider
     when_i_search_for_an_accredited_provider_with_a_valid_query
+    click_continue
     when_i_select_the_provider
-    when_i_input_some_information
+    click_continue
+    when_i_enter_a_description
+    click_continue
   end
 
-  def and_i_should_see_a_success_message
+  def and_i_see_a_success_message
     expect(page).to have_content('Accredited provider added')
   end
 
@@ -178,7 +246,7 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     expect(page).to have_content('Accredited provider removed')
   end
 
-  def then_i_should_be_taken_to_the_index_page
+  def then_i_am_taken_to_the_index_page
     expect(page).to have_current_path(publish_provider_recruitment_cycle_accredited_partnerships_path(@provider.provider_code, @provider.recruitment_cycle_year))
   end
 
@@ -188,34 +256,28 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     end.to have_enqueued_email(Users::OrganisationMailer, :added_as_an_organisation_to_training_partner)
   end
 
-  def then_i_should_see_the_information_i_added
+  def then_i_see_the_description
     expect(page).to have_text('This is a description')
   end
 
-  def then_i_should_see_the_different_information
+  def then_i_see_the_different_description
     expect(page).to have_text('updates to the AP description')
   end
 
-  alias_method :then_i_should_see_the_description, :then_i_should_see_the_information_i_added
-
-  def when_i_input_some_information
+  def when_i_enter_a_description
     fill_in 'About the accredited provider', with: 'This is a description'
-    click_continue
   end
 
-  def when_i_input_some_different_information
+  def when_i_enter_a_different_description
     fill_in 'About the accredited provider', with: 'updates to the AP description'
-    click_link_or_button 'Update description'
   end
 
   def and_i_search_with_an_invalid_query
     fill_in form_title, with: ''
-    click_continue
   end
 
   def when_i_select_an_existing_partner
     choose @provider.accredited_partners.first.provider_name
-    click_continue
   end
 
   def then_i_see_an_error_that_i_cannot_add_the_provider
@@ -225,20 +287,19 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
 
   def when_i_select_the_provider
     choose @accredited_provider.provider_name
-    click_continue
   end
 
-  def then_i_should_still_see_the_provider_i_searched_for
+  def then_i_still_see_the_provider_i_searched_for
     expect(page).to have_content(@accredited_provider.provider_name)
     expect(page).to have_no_content(@accredited_provider_two.provider_name)
     expect(page).to have_no_content(@accredited_provider_three.provider_name)
   end
 
-  def and_i_should_see_an_error_message(error_message = form_title)
+  def and_i_see_an_error_message(error_message = form_title)
     expect(page).to have_content(error_message)
   end
 
-  alias_method :then_i_should_see_an_error_message, :and_i_should_see_an_error_message
+  alias_method :then_i_see_an_error_message, :and_i_see_an_error_message
 
   def when_i_continue_without_selecting_an_accredited_provider
     click_continue
@@ -260,12 +321,10 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
 
   def when_i_search_for_an_existing_accredited_partner
     fill_in form_title, with: @provider.accredited_partners.first.provider_name
-    click_continue
   end
 
   def when_i_search_for_an_accredited_provider_with_a_valid_query
     fill_in form_title, with: @accredited_provider.provider_name
-    click_continue
   end
 
   def when_i_click_add_accredited_provider
@@ -308,7 +367,7 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     @provider.accredited_partnerships.create(accredited_provider: course.accrediting_provider, description: 'Great provider!')
   end
 
-  def then_i_should_see_the_accredited_provider_name_displayed
+  def then_i_see_the_accredited_provider_name_displayed
     expect(page).to have_css('h2', text: 'Accrediting provider name')
   end
 end


### PR DESCRIPTION
## Context

  The way we use the ProviderPartnershipForm and redirect from the
  accredited provider search is haphazard. We need to maintain state in
  the form, but the form is designed to update a model.

## Changes proposed in this pull request

  This change gets the chosen accredited provider id from the params or
  form. It will always be in one.

  Added a spec to test this scenario specifically.

[Screencast from 11-02-25 17:15:38.webm](https://github.com/user-attachments/assets/0a6dc43b-3316-4c66-8f3d-467163b50b64)


## Guidance to review

This code is far from ideal. Any immediate suggestions on how to improve it are welcome.

## Trello
https://trello.com/c/9J5caX5Q/457-bug-fix-allow-user-to-change-accredited-partnership-description-before-save