### PR TITLE
Convert FlashBanner type to symbol so test works properly

### DIFF
--- a/spec/components/flash_banner_spec.rb
+++ b/spec/components/flash_banner_spec.rb
@@ -11,7 +11,7 @@ describe FlashBanner do
       let(:message) { "Provider #{type}" }
       let(:flash) { ActionDispatch::Flash::FlashHash.new(type => message) }
       let(:expected_title) do
-        { success: 'Success', warning: 'Important', info: 'Important' }[type]
+        { success: 'Success', warning: 'Important', info: 'Important' }[type.to_sym]
       end
 
       before do


### PR DESCRIPTION
## Context

![image](https://github.com/user-attachments/assets/98e07223-2150-4d07-b786-3cd417784104)

## Changes proposed in this pull request

Convert FlashBanner type to symbol so test works properly
  expected_title was evaluating to nil because we indexed the hash which
  has symbol keys with a string


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
