### PR TITLE
Remove include blank from sorting results

### DIFF
--- a/app/views/find/v2/results/index.html.erb
+++ b/app/views/find/v2/results/index.html.erb
@@ -97,8 +97,7 @@
                   :id,
                   :name,
                   label: { text: t("helpers.label.courses_search_form.ordering.non_location"), class: "govuk-!-display-inline-block" },
-                  role: "listbox", form_group: {},
-                  options: { include_blank: true }
+                  role: "listbox", form_group: {}
                 ) %>
 
               <%= form.govuk_submit t("helpers.submit.courses_search_form.order", class: "govuk-!-display-inline-block"), name: "utm_medium", value: "sort" %>

--- a/spec/system/find/v2/results/search_results_tracking_spec.rb
+++ b/spec/system/find/v2/results/search_results_tracking_spec.rb
@@ -440,6 +440,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            order: 'course_name_ascending',
             subjects: ['00']
           }
         ],
@@ -474,6 +475,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            order: 'course_name_ascending',
             subjects: ['00']
           }
         ],
@@ -522,6 +524,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
         page: 1,
         search_params: [
           {
+            order: 'course_name_ascending',
             subject_code: 'W1',
             subject_name: 'Art and design',
             send_courses: true

--- a/spec/system/find/v2/results/view_course_spec.rb
+++ b/spec/system/find/v2/results/view_course_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'V2 results - view a course', :js, service: :find do
         subject_code: 'W1',
         location: '',
         radius: '10',
-        order: '',
+        order: 'course_name_ascending',
         provider_name: '',
         provider_code: ''
       }


### PR DESCRIPTION
## Context

When I search for without a location, the sort dropdown appear correctly. However it does not have a label to indicate how the list of sorted on default load of the page.

## Changes proposed in this pull request

Remove the include blank option on ordering.

## Guidance to review

1. Visit /results
2. Change options around sorting.
