### PR TITLE
DataMigration correct visa sponsorship data

### DIFF
--- a/db/data/20250218095818_correct_course_visa_data.rb
+++ b/db/data/20250218095818_correct_course_visa_data.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CorrectCourseVisaData < ActiveRecord::Migration[8.0]
+  def up
+    Course.where(funding: 'apprenticeship', can_sponsor_student_visa: true).update_all(can_sponsor_student_visa: false)
+    Course.where(funding: 'salary', can_sponsor_student_visa: true).update_all(can_sponsor_student_visa: false)
+    Course.where(funding: 'fee', can_sponsor_skilled_worker_visa: true).update_all(can_sponsor_skilled_worker_visa: false)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Context

  Salary courses shouldn't be sponsoring student visa.
  Fee courses shouldn't sponsoring worker visa.
  Apprenticeship courses shouldn't be sponsoring student visa.

## Changes proposed in this pull request

Add a DataMigration to corrrect data in the database.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/9yxsiYG0/383-fix-visa-sponsorship-data-in-the-database