### PR TITLE
Add Engineers teach physics filter

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -42,6 +42,7 @@ module Find
           :provider_code,
           :provider_name,
           :radius,
+          :engineers_teach_physics,
           :send_courses,
           :sortby,
           :subject_code,

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -18,6 +18,7 @@ module Courses
     attribute :location
     attribute :longitude
     attribute :minimum_degree_required
+    attribute :engineers_teach_physics
     attribute :order
     attribute :provider_code
     attribute :provider_name
@@ -137,6 +138,18 @@ module Courses
       end
     end
 
+    PHYSICS_SUBJECT_CODE = 'F3'
+
+    def search_for_physics?
+      PHYSICS_SUBJECT_CODE.in?(Array(subjects)) || subject_code == PHYSICS_SUBJECT_CODE
+    end
+
+    def engineers_teach_physics
+      return unless search_for_physics?
+
+      super
+    end
+
     private
 
     def transform_old_parameters(params)
@@ -151,6 +164,8 @@ module Courses
     def inject_defaults(params)
       params.tap do
         params[:radius] = (radius if location.present?)
+
+        params[:engineers_teach_physics] = nil unless search_for_physics?
       end
     end
 

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -27,6 +27,7 @@ module Courses
 
     def call
       @scope = visa_sponsorship_scope
+      @scope = engineers_teach_physics_scope
       @scope = subjects_scope
       @scope = study_modes_scope
       @scope = qualifications_scope
@@ -66,6 +67,14 @@ module Courses
             can_sponsor_skilled_worker_visa: true
           )
         )
+    end
+
+    def engineers_teach_physics_scope
+      return @scope if params[:engineers_teach_physics].blank?
+
+      @applied_scopes[:engineers_teach_physics] = params[:engineers_teach_physics]
+
+      @scope.where(campaign_name: Course.campaign_names[:engineers_teach_physics])
     end
 
     def subjects_scope

