### PR TITLE
Skip provider relationship association if accredited provider is not found

### DIFF
--- a/db/data/20250303121528_backfill_provider_partnerships.rb
+++ b/db/data/20250303121528_backfill_provider_partnerships.rb
@@ -40,6 +40,9 @@ class BackfillProviderPartnerships < ActiveRecord::Migration[8.0]
 
       accredited_codes.each do |accredited_code|
         accredited_provider = Provider.in_current_cycle.find_by(provider_code: accredited_code)
+
+        next if accredited_provider.nil?
+
         train_with_us = accredited_provider.train_with_us || ''
 
         # If train_with_us is more than 100 words, it will be invalid.


### PR DESCRIPTION
## Context

In sandbox, accredited provider are not always being found in the current cycle for the provider relationships data migration.

## Changes proposed in this pull request

- Skip associating provider relationships when the accredited provider is not found in the current cycle.

## Guidance to review

- Should we take an alternative route to addressing this?
  - Do we need to clean up the sandbox data?
