### PR TITLE
Use the new govuk typography scale

### DIFF
--- a/app/assets/stylesheets/govuk_style_setup.scss
+++ b/app/assets/stylesheets/govuk_style_setup.scss
@@ -1,5 +1,6 @@
 $govuk-fonts-path: "/";
 $govuk-images-path: "/";
+$govuk-new-typography-scale: true;
 
 @import "govuk-frontend/dist/govuk/all";
 @import "@ministryofjustice/frontend/moj/all";


### PR DESCRIPTION
## Context

The `govuk-frontend` library [introduced a new type scale](https://design-system.service.gov.uk/styles/type-scale/#:~:text=February%202024%3A%20GOV.UK%20Frontend,view%20the%20old%20type%20scale.) that increases the mobile text font sizes. It is currently behind a feature flag, but we should take advantage of the upcoming standard.

## Changes proposed in this pull request

- Set the `$govuk-new-typography-scale` variable to `true`.

## Guidance to review

- View the service on mobile, this is where the majority of changes should be.
  - Compare it with production on mobile.
- View the service on desktop, there should be no changes between the changes on this PR and production.
