### PR TITLE
Show filter button when there are no results

### DIFF
--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -130,6 +130,10 @@
         <%= render partial: "find/v2/results/courses_guidance/show" %>
         <%= govuk_pagination(pagy: @pagy) %>
       <% else %>
+        <button type="button" class="govuk-button govuk-button--secondary app-filter__toggle govuk-!-margin-top-5" aria-haspopup="true" aria-expanded="false" data-visibility-target="trigger" data-action="visibility#show">
+          Filter results
+        </button>
+
         <%= render Courses::NoResultsComponent.new(
           country: @search_params[:country],
           minimum_degree_required: @search_params[:minimum_degree_required],


### PR DESCRIPTION
## Context

When a user filters results and there are none left, the sort and filter buttons disappear. We have no need to change the sort order of 0 results, but we may want to change filters to get some results.

## Changes proposed in this pull request

- Add the filter button to the no results condition

## Guidance to review

- Try searching for something with no results, e.g. Ancient Greek.
- You should see the filter button.
