### PR TITLE
Fallback to page 1 if page parameter can not be parsed

### DIFF
--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -12,7 +12,8 @@ module Find
       @courses_query = ::Courses::Query.new(params: @search_params.dup)
       @courses = @courses_query.call
       @courses_count = @courses_query.count
-      @pagy, @results = pagy(@courses, count: @courses_count)
+
+      @pagy, @results = pagy(@courses, count: @courses_count, page:)
     end
 
     private
@@ -68,6 +69,10 @@ module Find
 
     def store_result_fullpath_for_backlinks
       session[:results_path] = request.fullpath
+    end
+
+    def page
+      params[:page].to_i.clamp(1..)
     end
   end
 end

--- a/spec/requests/find/results_spec.rb
+++ b/spec/requests/find/results_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Find
+  describe '/results' do
+    before do
+      host! 'www.find-example.com'
+    end
+
+    context 'when page parameter is invalid' do
+      before do
+        get '/results', params: { page: 'some-site-.co.uk' }
+      end
+
+      it 'responds successfully' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Some requests are returning 500.because requests are adding custom value to the page parameter.O

e.g /results?page=something

This PR handle this parameter by fallback to first page if something is wrong with params[:page]

## Guidance to review

1. Visit `/results?page=something`
2. Does it fallback to the first page?
3. Apply filters and then change the page parameter again
4. Does it fallback to the first page?
