### PR TITLE
Update salary details on course details page to match results page

### DIFF
--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -154,13 +154,11 @@ module Courses
     end
 
     def uk_fees(fee_uk = enrichment.fee_uk_eu)
-      t('.fee_value.fee.uk_fees_html', value: content_tag(:b, number_to_currency(fee_uk.to_f)))
+      t('.fee_value.fee.uk_fees_html', value: content_tag(:b, number_to_currency(fee_uk.to_f))) if fee_uk.present?
     end
 
     def international_fees(fee_international = enrichment.fee_international)
-      return if fee_international.blank?
-
-      t('.fee_value.fee.international_fees_html', value: content_tag(:b, number_to_currency(fee_international.to_f)))
+      t('.fee_value.fee.international_fees_html', value: content_tag(:b, number_to_currency(fee_international.to_f))) if fee_international.present?
     end
 
     def hide_fee_hint?

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -4,21 +4,12 @@
 
 <%= govuk_summary_list(actions: false) do |summary_list| %>
   <% summary_list.with_row do |row| %>
-    <% row.with_key(text: t(".course_fee")) %>
+    <% row.with_key(text: t(".fee_key")) %>
     <% row.with_value do %>
-      <% if course.salaried? %>
-      <%= t(".pays_salary_html") %>
-        <% if course.apprenticeship? %>
-        <%= t(".teaching_apprenticeship") %>
-        <% end %>
-        <br>
-        <span class="govuk-hint govuk-!-font-size-16"><%= t(".no_fee") %></span>
-      <% elsif course.apprenticeship? %>
-        <%= t(".pays_salary_html") %>
-        <span class="govuk-hint govuk-!-font-size-16"><%= t(".no_fee") %></span>
-      <% else %>
-        <%= course.course_fee_content %>
-        <div><span class="govuk-hint govuk-!-font-size-16"><%= course.funding_option %></span></div>
+      <%= fee_value %>
+
+      <% if fee_hint.present? %>
+        <div class="govuk-hint govuk-!-font-size-16"><%= fee_hint %></div>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -31,6 +31,36 @@ module Find
           @course = course
         end
 
+        def fee_value
+          if course.salary? || course.apprenticeship?
+            t(".fee_value.#{course.funding}")
+          else
+            safe_join([uk_fees, international_fees].compact_blank, tag.br)
+          end
+        end
+
+        def fee_hint
+          return if course.salary? || course.apprenticeship? || hide_fee_hint?
+
+          if financial_incentive.bursary_amount.present? && financial_incentive.scholarship.present?
+            t(
+              '.fee_value.fee.hint.bursaries_and_scholarship_html',
+              bursary_amount: number_to_currency(financial_incentive.bursary_amount),
+              scholarship_amount: number_to_currency(financial_incentive.scholarship)
+            )
+          elsif financial_incentive.bursary_amount.present?
+            t(
+              '.fee_value.fee.hint.bursaries_only_html',
+              bursary_amount: number_to_currency(financial_incentive.bursary_amount)
+            )
+          elsif financial_incentive.scholarship.present?
+            t(
+              '.fee_value.fee.hint.scholarship_only_html',
+              scholarship_amount: number_to_currency(financial_incentive.scholarship)
+            )
+          end
+        end
+
         def age_range_in_years_row
           if secondary_course?
             "#{age_range_in_years.humanize} - #{level}"
@@ -55,6 +85,67 @@ module Find
 
         def show_apply_from_row?
           course.applications_open_from&.future?
