### PR TITLE
Implement cicd for domains infrastructure

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -408,3 +408,51 @@ jobs:
           environment: sandbox
           sha: ${{ github.sha }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+
+  deploy_domains_infra:
+    name: Deploy Domains Infrastructure
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_domains_infra
+    needs: [deploy-aks-sandbox]
+    environment:
+      name: production
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Deploy Domains Infrastructure
+        uses: DFE-Digital/github-actions/deploy-domains-infra@master
+        with:
+          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          terraform-base: terraform/custom_domains/infrastructure
+
+  deploy_domains_env:
+    name: Deploy Domains to ${{ matrix.domain_environment }} environment
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_${{ matrix.domain_environment }}
+    needs: [deploy_domains_infra]
+    strategy:
+      max-parallel: 1
+      matrix:
+        domain_environment: [qa, staging, sandbox, production]
+    environment:
+      name: production
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Deploy Domains Environment
+        uses: DFE-Digital/github-actions/deploy-domains-env@master
+        with:
+          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          environment: ${{ matrix.domain_environment }}
+          healthcheck: healthcheck
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          terraform-base: terraform/custom_domains/environment_domains

--- a/bin/domains_healthcheck.sh
+++ b/bin/domains_healthcheck.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+external_urls=$(terraform -chdir=terraform/custom_domains/environment_domains output -json external_urls | jq -r '.[]')
+for url in ${external_urls} ; do
+    echo "Check health for ${url}/healthcheck ..."
+    curl -sS --fail "${url}/healthcheck" > /dev/null
+done

--- a/terraform/custom_domains/environment_domains/output.tf
+++ b/terraform/custom_domains/environment_domains/output.tf
@@ -1,0 +1,10 @@
+output "external_urls" {
+  value = flatten([
+    for zone_name, zone_values in var.hosted_zone : [
+        for domain in zone_values["domains"] : (domain == "apex" ?
+            "https://${zone_name}" :
+            "https://${domain}.${zone_name}"
+        )
+    ]
+  ])
+}


### PR DESCRIPTION
## Context

Implement cicd for domains infrastructure

## Changes proposed in this pull request

Add steps to build-and-deploy workflow
Add terraform output for environment urls, required for environment healthchecks
Changes to Makefile
script domains-hc added as publish has 2 separate terraform state files (find & publish).
- raised backlog ticket to investigate merging into one

## Guidance to review

https://github.com/DFE-Digital/publish-teacher-training/actions/runs/13807385592
retest after updates
https://github.com/DFE-Digital/publish-teacher-training/actions/runs/13833214381

make domains-infra-plan
make qa|staging|sandbox|production domains-plan
