### PR TITLE
Add recruitment cycle via Support interface

### DIFF
--- a/app/controllers/support/recruitment_cycles_controller.rb
+++ b/app/controllers/support/recruitment_cycles_controller.rb
@@ -3,5 +3,32 @@
 module Support
   class RecruitmentCyclesController < ApplicationController
     def index; end
+
+    def new
+      @support_recruitment_cycle_form = RecruitmentCycleForm.new
+    end
+
+    def create
+      @support_recruitment_cycle_form = RecruitmentCycleForm.new(
+        params
+          .expect(
+            support_recruitment_cycle_form: %i[year
+                                               application_start_date
+                                               application_end_date]
+          )
+      )
+
+      if @support_recruitment_cycle_form.valid?
+        RecruitmentCycleCreationService.call(
+          year: @support_recruitment_cycle_form.year,
+          application_start_date: @support_recruitment_cycle_form.application_start_date,
+          application_end_date: @support_recruitment_cycle_form.application_end_date
+        )
+
+        redirect_to support_recruitment_cycles_path, flash: { success: t('.added') }
+      else
+        render :new
+      end
+    end
   end
 end

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -2,4 +2,5 @@
 
 class ApplicationForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
 end

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -2,8 +2,6 @@
 
 module Courses
   class SearchForm < ApplicationForm
-    include ActiveModel::Attributes
-
     # Search parameters #
     attribute :applications_open, :boolean
     attribute :can_sponsor_visa, :boolean

--- a/app/forms/support/recruitment_cycle_form.rb
+++ b/app/forms/support/recruitment_cycle_form.rb
@@ -2,8 +2,6 @@
 
 module Support
   class RecruitmentCycleForm < ApplicationForm
-    include ActiveModel::Attributes
-
     attribute :year, :string
     attribute :application_start_date, :multiple_parameters_date
     attribute :application_end_date, :multiple_parameters_date

--- a/app/forms/support/recruitment_cycle_form.rb
+++ b/app/forms/support/recruitment_cycle_form.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Support
+  class RecruitmentCycleForm < ApplicationForm
+    include ActiveModel::Attributes
+
+    attribute :year, :string
+    attribute :application_start_date, :multiple_parameters_date
+    attribute :application_end_date, :multiple_parameters_date
+
+    validates :year, presence: true, numericality: { only_integer: true }
+    validates :application_start_date, :application_end_date, multiple_parameters_date: true
+    validate :application_end_date_must_be_after_start_date
+    validate :year_must_be_unique
+
+    def initialize(params = {})
+      processed_params = MultipleParametersDateType.process(params)
+
+      super(processed_params)
+    end
+
+    private
+
+    def application_end_date_must_be_after_start_date
+      return if application_start_date.blank? || application_end_date.blank?
+
+      return unless application_end_date <= application_start_date
+
+      errors.add(:application_start_date, :application_end_date_after_start_date)
+      errors.add(:application_end_date, :application_end_date_after_start_date)
+    end
+
+    def year_must_be_unique
+      return if year.blank?
+
+      errors.add(:year, :taken) if RecruitmentCycle.exists?(year:)
+    end
+  end
+end

--- a/app/jobs/rollover_job.rb
+++ b/app/jobs/rollover_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RolloverJob < ApplicationJob
+  queue_as :default
+
+  def perform(recruitment_cycle_id); end
+end

--- a/app/lib/multiple_parameters_date_type.rb
+++ b/app/lib/multiple_parameters_date_type.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class MultipleParametersDateType < ActiveModel::Type::Value
-  class PotentialDate
-    include ActiveModel::Model
-    attr_accessor :year, :month, :day
-  end
-
   def self.process(params)
     params.keys.select { |key| key.to_s.match?(/\(\d+i\)$/) }.each do |key|
       attribute_name = key.to_s.split('(').first

