### PR TITLE
Validate provider code is uppercase

### DIFF
--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -27,7 +27,7 @@ module Support
 
     validates :provider_name, presence: true, length: { maximum: 100 }
 
-    validates :provider_code, presence: true, length: { is: 3, message: :invalid }
+    validates :provider_code, presence: true, length: { is: 3 }
 
     validate :provider_code_taken
 

--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -17,6 +17,12 @@ module Support
     UNIVERSITY_ACCREDITED_PROVIDER_NUMBER_FORMAT = /\A1\d{3}\z/
     SCITT_ACCREDITED_PROVIDER_NUMBER_FORMAT = /\A5\d{3}\z/
     ACCREDITED_PROVIDER_NUMBER_FORMAT = /\A[15]\d{3}\z/
+    # Provider code must have at least one number and the rest are numbers or uppercase letters in any order
+    #
+    # ^(?=[A-Z0-9]{3}$): Ensures the string is exactly three characters long and consists of uppercase letters or digits.
+    # (?=.*\d): Ensures there is at least one digit.
+    # [A-Z\d]{3}$: Matches exactly three characters that are either uppercase letters or digits.
+    PROVIDER_CODE_FORMAT = /\A(?=[A-Z0-9]{3}$)(?=.*\d)[A-Z\d]{3}\z/
 
     attr_accessor(*FIELDS, :recruitment_cycle)
 
@@ -27,7 +33,7 @@ module Support
 
     validates :provider_name, presence: true, length: { maximum: 100 }
 
-    validates :provider_code, presence: true, length: { is: 3 }
+    validates :provider_code, presence: true, length: { is: 3 }, format: { with: PROVIDER_CODE_FORMAT }
 
     validate :provider_code_taken
 

--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -17,12 +17,12 @@ module Support
     UNIVERSITY_ACCREDITED_PROVIDER_NUMBER_FORMAT = /\A1\d{3}\z/
     SCITT_ACCREDITED_PROVIDER_NUMBER_FORMAT = /\A5\d{3}\z/
     ACCREDITED_PROVIDER_NUMBER_FORMAT = /\A[15]\d{3}\z/
-    # Provider code must have at least one number and the rest are numbers or uppercase letters in any order
+    # Provider code must have at least one number and the rest are numbers or letters in any order
     #
-    # ^(?=[A-Z0-9]{3}$): Ensures the string is exactly three characters long and consists of uppercase letters or digits.
+    # ^(?=[a-zA-Z0-9]{3}$): Ensures the string is exactly three characters long and consists of letters or digits.
     # (?=.*\d): Ensures there is at least one digit.
-    # [A-Z\d]{3}$: Matches exactly three characters that are either uppercase letters or digits.
-    PROVIDER_CODE_FORMAT = /\A(?=[A-Z0-9]{3}$)(?=.*\d)[A-Z\d]{3}\z/
+    # [a-zA-Z\d]{3}$: Matches exactly three characters that are either letters or digits.
+    PROVIDER_CODE_FORMAT = /\A(?=[a-zA-Z0-9]{3}$)(?=.*\d)[a-zA-Z\d]{3}\z/
 
     attr_accessor(*FIELDS, :recruitment_cycle)
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -58,6 +58,7 @@ class Provider < ApplicationRecord
   has_many :accredited_partnerships, foreign_key: :training_provider_id, class_name: 'ProviderPartnership', inverse_of: :training_provider
   has_many :accredited_partners, through: :accredited_partnerships, class_name: 'Provider', source: :accredited_provider
 
+  normalizes :provider_code, with: ->(value) { value.upcase }
   normalizes :provider_name, with: lambda { |value|
     value
       .gsub(/\s+/, ' ')        # Normalize spaces

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1191,6 +1191,7 @@ en:
               blank: "Enter a provider code"
               invalid: "Enter a valid provider code"
               taken: "Provider code already taken"
+              wrong_length: Provider code should be %{count} characters
             ukprn:
               blank: Enter a UK provider reference number (UKPRN)
               contains_eight_numbers_starting_with_one: Enter a valid UK provider reference number (UKPRN) - it must be 8 digits starting with a 1, like 12345678

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1189,7 +1189,7 @@ en:
               too_long: "Enter a provider name that is 100 characters or fewer"
             provider_code:
               blank: "Enter a provider code"
-              invalid: "Enter a valid provider code"
+              invalid: "Enter a valid provider code (One number, at least, with numbers or uppercase letters)"
               taken: "Provider code already taken"
               wrong_length: Provider code should be %{count} characters
             ukprn:

--- a/spec/forms/support/provider_form_spec.rb
+++ b/spec/forms/support/provider_form_spec.rb
@@ -94,11 +94,11 @@ module Support
           .with_message('Enter a provider name that is 100 characters or fewer')
       }
 
-      it {
+      it 'shows the error messages for invalid provider code length' do
         expect(subject).to validate_length_of(:provider_code)
           .is_equal_to(3)
-          .with_message('Enter a valid provider code')
-      }
+          .with_message('Provider code should be 3 characters')
+      end
 
       include_examples 'blank validation', :provider_name, 'Enter a provider name'
       include_examples 'blank validation', :provider_code, 'Enter a provider code'

