### PR TITLE
Enable pre filtering feature flag through /feature-flags

### DIFF
--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -5,7 +5,8 @@ class FeatureFlags
     [
       [:maintenance_mode, 'Puts Find into maintenance mode', 'Find and Publish team'],
       [:maintenance_banner, 'Displays the maintenance mode banner', 'Find and Publish team'],
-      [:bursaries_and_scholarships_announced, 'Display scholarship and bursary information', 'Find and Publish team']
+      [:bursaries_and_scholarships_announced, 'Display scholarship and bursary information', 'Find and Publish team'],
+      [:prefiltering_find_redesign, 'Prefiltering Find redesign', 'Find and Publish team']
     ]
   end
 end

--- a/app/lib/find_v1_results_constraint.rb
+++ b/app/lib/find_v1_results_constraint.rb
@@ -2,6 +2,6 @@
 
 class FindV1ResultsConstraint
   def self.matches?(_request)
-    Settings.features.v2_results.blank?
+    !FeatureFlag.active?(:prefiltering_find_redesign)
   end
 end

--- a/app/lib/find_v2_results_constraint.rb
+++ b/app/lib/find_v2_results_constraint.rb
@@ -2,6 +2,6 @@
 
 class FindV2ResultsConstraint
   def self.matches?(_request)
-    Settings.features.v2_results.present?
+    FeatureFlag.active?(:prefiltering_find_redesign)
   end
 end

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, "#{@course.name_and_code} with #{smart_quotes(@course.provider.provider_name)}" %>
 
-<% if Settings.features.v2_results.present? %>
+<% if FeatureFlag.active?(:prefiltering_find_redesign) %>
   <% if permitted_referrer? %>
     <%= content_for(:before_content) do %>
       <%= govuk_back_link(

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_title, title_with_error_prefix("Find courses by location or by training provider", flash[:error].present?) %>
 
-<% if Settings.features.v2_results.present? %>
+<% if FeatureFlag.active?(:prefiltering_find_redesign) %>
   <div class="app-homepage-search-container">
     <div class="app-homepage-search-content">
       <h1 class="govuk-heading-l">Find teacher training courses in England</h1>
@@ -172,7 +172,7 @@
   </div>
 <% end %>
 
-<% if Settings.features.v2_results.present? %>
+<% if FeatureFlag.active?(:prefiltering_find_redesign) %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <div class="quick-link-card">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,7 +82,6 @@ features:
   provider_partnerships: false
   api_summary_content_change: true
   send_request_data_to_bigquery: false
-  v2_results: false
   rollover:
     # Normally a short period of time between rollover and the next cycle
     # actually starting when it would be set to false

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -29,7 +29,6 @@ basic_auth:
 features:
   send_request_data_to_bigquery: true
   api_summary_content_change: true
-  v2_results: true
 
 find_valid_referers:
   - https://qa.find-teacher-training-courses.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -16,4 +16,3 @@ authentication:
 
 features:
   api_summary_content_change: true
-  v2_results: true

--- a/spec/system/find/v2/quick_links/primary_subjects_spec.rb
+++ b/spec/system/find/v2/quick_links/primary_subjects_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Primary subjects quick link', service: :find do
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
-    allow(Settings.features).to receive_messages(v2_results: true)
+    FeatureFlag.activate(:prefiltering_find_redesign)
   end
 
   context 'when filter by subjects' do

--- a/spec/system/find/v2/quick_links/secondary_subjects_spec.rb
+++ b/spec/system/find/v2/quick_links/secondary_subjects_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Secondary subjects quick link', service: :find do
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
-    allow(Settings.features).to receive_messages(v2_results: true)
+    FeatureFlag.activate(:prefiltering_find_redesign)
   end
 
   context 'when filter by subjects' do

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'V2 results - enabled', :js, service: :find do
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
-    allow(Settings.features).to receive_messages(v2_results: true)
+    FeatureFlag.activate(:prefiltering_find_redesign)
   end
 
   scenario 'when I filter by visa sponsorship' do

--- a/spec/system/find/v2/results/search_results_no_results_spec.rb
+++ b/spec/system/find/v2/results/search_results_no_results_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'V2 results - enabled', :js, service: :find do
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
-    allow(Settings.features).to receive_messages(v2_results: true)
+    FeatureFlag.activate(:prefiltering_find_redesign)
 
     given_courses_exist
     visit find_results_path

--- a/spec/system/find/v2/results/search_results_ordering_spec.rb
+++ b/spec/system/find/v2/results/search_results_ordering_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'V2 results ordering', :js, service: :find do
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
-    allow(Settings.features).to receive_messages(v2_results: true)
+    FeatureFlag.activate(:prefiltering_find_redesign)
 
     given_there_are_published_courses
   end

--- a/spec/system/find/v2/results/search_results_subject_and_location_spec.rb
+++ b/spec/system/find/v2/results/search_results_subject_and_location_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
 
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
-    allow(Settings.features).to receive_messages(v2_results: true)
+    FeatureFlag.activate(:prefiltering_find_redesign)
     allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache.lookup_store(:memory_store))
 
     given_courses_exist_in_various_locations

--- a/spec/system/find/v2/results/search_results_tracking_spec.rb
+++ b/spec/system/find/v2/results/search_results_tracking_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'V2 results - tracking', :js, service: :find do
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
-    allow(Settings.features).to receive_messages(v2_results: true)
+    FeatureFlag.activate(:prefiltering_find_redesign)
     allow(Settings.features).to receive(:send_request_data_to_bigquery).and_return(true)
 
     Rails.application.config.active_job.queue_adapter = :test

--- a/spec/system/find/v2/results/view_course_spec.rb
+++ b/spec/system/find/v2/results/view_course_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'V2 results - view a course', :js, service: :find do
 
   before do
     Timecop.travel(Find::CycleTimetable.mid_cycle)
-    allow(Settings.features).to receive_messages(v2_results: true)
+    FeatureFlag.activate(:prefiltering_find_redesign)
 
     given_courses_exist
     when_i_visit_the_results_page


### PR DESCRIPTION
## Context

It is better we enable or disable the prefiltering work through the browser rather than yaml file that requires a deployment.

## Changes proposed in this pull request

Visit `/feature-flags`.

<img width="897" alt="Screenshot 2025-02-21 at 10 13 30" src="https://github.com/user-attachments/assets/d401bbb0-a188-4692-b687-8ad0de2ae074" />

## Guidance to review

1. Visit `/feature-flags`.
2. Activate the  pre-filtering.
3. Visit '/'
4. Does the prefiltering work is working?
5. Deactivate the prefiltering feature flag
6. Does the old search is working?
