### PR TITLE
Prevent both types of visa sponsorship during course creation

### DIFF
--- a/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/student_visa_sponsorship_controller.rb
@@ -6,7 +6,7 @@ module Publish
       def new
         authorize(@provider, :can_create_course?)
         @course.can_sponsor_student_visa = @provider.can_sponsor_student_visa unless @course.can_sponsor_student_visa
-        return if course.fee_based?
+        return if course.fee?
 
         redirect_to next_step
       end

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -40,11 +40,20 @@ module Courses
 
       Publish::Courses::AssignTdaAttributesService.new(course).call if course.undergraduate_degree_with_qts?
       Courses::AssignProgramTypeService.new.execute(course.funding, course)
+      clean_up_visa_properies(course)
       course.valid?(:new) if course.errors.blank?
 
       course.remove_carat_from_error_messages
 
       course
+    end
+
+    def clean_up_visa_properies(course)
+      if course.fee?
+        course.can_sponsor_skilled_worker_visa = false
+      else
+        course.can_sponsor_student_visa = false
+      end
     end
 
     def course_attributes

--- a/app/views/publish/courses/student_visa_sponsorship/new.html.erb
+++ b/app/views/publish/courses/student_visa_sponsorship/new.html.erb
@@ -10,13 +10,13 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render CaptionText.new(text: t("course.add_course")) %>
     <%= form_with(
-          url:continue_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(
+          url: continue_publish_provider_recruitment_cycle_courses_student_visa_sponsorship_path(
             @provider.provider_code,
-            @provider.recruitment_cycle_year,
-            ),
+            @provider.recruitment_cycle_year
+          ),
           method: :get,
-          local: true,
-          )do |form| %>
+          local: true
+        ) do |form| %>
 
       <%= render "publish/courses/new_fields_holder", form:, except_keys: [:can_sponsor_student_visa] do |fields| %>
         <%= render "form_fields", form: fields %>

--- a/spec/forms/publish/course_funding_form_spec.rb
+++ b/spec/forms/publish/course_funding_form_spec.rb
@@ -79,215 +79,215 @@ describe Publish::CourseFundingForm, type: :model do
         end
       end
     end
+  end
 
-    describe '#is_fee_based?' do
-      context 'when funding type is fee based' do
-        let(:params) { { funding: 'fee' } }
+  describe '#is_fee_based?' do
+    context 'when funding type is fee based' do
+      let(:params) { { funding: 'fee' } }
 
-        it 'returns true' do
-          expect(subject.is_fee_based?).to be(true)
-        end
-      end
-
-      context 'when funding type is not fee based' do
-        let(:params) { { funding: 'apprenticeship' } }
-
-        it 'returns true' do
-          expect(subject.is_fee_based?).to be(false)
-        end
+      it 'returns true' do
+        expect(subject.is_fee_based?).to be(true)
       end
     end
 
-    describe '#visa_type' do
-      context 'when funding type is fee based' do
-        let(:params) { { funding: 'fee' } }
+    context 'when funding type is not fee based' do
+      let(:params) { { funding: 'apprenticeship' } }
 
-        it 'returns student' do
-          expect(subject.visa_type).to be(:student)
-        end
+      it 'returns true' do
+        expect(subject.is_fee_based?).to be(false)
       end
+    end
+  end
 
-      context 'when funding type is not fee based' do
-        let(:params) { { funding: 'apprenticeship' } }
+  describe '#visa_type' do
+    context 'when funding type is fee based' do
+      let(:params) { { funding: 'fee' } }
 
-        it 'returns skilled_worker' do
-          expect(subject.visa_type).to be(:skilled_worker)
-        end
+      it 'returns student' do
+        expect(subject.visa_type).to be(:student)
       end
     end
 
-    describe '#student_visa?' do
-      context 'when funding type is fee based' do
-        let(:params) { { funding: 'fee' } }
+    context 'when funding type is not fee based' do
+      let(:params) { { funding: 'apprenticeship' } }
 
-        it 'returns true' do
-          expect(subject.student_visa?).to be(true)
-        end
+      it 'returns skilled_worker' do
+        expect(subject.visa_type).to be(:skilled_worker)
       end
+    end
+  end
 
-      context 'when funding type is not fee based' do
-        let(:params) { { funding: 'apprenticeship' } }
+  describe '#student_visa?' do
+    context 'when funding type is fee based' do
+      let(:params) { { funding: 'fee' } }
 
-        it 'returns true' do
-          expect(subject.student_visa?).to be(false)
-        end
+      it 'returns true' do
+        expect(subject.student_visa?).to be(true)
       end
     end
 
