### PR TITLE
Show only open courses by default on Find searches

### DIFF
--- a/app/controllers/find/v2/primary_subjects_controller.rb
+++ b/app/controllers/find/v2/primary_subjects_controller.rb
@@ -13,7 +13,7 @@ module Find
 
       def submit
         if @form.valid?
-          redirect_to find_results_path({ subjects: @form.subjects }.merge(track_params))
+          redirect_to find_results_path({ subjects: @form.subjects, applications_open: true }.merge(track_params))
         else
           @primary_subject_options = Subject.primary
           render :index

--- a/app/controllers/find/v2/secondary_subjects_controller.rb
+++ b/app/controllers/find/v2/secondary_subjects_controller.rb
@@ -13,7 +13,7 @@ module Find
 
       def submit
         if @form.valid?
-          redirect_to find_results_path({ subjects: @form.subjects }.merge(track_params))
+          redirect_to find_results_path({ subjects: @form.subjects, applications_open: true }.merge(track_params))
         else
           @secondary_subject_options = formatted_secondary_subject_options
           render :index

--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -8,6 +8,7 @@
       <%= form_with model: @search_courses_form, scope: "", url: find_results_path, method: :get, class: "app-homepage-search-form-container" do |form| %>
         <%= form.hidden_field :utm_source, value: "home" %>
         <%= form.hidden_field :utm_medium, value: "main_search" %>
+        <%= form.hidden_field :applications_open, value: "true" %>
 
         <div class="app-homepage-search-input-container">
           <div class="app-homepage-search-input" data-controller="subjects-autocomplete">
@@ -194,7 +195,7 @@
       <%= govuk_accordion(html_attributes: { class: "accordion-without-controls" }) do |accordion| %>
         <%= accordion.with_section(heading_text: content_tag(:h3, t("find.search.tda.title"), class: "govuk-heading-m")) do %>
           <p class="govuk-body"><%= t("find.search.tda.degree") %></p>
-          <p class="govuk-body"><%= govuk_link_to(t("find.search.tda.browse_tda_courses"), find_results_path({ minimum_degree_required: "no_degree_required", utm_source: "home", utm_medium: "teacher_degree_apprenticeship_courses" })) %></p>
+          <p class="govuk-body"><%= govuk_link_to(t("find.search.tda.browse_tda_courses"), find_results_path({ minimum_degree_required: "no_degree_required", utm_source: "home", utm_medium: "teacher_degree_apprenticeship_courses", applications_open: true })) %></p>
           <p class="govuk-body"><%= t("find.search.learn_about") %> <%= govuk_link_to(t("find.search.tda.teacher_degree_apprenticeships"), t("find.get_into_teaching.url_tda")) %>.</p>
         <% end %>
 
