### PR TITLE
Make sure all old parameters work with the prefiltering work

### DIFF
--- a/app/controllers/find/v2/results_controller.rb
+++ b/app/controllers/find/v2/results_controller.rb
@@ -6,7 +6,7 @@ module Find
       after_action :store_result_fullpath_for_backlinks, :send_analytics_event, only: [:index]
 
       def index
-        coordinates = Geolocation::CoordinatesQuery.new(params[:location]).call
+        coordinates = Geolocation::CoordinatesQuery.new(location_params).call
 
         @search_courses_form = ::Courses::SearchForm.new(search_courses_params.merge(coordinates))
         @search_params = @search_courses_form.search_params
@@ -41,6 +41,7 @@ module Find
           :level,
           :location,
           :longitude,
+          :lq,
           :minimum_degree_required,
           :order,
           :provider_code,
@@ -54,11 +55,16 @@ module Find
           :university_degree_status,
           subjects: [],
           start_date: [],
+          study_type: [],
           study_types: [],
           qualifications: [],
           qualification: [],
           funding: []
         )
+      end
+
+      def location_params
+        params[:location] || params[:lq]
       end
 
       def store_result_fullpath_for_backlinks

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Courses::SearchForm do
       end
     end
 
+    context 'when study_types is an old parameter' do
+      let(:form) { described_class.new(study_type: %w[full_time part_time]) }
+
+      it 'returns the correct search params with study_types as an array' do
+        expect(form.search_params).to eq({ study_types: %w[full_time part_time] })
+        expect(form.study_types).to eq(%w[full_time part_time])
+      end
+    end
+
     context 'when further education is provided' do
       context 'when new level params' do
         let(:form) { described_class.new(level: 'further_education') }
@@ -53,11 +62,21 @@ RSpec.describe Courses::SearchForm do
         end
       end
 
-      context 'when old qualification params is used as string' do
+      context 'when old qualification params is used as array' do
         let(:form) { described_class.new(qualification: ['pgce pgde']) }
 
         it 'returns level search params' do
           expect(form.search_params).to eq({ level: 'further_education' })
+        end
+      end
+
+      context 'when all old qualification params is used' do
+        let(:form) { described_class.new(qualification: ['qts', 'pgce_with_qts', 'pgce pgde']) }
+
+        it 'returns level search params' do
+          expect(form.search_params).to eq({ qualifications: %w[qts qts_with_pgce_or_pgde], level: 'further_education' })
+          expect(form.qualifications).to eq(%w[qts qts_with_pgce_or_pgde])
+          expect(form.level).to eq('further_education')
         end
       end
     end
@@ -371,6 +390,24 @@ RSpec.describe Courses::SearchForm do
 
       it 'returns false' do
         expect(form.engineers_teach_physics).to be_nil
+      end
+    end
+  end
+
+  describe '#location' do
+    context 'when location is the old parameter' do
+      let(:form) { described_class.new(lq: 'London NW9, UK') }
+
+      it 'returns the correct search params with location details' do
+        expect(form.location).to eq('London NW9, UK')
+      end
+    end
+
+    context 'when location is set' do
+      let(:form) { described_class.new(location: 'London NW9, UK') }
+
+      it 'returns the correct search params with location details' do
+        expect(form.location).to eq('London NW9, UK')
       end
     end
   end


### PR DESCRIPTION
## Context

After went through a CSV from Logit to get all parameters from the prod requests I saw some bugs around backwards compatibility:

* qualification is now qualifications
* study_type is now study_types
* lq is now location

Also there are values conversion for more meaninful values

## Guidance to review

1. Visit the live site and go to the results page
2. Check all filters
3. Copy and paste the url (without the domain) to the review app and see the filters applied.
4. Do the same for search by provider
5. Do the same for search by location 