-    describe '#skilled_worker_visa?' do
-      context 'when funding type is fee based' do
-        let(:params) { { funding: 'fee' } }
+    context 'when funding type is not fee based' do
+      let(:params) { { funding: 'apprenticeship' } }
 
-        it 'returns true' do
-          expect(subject.skilled_worker_visa?).to be(false)
-        end
+      it 'returns true' do
+        expect(subject.student_visa?).to be(false)
       end
+    end
+  end
 
-      context 'when funding type is not fee based' do
-        let(:params) { { funding: 'apprenticeship' } }
+  describe '#skilled_worker_visa?' do
+    context 'when funding type is fee based' do
+      let(:params) { { funding: 'fee' } }
 
-        it 'returns true' do
-          expect(subject.skilled_worker_visa?).to be(true)
-        end
+      it 'returns true' do
+        expect(subject.skilled_worker_visa?).to be(false)
       end
     end
 
-    describe 'save!' do
-      context 'when the course is a fee based' do
-        let(:course) { create(:course, :fee_type_based, :draft_enrichment, funding: 'fee') }
+    context 'when funding type is not fee based' do
+      let(:params) { { funding: 'apprenticeship' } }
 
-        context 'when changing funding type to apprenticeship and can sponsor skilled worker visa' do
-          let(:params) { { funding: 'apprenticeship', can_sponsor_skilled_worker_visa: true } }
-
-          it 'updates the course with the new details' do
-            expect { subject.save! }
-              .to change(course, :funding).from('fee').to('apprenticeship')
-              .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
-              .and change { course.enrichments.last.fee_details }.to(nil)
-              .and change { course.enrichments.last.fee_international }.to(nil)
-              .and change { course.enrichments.last.fee_uk_eu }.to(nil)
-              .and change { course.enrichments.last.financial_support }.to(nil)
-          end
-        end
-
-        context 'when changing funding type to salary and can sponsor skilled worker visa' do
-          let(:params) { { funding: 'salary', can_sponsor_skilled_worker_visa: true } }
-
-          it 'updates the course with the new details' do
-            expect { subject.save! }
-              .to change(course, :funding).from('fee').to('salary')
-              .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
-              .and change { course.enrichments.last.fee_details }.to(nil)
-              .and change { course.enrichments.last.fee_international }.to(nil)
-              .and change { course.enrichments.last.fee_uk_eu }.to(nil)
-              .and change { course.enrichments.last.financial_support }.to(nil)
-          end
-        end
+      it 'returns true' do
+        expect(subject.skilled_worker_visa?).to be(true)
       end
+    end
+  end
 
-      context 'when the course is with salary' do
-        let(:course) { create(:course, :with_salary, :draft_enrichment, funding: 'salary') }
+  describe 'save!' do
+    context 'when the course is a fee based' do
+      let(:course) { create(:course, :fee_type_based, :draft_enrichment, funding: 'fee') }
 
-        context 'when changing funding type to apprenticeship and can sponsor skilled worker visa' do
-          let(:params) { { funding: 'apprenticeship', can_sponsor_skilled_worker_visa: true } }
+      context 'when changing funding type to apprenticeship and can sponsor skilled worker visa' do
+        let(:params) { { funding: 'apprenticeship', can_sponsor_skilled_worker_visa: true } }
 
-          it 'updates the course with the new details' do
-            expect { subject.save! }
-              .to change(course, :funding).from('salary').to('apprenticeship')
-              .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
-              .and change { course.enrichments.last.fee_details }.to(nil)
-              .and change { course.enrichments.last.fee_international }.to(nil)
-              .and change { course.enrichments.last.fee_uk_eu }.to(nil)
-              .and change { course.enrichments.last.financial_support }.to(nil)
-          end
-        end
-
-        context 'when changing funding type to fee and can sponsor student visa' do
-          let(:params) { { funding: 'fee', can_sponsor_student_visa: true } }
-
-          it 'updates the course with the new details' do
-            expect { subject.save! }
-              .to change(course, :funding).from('salary').to('fee')
-              .and change(course, :can_sponsor_student_visa).from(false).to(true)
-              .and change { course.enrichments.last.salary_details }.to(nil)
-          end
-        end
-      end
-
-      context 'when the course is with apprenticeship' do
-        let(:course) { create(:course, :with_apprenticeship, :draft_enrichment, funding: 'apprenticeship') }
-
-        context 'when changing funding type to salary and can sponsor skilled worker visa' do
-          let(:params) { { funding: 'salary', can_sponsor_skilled_worker_visa: true } }
-
-          it 'updates the course with the new details' do
-            expect { subject.save! }
-              .to change(course, :funding).from('apprenticeship').to('salary')
-              .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
-              .and change { course.enrichments.last.fee_details }.to(nil)
-              .and change { course.enrichments.last.fee_international }.to(nil)
-              .and change { course.enrichments.last.fee_uk_eu }.to(nil)
-              .and change { course.enrichments.last.financial_support }.to(nil)
-          end
-        end
-
-        context 'when changing funding type to fee and can sponsor student visa' do
-          let(:params) { { funding: 'fee', can_sponsor_student_visa: true } }
-
-          it 'updates the course with the new details' do
-            expect { subject.save! }
-              .to change(course, :funding).from('apprenticeship').to('fee')
-              .and change(course, :can_sponsor_student_visa).from(false).to(true)
-              .and change { course.enrichments.last.salary_details }.to(nil)
-          end
-        end
-      end
-
-      context 'blank funding' do
-        let(:params) { { funding: '' } }
-
-        it 'does not update the course with invalid details' do
+        it 'updates the course with the new details' do
           expect { subject.save! }
