### PR TITLE
Round up school placement distances in results summary cards

### DIFF
--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -35,7 +35,7 @@ module Courses
         t(
           '.location_value.distance',
           school_term:,
-          distance: content_tag(:span, pluralize(course.minimum_distance_to_search_location.ceil(2), 'mile'), class: 'govuk-!-font-weight-bold'),
+          distance: content_tag(:span, pluralize(course.minimum_distance_to_search_location.ceil, 'mile'), class: 'govuk-!-font-weight-bold'),
           location: content_tag(:span, sanitize(@location), class: 'govuk-!-font-weight-bold')
         ).html_safe
       else

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -156,9 +156,9 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
         course.define_singleton_method(:minimum_distance_to_search_location) { 0.2 }
       end
 
-      it_behaves_like 'school location row', :fee, 3, '0.2 miles from London'
-      it_behaves_like 'school location row', :salary, 3, '0.2 miles from London'
-      it_behaves_like 'school location row', :apprenticeship, 3, '0.2 miles from London'
+      it_behaves_like 'school location row', :fee, 3, '1 mile from London'
+      it_behaves_like 'school location row', :salary, 3, '1 mile from London'
+      it_behaves_like 'school location row', :apprenticeship, 3, '1 mile from London'
 
       it_behaves_like 'school location row', :fee, 1, 'Nearest of 1 potential placement school'
       it_behaves_like 'school location row', :fee, 3, 'Nearest of 3 potential placement schools'
@@ -177,7 +177,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
 
         it 'sanitizes user input by striping html tags' do
           expect(summary_card_content).to include(
-            '0.2 miles from alert("XSS") Nearest of 2 potential placement schools'
+            '1 mile from alert("XSS") Nearest of 2 potential placement schools'
           )
         end
       end


### PR DESCRIPTION
## Context

Showing decimal-precision distance of potential placements looks to show certainty of where a trainee could be placed. To put reduce the emphasis on distance, we want to round up the miles to the nearest whole number.

## Changes proposed in this pull request

- Round up distances in the results summary cards.

## Guidance to review

- Search a location, you should only see whole numbers in the returned results distances.
