### PR TITLE
The scrollable filter items needs to be partially hidden

### DIFF
--- a/app/assets/stylesheets/find/components/_filter-search.scss
+++ b/app/assets/stylesheets/find/components/_filter-search.scss
@@ -3,9 +3,16 @@
     .govuk-checkboxes {
       .scrollable-filter {
         margin-left: -10px;
-        max-height: 196px;
         overflow-y: auto;
         padding-left: 10px;
+      }
+
+      .primary-scrollable-filter {
+        max-height: 165px;
+      }
+
+      .secondary-scrollable-filter {
+        max-height: 155px;
       }
     }
   }

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -29,7 +29,7 @@
           <% end %>
 
           <%= form.govuk_check_boxes_fieldset :primary_subjects, legend: { text: t("helpers.legend.courses_search_form.primary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.primary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group" } do %>
-            <div class="scrollable-filter">
+            <div class="scrollable-filter primary-scrollable-filter">
               <% form.object.primary_subjects.each do |subject| %>
                 <%= form.govuk_check_box :subjects,
                 subject.subject_code,
@@ -39,7 +39,7 @@
           <% end %>
 
           <%= form.govuk_check_boxes_fieldset :secondary_subjects, legend: { text: t("helpers.legend.courses_search_form.secondary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.secondary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group", data: { controller: "filter-search" } } do %>
-            <div class="filter-search scrollable-filter" data-filter-search-target="optionsList">
+            <div class="filter-search scrollable-filter secondary-scrollable-filter" data-filter-search-target="optionsList">
               <% form.object.secondary_subjects.each do |subject| %>
                 <%= form.govuk_check_box :subjects,
                 subject.subject_code,


### PR DESCRIPTION
## Context

So the users can see is a scrollable section

See trello card for more info:
https://trello.com/c/52wJBhfW/428-bug-primary-and-secondary-filters-have-incorrect-height

## Changes proposed in this pull request

BEFORE:

![Screenshot_2025-02-05_at_12 53 04](https://github.com/user-attachments/assets/c691db6d-191f-48bc-90c2-6b410b237bee)

AFTER:

![Screenshot_2025-02-05_at_12 51 02](https://github.com/user-attachments/assets/2de2569a-f3a3-43db-ad07-96bd1b36f292)


## Guidance to review

1. It it right height on the web?
2. And on mobile?
