### PR TITLE
Update fee content

### DIFF
--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -28,8 +28,8 @@ en:
         salary: Salary
         apprenticeship: Salary (apprenticeship)
         fee:
-          uk_fees_html: "%{value} for UK citizens"
-          international_fees_html: "%{value} for Non-UK citizens"
+          uk_fees_html: "%{value} <b>fee</b> for UK citizens"
+          international_fees_html: "%{value} <b>fee</b> for Non-UK citizens"
           hint:
             bursaries_and_scholarship_html: "Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available"
             bursaries_only_html: "Bursaries of %{bursary_amount} are available"
@@ -321,8 +321,8 @@ en:
             salary: Salary
             apprenticeship: Salary (apprenticeship)
             fee:
-              uk_fees_html: "%{value} for UK citizens"
-              international_fees_html: "%{value} for Non-UK citizens"
+              uk_fees_html: "%{value} <b>fee</b> for UK citizens"
+              international_fees_html: "%{value} <b>fee</b> for Non-UK citizens"
               hint:
                 bursaries_and_scholarship_html: "Scholarships of %{scholarship_amount} or bursaries of %{bursary_amount} are available"
                 bursaries_only_html: "Bursaries of %{bursary_amount} are available"

--- a/spec/components/courses/summary_card_component_spec.rb
+++ b/spec/components/courses/summary_card_component_spec.rb
@@ -243,8 +243,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£9,250 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£17,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£9,250 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£17,900 fee for Non-UK citizens'
         it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, 'Bursaries of £10,000 are available'
       end
 
@@ -263,8 +263,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,000 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£11,000 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,000 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£11,000 fee for Non-UK citizens'
         it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, 'Scholarships of £10,000 are available'
       end
 
@@ -283,8 +283,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£7,000 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£7,000 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£7,000 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£7,000 fee for Non-UK citizens'
         it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, 'Scholarships of £10,000 or bursaries of £9,000 are available'
       end
 
@@ -303,8 +303,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£8,000 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£8,000 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£8,000 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£8,000 fee for Non-UK citizens'
 
         it 'does not show bursaries or scholarship' do
           expect(summary_card_content).not_to include('Bursaries')
@@ -327,7 +327,7 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£10,000 for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£10,000 fee for UK citizens'
         it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, 'Scholarships of £5,000 or bursaries of £6,000 are available'
       end
 
@@ -346,8 +346,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,250 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,250 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, { can_sponsor_visa: true }, '£6,900 fee for Non-UK citizens'
 
         it 'does not show bursaries or scholarship' do
           expect(summary_card_content).not_to include('Bursaries')
@@ -415,8 +415,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, {}, '£6,250 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,250 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 fee for Non-UK citizens'
         it_behaves_like 'fee or salary row', :fee, {}, 'Bursaries of £9,000 are available'
       end
 
@@ -435,8 +435,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, {}, '£6,250 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,250 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 fee for Non-UK citizens'
         it_behaves_like 'fee or salary row', :fee, {}, 'Scholarships of £9,000 are available'
       end
 
@@ -455,8 +455,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, {}, '£7,250 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£7,250 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 fee for Non-UK citizens'
         it_behaves_like 'fee or salary row', :fee, {}, 'Scholarships of £9,000 or bursaries of £7,000 are available'
       end
 
@@ -475,8 +475,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, {}, '£7,500 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£7,500 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£6,900 fee for Non-UK citizens'
 
         it 'does not show bursaries or scholarship' do
           expect(summary_card_content).not_to include('Bursaries')
@@ -499,8 +499,8 @@ RSpec.describe Courses::SummaryCardComponent, type: :component do
           )
         end
 
-        it_behaves_like 'fee or salary row', :fee, {}, '£8,500 for UK citizens'
-        it_behaves_like 'fee or salary row', :fee, {}, '£8,500 for Non-UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£8,500 fee for UK citizens'
+        it_behaves_like 'fee or salary row', :fee, {}, '£8,500 fee for Non-UK citizens'
 
         it 'does not show bursaries or scholarship' do
           expect(summary_card_content).not_to include('Bursaries')

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -142,7 +142,7 @@ module Find
 
             result = render_inline(described_class.new(course))
             expect(result.text).to include('Fee or salary')
-            expect(result.text).to include('£9,250 for UK citizens')
+            expect(result.text).to include('£9,250 fee for UK citizens')
           end
         end
 
@@ -151,7 +151,7 @@ module Find
             course = create(:course, :fee, enrichments: [create(:course_enrichment, fee_international: 14_000)]).decorate
 
             result = render_inline(described_class.new(course))
-            expect(result.text).to include('£14,000 for Non-UK citizens')
+            expect(result.text).to include('£14,000 fee for Non-UK citizens')
           end
         end
 
@@ -161,8 +161,8 @@ module Find
 
             result = render_inline(described_class.new(course))
 
-            expect(result.text).to include('£9,250 for UK citizens')
-            expect(result.text).not_to include('for Non-UK citizens')
+            expect(result.text).to include('£9,250 fee for UK citizens')
+            expect(result.text).not_to include('fee for Non-UK citizens')
           end
         end
 
@@ -172,8 +172,8 @@ module Find
 
             result = render_inline(described_class.new(course))
 
-            expect(result.text).not_to include('for UK citizens')
-            expect(result.text).to include('£14,000 for Non-UK citizens')
+            expect(result.text).not_to include('fee for UK citizens')
+            expect(result.text).to include('£14,000 fee for Non-UK citizens')
           end
         end
 


### PR DESCRIPTION
## Context

The content on the search results and course summary pages is not clear whether a course is fee or salary.

## Changes proposed in this pull request

Update the content to match the designs here: https://trello.com/c/Jq22IvMJ/533-bug-fee-content-has-not-been-updated

## Guidance to review

- View a fee based course on the results page
- View that course and check the content matches

<img width="524" alt="Screenshot 2025-03-05 at 13 02 59" src="https://github.com/user-attachments/assets/57053e54-4295-4e26-aa67-8213005b3050" />

<img width="807" alt="Screenshot 2025-03-05 at 13 03 06" src="https://github.com/user-attachments/assets/b3155451-3cf8-47af-a64a-d080bc067c2b" />
