### PR TITLE
Move specs from features to system 1

### DIFF
--- a/spec/support/derived_metadata.rb
+++ b/spec/support/derived_metadata.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.define_derived_metadata(file_path: Regexp.new("/spec/features/find")) do |metadata|
+  config.define_derived_metadata(file_path: Regexp.new("/spec/(system|features)/find")) do |metadata|
     metadata[:find_features] = true
     metadata[:with_find_constraint] = true
   end
 
-  config.define_derived_metadata(file_path: Regexp.new("/spec/features/publish")) do |metadata|
+  config.define_derived_metadata(file_path: Regexp.new("/spec/(system|features)/publish")) do |metadata|
     metadata[:publish_features] = true
     metadata[:auth_features] = true
 
     metadata[:with_publish_constraint] = true
   end
 
-  config.define_derived_metadata(file_path: Regexp.new("/spec/features/support")) do |metadata|
+  config.define_derived_metadata(file_path: Regexp.new("/spec/(system|features)/support")) do |metadata|
     metadata[:support_features] = true
     metadata[:auth_features] = true
 
     metadata[:with_publish_constraint] = true
   end
 
-  config.define_derived_metadata(file_path: Regexp.new("/spec/features/auth")) do |metadata|
+  config.define_derived_metadata(file_path: Regexp.new("/spec/(system|features)/auth")) do |metadata|
     metadata[:auth_features] = true
     metadata[:support_features] = true
     metadata[:publish_features] = true

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -2,11 +2,13 @@
 
 RSpec.configure do |config|
   config.include FeatureHelpers::Authentication, type: :feature
+  config.include FeatureHelpers::Authentication, type: :system
   config.include FeatureHelpers::NewCourseParam, type: :feature
   config.include FeatureHelpers::GovukComponents, type: :feature
   config.include FeatureHelpers::CourseSteps, type: :feature
   config.include FeatureHelpers::PageWithQuery, type: :feature
   config.include DfESignInUserHelper, type: :feature
+  config.include DfESignInUserHelper, type: :system
   config.include FeatureHelpers::PageObject::Support, :support_features
   config.include FeatureHelpers::PageObject::Publish, :publish_features
   config.include FeatureHelpers::PageObject::Find, :find_features

--- a/spec/system/auth/magic_link_spec.rb
+++ b/spec/system/auth/magic_link_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Authentication with magic links" do
+RSpec.describe "Authentication with magic links" do
   include ActiveJob::TestHelper
 
   before do

--- a/spec/system/auth/persona_spec.rb
+++ b/spec/system/auth/persona_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Authentication with Personas" do
+RSpec.describe "Authentication with Personas" do
   before do
     given_persona_based_authentication_is_active
   end

--- a/spec/system/auth/provider_user_signs_in_spec.rb
+++ b/spec/system/auth/provider_user_signs_in_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Authentication" do
+RSpec.describe "Authentication" do
   scenario "Provider user signs in", { can_edit_current_and_next_cycles: false } do
     given_i_am_a_provider_user
     when_i_visit_the_root_path

--- a/spec/system/auth/support_user_signs_in_spec.rb
+++ b/spec/system/auth/support_user_signs_in_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Authentication" do
+RSpec.describe "Authentication" do
   scenario "Support user signs in" do
     given_i_am_a_support_user
     when_i_visit_the_support_interface

--- a/spec/system/canonical_tags_spec.rb
+++ b/spec/system/canonical_tags_spec.rb
@@ -2,13 +2,13 @@
 
 require "rails_helper"
 
-feature "Canonical tags", :with_find_constraint do
+RSpec.describe "Canonical tags" do
   before do
     given_i_have_courses
     and_i_visit_the_home_page
   end
 
-  describe "Canonical tags on Find pages" do
+  describe "Canonical tags on Find pages", service: :find do
     scenario "without query params" do
       then_the_page_contains_canonical_tags_with_no_query_params
     end
@@ -30,7 +30,7 @@ feature "Canonical tags", :with_find_constraint do
     end
   end
 
-  describe "Canonical tags on Publish pages", :with_publish_constraint do
+  describe "Canonical tags on Publish pages", service: :publish do
     scenario "Publish page contains canonical tags" do
       and_i_visit_the_publish_page
       then_the_publish_page_contains_canonical_tags
@@ -67,7 +67,7 @@ feature "Canonical tags", :with_find_constraint do
   end
 
   def then_the_page_contains_canonical_tags_for_a_course
-    canonical_url = "http://www.example.com/course/#{@mathematics_course.provider.provider_code}/#{@mathematics_course.course_code}/"
+    canonical_url = "http://www.find-test.lvh.me/course/#{@mathematics_course.provider.provider_code}/#{@mathematics_course.course_code}/"
 
     link_tag = page.find("link[rel='canonical']", visible: :all)
     expect(link_tag[:href]).to eq(canonical_url)
@@ -77,17 +77,17 @@ feature "Canonical tags", :with_find_constraint do
   end
 
   def then_the_page_contains_canonical_tags_with_no_query_params