-            .not_to(change(course, :funding))
+            .to change(course, :funding).from('fee').to('apprenticeship')
+            .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
+            .and change { course.enrichments.last.fee_details }.to(nil)
+            .and change { course.enrichments.last.fee_international }.to(nil)
+            .and change { course.enrichments.last.fee_uk_eu }.to(nil)
+            .and change { course.enrichments.last.financial_support }.to(nil)
         end
       end
 
-      context 'student visa is nil' do
-        let(:params) { { can_sponsor_student_visa: nil } }
-
-        it 'does not update the course with invalid details' do
-          expect { subject.save! }
-            .not_to(change(course, :can_sponsor_student_visa))
-        end
-      end
-
-      context 'skilled worker visa is nil' do
-        let(:course) { create(:course, :salary) }
-        let(:params) { { can_sponsor_skilled_worker_visa: nil } }
-
-        it 'does not update the course with invalid details' do
-          expect { subject.save! }
-            .not_to(change(course, :can_sponsor_skilled_worker_visa))
-        end
-      end
-    end
-
-    describe '#stash' do
-      context 'valid details' do
+      context 'when changing funding type to salary and can sponsor skilled worker visa' do
         let(:params) { { funding: 'salary', can_sponsor_skilled_worker_visa: true } }
 
-        it 'returns true' do
-          expect(subject.stash).to be true
+        it 'updates the course with the new details' do
+          expect { subject.save! }
+            .to change(course, :funding).from('fee').to('salary')
+            .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
+            .and change { course.enrichments.last.fee_details }.to(nil)
+            .and change { course.enrichments.last.fee_international }.to(nil)
+            .and change { course.enrichments.last.fee_uk_eu }.to(nil)
+            .and change { course.enrichments.last.financial_support }.to(nil)
+        end
+      end
+    end
+
+    context 'when the course is with salary' do
+      let(:course) { create(:course, :with_salary, :draft_enrichment, funding: 'salary') }
+
+      context 'when changing funding type to apprenticeship and can sponsor skilled worker visa' do
+        let(:params) { { funding: 'apprenticeship', can_sponsor_skilled_worker_visa: true } }
+
+        it 'updates the course with the new details' do
+          expect { subject.save! }
+            .to change(course, :funding).from('salary').to('apprenticeship')
+            .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
+            .and change { course.enrichments.last.fee_details }.to(nil)
+            .and change { course.enrichments.last.fee_international }.to(nil)
+            .and change { course.enrichments.last.fee_uk_eu }.to(nil)
+            .and change { course.enrichments.last.financial_support }.to(nil)
         end
       end
 
-      context 'blank funding' do
-        let(:params) { { funding: '' } }
+      context 'when changing funding type to fee and can sponsor student visa' do
+        let(:params) { { funding: 'fee', can_sponsor_student_visa: true } }
 
-        it 'does not update the course with invalid details' do
-          expect(subject.stash).to be_nil
-          expect(subject.errors.messages).to eq({ funding: ['Select a funding type'] })
+        it 'updates the course with the new details' do
+          expect { subject.save! }
+            .to change(course, :funding).from('salary').to('fee')
+            .and change(course, :can_sponsor_student_visa).from(false).to(true)
+            .and change { course.enrichments.last.salary_details }.to(nil)
         end
