### PR TITLE
Dd/add sidekiq to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - deploy
+      - dependencies
+      - ruby
     ignore:
       - dependency-name: audited
+      - dependency-name: sidekiq
   - package-ecosystem: bundler
     directory: "/docs"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
     ignore:
       - dependency-name: audited
       - dependency-name: sidekiq
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - deploy
+      - dependencies
+      - javascript
   - package-ecosystem: bundler
     directory: "/docs"
     schedule:


### PR DESCRIPTION
## Context

- A PR to update Sidekiq is being opened by dependabot.
- We don't have dependabot enabled for javascript packages and we should.

## Changes proposed in this pull request

- Add Sidekiq to dependabot bundler ignore list.
- Add javascript dependabot rules.

## Guidance to review

- Does all look good? We'll only be able to see the results tomorrow once it runs.
