### PR TITLE
Smart quote site name and address in SiteDecorator

### DIFF
--- a/app/components/find/courses/training_locations/view.html.erb
+++ b/app/components/find/courses/training_locations/view.html.erb
@@ -15,8 +15,8 @@
         <% course.study_sites.each do |study_site| %>
           <li>
             <p class="govuk-hint govuk-!-font-size-16">
-              <strong><%= smart_quotes(study_site.location_name) %></strong><br>
-              <%= smart_quotes(study_site.decorate.full_address) %>
+              <strong><%= study_site.decorate.location_name %></strong><br>
+              <%= study_site.decorate.full_address %>
             </p>
           </li>
         <% end %>

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
 class SiteDecorator < Draper::Decorator
+  include PublishHelper
   delegate_all
 
   def full_address(join_on_separator = ', ')
-    [object.address1, object.address2, object.address3, object.town, object.address4, object.postcode].compact_blank.join(join_on_separator).html_safe
+    smart_quotes([object.address1, object.address2, object.address3, object.town, object.address4, object.postcode].compact_blank.join(join_on_separator).html_safe)
   end
 
   def full_address_on_seperate_lines
     full_address('<br>')
+  end
+
+  def location_name
+    smart_quotes(super)
   end
 end

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -8,9 +8,9 @@
 <ul class="govuk-list govuk-list--spaced" id="course_school_placements">
   <% course.preview_site_statuses.each do |site_status| %>
     <li>
-      <strong><%= smart_quotes(site_status.site.location_name) %></strong>
+      <strong><%= site_status.site.location_name %></strong>
       <br>
-      <%= smart_quotes(site_status.site.decorate.full_address) %>
+      <%= site_status.site.decorate.full_address %>
     </li>
   <% end %>
 </ul>

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -47,8 +47,8 @@ describe Find::Courses::TrainingLocations::View, type: :component do
       end
 
       it 'renders the study site names and addresses' do
-        expect(subject).to have_css('.govuk-hint strong', text: study_site.location_name)
-        expect(subject).to have_css('.govuk-hint', text: study_site.full_address)
+        expect(subject).to have_css('.govuk-hint strong', text: study_site.decorate.location_name)
+        expect(subject).to have_css('.govuk-hint', text: study_site.decorate.full_address)
       end
     end
   end

--- a/spec/features/find/course/viewing_a_course_spec.rb
+++ b/spec/features/find/course/viewing_a_course_spec.rb
@@ -380,7 +380,7 @@ feature 'Viewing a findable course' do
       'You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.'
     )
     @course.site_statuses.new_or_running.map(&:site).uniq.each do |site|
-      expect(find_course_show_page).to have_content(smart_quotes(site.decorate.full_address))
+      expect(find_course_show_page).to have_content(site.decorate.full_address)
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1030,7 +1030,7 @@ describe Provider do
       end
 
       it 'returns the current recruitment accredited bodies' do
-        expect(subject.accredited_bodies.map(&:id)).to match(accredited_partnerships.map(&:accredited_provider_id))
+        expect(subject.accredited_bodies.map(&:id)).to match_array(accredited_partnerships.map(&:accredited_provider_id))
       end
     end
   end


### PR DESCRIPTION
## Context

We're getting flaky tests because the address of a Study site is having single quotes converted to ascii left quotes and our tests don't account for this.

I think it's better to convert the content for smart quotes in the decorator. We can assert the content rendered more easily that way

![image](https://github.com/user-attachments/assets/c3e8be32-11cd-4d44-ae5e-8439e2fc4f79)


## Changes proposed in this pull request

"smart quotify" site addres and name in the SiteDecorator

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
