### PR TITLE
Use setup-ruby bundler cache

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -193,13 +193,6 @@ jobs:
       - run: bundle exec rails parallel:setup
       - run: bundle exec rails spec:prepare
 
-      # - name: Setup tests
-      #   run: |
-      #     docker compose up --no-build -d
-      #     docker compose exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
-      #     docker compose exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
-      #     docker compose exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
-
       - name: ${{ matrix.tests.name }} tests with feature flags
         run: |
           ${{ env.FEATURE_FLAGS }} bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"
@@ -229,6 +222,7 @@ jobs:
   build:
     name: Build
     needs: [lint, analytics-checks, javascript-tests, rails-tests]
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
     outputs:
       docker_image: ${{ env.DOCKER_IMAGE }}
       image_tag: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,12 +35,16 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
-
-      - run: bundle install
+        with:
+          bundler-cache: true
 
       - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+      - run: yarn install --frozen-lockfile
 
-      - run: yarn install
+      - run: gem env
+      - run: cat Gemfile.lock
 
       - name: ${{ matrix.tests.name }}
         run: ${{ env.COMMAND }}
@@ -68,9 +72,9 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
-
-      - name: Install dependencies
-        run: yarn install
+        with:
+          cache: yarn
+      - run: yarn install --frozen-lockfile
 
       - name: yarn test
         run: yarn run test --run
@@ -110,9 +114,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
-
-      - name: Install dependencies
-        run: bundle install
+        with:
+          bundler-cache: true
 
       - name: Setup database
         run: bundle exec rails db:prepare
@@ -179,10 +182,13 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
-      - run: bundle install
+        with:
+          bundler-cache: true
 
       - uses: actions/setup-node@v4
-      - run: yarn install
+        with:
+          cache: yarn
+      - run: yarn install --frozen-lockfile
 
       - run: bundle exec rails parallel:setup
       - run: bundle exec rails spec:prepare

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,12 +15,12 @@ inherit_from:
   - ./config/rubocop/style.yml
   - ./config/rubocop/factory_bot.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   NewCops: enable
-  Exclude:
-    - "bin/*"
-    - "db/schema.rb"
-    - "node_modules/**/*"
 
 RSpec/AnyInstance:
   Enabled: false


### PR DESCRIPTION
## Context

Our CICD pipeline currently installs all gems from scratch for every job that need Ruby and gems installed. We can improve this by caching the installed gems.

In previous attempts, caching was problematic as the `bundle exec rubocop` command was failing.

After some thorough investigation, we ran into https://stackoverflow.com/questions/69415433/bundle-exec-rubocop-failling-on-github-actions-but-runs-successfully-locally that outlined the potential cause. Robocop configurations were being picked up from the `./vendor` path.

The solution is to add the following configuration to _our_ `.rubocop.yml` configuration.

```yaml
inherit_mode:
  merge:
    - Exclude
```

This works, as the `rubocop-rails` gem defines an exclusion of the `./vendor/**/*` files: https://github.com/rubocop/rubocop-rails/blob/master/.rubocop.yml#L15.

## Changes proposed in this pull request

- Cache Ruby gems and node packages in build-and-deploy GA workflow.
- Only run the `build` job if the `deploy` label is present.

## Guidance to review

The workflow caches Ruby gems as intended and all steps succeed.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