+        end
+
+        private
+
+        def uk_fees(fee_uk = course.enrichment_attribute(:fee_uk_eu))
+          t('.fee_value.fee.uk_fees_html', value: content_tag(:b, number_to_currency(fee_uk.to_f))) if fee_uk.present?
+        end
+
+        def international_fees(fee_international = course.enrichment_attribute(:fee_international))
+          t('.fee_value.fee.international_fees_html', value: content_tag(:b, number_to_currency(fee_international.to_f))) if fee_international.present?
+        end
+
+        def hide_fee_hint?
+          !bursary_and_scholarship_flag_active_or_preview? ||
+            (search_by_visa_sponsorship? && !physics? && !languages?) ||
+            financial_incentive.blank?
+        end
+
+        def bursary_and_scholarship_flag_active_or_preview?
+          FeatureFlag.active?(:bursaries_and_scholarships_announced)
+        end
+
+        def search_by_visa_sponsorship?
+          @visa_sponsorship.present?
+        end
+
+        def main_subject
+          @main_subject ||= Subject.find_by(id: course.master_subject_id)
+        end
+
+        PHYSICS_SUBJECT = 'Physics'
+        private_constant :PHYSICS_SUBJECT
+
+        def physics?
+          main_subject&.subject_name == PHYSICS_SUBJECT
+        end
+
+        LANGUAGE_SUBJECTS = [
+          'Ancient Greek',
+          'Ancient Hebrew',
+          'English',
+          'English as a second or other language',
+          'French',
+          'German',
+          'Italian',
+          'Japanese',
+          'Latin',
+          'Mandarin',
+          'Modern Languages',
+          'Modern languages (other)',
+          'Russian',
+          'Spanish'
+        ].freeze
+        private_constant :LANGUAGE_SUBJECTS
+
+        def languages?
+          main_subject&.subject_name.in?(LANGUAGE_SUBJECTS)
+        end
+
+        def financial_incentive
+          @financial_incentive ||= main_subject&.financial_incentive
         end
       end
     end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -74,14 +74,6 @@ class CourseDecorator < ApplicationDecorator
     object.is_send? ? 'Yes' : 'No'
   end
 
-  def funding
-    {
-      'salary' => 'Salary',
-      'apprenticeship' => 'Teaching apprenticeship - with salary',
-      'fee' => 'Fee - no salary'
-    }[object.funding]
-  end
-
   def subject_name
     if object.subjects.size == 1
       object.course_subjects.first.subject.subject_name

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -74,7 +74,7 @@
 
      summary_list.with_row(html_attributes: { data: { qa: "course__funding" } }) do |row|
        row.with_key { "Funding type" }
-       row.with_value { course.funding }
+       row.with_value { Course.human_attribute_name("funding.#{course.funding}") }
 
        if course.cannot_change_funding_type?
          row.with_action

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -81,7 +81,7 @@
 
         <% summary_list.with_row(html_attributes: { data: { qa: "course__funding_type" } }) do |row| %>
           <% row.with_key { "Funding type" } %>
