### PR TITLE
change title on school placements page

### DIFF
--- a/app/views/find/placements/index.html.erb
+++ b/app/views/find/placements/index.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title do %>
   <%= t(
     "find.courses.placements.heading",
-    course_name_and_code: @course.name_and_code
+    provider_name: @course.provider_name
   ) %>
 <% end %>
 <% content_for :before_content do %>

--- a/app/views/find/placements/index.html.erb
+++ b/app/views/find/placements/index.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :page_title do %>
   <%= t(
     "find.courses.placements.heading",
-    provider_name: @course.provider_name
+    course_name_and_code: @course.name_and_code
   ) %>
 <% end %>
 <% content_for :before_content do %>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">
-<span class="govuk-caption-xl">
- <%= t(".course_provider", provider_name: course.provider_name) %>
-</span>
+  <span class="govuk-caption-xl">
+    <%= t(".heading", provider_name: course.provider_name) %>
+    </span>
   <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>
 

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl">
-  <%= t(".heading", provider_name: course.provider_name) %>
+  <%= t(".heading", course_name: course.course_name) %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
-    <%= t(".provider_name", provider_name: course.provider_name) %>
+    <%= t(".provider_name", provider_name: @course.provider_name) %>
     </span>
   <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,8 +1,8 @@
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
-    <%= t(".thing) %>
+    <%= t(".thing") %>
     </span>
-  <%= t(".heading", course_name_and_code: @course.name_and_code) %>
+  <%= t(".heading, course_name_and_code: @course.name_and_code") %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl">
-  <%= t(".heading", provider_name: course.provider_name) %>
+  <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
-    <%= t(".thing, provider_name: course.provider_name) %>
+    <%= t(".thing", provider_name: course.provider_name) %>
     </span>
   <%= t(".heading", course_name: course.course_name) %>
 </h1>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
-    <%= t(".provider_name", provider_name: @course.provider_name) %>
+    <%= t(".heading", provider_name: course.provider_name) %>
     </span>
   <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl">
-  <%= t(".heading", course_name: course.course_name) %>
+  <%= t(".heading", provider_name: course.provider_name) %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,8 +1,8 @@
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
-    <%= t(".thing") %>
+    <%= t(".thing, provider_name: course.provider_name) %>
     </span>
-  <%= t(".heading, course_name_and_code: @course.name_and_code") %>
+  <%= t(".heading", course_name: course.course_name) %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -2,7 +2,7 @@
   <span class="govuk-caption-xl">
     <%= t(".thing", provider_name: course.provider_name) %>
     </span>
-  <%= t(".heading", course_name: course.course_name) %>
+  <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>
 
 <p class="govuk-body"><%= t(".schools_to_be_placed") %></p>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,4 +1,7 @@
 <h1 class="govuk-heading-xl">
+<span class="govuk-caption-xl">
+ <%= t(".course_provider", provider_name: course.provider_name) %>
+</span>
   <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>
 

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
-    <%= t(".heading", provider_name: course.provider_name) %>
+    <%= t(".thing) %>
     </span>
   <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
-    <%= t(".heading", provider_name: course.provider_name) %>
+    <%= t(".provider_name", provider_name: course.provider_name) %>
     </span>
   <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>

--- a/app/views/shared/courses/_placements.html.erb
+++ b/app/views/shared/courses/_placements.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
-    <%= t(".thing", provider_name: course.provider_name) %>
+    <%= t(".caption", provider_name: course.provider_name) %>
     </span>
   <%= t(".heading", course_name_and_code: @course.name_and_code) %>
 </h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,6 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        course_provider: %{provider_name}
         heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        heading: School placements for %{course_name}
+        heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'
       school_placements_advice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,6 @@ en:
         heading: Contact %{provider_name}
       placements:
         heading: School placements for %{course_name_and_code}
-        provider_name: %{provider_name}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'
       school_placements_advice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        thing: some text 
+        thing: some text %{provider_name}
         heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
+        course_provider: %{provider_name}
         heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@ en:
         heading: Contact %{provider_name}
       placements:
         heading: School placements for %{course_name_and_code}
+        provider_name: %{provider_name}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'
       school_placements_advice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        thing: School placements for %{provider_name}
+        caption: School placements for %{provider_name}
         heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        heading: School placements at %{provider_name}
+        heading: School placements for %{provider_name}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'
       school_placements_advice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        thing: some text %{provider_name}
+        thing: School placements for %{provider_name}
         heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        caption: School placements for %{provider_name}
+        caption: "%{provider_name}"
         heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
+        thing: some text 
         heading: School placements for %{course_name_and_code}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       provider:
         heading: Contact %{provider_name}
       placements:
-        heading: School placements for %{provider_name}
+        heading: School placements for %{course_name}
         schools_to_be_placed: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
         schools_you_can_choose: 'The schools you can choose from are:'
       school_placements_advice:


### PR DESCRIPTION
## Context

We continue to receive feedback from providers that the new changes to how we communicate location have resulted in confusion or inaccuracy.

One thing that needs to be improved is the content on the school placements page, to make it clearer that the schools have been attached to the course and not the provider.

## Change title of school placements page 


