### PR TITLE
Change content on how school placements work salaried

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,7 @@ en:
             selectable_school: You will be able to select a preferred placement location, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
             fee: The training provider will select placement schools for you. They will contact you and discuss your situation to help them select a location that you can travel to.
             fee_and_placement: You will be able to select a preferred placement school, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
-            salary: You usually cannot choose your employing school. The training provider will contact you and discuss your situation to help them select a location you can travel to.
+            salary: Check with the provider before applying. They may require you to find your own school or want to discuss your situation to help them choose a school you can travel to.
             salary_and_placement: You will be able to select a preferred employing school, but there is no guarantee you will be placed in the school you have chosen. The training provider will contact you to discuss your choice to help them select a location that suits you.
   markdown_formatting:
     summary_text: Help formatting your text

--- a/spec/components/find/courses/about_schools_component/view_spec.rb
+++ b/spec/components/find/courses/about_schools_component/view_spec.rb
@@ -31,7 +31,7 @@ describe Find::Courses::AboutSchoolsComponent::View, type: :component do
 
       expect(result.text).to include('You will spend most of your time in one school which will employ you. You will also spend some time in another school and at a location where you will study.')
       expect(result).to have_css('.app-advice__title', text: 'How school placements work')
-      expect(result.text).to include('You usually cannot choose your employing school. The training provider will contact you and discuss your situation to help them select a location you can travel to.')
+      expect(result.text).to include('Check with the provider before applying. They may require you to find your own school or want to discuss your situation to help them choose a school you can travel to.')
       expect(result.text).not_to include('Find out more about how school placements work')
     end
   end

--- a/spec/components/shared/courses/school_placements_advice/view_spec.rb
+++ b/spec/components/shared/courses/school_placements_advice/view_spec.rb
@@ -17,7 +17,7 @@ describe Shared::Courses::SchoolPlacementsAdvice::View, type: :component do
       result = render_inline(described_class.new(course))
 
       expect(result).to have_css('.app-advice__title', text: 'How school placements work')
-      expect(result.text).to include('You usually cannot choose your employing school. The training provider will contact you and discuss your situation to help them select a location you can travel to.')
+      expect(result.text).to include('Check with the provider before applying. They may require you to find your own school or want to discuss your situation to help them choose a school you can travel to.')
       expect(result.text).not_to include('Find out more about how school placements work')
     end
   end

--- a/spec/features/publish/courses/editing_course_school_placements_spec.rb
+++ b/spec/features/publish/courses/editing_course_school_placements_spec.rb
@@ -149,7 +149,7 @@ feature 'Editing how placements work', { can_edit_current_and_next_cycles: false
 
   def then_i_see_salaried_course_school_placement_guidance
     expect(page).to have_content(
-      'You usually cannot choose your employing school. The training provider will contact you and discuss your situation to help them select a location you can travel to.'
+      'Check with the provider before applying. They may require you to find your own school or want to discuss your situation to help them choose a school you can travel to.'
     )
     expect(page).to have_no_content('Find out more about how school placements work')
   end


### PR DESCRIPTION
## Context

Providers sometimes want candidates to secure their own employing school before they apply. We need to reflect this in the Where you’ll train information on salaried course pages.

## Changes proposed in this pull request
Changing content on How school placements work content to reflect the need for candidates to secure their own placements. 


