### PR TITLE
Improve results update get into teaching banner on the search results page

### DIFF
--- a/app/assets/stylesheets/find/components/_accordion.scss
+++ b/app/assets/stylesheets/find/components/_accordion.scss
@@ -7,3 +7,35 @@ body:not(.js-enabled) {
     margin-bottom: govuk-spacing(3);
   }
 }
+
+.app-courses-guidance {
+  .govuk-accordion__controls {
+    display: none;
+  }
+
+  .govuk-accordion__section {
+    border-left: 5px solid govuk-colour("orange");
+    background-color: #f3f2f1;
+    padding-bottom: 1px;
+  }
+
+  .govuk-accordion__section-heading {
+    .govuk-accordion__section-button {
+      padding-bottom: 0;
+      padding-left: 20px;
+      padding-right: 20px;
+    }
+  }
+
+  .govuk-accordion__section-content {
+    display: block;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .accordion--last-child {
+    padding-bottom: 30px;
+  }
+}

--- a/app/assets/stylesheets/find/components/_accordion.scss
+++ b/app/assets/stylesheets/find/components/_accordion.scss
@@ -15,27 +15,26 @@ body:not(.js-enabled) {
 
   .govuk-accordion__section {
     border-left: 5px solid govuk-colour("orange");
-    background-color: #f3f2f1;
-    padding-bottom: 1px;
+    background-color: govuk-colour("light-grey");
+    padding-bottom: govuk-spacing(1);
   }
 
   .govuk-accordion__section-heading {
     .govuk-accordion__section-button {
       padding-bottom: 0;
-      padding-left: 20px;
-      padding-right: 20px;
+      padding-left: govuk-spacing(4);
+      padding-right: govuk-spacing(4);
     }
   }
 
   .govuk-accordion__section-content {
-    display: block;
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: govuk-spacing(4);
+    padding-right: govuk-spacing(4);
     padding-top: 0;
     padding-bottom: 0;
   }
 
   .accordion--last-child {
-    padding-bottom: 30px;
+    padding-bottom: govuk-spacing(5);
   }
 }

--- a/app/views/find/v2/results/courses_guidance/_show.html.erb
+++ b/app/views/find/v2/results/courses_guidance/_show.html.erb
@@ -1,0 +1,13 @@
+<%= govuk_accordion(classes: ["app-courses-guidance"]) do |accordion| %>
+  <% accordion.with_section heading_text: t(".heading") do %>
+    <p class="govuk-body">
+      <%= govuk_link_to t(".links.choose_course"), t(".urls.choose_course") %>
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to t(".links.training_adviser"), t(".urls.training_adviser") %>
+    </p>
+    <p class="govuk-body accordion--last-child">
+      <%= govuk_link_to t(".links.events"), t(".urls.events") %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/find/v2/results/courses_guidance/_show.html.erb
+++ b/app/views/find/v2/results/courses_guidance/_show.html.erb
@@ -1,13 +1,13 @@
 <%= govuk_accordion(classes: ["app-courses-guidance"]) do |accordion| %>
   <% accordion.with_section heading_text: t(".heading") do %>
     <p class="govuk-body">
-      <%= govuk_link_to t(".links.choose_course"), t(".urls.choose_course") %>
+      <%= govuk_link_to t(".links.choose_course"), find_track_click_path(url: t("find.get_into_teaching.url_choose_course")) %>
     </p>
     <p class="govuk-body">
-      <%= govuk_link_to t(".links.training_adviser"), t(".urls.training_adviser") %>
+      <%= govuk_link_to t(".links.training_adviser"), find_track_click_path(url: t("find.get_into_teaching.url_training_adviser")) %>
     </p>
     <p class="govuk-body accordion--last-child">
-      <%= govuk_link_to t(".links.events"), t(".urls.events") %>
+      <%= govuk_link_to t(".links.events"), find_track_click_path(url: t("find.get_into_teaching.url_teacher_training_events")) %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -88,82 +88,85 @@
             <%= form.govuk_submit t("helpers.submit.courses_search_form.filters") %>
           </div>
         </div>
-    </div>
-
-    <div class="app-filter-layout__content">
-      <div class="app-search-results-controls">
-        <div class="govuk-form-group" data-controller="subjects-autocomplete">
-          <%= render DfE::Autocomplete::View.new(
-             form,
-             attribute_name: :subject_code,
-             form_field: form.govuk_select(
-               :subject_code,
-               options_for_select(
-                 dfe_autocomplete_options(form.object.all_subjects, synonyms_fields: %i[subject_code]),
-                 form.object.subject_code
-               ),
-               label: { text: t("helpers.label.courses_search_form.subject_name"), size: "s" }
-             )
-           ) %>
-        </div>
-
-        <%= form.govuk_text_field :location,
-          label: { text: t("helpers.label.courses_search_form.location"), size: "s" },
-          form_group: {
-            "data-controller" => "locations-autocomplete",
-            "data-locations-autocomplete-path-value" => find_geolocation_suggestions_path
-          },
-          autocomplete: "off",
-          data: { locations_autocomplete_target: "input" } %>
-
-        <%= form.govuk_collection_select :radius, form.object.radius_options, :value, :name,
-          label: { text: t("helpers.label.courses_search_form.radius"), size: "s" } %>
-
-        <%= form.govuk_submit t("helpers.submit.courses_search_form.search") %>
       </div>
 
-    <% if @results.present? %>
-        <div class="app-search-results-header">
-          <div class="app-search-results-header__sort">
-            <% if @search_params[:location].present? %>
-              <p class="govuk-body">
-                <%= I18n.t("helpers.label.courses_search_form.ordering.location") %>
-              </p>
-            <% else %>
-              <%= form.govuk_collection_select(
-                  :order,
-                  form.object.ordering_options,
-                  :id,
-                  :name,
-                  label: { text: t("helpers.label.courses_search_form.ordering.non_location"), class: "govuk-!-display-inline-block" },
-                  role: "listbox", form_group: {},
-                  options: { include_blank: true }
-                ) %>
+      <div class="app-filter-layout__content">
+        <%= render partial: "find/v2/results/courses_guidance/show" %>
 
-              <%= form.govuk_submit t("helpers.submit.courses_search_form.order", class: "govuk-!-display-inline-block") %>
-            <% end %>
+        <div class="app-search-results-controls">
+          <div class="govuk-form-group" data-controller="subjects-autocomplete">
+            <%= render DfE::Autocomplete::View.new(
+               form,
+               attribute_name: :subject_code,
+               form_field: form.govuk_select(
+                 :subject_code,
+                 options_for_select(
+                   dfe_autocomplete_options(form.object.all_subjects, synonyms_fields: %i[subject_code]),
+                   form.object.subject_code
+                 ),
+                 label: { text: t("helpers.label.courses_search_form.subject_name"), size: "s" }
+               )
+             ) %>
           </div>
+
+          <%= form.govuk_text_field :location,
+            label: { text: t("helpers.label.courses_search_form.location"), size: "s" },
+            form_group: {
+              "data-controller" => "locations-autocomplete",
+              "data-locations-autocomplete-path-value" => find_geolocation_suggestions_path
+            },
+            autocomplete: "off",
+            data: { locations_autocomplete_target: "input" } %>
+
+          <%= form.govuk_collection_select :radius, form.object.radius_options, :value, :name,
+            label: { text: t("helpers.label.courses_search_form.radius"), size: "s" } %>
+
+          <%= form.govuk_submit t("helpers.submit.courses_search_form.search") %>
         </div>
 
-        <ul class="app-search-results">
-          <% @results.each do |course| %>
-            <%= render Courses::SummaryCardComponent.new(
-              course:,
-              location: @search_params[:formatted_address] || @search_params[:location],
-              visa_sponsorship: @search_params[:can_sponsor_visa]
-            ) %>
+      <% if @results.present? %>
+          <div class="app-search-results-header">
+            <div class="app-search-results-header__sort">
+              <% if @search_params[:location].present? %>
+                <p class="govuk-body">
+                  <%= I18n.t("helpers.label.courses_search_form.ordering.location") %>
+                </p>
+              <% else %>
+                <%= form.govuk_collection_select(
+                    :order,
+                    form.object.ordering_options,
+                    :id,
+                    :name,
+                    label: { text: t("helpers.label.courses_search_form.ordering.non_location"), class: "govuk-!-display-inline-block" },
+                    role: "listbox", form_group: {},
+                    options: { include_blank: true }
+                  ) %>
 
-            <%= render Courses::SchoolDistancesDebugComponent.new(
-              course:,
-              latitude: @search_params[:latitude],
-              longitude: @search_params[:longitude],
-              debug: params[:debug]
-            ) %>
-          <% end %>
-        </ul>
+                <%= form.govuk_submit t("helpers.submit.courses_search_form.order", class: "govuk-!-display-inline-block") %>
+              <% end %>
+            </div>
+          </div>
 
-        <%= govuk_pagination(pagy: @pagy) %>
-    <% end %>
+          <ul class="app-search-results">
+            <% @results.each do |course| %>
+              <%= render Courses::SummaryCardComponent.new(
+                course:,
+                location: @search_params[:formatted_address] || @search_params[:location],
+                visa_sponsorship: @search_params[:can_sponsor_visa]
+              ) %>
+
+              <%= render Courses::SchoolDistancesDebugComponent.new(
+                course:,
+                latitude: @search_params[:latitude],
+                longitude: @search_params[:longitude],
+                debug: params[:debug]
+              ) %>
+            <% end %>
+          </ul>
+
+          <%= render partial: "find/v2/results/courses_guidance/show" %>
+          <%= govuk_pagination(pagy: @pagy) %>
+      <% end %>
+    </div>
   </div>
-</div>
 <% end %>

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -125,47 +125,47 @@
         </div>
 
       <% if @results.present? %>
-          <div class="app-search-results-header">
-            <div class="app-search-results-header__sort">
-              <% if @search_params[:location].present? %>
-                <p class="govuk-body">
-                  <%= I18n.t("helpers.label.courses_search_form.ordering.location") %>
-                </p>
-              <% else %>
-                <%= form.govuk_collection_select(
-                    :order,
-                    form.object.ordering_options,
-                    :id,
-                    :name,
-                    label: { text: t("helpers.label.courses_search_form.ordering.non_location"), class: "govuk-!-display-inline-block" },
-                    role: "listbox", form_group: {},
-                    options: { include_blank: true }
-                  ) %>
+        <div class="app-search-results-header">
+          <div class="app-search-results-header__sort">
+            <% if @search_params[:location].present? %>
+              <p class="govuk-body">
+                <%= I18n.t("helpers.label.courses_search_form.ordering.location") %>
+              </p>
+            <% else %>
+              <%= form.govuk_collection_select(
+                  :order,
+                  form.object.ordering_options,
+                  :id,
+                  :name,
+                  label: { text: t("helpers.label.courses_search_form.ordering.non_location"), class: "govuk-!-display-inline-block" },
+                  role: "listbox", form_group: {},
+                  options: { include_blank: true }
+                ) %>
 
-                <%= form.govuk_submit t("helpers.submit.courses_search_form.order", class: "govuk-!-display-inline-block") %>
-              <% end %>
-            </div>
-          </div>
-
-          <ul class="app-search-results">
-            <% @results.each do |course| %>
-              <%= render Courses::SummaryCardComponent.new(
-                course:,
-                location: @search_params[:formatted_address] || @search_params[:location],
-                visa_sponsorship: @search_params[:can_sponsor_visa]
-              ) %>
-
-              <%= render Courses::SchoolDistancesDebugComponent.new(
-                course:,
-                latitude: @search_params[:latitude],
-                longitude: @search_params[:longitude],
-                debug: params[:debug]
-              ) %>
+              <%= form.govuk_submit t("helpers.submit.courses_search_form.order", class: "govuk-!-display-inline-block") %>
             <% end %>
-          </ul>
+          </div>
+        </div>
 
-          <%= render partial: "find/v2/results/courses_guidance/show" %>
-          <%= govuk_pagination(pagy: @pagy) %>
+        <ul class="app-search-results">
+          <% @results.each do |course| %>
+            <%= render Courses::SummaryCardComponent.new(
+              course:,
+              location: @search_params[:formatted_address] || @search_params[:location],
+              visa_sponsorship: @search_params[:can_sponsor_visa]
+            ) %>
+
+            <%= render Courses::SchoolDistancesDebugComponent.new(
+              course:,
+              latitude: @search_params[:latitude],
+              longitude: @search_params[:longitude],
+              debug: params[:debug]
+            ) %>
+          <% end %>
+        </ul>
+
+        <%= render partial: "find/v2/results/courses_guidance/show" %>
+        <%= govuk_pagination(pagy: @pagy) %>
       <% end %>
     </div>
   </div>

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -461,6 +461,17 @@ en:
             zero: "No courses found"
             one: "1 course found"
             other: "%{formatted_count} courses found"
+        courses_guidance:
+          show:
+            heading: "Not sure which course is right for you?"
+            links:
+              choose_course: "Find out how to choose a course"
+              training_adviser: "Get a free teacher training adviser"
+              events: "Talk to teacher training providers at an event near you"
+            urls:
+              choose_course: "https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-choose-your-teacher-training-course"
+              training_adviser: "https://getintoteaching.education.gov.uk/teacher-training-advisers"
+              events: "https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events"
       subjects:
         primary:
           page_title: Browse primary courses

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -433,6 +433,8 @@ en:
       url_school_placements: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/school-placements
       url_fund_your_training: https://getintoteaching.education.gov.uk/funding-and-support
       url_visas_for_non_uk_trainees: https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-trainees
+      url_choose_course: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-choose-your-teacher-training-course
+      url_training_adviser: https://getintoteaching.education.gov.uk/teacher-training-advisers
     qualification:
       description_with_abbreviation:
         qts:
@@ -468,10 +470,6 @@ en:
               choose_course: "Find out how to choose a course"
               training_adviser: "Get a free teacher training adviser"
               events: "Talk to teacher training providers at an event near you"
-            urls:
-              choose_course: "https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-choose-your-teacher-training-course"
-              training_adviser: "https://getintoteaching.education.gov.uk/teacher-training-advisers"
-              events: "https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events"
       subjects:
         primary:
           page_title: Browse primary courses


### PR DESCRIPTION
## Context

Add a new banner with GiT links in the results page.

## Changes proposed in this pull request

<img width="636" alt="Screenshot 2025-02-12 at 10 23 36" src="https://github.com/user-attachments/assets/70f0fcd3-ba3c-4c26-9a35-18a1883d11e2" />

<img width="644" alt="Screenshot 2025-02-12 at 10 23 42" src="https://github.com/user-attachments/assets/79f27bca-b860-49e0-a723-60e40145d046" />

## Guidance to review

Visit `/v2/results`

1. Are the links working?
2. Are the links being tracked?
3. Is the banner responsive?
