### PR TITLE
Update content on new secondary subjects page

### DIFF
--- a/app/helpers/find/financial_incentive_helper.rb
+++ b/app/helpers/find/financial_incentive_helper.rb
@@ -3,6 +3,7 @@
 module Find
   module FinancialIncentiveHelper
     include ActiveSupport::NumberHelper
+    include ActionView::Helpers::TagHelper
 
     def financial_information(financial_incentive)
       return unless FeatureFlag.active?(:bursaries_and_scholarships_announced) && financial_incentive.present?
@@ -10,17 +11,19 @@ module Find
       scholarship = financial_incentive.scholarship
       bursary = financial_incentive.bursary_amount
 
-      if scholarship && bursary
-        I18n.t(
-          '.find.v2.subjects.fee_value.fee.hint.bursaries_and_scholarship_html',
-          bursary_amount: number_to_currency(bursary),
-          scholarship_amount: number_to_currency(scholarship)
-        )
-      elsif scholarship
-        I18n.t('.find.v2.subjects.fee_value.fee.hint.scholarship_only_html', scholarship_amount: number_to_currency(scholarship))
-      elsif bursary
-        I18n.t('.find.v2.subjects.fee_value.fee.hint.bursaries_only_html', bursary_amount: number_to_currency(bursary))
-      end
+      content = if scholarship && bursary
+                  I18n.t(
+                    '.find.v2.subjects.fee_value.fee.hint.bursaries_and_scholarship_html',
+                    bursary_amount: number_to_currency(bursary),
+                    scholarship_amount: number_to_currency(scholarship)
+                  )
+                elsif scholarship
+                  I18n.t('.find.v2.subjects.fee_value.fee.hint.scholarship_only_html', scholarship_amount: number_to_currency(scholarship))
+                elsif bursary
+                  I18n.t('.find.v2.subjects.fee_value.fee.hint.bursaries_only_html', bursary_amount: number_to_currency(bursary))
+                end
+
+      content_tag(:p, content, class: 'govuk-hint govuk-!-font-size-16 govuk-!-margin-top-0 govuk-!-margin-bottom-0') if content
     end
   end
 end

--- a/app/views/find/v2/secondary_subjects/index.erb
+++ b/app/views/find/v2/secondary_subjects/index.erb
@@ -18,9 +18,9 @@
 
       <%= render Shared::AdviceComponent::View.new(title: t(".financial_support.title")) do %>
         <h4 class="govuk-heading-s"><%= t(".financial_support.bursaries_and_scholarship_heading") %></h4>
-        <p><%= govuk_link_to(t(".financial_support.eligible_for_bursaries_and_scholarship"), find_track_click_path(utm_content: "secondary_bursaries_and_scholarship", url: t("find.get_into_teaching.url_bursaries_and_scholarships_support"))) %></p>
+        <p class="govuk-body"><%= govuk_link_to(t(".financial_support.eligible_for_bursaries_and_scholarship"), find_track_click_path(utm_content: "secondary_bursaries_and_scholarship", url: t("find.get_into_teaching.url_bursaries_and_scholarships_support"))) %></p>
         <h4 class="govuk-heading-s"><%= t(".financial_support.student_loans") %></h4>
-        <p><%= govuk_link_to(t(".financial_support.loans_text"), find_track_click_path(utm_content: "secondary_subjects_loans", url: t("find.get_into_teaching.url_maintenance_loans"))) %></p>
+        <p class="govuk-body"><%= govuk_link_to(t(".financial_support.loans_text"), find_track_click_path(utm_content: "secondary_subjects_loans", url: t("find.get_into_teaching.url_maintenance_loans"))) %></p>
       <% end %>
     </div>
   </div>

--- a/spec/helpers/find/financial_incentive_helper_spec.rb
+++ b/spec/helpers/find/financial_incentive_helper_spec.rb
@@ -18,7 +18,9 @@ module Find
         let(:bursary_amount) { 2000 }
 
         it 'returns formatted bursary and scholarship information' do
-          expect(helper.financial_information(financial_incentive)).to eq('Scholarships of £3,000 or bursaries of £2,000 are available')
+          expect(helper.financial_information(financial_incentive)).to have_css(
+            'p.govuk-hint', text: 'Scholarships of £3,000 or bursaries of £2,000 are available'
+          )
         end
       end
 
@@ -26,7 +28,9 @@ module Find
         let(:bursary_amount) { 5000 }
 
         it 'returns formatted bursary information' do
-          expect(helper.financial_information(financial_incentive)).to eq('Bursaries of £5,000 are available')
+          expect(helper.financial_information(financial_incentive)).to have_css(
+            'p.govuk-hint', text: 'Bursaries of £5,000 are available'
+          )
         end
       end
 
@@ -34,7 +38,9 @@ module Find
         let(:scholarship) { 5000 }
 
         it 'returns formatted scholarship information' do
-          expect(helper.financial_information(financial_incentive)).to eq('Scholarships of £5,000 are available')
+          expect(helper.financial_information(financial_incentive)).to have_css(
+            'p.govuk-hint', text: 'Scholarships of £5,000 are available'
+          )
         end
       end
 


### PR DESCRIPTION
## Context

Update content and stylings for the V2 secondary subjects page

Tickets: 
- https://trello.com/c/GfbdR0RY/499-bug-missing-class-on-secondary-subjects-page-financial-support-links
- https://trello.com/c/pEcwI96b/492-bug-secondary-subject-hint-text-not-styled-correctly

## Changes proposed in this pull request

- Ensure the financial incentive links are updated to have a class of `class="govuk-body`
- Update the secondary subject hint text to be 16px 

## Guidance to review

- Visit the secondary subjects page and check the css stylings 
