### PR TITLE
Set search radius of 50 on large geocoded areas

### DIFF
--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -116,6 +116,7 @@ module Courses
     RadiusOption = Struct.new(:value, :name, keyword_init: true)
     RADIUS_VALUES = [1, 5, 10, 15, 20, 25, 50, 100, 200].freeze
     DEFAULT_RADIUS = 10
+    LARGE_RADIUS = 50
 
     def radius_options
       RADIUS_VALUES.map do |value|
@@ -127,7 +128,9 @@ module Courses
     end
 
     def radius
-      super.presence || DEFAULT_RADIUS
+      return super if super.present?
+
+      types&.include?('administrative_area_level_2') ? LARGE_RADIUS : DEFAULT_RADIUS
     end
 
     def providers_list

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -228,6 +228,14 @@ RSpec.describe Courses::SearchForm do
       end
     end
 
+    context 'when location is provided with administrative_area_level type and no radius' do
+      let(:form) { described_class.new(location: 'Cornwall, UK', latitude: 51.53328, longitude: -0.1734435, types: %w[administrative_area_level_2]) }
+
+      it 'returns the large area radius' do
+        expect(form.search_params).to eq(location: 'Cornwall, UK', latitude: 51.53328, longitude: -0.1734435, radius: 50, types: %w[administrative_area_level_2])
+      end
+    end
+
     context 'when ordering is provided' do
       context 'when new params' do
         let(:form) { described_class.new(order: 'course_name_ascending') }


### PR DESCRIPTION
## Context

  When a user searches for Cornwall, we want to widen the default radius
  from 10 to 50 miles, otherwise many training locations in Cornwall are
  not returned in the search results

  We identify a large area by the presence of
  "administrative_area_level_2" in the types property returned by Google
  Geocoder API:

  ```
      "types": [
        "administrative_area_level_2",
        "political"
      ]
  ```


## Changes proposed in this pull request

If a course search has been made relative to a location, if the location is a large area - according to Google - we increase the search radius to 50 miles from the default 10 miles. If an explicit radius is provided, that radius is used to filter the results.

## Guidance to review


https://github.com/user-attachments/assets/a822d676-b53e-4c92-bba5-49ed47dc9fd1



## Trello 
https://trello.com/c/huzf9Dlw/484-bug-searching-for-cornwall-the-default-radius-is-10miles-should-it-be-50
