### PR TITLE
Return the number of pods pre filtering launch

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -8,7 +8,7 @@
   "resource_group_name": "s189p01-ptt-pd-rg",
   "main_app": {
     "main": {
-      "replicas": 6,
+      "replicas": 4,
       "max_memory": "3Gi"
     }
   },


### PR DESCRIPTION
## Context

The graphs are almost unchanged so we can safely return to 4 pods.

Nonetheles it is always good to be cautious in a launch of a redesign of the whole site and its search mechanisms. 

## Guidance to review

1. See Azure DB CPU percentage and mem used
2. See Redis cache size
3. See Grafana metrics
4. Are we good to return to 4 pods?