-    expect(page).to have_css("link[rel='canonical'][href='http://www.example.com/']", visible: :all)
-    expect(page).to have_css("meta[property='og:url'][content='http://www.example.com/']", visible: :all)
+    expect(page).to have_css("link[rel='canonical'][href='http://www.find-test.lvh.me/']", visible: :all)
+    expect(page).to have_css("meta[property='og:url'][content='http://www.find-test.lvh.me/']", visible: :all)
   end
 
   def then_the_page_contains_canonical_tags_without_query_params
-    expect(page).to have_css("link[rel='canonical'][href='http://www.example.com/results/']", visible: :all)
-    expect(page).to have_css("meta[property='og:url'][content='http://www.example.com/results/']", visible: :all)
+    expect(page).to have_css("link[rel='canonical'][href='http://www.find-test.lvh.me/results/']", visible: :all)
+    expect(page).to have_css("meta[property='og:url'][content='http://www.find-test.lvh.me/results/']", visible: :all)
   end
 
   def then_the_publish_page_contains_canonical_tags
-    expect(page).to have_css("link[rel='canonical'][href='http://www.example.com/sign-in/']", visible: :all)
-    expect(page).to have_css("meta[property='og:url'][content='http://www.example.com/sign-in/']", visible: :all)
+    expect(page).to have_css("link[rel='canonical'][href='http://www.publish-test.lvh.me/sign-in/']", visible: :all)
+    expect(page).to have_css("meta[property='og:url'][content='http://www.publish-test.lvh.me/sign-in/']", visible: :all)
   end
 end

--- a/spec/system/support/filters/provider_course_search_filters_spec.rb
+++ b/spec/system/support/filters/provider_course_search_filters_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Filter providers by type" do
+RSpec.describe "Filter providers by type" do
   before do
     given_i_am_authenticated(user: create(:user, :admin))
     and_there_are_providers_with_different_types

--- a/spec/system/support/filters/provider_filters_spec.rb
+++ b/spec/system/support/filters/provider_filters_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Filter providers" do
+RSpec.describe "Filter providers" do
   before do
     given_i_am_authenticated(user: create(:user, :admin))
     and_there_are_providers_with_courses

--- a/spec/system/support/filters/user_filters_spec.rb
+++ b/spec/system/support/filters/user_filters_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Filter users" do
+RSpec.describe "Filter users" do
   before do
     given_i_am_authenticated(user: create(:user, :admin))
     and_there_are_users

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Support index" do
+RSpec.describe "Support index" do
   scenario "viewing support cycles page during rollover" do
     given_we_are_in_rollover
     and_there_are_two_recruitment_cycles

--- a/spec/system/support/providers/view_components_spec.rb
+++ b/spec/system/support/providers/view_components_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "view components" do
+RSpec.describe "view components" do
   shared_examples "navigate to" do |link|
     scenario "navigate to #{link}" do
       visit link

--- a/spec/system/support/users/creating_a_new_user_spec.rb
+++ b/spec/system/support/users/creating_a_new_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Creating a new user" do
+RSpec.describe "Creating a new user" do
   let(:user) { create(:user, :admin) }
 
   before do

--- a/spec/system/support/users/deleting_a_user_spec.rb
+++ b/spec/system/support/users/deleting_a_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Deleting a new user" do
+RSpec.describe "Deleting a new user" do
   before do
     given_i_am_authenticated(user: create(:user, :admin))
     and_a_user_exists_to_delete

--- a/spec/system/support/users/deleting_user_from_provider_spec.rb
+++ b/spec/system/support/users/deleting_user_from_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Deleting a provider from user" do
+RSpec.describe "Deleting a provider from user" do
   before do
     given_i_am_authenticated(user: create(:user, :admin))
     and_a_user_provider_relationship_exists_to_remove

--- a/spec/system/support/users/editing_a_user_spec.rb
+++ b/spec/system/support/users/editing_a_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Editing a user" do
+RSpec.describe "Editing a user" do
   before do
     given_i_am_authenticated(user: admin)
     and_a_user_exists

--- a/spec/system/support/users/providers_list_spec.rb
+++ b/spec/system/support/users/providers_list_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "View providers" do
+RSpec.describe "View providers" do
   let(:user) { create(:user, :admin) }
 
   before do

--- a/spec/system/support/users/users_list_spec.rb
+++ b/spec/system/support/users/users_list_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "View users" do
+RSpec.describe "View users" do
   let(:user) { create(:user, :admin) }
 
   scenario "i can view users" do

--- a/spec/system/view_pages_spec.rb
+++ b/spec/system/view_pages_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "View pages", :with_publish_constraint do
+RSpec.describe "View pages", :with_publish_constraint do
   scenario "Environment label and class are read from settings" do
     visit "/cookies"
 


### PR DESCRIPTION
## Context

We are aiming to move away from feature tests and rely only on Rails system tests. This will allow us to remove DatabaseCleaner and move forward with more canonical testing methodologies.

## Changes proposed in this pull request

Move the base feature tests to the system test directory.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
