### PR TITLE
Add snyk scan level input for build-no-cache

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -2,6 +2,15 @@ name: Build No Cache
 
 on:
   workflow_dispatch:
+    inputs:
+      level:
+        description: Snyk scan level
+        type: choice
+        default: low
+        options:
+        - low
+        - high
+        required: false
 
   schedule:
     - cron: '0 13 * * 0'
@@ -19,6 +28,7 @@ jobs:
       name: review
     env:
       DOCKER_IMAGE: ghcr.io/dfe-digital/publish-teacher-training
+      SNYK_LEVEL: ${{ inputs.level || 'low'  }}
 
     steps:
       - name: Checkout
@@ -91,7 +101,7 @@ jobs:
           SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
         with:
           image: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
-          args: --file=Dockerfile --exclude-app-vulns
+          args: --file=Dockerfile --exclude-app-vulns --severity-threshold=${SNYK_LEVEL}
 
       - name: Push ${{ env.DOCKER_IMAGE }} images
         if: ${{ success() }}


### PR DESCRIPTION
## Context

Add input for the SNYK scan level in the build-no-cache workflow, so the default can be changed on manual run.

## Changes proposed in this pull request

Add level input to the workflow

## Guidance to review

see https://github.com/DFE-Digital/publish-teacher-training/actions/runs/13783834957
