### PR TITLE
changed content from courses are currently closed

### DIFF
--- a/app/components/find/courses/apply_component/view.html.erb
+++ b/app/components/find/courses/apply_component/view.html.erb
@@ -11,7 +11,7 @@
             ) %>
       </p>
     <% else %>
-      <%= govuk_warning_text(text: "You cannot apply for this course as it is closed for applications. To find courses open for applications, change your search to ‘Only show courses open for applications’.") %>
+      <%= govuk_warning_text(text: t(".not_accepting_applications")) %>
     <% end %>
   <% else %>
     <div data-qa="course__end_of_cycle_notice">

--- a/app/views/find/courses/_course_closed.html.erb
+++ b/app/views/find/courses/_course_closed.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
-    You cannot apply for this course as it is closed for applications. To find courses open for applications, change your search to ‘Only show courses open for applications’.
+  <%= t(".applications_closed_currently") %>
   </strong>
 </div>

--- a/config/locales/en/components/find/courses/apply_component.yml
+++ b/config/locales/en/components/find/courses/apply_component.yml
@@ -1,0 +1,6 @@
+en:
+  find:
+    courses:
+      apply_component:
+        view:
+          not_accepting_applications: This course is not accepting applications at the moment. You can contact the provider for more information.

--- a/config/locales/en/components/find/courses/course_closed.yml
+++ b/config/locales/en/components/find/courses/course_closed.yml
@@ -1,0 +1,5 @@
+en:
+    find:
+       courses:
+         course_closed:
+            applications_closed_currently: This course is not accepting applications at the moment. You can contact the provider for more information.

--- a/spec/components/find/courses/apply_component/view_spec.rb
+++ b/spec/components/find/courses/apply_component/view_spec.rb
@@ -34,7 +34,7 @@ describe Find::Courses::ApplyComponent::View, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('You cannot apply for this course as it is closed for applications.')
+      expect(result.text).to include('This course is not accepting applications at the moment.')
     end
   end
 


### PR DESCRIPTION
## Context

TDA providers want to publish courses that are searchable on Find, but that cannot be applied to. They want to gauge interest in candidate demand without having to deal with applications.

As a result, they want the content returned for these courses, modified, to include a recommendation for candidates to contact the provider off-service via email.
