### PR TITLE
Always link to the course's provider in the _course_table_row partial

### DIFF
--- a/app/views/publish/courses/_course_table_row.html.erb
+++ b/app/views/publish/courses/_course_table_row.html.erb
@@ -15,11 +15,7 @@
     <%= course.status_tag %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__findable">
-    <% if @training_provider.present? %>
-      <%= course.on_find(@training_provider) %>
-    <% else %>
-      <%= course.on_find(@provider) %>
-    <% end %>
+    <%= course.on_find(course.provider) %>
   </td>
   <td class="govuk-table__cell" data-qa="courses-table__applications">
     <% if course.is_running? || course.is_withdrawn? %>


### PR DESCRIPTION
## Context

We received a support ticket mentioning that all courses of a provider could not be found (404 error). It seems the issue is that the link is incorrectly pointing to the accredited provider, not the training provider when signed in as the accredited provider.

## Changes proposed in this pull request

- Update "on find" call to `course.on_find(course.provider)`.

## Guidance to review

- Visit courses of training providers while viewing the accredited provider's page.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
