### PR TITLE
Make sure we smart quotes provider name before saving into the DB

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -58,7 +58,24 @@ class Provider < ApplicationRecord
   has_many :accredited_partnerships, foreign_key: :training_provider_id, class_name: 'ProviderPartnership', inverse_of: :training_provider
   has_many :accredited_partners, through: :accredited_partnerships, class_name: 'Provider', source: :accredited_provider
 
-  normalizes :provider_name, with: ->(value) { value.gsub(/\s+/, ' ').strip }
+  normalizes :provider_name, with: lambda { |value|
+    value
+      .gsub(/\s+/, ' ')        # Normalize spaces
+      .strip                   # Remove leading/trailing spaces
+      .then do |string|
+        RubyPants.new(
+          string,
+          [2, :dashes],
+          double_left_quote: '“',
+          double_right_quote: '”',
+          single_left_quote: '‘',
+          single_right_quote: '’',
+          ellipsis: '…',
+          em_dash: '—',
+          en_dash: '–'
+        ).to_html
+      end
+  }
 
   def accredited_providers
     if Settings.features.provider_partnerships

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -36,9 +36,9 @@ describe Provider do
         provider = create(:provider, :accredited_provider)
 
         expect do
-          provider.update(ukprn: '12345678', provider_name: "St Leo's and Southmead/Provider", postcode: 'sw1a 1aa')
+          provider.update(ukprn: '12345678', provider_name: 'St Leo and Southmead/Provider', postcode: 'sw1a 1aa')
         end.to change { provider.reload.searchable }.to(
-          "'12345678':1 '1aa':13 'and':5,9 'leo':3 'leos':8 'provider':11 's':4 'southmead':10 'southmead/provider':6 'st':2,7 'sw1a':12 'sw1a1aa':14"
+          "'12345678':1 '1aa':12 'and':4,8 'leo':3,7 'provider':10 'southmead':9 'southmead/provider':5 'st':2,6 'sw1a':11 'sw1a1aa':13"
         )
       end
     end
@@ -128,6 +128,9 @@ describe Provider do
 
   describe 'normalizations' do
     it { is_expected.to normalize(:provider_name).from('  ACME  SCITT  ').to('ACME SCITT') }
+    it { is_expected.to normalize(:provider_name).from('regular "quotes" used').to('regular “quotes” used') }
+    it { is_expected.to normalize(:provider_name).from("it's a 'quoted' word").to('it’s a ‘quoted’ word') }
+    it { is_expected.to normalize(:provider_name).from("  'single' and \"double\" quotes  with  spaces  ").to('‘single’ and “double” quotes with spaces') }
   end
 
   describe 'organisation' do


### PR DESCRIPTION
## Context

On our search results, providers which has single quotes on their names are not displaying smart quotes.

We should make sure smart quotes are saved into the database instead of changing on the presentation layer.

## Changes proposed in this pull request

* Normalize the provider name attribute

## Guidance to review

1. When you save does the provider name is converted properly?
