### PR TITLE
[798] Use real visa sponsorship application deadline at date in API r…

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -150,9 +150,7 @@ module API
         end
 
         attribute :visa_sponsorship_application_deadline_at do
-          # A date_time attribute is required for Apply to block candidates who require visa sponsorship from applying to
-          # courses with early deadlines. The value is nil until the UI is built to collect the data. (4/2/2025)
-          nil
+          @object.visa_sponsorship_application_deadline_at&.iso8601
         end
 
         enrichment_attribute :about_course

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe API::Public::V1::SerializableCourse do
     it { is_expected.to have_attribute(:bursary_amount).with_value('24000') }
   end
 
+  context 'when course sponsors visas and has a visa sponsorship application deadline' do
+    let(:provider) { create(:provider) }
+    let(:deadline) { (provider.recruitment_cycle.application_end_date - 1.day).end_of_day }
+    let(:course) do
+      create(
+        :course,
+        :open,
+        :published,
+        :can_sponsor_skilled_worker_visa,
+        provider:,
+        visa_sponsorship_application_deadline_at: deadline
+      )
+    end
+
+    it { is_expected.to have_attribute(:visa_sponsorship_application_deadline_at).with_value(deadline.iso8601) }
+  end
+
   it { is_expected.to have_attribute(:bursary_requirements).with_value(course.bursary_requirements) }
   it { is_expected.to have_attribute(:changed_at).with_value(course.changed_at.iso8601) }
   it { is_expected.to have_attribute(:code).with_value(course.course_code) }


### PR DESCRIPTION
## Context

Now that we are able to enter `visa_sponsorship_application_deadline_at` dates (behind a feature flag) we can send real dates over the API to be consumed by Apply. 

[Trello card](https://trello.com/c/bG4bDGn5)

## Changes proposed in this pull request

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/781490a8-6454-46c2-96cf-f36e9ddbf918" />


## Guidance to review

- Update a open / published course locally to have a `visa_sponsorship_application_deadline_at` date. 
- Hit the API locally, with an `updated_since` param in the past few minutes, otherwise you'll get too many courses to sort through. 
- You should see the course you updated and the date on the `visa_sponsorship_application_deadline_at` field.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
