### PR TITLE
Get provider partnership tests passing

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -165,7 +165,7 @@ FactoryBot.define do
 
       after(:create) do |course|
         if Settings.features.provider_partnerships
-          create(:provider_partnership, training_provider: course.provider, accredited_provider: course.accrediting_provider)
+          create(:provider_partnership, training_provider: course.provider, accredited_provider: course.accrediting_provider, description: 'EnrichmentDescription')
         else
           course.provider.update(accrediting_provider_enrichments: [AccreditingProviderEnrichment.new(Description: 'EnrichmentDescription', UcasProviderCode: course.accrediting_provider.provider_code)])
         end

--- a/spec/features/publish/courses/copy_from_list_spec.rb
+++ b/spec/features/publish/courses/copy_from_list_spec.rb
@@ -6,7 +6,7 @@ feature 'Copying course information', { can_edit_current_and_next_cycles: false 
   context 'with accredited courses' do
     before do
       given_i_am_authenticated_as_an_accredited_provider_user
-      and_there_is_an_accredited_course_i_want_to_edit
+      and_there_is_a_course_i_want_to_edit
 
       when_i_visit_the_how_school_placements_work_page
       then_i_see_the_current_course_information
@@ -50,6 +50,10 @@ feature 'Copying course information', { can_edit_current_and_next_cycles: false 
 
   def given_i_am_authenticated_as_an_accredited_provider_user
     given_i_am_authenticated(user: create(:user, :with_accredited_provider))
+  end
+
+  def and_there_is_an_accredited_course_i_want_to_edit
+    given_a_course_exists(enrichments: [build(:course_enrichment, :published)])
   end
 
   def and_there_is_an_accredited_course_i_want_to_edit

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -28,7 +28,7 @@ describe '#publishable?' do
     let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
     let(:primary_with_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
     let(:course) do
-      create(:course, :with_gcse_equivalency, :with_accrediting_provider, :self_accredited, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status], study_sites: [study_site])
+      create(:course, :with_gcse_equivalency, :with_accrediting_provider, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status], study_sites: [study_site])
     end
 
     it 'is not publishable' do
@@ -41,7 +41,7 @@ describe '#publishable?' do
     let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
     let(:primary_with_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
     let(:course) do
-      create(:course, :with_gcse_equivalency, :with_accrediting_provider, :self_accredited, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status], study_sites: [study_site])
+      create(:course, :with_gcse_equivalency, :with_accrediting_provider, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status], study_sites: [study_site])
     end
 
     its(:publishable?) { is_expected.to be_truthy }


### PR DESCRIPTION
## Context

Some tests are failing when the Provider partnership Setting is enabled.

## Changes proposed in this pull request

Make changes to the test suite so that all tests are passing when provider partnerships is enabled

## Guidance to review

All changes are affecting the test suite, and specifically when the `Settings.features.provider_partnerships` setting is enabled.
These tests all pass when run in the settings matrix defined in [this PR](https://github.com/DFE-Digital/publish-teacher-training/pull/4915)