+      end
+    end
+
+    context 'when the course is with apprenticeship' do
+      let(:course) { create(:course, :with_apprenticeship, :draft_enrichment, funding: 'apprenticeship') }
+
+      context 'when changing funding type to salary and can sponsor skilled worker visa' do
+        let(:params) { { funding: 'salary', can_sponsor_skilled_worker_visa: true } }
+
+        it 'updates the course with the new details' do
+          expect { subject.save! }
+            .to change(course, :funding).from('apprenticeship').to('salary')
+            .and change(course, :can_sponsor_skilled_worker_visa).from(false).to(true)
+            .and change { course.enrichments.last.fee_details }.to(nil)
+            .and change { course.enrichments.last.fee_international }.to(nil)
+            .and change { course.enrichments.last.fee_uk_eu }.to(nil)
+            .and change { course.enrichments.last.financial_support }.to(nil)
+        end
+      end
+
+      context 'when changing funding type to fee and can sponsor student visa' do
+        let(:params) { { funding: 'fee', can_sponsor_student_visa: true } }
+
+        it 'updates the course with the new details' do
+          expect { subject.save! }
+            .to change(course, :funding).from('apprenticeship').to('fee')
+            .and change(course, :can_sponsor_student_visa).from(false).to(true)
+            .and change { course.enrichments.last.salary_details }.to(nil)
+        end
+      end
+    end
+
+    context 'blank funding' do
+      let(:params) { { funding: '' } }
+
+      it 'does not update the course with invalid details' do
+        expect { subject.save! }
+          .not_to(change(course, :funding))
+      end
+    end
+
+    context 'student visa is nil' do
+      let(:params) { { can_sponsor_student_visa: nil } }
+
+      it 'does not update the course with invalid details' do
+        expect { subject.save! }
+          .not_to(change(course, :can_sponsor_student_visa))
+      end
+    end
+
+    context 'skilled worker visa is nil' do
+      let(:course) { create(:course, :salary) }
+      let(:params) { { can_sponsor_skilled_worker_visa: nil } }
+
+      it 'does not update the course with invalid details' do
+        expect { subject.save! }
+          .not_to(change(course, :can_sponsor_skilled_worker_visa))
+      end
+    end
+  end
+
+  describe '#stash' do
+    context 'valid details' do
+      let(:params) { { funding: 'salary', can_sponsor_skilled_worker_visa: true } }
+
+      it 'returns true' do
+        expect(subject.stash).to be true
+      end
+    end
+
+    context 'blank funding' do
+      let(:params) { { funding: '' } }
+
+      it 'does not update the course with invalid details' do
+        expect(subject.stash).to be_nil
+        expect(subject.errors.messages).to eq({ funding: ['Select a funding type'] })
       end
     end
   end

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -19,6 +19,59 @@ describe Courses::CreationService do
 
   let(:next_available_course_code) { false }
 
+  context 'visa sponsorship is duplicated in params' do
+    context 'when funding is fee' do
+      let(:valid_course_params) do
+        {
+          'level' => 'primary',
+          'can_sponsor_skilled_worker_visa' => 'true',
+          'can_sponsor_student_visa' => 'true',
+          'funding' => 'fee',
+          'qualification' => 'pgde'
+        }
+      end
+
+      it 'cannot sponsor skilled workers visas' do
+        expect(subject.can_sponsor_student_visa).to be(true)
+        expect(subject.can_sponsor_skilled_worker_visa).to be(false)
+      end
+    end
+
+    context 'when funding is salary' do
+      let(:valid_course_params) do
+        {
+          'level' => 'primary',
+          'can_sponsor_skilled_worker_visa' => 'true',
+          'can_sponsor_student_visa' => 'true',
+          'funding' => 'salary',
+          'qualification' => 'pgde'
+        }
+      end
+
+      it 'cannot sponsor skilled workers visas' do
+        expect(subject.can_sponsor_student_visa).to be(false)
+        expect(subject.can_sponsor_skilled_worker_visa).to be(true)
+      end
+    end
+
+    context 'when funding is apprenticeship' do
+      let(:valid_course_params) do
+        {
+          'level' => 'primary',
+          'can_sponsor_skilled_worker_visa' => 'true',
+          'can_sponsor_student_visa' => 'true',
+          'funding' => 'apprenticeship',
+          'qualification' => 'pgde'
+        }
+      end
+
+      it 'cannot sponsor skilled workers visas' do
+        expect(subject.can_sponsor_student_visa).to be(false)
+        expect(subject.can_sponsor_skilled_worker_visa).to be(true)
+      end
+    end
+  end
+
   context 'when teacher degree apprenticeship course' do
     let(:valid_course_params) do
       {


### PR DESCRIPTION
## Context

It is possible to create a course that "can sponsor" Student visas and Skilled worker visas.

If the user uses the Add course flow and chooses Fee funding and chooses to sponsor student visas, when they reach the confirmation page they can change the funding type to apprenticeship or salary and add Skilled working visa sponsorship.
When that course is created it is create with both sponsorship types.



## Changes proposed in this pull request

We will force the Skilled Worker sponsorship to `false` if the funding is `fee` or force the Student sponsorship to `false` if the funding type is `salary` of `apprenticeship`.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/9yxsiYG0/383-fix-visa-sponsorship-data-in-the-database