### PR TITLE
Course preview page does not look like the live course page

### DIFF
--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -3,12 +3,12 @@
   <% if course.training_locations? || preview? %>
     <li><%= govuk_link_to t(".where_you_will_train"), "#training-locations" %></li>
   <% end %>
-  <% if salaried? %>
-    <li><%= govuk_link_to t(".salary"), "#section-salary" %></li>
-  <% end %>
   <li><%= govuk_link_to t(".fees_and_financial_support"), "#section-financial-support" %></li>
   <% if about_course.present? || preview? %>
     <li><%= govuk_link_to t(".course_details"), "#section-about" %></li>
+  <% end %>
+  <% if salaried? %>
+    <li><%= govuk_link_to t(".salary"), "#section-salary" %></li>
   <% end %>
   <% if interview_process.present? %>
     <li><%= govuk_link_to t(".interview_process"), "#section-interviews" %></li>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -48,14 +48,14 @@
 
     <%= render Find::Courses::AboutSchoolsComponent::View.new(@course, preview: preview?(params)) %>
 
-    <% if @course.salaried? %>
-      <%= render partial: "find/courses/salary", locals: { course: @course } %>
-    <% end %>
-
     <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
 
     <% if @course.published_about_course.present? %>
       <%= render partial: "find/courses/about_course", locals: { course: @course } %>
+    <% end %>
+
+    <% if @course.salaried? %>
+      <%= render partial: "find/courses/salary", locals: { course: @course } %>
     <% end %>
 
     <% if @course.published_interview_process.present? %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -27,15 +27,15 @@
 
     <%= render Find::Courses::ContentsComponent::View.new(course) %>
 
+    <%= render Find::Courses::AboutSchoolsComponent::View.new(course, preview: preview?(params)) %>
+
+    <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
+
     <%= render partial: "find/courses/about_course", locals: { course: } %>
 
     <% if course.salaried? %>
       <%= render partial: "find/courses/salary", locals: { course: } %>
     <% end %>
-
-    <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
-
-    <%= render Find::Courses::AboutSchoolsComponent::View.new(course, preview: preview?(params)) %>
 
     <% if course.interview_process.present? %>
       <%= render partial: "find/courses/interview_process", locals: { course: } %>


### PR DESCRIPTION
## Context

Course preview page does not look like the live course page

A provider can preview the course page before publishing the course. This preview is supposed to look identical to the published page. It’s been discovered that the preview does not match the layout of the live course page.

## Changes proposed in this pull request

- Reorder the preview course page to match the course show page
- Reorder the course show page contents so it matches the contents section

## Guidance to review

- Vist course preview page via publish
- Visit that course show page via find
- Check that the contents of the course preview page order matches that of the show page
- Check the sections of the course preview page matches the sections of the show page
