### PR TITLE
Remove ", UK" from location suggestions

### DIFF
--- a/app/javascript/find/controllers/locations_autocomplete_controller.js
+++ b/app/javascript/find/controllers/locations_autocomplete_controller.js
@@ -1,4 +1,19 @@
 import RemoteAutocompleteController from './remote_autocomplete_controller'
 
 export default class extends RemoteAutocompleteController {
+  suggestionTemplate (result) {
+    if (typeof result === 'string') {
+      return result
+    }
+
+    if (result?.formatted_name && result.formatted_name.trim() !== '') {
+      return result.formatted_name
+    }
+
+    if (result?.name) {
+      return result.name
+    }
+
+    return ''
+  }
 }

--- a/app/lib/google_old_places_api/client.rb
+++ b/app/lib/google_old_places_api/client.rb
@@ -30,6 +30,7 @@ module GoogleOldPlacesAPI
       Array(response['predictions']).map do |prediction|
         {
           name: prediction['description'],
+          formatted_name: format_prediction(prediction['description']),
           place_id: prediction['place_id'],
           types: prediction['types']
         }
@@ -74,6 +75,12 @@ module GoogleOldPlacesAPI
       address_components = Array(result['address_components']).pluck('long_name')
 
       (address_components & (DEVOLVED_NATIONS + ['England'])).first
+    end
+
+    def format_prediction(description)
+      uk_suffix = /, UK$/
+
+      description.to_s.sub(uk_suffix, '')
     end
   end
 end

--- a/app/services/geolocation/coordinates_query.rb
+++ b/app/services/geolocation/coordinates_query.rb
@@ -28,9 +28,9 @@ module Geolocation
     def cached_coordinates
       @cache.read(cache_key).tap do |cached_data|
         if cached_data
-          logger.info("Cache HIT for: #{query}")
+          logger.info("Cache HIT '#{cache_key}' for: #{query}")
         else
-          logger.info("Cache MISS for: #{query}")
+          logger.info("Cache MISS '#{cache_key}' for: #{query}")
         end
       end
     end

--- a/app/services/geolocation/suggestions.rb
+++ b/app/services/geolocation/suggestions.rb
@@ -19,9 +19,9 @@ module Geolocation
     def cached_suggestions
       @cache.read(cache_key).tap do |cached_data|
         if cached_data
-          @logger.info("CACHE HIT suggestion for: #{@query}")
+          @logger.info("CACHE HIT '#{cache_key}' suggestion for: #{@query}")
         else
-          @logger.info("CACHE MISS suggestion for: #{@query}")
+          @logger.info("CACHE MISS '#{cache_key}' suggestion for: #{@query}")
         end
       end
     end