-          <% row.with_value { course.funding } %>
+          <% row.with_value { Course.human_attribute_name("funding.#{course.funding}") if course.funding.present? } %>
           <% unless course.teacher_degree_apprenticeship?
                row.with_action(
             href: new_publish_provider_recruitment_cycle_courses_funding_type_path(course.provider.provider_code, course.recruitment_cycle.year, params.to_unsafe_h.merge(goto_visa: true, goto_confirmation: true)),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -855,6 +855,10 @@ en:
     attributes:
       course:
         name: "Title"
+      course/funding:
+        salary: Salary
+        apprenticeship: Salary (apprenticeship)
+        fee: Fee - no salary
       provider:
         scitt: "SCITT"
         lead_school: "Lead school"

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -14,11 +14,11 @@ en:
       location_value:
         not_listed: Not listed yet
         school_term:
-          fee: 'placement'
-          default: 'employing'
+          fee: "placement"
+          default: "employing"
         potential_schools:
-          one: '1 potential %{school_term} school'
-          other: '%{count} potential %{school_term} schools'
+          one: "1 potential %{school_term} school"
+          other: "%{count} potential %{school_term} schools"
         distance: "%{distance} from %{location}"
         distance_hint_html:
           one: "Nearest of %{count} potential %{school_term} school"
@@ -28,12 +28,12 @@ en:
         salary: Salary
         apprenticeship: Salary (apprenticeship)
         fee:
-          uk_fees_html: '%{value} for UK citizens'
-          international_fees_html: '%{value} for Non-UK citizens'
+          uk_fees_html: "%{value} for UK citizens"
+          international_fees_html: "%{value} for Non-UK citizens"
           hint:
-            bursaries_and_scholarship_html: 'Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available'
-            bursaries_only_html: 'Bursaries of %{bursary_amount} are available'
-            scholarship_only_html: 'Scholarships of %{scholarship_amount} are available'
+            bursaries_and_scholarship_html: "Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available"
+            bursaries_only_html: "Bursaries of %{bursary_amount} are available"
+            scholarship_only_html: "Scholarships of %{scholarship_amount} are available"
       length_key: Course length
       length_value:
         OneYear: 1 year
@@ -50,10 +50,10 @@ en:
       degree_requirements_key: Degree required
       degree_requirements_value:
         postgraduate:
-          two_one: '2:1 bachelor’s degree'
-          two_two: '2:2 bachelor’s degree'
-          third_class: 'Bachelor’s degree'
-          not_required: 'Bachelor’s degree'
+          two_one: "2:1 bachelor’s degree"
+          two_two: "2:2 bachelor’s degree"
+          third_class: "Bachelor’s degree"
+          not_required: "Bachelor’s degree"
         undergraduate:
           not_required: No degree required
       degree_requirements_hint:
@@ -62,21 +62,19 @@ en:
         two_two:
           <<: *two_one_html
         third_class:
-          html:
-            <br>
+          html: <br>
             <span class="govuk-hint govuk-!-font-size-16">
-              or equivalent qualification
+            or equivalent qualification
             </span>
             <br>
             <br>
             <span class="govuk-hint govuk-!-font-size-16">
-              This should be an honours degree (Third or above), or equivalent
+            This should be an honours degree (Third or above), or equivalent
             </span>
         not_required:
-          html:
-            <br>
+          html: <br>
             <span class="govuk-hint govuk-!-font-size-16">
-              or equivalent qualification
+            or equivalent qualification
             </span>
       visa_sponsorship_key: Visa sponsorship
       visa_sponsorship_value:
@@ -91,13 +89,13 @@ en:
       devolved_nation:
         heading: This service is for courses in England
         northern_ireland:
-          link_content: 'Learn more about teacher training in Northern Ireland'
+          link_content: "Learn more about teacher training in Northern Ireland"
           link: https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland
         scotland:
-          link_content: 'Learn more about teacher training in Scotland'
+          link_content: "Learn more about teacher training in Scotland"
           link: https://teachinscotland.scot
         wales:
-          link_content: 'Learn more about teacher training in Wales'
+          link_content: "Learn more about teacher training in Wales"
           link: https://educators.wales/teacher
       undergraduate:
         message_html: There are not many teacher degree apprenticeship (TDA) courses on the service at the moment. You can try again soon when there may be more courses, or get in touch with us at %{contact}.
@@ -308,9 +306,7 @@ en:
           pays_salary_html: This course pays a <strong>salary</strong>
           teaching_apprenticeship: It is a teaching apprenticeship
           no_fee: There is no fee
-          fee_or_salary: Fee or salary
           course_summary: Course summary
-          course_fee: Course fee
           course_length: Course length
           age_range: Age range
           date_can_apply: Date you can apply from
@@ -320,6 +316,17 @@ en:
           accredited_by: Accredited by
           for_uk_citizens: for UK citizens
           for_non_uk_citizens: for Non-UK citizens
+          fee_key: Fee or salary
+          fee_value:
+            salary: Salary
+            apprenticeship: Salary (apprenticeship)
+            fee:
+              uk_fees_html: "%{value} for UK citizens"
+              international_fees_html: "%{value} for Non-UK citizens"
+              hint:
+                bursaries_and_scholarship_html: "Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available"
+                bursaries_only_html: "Bursaries of %{bursary_amount} are available"
+                scholarship_only_html: "Scholarships of %{scholarship_amount} are available"
       providers:
         show:
           heading: About %{provider_name}
@@ -493,9 +500,9 @@ en:
         fee_value:
           fee:
             hint:
-              bursaries_and_scholarship_html: 'Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available'
-              bursaries_only_html: 'Bursaries of %{bursary_amount} are available'
-              scholarship_only_html: 'Scholarships of %{scholarship_amount} are available'
+              bursaries_and_scholarship_html: "Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available"
+              bursaries_only_html: "Bursaries of %{bursary_amount} are available"
+              scholarship_only_html: "Scholarships of %{scholarship_amount} are available"
       primary_subjects:
         index:
           page_title: Browse primary courses
@@ -568,7 +575,7 @@ en:
           salary: Salary
           apprenticeship: Teaching apprenticeship - with salary
         start_date_options:
-          september: 'September %{recruitment_cycle_year}'
+          september: "September %{recruitment_cycle_year}"
           all_other_dates: All other dates
         ordering:
           location: Sorted by distance

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -12,7 +12,7 @@ module Find
 
           result = render_inline(described_class.new(course))
           expect(result.text).to include(
-            'Course fee',
+            'Fee or salary',
             'Course length',
             'Age range',
             'Qualification',
@@ -28,9 +28,8 @@ module Find
 
             result = render_inline(described_class.new(course))
             expect(result.text).not_to include('£9,250')
-            expect(result.text).to include('Course fee')
-            expect(result.text).to include('This course pays a salary')
-            expect(result.text).to include('It is a teaching apprenticeship')
+            expect(result.text).to include('Fee or salary')
+            expect(result.text).to include('Salary (apprenticeship)')
           end
         end
 
@@ -142,8 +141,8 @@ module Find
             course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_uk_eu: 9250)]).decorate
 
             result = render_inline(described_class.new(course))
