### PR TITLE
Arrange course tests better

### DIFF
--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -267,196 +267,6 @@ describe Course do
     end
   end
 
-  context 'ordering' do
-    describe 'canonical' do
-      let(:provider_a) { create(:provider, provider_name: 'Provider A') }
-      let(:course_a) do
-        create(:course,
-               name: 'Course A',
-               course_code: 'AAA',
-               provider: provider_a)
-      end
-
-      let(:another_course_a) do
-        create(:course,
-               name: 'Course A',
-               course_code: 'BBB',
-               provider: provider_a)
-      end
-
-      let(:course_a_with_provider_b) do
-        create(:course,
-               name: 'Course A',
-               course_code: 'AAA',
-               provider: provider_b)
-      end
-
-      let(:course_a_with_provider_b_with_different_course_code) do
-        create(:course,
-               name: 'Course A',
-               course_code: 'AAB',
-               provider: provider_b)
-      end
-
-      let(:course_b) do
-        create(
-          :course,
-          name: 'Course B',
-          provider: provider_a
-        )
-      end
-
-      let(:provider_b) { create(:provider, provider_name: 'Provider B') }
-      let(:course_c) do
-        create(
-          :course,
-          name: 'Course C',
-          provider: provider_b
-        )
-      end
-
-      let(:course_d) do
-        create(
-          :course,
-          name: 'Course D',
-          provider: provider_b
-        )
-      end
-
-      before do
-        course_d
-        course_c
-        course_a
-        course_b
-      end
-
-      describe '#ascending_provider_canonical_order' do
-        subject { described_class.ascending_provider_canonical_order }
-
-        it 'sorts in ascending order of provider name and course name' do
-          expect(subject).to eq([course_a, course_b, course_c, course_d])
-        end
-
-        context 'when there are multiple courses with the same name' do
-          before { another_course_a }
-
-          it 'sorts by course_code' do
-            expect(subject).to eq([course_a, another_course_a, course_b, course_c, course_d])
-          end
-        end
-      end
-
-      describe '#descending_provider_canonical_order' do
-        subject { described_class.descending_provider_canonical_order }
-
-        it 'sorts in descending order of provider name' do
-          expect(subject).to eq([course_c, course_d, course_a, another_course_a, course_b])
-        end
-
-        context 'when there are multiple courses with the same name' do
-          before { another_course_a }
-
-          it 'sorts by course_code' do
-            expect(subject).to eq([course_c, course_d, course_a, another_course_a, course_b])
-          end
-        end
-      end
-
-      describe '#ascending_course_canonical_order' do
-        subject { described_class.ascending_course_canonical_order }
-
-        it 'sorts in ascending order of course name' do
-          expect(subject).to eq([course_a, course_b, course_c, course_d])
-        end
-
-        context 'when there are multiple courses with the same name' do
-          before do
-            course_a_with_provider_b
-            another_course_a
-          end
-
-          it 'sorts by provider_name' do
-            expect(subject).to eq([course_a, another_course_a, course_a_with_provider_b, course_b, course_c, course_d])
-          end
-
-          context 'when there are multiple providers with the same name' do
-            before { course_a_with_provider_b_with_different_course_code }
-
-            it 'sorts by course_code' do
-              expect(subject).to eq([course_a,
-                                     another_course_a,
-                                     course_a_with_provider_b,
-                                     course_a_with_provider_b_with_different_course_code,
-                                     course_b,
-                                     course_c,
-                                     course_d])
-            end
-          end
-        end
-      end
-
-      describe '#descending_course_canonical_order' do
-        subject { described_class.descending_course_canonical_order }
-
-        it 'sorts in descending order of course name' do
-          expect(subject).to eq([course_d, course_c, course_b, course_a])
-        end
-
-        context 'when there are multiple courses with the same name' do
-          before do
-            course_a_with_provider_b
-            another_course_a
-          end
-
-          it 'sorts by provider_name' do
-            expect(subject).to eq([course_d, course_c, course_b, course_a, another_course_a, course_a_with_provider_b])
-          end
-
-          context 'when there are multiple providers with the same name' do
-            before { course_a_with_provider_b_with_different_course_code }
-
-            it 'sorts by course_code' do
-              expect(subject).to eq([course_d,
-                                     course_c,
-                                     course_b,
-                                     course_a,
-                                     another_course_a,
-                                     course_a_with_provider_b,
-                                     course_a_with_provider_b_with_different_course_code])
-            end
-          end
-        end
-      end
-    end
-
-    describe 'accredited_provider_order' do
-      subject { described_class.accredited_provider_order(provider.provider_name) }
-
-      let(:provider) { create(:provider) }
-      let(:delivered_course) { create(:course, provider:) }
-      let(:accredited_course) { create(:course, accrediting_provider: provider) }
-
-      before do
-        accredited_course
-        delivered_course
-      end
-
-      it 'returns courses accredited after courses delivered' do
-        expect(subject).to eq([delivered_course, accredited_course])
-      end
-    end
-
-    describe 'case_insensitive_search' do
-      subject { described_class.case_insensitive_search('2vVZ') }
-
-      let(:course) { create(:course, course_code: '2VvZ') }
-
-      it 'returns correct course with incorrect' do
-        expect(subject).to eq([course])
-      end
-    end
-  end
-
   describe 'validations' do
     it { is_expected.to validate_presence_of(:course_code) }
     it { is_expected.to validate_presence_of(:name) }
