### PR TITLE
Update course ratifying provider description

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -421,9 +421,7 @@ class Course < ApplicationRecord
   end
 
   def ratifying_provider_description
-    return nil unless accrediting_provider
-
-    Provider.in_current_cycle.find_by(provider_code: accrediting_provider.provider_code).train_with_us
+    accrediting_provider&.train_with_us
   end
 
   def accrediting_provider_description


### PR DESCRIPTION
## Context

The error we were seeing is that courses from previous recruitment cycles may have providers that are not in the current cycle.

We can safely return the description of a ratifying provider's details from a previous recruitment cycle.

## Changes proposed in this pull request

- Use the `accrediting_provider` instance directly instead of trying to re-lookup the provider.

## Guidance to review

Try using the API to fetch a course from a previous cycle where their provider is not in the current cycle, it will break.

> https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2024/courses

Try using the review app, it will succeed.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
