### PR TITLE
Improve tracking on the prefiltering work

### DIFF
--- a/app/controllers/find/v2/primary_subjects_controller.rb
+++ b/app/controllers/find/v2/primary_subjects_controller.rb
@@ -13,7 +13,7 @@ module Find
 
       def submit
         if @form.valid?
-          redirect_to find_results_path(subjects: @form.subjects)
+          redirect_to find_results_path({ subjects: @form.subjects }.merge(track_params))
         else
           @primary_subject_options = Subject.primary
           render :index
@@ -28,6 +28,10 @@ module Find
 
       def subject_params
         params.fetch(:find_v2_subjects_primary_form, {}).permit(subjects: [])
+      end
+
+      def track_params
+        params.fetch(:find_v2_subjects_primary_form, {}).permit(:utm_source, :utm_medium)
       end
     end
   end

--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -18,7 +18,7 @@ module Find
           total: @courses_count,
           page: @pagy.page,
           search_params: @search_params,
-          track_params:,
+          track_params: params.permit(:utm_source, :utm_medium),
           results: @results
         ).send_event
       end
@@ -54,14 +54,6 @@ module Find
           qualification: [],
           funding: []
         )
-      end
-
-      def track_params
-        if request.referer.present?
-          params.permit(:utm_source, :utm_medium)
-        else
-          { utm_source: 'results', utm_medium: 'no_referer' }
-        end
       end
     end
   end

--- a/app/controllers/find/v2/secondary_subjects_controller.rb
+++ b/app/controllers/find/v2/secondary_subjects_controller.rb
@@ -13,7 +13,7 @@ module Find
 
       def submit
         if @form.valid?
-          redirect_to find_results_path(subjects: @form.subjects)
+          redirect_to find_results_path({ subjects: @form.subjects }.merge(track_params))
         else
           @secondary_subject_options = formatted_secondary_subject_options
           render :index
@@ -41,6 +41,10 @@ module Find
 
       def subject_params
         params.fetch(:find_v2_subjects_secondary_form, {}).permit(subjects: [])
+      end
+
+      def track_params
+        params.fetch(:find_v2_subjects_secondary_form, {}).permit(:utm_source, :utm_medium)
       end
     end
   end

--- a/app/views/find/v2/primary_subjects/index.erb
+++ b/app/views/find/v2/primary_subjects/index.erb
@@ -1,6 +1,9 @@
 <% content_for :page_title, title_with_error_prefix(t(".page_title"), @form.errors.present?) %>
 
 <%= form_with model: @form, url: find_primary_path, method: :post do |f| %>
+  <%= f.hidden_field :utm_source, value: 'home' %>
+  <%= f.hidden_field :utm_medium, value: 'primary_courses' %>
+
   <%= f.govuk_error_summary link_base_errors_to: :subjects %>
 
   <div class="govuk-grid-row">

--- a/app/views/find/v2/secondary_subjects/index.erb
+++ b/app/views/find/v2/secondary_subjects/index.erb
@@ -1,6 +1,9 @@
 <% content_for :page_title, title_with_error_prefix(t(".page_title"), @form.errors.present?) %>
 
 <%= form_with model: @form, url: find_secondary_path, method: :post do |f| %>
+  <%= f.hidden_field :utm_source, value: 'home' %>
+  <%= f.hidden_field :utm_medium, value: 'secondary_courses' %>
+
   <%= f.govuk_error_summary link_base_errors_to: :subjects %>
 
   <div class="govuk-grid-row">

--- a/spec/services/find/analytics/search_results_event_spec.rb
+++ b/spec/services/find/analytics/search_results_event_spec.rb
@@ -39,23 +39,79 @@ RSpec.describe Find::Analytics::SearchResultsEvent do
       }
     end
 
-    it 'returns a hash with all the results information' do
-      expect(subject.event_data).to eq(
-        total: 1360,
-        page: 2,
-        visible_courses: [
-          { code: 'abc', provider_code: 'rst' },
-          { code: 'def', provider_code: 'uvw' }
-        ],
-        search_params: {
-          send_courses: true,
-          can_sponsor_visa: true
-        },
-        track_params: {
-          utm_source: 'homepage',
-          utm_medium: 'search-form'
-        }
-      )
+    context 'when there is a referer' do
+      it 'returns a hash with all the results information' do
+        allow(request).to receive(:referer).and_return('/')
+
+        expect(subject.event_data).to eq(
+          total: 1360,
+          page: 2,
+          visible_courses: [
+            { code: 'abc', provider_code: 'rst' },
+            { code: 'def', provider_code: 'uvw' }
+          ],
+          search_params: {
+            send_courses: true,
+            can_sponsor_visa: true
+          },
+          track_params: {
+            utm_source: 'homepage',
+            utm_medium: 'search-form'
+          }
+        )
+      end
+    end
+
+    context 'when there is not a referer' do
+      before do
+        allow(request).to receive(:referer).and_return(nil)
+      end
+
+      it 'returns a hash with all the results information and no referer' do
+        expect(subject.event_data).to eq(
+          total: 1360,
+          page: 2,
+          visible_courses: [
+            { code: 'abc', provider_code: 'rst' },
+            { code: 'def', provider_code: 'uvw' }
+          ],
+          search_params: {
+            send_courses: true,
+            can_sponsor_visa: true
+          },
+          track_params: {
+            utm_source: 'results',
+            utm_medium: 'no_referer'
+          }
+        )
+      end
+    end
+
+    context 'when the referer is the course view page' do
+      before do
+        allow(request).to receive(:referer).and_return('/course/19S/2DTK')
+      end
+
+      it 'returns a hash with all the results information and course referer' do
+        expect(subject.event_data).to eq(
+          total: 1360,
+          page: 2,
+          visible_courses: [
+            { code: 'abc', provider_code: 'rst' },
+            { code: 'def', provider_code: 'uvw' }
+          ],
+          search_params: {
+            send_courses: true,
+            can_sponsor_visa: true
+          },
+          track_params: {
+            utm_source: 'course',
+            utm_medium: 'course_view',
+            code: '2DTK',
+            provider_code: '19S'
+          }
+        )
+      end
     end
   end
 end

--- a/spec/system/find/v2/results/search_results_tracking_spec.rb
+++ b/spec/system/find/v2/results/search_results_tracking_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
     end
 
     scenario 'when browse secondary courses' do
-      pending 'waiting for the secondary work to be merged'
       when_i_browse_secondary_courses
       and_i_choose_art_and_design
       and_i_click_find_secondary_courses
@@ -149,6 +148,9 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
       course_code: 'Y565',
       provider: build(:provider, provider_name: 'Brighton university', provider_code: '1UR')
     )
+
+    subject_group = create(:subject_group, name: 'Arts, humanities and social sciences')
+    find_or_create(:secondary_subject, :art_and_design).update(subject_group:)
   end
 
   def when_i_visit_the_homepage


### PR DESCRIPTION
## Context

Now that primary and secondary pages are working:

* Add utm_source and utm_medium to primary and secondary courses

And in the case of course vieweing:

* If the user viewed a course and clicked "Back to results" we send an event to DfE analytics

## Changes proposed in this pull request

* Add tracking from the course view to the results
* Add tracking for the primary form
* Add tracking for the secondary form

## Guidance to review

1. Visit homepage
2. Click on primary link and check a primary course and find primary courses. What is the utm source and utm medium?
3. View a course clicking from the search results and click back to search resuits. A DfE analytics event should be send with the right track params
