### PR TITLE
Set azure-kubelogin version to latest

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ yarn                 1.22.22
 nodejs               20.10.0
 terraform            1.4.5
 azure-cli            2.70.0
-azure-kubelogin      0.2.6
+azure-kubelogin      latest
 jq                   1.7.1
 make                 4.4.1
 caddy                2.9.1


### PR DESCRIPTION
## Context

Azure seem to remove their kubelogin versions once a new version is released. This is annoying when you go to use kubelogin and it won't install.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