--- a/spec/forms/support/provider_form_spec.rb
+++ b/spec/forms/support/provider_form_spec.rb
@@ -100,6 +100,16 @@ module Support
           .with_message('Provider code should be 3 characters')
       end
 
+      it 'shows the error message for invalid provider code format' do
+        expect(subject).not_to allow_values(
+          'ggg',
+          '11g',
+          'GGG'
+        )
+          .for(:provider_code)
+          .with_message('Enter a valid provider code (One number, at least, with numbers or uppercase letters)')
+      end
+
       include_examples 'blank validation', :provider_name, 'Enter a provider name'
       include_examples 'blank validation', :provider_code, 'Enter a provider code'
       include_examples 'blank validation', :ukprn, 'Enter a UK provider reference number (UKPRN)'

--- a/spec/forms/support/provider_form_spec.rb
+++ b/spec/forms/support/provider_form_spec.rb
@@ -103,7 +103,8 @@ module Support
       it 'shows the error message for invalid provider code format' do
         expect(subject).not_to allow_values(
           'ggg',
-          '11g',
+          '11&',
+          '11!',
           'GGG'
         )
           .for(:provider_code)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -126,11 +126,16 @@ describe Provider do
     end
   end
 
-  describe 'normalizations' do
+  describe 'provider name normalizations' do
     it { is_expected.to normalize(:provider_name).from('  ACME  SCITT  ').to('ACME SCITT') }
     it { is_expected.to normalize(:provider_name).from('regular "quotes" used').to('regular “quotes” used') }
     it { is_expected.to normalize(:provider_name).from("it's a 'quoted' word").to('it’s a ‘quoted’ word') }
     it { is_expected.to normalize(:provider_name).from("  'single' and \"double\" quotes  with  spaces  ").to('‘single’ and “double” quotes with spaces') }
+  end
+
+  describe 'provider code normalizations' do
+    it { is_expected.to normalize(:provider_code).from('u2u').to('U2U') }
+    it { is_expected.to normalize(:provider_code).from('ab1').to('AB1') }
   end
 
   describe 'organisation' do

--- a/spec/services/find/analytics/search_results_event_spec.rb
+++ b/spec/services/find/analytics/search_results_event_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Find::Analytics::SearchResultsEvent do
           utm_medium: 'search-form'
         },
         results: [
-          create(:course, course_code: 'abc', provider: build(:provider, provider_code: 'rst')),
-          create(:course, course_code: 'def', provider: build(:provider, provider_code: 'uvw'))
+          create(:course, course_code: 'abc', provider: build(:provider, provider_code: 'RST')),
+          create(:course, course_code: 'def', provider: build(:provider, provider_code: 'UVW'))
         ]
       }
     end
@@ -48,8 +48,8 @@ RSpec.describe Find::Analytics::SearchResultsEvent do
           total: 1360,
           page: 2,
           visible_courses: [
-            { code: 'abc', provider_code: 'rst' },
-            { code: 'def', provider_code: 'uvw' }
+            { code: 'abc', provider_code: 'RST' },
+            { code: 'def', provider_code: 'UVW' }
           ],
           search_params: {
             send_courses: true,
@@ -74,8 +74,8 @@ RSpec.describe Find::Analytics::SearchResultsEvent do
           total: 1360,
           page: 2,
           visible_courses: [
-            { code: 'abc', provider_code: 'rst' },
-            { code: 'def', provider_code: 'uvw' }
+            { code: 'abc', provider_code: 'RST' },
+            { code: 'def', provider_code: 'UVW' }
           ],
           search_params: {
             send_courses: true,
@@ -100,8 +100,8 @@ RSpec.describe Find::Analytics::SearchResultsEvent do
           total: 1360,
           page: 2,
           visible_courses: [
-            { code: 'abc', provider_code: 'rst' },
-            { code: 'def', provider_code: 'uvw' }
+            { code: 'abc', provider_code: 'RST' },
+            { code: 'def', provider_code: 'UVW' }
           ],
           search_params: {
             send_courses: true,


### PR DESCRIPTION
## Context

We had a support issue some time back where someone created a provider and one or more of the letters were entered downcase. The providers courses would not load on find.

## Changes proposed in this pull request

Validate that when creating a new Provider that their provider code is the correct format:
 - 3 characters long
 - At least one number
 - the other two characters can be numbers or letters.
 - Any order

Add normalization to the provider_code column so that any input is upcased.

## Guidance to review

|Provide code length|Doesn't validate upcase|Validates invalid format|
|---|---|---|
|![image](https://github.com/user-attachments/assets/33d47cd9-c515-4d78-89c7-2b95d6012de3)|![image](https://github-production-user-asset-6210df.s3.amazonaws.com/135042929/430851720-bf9e0964-dcb7-460b-b047-92c8935186d7.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20250407%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250407T082927Z&X-Amz-Expires=300&X-Amz-Signature=e9f98e52a0f099470d06c55aa1fcdc13d5d9ef4cf705b7d7add3e6f3dce6a734&X-Amz-SignedHeaders=host)|![image](https://github.com/user-attachments/assets/db0bb2f3-1d3c-4ef8-8bf0-745e1579fa34)|



## Trello
https://trello.com/c/7NsqwHo4/527-bug-validate-upper-case-provider-code-on

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
