### PR TITLE
Fix backlinks on course show page in Find

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -3,6 +3,8 @@
 module Find
   module V2
     class ResultsController < Find::ApplicationController
+      after_action :store_result_fullpath_for_backlinks, only: [:index]
+
       def index
         coordinates = Geolocation::CoordinatesQuery.new(params[:location]).call
 
@@ -55,6 +57,10 @@ module Find
           qualification: [],
           funding: []
         )
+      end
+
+      def store_result_fullpath_for_backlinks
+        session[:results_path] = request.fullpath
       end
     end
   end

--- a/app/helpers/find/view_helper.rb
+++ b/app/helpers/find/view_helper.rb
@@ -16,5 +16,15 @@ module Find
       request.referer.include?(request.host_with_port) ||
         Settings.find_valid_referers.any? { |url| request.referer.start_with?(url) }
     end
+
+    def course_back_link
+      referer = URI(request.referer)
+      if referer.request_uri =~ %r{^/results}
+
+        request.referer
+      elsif referer && session[:results_path] =~ %r{^/results}
+        session[:results_path]
+      end
+    end
   end
 end

--- a/app/views/find/courses/accrediting_providers/show.html.erb
+++ b/app/views/find/courses/accrediting_providers/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    href: x_find_course_page_url(
+    href: find_course_path(
       provider_code: @course.provider_code,
       course_code: @course.course_code
     ),

--- a/app/views/find/courses/providers/show.html.erb
+++ b/app/views/find/courses/providers/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    href: x_find_course_page_url(
+    href: find_course_path(
       provider_code: @course.provider_code,
       course_code: @course.course_code
     ),

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -1,11 +1,11 @@
 <%= content_for :page_title, "#{@course.name_and_code} with #{smart_quotes(@course.provider.provider_name)}" %>
 
 <% if FeatureFlag.active?(:prefiltering_find_redesign) %>
-  <% if permitted_referrer? %>
+  <% if permitted_referrer? && course_back_link %>
     <%= content_for(:before_content) do %>
       <%= govuk_back_link(
         text: t("find.courses.show.back_to_search"),
-        href: request.referer || find_results_path
+        href: course_back_link
       ) %>
     <% end %>
   <% end %>

--- a/app/views/find/placements/index.html.erb
+++ b/app/views/find/placements/index.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    href: x_find_course_page_url(
+    href: find_course_path(
       provider_code: @course.provider_code,
       course_code: @course.course_code
     ),

--- a/spec/features/find/course/viewing_a_course_spec.rb
+++ b/spec/features/find/course/viewing_a_course_spec.rb
@@ -417,11 +417,8 @@ feature 'Viewing a findable course' do
   end
 
   def then_i_should_be_on_the_course_page
-    expect(page.current_url).to eq(
-      URI.join(
-        Settings.find_url,
-        "/course/#{@course.provider_code}/#{@course.course_code}"
-      ).to_s
+    expect(page).to have_current_path(
+      find_course_path(provider_code: @course.provider_code, course_code: @course.course_code)
     )
   end
 

--- a/spec/features/find/result_page_filters/back_to_results_spec.rb
+++ b/spec/features/find/result_page_filters/back_to_results_spec.rb
@@ -83,6 +83,7 @@ RSpec.feature 'Back to results back button' do
 
   def and_i_see_the_number_of_courses
     expect(find_results_page.courses.count).to eq(2)
+    @request_uri = URI(page.current_url).request_uri
   end
 
   def i_select_a_course
@@ -102,6 +103,6 @@ RSpec.feature 'Back to results back button' do
   end
 
   def and_then_i_am_taken_back_to_the_results_page
-    expect(page).to have_current_path(find_results_path)
+    expect(page).to have_current_path(@request_uri)
   end
 end

--- a/spec/system/find/v2/results/view_course_spec.rb
+++ b/spec/system/find/v2/results/view_course_spec.rb
@@ -10,22 +10,37 @@ RSpec.describe 'V2 results - view a course', :js, service: :find do
     FeatureFlag.activate(:prefiltering_find_redesign)
 
     given_courses_exist
-    when_i_visit_the_results_page
   end
 
   scenario 'viewing a course from the search results' do
+    when_i_visit_the_results_page
     when_i_filter_for_send_courses
     and_i_search_for_art_and_design_subject
     and_i_click_search
-    and_i_click_on_the_first_result
-    and_i_am_on_the_course_page
+    when_i_click_on_the_first_result
+    then_i_am_on_the_course_page
 
+    when_i_click_on_the_provider_link
+    and_i_click_back_to_course
     when_i_click_back_to_results
     then_i_am_on_search_results_page_with_the_applied_search
   end
 
+  scenario 'navigating directly to a course' do
+    when_i_visit_a_course_page_directly
+    then_i_am_on_the_course_page
+
+    when_i_click_on_the_provider_link
+    and_i_click_back_to_course
+    then_there_is_no_back_link
+  end
+
+  def when_i_visit_a_course_page_directly
+    visit(find_course_path(provider_code: @course.provider.provider_code, course_code: @course.course_code))
+  end
+
   def given_courses_exist
-    create(
+    @course = create(
       :course,
       :with_full_time_sites,
       :secondary,
@@ -60,17 +75,29 @@ RSpec.describe 'V2 results - view a course', :js, service: :find do
     click_link_or_button 'Search'
   end
 
-  def and_i_click_on_the_first_result
+  def when_i_click_on_the_first_result
     page.first('.app-search-results').first('a').click
   end
 
-  def and_i_am_on_the_course_page
+  def when_i_click_on_the_provider_link
+    page.find_link(@course.provider.provider_name).click
+  end
+
+  def then_i_am_on_the_course_page
     expect(page).to have_current_path(
       find_course_path(
         provider_code: 'RO1',
         course_code: 'F314'
       )
     )
+  end
+
+  def and_i_click_back_to_course
+    click_link_or_button "Back to #{@course.name_and_code}"
+  end
+
+  def then_there_is_no_back_link
+    expect(page).to have_no_link('Back to search results')
   end
 
   def when_i_click_back_to_results


### PR DESCRIPTION
## Context

There is a bug in the back link on the Course show page in Find.

Normally the user arrives at the course show page via a link on the results page. If this was always the case, we could use the request referer to generate the link back to the exact results from which the user came.

However, the user may click the provider information link on the course page and then click the back button to arrive back on the course show page. At this point we have lost the original referer.


## Changes proposed in this pull request

Save the fullpath of the find search results everytime the user makes a search. Keeping this in the session means it's always available to us to generate a back link on the course show page.

## Guidance to review


https://github.com/user-attachments/assets/c1708f78-4310-4a09-af32-a59ce7a6bbc1



## Trello
https://trello.com/c/jWnGUGoE/487-bug-cant-get-back-to-search-results
