### PR TITLE
[340] Add visa sponsorship deadline to find

### DIFF
--- a/app/components/find/courses/apply_component/view.html.erb
+++ b/app/components/find/courses/apply_component/view.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8" id="section-apply">
   <% if Find::CycleTimetable.mid_cycle? %>
     <% if application_status_open? %>
-      <p class="govuk-body">
+      <p class="govuk-body govuk-!-margin-0">
         <%= govuk_start_button(
               text: "Apply for this course",
               href: apply_path,
@@ -10,6 +10,11 @@
               }
             ) %>
       </p>
+      <% if show_application_deadline? %>
+        <p class="govuk-body">
+          <%= t(".visa_sponsorship_deadline_notice_html", application_deadline:) %>
+        </p>
+      <% end %>
     <% else %>
       <%= govuk_warning_text(text: t(".not_accepting_applications")) %>
     <% end %>

--- a/app/components/find/courses/apply_component/view.rb
+++ b/app/components/find/courses/apply_component/view.rb
@@ -18,6 +18,14 @@ module Find
 
           apply_publish_provider_recruitment_cycle_course_path(provider_code: course.provider.provider_code, code: course.course_code, recruitment_cycle_year: provider.recruitment_cycle.year)
         end
+
+        def show_application_deadline?
+          course.visa_sponsorship_application_deadline_at.present? && FeatureFlag.active?(:visa_sponsorship_deadline)
+        end
+
+        def application_deadline
+          course.visa_sponsorship_application_deadline_at.to_fs(:govuk_date)
+        end
       end
     end
   end

--- a/config/locales/en/components/find/courses/apply_component.yml
+++ b/config/locales/en/components/find/courses/apply_component.yml
@@ -4,3 +4,4 @@ en:
       apply_component:
         view:
           not_accepting_applications: This course is not accepting applications at the moment. You can contact the provider for more information.
+          visa_sponsorship_deadline_notice_html: Non-UK citizens, apply by <b>%{application_deadline}</b>

--- a/spec/components/find/courses/apply_component/view_spec.rb
+++ b/spec/components/find/courses/apply_component/view_spec.rb
@@ -36,6 +36,25 @@ describe Find::Courses::ApplyComponent::View, type: :component do
 
       expect(result.text).to include('This course is not accepting applications at the moment.')
     end
+
+    context 'when the course has a deadline for candidates who require visa sponsorship' do
+      before { FeatureFlag.activate(:visa_sponsorship_deadline) }
+
+      it 'renders the deadline' do
+        deadline = 2.days.from_now.change(hour: 11, min: 59)
+        course = build(
+          :course,
+          :open,
+          :can_sponsor_student_visa,
+          visa_sponsorship_application_deadline_at: deadline,
+          provider:
+        )
+
+        result = render_inline(described_class.new(course))
+
+        expect(result.text).to include "Non-UK citizens, apply by #{deadline.to_fs(:govuk_date)}"
+      end
+    end
   end
 
   context 'it is not mid cycle' do


### PR DESCRIPTION
## Context

We have added the the visa sponsorship deadlines to the create flow and have a PR out for the edit flow. This PR show the deadline in find. 

[Trello card](https://trello.com/c/eXqdI8cu)

## Changes proposed in this pull request

| Before | After |
| ------ | ------ | 
| <img width="732" alt="image" src="https://github.com/user-attachments/assets/08674e35-6a21-4c6e-9fe3-e142a8492ed9" /> | <img width="729" alt="image" src="https://github.com/user-attachments/assets/84e6fd92-6b02-4920-a32f-f7f24dda0509" /> |

## Guidance to review

- Create a publish a course with a deadline for visa sponsorship.
- Look at that course on find. You should the date under the button.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
