### PR TITLE
Fix support accredited provider autocomplete

### DIFF
--- a/app/javascript/publish/autocomplete/accredited_provider.js
+++ b/app/javascript/publish/autocomplete/accredited_provider.js
@@ -5,8 +5,10 @@ const providerSuggestionTemplate = (result) => result && `${result.provider_name
 const onConfirm = (input) => (option) => (input.value = option ? option.id : '')
 
 function init () {
-  const recruitmentCycleYear = document.getElementById('accredited_provider_search_form_recruitment_cycle_year')?.value
-  if (!recruitmentCycleYear) return
+  const accreditedProviderSearchForm = document.querySelector('form[data-recruitment-cycle-year]')
+  if (!accreditedProviderSearchForm) return
+
+  const recruitmentCycleYear = document.querySelector('form[data-recruitment-cycle-year]').dataset.recruitmentCycleYear
   const options = {
     path: `/api/${recruitmentCycleYear}/accredited_provider_suggestions`,
     template: {

--- a/app/views/publish/providers/accredited_provider_search/new.html.erb
+++ b/app/views/publish/providers/accredited_provider_search/new.html.erb
@@ -3,7 +3,9 @@
 <%= form_with(
         model: @accredited_provider_search_form,
         url: search_publish_provider_recruitment_cycle_accredited_providers_path,
-        method: :post
+        html: {
+          data: { recruitment_cycle_year: @recruitment_cycle.year }
+        }
       ) do |f| %>
 
   <% content_for :before_content do %>

--- a/app/views/support/providers/accredited_provider_search/new.html.erb
+++ b/app/views/support/providers/accredited_provider_search/new.html.erb
@@ -6,7 +6,9 @@
     <%= form_with(
         model: @accredited_provider_search_form,
         url: search_support_recruitment_cycle_provider_accredited_providers_path,
-        method: :post
+        html: {
+          data: { recruitment_cycle_year: @recruitment_cycle.year }
+        }
       ) do |f| %>
 
       <%= content_for(:breadcrumbs) do %>


### PR DESCRIPTION
## Context

  The accredited provider search api requires the recruitment cycle. We
  now get the appropriate recruitment cycle year from the window.location (the url)

## Changes proposed in this pull request

Get the required recruitment cycle year from the url to search the accredited providers

https://publish-review-5078.test.teacherservices.cloud/support/2025/providers/20584/accredited-providers/search

## Guidance to review

Is there a better way to get the recruitment cycle year?
Is the implementation sound?

## Trello

https://trello.com/c/mvWmywc7/588-autocomplete-is-not-working-for-provider-search
