### PR TITLE
Correct Course edit "Change ratifying provider" link for provider partnerships

### DIFF
--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -165,7 +165,7 @@
      end
 
      unless @provider.accredited?
-       summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row|
+       summary_list.with_row(html_attributes: { data: { qa: "course__ratifying_provider" } }) do |row|
          row.with_key { t(".ratifying_provider") }
          row.with_value { course.accrediting_provider&.provider_name }
          if course.is_published? || course.is_withdrawn?

--- a/app/views/publish/courses/accredited_provider/edit.html.erb
+++ b/app/views/publish/courses/accredited_provider/edit.html.erb
@@ -20,7 +20,7 @@
                     url: accredited_provider_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                     method: :put do |form| %>
 
-        <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__accredited_provider">
+        <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__ratifying_provider">
           <%= render partial: "provider_suggestion", collection: @provider.accredited_bodies, locals: { form: } %>
         </div>
 

--- a/app/views/publish/courses/accredited_provider/new.html.erb
+++ b/app/views/publish/courses/accredited_provider/new.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-full">
   <%= form_with url: continue_publish_provider_recruitment_cycle_courses_accredited_provider_path(@provider.provider_code, @provider.recruitment_cycle_year), method: :get do |form| %>
     <%= render "publish/courses/new_fields_holder", form:, except_keys: [:accredited_provider_code] do |fields| %>
-      <%= render "publish/shared/error_wrapper", error_keys: [:accredited_provider_code], data_qa: "course__accredited_provider" do %>
+      <%= render "publish/shared/error_wrapper", error_keys: [:accredited_provider_code], data_qa: "course__ratifying_provider" do %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
@@ -20,7 +20,7 @@
         </legend>
         <%= render "publish/shared/error_messages", error_keys: [:accredited_provider_code] %>
 
-        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_provider">
+        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__ratifying_provider">
           <%= render partial: "provider_suggestion", collection: @provider.accredited_bodies.sort_by { |k| k[:provider_name] }, locals: { form: fields } %>
         </div>
       <% end %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -152,12 +152,17 @@
         <% end %>
 
         <% unless @provider.accredited? || course.is_further_education? %>
+          <% change_ratifying_provider_url = if Settings.features.provider_partnerships
+                                               new_publish_provider_recruitment_cycle_courses_ratifying_provider_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true))
+                                             else
+                                               new_publish_provider_recruitment_cycle_courses_accredited_provider_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true))
+                                             end %>
           <% summary_list.with_row(html_attributes: { data: { qa: "course__ratifying_provider" } }) do |row| %>
             <% row.with_key { t(".ratifying_provider") } %>
             <% row.with_value { course.accrediting_provider.provider_name } %>
             <% if @provider.accredited_bodies.length > 1 %>
               <% row.with_action(
-                href: new_publish_provider_recruitment_cycle_courses_accredited_provider_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_confirmation: true)),
+                href: change_ratifying_provider_url,
                 visually_hidden_text: "ratifying provider"
               ) %>
             <% else %>

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -152,7 +152,7 @@
         <% end %>
 
         <% unless @provider.accredited? || course.is_further_education? %>
-          <% summary_list.with_row(html_attributes: { data: { qa: "course__accredited_provider" } }) do |row| %>
+          <% summary_list.with_row(html_attributes: { data: { qa: "course__ratifying_provider" } }) do |row| %>
             <% row.with_key { t(".ratifying_provider") } %>
             <% row.with_value { course.accrediting_provider.provider_name } %>
             <% if @provider.accredited_bodies.length > 1 %>

--- a/app/views/publish/courses/ratifying_provider/edit.html.erb
+++ b/app/views/publish/courses/ratifying_provider/edit.html.erb
@@ -20,7 +20,7 @@
                     url: ratifying_provider_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                     method: :put do |form| %>
 
-        <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__accredited_provider">
+        <div class="govuk-radios govuk-!-margin-top-2" data-module="govuk-radios" data-qa="course__ratifying_provider">
           <%= render partial: "provider_suggestion", collection: accredited_partners, locals: { form: } %>
         </div>
 

--- a/app/views/publish/courses/ratifying_provider/new.html.erb
+++ b/app/views/publish/courses/ratifying_provider/new.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-full">
   <%= form_with url: continue_publish_provider_recruitment_cycle_courses_ratifying_provider_path(@provider.provider_code, @provider.recruitment_cycle_year), method: :get do |form| %>
     <%= render "publish/courses/new_fields_holder", form:, except_keys: [:accredited_provider_code] do |fields| %>
