### PR TITLE
Add missing Skip to main content link across Find

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,9 +28,9 @@
   </head>
 
   <body class="govuk-template__body <%= yield :body_class %>">
-    <%= render "layouts/add_js_enabled_class_to_body" %>
-
     <%= govuk_skip_link %>
+
+    <%= render "layouts/add_js_enabled_class_to_body" %>
 
     <%= render Header.new(service_name: I18n.t("service_name.publish"), current_user:) %>
 

--- a/app/views/layouts/find.html.erb
+++ b/app/views/layouts/find.html.erb
@@ -28,6 +28,8 @@
   </head>
 
   <body class="govuk-template__body">
+    <%= govuk_skip_link %>
+
     <%= render "layouts/add_js_enabled_class_to_body" %>
 
     <%= render HeaderComponent.new(service_name: I18n.t("service_name.find")) do |header| %>


### PR DESCRIPTION
## Context

The comply with accessibility standards, Find needs to have ‘Skip to main content’ links at the top of each page, which become visible using keyboard navigation, and on selection jump the user down to the page content and H1.

This link is missing on all pages of Find. This ticket is to add the link.

## Changes proposed in this pull request

Following https://govuk-components.netlify.app/helpers/skip-link/ added the new component

## Guidance to review

Visit any find page hit TAB and then you will see the skip to main content link at the top of the page. If selected it will take you to the main content of that page
