### PR TITLE
Fix server error submit blank description change

### DIFF
--- a/app/components/accredited_provider_component.html.erb
+++ b/app/components/accredited_provider_component.html.erb
@@ -2,5 +2,5 @@
       card.with_action { govuk_link_to("Remove", remove_path, class: "app-link--destructive govuk-!-font-weight-regular", data: { qa: "remove-link" }) }
       card.with_summary_list(rows: [{ key: { text: "About the accredited provider" },
                                       value: { text: markdown(about_accredited_provider) },
-                                      actions: [{ href: change_about_accredited_provider_path }] }])
+                                      actions: [{ href: change_about_accredited_provider_path, visually_hidden_text: "description" }] }])
     end %>

--- a/app/controllers/support/providers/accredited_partnerships_controller.rb
+++ b/app/controllers/support/providers/accredited_partnerships_controller.rb
@@ -50,7 +50,6 @@ module Support
           ), flash: { success: t('.updated') }
 
         else
-          accredited_provider
           render(:edit)
         end
       end

--- a/app/views/support/providers/accredited_partnerships/edit.html.erb
+++ b/app/views/support/providers/accredited_partnerships/edit.html.erb
@@ -18,6 +18,7 @@
         url: support_recruitment_cycle_provider_accredited_partnership_path,
         method: :put
       ) do |f| %>
+      <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_area(
           :description,

--- a/spec/features/support/providers/accredited_partnerships_spec.rb
+++ b/spec/features/support/providers/accredited_partnerships_spec.rb
@@ -67,6 +67,15 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
     then_i_see_the_cannot_remove_text
   end
 
+  scenario 'i edit the description of a partnership' do
+    and_my_provider_has_accrediting_providers
+    and_i_click_on_the_accredited_provider_tab
+    and_i_click_change_description
+    and_i_delete_all_the_text
+    and_i_click_update_description
+    then_i_see_an_error_message('Enter details about the accredited provider')
+  end
+
   scenario 'i can delete accredited partnerships not attached to a course' do
     and_i_click_on_the_accredited_provider_tab
     and_i_click_add_accredited_provider
@@ -238,5 +247,17 @@ feature 'Accredited partnership flow', { can_edit_current_and_next_cycles: false
       'h2.govuk-summary-card__title a.govuk-link',
       text: 'Accrediting provider name'
     )
+  end
+
+  def and_i_click_change_description
+    page.click_link_or_button 'Change description'
+  end
+
+  def and_i_delete_all_the_text
+    fill_in 'About the accredited provider', with: ''
+  end
+
+  def and_i_click_update_description
+    click_link_or_button 'Update description'
   end
 end


### PR DESCRIPTION
## Context

When submitting an invalid description, the user raises a 500 error.
This was due to a misplaced identifier that serves no purpose.

## Changes proposed in this pull request

- Remove identifier.
- Add spec for invalid description case.
- Add missing `govuk_error_summary`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello

https://trello.com/c/HBdXhS9B/587-changing-description-of-accredited-partnership-raises-error