-      <%= render "publish/shared/error_wrapper", error_keys: [:accredited_provider_code], data_qa: "course__accredited_provider" do %>
+      <%= render "publish/shared/error_wrapper", error_keys: [:accredited_provider_code], data_qa: "course__ratifying_provider" do %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
@@ -20,7 +20,7 @@
         </legend>
         <%= render "publish/shared/error_messages", error_keys: [:accredited_provider_code] %>
 
-        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__accredited_provider">
+        <div class="govuk-radios" data-module="govuk-radios" data-qa="course__ratifying_provider">
           <%= render partial: "provider_suggestion", collection: @provider.accredited_bodies.sort_by { |k| k[:provider_name] }, locals: { form: fields } %>
         </div>
       <% end %>

--- a/spec/features/publish/courses/editing_course_ratifying_provider_spec.rb
+++ b/spec/features/publish/courses/editing_course_ratifying_provider_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Editing course ratifying provider', { can_edit_current_and_next_cycles: false } do
+  scenario 'published' do
+    given_i_am_authenticated_as_a_training_provider_user
+    and_there_is_a_published_course_i_want_to_edit
+    when_i_visit_the_course_details_page
+    then_i_do_not_see_a_change_link_for_ratifying_provider
+  end
+
+  scenario 'unratified and unpublished with no accredited partnerships' do
+    given_i_am_authenticated_as_a_training_provider_user
+    and_there_is_an_unratified_and_unpublished_course_i_want_to_edit
+
+    when_i_visit_the_course_details_page
+    then_i_see_a_message_to_add_an_ratifying_provider
+  end
+
+  scenario 'unratified and unpublished with one accredited partnership' do
+    given_i_am_authenticated_as_a_training_provider_user
+    and_there_is_an_unratified_and_unpublished_course_i_want_to_edit
+    and_there_is_a_second_provider_partnership
+
+    when_i_visit_the_course_details_page
+    then_i_see_a_message_to_select_an_ratifying_provider
+  end
+
+  scenario 'unpublished with one accredited partnerships' do
+    given_i_am_authenticated_as_a_training_provider_user
+    and_there_is_a_unpublished_course_i_want_to_edit
+
+    when_i_visit_the_course_details_page
+    then_i_do_not_see_a_change_link_for_ratifying_provider
+  end
+
+  scenario 'unpublished with two accredited partnerships' do
+    given_i_am_authenticated_as_a_training_provider_user
+    and_there_is_a_unpublished_course_i_want_to_edit
+    and_there_is_a_second_provider_partnership
+
+    when_i_visit_the_course_details_page
+    and_i_click_to_change_the_ratifying_provider
+    then_i_can_choose_a_different_accredited_provider
+
+    when_i_click_update
+    then_i_see_a_success_message
+    and_i_see_the_ratifying_provider_is_updated
+  end
+
+  private
+
+  def given_i_am_authenticated_as_a_training_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_an_unratified_and_unpublished_course_i_want_to_edit
+    given_a_course_exists(:unpublished)
+  end
+
+  def and_there_is_a_unpublished_course_i_want_to_edit
+    given_a_course_exists(:unpublished, :with_accrediting_provider)
+  end
+
+  def and_there_is_a_second_provider_partnership
+    @new_ratifying_provider = create(:accredited_provider) do |accredited_provider|
+      if Settings.features.provider_partnerships
+        create(:provider_partnership, training_provider: provider, accredited_provider:)
+      else
+        provider.accrediting_provider_enrichments ||= []
+        provider.accrediting_provider_enrichments << AccreditingProviderEnrichment.new(
+          UcasProviderCode: accredited_provider.provider_code,
+          Description: ''
+        )
+        provider.save
+      end
+    end
+  end
+
+  def when_i_visit_the_course_details_page
+    publish_courses_details_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      course_code: @course.course_code
+    )
+  end
+
+  def then_i_see_a_message_to_add_an_ratifying_provider
+    expect(page).to have_content('Add at least one accredited provider')
+  end
+
+  def then_i_see_a_message_to_select_an_ratifying_provider
+    expect(page).to have_content('Select an accredited provider')
+  end
+
+  def and_i_click_to_change_the_ratifying_provider
+    click_on 'Change accredited provider'
+  end
+
+  def then_i_do_not_see_a_change_link_for_ratifying_provider
+    expect(page).to have_no_content('Change accredited provdier')
+  end
+
+  def then_i_can_choose_a_different_accredited_provider
+    choose @new_ratifying_provider.provider_name
+  end
+
+  def when_i_click_update
+    click_on 'Update accredited provider'
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_content("Success\nAccredited provider updated")
+  end
+
+  def and_i_see_the_ratifying_provider_is_updated
+    expect(page).to have_content("Accredited provider#{@new_ratifying_provider.provider_name}")
+  end
+
+  def and_there_is_a_published_course_i_want_to_edit
+    given_a_course_exists(:published, :with_accrediting_provider)
+  end
+
+  def when_i_visit_the_publish_course_information_edit_page
+    visit school_placements_publish_provider_recruitment_cycle_course_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      code: @course.course_code
+    )
+  end
+
+  def and_i_submit
+    click_on 'Update how placements work'
+  end
+
+  def and_the_course_information_is_updated
+    enrichment = course.reload.enrichments.find_or_initialize_draft
+
+    expect(enrichment.how_school_placements_work).to eq(@school_placements)
+  end
+
+  def then_i_see_an_error_message_about_reducing_word_count
+    expect(page).to have_content('Reduce the word count for how placements work').twice
+  end
+
+  def then_i_see_an_error_message_about_entering_data
+    expect(page).to have_content('Enter details about how placements work').twice
+  end
+
+  def provider
+    @provider ||= @current_user.providers.first
+  end
+end

