### PR TITLE
Enable CI Settings matrix test runs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -212,6 +212,14 @@ jobs:
             integration_support,
             integration_other,
           ]
+        # Pass Settings compatible env vars to runs tests with
+        # feature flag(s) enables
+        # Separate mutliple flags with a space
+        feature-flags:
+          [
+            "",
+            "SETTINGS__FEATURES__PROVIDER_PARTNERSHIPS=true"
+          ]
         include:
           - tests: unit_models
             include-pattern: spec/models/.*_spec.rb
@@ -254,14 +262,15 @@ jobs:
           docker compose exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
           docker compose exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
 
-      - name: ${{ matrix.tests }} tests
+      - name: ${{ matrix.tests }} tests with feature flags
         run: |
-          docker compose exec -T web /bin/sh -c 'bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"'
+          docker compose exec -T web /bin/sh -c '${{ env.FEATURE_FLAGS }} bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"'
         env:
           IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}
           INCLUDE_PATTERN: ${{ matrix.include-pattern }}
           EXCLUDE_PATTERN: ${{ matrix.exclude-pattern || ' ' }}
           TEST_MATRIX_NODE_NAME: ${{ matrix.tests }}
+          FEATURE_FLAGS: ${{ matrix.feature-flags }}
 
       - name: Upload coverage results
         if: always()

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,6 +76,13 @@ RSpec.configure do |config|
       ActiveRecord::Base.connection.execute('DROP EXTENSION IF EXISTS postgis CASCADE;')
       ActiveRecord::Base.connection.execute('CREATE EXTENSION IF NOT EXISTS postgis;')
     end
+
+    # Pass a Settings env var to the process to override settings.yml
+    #
+    # This is mainly used in GH actions for testing matrix
+    # ../.github/workflows/build-and-deploy.yml (Jobs: Test)
+    Settings.add_source!(ENV.select { |k, _v| k[/SETTINGS__FEATURES_/] })
+    Settings.reload!
   end
 
   # start the transaction strategy as examples are run


### PR DESCRIPTION
## Context

When we build features behind feature flags, we often want to know that existing tests pass when the feature flag is enabled and disabled.


## Changes proposed in this pull request

Add a way to override Settings in CI and run the suite with settings enabled and disabled

## Guidance to review

![image](https://github.com/user-attachments/assets/6a84e1fb-64c1-4039-bbe0-9c8b746b877a)


There's probably a better way to work with the workflows. Any improvements are welcomed!
