### PR TITLE
fix: Adding connection string required for restore workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,3 +46,4 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
           sha: ${{ github.event.inputs.sha }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          azure-storage-connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_SANITISED }}


### PR DESCRIPTION
## Context

The input for the restore workflow which runs against the review environment is missing.

## Changes proposed in this pull request

Adding the value AZURE_STORAGE_CONNECTION_STRING_SANITISED

## Guidance to review

Validate the review app build runs cleanly
