### PR TITLE
Sort course codes before testing rendered text

### DIFF
--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Support::CopyCourses' do
         expect(courses.flat_map(&:sites).length).to eq(3)
         expect(response).to redirect_to(support_recruitment_cycle_provider_courses_path(year, target_provider.id))
         follow_redirect!
-        expect(response.parsed_body.css('.govuk-notification-banner--success').text).to match(format('Courses copied: %s', source_provider.courses.map(&:course_code).to_sentence))
+        expect(response.parsed_body.css('.govuk-notification-banner--success').text).to match(format('Courses copied: %s', source_provider.courses.map(&:course_code).sort.to_sentence))
       end
     end
 


### PR DESCRIPTION
## Context

We put the codes of courses copied from one provider to another on screen. Our tests asserts that this text is present but sometimes the codes are in a different order and the tests fail.

## Changes proposed in this pull request

Sort the codes before testing the text we render to the UI

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
