### PR TITLE
Replace enrichments with partnerships where they were missed

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -68,7 +68,7 @@ module BreadcrumbHelper
   end
 
   def training_providers_breadcrumb
-    path = publish_provider_recruitment_cycle_training_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    path = publish_provider_recruitment_cycle_training_partners_path(@provider.provider_code, @provider.recruitment_cycle_year)
     provider_breadcrumb.merge({ 'Courses as an Accredited provider' => path })
   end
 

--- a/app/views/publish/recruitment_cycles/_courses_accredited_provider.html.erb
+++ b/app/views/publish/recruitment_cycles/_courses_accredited_provider.html.erb
@@ -1,6 +1,6 @@
 <% if @provider.accredited? %>
   <h2 class="govuk-heading-m">
-    <%= govuk_link_to "Courses as an accredited provider", publish_provider_recruitment_cycle_training_providers_path(@provider.provider_code, year), data: { qa: "courses-as-an-accredited-body" } %>
+    <%= govuk_link_to "Courses as an accredited provider", publish_provider_recruitment_cycle_training_partners_path(@provider.provider_code, year), data: { qa: "courses-as-an-accredited-body" } %>
   </h2>
   <p class="govuk-body">Use this section to:</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">


### PR DESCRIPTION

## Context

  During the move from provider enrichments to partnerships, some
  templates didn't have feature flags wrapping the enrichments. Now
  partnerships is released we'll just replace enrichments with
  partnerships.


## Changes proposed in this pull request

Replace code that depends on accrediting provider enrichments to instead depend on provider partnerships.
No feature flag added because Provider Partnerships is live

## Guidance to review

Any where else that needs updating?

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
