### PR TITLE
Sort courses copied codes to consistency and stability

### DIFF
--- a/app/controllers/support/providers/copy_courses_controller.rb
+++ b/app/controllers/support/providers/copy_courses_controller.rb
@@ -27,7 +27,7 @@ module Support
 
           @courses_copied = copier.courses_copied
           @courses_not_copied = copier.courses_not_copied
-          flash[:success] = "Courses copied: #{@courses_copied.map(&:course_code).to_sentence}"
+          flash[:success] = "Courses copied: #{@courses_copied.map(&:course_code).sort.to_sentence}"
           flash[:warning] = "Courses not copied: #{@courses_not_copied.map(&:course_code).to_sentence}"
 
           redirect_to support_recruitment_cycle_provider_courses_path(recruitment_cycle.year, @copy_courses_form.target_provider.id)

--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Support::CopyCourses' do
 
       expect(response).to redirect_to(support_recruitment_cycle_provider_courses_path(year, target_provider.id))
       follow_redirect!
-      expect(response.parsed_body.css('.govuk-notification-banner--success').text).to match(format('Courses copied: %s', source_provider.courses.map(&:course_code).to_sentence))
+      expect(response.parsed_body.css('.govuk-notification-banner--success').text).to match(format('Courses copied: %s', source_provider.courses.map(&:course_code).sort.to_sentence))
     end
 
     context 'with schools' do


### PR DESCRIPTION
## Context

Inconsistent ordering of course codes in the Copy courses feature is leading to flakey tests.

## Changes proposed in this pull request

Sort the codes we display in the UI to make sure the test subjects are consistent

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
