### PR TITLE
Td/add rake task to create subject groups

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -32,7 +32,10 @@ class Subject < ApplicationRecord
   end
 
   def self.secondary_subjects_with_subject_groups
-    secondary.where.not(subject_group: nil)
+    secondary
+      .where.not(subject_group: nil)
+      .includes(:subject_group)
+      .reorder('subject_group.created_at ASC, subject.subject_name ASC')
   end
 
   def secondary_subject?

--- a/lib/tasks/populate_subject_groups.rake
+++ b/lib/tasks/populate_subject_groups.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+desc 'Create SubjectGroups and populate with subjects'
+task create_and_populate_subject_groups: :environment do
+  subject_groups = {
+    'Science, technology, engineering and mathematics (STEM)' => [
+      'Biology', 'Chemistry', 'Computing', 'Design and technology', 'Mathematics', 'Physics', 'Science'
+    ],
+    'Languages and literature' => [
+      'English', 'Ancient Greek', 'Ancient Hebrew', 'French', 'German', 'Italian', 'Japanese', 'Latin', 'Mandarin', 'Russian', 'Spanish'
+    ],
+    'Art, humanities and social sciences' => [
+      'Art and design', 'Business studies', 'Citizenship', 'Classics', 'Communication and media studies', 'Dance', 'Drama', 'Economics', 'Geography', 'History', 'Music', 'Philosophy', 'Psychology', 'Religious studies', 'Social sciences'
+    ],
+    'Health and physical education' => [
+      'Health and social care', 'Physical education'
+    ]
+  }
+
+
+  subject_groups.each do |group_name, subjects|
+    subject_group = SubjectGroup.find_or_create_by!(name: group_name)
+    subjects.each do |subject_name|
+      puts "Creating subject: #{subject_name} in group: #{group_name}"
+      # Subject.update(subject_name: subject_name, subject_group: subject_group)
+    end
+  end
+end

--- a/lib/tasks/populate_subject_groups.rake
+++ b/lib/tasks/populate_subject_groups.rake
@@ -7,7 +7,7 @@ task create_and_populate_subject_groups: :environment do
       'Biology', 'Chemistry', 'Computing', 'Design and technology', 'Mathematics', 'Physics', 'Science'
     ],
     'Languages and literature' => [
-      'English', 'Ancient Greek', 'Ancient Hebrew', 'French', 'German', 'Italian', 'Japanese', 'Latin', 'Mandarin', 'Russian', 'Spanish'
+      'English', 'Ancient Greek', 'Ancient Hebrew', 'French', 'German', 'Italian', 'Japanese', 'Latin', 'Mandarin', 'Russian', 'Spanish', 'Modern languages (other)'
     ],
     'Art, humanities and social sciences' => [
       'Art and design', 'Business studies', 'Citizenship', 'Classics', 'Communication and media studies', 'Dance', 'Drama', 'Economics', 'Geography', 'History', 'Music', 'Philosophy', 'Psychology', 'Religious education', 'Social sciences'

--- a/lib/tasks/populate_subject_groups.rake
+++ b/lib/tasks/populate_subject_groups.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-desc 'Create SubjectGroups and populate with subjects'
+desc 'Create SubjectGroups and populate with subjects in order'
 task create_and_populate_subject_groups: :environment do
   subject_groups = {
     'Science, technology, engineering and mathematics (STEM)' => [
@@ -10,19 +10,33 @@ task create_and_populate_subject_groups: :environment do
       'English', 'Ancient Greek', 'Ancient Hebrew', 'French', 'German', 'Italian', 'Japanese', 'Latin', 'Mandarin', 'Russian', 'Spanish'
     ],
     'Art, humanities and social sciences' => [
-      'Art and design', 'Business studies', 'Citizenship', 'Classics', 'Communication and media studies', 'Dance', 'Drama', 'Economics', 'Geography', 'History', 'Music', 'Philosophy', 'Psychology', 'Religious studies', 'Social sciences'
+      'Art and design', 'Business studies', 'Citizenship', 'Classics', 'Communication and media studies', 'Dance', 'Drama', 'Economics', 'Geography', 'History', 'Music', 'Philosophy', 'Psychology', 'Religious education', 'Social sciences'
     ],
     'Health and physical education' => [
       'Health and social care', 'Physical education'
     ]
   }
 
+  current_time = Time.current
 
-  subject_groups.each do |group_name, subjects|
-    subject_group = SubjectGroup.find_or_create_by!(name: group_name)
+  subject_groups.each_with_index do |(group_name, subjects), group_index|
+    subject_group = SubjectGroup.find_or_create_by!(name: group_name) do |group|
+      # forcing the created at so appear in the right order
+      group.created_at = current_time + group_index.seconds
+    end
+
     subjects.each do |subject_name|
-      puts "Creating subject: #{subject_name} in group: #{group_name}"
-      # Subject.update(subject_name: subject_name, subject_group: subject_group)
+      subject = Subject.find_by(subject_name:)
+
+      if subject
+        subject.update!(subject_group: subject_group)
+      else
+        puts '=' * 80
+        puts "Subject #{subject_name} not found."
+        puts '=' * 80
+      end
+
+      puts "Processed subject: #{subject_name} in group: #{group_name}"
     end
   end
 end


### PR DESCRIPTION
## Context

We need to create the subject groups for subjects in the secondary page.

## Changes proposed in this pull request

![screencapture-find-localhost-secondary-2025-02-19-12_00_44](https://github.com/user-attachments/assets/5abc7e1f-6aa2-4a70-a02b-7d4048f7042d)


## Guidance to review

1. Does it work on the review app?
2. If you visit the homepage and browse secondary courses, can you see all groups?
