### PR TITLE
Move rubocop-factory_bot into rubocop's plugin section

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 plugins:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-factory_bot
 
 require:
   - rubocop-capybara
-  - rubocop-factory_bot
   - rubocop-rspec_rails
 
 inherit_from:
@@ -67,20 +67,20 @@ Rails/I18nLocaleTexts:
 
 Style/HashSyntax:
   Exclude:
-    - 'docs/lib/govuk_tech_docs/open_api/renderer.rb'
+    - "docs/lib/govuk_tech_docs/open_api/renderer.rb"
 
 Style/MapIntoArray:
   Exclude:
-    - 'docs/lib/govuk_tech_docs/open_api/renderer.rb'
+    - "docs/lib/govuk_tech_docs/open_api/renderer.rb"
 
 Naming/BlockForwarding:
   Exclude:
-    - 'docs/lib/govuk_tech_docs/open_api/extension.rb'
+    - "docs/lib/govuk_tech_docs/open_api/extension.rb"
 
 RSpec/NoExpectationExample:
   Exclude:
-    - 'spec/features/**/*'
-    - 'spec/system/**/*'
+    - "spec/features/**/*"
+    - "spec/system/**/*"
 
 RSpec/MultipleMemoizedHelpers:
   Max: 29


### PR DESCRIPTION
## Context

The `rubocop-factory_bot` gem has been updated to support Rubocop's new plugin system.

## Changes proposed in this pull request

- Move `rubocop-factory_bot` into the plugins section.

## Guidance to review

- Try running `bundle exec rubocop` locally.