@@ -840,6 +650,167 @@ describe Course do
   end
 
   describe 'scopes' do
+    describe 'canonical' do
+      let(:provider_a) { create(:provider, provider_name: 'Provider A') }
+      let(:course_a) do
+        create(:course,
+               name: 'Course A',
+               course_code: 'AAA',
+               provider: provider_a)
+      end
+
+      let(:another_course_a) do
+        create(:course,
+               name: 'Course A',
+               course_code: 'BBB',
+               provider: provider_a)
+      end
+
+      let(:course_a_with_provider_b) do
+        create(:course,
+               name: 'Course A',
+               course_code: 'AAA',
+               provider: provider_b)
+      end
+
+      let(:course_a_with_provider_b_with_different_course_code) do
+        create(:course,
+               name: 'Course A',
+               course_code: 'AAB',
+               provider: provider_b)
+      end
+
+      let(:course_b) do
+        create(
+          :course,
+          name: 'Course B',
+          provider: provider_a
+        )
+      end
+
+      let(:provider_b) { create(:provider, provider_name: 'Provider B') }
+      let(:course_c) do
+        create(
+          :course,
+          name: 'Course C',
+          provider: provider_b
+        )
+      end
+
+      let(:course_d) do
+        create(
+          :course,
+          name: 'Course D',
+          provider: provider_b
+        )
+      end
+
+      before do
+        course_d
+        course_c
+        course_a
+        course_b
+      end
+
+      describe '.ascending_provider_canonical_order' do
+        subject { described_class.ascending_provider_canonical_order }
+
+        it 'sorts in ascending order of provider name and course name' do
+          expect(subject).to eq([course_a, course_b, course_c, course_d])
+        end
+
+        context 'when there are multiple courses with the same name' do
+          before { another_course_a }
+
+          it 'sorts by course_code' do
+            expect(subject).to eq([course_a, another_course_a, course_b, course_c, course_d])
+          end
+        end
+      end
+
+      describe '.descending_provider_canonical_order' do
+        subject { described_class.descending_provider_canonical_order }
+
+        it 'sorts in descending order of provider name' do
+          expect(subject).to eq([course_c, course_d, course_a, another_course_a, course_b])
+        end
+
+        context 'when there are multiple courses with the same name' do
+          before { another_course_a }
+
+          it 'sorts by course_code' do
+            expect(subject).to eq([course_c, course_d, course_a, another_course_a, course_b])
+          end
+        end
+      end
+
+      describe '.ascending_course_canonical_order' do
+        subject { described_class.ascending_course_canonical_order }
+
+        it 'sorts in ascending order of course name' do
+          expect(subject).to eq([course_a, course_b, course_c, course_d])
+        end
+
+        context 'when there are multiple courses with the same name' do
+          before do
+            course_a_with_provider_b
+            another_course_a
+          end
+
+          it 'sorts by provider_name' do
+            expect(subject).to eq([course_a, another_course_a, course_a_with_provider_b, course_b, course_c, course_d])
+          end
+
+          context 'when there are multiple providers with the same name' do
+            before { course_a_with_provider_b_with_different_course_code }
+
+            it 'sorts by course_code' do
+              expect(subject).to eq([course_a,
+                                     another_course_a,
+                                     course_a_with_provider_b,
+                                     course_a_with_provider_b_with_different_course_code,
+                                     course_b,
+                                     course_c,
+                                     course_d])
+            end
+          end
+        end
+      end
+
+      describe '.descending_course_canonical_order' do
+        subject { described_class.descending_course_canonical_order }
+
+        it 'sorts in descending order of course name' do
+          expect(subject).to eq([course_d, course_c, course_b, course_a])
+        end
+
+        context 'when there are multiple courses with the same name' do
+          before do
+            course_a_with_provider_b
+            another_course_a
+          end
+
+          it 'sorts by provider_name' do
+            expect(subject).to eq([course_d, course_c, course_b, course_a, another_course_a, course_a_with_provider_b])
+          end
+
+          context 'when there are multiple providers with the same name' do
+            before { course_a_with_provider_b_with_different_course_code }
+
+            it 'sorts by course_code' do
+              expect(subject).to eq([course_d,
+                                     course_c,
+                                     course_b,
+                                     course_a,
+                                     another_course_a,
+                                     course_a_with_provider_b,
+                                     course_a_with_provider_b_with_different_course_code])
+            end
+          end
+        end
+      end
+    end
+
     describe '.accredited_provider_order' do
       subject { described_class.accredited_provider_order(provider.provider_name) }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -448,33 +448,6 @@ describe Course do
         expect(subject).to eq([course])
       end
     end
