### PR TITLE
Add PE with an EBacc subject to subject group

### DIFF
--- a/lib/tasks/populate_subject_groups.rake
+++ b/lib/tasks/populate_subject_groups.rake
@@ -13,7 +13,7 @@ task create_and_populate_subject_groups: :environment do
       'Art and design', 'Business studies', 'Citizenship', 'Classics', 'Communication and media studies', 'Dance', 'Drama', 'Economics', 'Geography', 'History', 'Music', 'Philosophy', 'Psychology', 'Religious education', 'Social sciences'
     ],
     'Health and physical education' => [
-      'Health and social care', 'Physical education'
+      'Health and social care', 'Physical education', 'Physical education with an EBacc subject'
     ]
   }
 


### PR DESCRIPTION
## Context

When viewing the list of secondary subjects, "Physical education with an EBacc subject" is missing from the "Health and physical education" subject group.

## Changes proposed in this pull request

- Add "Physical education with an EBacc subject" to the populate subject groups rake task.

## Guidance to review

- Try running `rails create_and_populate_subject_groups` locally.
- The "Physical education with an EBacc subject" subject should now be present.
