### PR TITLE
Increase the number of pods

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -8,7 +8,7 @@
   "resource_group_name": "s189p01-ptt-pd-rg",
   "main_app": {
     "main": {
-      "replicas": 4,
+      "replicas": 6,
       "max_memory": "3Gi"
     }
   },


### PR DESCRIPTION
## Context

Next week we are releasing pre-filtering work and we are slightly increasing the number of pods.

The new /results page on Find needs to hit Google API for the location searches on the first time only, then it caches for 30 days. This is IO bound but with 5 concurrency as limitation, a low risk but better to increase slightly for the first week and decrease if needed after.

Increasing the number of pods slightly just as manner of cautious while we monitor the DB CPU and application performance next week.