-
-    context 'by name' do
-      let(:course_a) do
-        create(:course, name: 'Course A')
-      end
-
-      let(:course_b) do
-        create(:course, name: 'Course B')
-      end
-
-      before do
-        course_a
-        course_b
-      end
-
-      describe '#by_name_ascending' do
-        it 'sorts in ascending order of provider name' do
-          expect(described_class.by_name_ascending).to eq([course_a, course_b])
-        end
-      end
-
-      describe '#by_name_descending' do
-        it 'sorts in descending order of provider name' do
-          expect(described_class.by_name_descending).to eq([course_b, course_a])
-        end
-      end
-    end
   end
 
   describe '#modern_languages_subjects' do
@@ -867,6 +840,60 @@ describe Course do
   end
 
   describe 'scopes' do
+    describe '.accredited_provider_order' do
+      subject { described_class.accredited_provider_order(provider.provider_name) }
+
+      let(:provider) { create(:provider) }
+      let(:delivered_course) { create(:course, provider:) }
+      let(:accredited_course) { create(:course, accrediting_provider: provider) }
+
+      before do
+        accredited_course
+        delivered_course
+      end
+
+      it 'returns courses accredited after courses delivered' do
+        expect(subject).to eq([delivered_course, accredited_course])
+      end
+    end
+
+    describe 'case_insensitive_search' do
+      subject { described_class.case_insensitive_search('2vVZ') }
+
+      let(:course) { create(:course, course_code: '2VvZ') }
+
+      it 'returns correct course with incorrect' do
+        expect(subject).to eq([course])
+      end
+    end
+
+    describe '.by_name_(ascending|descending)' do
+      let(:course_a) do
+        create(:course, name: 'Course A')
+      end
+
+      let(:course_b) do
+        create(:course, name: 'Course B')
+      end
+
+      before do
+        course_a
+        course_b
+      end
+
+      describe '.by_name_ascending' do
+        it 'sorts in ascending order of provider name' do
+          expect(described_class.by_name_ascending).to eq([course_a, course_b])
+        end
+      end
+
+      describe '.by_name_descending' do
+        it 'sorts in descending order of provider name' do
+          expect(described_class.by_name_descending).to eq([course_b, course_a])
+        end
+      end
+    end
+
     describe '.within' do
       let(:published_enrichment) { build(:course_enrichment, :published) }
       let(:enrichments) { [published_enrichment] }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -894,6 +894,48 @@ describe Course do
       end
     end
 
