### PR TITLE
Update restore-backup script and instructions

### DIFF
--- a/bin/restore-backup
+++ b/bin/restore-backup
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Download today's sanitized backup of the publish database to the Downloads directory
 # Drop and recreate the development and test databases

--- a/guides/setup-development.md
+++ b/guides/setup-development.md
@@ -65,14 +65,15 @@ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keyc
 
 ## Seeding Data
 
+> _Choose **either** the download script (1) or the manual download (2) instructions below_
+
 The commands from the previous section will seed the database with some test data, but you must seed the database with a sanitised production dump to run the application locally using the personas.
 
 To seed the database with a sanitised production dump:
 
 - Request a PIM approval for the production environment.
 
-
-### Use the script to reset your local development db directly
+### Option 1) Use the script to reset your local development db directly
 
 Make sure there are no connections to your database
 
@@ -81,7 +82,7 @@ az login # select the production subscription
 bin/restore-backup
 ```
 
-### Download the sanitised production dump from the Azure Storage Account.
+### Option 2) Download the sanitised production dump from the Azure Storage Account.
 - In the Azure portal, go to 'Storage Accounts' -> 's189p01pttdbbkpsanpdsa' -> 'Containers' -> 'database-backup'
 - Download the latest sanitised backup.
 - Unzip the file and you should see a file called `publish_sanitised_YYYY-MM-DD.sql`.


### PR DESCRIPTION
## Context

`#!/usr/bin/env` is more portable than `#!/bin/env`
The instructions for restoring the database weren't clear enough that only 1 option should be used.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