@@ -205,6 +206,7 @@
             t("find.search.send.browse_primary_send"),
             find_results_path(
               {
+                applications_open: true,
                 send_courses: true,
                 subjects: @search_courses_form.primary_subject_codes,
                 utm_source: "home",
@@ -218,6 +220,7 @@
             t("find.search.send.browse_secondary_send"),
             find_results_path(
               {
+                applications_open: true,
                 send_courses: true,
                 subjects: @search_courses_form.secondary_subject_codes,
                 utm_source: "home",
@@ -238,7 +241,7 @@
           <h4 class="govuk-heading-s"><%= t("find.search.other_stages.further_ed.title") %></h4>
 
           <p class="govuk-body"><%= t("find.search.other_stages.further_ed.teach_young_people") %></p>
-          <p class="govuk-body"><%= govuk_link_to(t("find.search.other_stages.further_ed.browse_further_ed"), find_results_path({ level: "further_education", utm_source: "home", utm_medium: "further_education_courses" })) %></p>
+          <p class="govuk-body"><%= govuk_link_to(t("find.search.other_stages.further_ed.browse_further_ed"), find_results_path({ level: "further_education", utm_source: "home", utm_medium: "further_education_courses", applications_open: true })) %></p>
           <p class="govuk-body"><%= t("find.search.learn_about") %> <%= govuk_link_to(t("find.search.other_stages.further_ed.teaching_further_ed"), t("find.get_into_teaching.further_ed")) %>.</p>
         <% end %>
       <% end %>

--- a/spec/system/find/v2/quick_links/primary_subjects_spec.rb
+++ b/spec/system/find/v2/quick_links/primary_subjects_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe 'Primary subjects quick link', service: :find do
   end
 
   def given_there_are_courses_with_primary_subjects
-    create(:course, :with_full_time_sites, :primary, name: 'Primary', course_code: 'S872', subjects: [find_or_create(:primary_subject, :primary)])
-    create(:course, :with_full_time_sites, :primary, name: 'Primary with english', course_code: 'K592', subjects: [find_or_create(:primary_subject, :primary_with_english)])
-    create(:course, :with_full_time_sites, :primary, name: 'Primary with mathematics', course_code: 'L364', subjects: [find_or_create(:primary_subject, :primary_with_mathematics)])
-    create(:course, :with_full_time_sites, :primary, name: 'Primary with science', course_code: '4RTU', subjects: [find_or_create(:primary_subject, :primary_with_science)])
+    create(:course, :open, :with_full_time_sites, :primary, name: 'Primary', course_code: 'S872', subjects: [find_or_create(:primary_subject, :primary)])
+    create(:course, :open, :with_full_time_sites, :primary, name: 'Primary with english', course_code: 'K592', subjects: [find_or_create(:primary_subject, :primary_with_english)])
+    create(:course, :open, :with_full_time_sites, :primary, name: 'Primary with mathematics', course_code: 'L364', subjects: [find_or_create(:primary_subject, :primary_with_mathematics)])
+    create(:course, :open, :with_full_time_sites, :primary, name: 'Primary with science', course_code: '4RTU', subjects: [find_or_create(:primary_subject, :primary_with_science)])
   end
 
   def when_i_visit_the_find_homepage

--- a/spec/system/find/v2/quick_links/secondary_subjects_spec.rb
+++ b/spec/system/find/v2/quick_links/secondary_subjects_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe 'Secondary subjects quick link', service: :find do
   end
 
   def given_there_are_courses_with_secondary_subjects
-    create(:course, :with_full_time_sites, :secondary, name: 'Biology', course_code: 'S872', subjects: [find_or_create(:secondary_subject, :biology)])
-    create(:course, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592', subjects: [find_or_create(:secondary_subject, :chemistry)])
-    create(:course, :with_full_time_sites, :secondary, name: 'Computing', course_code: 'L364', subjects: [find_or_create(:secondary_subject, :computing)])
-    create(:course, :with_full_time_sites, :secondary, name: 'Mathematics', course_code: '4RTU', subjects: [find_or_create(:secondary_subject, :mathematics)])
+    create(:course, :open, :with_full_time_sites, :secondary, name: 'Biology', course_code: 'S872', subjects: [find_or_create(:secondary_subject, :biology)])
+    create(:course, :open, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592', subjects: [find_or_create(:secondary_subject, :chemistry)])
+    create(:course, :open, :with_full_time_sites, :secondary, name: 'Computing', course_code: 'L364', subjects: [find_or_create(:secondary_subject, :computing)])
+    create(:course, :open, :with_full_time_sites, :secondary, name: 'Mathematics', course_code: '4RTU', subjects: [find_or_create(:secondary_subject, :mathematics)])
   end
 
   def when_subjects_are_grouped_by_subject_groups

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -382,19 +382,19 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   end
 
   def given_there_are_courses_with_secondary_subjects
-    @biology_course = create(:course, :with_full_time_sites, :secondary, name: 'Biology', course_code: 'S872', subjects: [find_or_create(:secondary_subject, :biology)])
-    @chemistry_course = create(:course, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592', subjects: [find_or_create(:secondary_subject, :chemistry)])
-    @computing_course = create(:course, :with_full_time_sites, :secondary, name: 'Computing', course_code: 'L364', subjects: [find_or_create(:secondary_subject, :computing)])
-    @mathematics_course = create(:course, :with_full_time_sites, :secondary, name: 'Mathematics', course_code: '4RTU', subjects: [find_or_create(:secondary_subject, :mathematics)])
-    @physics_course = create(:course, :with_full_time_sites, :secondary, name: 'Physics', course_code: '3DDW', subjects: [find_or_create(:secondary_subject, :physics)])
-    @engineers_teach_physics_course = create(:course, :with_full_time_sites, :secondary, :engineers_teach_physics, name: 'Engineers Teach Physics', course_code: 'R232', subjects: [find_or_create(:secondary_subject, :physics)])
+    @biology_course = create(:course, :open, :with_full_time_sites, :secondary, name: 'Biology', course_code: 'S872', subjects: [find_or_create(:secondary_subject, :biology)])
+    @chemistry_course = create(:course, :open, :with_full_time_sites, :secondary, name: 'Chemistry', course_code: 'K592', subjects: [find_or_create(:secondary_subject, :chemistry)])
+    @computing_course = create(:course, :open, :with_full_time_sites, :secondary, name: 'Computing', course_code: 'L364', subjects: [find_or_create(:secondary_subject, :computing)])
+    @mathematics_course = create(:course, :open, :with_full_time_sites, :secondary, name: 'Mathematics', course_code: '4RTU', subjects: [find_or_create(:secondary_subject, :mathematics)])
+    @physics_course = create(:course, :open, :with_full_time_sites, :secondary, name: 'Physics', course_code: '3DDW', subjects: [find_or_create(:secondary_subject, :physics)])
+    @engineers_teach_physics_course = create(:course, :open, :with_full_time_sites, :secondary, :engineers_teach_physics, name: 'Engineers Teach Physics', course_code: 'R232', subjects: [find_or_create(:secondary_subject, :physics)])
   end
 
   def and_there_are_courses_with_primary_subjects
-    create(:course, :with_full_time_sites, :primary, name: 'Primary', course_code: 'S872', subjects: [find_or_create(:primary_subject, :primary)])
-    create(:course, :with_full_time_sites, :primary, name: 'Primary with english', course_code: 'K592', subjects: [find_or_create(:primary_subject, :primary_with_english)])
-    create(:course, :with_full_time_sites, :primary, name: 'Primary with mathematics', course_code: 'L364', subjects: [find_or_create(:primary_subject, :primary_with_mathematics)])
-    create(:course, :with_full_time_sites, :primary, name: 'Primary with science', course_code: '4RTU', subjects: [find_or_create(:primary_subject, :primary_with_science)])
+    create(:course, :open, :with_full_time_sites, :primary, name: 'Primary', course_code: 'S872', subjects: [find_or_create(:primary_subject, :primary)])
+    create(:course, :open, :with_full_time_sites, :primary, name: 'Primary with english', course_code: 'K592', subjects: [find_or_create(:primary_subject, :primary_with_english)])
+    create(:course, :open, :with_full_time_sites, :primary, name: 'Primary with mathematics', course_code: 'L364', subjects: [find_or_create(:primary_subject, :primary_with_mathematics)])
+    create(:course, :open, :with_full_time_sites, :primary, name: 'Primary with science', course_code: '4RTU', subjects: [find_or_create(:primary_subject, :primary_with_science)])
   end
 
   def given_there_are_courses_containing_all_qualifications

--- a/spec/system/find/v2/results/search_results_subject_and_location_spec.rb
+++ b/spec/system/find/v2/results/search_results_subject_and_location_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     @london_primary_course = create(
       :course,
       :primary,
+      :open,
       name: 'Primary - London',
       provider: create(:provider, provider_name: 'First university'),
       site_statuses: [create(:site_status, :findable, site: create(:site, latitude: london.latitude, longitude: london.longitude))],
@@ -151,6 +152,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     @romford_primary_course = create(
       :course,
       :primary,
+      :open,
       name: 'Primary - Romford',
       provider: create(:provider, provider_name: 'Second university'),
       site_statuses: [create(:site_status, :findable, site: create(:site, latitude: romford.latitude, longitude: romford.longitude))],
@@ -160,6 +162,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     @watford_primary_course = create(
       :course,
       :primary,
+      :open,
       name: 'Primary - Watford',
       site_statuses: [create(:site_status, :findable, site: create(:site, latitude: watford.latitude, longitude: watford.longitude))],
       subjects: [primary_subject]
@@ -169,6 +172,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
       :course,
       :primary,
       :can_not_sponsor_visa,
+      :open,
       name: 'Primary - Edinburgh',
       site_statuses: [create(:site_status, :findable, site: create(:site, latitude: edinburgh.latitude, longitude: edinburgh.longitude))],
       subjects: [primary_subject]
@@ -177,6 +181,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     @london_mathematics_course = create(
       :course,
       :secondary,
+      :open,
       name: 'Mathematics - London',
       can_sponsor_student_visa: true,
       site_statuses: [create(:site_status, :findable, site: create(:site, latitude: london.latitude, longitude: london.longitude))],
@@ -187,6 +192,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
       :course,
       :secondary,
       :can_not_sponsor_visa,
+      :open,
       name: 'Mathematics - Romford',
       site_statuses: [create(:site_status, :findable, site: create(:site, latitude: romford.latitude, longitude: romford.longitude))],
       subjects: [mathematics_subject]
@@ -196,6 +202,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
       :course,
       :secondary,
       :can_not_sponsor_visa,
+      :open,
       name: 'Mathematics - Watford',
       site_statuses: [create(:site_status, :findable, site: create(:site, latitude: watford.latitude, longitude: watford.longitude))],
       subjects: [mathematics_subject]
@@ -205,6 +212,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
       :course,
       :secondary,
       :can_not_sponsor_visa,
+      :open,
       name: 'Mathematics - Edinburgh',
       site_statuses: [create(:site_status, :findable, site: create(:site, latitude: edinburgh.latitude, longitude: edinburgh.longitude))],
       subjects: [mathematics_subject]
@@ -391,13 +399,14 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   def and_i_am_on_the_results_page_with_london_location_as_parameter
     and_i_am_on_the_results_page
 
-    expect(search_params).to eq(subject_name: '', subject_code: '', location: 'London, UK')
+    expect(search_params).to eq(applications_open: 'true', subject_name: '', subject_code: '', location: 'London, UK')
   end
 
   def and_i_am_on_the_results_page_with_mathematics_subject_and_london_location_and_sponsor_visa_as_parameter
     and_i_am_on_the_results_page
 
     expect(search_params).to eq(
+      applications_open: 'true',
       subject_name: 'Mathematics',
       subject_code: 'G1',
       location: 'London, UK',

--- a/spec/system/find/v2/results/search_results_tracking_spec.rb
+++ b/spec/system/find/v2/results/search_results_tracking_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
       :course,
       :with_full_time_sites,
       :secondary,
+      :open,
       name: 'Biology',
       course_code: '2DTK',
       provider: build(:provider, provider_name: 'London university', provider_code: '19S')
@@ -108,6 +109,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
       :with_full_time_sites,
       :published_teacher_degree_apprenticeship,
       :secondary,
+      :open,
       name: 'Mathematics',
       course_code: 'TDA1',
       provider: build(:provider, provider_name: 'Bristol university', provider_code: '23T'),
@@ -117,6 +119,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
       :course,
       :with_full_time_sites,
       :primary,
+      :open,
       :with_special_education_needs,
       name: 'Primary (SEND)',
       course_code: 'P123',
@@ -126,6 +129,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
       :course,
       :with_full_time_sites,
       :secondary,
+      :open,
       :with_special_education_needs,
       name: 'Art and design (SEND)',
       course_code: 'F314',
@@ -135,6 +139,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
     create(
       :course,
       :with_full_time_sites,
+      :open,
       name: 'Further Education',
       course_code: 'F3D',
       provider: build(:provider, provider_name: 'Birmingham university', provider_code: 'JL1'),
@@ -144,6 +149,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
       :course,
       :with_full_time_sites,
       :primary,
+      :open,
       name: 'Primary',
       course_code: 'Y565',
       provider: build(:provider, provider_name: 'Brighton university', provider_code: '1UR')
@@ -166,7 +172,11 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
       {
         total: 6,
         page: 1,
-        search_params: [{}],
+        search_params: [
+          {
+            applications_open: true
+          }
+        ],
         track_params: [
           {
             utm_source: 'home',
@@ -226,6 +236,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            applications_open: true,
             subjects: [
               '00'
             ]
@@ -270,6 +281,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            applications_open: true,
             subjects: [
               'W1'
             ]
@@ -307,6 +319,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            applications_open: true,
             minimum_degree_required: 'no_degree_required'
           }
         ],
@@ -343,6 +356,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            applications_open: true,
             subjects: Subject.primary_subject_codes,
             send_courses: true
           }
@@ -370,6 +384,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            applications_open: true,
             subjects: Subject.secondary_subject_codes_with_incentives,
             send_courses: true
           }
@@ -402,6 +417,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            applications_open: true,
             level: 'further_education'
           }
         ],


### PR DESCRIPTION
## Context

Same as the live site, the applications open filter should be on by default.

## Guidance to review

1. Click in all homepage links (include the main search).
2. Does the applications open filter is on by default?