--- a/spec/support/page_objects/find/course_show.rb
+++ b/spec/support/page_objects/find/course_show.rb
@@ -8,7 +8,7 @@ module PageObjects
       element :page_heading, '.govuk-heading-xl'
       element :sub_title, '[data-qa=course__provider_name]'
       element :extended_qualification_descriptions, '[data-qa=course__extended_qualification_descriptions]'
-      element :accredited_provider, '[data-qa=course__accredited_provider]'
+      element :accredited_provider, '[data-qa=course__ratifying_provider]'
       element :provider_website, '[data-qa=course__provider_website]'
       element :vacancies, '[data-qa=course__vacancies]'
       element :about_course, '[data-qa=course__about_course]'

--- a/spec/support/page_objects/publish/course_confirmation.rb
+++ b/spec/support/page_objects/publish/course_confirmation.rb
@@ -24,7 +24,7 @@ module PageObjects
         section :study_mode, SummaryList, '[data-qa=course__study_mode]'
         section :schools, SummaryList, '[data-qa=course__schools]'
         section :study_sites, SummaryList, '[data-qa=course__study_sites]'
-        section :accredited_provider, SummaryList, '[data-qa=course__accredited_provider]'
+        section :accredited_provider, SummaryList, '[data-qa=course__ratifying_provider]'
         section :applications_open, SummaryList, '[data-qa=course__applications_open]'
         section :start_date, SummaryList, '[data-qa=course__start_date]'
         section :name, SummaryList, '[data-qa=course__name]'

--- a/spec/support/page_objects/publish/course_preview.rb
+++ b/spec/support/page_objects/publish/course_preview.rb
@@ -7,7 +7,7 @@ module PageObjects
 
       element :sub_title, '[data-qa=course__provider_name]'
       element :description, '[data-qa=course__description]'
-      element :accredited_provider, '[data-qa=course__accredited_provider]'
+      element :accredited_provider, '[data-qa=course__ratifying_provider]'
       element :provider_website, '[data-qa=course__provider_website]'
       element :vacancies, '[data-qa=course__vacancies]'
       element :about_course, '[data-qa=course__about_course]'

--- a/spec/support/page_objects/publish/courses/details.rb
+++ b/spec/support/page_objects/publish/courses/details.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    module Courses
+      class Details < PageObjects::Base
+        set_url '/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/details'
+
+        section :details, '[id="basic_details"]' do
+          element :ratifying_provider_row, '[data-qa="course__ratifying_provider"]'
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/provider_courses_details.rb
+++ b/spec/support/page_objects/publish/provider_courses_details.rb
@@ -19,7 +19,7 @@ module PageObjects
       section :funding, Sections::SummaryList, '[data-qa="course__funding"]'
       section :study_mode, Sections::SummaryList, '[data-qa="course__study_mode"]'
       section :schools, Sections::SummaryList, '[data-qa="course__schools"]'
-      section :accredited_provider, Sections::SummaryList, '[data-qa="course__accredited_provider"]'
+      section :accredited_provider, Sections::SummaryList, '[data-qa="course__ratifying_provider"]'
       section :applications_open, Sections::SummaryList, '[data-qa="course__applications_open"]'
       section :start_date, Sections::SummaryList, '[data-qa="course__start_date"]'
       section :contact_support_link, Sections::SummaryList, '[data-qa="course__contact_support_link"]'


### PR DESCRIPTION
## Context

The correct link for editing the ratifying provider of a course was not applied when provider partnerships is enabled

## Changes proposed in this pull request

Set the correct URL for `Change ratifying provider`

## Guidance to review
[Screencast from 13-02-25 16:07:35.webm](https://github.com/user-attachments/assets/dcb69a87-b7ee-4e28-952d-e3b6c10fd0a8)

## Trello 

https://trello.com/c/h1iAfSzg/465-correct-url-for-changing-ratifying-provider-of-a-course