--- a/app/views/find/v2/results/filters/_all.html.erb
+++ b/app/views/find/v2/results/filters/_all.html.erb
@@ -1,0 +1,78 @@
+<div class="app-filter__content">
+  <%= form.govuk_submit "Apply filters", name: "utm_medium", value: "apply_filters_top" %>
+
+  <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_search_form.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.can_sponsor_visa"), size: "s" } %>
+  <% end %>
+
+  <% if @search_courses_form.search_for_physics? %>
+    <%= form.govuk_check_boxes_fieldset :engineers_teach_physics, multiple: false, legend: { text: t("helpers.legend.courses_search_form.engineers_teach_physics_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+      <%= form.govuk_check_box :engineers_teach_physics, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.engineers_teach_physics"), size: "s" } %>
+    <% end %>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :primary_subjects, legend: { text: t("helpers.legend.courses_search_form.primary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.primary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group" } do %>
+    <div class="scrollable-filter primary-scrollable-filter">
+      <% form.object.primary_subjects.each do |subject| %>
+        <%= form.govuk_check_box :subjects,
+        subject.subject_code,
+        label: { text: subject.subject_name } %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :secondary_subjects, legend: { text: t("helpers.legend.courses_search_form.secondary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.secondary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group", data: { controller: "filter-search" } } do %>
+    <div class="filter-search scrollable-filter secondary-scrollable-filter" data-filter-search-target="optionsList">
+      <% form.object.secondary_subjects.each do |subject| %>
+        <%= form.govuk_check_box :subjects,
+        subject.subject_code,
+        label: { text: subject.subject_name } %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :study_types, legend: { text: t("helpers.legend.courses_search_form.study_type_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_check_box :study_types, "full_time", label: { text: t("helpers.label.courses_search_form.study_type_options.full_time"), size: "s" }, include_hidden: false %>
+    <%= form.govuk_check_box :study_types, "part_time", label: { text: t("helpers.label.courses_search_form.study_type_options.part_time"), size: "s" }, include_hidden: false %>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :qualifications, legend: { text: t("helpers.legend.courses_search_form.qualifications_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_check_box :qualifications, "qts", label: { text: t("helpers.label.courses_search_form.qualification_options.qts"), size: "s" }, include_hidden: false %>
+    <%= form.govuk_check_box :qualifications, "qts_with_pgce_or_pgde", label: { text: t("helpers.label.courses_search_form.qualification_options.qts_with_pgce_or_pgde"), size: "s" }, include_hidden: false %>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :further_education, legend: { text: t("helpers.legend.courses_search_form.further_education_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.further_education"), class: "govuk-!-font-size-16" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_check_box :level, "further_education", label: { text: t("helpers.label.courses_search_form.further_education"), size: "s" }, multiple: false %>
+  <% end %>
+
+  <%= form.govuk_radio_buttons_fieldset :minimum_degree_required, legend: { text: t("helpers.legend.courses_search_form.minimum_degree_required_html"), size: "s" }, class: "app-filter__group govuk-radios--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_radio_button :minimum_degree_required, "two_one", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.two_one"), size: "s" } %>
+    <%= form.govuk_radio_button :minimum_degree_required, "two_two", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.two_two"), size: "s" } %>
+    <%= form.govuk_radio_button :minimum_degree_required, "third_class", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.third_class"), size: "s" } %>
+    <%= form.govuk_radio_button :minimum_degree_required, "pass", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.pass"), size: "s" } %>
+    <%= form.govuk_radio_button :minimum_degree_required, "no_degree_required", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.no_degree_required"), size: "s" } %>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_search_form.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.special_education_needs"), size: "s" } %>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :funding, legend: { text: t("helpers.legend.courses_search_form.funding_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_check_box :funding, "fee", label: { text: t("helpers.label.courses_search_form.funding_options.fee"), size: "s" }, include_hidden: false %>
+    <%= form.govuk_check_box :funding, "salary", label: { text: t("helpers.label.courses_search_form.funding_options.salary"), size: "s" }, include_hidden: false %>
+    <%= form.govuk_check_box :funding, "apprenticeship", label: { text: t("helpers.label.courses_search_form.funding_options.apprenticeship"), size: "s" }, include_hidden: false %>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :applications_open, multiple: false, legend: { text: t("helpers.legend.courses_search_form.applications_open_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.applications_open"), size: "s" } %>
+  <% end %>
+
+  <%= form.govuk_check_boxes_fieldset :start_date, legend: { text: t("helpers.legend.courses_search_form.start_date_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
+    <%= form.govuk_check_box :start_date, "september", label: { text: t("helpers.label.courses_search_form.start_date_options.september", recruitment_cycle_year: Settings.current_recruitment_cycle_year), size: "s" }, include_hidden: false %>
+    <%= form.govuk_check_box :start_date, "all_other_dates", label: { text: t("helpers.label.courses_search_form.start_date_options.all_other_dates"), size: "s" }, include_hidden: false %>
+  <% end %>
+
+  <div class="govuk-!-margin-top-4">
+    <%= form.govuk_submit t("helpers.submit.courses_search_form.filters"), name: "utm_medium", value: "apply_filters_bottom" %>
+  </div>
+</div>

--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -17,137 +17,66 @@
 
   <div class="app-filter-layout">
     <div class="app-filter-layout__filter app-filter">
-        <div class="app-filter__header">
-          <h2 class="govuk-heading-m">Filters</h2>
-        </div>
-
-        <div class="app-filter__content">
-          <%= form.govuk_submit "Apply filters", name: "utm_medium", value: "apply_filters_top" %>
-
-          <%= form.govuk_check_boxes_fieldset :can_sponsor_visa, multiple: false, legend: { text: t("helpers.legend.courses_search_form.can_sponsor_visa_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.can_sponsor_visa"), size: "s" } %>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :primary_subjects, legend: { text: t("helpers.legend.courses_search_form.primary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.primary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group" } do %>
-            <div class="scrollable-filter primary-scrollable-filter">
-              <% form.object.primary_subjects.each do |subject| %>
-                <%= form.govuk_check_box :subjects,
-                subject.subject_code,
-                label: { text: subject.subject_name } %>
-              <% end %>
-            </div>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :secondary_subjects, legend: { text: t("helpers.legend.courses_search_form.secondary_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.secondary"), class: "govuk-!-font-size-16" }, class: "govuk-checkboxes--small", hidden: false, multiple: false, form_group: { class: "app-filter__group", data: { controller: "filter-search" } } do %>
-            <div class="filter-search scrollable-filter secondary-scrollable-filter" data-filter-search-target="optionsList">
-              <% form.object.secondary_subjects.each do |subject| %>
-                <%= form.govuk_check_box :subjects,
-                subject.subject_code,
-                label: { text: subject.subject_name } %>
-              <% end %>
-            </div>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :study_types, legend: { text: t("helpers.legend.courses_search_form.study_type_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_check_box :study_types, "full_time", label: { text: t("helpers.label.courses_search_form.study_type_options.full_time"), size: "s" }, include_hidden: false %>
-            <%= form.govuk_check_box :study_types, "part_time", label: { text: t("helpers.label.courses_search_form.study_type_options.part_time"), size: "s" }, include_hidden: false %>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :qualifications, legend: { text: t("helpers.legend.courses_search_form.qualifications_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_check_box :qualifications, "qts", label: { text: t("helpers.label.courses_search_form.qualification_options.qts"), size: "s" }, include_hidden: false %>
-            <%= form.govuk_check_box :qualifications, "qts_with_pgce_or_pgde", label: { text: t("helpers.label.courses_search_form.qualification_options.qts_with_pgce_or_pgde"), size: "s" }, include_hidden: false %>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :further_education, legend: { text: t("helpers.legend.courses_search_form.further_education_html"), size: "s" }, hint: { text: t("helpers.hint.courses_search_form.further_education"), class: "govuk-!-font-size-16" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_check_box :level, "further_education", label: { text: t("helpers.label.courses_search_form.further_education"), size: "s" }, multiple: false %>
-          <% end %>
-
-          <%= form.govuk_radio_buttons_fieldset :minimum_degree_required, legend: { text: t("helpers.legend.courses_search_form.minimum_degree_required_html"), size: "s" }, class: "app-filter__group govuk-radios--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_radio_button :minimum_degree_required, "two_one", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.two_one"), size: "s" } %>
-            <%= form.govuk_radio_button :minimum_degree_required, "two_two", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.two_two"), size: "s" } %>
-            <%= form.govuk_radio_button :minimum_degree_required, "third_class", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.third_class"), size: "s" } %>
-            <%= form.govuk_radio_button :minimum_degree_required, "pass", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.pass"), size: "s" } %>
-            <%= form.govuk_radio_button :minimum_degree_required, "no_degree_required", label: { text: t("helpers.label.courses_search_form.minimum_degree_required_options.no_degree_required"), size: "s" } %>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :send_courses, multiple: false, legend: { text: t("helpers.legend.courses_search_form.special_education_needs_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_check_box :send_courses, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.special_education_needs"), size: "s" } %>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :funding, legend: { text: t("helpers.legend.courses_search_form.funding_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_check_box :funding, "fee", label: { text: t("helpers.label.courses_search_form.funding_options.fee"), size: "s" }, include_hidden: false %>
-            <%= form.govuk_check_box :funding, "salary", label: { text: t("helpers.label.courses_search_form.funding_options.salary"), size: "s" }, include_hidden: false %>
-            <%= form.govuk_check_box :funding, "apprenticeship", label: { text: t("helpers.label.courses_search_form.funding_options.apprenticeship"), size: "s" }, include_hidden: false %>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :applications_open, multiple: false, legend: { text: t("helpers.legend.courses_search_form.applications_open_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", hidden: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_check_box :applications_open, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.applications_open"), size: "s" } %>
-          <% end %>
-
-          <%= form.govuk_check_boxes_fieldset :start_date, legend: { text: t("helpers.legend.courses_search_form.start_date_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-            <%= form.govuk_check_box :start_date, "september", label: { text: t("helpers.label.courses_search_form.start_date_options.september", recruitment_cycle_year: Settings.current_recruitment_cycle_year), size: "s" }, include_hidden: false %>
-            <%= form.govuk_check_box :start_date, "all_other_dates", label: { text: t("helpers.label.courses_search_form.start_date_options.all_other_dates"), size: "s" }, include_hidden: false %>
-          <% end %>
-
-          <div class="govuk-!-margin-top-4">
-            <%= form.govuk_submit t("helpers.submit.courses_search_form.filters"), name: "utm_medium", value: "apply_filters_bottom" %>
-          </div>
-        </div>
+      <div class="app-filter__header">
+        <h2 class="govuk-heading-m">Filters</h2>
       </div>
 
-      <div class="app-filter-layout__content">
-        <%= render partial: "find/v2/results/courses_guidance/show" %>
+      <%= render "find/v2/results/filters/all", form: %>
+    </div>
 
-        <div class="app-search-results-controls">
-          <div class="govuk-form-group" data-controller="subjects-autocomplete">
-            <%= render DfE::Autocomplete::View.new(
-               form,
-               attribute_name: :subject_code,
-               form_field: form.govuk_select(
-                 :subject_code,
-                 options_for_select(
-                   dfe_autocomplete_options(form.object.all_subjects, synonyms_fields: %i[subject_code]),
-                   form.object.subject_code
-                 ),
-                 label: { text: t("helpers.label.courses_search_form.subject_name"), size: "s" }
-               )
-             ) %>
-          </div>
+    <div class="app-filter-layout__content">
+      <%= render partial: "find/v2/results/courses_guidance/show" %>
 
-          <%= form.govuk_text_field :location,
-            label: { text: t("helpers.label.courses_search_form.location"), size: "s" },
-            form_group: {
-              "data-controller" => "locations-autocomplete",
-              "data-locations-autocomplete-path-value" => find_geolocation_suggestions_path
-            },
-            autocomplete: "off",
-            data: { locations_autocomplete_target: "input" } %>
-
-          <%= form.govuk_collection_select :radius, form.object.radius_options, :value, :name,
-            label: { text: t("helpers.label.courses_search_form.radius"), size: "s" } %>
-
-          <details class="govuk-details" data-module="govuk-details" <%= "open" if form.object.provider_name.present? %>>
-            <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text">
-                Search by training provider
-              </span>
-            </summary>
-
-            <div class="govuk-details__text">
-              <div class="govuk-form-group" data-controller="v2-provider-autocomplete">
-                <%= render Find::AutocompleteComponent.new(
-                  form_field: form.govuk_select(
-                    :provider_code,
-                    dfe_autocomplete_options(form.object.providers_list, synonyms_fields: %i[code]),
-                    label: { text: t("helpers.label.courses_search_form.provider"), size: "s" }
-                  )
-                ) %>
-              </div>
-            </div>
-          </details>
-
-          <%= form.govuk_submit t("helpers.submit.courses_search_form.search"), name: "utm_medium", value: "search" %>
+      <div class="app-search-results-controls">
+        <div class="govuk-form-group" data-controller="subjects-autocomplete">
+          <%= render DfE::Autocomplete::View.new(
+             form,
+             attribute_name: :subject_code,
+             form_field: form.govuk_select(
+               :subject_code,
+               options_for_select(
+                 dfe_autocomplete_options(form.object.all_subjects, synonyms_fields: %i[subject_code]),
+                 form.object.subject_code
+               ),
+               label: { text: t("helpers.label.courses_search_form.subject_name"), size: "s" }
+             )
+           ) %>
         </div>
+
+        <%= form.govuk_text_field :location,
+          label: { text: t("helpers.label.courses_search_form.location"), size: "s" },
+          form_group: {
+            "data-controller" => "locations-autocomplete",
+            "data-locations-autocomplete-path-value" => find_geolocation_suggestions_path
+          },
+          autocomplete: "off",
+          data: { locations_autocomplete_target: "input" } %>
+
+        <%= form.govuk_collection_select :radius, form.object.radius_options, :value, :name,
+          label: { text: t("helpers.label.courses_search_form.radius"), size: "s" } %>
+
+        <details class="govuk-details" data-module="govuk-details" <%= "open" if form.object.provider_name.present? %>>
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Search by training provider
+            </span>
+          </summary>
+
+          <div class="govuk-details__text">
+            <div class="govuk-form-group" data-controller="v2-provider-autocomplete">
+              <%= render Find::AutocompleteComponent.new(
+                form_field: form.govuk_select(
+                  :provider_code,
+                  dfe_autocomplete_options(form.object.providers_list, synonyms_fields: %i[code]),
+                  label: { text: t("helpers.label.courses_search_form.provider"), size: "s" }
+                )
+              ) %>
+            </div>
+          </div>
+        </details>
+
+        <%= form.govuk_submit t("helpers.submit.courses_search_form.search"), name: "utm_medium", value: "search" %>
+      </div>
 
       <% if @results.present? %>
         <div class="app-search-results-header">

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -518,6 +518,7 @@ en:
     legend:
       courses_search_form:
         can_sponsor_visa_html: Visa sponsorship<span class="govuk-visually-hidden"> filter</span>
+        engineers_teach_physics_html: Engineers teach physics<span class="govuk-visually-hidden"> filter</span>
         primary_html: Primary<span class="govuk-visually-hidden"> filter</span>
         secondary_html: Secondary<span class="govuk-visually-hidden"> filter</span>
         study_type_html: Study type<span class="govuk-visually-hidden"> filter</span>
@@ -546,6 +547,7 @@ en:
         provider: Enter a provider name
         can_sponsor_visa: Only show courses with visa sponsorship
         visa_sponsorship: Only show courses that offer visa sponsorship
+        engineers_teach_physics: Only show Engineers teach physics courses
         special_education_needs: Only show courses with a SEND specialism
         applications_open: Only show courses open for applications
         study_type_options:

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -298,4 +298,72 @@ RSpec.describe Courses::SearchForm do
       end
     end
   end
+
+  describe '#search_for_physics?' do
+    context 'when subjects include physics subject' do
+      let(:form) { described_class.new(subjects: ['F3']) }
+
+      it 'returns true' do
+        expect(form.search_for_physics?).to be true
+      end
+    end
+
+    context 'when subjects include physics subject code' do
+      let(:form) { described_class.new(subject_code: 'F3') }
+
+      it 'returns true' do
+        expect(form.search_for_physics?).to be true
+      end
+    end
+
+    context 'when engineers_teach_physics is present only without physics' do
+      let(:form) { described_class.new(engineers_teach_physics: 'true') }
+
+      it 'returns false' do
+        expect(form.search_for_physics?).to be false
+      end
+    end
+
+    context 'when neither subjects include physics nor engineers_teach_physics is present' do
+      let(:form) { described_class.new(subjects: ['01']) }
+
+      it 'returns false' do
+        expect(form.search_for_physics?).to be false
+      end
+    end
+  end
+
+  describe '#engineers_teach_physics' do
+    context 'when subjects include physics subject' do
+      let(:form) { described_class.new(subjects: ['F3'], engineers_teach_physics: true) }
+
+      it 'returns true' do
+        expect(form.engineers_teach_physics).to be true
+      end
+    end
+
+    context 'when subjects include physics subject code' do
+      let(:form) { described_class.new(subject_code: 'F3', engineers_teach_physics: true) }
+
+      it 'returns true' do
+        expect(form.engineers_teach_physics).to be true
+      end
+    end
+
+    context 'when engineers_teach_physics is present only without physics' do
+      let(:form) { described_class.new(engineers_teach_physics: true) }
+
+      it 'returns false' do
+        expect(form.engineers_teach_physics).to be_nil
+      end
+    end
+
+    context 'when neither subjects include physics nor engineers_teach_physics is present' do
+      let(:form) { described_class.new(subjects: ['01']) }
+
+      it 'returns false' do
+        expect(form.engineers_teach_physics).to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -53,6 +53,49 @@ RSpec.describe Courses::Query do
       end
     end
 
+    context 'when filter for engineers teach physics' do
+      let!(:biology_course) do
+        create(
+          :course,
+          :with_full_time_sites,
+          :secondary,
+          name: 'Biology',
+          course_code: 'S872',
+          subjects: [find_or_create(:secondary_subject, :biology)]
+        )
+      end
+      let!(:physics_course) do
+        create(
+          :course,
+          :with_full_time_sites,
+          :secondary,
+          name: 'Physics',
+          course_code: 'P45D',
+          subjects: [find_or_create(:secondary_subject, :physics)]
+        )
+      end
+      let!(:engineers_teach_physics_course) do
+        create(
+          :course,
+          :with_full_time_sites,
+          :secondary,
+          :engineers_teach_physics,
+          name: 'Engineers teach physics',
+          course_code: 'ETP1',
+          subjects: [find_or_create(:secondary_subject, :physics)]
+        )
+      end
+
+      let(:params) { { engineers_teach_physics: true } }
+
+      it 'returns courses that sponsor visa' do
+        expect(results).to match_collection(
+          [engineers_teach_physics_course],
+          attribute_names: %w[id name campaign_name]
+        )
+      end
+    end
+
     context 'when filter by subject code' do
       let!(:biology) do
         create(:course, :with_full_time_sites, :secondary, name: 'Biology', subjects: [find_or_create(:secondary_subject, :biology)])

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -307,6 +307,50 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     end
   end
 
+  context 'when searching for engineers teach physics' do
+    before do
+      given_there_are_courses_with_secondary_subjects
+      and_there_are_courses_with_primary_subjects
+      when_i_visit_the_find_results_page
+    end
+
+    scenario 'when searching for physics' do
+      then_engineers_teach_physics_filter_is_not_visible
+
+      when_i_check_physics
+      and_i_apply_the_filters
+      then_engineers_teach_physics_filter_is_visible
+      and_physics_and_engineers_teach_physics_courses_are_visible
+      and_i_see_that_two_courses_are_found
+
+      when_i_check_engineers_teach_physics_only_filter
+      and_i_apply_the_filters
+      then_engineers_teach_physics_filter_is_visible
+      and_only_engineers_teach_physics_courses_are_visible
+      and_i_see_that_there_is_one_course_found
+
+      when_i_uncheck_physics
+      and_i_apply_the_filters
+      then_engineers_teach_physics_filter_is_not_visible
+      and_i_see_that_ten_courses_are_found
+    end
+
+    scenario 'when searching for physics on subjects field' do
+      then_engineers_teach_physics_filter_is_not_visible
+
+      when_i_search_for_physics_in_subjects_autocomplete
+      and_i_select_the_first_subject_suggestion
+      and_i_click_search
+      then_engineers_teach_physics_filter_is_visible
+      and_physics_and_engineers_teach_physics_courses_are_visible
+      and_i_see_that_two_courses_are_found
+
+      and_i_remove_the_subject
+      and_i_click_search
+      then_engineers_teach_physics_filter_is_not_visible
+    end
+  end
+
   scenario 'when no results' do
     when_i_visit_the_find_results_page
     then_i_see_no_courses_found
@@ -338,10 +382,12 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   end
 
   def given_there_are_courses_with_secondary_subjects
-    create(:course, :with_full_time_sites, :secondary, name: 'Biology', course_code: 'S872', subjects: [find_or_create(:secondary_subject, :biology)])
-    create(:course, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592', subjects: [find_or_create(:secondary_subject, :chemistry)])
-    create(:course, :with_full_time_sites, :secondary, name: 'Computing', course_code: 'L364', subjects: [find_or_create(:secondary_subject, :computing)])
-    create(:course, :with_full_time_sites, :secondary, name: 'Mathematics', course_code: '4RTU', subjects: [find_or_create(:secondary_subject, :mathematics)])
+    @biology_course = create(:course, :with_full_time_sites, :secondary, name: 'Biology', course_code: 'S872', subjects: [find_or_create(:secondary_subject, :biology)])
+    @chemistry_course = create(:course, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592', subjects: [find_or_create(:secondary_subject, :chemistry)])
+    @computing_course = create(:course, :with_full_time_sites, :secondary, name: 'Computing', course_code: 'L364', subjects: [find_or_create(:secondary_subject, :computing)])
+    @mathematics_course = create(:course, :with_full_time_sites, :secondary, name: 'Mathematics', course_code: '4RTU', subjects: [find_or_create(:secondary_subject, :mathematics)])
+    @physics_course = create(:course, :with_full_time_sites, :secondary, name: 'Physics', course_code: '3DDW', subjects: [find_or_create(:secondary_subject, :physics)])
+    @engineers_teach_physics_course = create(:course, :with_full_time_sites, :secondary, :engineers_teach_physics, name: 'Engineers Teach Physics', course_code: 'R232', subjects: [find_or_create(:secondary_subject, :physics)])
   end
 
   def and_there_are_courses_with_primary_subjects
@@ -934,6 +980,66 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   def and_i_see_that_six_courses_are_found
     expect(page).to have_content('6 courses found')
     expect(page).to have_title('6 courses found')
+  end
+
+  def when_i_search_for_physics_in_subjects_autocomplete
+    fill_in 'Subject', with: 'Physics'
+  end
+
+  def and_i_remove_the_subject
+    fill_in 'Subject', with: ''
+    page.find('input[name="subject_name"]').send_keys(:backspace)
+  end
+
+  def and_i_select_the_first_subject_suggestion
+    page.find('input[name="subject_name"]').native.send_keys(:return)
+  end
+
+  def and_i_click_search
+    click_link_or_button 'Search'
+  end
+
+  def then_engineers_teach_physics_filter_is_not_visible
+    expect(page).to have_no_content('Only show Engineers teach physics courses')
+  end
+
+  def when_i_check_physics
+    check 'Physics', visible: :all
+  end
+
+  def when_i_uncheck_physics
+    uncheck 'Physics', visible: :all
+  end
+
+  def and_physics_and_engineers_teach_physics_courses_are_visible
+    expect(page).to have_content(@physics_course.name_and_code)
+    expect(page).to have_content(@engineers_teach_physics_course.name_and_code)
+    expect(page).to have_no_content(@biology_course.name_and_code)
+    expect(page).to have_no_content(@chemistry_course.name_and_code)
+    expect(page).to have_no_content(@computing_course.name_and_code)
+    expect(page).to have_no_content(@mathematics_course.name_and_code)
+  end
+
+  def then_engineers_teach_physics_filter_is_visible
+    expect(page).to have_content('Only show Engineers teach physics courses')
+  end
+
+  def when_i_check_engineers_teach_physics_only_filter
+    check 'Only show Engineers teach physics courses', visible: :all
+  end
+
+  def and_only_engineers_teach_physics_courses_are_visible
+    expect(page).to have_content(@engineers_teach_physics_course.name_and_code)
+    expect(page).to have_no_content(@physics_course.name_and_code)
+    expect(page).to have_no_content(@biology_course.name_and_code)
+    expect(page).to have_no_content(@chemistry_course.name_and_code)
+    expect(page).to have_no_content(@computing_course.name_and_code)
+    expect(page).to have_no_content(@mathematics_course.name_and_code)
+  end
+
+  def and_i_see_that_ten_courses_are_found
+    expect(page).to have_content('10 courses found')
+    expect(page).to have_title('10 courses found')
   end
 
   private


### PR DESCRIPTION
## Context

Add a new filter (same as the live site).

The filter is only visible when user is searching for physics.

## Changes proposed in this pull request

<img width="258" alt="Screenshot 2025-02-24 at 18 21 02" src="https://github.com/user-attachments/assets/2b00d074-27bd-481e-bb39-4916a58f71bb" />


## Guidance to review

1. Search for physics
2. Does the new filter appears?
3. Check the new filter.
4. Does the Engineers teach Physics course appear?
5. If you uncheck Physics. 
6. Does the filter still appear?
