### PR TITLE
Add the deploy label to all dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,43 +1,23 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: audited
-  - dependency-name: simplecov
-    versions:
-    - ">= 0.18.a, < 0.19"
-  - dependency-name: simplecov
-    versions:
-    - ">= 0.19.a, < 0.20"
-  - dependency-name: simplecov
-    versions:
-    - ">= 0.20.a, < 0.21"
-  - dependency-name: govuk_design_system_formbuilder
-    versions:
-    - 2.4.0
-  - dependency-name: parallel_tests
-    versions:
-    - 3.5.1
-  - dependency-name: rails
-    versions:
-    - 6.1.1
-    - 6.1.2
-    - 6.1.2.1
-- package-ecosystem: bundler
-  directory: "/docs"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - DevOps
-  - dependencies
-  - github_actions
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - deploy
+    ignore:
+      - dependency-name: audited
+  - package-ecosystem: bundler
+    directory: "/docs"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - github_actions


### PR DESCRIPTION
## Context

When testing dependabot PRs, it's always easier to deploy them first to see that the build suceed

## Changes proposed in this pull request

- Add configuration for adding the `deploy` label to dependabot PRs.
- Remove ignored dependencies in the `dependabot.yml` - namely those that are outdated.

## Guidance to review

- Does all look good?