+            expect(result.text).to include('Fee or salary')
             expect(result.text).to include('£9,250 for UK citizens')
-            expect(result.text).to include('Course fee')
           end
         end
 
@@ -186,7 +185,7 @@ module Find
 
             expect(result.text).not_to include('for UK citizens')
             expect(result.text).not_to include('£14,000 for Non-UK citizens')
-            expect(result.text).to include('Course fee')
+            expect(result.text).to include('Fee or salary')
           end
         end
       end

--- a/spec/features/find/course/viewing_a_course_spec.rb
+++ b/spec/features/find/course/viewing_a_course_spec.rb
@@ -20,6 +20,7 @@ feature 'Viewing a findable course' do
       Timecop.freeze(Find::CycleTimetable.apply_deadline - 1.hour) do
         when_i_visit_the_course_page
         then_i_should_see_the_course_information
+        and_i_should_see_funding_options
       end
     end
 
@@ -232,10 +233,6 @@ feature 'Viewing a findable course' do
     )
 
     expect(find_course_show_page).to have_content(
-      @course.decorate.funding_option
-    )
-
-    expect(find_course_show_page).to have_content(
       '1 year - full time'
     )
 
@@ -319,6 +316,10 @@ feature 'Viewing a findable course' do
     expect(find_course_show_page).not_to have_end_of_cycle_notice
 
     expect(find_course_show_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/candidate/find-feedback?path=/course/#{provider.provider_code}/#{@course.course_code}&find_controller=find/courses")
+  end
+
+  def and_i_should_see_funding_options
+    expect(find_course_show_page).to have_content('Bursaries of £4,000 and scholarships of £2,000 are available to eligible trainees.')
   end
 
   def then_i_should_not_see_the_apply_button

--- a/spec/features/publish/courses/new_tda_course_enrichments_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_enrichments_spec.rb
@@ -376,7 +376,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   def and_i_can_not_change_funding_type
     expect(
       publish_course_confirmation_page.details.funding_type.value.text
-    ).to eq('Teaching apprenticeship - with salary')
+    ).to eq('Salary (apprenticeship)')
 
     expect(
       publish_course_confirmation_page.details.funding_type.text

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -369,7 +369,7 @@ feature 'Adding a teacher degree apprenticeship course', :can_edit_current_and_n
   def and_i_can_not_change_funding_type
     expect(
       publish_course_confirmation_page.details.funding_type.value.text
-    ).to eq('Teaching apprenticeship - with salary')
+    ).to eq('Salary (apprenticeship)')
 
     expect(
       publish_course_confirmation_page.details.funding_type.text

--- a/spec/features/publish/viewing_a_course_details_spec.rb
+++ b/spec/features/publish/viewing_a_course_details_spec.rb
@@ -143,7 +143,7 @@ feature 'Course show' do
     )
 
     expect(publish_provider_courses_details_page.funding).to have_content(
-      'Teaching apprenticeship - with salary'
+      'Salary (apprenticeship)'
     )
     expect(publish_provider_courses_details_page.accredited_provider).to have_content(
       course.accrediting_provider.provider_name

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -211,10 +211,6 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
     )
 
     expect(publish_course_preview_page).to have_content(
-      decorated_course.funding_option
-    )
-
-    expect(publish_course_preview_page).to have_content(
       'Up to 2 years - full time'
     )
     expect(publish_course_preview_page).to have_content(
@@ -469,7 +465,8 @@ feature 'Course show', { can_edit_current_and_next_cycles: false } do
   end
 
   def and_i_do_not_see_financial_support
-    expect(publish_course_preview_page).not_to have_scholarship_amount
+    expect(publish_course_preview_page).to have_no_content('Bursaries')
+    expect(publish_course_preview_page).to have_no_content('Scholarships')
   end
 
   def then_i_should_be_on_the_school_placements_page


### PR DESCRIPTION
## Context

The salary details of a course in the course details page currently has 1) Incorrect grammar (missing period) and 2) Mentions there are no fees for Salaried courses, which can be incorrect.

## Changes proposed in this pull request

- Change the course details page salary information to match the v2 results page.

## Guidance to review

- Search for salary, fee, and, apprenticeship courses.
- Check the inner page details match the results page details - specifically the salary or fee part.
- https://trello.com/c/2mecaJDh/480-grammar-on-course-fee-content-for-salaried-apprenticeship-bug-party-1-2025-content-feedback