+    describe '.changed_since' do
+      context 'with no parameters' do
+        subject { described_class.changed_since(nil) }
+
+        let!(:old_course) { create(:course, age: 1.hour.ago) }
+        let!(:course) { create(:course, age: 1.hour.ago) }
+
+        it { is_expected.to include course }
+        it { is_expected.to include old_course }
+      end
+
+      context 'with a course that was just updated' do
+        subject { described_class.changed_since(10.minutes.ago) }
+
+        let(:course) { create(:course, age: 1.hour.ago) }
+        let!(:old_course) { create(:course, age: 1.hour.ago) }
+
+        before { course.touch }
+
+        it { is_expected.to include course }
+        it { is_expected.not_to include old_course }
+      end
+
+      context 'with a course that has been changed less than a second after the given timestamp' do
+        subject { described_class.changed_since(timestamp) }
+
+        let(:timestamp) { 5.minutes.ago }
+        let(:course) { create(:course, changed_at: timestamp + 0.001.seconds) }
+
+        it { is_expected.to include course }
+      end
+
+      context 'with a course that has been changed exactly at the given timestamp' do
+        subject { described_class.changed_since(timestamp) }
+
+        let(:timestamp) { 10.minutes.ago }
+        let(:course) { create(:course, changed_at: timestamp) }
+
+        it { is_expected.not_to include course }
+      end
+    end
+
     describe '.within' do
       let(:published_enrichment) { build(:course_enrichment, :published) }
       let(:enrichments) { [published_enrichment] }
@@ -1959,48 +2001,6 @@ describe Course do
     its(:findable?) { is_expected.to be false }
     its(:open_for_applications?) { is_expected.to be false }
     its(:has_vacancies?) { is_expected.to be false }
-  end
-
-  describe '#changed_since' do
-    context 'with no parameters' do
-      subject { described_class.changed_since(nil) }
-
-      let!(:old_course) { create(:course, age: 1.hour.ago) }
-      let!(:course) { create(:course, age: 1.hour.ago) }
-
-      it { is_expected.to include course }
-      it { is_expected.to include old_course }
-    end
-
-    context 'with a course that was just updated' do
-      subject { described_class.changed_since(10.minutes.ago) }
-
-      let(:course) { create(:course, age: 1.hour.ago) }
-      let!(:old_course) { create(:course, age: 1.hour.ago) }
-
-      before { course.touch }
-
-      it { is_expected.to include course }
-      it { is_expected.not_to include old_course }
-    end
-
-    context 'with a course that has been changed less than a second after the given timestamp' do
-      subject { described_class.changed_since(timestamp) }
-
-      let(:timestamp) { 5.minutes.ago }
-      let(:course) { create(:course, changed_at: timestamp + 0.001.seconds) }
-
-      it { is_expected.to include course }
-    end
-
-    context 'with a course that has been changed exactly at the given timestamp' do
-      subject { described_class.changed_since(timestamp) }
-
-      let(:timestamp) { 10.minutes.ago }
-      let(:course) { create(:course, changed_at: timestamp) }
-
-      it { is_expected.not_to include course }
-    end
   end
 
   describe '#study_mode_description' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -176,6 +176,13 @@ describe Course do
         expect(subjects.second).to eq(english)
       end
     end
+
+    describe '#modern_languages_subjects' do
+      it 'gets modern language subjects' do
+        course = create(:course, level: 'secondary', subjects: [modern_languages, french])
+        expect(course.modern_languages_subjects).to contain_exactly(french)
+      end
+    end
   end
 
   describe '#find_a_level_subject_requirement!' do
@@ -447,13 +454,6 @@ describe Course do
       it 'returns correct course with incorrect' do
         expect(subject).to eq([course])
       end
-    end
-  end
-
-  describe '#modern_languages_subjects' do
-    it 'gets modern language subjects' do
-      course = create(:course, level: 'secondary', subjects: [modern_languages, french])
-      expect(course.modern_languages_subjects).to contain_exactly(french)
     end
   end
 


### PR DESCRIPTION
## Context

The `course_spec.rb` needs to be better arranged. There is a `describe "scopes"` block but many of the tests for scopes are not in this block and are mislabled.

## Changes proposed in this pull request

Rearrange Course unit tests 
- Move all the tests in `context 'ordering'` into `describe 'scopes'`
- Move `#modern_language_subjects` test into 'associations' block
- Move `.changed_since` scope into `scopes` block
- Move `.by_name_*` scope tests into `scopes` block

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
