### PR TITLE
Add script to download DB backup and restore to development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,8 @@ coverage
 .git
 .github
 terraform
+# Better safe than sorry
+bin/restore-backup
 
 # work is my local project-specific non-committed workspace --Misha
 work

--- a/bin/restore-backup
+++ b/bin/restore-backup
@@ -1,0 +1,43 @@
+#!/bin/env bash
+
+# Download today's sanitized backup of the publish database to the Downloads directory
+# Drop and recreate the development and test databases
+# Restore the development database with today's sanitized backup.
+
+set -e
+
+log() {
+  echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
+}
+
+log "Starting backup download..."
+
+az storage blob download \
+  --account-name s189p01pttdbbkpsanpdsa \
+  --container-name database-backup \
+  --name "publish_sanitised_$(date +%Y-%m-%d).sql.gz" \
+  --file  ~/Downloads/sanitised_backup.sql.gz \
+  --connection-string "$(az storage account show-connection-string -g s189p01-ptt-pd-rg -n s189p01pttdbbkpsanpdsa --query 'connectionString')"
+
+RAILS_ENV=development DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/rails db:drop db:create 
+
+[[ -e ~/Downloads/sanitised_backup.sql.gz ]] && gunzip -fd ~/Downloads/sanitised_backup.sql.gz  
+
+log "Checking if backup file exists..."
+if [[ -e ~/Downloads/sanitised_backup.sql.gz ]]; then
+  log "Decompressing backup file..."
+  gunzip -fd ~/Downloads/sanitised_backup.sql.gz
+  log "Backup file decompressed."
+else
+  log "Backup file not found!"
+  exit 1
+fi
+
+log "Restoring development database..."
+if [[ -x pv ]];then
+  pv ~/Downloads/sanitised_backup.sql | psql manage_courses_backend_development > /dev/null 2>&1
+else
+  psql manage_courses_backend_development < ~/Downloads/sanitised_backup.sql
+fi
+
+log "Development database restored."

--- a/bin/restore-backup
+++ b/bin/restore-backup
@@ -43,5 +43,7 @@ if [[ -x pv ]];then
 else
   psql manage_courses_backend_development < ~/Downloads/sanitised_backup.sql
 fi
+psql manage_courses_backend_development -c 'CREATE EXTENSION IF NOT EXISTS postgis;' > /dev/null 2>&1
+psql manage_courses_backend_test -c 'CREATE EXTENSION IF NOT EXISTS postgis;' > /dev/null 2>&1
 
 log "Development database restored."

--- a/bin/restore-backup
+++ b/bin/restore-backup
@@ -19,9 +19,13 @@ az storage blob download \
   --file  ~/Downloads/sanitised_backup.sql.gz \
   --connection-string "$(az storage account show-connection-string -g s189p01-ptt-pd-rg -n s189p01pttdbbkpsanpdsa --query 'connectionString')"
 
+log "Backup download completed."
+
+log "Dropping and recreating development database..."
+
 RAILS_ENV=development DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/rails db:drop db:create 
 
-[[ -e ~/Downloads/sanitised_backup.sql.gz ]] && gunzip -fd ~/Downloads/sanitised_backup.sql.gz  
+log "Development database recreated."
 
 log "Checking if backup file exists..."
 if [[ -e ~/Downloads/sanitised_backup.sql.gz ]]; then

--- a/guides/setup-development.md
+++ b/guides/setup-development.md
@@ -92,38 +92,6 @@ Then run the following command to populate the database:
 psql manage_courses_backend_development < ~/Downloads/publish_sanitised_YYYY-MM-DD.sql
 ```
 
-## Seeding GiasSchool Data
-
-The `rails gias_update` command takes an optional filename, the default is set in lib/tasks/gias_update.rake.
-
-1. With existing csv file e.g 'csv/edubasealldata20230306.csv'. Check the default `CSV_PATH` in lib/tasks/gias_update.rake matches the name of the csv file.
-
-You can then run `rails gias_update` or `rails 'gias_update[csv/<file_name>]'` where <file_name> is the csv filename.
-
-2. You can obtain an updated csv from https://www.get-information-schools.service.gov.uk/Downloads the `establishment fields CSV` checkbox. This can be uploaded to the `csv` directory as a local commit and pushed to main.
-
-Ensure the default `CSV_PATH` in lib/tasks/gias_update.rake matches the name of the new csv file if required.
-
-Test the import function locally with `rails 'gias_update[csv/<file_name>]'`
-You should see console output on completion similar to:
-
-```
-I, [2023-03-10T13:35:43.050939 #7966]  INFO -- : Done! 22843 schools upserted
-I, [2023-03-10T13:35:43.051021 #7966]  INFO -- : Failures 483
-I, [2023-03-10T13:35:43.052223 #7966]  INFO -- : Errors - [{:town=>["can't be blank"]} ...
-```
-
-You can check the `GiasSchool.count` in the database is correct.
-
-Once the file is merged to main, you can run the process in the required environment.
-Use the following sequence to allow the above console output to display, chaining the commands does update the database but does not display the console ouptut.
-
-```
-make <environment> console
-cd /app
-/usr/local/bin/bundle exec rails 'gias_update[csv/<file_name>]'
-```
-
 ## Configuring local domains
 
 This app is setup to serve two domains for two live services. In order to develop locally you will need to configure your local machine to resolve these domains to `localhost`. You can use [Caddy](https://caddyserver.com/) to do this.

--- a/guides/setup-development.md
+++ b/guides/setup-development.md
@@ -69,8 +69,19 @@ The commands from the previous section will seed the database with some test dat
 
 To seed the database with a sanitised production dump:
 
-### Download the sanitised production dump from the Azure Storage Account.
 - Request a PIM approval for the production environment.
+
+
+### Use the script to reset your local development db directly
+
+Make sure there are no connections to your database
+
+```shell
+az login # select the production subscription
+bin/restore-backup
+```
+
+### Download the sanitised production dump from the Azure Storage Account.
 - In the Azure portal, go to 'Storage Accounts' -> 's189p01pttdbbkpsanpdsa' -> 'Containers' -> 'database-backup'
 - Download the latest sanitised backup.
 - Unzip the file and you should see a file called `publish_sanitised_YYYY-MM-DD.sql`.


### PR DESCRIPTION
## Context

It's good to test locally with up to date sanitized backup from prod. It's a bit annoying to have to download in the browser.

This script downloads the sanitzed backup, drops and recreates the database and seeds the local development database with the sanitized backup.

## Changes proposed in this pull request

Add a convenience script to reload local db with sanitized backup.

## Guidance to review

A similar script already exists, I discovered after writing this one.
https://github.com/DFE-Digital/publish-teacher-training/blob/main/bin/download-nightly-backup

I don't think we need all those environment variables set. But lets test.
