### PR TITLE
change school placements content

### DIFF
--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,8 +1,8 @@
 <h1 class="govuk-heading-xl">
-<span class="govuk-caption-xl" data-qa="course__provider_name">
-  <%= smart_quotes(@course.provider.provider_name) %>
-</span>
-<%= @course.name_and_code %>
+ <span class="govuk-caption-xl" data-qa="course__provider_name"> 
+  <%= t(".heading", name_and_code: course.name_and_code) %>
+ </span>
+ <%= t(".heading", provider_name: course.provider_name) %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl">
  <span class="govuk-caption-xl" data-qa="course__provider_name"> 
-  <%= t(".heading", name_and_code: course.name_and_code) %>
+  <%= t(".label", name_and_code: course.name_and_code) %>
  </span>
  <%= t(".heading", provider_name: course.provider_name) %>
 </h1>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,5 +1,8 @@
 <h1 class="govuk-heading-xl">
-<%= content_for :page_title, "#{@course.name_and_code} with #{smart_quotes(@course.provider.provider_name)}" %>
+<span class="govuk-caption-xl" data-qa="course__provider_name">
+  <%= smart_quotes(@course.provider.provider_name) %>
+</span>
+<%= @course.name_and_code %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl">
-  <%= t(".heading", provider_name: course.provider_name) %>
+<%= content_for :page_title, "#{@course.name_and_code} with #{smart_quotes(@course.provider.provider_name)}" %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
+        label: %{provider_name}
         heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        heading: School placements at %{provider_name}
+        heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'
       school_placements_advice:


### PR DESCRIPTION
## Context

<!-- We continue to receive feedback from providers that the new changes to how we communicate location have resulted in confusion or inaccuracy.

One thing that needs to be improved is the content on the school placements page, to make it clearer that the schools have been attached to the course and not the provider.  -->

## Changing content to the title of school placements 




