### PR TITLE
Add FInd namespace to search results event

### DIFF
--- a/app/services/find/analytics/search_results_event.rb
+++ b/app/services/find/analytics/search_results_event.rb
@@ -12,6 +12,7 @@ module Find
 
       def event_data
         {
+          namespace: 'find',
           total:,
           page:,
           search_params:,

--- a/spec/services/find/analytics/search_results_event_spec.rb
+++ b/spec/services/find/analytics/search_results_event_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Find::Analytics::SearchResultsEvent do
         allow(request).to receive(:referer).and_return('/')
 
         expect(subject.event_data).to eq(
+          namespace: 'find',
           total: 1360,
           page: 2,
           visible_courses: [
@@ -69,6 +70,7 @@ RSpec.describe Find::Analytics::SearchResultsEvent do
 
       it 'returns a hash with all the results information and no referer' do
         expect(subject.event_data).to eq(
+          namespace: 'find',
           total: 1360,
           page: 2,
           visible_courses: [
@@ -94,6 +96,7 @@ RSpec.describe Find::Analytics::SearchResultsEvent do
 
       it 'returns a hash with all the results information and course referer' do
         expect(subject.event_data).to eq(
+          namespace: 'find',
           total: 1360,
           page: 2,
           visible_courses: [

--- a/spec/system/find/v2/results/search_results_tracking_spec.rb
+++ b/spec/system/find/v2/results/search_results_tracking_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_one_search_result_is_tracked_from_homepage_form
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 6,
         page: 1,
         search_params: [
@@ -232,6 +233,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_one_search_result_is_tracked_from_primary_courses_form
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 2,
         page: 1,
         search_params: [
@@ -277,6 +279,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_one_search_result_is_tracked_from_secondary_courses_form
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 1,
         page: 1,
         search_params: [
@@ -315,6 +318,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_one_search_result_is_tracked_from_teacher_degree_apprenticeship_link
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 1,
         page: 1,
         search_params: [
@@ -352,6 +356,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_one_search_result_is_tracked_from_send_primary_link
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 1,
         page: 1,
         search_params: [
@@ -380,6 +385,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_one_search_result_is_tracked_from_send_secondary_link
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 1,
         page: 1,
         search_params: [
@@ -413,6 +419,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_one_search_result_is_tracked_from_further_education_link
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 1,
         page: 1,
         search_params: [
@@ -452,6 +459,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_search_result_is_tracked_with_applied_filters_with_top_applied_filter
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 2,
         page: 1,
         search_params: [
@@ -487,6 +495,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_search_result_is_tracked_with_applied_filters_with_bottom_applied_filter
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 2,
         page: 1,
         search_params: [
@@ -536,6 +545,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_search_result_is_tracked_with_new_search
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 1,
         page: 1,
         search_params: [
@@ -573,6 +583,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_search_result_order_is_tracked
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 6,
         page: 1,
         search_params: [
@@ -623,6 +634,7 @@ RSpec.describe 'V2 results - tracking', :js, service: :find do
   def then_search_result_is_tracked_with_new_search_using_results_as_utm_medium
     expect(search_results_enqueued_data).to eq(
       {
+        namespace: 'find',
         total: 6,
         page: 1,
         search_params: [{}],


### PR DESCRIPTION
## Context

Both Find and Publish events are sent to the events_publish table. The namespace field allows us to split out the two services when creating downstream tables in Dataform e.g. find_searches, course_details_publish and find_sessions_extended. E.g: namespace = ‘find’ or namespace = ‘publish’.

Some of the events in Find are currently sending through a null namespace value, in particular the search_results events.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

1. Does it includes the find namespace in the events hash to DfE analytics?
