### PR TITLE
Set SRID 4326 for spatial queries in course location calculations

### DIFF
--- a/app/services/courses/nearest_school_query.rb
+++ b/app/services/courses/nearest_school_query.rb
@@ -34,8 +34,8 @@ module Courses
         site.latitude,
         site.longitude,
         ST_DistanceSphere(
-          ST_MakePoint(site.longitude::float, site.latitude::float),
-          ST_MakePoint(#{Float(@longitude)}, #{Float(@latitude)})
+          ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
+          ST_SetSRID(ST_MakePoint(#{Float(@longitude)}, #{Float(@latitude)}), 4326)
         ) / 1609.34 AS distance_to_search_location
       SQL
     end

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -201,8 +201,8 @@ module Courses
         .where(
           <<~SQL.squish, longitude, latitude, radius_in_meters
             ST_DistanceSphere(
-              ST_MakePoint(site.longitude::float, site.latitude::float),
-              ST_MakePoint(?::float, ?::float)
+              ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
+              ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
             ) <= ?
           SQL
         )
@@ -212,8 +212,8 @@ module Courses
               <<~SQL.squish,
                 course.*,
                 MIN(ST_DistanceSphere(
-                  ST_MakePoint(site.longitude::float, site.latitude::float),
-                  ST_MakePoint(?::float, ?::float)
+                  ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
+                  ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
                 ) / 1609.344) AS minimum_distance_to_search_location
               SQL
               longitude, latitude

--- a/app/services/courses/school_distances_query.rb
+++ b/app/services/courses/school_distances_query.rb
@@ -47,8 +47,8 @@ module Courses
         site.latitude,
         site.longitude,
         ST_DistanceSphere(
-          ST_MakePoint(site.longitude::float, site.latitude::float),
-          ST_MakePoint(#{Float(@longitude)}, #{Float(@latitude)})
+          ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
+          ST_SetSRID(ST_MakePoint(#{Float(@longitude)}, #{Float(@latitude)}), 4326)
         ) / 1609.34 AS distance_to_search_location
       SQL
     end


### PR DESCRIPTION
## Context

This update wraps ST_MakePoint calls with
ST_SetSRID(..., 4326) across all spatial queries.

SRID 4326 corresponds to the WGS 84 coordinate system, ensuring that latitude/longitude values are interpreted correctly for accurate distance computations.

You can learn more about SRID 4326 and the WGS 84 coordinate system here:

- [PostGIS Documentation – ST_SetSRID](https://postgis.net/docs/ST_SetSRID.html)
- [PostGIS Documentation – Spatial Reference System Identifiers (SRID)](https://postgis.net/docs/using_postgis_dbmanagement.html#spatial_ref_sys)
- [EPSG:4326 on EPSG.io](https://epsg.io/4326) (Provides a visual representation and detailed metadata)
- [Wikipedia – World Geodetic System (WGS 84)](https://en.wikipedia.org/wiki/World_Geodetic_System)

## Guidance to review

1. Test the location search (for app/services/courses/nearest_school_query.rb)
2.  (add `&debug=true` to see the usage  of `app/services/courses/nearest_school_query.rb` and `app/services/courses/school_distances_query.rb`
