### PR TITLE
Update show filter button

### DIFF
--- a/app/javascript/find/application.js
+++ b/app/javascript/find/application.js
@@ -34,9 +34,9 @@ const filterToggleButton = new FilterToggleButton({
   startHidden: false,
   toggleButton: {
     container: $('.app-filter-toggle'),
-    showText: 'Show filters',
+    showText: 'Filter results',
     hideText: 'Hide filters',
-    classes: 'govuk-button--secondary'
+    classes: 'govuk-button--secondary govuk-!-font-weight-bold'
   },
   closeButton: {
     container: $('.app-filter__header'),

--- a/app/javascript/find/filter-toggle-button.js
+++ b/app/javascript/find/filter-toggle-button.js
@@ -27,7 +27,6 @@ export const FilterToggleButton = class {
 
   enableSmallMode () {
     this.options.filter.container.attr('tabindex', '-1')
-    this.hideMenu()
     this.addMenuButton()
     this.addCloseButton()
   }

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -13,8 +13,6 @@
 ) %>
 
 <%= form_with model: @search_courses_form, scope: "", url: find_v2_results_path, method: :get do |form| %>
-  <div class="app-filter-toggle"></div>
-
   <div class="app-filter-layout">
     <div class="app-filter-layout__filter app-filter">
         <div class="app-filter__header">
@@ -23,7 +21,6 @@
 
         <div class="app-filter__content">
           <%= form.govuk_submit "Apply filters" %>
-
           <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_search_form.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
             <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.can_sponsor_visa"), size: "s" } %>
           <% end %>
@@ -145,6 +142,7 @@
               <%= form.govuk_submit t("helpers.submit.courses_search_form.order", class: "govuk-!-display-inline-block") %>
             <% end %>
           </div>
+          <div class="app-filter-toggle govuk-!-padding-top-5"></div>
         </div>
 
         <ul class="app-search-results">


### PR DESCRIPTION
## Context

Context
In the user research sessions in July and December, we found that all participants navigating the search results page on a mobile device did not see the ‘Show filters' button, and therefore were not able to narrow down to a manageable and relevant list of courses.

[See live site for location search](https://trello.com/1/cards/6790fcb990d551f615afb738/attachments/6790fda65c85000e546ee640/download/live-site-location-search.png)
[See live site for across England search](https://trello.com/1/cards/6790fcb990d551f615afb738/attachments/6790fda6d9d5c94c96b9c7cf/download/live-site-across-england.png)

We iterated and tested designs that were found to improve discoverability.

[See design for location search](https://trello.com/1/cards/6790fcb990d551f615afb738/attachments/6790fda6fb3969ed805e3a67/download/design-location-search.png)
[See design for across England search](https://trello.com/1/cards/6790fcb990d551f615afb738/attachments/6790fda633a6e0395130ac29/download/design-across-england.png)

This ticket is to make changes to the ‘Show filters’ button.

**It’s done when**

The ‘Show filters’ button content and location is updated

1. Move the button
Move the button down the page, to sit directly above the first search result.

2. Update content
<button> Filter results

2. Update styling
Made the button text bold

## Changes proposed in this pull request

Attach the stimulus controller to the new v2 results filters panel

## Guidance to review

- Visit the review app
- Navigate to the V2 results page (You can get there by using the primary subjects quick link for this)
- Shrink the screen size where you see the `Filter results` button 
- Toggle the side panel using the `close` located on the right hand side of the panel
- Toggle the results using the button located below the sort button


https://github.com/user-attachments/assets/fb39576d-a739-4eb6-bac3-70d8430b00f5
