### PR TITLE
As a Support User, I want to see a list of all Recruitment Cycles

### DIFF
--- a/app/controllers/support/recruitment_cycles_controller.rb
+++ b/app/controllers/support/recruitment_cycles_controller.rb
@@ -2,7 +2,9 @@
 
 module Support
   class RecruitmentCyclesController < ApplicationController
-    def index; end
+    def index
+      @recruitment_cycles = RecruitmentCycle.order(year: :desc)
+    end
 
     def new
       @support_recruitment_cycle_form = RecruitmentCycleForm.new

--- a/app/views/support/recruitment_cycles/index.html.erb
+++ b/app/views/support/recruitment_cycles/index.html.erb
@@ -6,6 +6,30 @@
       <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
 
       <%= govuk_button_link_to t(".add_recruitment_cycle"), new_support_recruitment_cycle_path %>
+
+      <%= govuk_table do |table| %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell text: RecruitmentCycle.human_attribute_name(:year) %>
+            <% row.with_cell text: RecruitmentCycle.human_attribute_name(:start_date) %>
+            <% row.with_cell text: RecruitmentCycle.human_attribute_name(:end_date) %>
+            <% row.with_cell text: RecruitmentCycle.human_attribute_name(:status) %>
+          <% end %>
+        <% end %>
+
+        <% table.with_body do |body| %>
+          <% @recruitment_cycles.each do |recruitment_cycle| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell text: recruitment_cycle.year %>
+              <% row.with_cell text: recruitment_cycle.application_start_date.strftime("%-d %B %Y") %>
+              <% row.with_cell text: recruitment_cycle.application_end_date.strftime("%-d %B %Y") %>
+              <% row.with_cell do %>
+                <%= govuk_tag(text: (recruitment_cycle.current? ? t(".status_current") : t(".status_inactive")), colour: (recruitment_cycle.current? ? "green" : "grey")) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    attributes:
+      recruitment_cycle:
+        year: Year
+        start_date: Start date
+        end_date: End date
+        status: Status

--- a/config/locales/en/support/recruitment_cycles.yml
+++ b/config/locales/en/support/recruitment_cycles.yml
@@ -4,6 +4,8 @@ en:
       index:
         page_title: Recruitment Cycles
         add_recruitment_cycle: Add recruitment cycle
+        status_current: Current
+        status_inactive: Past
       new:
         page_title: Recruitment cycle details
         page_caption: Add recruitment cycle

--- a/spec/system/support/recruitment_cycles/view_recruitment_cycles_spec.rb
+++ b/spec/system/support/recruitment_cycles/view_recruitment_cycles_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Viewing recruitment cycles', service: :publish do
+  include DfESignInUserHelper
+  let(:provider) { create(:provider) }
+  let(:user) { create(:user, :admin, providers: [provider]) }
+  let!(:previous_recruitment_cycle) { create(:recruitment_cycle, year: '2024') }
+
+  before do
+    Timecop.travel(Time.zone.local(2025, 1, 1))
+
+    driven_by(:rack_test)
+    sign_in_system_test(user:)
+  end
+
+  scenario 'I view all recruitment cycles' do
+    given_i_visit_support_settings
+    when_i_click_recruitment_cycles
+    then_i_see_the_current_recruitment_cycle
+    then_i_see_the_past_recruitment_cycles
+  end
+
+  def given_i_visit_support_settings
+    visit support_settings_path
+  end
+
+  def when_i_click_recruitment_cycles
+    click_link_or_button 'Recruitment Cycles'
+  end
+
+  def then_i_see_the_current_recruitment_cycle
+    first_row = first(:css, '.govuk-table tbody tr', visible: true)
+
+    within(first_row) do
+      expect(page).to have_text('2025')
+      expect(page).to have_text('1 October 2024')
+      expect(page).to have_text('30 September 2025')
+      expect(page).to have_css('.govuk-tag.govuk-tag--green', text: 'Current')
+    end
+  end
+
+  def then_i_see_the_past_recruitment_cycles
+    second_row = all(:css, '.govuk-table tbody tr', visible: true)[1]
+
+    within(second_row) do
+      expect(page).to have_text('2024')
+      expect(page).to have_text('1 October 2023')
+      expect(page).to have_text('30 September 2024')
+      expect(page).to have_css('.govuk-tag.govuk-tag--grey', text: 'Past')
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to trigger Rollover via the Support Console.

## Changes proposed in this pull request

Add a Recruitment Cycles index page to list all past and present cycles 

## Guidance to review

- Viisit publish
- Visit Settings
- Visit Recruitment Cycles tab

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.


<img width="1236" alt="Screenshot 2025-04-07 at 22 10 44" src="https://github.com/user-attachments/assets/60aa6245-964c-4d6a-84f5-21116095254a" />