--- a/app/lib/multiple_parameters_date_type.rb
+++ b/app/lib/multiple_parameters_date_type.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class MultipleParametersDateType < ActiveModel::Type::Value
+  class PotentialDate
+    include ActiveModel::Model
+    attr_accessor :year, :month, :day
+  end
+
+  def self.process(params)
+    params.keys.select { |key| key.to_s.match?(/\(\d+i\)$/) }.each do |key|
+      attribute_name = key.to_s.split('(').first
+
+      year = params.delete("#{attribute_name}(1i)")
+      month = params.delete("#{attribute_name}(2i)")
+      day = params.delete("#{attribute_name}(3i)")
+
+      params[attribute_name] = PotentialDate.new(year:, month:, day:) if year.present? && month.present? && day.present?
+    end
+
+    params
+  end
+
+  def cast(value)
+    if value.is_a?(PotentialDate)
+      begin
+        Date.new(value.year.to_i, value.month.to_i, value.day.to_i)
+      rescue ArgumentError
+        nil
+      end
+    else
+      super
+    end
+  end
+end

--- a/app/lib/potential_date.rb
+++ b/app/lib/potential_date.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class PotentialDate
+  include ActiveModel::Model
+  attr_accessor :year, :month, :day
+end

--- a/app/services/recruitment_cycle_creation_service.rb
+++ b/app/services/recruitment_cycle_creation_service.rb
@@ -3,16 +3,19 @@
 class RecruitmentCycleCreationService
   include ServicePattern
 
-  def initialize(year:, application_start_date:, application_end_date:, summary: false)
+  def initialize(year:, application_start_date:, application_end_date:)
     @year = year
     @application_start_date = application_start_date
     @application_end_date = application_end_date
-    @summary = summary
   end
 
   def call
-    RecruitmentCycle.create!(year: @year, application_start_date: @application_start_date, application_end_date: @application_end_date)
+    recruitment_cycle = RecruitmentCycle.create!(
+      year: @year,
+      application_start_date: @application_start_date,
+      application_end_date: @application_end_date
+    )
 
-    Rails.logger.info { "The new RecruitmentCycle has been successfully created for:\n\nyear: '#{@year}'\napplication_start_date: '#{@application_start_date}'\napplication_end_date: '#{@application_end_date}'\n\n" } if @summary
+    RolloverJob.perform_later(recruitment_cycle.id)
   end
 end

--- a/app/validators/multiple_parameters_date_validator.rb
+++ b/app/validators/multiple_parameters_date_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MultipleParametersDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, _value)
+    potential_date = record.instance_variable_get(:@attributes)[attribute.to_s].value_before_type_cast
+
+    record.errors.add(attribute, :blank) if potential_date.blank?
+
+    Date.new(potential_date.year.to_i, potential_date.month.to_i, potential_date.day.to_i)
+  rescue StandardError
+    record.errors.add(attribute, :invalid_date)
+  end
+end

--- a/app/views/support/recruitment_cycles/index.html.erb
+++ b/app/views/support/recruitment_cycles/index.html.erb
@@ -1,3 +1,11 @@
 <% content_for :page_title, t(".page_title") %>
 
