### PR TITLE
aria-current must have a value "page"

### DIFF
--- a/app/components/secondary_navigation_component.rb
+++ b/app/components/secondary_navigation_component.rb
@@ -23,7 +23,7 @@ class SecondaryNavigationComponent < ViewComponent::Base
     attr_reader :name, :url, :current
 
     def current?
-      current || current_page?(url)
+      (current || current_page?(url)) && 'page'
     end
   end
 end


### PR DESCRIPTION
## Context

  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current#page


## Changes proposed in this pull request

Add `aria-current="page"` to current page navigation link

## Guidance to review

Is the current page highlighted

https://github.com/user-attachments/assets/10e0ee4d-0f09-4d1d-93d3-397ccbfe2edd

## Trello
https://trello.com/c/2Xbwyy84/616-bug-description-basic-details-tab-is-not-highlighted-on-the-publish-course-page

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
