### PR TITLE
Add provider search into the homepage

### DIFF
--- a/app/views/find/search/locations/_form.html.erb
+++ b/app/views/find/search/locations/_form.html.erb
@@ -42,6 +42,28 @@
               <%= form.govuk_check_box :can_sponsor_visa, "true", multiple: false, label: { text: t("helpers.label.courses_search_form.visa_sponsorship") } %>
             <% end %>
           </div>
+
+          <div class="govuk-!-width-full">
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Search by training provider
+                </span>
+              </summary>
+
+              <div class="govuk-details__text">
+                <div class="govuk-form-group" data-controller="v2-provider-autocomplete">
+                  <%= render Find::AutocompleteComponent.new(
+                    form_field: form.govuk_select(
+                      :provider_code,
+                      dfe_autocomplete_options(form.object.providers_list, synonyms_fields: %i[code]),
+                      label: { text: t("helpers.label.courses_search_form.provider"), size: "s" }
+                    )
+                  ) %>
+                </div>
+              </div>
+            </details>
+          </div>
         </div>
 
         <div>

--- a/spec/system/find/v2/results/search_results_subject_and_location_spec.rb
+++ b/spec/system/find/v2/results/search_results_subject_and_location_spec.rb
@@ -115,6 +115,14 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
       and_i_am_on_the_results_page_with_london_location_as_parameter
     end
 
+    scenario 'when I search for a specific provider from the homepage' do
+      when_i_search_for_a_provider
+      and_i_choose_the_first_provider_suggestion
+      and_i_click_search
+      then_i_see_only_courses_from_that_provider
+      and_the_provider_field_is_visible
+    end
+
     scenario 'when I search all filters from the homepage' do
       when_i_search_for_math
       and_i_choose_the_first_subject_suggestion
@@ -399,7 +407,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
   def and_i_am_on_the_results_page_with_london_location_as_parameter
     and_i_am_on_the_results_page
 
-    expect(search_params).to eq(applications_open: 'true', subject_name: '', subject_code: '', location: 'London, UK')
+    expect(search_params).to eq(applications_open: 'true', subject_name: '', subject_code: '', location: 'London, UK', provider_name: '', provider_code: '')
   end
 
   def and_i_am_on_the_results_page_with_mathematics_subject_and_london_location_and_sponsor_visa_as_parameter
@@ -410,7 +418,9 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
       subject_name: 'Mathematics',
       subject_code: 'G1',
       location: 'London, UK',
-      can_sponsor_visa: 'true'
+      can_sponsor_visa: 'true',
+      provider_name: '',
+      provider_code: ''
     )
   end
 


### PR DESCRIPTION
## Context

Add provider search to the homepage.

## Changes proposed in this pull request

<img width="881" alt="Screenshot 2025-03-03 at 16 36 58" src="https://github.com/user-attachments/assets/22c647bd-ad4c-4e63-a4f8-dee545a7df54" />
<img width="878" alt="Screenshot 2025-03-03 at 16 37 08" src="https://github.com/user-attachments/assets/3390d5b4-59a0-4647-b2a6-5aab79b5b027" />

## Guidance to review

1. Search by a provider on the homepage?
2. Does it filter on the results page?
3. Does the provider field is open on the results page?
4. Does it work on mobile?
