### PR TITLE
Clear the dfe-autocomplete select value on input

### DIFF
--- a/app/javascript/find/controllers/provider_autocomplete_controller.js
+++ b/app/javascript/find/controllers/provider_autocomplete_controller.js
@@ -9,6 +9,8 @@ export default class extends Controller {
   }
 
   connect () {
+    const selectEl = this.element.querySelector('select')
+
     dfeAutocompleteField(
       this.element,
       {
@@ -17,5 +19,13 @@ export default class extends Controller {
         name: 'provider_name'
       }
     )
+
+    this.element.querySelector('input').addEventListener('input', this.clearSelect.bind(this, selectEl))
+  }
+
+  clearSelect (selectEl, event) {
+    if (event.target.value === '') {
+      selectEl.value = ''
+    }
   }
 }


### PR DESCRIPTION
## Context

  when a user selects a value in the dfe-autocomplete component the
  underslying select tag has the value selected. When the text is
  removed from the input, the underlying select tag is not reset.


## Changes proposed in this pull request

  We add an event listener to the dfe-autocomplete text input on 'input'
  event and reset the select tag value to empty string (falsey).

  Ideally this should be handled by the library


## Guidance to review

The solution is copied from the subject autocomplete component. Thanks to @tomas-stefano for pointing that out


https://github.com/user-attachments/assets/18663eaf-ddfb-4b79-ac6f-d818c34f36a9



## Trello

https://trello.com/c/i421ZwzJ/485-bug-training-provider-search-persists-after-removal