### PR TITLE
Default radius if radius parameter can not be parsed

### DIFF
--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -226,7 +226,6 @@ module Courses
     def location_scope
       return @scope.distinct if params[:latitude].blank? || params[:longitude].blank?
 
-      radius_in_miles = Float(params[:radius].presence || DEFAULT_RADIUS_IN_MILES)
       radius_in_meters = radius_in_miles * 1609.34
       latitude = Float(params[:latitude])
       longitude = Float(params[:longitude])
@@ -340,6 +339,12 @@ module Courses
             courses_table[:course_code] => :asc
           }
         )
+    end
+
+    def radius_in_miles
+      Float(params[:radius].presence || DEFAULT_RADIUS_IN_MILES)
+    rescue StandardError
+      DEFAULT_RADIUS_IN_MILES
     end
 
     private

--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -958,6 +958,18 @@ RSpec.describe Courses::Query do
         end
       end
 
+      context 'when radius is invalid default radius to 10 miles' do
+        it_behaves_like 'location search results', radius: '10ºdegree' do
+          let(:expected) do
+            [
+              course_london_result,
+              course_canary_wharf_result,
+              course_lewisham_result
+            ]
+          end
+        end
+      end
+
       context 'when radius is blank default radius to 10 miles' do
         it_behaves_like 'location search results', radius: '' do
           let(:expected) do
@@ -1058,9 +1070,7 @@ RSpec.describe Courses::Query do
         malicious_radius = "10; DELETE FROM #{Course.table_name} WHERE 1=1; --"
         params = { latitude: valid_latitude, longitude: valid_longitude, radius: malicious_radius }
 
-        expect { described_class.call(params: params) }.to raise_error(
-          ArgumentError, "invalid value for Float(): \"#{malicious_radius}\""
-        )
+        expect(described_class.new(params:).radius_in_miles).to be(10)
       end
     end
 


### PR DESCRIPTION
## Context

Users bookmarked bad formatted URLs from the old live site.

With the prefiltering this won't happen anymore but if the user bookmarked their searches we need to make sure we don't break the prefiltering results.

## Changes proposed in this pull request

Default radius if radius can't be parsed.

## Guidance to review

1. Attempt to visit a bad formatted radius with degrees on it `radius=10ºdegree_required=show_all_courses` 
2. Radius should use the default
