### PR TITLE
changing-filters-to-only-return-their-type

### DIFF
--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Courses::SearchForm do
 
       context 'when old 2:1 params is used' do
         include_examples 'minimum degree required in search params',
-                         from: { degree_required: 'show_all_courses' },
+                         from: { degree_required: 'two_one' },
                          to: { minimum_degree_required: 'two_one' }
       end
 

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     scenario 'when 2:1 degree requirement shows courses requiring 2:1, 2:2, third-class, or pass degrees' do
       when_i_visit_the_find_results_page
       and_i_filter_courses_requiring_two_one_degree
-      then_courses_with_two_one_requirement_are_visible
+      then_courses_with_two_one_degree_requirement_are_visible
       and_the_two_one_filter_is_checked
       and_i_see_that_four_courses_are_found
     end
@@ -94,7 +94,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     scenario 'when 2:2 degree requirement shows courses requiring 2:2, third-class, or pass degrees' do
       when_i_visit_the_find_results_page
       and_i_filter_courses_requiring_two_two_degree
-      then_courses_with_two_two_requirement_are_visible
+      then_courses_with_two_two_degree_requirement_are_visible
       and_the_two_two_filter_is_checked
       and_i_see_that_three_courses_are_found
     end

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     scenario 'when 2:1 degree requirement shows courses requiring 2:1, 2:2, third-class, or pass degrees' do
       when_i_visit_the_find_results_page
       and_i_filter_courses_requiring_two_one_degree
-      then_courses_with_two_one_or_lower_degree_requirement_are_visible
+      then_courses_with_two_one_requirement_are_visible
       and_the_two_one_filter_is_checked
       and_i_see_that_four_courses_are_found
     end
@@ -94,7 +94,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     scenario 'when 2:2 degree requirement shows courses requiring 2:2, third-class, or pass degrees' do
       when_i_visit_the_find_results_page
       and_i_filter_courses_requiring_two_two_degree
-      then_courses_with_two_two_or_lower_degree_requirement_are_visible
+      then_courses_with_two_two_requirement_are_visible
       and_the_two_two_filter_is_checked
       and_i_see_that_three_courses_are_found
     end
@@ -102,7 +102,7 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
     scenario 'when "Third class" shows courses requiring third-class or an ordinary degree' do
       when_i_visit_the_find_results_page
       and_i_filter_courses_requiring_third_class_grade
-      then_courses_with_third_class_or_lower_degree_requirement_are_visible
+      then_courses_with_third_class_degree_requirement_are_visible
       and_the_third_class_filter_is_checked
       and_i_see_that_two_courses_are_found
     end

--- a/spec/system/find/v2/results/search_results_enabled_spec.rb
+++ b/spec/system/find/v2/results/search_results_enabled_spec.rb
@@ -83,26 +83,26 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
       given_there_are_courses_with_various_degree_requirements
     end
 
-    scenario 'when 2:1 degree requirement shows courses requiring 2:1, 2:2, third-class, or pass degrees' do
+    scenario 'when 2:1 degree requirement shows courses requiring 2:1 degree' do
       when_i_visit_the_find_results_page
       and_i_filter_courses_requiring_two_one_degree
-      then_courses_with_two_one_degree_requirement_are_visible
+      then_only_courses_with_two_one_degree_requirement_are_visible
       and_the_two_one_filter_is_checked
       and_i_see_that_four_courses_are_found
     end
 
-    scenario 'when 2:2 degree requirement shows courses requiring 2:2, third-class, or pass degrees' do
+    scenario 'when 2:2 degree requirement shows courses requiring 2:2 degree' do
       when_i_visit_the_find_results_page
       and_i_filter_courses_requiring_two_two_degree
-      then_courses_with_two_two_degree_requirement_are_visible
+      then_only_courses_with_two_two_degree_requirement_are_visible
       and_the_two_two_filter_is_checked
       and_i_see_that_three_courses_are_found
     end
 
-    scenario 'when "Third class" shows courses requiring third-class or an ordinary degree' do
+    scenario 'when "Third class" shows courses requiring third-class degree' do
       when_i_visit_the_find_results_page
       and_i_filter_courses_requiring_third_class_grade
-      then_courses_with_third_class_degree_requirement_are_visible
+      then_only_courses_with_third_class_degree_requirement_are_visible
       and_the_third_class_filter_is_checked
       and_i_see_that_two_courses_are_found
     end
@@ -125,21 +125,21 @@ RSpec.describe 'V2 results - enabled', :js, service: :find do
 
     scenario 'legacy parameters for 2:1 degree requirements shows relevant courses' do
       when_i_visit_the_find_results_page_using_old_two_one_parameter
-      then_courses_with_two_one_or_lower_degree_requirement_are_visible
+      then_only_courses_with_two_one_degree_requirement_are_visible
       and_the_two_one_filter_is_checked
       and_i_see_that_four_courses_are_found
     end
 
     scenario 'legacy parameters for 2:2 degree requirements shows relevant courses' do
       when_i_visit_the_find_results_page_using_old_two_two_parameter
-      then_courses_with_two_two_or_lower_degree_requirement_are_visible
+      then_only_courses_with_two_two_degree_requirement_are_visible
       and_the_two_two_filter_is_checked
       and_i_see_that_three_courses_are_found
     end
 
     scenario 'legacy parameters for third class degree requirements shows relevant courses' do
       when_i_visit_the_find_results_page_using_old_third_class_parameter
-      then_courses_with_third_class_or_lower_degree_requirement_are_visible
+      then_only_courses_with_third_class_degree_requirement_are_visible
       and_the_third_class_filter_is_checked
       and_i_see_that_two_courses_are_found
     end


### PR DESCRIPTION
## Context

Research shows that users are currently getting confused by selecting filters and the results that are shown for minimum degree. 

For example when they select 2:1 they expect only 2:1 courses to be shown. 

We are changing the logic to only bring back courses that meet the criteria of the filter. 
