### PR TITLE
Fix issue where you search, click on a course and return to search

### DIFF
--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -1,14 +1,25 @@
 <%= content_for :page_title, "#{@course.name_and_code} with #{smart_quotes(@course.provider.provider_name)}" %>
 
-<% if permitted_referrer? %>
-  <%= content_for(:before_content) do %>
-    <%= govuk_back_link(
-      text: t("find.courses.show.back_to_search"),
-      href: find_results_path(session[:search_params]),
-      html_attributes: {
-        data: { qa: "page-back" }
-      }
-    ) %>
+<% if Settings.features.v2_results.present? %>
+  <% if permitted_referrer? %>
+    <%= content_for(:before_content) do %>
+      <%= govuk_back_link(
+        text: t("find.courses.show.back_to_search"),
+        href: request.referer || find_results_path
+      ) %>
+    <% end %>
+  <% end %>
+<% else %>
+  <% if permitted_referrer? %>
+    <%= content_for(:before_content) do %>
+      <%= govuk_back_link(
+        text: t("find.courses.show.back_to_search"),
+        href: find_results_path(session[:search_params]),
+        html_attributes: {
+          data: { qa: "page-back" }
+        }
+      ) %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/spec/system/find/v2/results/view_course_spec.rb
+++ b/spec/system/find/v2/results/view_course_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'V2 results - view a course', :js, service: :find do
+  include FiltersFeatureSpecsHelper
+
+  before do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
+    allow(Settings.features).to receive_messages(v2_results: true)
+
+    given_courses_exist
+    when_i_visit_the_results_page
+  end
+
+  scenario 'viewing a course from the search results' do
+    when_i_filter_for_send_courses
+    and_i_search_for_art_and_design_subject
+    and_i_click_search
+    and_i_click_on_the_first_result
+    and_i_am_on_the_course_page
+
+    when_i_click_back_to_results
+    then_i_am_on_search_results_page_with_the_applied_search
+  end
+
+  def given_courses_exist
+    create(
+      :course,
+      :with_full_time_sites,
+      :secondary,
+      :with_special_education_needs,
+      :published,
+      name: 'Art and design (SEND)',
+      course_code: 'F314',
+      provider: build(:provider, provider_name: 'York university', provider_code: 'RO1'),
+      subjects: [find_or_create(:secondary_subject, :art_and_design)]
+    )
+  end
+
+  def when_i_visit_the_results_page
+    visit(find_v2_results_path)
+  end
+
+  def when_i_filter_for_send_courses
+    check 'Only show courses with a SEND specialism', visible: :all
+  end
+
+  def and_i_search_for_art_and_design_subject
+    fill_in 'Subject', with: 'Art'
+
+    and_i_choose_the_first_subject_suggestion
+  end
+
+  def and_i_choose_the_first_subject_suggestion
+    page.find('input[name="subject_name"]').native.send_keys(:return)
+  end
+
+  def and_i_click_search
+    click_link_or_button 'Search'
+  end
+
+  def and_i_click_on_the_first_result
+    page.first('.app-search-results').first('a').click
+  end
+
+  def and_i_am_on_the_course_page
+    expect(page).to have_current_path(
+      find_course_path(
+        provider_code: 'RO1',
+        course_code: 'F314'
+      )
+    )
+  end
+
+  def when_i_click_back_to_results
+    click_link_or_button 'Back to search results'
+  end
+
+  def then_i_am_on_search_results_page_with_the_applied_search
+    expect(page).to have_current_path(find_v2_results_path, ignore_query: true)
+
+    expect(
+      query_params(URI(page.current_url)).symbolize_keys
+    ).to eq(
+      {
+        send_courses: 'true',
+        subject_name: 'Art and design',
+        subject_code: 'W1',
+        location: '',
+        radius: '10',
+        order: ''
+      }
+    )
+  end
+end


### PR DESCRIPTION
## Context

This PR fixes the bug on the pre-filtering work that you can't return to the search after you view a course.

Steps to replicate (on main branch)

1. Visit /v2/results
2. Apply any filters
3. Click on any course.
4. Then click “Back to results”.

The search on step 2 should be there.

The reason the bug exists si that back to results relies on the params in the url and this solution is flakey.

**Solution:** I used the referrer if is a permitted referrer.

## Changes proposed in this pull request

**Solution:** I used the referrer if is a permitted referrer.

## Guidance to review

1. Is it secure to use the permitted referrer instead relying on the parameters?
