### PR TITLE
Atomic accredited provider demotion

### DIFF
--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -37,6 +37,7 @@ module Support
 
     validates :provider_type, presence: true
     validate :provider_type_school_is_an_invalid_accredited_provider
+    validate :provider_cannot_be_demoted_with_open_courses
 
     validates :urn, presence: true, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: :invalid }, if: -> { !accredited? && lead_school? }
 
@@ -69,6 +70,10 @@ module Support
 
     def provider_code_taken
       errors.add(:provider_code, :taken) if providers.exists?(provider_code:)
+    end
+
+    def provider_cannot_be_demoted_with_open_courses
+      errors.add(:provider_type, :provider_cannot_be_demoted_with_open_courses) if !accredited? && provider.accredited? && provider.courses.published.exists?
     end
 
     def provider_type_school_is_an_invalid_accredited_provider

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,7 +79,7 @@ feedback:
   link: https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-SKECobyE75EtuJMp8rYxZtURTNaTTJaTVhBQlQzM1RESTJDVlBERk1JQS4u
 
 features:
-  provider_partnerships: false
+  provider_partnerships: true
   api_summary_content_change: true
   send_request_data_to_bigquery: false
   rollover:


### PR DESCRIPTION
## Context

Currently we can demote (remove accredited status) from a provider when they are running courses.
This will leave the courses in an invalid, unratified state.

We should create an atomic operation that will 
 1. Demote the provider
 2. Create partnerships for the provider
 3. Set the ratifying provider for the courses to the partner

This is a work in progress

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
