### PR TITLE
Watch find and publish javascript in Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,5 @@
-js: yarn build:js --watch
+js-find: yarn build:js:find --watch
+js-publish: yarn build:js:publish --watch
 css: yarn build:css --watch
 web: bin/rails server -p 3001
 worker: bundle exec sidekiq -t 25 -C config/sidekiq.yml


### PR DESCRIPTION
## Context

bin/dev that runs the Procfile.dev doesn't reload publish javascript bundle in dev because the package.json script calls two commands joined by && and only watches the last one run (find)



## Changes proposed in this pull request

  The previous command only watched the last command in the package
  script (find)

      yarn run build:js:publish && yarn run build:js:find

  We need to watch the builds separately to have them both reload

## Guidance to review


