### PR TITLE
rubocop-rails and rspec should use plugin format

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,11 @@
-require:
+plugins:
   - rubocop-rails
   - rubocop-rspec
-  - rubocop-rspec_rails
+
+require:
   - rubocop-capybara
   - rubocop-factory_bot
+  - rubocop-rspec_rails
 
 inherit_from:
   - ./config/rubocop/layout.yml


### PR DESCRIPTION
## Context

   rubocop-rspec extension supports plugin, specify `plugins:
  rubocop-rspec` instead of `require: rubocop-rspec` in
  /.../publish-teacher-training/.rubocop.yml.
  For more information, see
  https://docs.rubocop.org/rubocop/plugin_migration_guide.html.


## Changes proposed in this pull request

There are PRs on rubocop-capybara and rubycop-factory_bot to migrate those projects to the plugin system but they have not been released yet

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
