### PR TITLE
Split SCSS build watch into find and publish processes

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,6 +1,7 @@
 js-find: yarn build:js:find --watch
 js-publish: yarn build:js:publish --watch
-css: yarn build:css --watch
+css-find: yarn build:css:find --watch
+css-publish: yarn build:css:publish --watch
 web: bin/rails server -p 3001
 worker: bundle exec sidekiq -t 25 -C config/sidekiq.yml
 caddy: caddy run


### PR DESCRIPTION
## Context

  without splitting, the first defined yarn command does not get watched

The publish scss files are not auto loaded if this is the yarn command run in the Procfile

```json
    "build:css": "yarn run build:css:publish && yarn run build:css:find",
```
## Changes proposed in this pull request

Split the Procfile "build:css" between Publish and Find

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