--- a/spec/lib/google_old_places_api/client_spec.rb
+++ b/spec/lib/google_old_places_api/client_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe GoogleOldPlacesAPI::Client do
           [
             {
               name: 'London, UK',
+              formatted_name: 'London',
               place_id: 'ChIJdd4hrwug2EcRmSrV3Vo6llI',
               types: %w[locality political]
             }

--- a/spec/services/geolocation/coordinates_query_spec.rb
+++ b/spec/services/geolocation/coordinates_query_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Geolocation::CoordinatesQuery do
       end
 
       it 'logs a cache hit' do
-        expect(Rails.logger).to receive(:info).with("Cache HIT for: #{query}")
+        expect(Rails.logger).to receive(:info).with("Cache HIT 'geolocation:query:london' for: #{query}")
         coordinates
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe Geolocation::CoordinatesQuery do
       end
 
       it 'logs a cache miss' do
-        expect(Rails.logger).to receive(:info).with("Cache MISS for: #{query}")
+        expect(Rails.logger).to receive(:info).with("Cache MISS 'geolocation:query:london' for: #{query}")
         coordinates
       end
     end
@@ -124,7 +124,7 @@ RSpec.describe Geolocation::CoordinatesQuery do
       end
 
       it 'logs the cache miss when coordinates are fetched' do
-        expect(Rails.logger).to receive(:info).with("Cache MISS for: #{query}")
+        expect(Rails.logger).to receive(:info).with("Cache MISS 'geolocation:query:london' for: #{query}")
         coordinates
       end
     end

--- a/spec/services/geolocation/suggestions_spec.rb
+++ b/spec/services/geolocation/suggestions_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Geolocation::Suggestions do
       end
 
       it 'logs a cache hit' do
-        expect(Rails.logger).to receive(:info).with("CACHE HIT suggestion for: #{query}")
+        expect(Rails.logger).to receive(:info).with("CACHE HIT 'geolocation:suggestions:london' suggestion for: #{query}")
         suggestions
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe Geolocation::Suggestions do
       end
 
       it 'logs a cache miss' do
-        expect(Rails.logger).to receive(:info).with("CACHE MISS suggestion for: #{query}")
+        expect(Rails.logger).to receive(:info).with("CACHE MISS 'geolocation:suggestions:london' suggestion for: #{query}")
         suggestions
       end
     end

--- a/spec/system/find/v2/results/search_results_subject_and_location_spec.rb
+++ b/spec/system/find/v2/results/search_results_subject_and_location_spec.rb
@@ -236,6 +236,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
       [
         {
           name: 'London, UK',
+          formatted_name: 'London',
           place_id: 'ChIJdd4hrwug2EcRmSrV3Vo6llI',
           types: %w[locality political]
         }
@@ -244,7 +245,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   end
 
   def and_the_location_search_for_coordinates_is_cached
-    expect(Rails.cache.read('geolocation:query:london-uk')).to eq(
+    expect(Rails.cache.read('geolocation:query:london')).to eq(
       {
         formatted_address: 'London, UK',
         latitude: 51.5072178,
@@ -274,7 +275,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
 
   def then_i_see_location_suggestions
     expect(page).to have_css('#location-field__listbox', visible: :visible)
-    expect(page.find_by_id('location-field__listbox')).to have_content('London, UK')
+    expect(page.find_by_id('location-field__listbox')).to have_content('London')
   end
 
   def when_i_select_the_first_suggestion
@@ -391,7 +392,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   def and_i_am_on_the_results_page_with_london_location_as_parameter
     and_i_am_on_the_results_page
 
-    expect(search_params).to eq(subject_name: '', subject_code: '', location: 'London, UK')
+    expect(search_params).to eq(subject_name: '', subject_code: '', location: 'London')
   end
 
   def and_i_am_on_the_results_page_with_mathematics_subject_and_london_location_and_sponsor_visa_as_parameter
@@ -400,7 +401,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     expect(search_params).to eq(
       subject_name: 'Mathematics',
       subject_code: 'G1',
-      location: 'London, UK',
+      location: 'London',
       can_sponsor_visa: 'true'
     )
   end
@@ -452,13 +453,13 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   def when_i_search_courses_in_london_using_old_parameters
     stub_london_location_search
 
-    visit find_results_path(lq: 'London, UK')
+    visit find_results_path(lq: 'London')
   end
 
   def and_london_is_displayed_in_text_field
     expect(
       page.find_field('City, town or postcode').value
-    ).to eq('London, UK')
+    ).to eq('London')
   end
 
   private
@@ -474,7 +475,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   def stub_london_location_search
     stub_request(
       :get,
-      'https://maps.googleapis.com/maps/api/geocode/json?address=London,%20UK&components=country:UK&key=replace_me&language=en'
+      'https://maps.googleapis.com/maps/api/geocode/json?address=London&components=country:UK&key=replace_me&language=en'
     )
       .with(
         headers: {


### PR DESCRIPTION
## Context

When searching for Cornwall, a different set of results populate the search than in production

Old live site: Cornwall
Prefiltering: Cornwall, UK

## Changes proposed in this pull request

Remove ", UK" from suggestions.

## Guidance to review

1. Search for any location
2. ", UK" should not appear on suggestions