-<h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+      <%= govuk_button_link_to t(".add_recruitment_cycle"), new_support_recruitment_cycle_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/support/recruitment_cycles/new.html.erb
+++ b/app/views/support/recruitment_cycles/new.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, t(".page_title") %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: support_recruitment_cycles_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= form_with(model: @support_recruitment_cycle_form, url: support_recruitment_cycles_path) do |f| %>
+    <%= f.govuk_error_summary %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l"><%= t(".page_caption") %></span>
+        <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field :year,
+                class: "govuk-input--width-4",
+                label: { text: Support::RecruitmentCycleForm.human_attribute_name(:year), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_date_field :application_start_date,
+                                  class: "govuk-input--width-20",
+                                  legend: { text: Support::RecruitmentCycleForm.human_attribute_name(:application_start_date), size: "s" } %>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= f.govuk_date_field :application_end_date,
+                                  class: "govuk-input--width-20",
+                                  legend: { text: Support::RecruitmentCycleForm.human_attribute_name(:application_end_date), size: "s" } %>
+        </div>
+
+        <%= f.govuk_submit t(".submit") %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to t(".cancel"), support_recruitment_cycles_path, no_visited_state: true %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/initializers/active_record_config.rb
+++ b/config/initializers/active_record_config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency Rails.root.join('app/lib/multiple_parameters_date_type')
+
 ActiveRecord::SchemaDumper.ignore_tables |= %w[
   geography_columns
   geometry_columns
@@ -9,3 +11,5 @@ ActiveRecord::SchemaDumper.ignore_tables |= %w[
   spatial_ref_sys
   topology
 ]
+
+ActiveModel::Type.register(:multiple_parameters_date, MultipleParametersDateType)

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -1,0 +1,23 @@
+en:
+  activemodel:
+    attributes:
+      support/recruitment_cycle_form:
+        year: Recruitment cycle year
+        application_start_date: Application start date
+        application_end_date: Application end date
+    errors:
+      models:
+        support/recruitment_cycle_form:
+          attributes:
+            year:
+              blank: Enter a year
+              not_a_number: Enter a number
+              taken: Year has already been taken
+            application_start_date:
+              blank: Enter an application start date
+              application_end_date_after_start_date: Start date must be before the application end date
+              invalid_date: Enter a valid date
+            application_end_date:
+              blank: Enter an application end date
+              application_end_date_after_start_date: End date must be after the application start date
+              invalid_date: Enter a valid date

--- a/config/locales/en/support/recruitment_cycles.yml
+++ b/config/locales/en/support/recruitment_cycles.yml
@@ -3,3 +3,11 @@ en:
     recruitment_cycles:
       index:
         page_title: Recruitment Cycles
+        add_recruitment_cycle: Add recruitment cycle
+      new:
+        page_title: Recruitment cycle details
+        page_caption: Add recruitment cycle
+        submit: Continue
+        cancel: Cancel
+      create:
+        added: Recruitment cycle added

--- a/spec/forms/support/recruitment_cycle_form_spec.rb
+++ b/spec/forms/support/recruitment_cycle_form_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Support::RecruitmentCycleForm do
+  describe 'attribute assignment' do
+    it 'parses multi-parameter dates for application start date' do
+      form = described_class.new(
+        'application_start_date(1i)' => '2024',
+        'application_start_date(2i)' => '09',
+        'application_start_date(3i)' => '30'
+      )
+      expect(form.application_start_date).to eq(Date.new(2024, 9, 30))
+    end
+
+    it 'parses multi-parameter dates for application end date' do
+      form = described_class.new(
+        'application_end_date(1i)' => '2025',
+        'application_end_date(2i)' => '10',
+        'application_end_date(3i)' => '2'
+      )
+      expect(form.application_end_date).to eq(Date.new(2025, 10, 2))
+    end
+
+    it 'handles invalid dates gracefully' do
+      form = described_class.new(
+        'application_start_date(1i)' => '2025',
+        'application_start_date(2i)' => '02',
+        'application_start_date(3i)' => '30'
+      )
+      expect(form.application_start_date).to be_nil
+    end
+
+    it 'handles incomplete dates gracefully' do
+      form = described_class.new(
+        'application_start_date(1i)' => '',
+        'application_start_date(2i)' => '',
+        'application_start_date(3i)' => ''
+      )
+      expect(form.application_start_date).to be_nil
+    end
+  end
+
+  describe 'validations' do
+    subject(:form) { described_class.new(params) }
+
+    context 'when required fields are missing' do
+      let(:params) { {} }
+
+      it 'is invalid without a year' do
+        expect(form).not_to be_valid
+        expect(form.errors[:year]).to include('Enter a year')
+      end
+
+      it 'is invalid without an application start date' do
+        expect(form).not_to be_valid
+        expect(form.errors[:application_start_date]).to include('Enter an application start date')
+      end
+
+      it 'is invalid without an application end date' do
+        expect(form).not_to be_valid
+        expect(form.errors[:application_end_date]).to include('Enter an application end date')
+      end
+    end
+
+    context 'when year is not a number' do
+      let(:params) { { year: 'twenty twenty five' } }
+
+      it 'is invalid' do
+        expect(form).not_to be_valid
+        expect(form.errors[:year]).to include('Enter a number')
+      end
+    end
+
+    context 'when dates are valid' do
+      let(:params) do
+        {
+          'year' => '2051',
+          'application_start_date(1i)' => '2050',
+          'application_start_date(2i)' => '10',
+          'application_start_date(3i)' => '15',
+          'application_end_date(1i)' => '2051',
+          'application_end_date(2i)' => '03',
+          'application_end_date(3i)' => '10'
+        }
+      end
+
+      it 'is valid' do
+        expect(form).to be_valid
+      end
+    end
+
+    context 'when end date is before start date' do
+      let(:params) do
+        {
+          'year' => '2025',
+          'application_start_date(1i)' => '2025',
+          'application_start_date(2i)' => '03',
+          'application_start_date(3i)' => '15',
+          'application_end_date(1i)' => '2025',
+          'application_end_date(2i)' => '03',
+          'application_end_date(3i)' => '10'
+        }
+      end
+
+      it 'is invalid' do
+        expect(form).not_to be_valid
+        expect(form.errors[:application_start_date]).to include('Start date must be before the application end date')
+        expect(form.errors[:application_end_date]).to include('End date must be after the application start date')
+      end
+    end
+
+    context 'when dates are invalid' do
+      let(:params) do
+        {
+          'year' => '2025',
+          'application_start_date(1i)' => '2025',
+          'application_start_date(2i)' => '02',
+          'application_start_date(3i)' => '30',
+          'application_end_date(1i)' => '2025',
+          'application_end_date(2i)' => '03',
+          'application_end_date(3i)' => '50'
+        }
+      end
+
+      it 'is invalid' do
+        expect(form).not_to be_valid
+        expect(form.errors[:application_start_date]).to include('Enter a valid date')
+        expect(form.errors[:application_end_date]).to include('Enter a valid date')
+      end
+    end
+
+    context 'when dates are incomplete' do
+      let(:params) do
+        {
+          'year' => '2025',
+          'application_start_date(1i)' => '2025',
+          'application_start_date(2i)' => '02',
+          'application_end_date(1i)' => '2025',
+          'application_end_date(2i)' => '03',
+          'application_end_date(3i)' => '10'
+        }
+      end
+
+      it 'is invalid' do
+        expect(form).not_to be_valid
+        expect(form.errors[:application_start_date]).to include('Enter an application start date')
+      end
+    end
+
+    context 'when year is not unique' do
+      let(:params) { { year: } }
+      let(:year) { '2025' }
+
+      before { create(:recruitment_cycle, year:) }
+
+      it 'is not valid' do
+        expect(form).not_to be_valid
+        expect(form.errors[:year]).to include('Year has already been taken')
+      end
+    end
+  end
+end

--- a/spec/services/recruitment_cycle_creation_service_spec.rb
+++ b/spec/services/recruitment_cycle_creation_service_spec.rb
@@ -4,15 +4,57 @@ require 'rails_helper'
 
 describe RecruitmentCycleCreationService do
   describe '.call' do
-    subject { described_class.call(year: 2030, application_start_date: '2031-09-01', application_end_date: '2032-09-01') }
-
-    it 'calls the recruitment cycle creation service' do
-      expect(described_class).to receive(:call)
-      subject
+    subject(:service) do
+      described_class.call(
+        year: year,
+        application_start_date: application_start_date,
+        application_end_date: application_end_date
+      )
     end
 
-    it 'returns nil' do
-      expect(subject).to be_nil
+    let(:year) { 2030 }
+    let(:application_start_date) { Date.new(2031, 9, 1) }
+    let(:application_end_date) { Date.new(2032, 9, 1) }
+
+    context 'when creation succeeds' do
+      it 'creates a recruitment cycle with correct attributes' do
+        expect { service }.to change(RecruitmentCycle, :count).by(1)
+
+        recruitment_cycle = RecruitmentCycle.last
+        expect(recruitment_cycle.year.to_i).to eq(year)
+        expect(recruitment_cycle.application_start_date).to eq(application_start_date)
+        expect(recruitment_cycle.application_end_date).to eq(application_end_date)
+      end
+
+      it 'enqueues the rollover job with the recruitment cycle ID' do
+        allow(RolloverJob).to receive(:perform_later)
+
+        service
+
+        recruitment_cycle = RecruitmentCycle.find_by(year: year)
+        expect(RolloverJob).to have_received(:perform_later).with(recruitment_cycle.id)
+      end
+    end
+
+    context 'when creation fails' do
+      before do
+        allow(RecruitmentCycle).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(RecruitmentCycle.new))
+      end
+
+      it 'does not create a recruitment cycle' do
+        RecruitmentCycle.delete_all
+
+        expect { service }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(RecruitmentCycle.count).to eq(0)
+      end
+
+      it 'does not enqueue the rollover job' do
+        allow(RolloverJob).to receive(:perform_later)
+
+        expect { service }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(RolloverJob).not_to have_received(:perform_later)
+      end
     end
   end
 end

--- a/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Adding a new recruitment cycle', service: :publish do
+  include DfESignInUserHelper
+  let(:provider) { create(:provider) }
+  let(:user) { create(:user, :admin, providers: [provider]) }
+
+  before do
+    Timecop.travel(Time.zone.local(2025, 1, 1))
+
+    driven_by(:rack_test)
+    sign_in_system_test(user:)
+  end
+
+  scenario 'add a recruitment cycle' do
+    given_i_visit_support_settings
+    when_i_click_recruitment_cycles
+    and_i_click_add_recruitment_cycle
+    and_i_submit_without_filling_in_the_form
+    then_i_see_error_messages_for_missing_fields
+    when_i_fill_in_valid_recruitment_cycle_details
+    and_i_submit_the_form
+    then_i_see_the_success_message
+  end
+
+  def given_i_visit_support_settings
+    visit support_settings_path
+  end
+
+  def when_i_click_recruitment_cycles
+    click_link_or_button 'Recruitment Cycles'
+  end
+
+  def and_i_click_add_recruitment_cycle
+    click_link_or_button 'Add recruitment cycle'
+  end
+
+  def and_i_submit_without_filling_in_the_form
+    click_link_or_button 'Continue'
+  end
+
+  def then_i_see_error_messages_for_missing_fields
+    expect(page).to have_text('There is a problem')
+    expect(page).to have_text('Enter a year')
+    expect(page).to have_text('Enter an application start date')
+    expect(page).to have_text('Enter an application end date')
+  end
+
+  def when_i_fill_in_valid_recruitment_cycle_details
+    fill_in 'Recruitment cycle year', with: '2026'
+    fill_in 'support_recruitment_cycle_form[application_start_date(3i)]', with: '04'
+    fill_in 'support_recruitment_cycle_form[application_start_date(2i)]', with: '10'
+    fill_in 'support_recruitment_cycle_form[application_start_date(1i)]', with: '2025'
+    fill_in 'support_recruitment_cycle_form[application_end_date(3i)]', with: '04'
+    fill_in 'support_recruitment_cycle_form[application_end_date(2i)]', with: '10'
+    fill_in 'support_recruitment_cycle_form[application_end_date(1i)]', with: '2026'
+  end
+
+  def and_i_submit_the_form
+    click_link_or_button 'Continue'
+  end
+
+  def then_i_see_the_success_message
+    expect(page).to have_text('Recruitment cycle added')
+  end
+end


### PR DESCRIPTION
## Context

Add the possibility to add a recruitment cycle via support interface this will call the RolloverJob

## Caveats

* For now the Rollover job is empty and will be done in future PR.

## Guidance to review

1. Visit Support
2. Click Settings
3. Click Recruitment cycles
4. Click Add recruitment cycle
5. Test validations
6. Create one recruitment cycle
