### PR TITLE
Remove the 'rails-controller-testing' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -178,8 +178,6 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
 
-  gem 'rails-controller-testing'
-
   gem 'rails-erd'
 
   gem 'rb-readline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,10 +557,6 @@ GEM
       activesupport (= 8.0.2)
       bundler (>= 1.15.0)
       railties (= 8.0.2)
-    rails-controller-testing (1.0.5)
-      actionpack (>= 5.0.1.rc1)
-      actionview (>= 5.0.1.rc1)
-      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -845,7 +841,6 @@ DEPENDENCIES
   pundit
   rack-cors
   rails (= 8.0.2)
-  rails-controller-testing
   rails-erd
   rails_semantic_logger
   rb-readline

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -69,7 +69,7 @@ module Find
           course_code: '123'
         }
 
-        expect(response).to render_template('errors/not_found')
+        expect(response).to be_not_found
       end
     end
   end

--- a/spec/controllers/find/placements_controller_spec.rb
+++ b/spec/controllers/find/placements_controller_spec.rb
@@ -16,7 +16,7 @@ module Find
             course_code: '123'
           }
 
-          expect(response).to render_template('errors/not_found')
+          expect(response).to be_not_found
         end
       end
 
@@ -30,7 +30,7 @@ module Find
             course_code: course.course_code
           }
 
-          expect(response).to render_template('errors/not_found')
+          expect(response).to be_not_found
         end
       end
 
@@ -44,7 +44,7 @@ module Find
             course_code: course.course_code
           }
 
-          expect(response).to render_template('errors/not_found')
+          expect(response).to be_not_found
         end
       end
 

--- a/spec/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller_spec.rb
+++ b/spec/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller_spec.rb
@@ -34,7 +34,7 @@ module Publish
             end
 
             it 'assign the existing subject requirement to current step' do
-              current_step = assigns(:wizard).current_step
+              current_step = @controller.instance_variable_get(:@wizard).current_step
               expect(current_step.uuid).to eq('a-uuid')
               expect(current_step.subject).to eq('any_subject')
             end
@@ -49,9 +49,11 @@ module Publish
           end
 
           context 'when uuid is not provided' do
+            render_views
+
             it 'renders the :new template' do
               get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code }
-              expect(response).to render_template(:new)
+              expect(response.body).to have_content 'What A level or equivalent qualification is required?'
             end
           end
 
@@ -73,13 +75,15 @@ module Publish
           end
 
           context 'when uuid is provided and maximum A level subject requirements' do
+            render_views
+
             let(:a_level_subject_requirements) do
               4.times.map { |number| { uuid: "a-uuid-#{number}", subject: 'any_subject' } }
             end
 
             it 'renders the page so user can edit the A level subject requirement' do
               get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code, uuid: 'a-uuid-1' }
-              expect(response).to render_template(:new)
+              expect(response.body).to have_content 'What A level or equivalent qualification is required?'
             end
           end
         end

--- a/spec/controllers/publish/courses/outcome_controller_spec.rb
+++ b/spec/controllers/publish/courses/outcome_controller_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Publish::Courses::OutcomeController do
     end
 
     context 'when teacher degree apprenticeship draft course' do
+      render_views
+
       it 'renders the edit outcome' do
         course = create(
           :course,
@@ -58,7 +60,7 @@ RSpec.describe Publish::Courses::OutcomeController do
           code: course.course_code
         }
 
-        expect(response).to render_template(:edit)
+        expect(response.body).to have_content "Qualification – #{course.name_and_code}"
       end
     end
   end

--- a/spec/controllers/sign_in_controller_spec.rb
+++ b/spec/controllers/sign_in_controller_spec.rb
@@ -4,9 +4,12 @@ require 'rails_helper'
 
 describe SignInController do
   describe '#index' do
+    render_views
+
     it 'renders the index page' do
       get :index
-      expect(response).to render_template('sign_in/index')
+
+      expect(response.body).to have_content 'Sign in to Publish teacher training courses'
     end
   end
 end

--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -61,8 +61,9 @@ RSpec.describe 'Support::CopyCourses' do
     context 'when copying courses to the same provider' do
       it 'renders the new action with error messages' do
         login_user(user)
+
         post "/support/#{year}/providers/#{target_provider.id}/copy_courses", params: { 'course[autocompleted_provider_code]' => target_provider.provider_code }
-        expect(response).to render_template(:new)
+
         expect(response.parsed_body.css('.govuk-error-summary').text).to match('Choose different providers')
       end
     end


### PR DESCRIPTION
## Context

We want to reduce the dependencies we use and need to maintain.

## Changes proposed in this pull request

- Remove usage of `assigns` and access the controller's instance variables directly.

## Guidance to review

- Tests should pass.
