### PR TITLE
Add some docs around Geolocation in the service

### DIFF
--- a/app/lib/google_old_places_api/client.rb
+++ b/app/lib/google_old_places_api/client.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module GoogleOldPlacesAPI
+  # Wrapper around Google REST APIs for Geocoding and Autocomplete
+  #
   class Client
     BASE_URL = 'https://maps.googleapis.com/maps/api/'
 
@@ -15,6 +17,7 @@ module GoogleOldPlacesAPI
       end
     end
 
+    # @see https://developers.google.com/maps/documentation/places/web-service/autocomplete
     def autocomplete(query)
       response = get(
         endpoint: 'place/autocomplete/json',
@@ -36,6 +39,7 @@ module GoogleOldPlacesAPI
       end
     end
 
+    # @see https://developers.google.com/maps/documentation/geocoding/start
     def geocode(location_name)
       response = get(
         endpoint: 'geocode/json',

--- a/app/services/geolocation/coordinates_query.rb
+++ b/app/services/geolocation/coordinates_query.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Geolocation
+  # Geocode a place name to get coordinates
+  #
+  # @see GoogleOldPlacesAPI::Client
+  #
   class CoordinatesQuery
     attr_reader :query, :logger, :cache, :client, :cache_expiration
 

--- a/app/services/geolocation/suggestions.rb
+++ b/app/services/geolocation/suggestions.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module Geolocation
+  # Query Google autocomplete API with a text query to get GooglePlaces API response json
+  #
+  # @see GoogleOldPlacesAPI::Client
   class Suggestions
     def initialize(query, cache: Rails.cache, cache_expiration: 30.days, logger: Rails.logger, client: GoogleOldPlacesAPI::Client.new)
       @query = query

--- a/guides/geolocation.md
+++ b/guides/geolocation.md
@@ -1,0 +1,28 @@
+# Geolocation
+
+We use geolocation services in two ways. 
+
+1. Autocomplete a users text input when searching for a location.
+2. Retreiving the geographic coordinates of the corresponding place.
+
+### *Example:*
+- A user wants to find the courses near Bristol and order the courses by their distance to Bristol.
+
+#### Scenario
+1. First the user types 'Bristol' into the search for the location.
+2. This is the Google geocode service. It returns a matching place and location types (postcode, administrative_area_2, etc.).
+3. We then pass the autocompleted place name to get the coordinates of the place using the geocode API.
+4. When we get the coordinates, we can use postgis to select all the courses whose schools are within a given distance of this place.
+5. We return the filtered and sorted list of courses.
+
+
+## Classes
+
+### `Geolocation::Suggestions`
+
+We take user input for a place or region in the UK to search for courses. This query is sent to Google and returns the responses to the user.
+When the user chooses an option and submits their selection we then need to get the coordtinates for that place.
+
+### `Geolocation::CoordinatesQuery`
+
+We take the autocompleted place name from the `Geolocation::Suggestions` and use that to fetch the coordinates of the place from the geocode API in Google.


### PR DESCRIPTION
## Context

Add a markdown doc describing what Geolocation/Geocoding we do and where to find it.

Why is `Query` in`CoordinatesQuery`, and not `Suggestions`


## Changes proposed in this pull request

https://github.com/DFE-Digital/publish-teacher-training/blob/8f50906ed7afadd4fbb057afc551745a49cc9848/guides/geolocation.md

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
