### PR TITLE
Timecop.freeze only works reliably inside the example

### DIFF
--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -77,8 +77,8 @@ describe AuthenticationService do
           expect { subject }.to(change { user.reload.email }.to(email))
         end
 
-        Timecop.freeze do # TODO: possible race condition here
-          it 'updates the existing users email to example email' do
+        it 'updates the existing users email to example email' do
+          Timecop.freeze do
             expect { subject }.to(change { existing_user.reload.email }.to("bob_#{Time.now.to_i}_gmail.com@example.com"))
           end
         end


### PR DESCRIPTION
## Context

Misuse of Timecop.freeze leads to flaky tests.

![image](https://github.com/user-attachments/assets/7bb44ce5-8bac-4246-b513-cb155265f5b0)


## Changes proposed in this pull request

Call Timecop.freeze inside the example.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
