### PR TITLE
Update .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,7 +3,7 @@ kubelogin 0.2.6
 kubectl   1.32.2
 yarn      1.22.22
 nodejs    20.10.0
-terraform 1.11.2
+terraform 1.4.5
 azure-cli 2.70.0
 jq        1.7.1
 make      4.4.1


### PR DESCRIPTION
## Context

Terrarform version 1.4.5 is required


>╷
│ Error: Unsupported Terraform Core version
│
│   on providers.tf line 2, in terraform:
│    2:   required_version = "=1.4.5"
│
│ This configuration does not support Terraform version 1.11.2. To proceed, either choose another supported Terraform version or update this version constraint. Version constraints are
│ normally set for good reason, so updating the constraint may lead to other errors or unexpected behavior.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
