### PR TITLE
Show ratifying providers' train_with_us for their description on course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -421,8 +421,7 @@ class Course < ApplicationRecord
   def ratifying_provider_description
     return nil unless accrediting_provider
 
-    subquery = RecruitmentCycle.current.providers.where(provider_code: accrediting_provider.provider_code).select(:id)
-    provider.accredited_partnerships.find_by(accredited_provider_id: subquery)&.description
+    Provider.in_current_cycle.find_by(provider_code: accrediting_provider.provider_code).train_with_us
   end
 
   def accrediting_provider_description

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2327,13 +2327,13 @@ describe Course do
       let(:course) { create(:course, provider:, accrediting_provider:) }
 
       context 'without any provider partnership' do
-        it { is_expected.to be_nil }
+        it { is_expected.to eq(accrediting_provider.train_with_us) }
       end
 
       context 'with accrediting_provider_enrichments' do
         let(:provider) { create(:provider, accredited_partnerships: [build(:provider_partnership, accredited_provider: accrediting_provider, description: 'one two three')]) }
 
-        it { is_expected.to match 'one two three' }
+        it { is_expected.to eq(accrediting_provider.train_with_us) }
       end
     end
   end

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe API::Public::V1::SerializableCourse do
       course.provider.accredited_partnerships.create(description: 'foo', accredited_provider: course.accrediting_provider)
     end
 
-    it { is_expected.to have_attribute(:about_accredited_body).with_value(course.provider.accredited_partnerships.find_by(accredited_provider_id: course.accrediting_provider).description) }
+    it { is_expected.to have_attribute(:about_accredited_body).with_value(course.accrediting_provider.train_with_us) }
   end
 
-  it { is_expected.to have_attribute(:about_accredited_body).with_value('EnrichmentDescription') }
+  it { is_expected.to have_attribute(:about_accredited_body).with_value(course.accrediting_provider.train_with_us) }
   it { is_expected.to have_attribute(:about_course).with_value(course.latest_published_enrichment.about_course) }
   it { is_expected.to have_attribute(:accredited_body_code).with_value(course.accredited_provider_code) }
   it { is_expected.to have_attribute(:age_minimum).with_value(3) }


### PR DESCRIPTION
## Context

  Previously we would show the description that the training provider
  entered on the partnership but this is inconsistent.


## Changes proposed in this pull request



## Guidance to review

|Course page|Course ratifying provider page|
|---|---|
|![image](https://github.com/user-attachments/assets/c9522e37-721e-41f4-9668-bba8e8169e1f)|![image](https://github.com/user-attachments/assets/5d21710f-74e9-4a73-b47c-42dcf45f9c7b)|

## Trello
https://trello.com/c/ahJv8TTh/599-display-accredited-providers-about-us-content-in-the-courses-about-accredited-provider-page

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
