### PR TITLE
Add back links to Primary and Secondary filter pages

### DIFF
--- a/app/views/find/primary_subjects/index.erb
+++ b/app/views/find/primary_subjects/index.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title, title_with_error_prefix(t(".page_title"), @form.errors.present?) %>
-
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(find_path) %>
+<% end %>
 <%= form_with model: @form, url: find_primary_path, method: :post do |f| %>
   <%= f.hidden_field :utm_source, value: 'home' %>
   <%= f.hidden_field :utm_medium, value: 'primary_courses' %>

--- a/app/views/find/secondary_subjects/index.erb
+++ b/app/views/find/secondary_subjects/index.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title, title_with_error_prefix(t(".page_title"), @form.errors.present?) %>
-
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(find_path) %>
+<% end %>
 <%= form_with model: @form, url: find_secondary_path, method: :post do |f| %>
   <%= f.hidden_field :utm_source, value: 'home' %>
   <%= f.hidden_field :utm_medium, value: 'secondary_courses' %>

--- a/spec/system/find/homepage/quick_links/primary_subjects_spec.rb
+++ b/spec/system/find/homepage/quick_links/primary_subjects_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe "Primary subjects quick link", service: :find do
       click_link_or_button "Find primary courses"
       then_i_see_errors
     end
+
+    scenario "check for backlink presence and navigation on primary page" do
+      click_link_or_button "Browse primary courses"
+      then_i_see_backlink_to_find_homepage
+      click_link_or_button "Back"
+      then_i_am_on_the_find_homepage
+    end
   end
 
   def given_there_are_courses_with_primary_subjects
@@ -69,5 +76,13 @@ RSpec.describe "Primary subjects quick link", service: :find do
 
   def then_i_see_errors
     expect(page).to have_content("Select at least one type of primary course")
+  end
+
+  def then_i_see_backlink_to_find_homepage
+    expect(page).to have_link("Back", href: find_path)
+  end
+
+  def then_i_am_on_the_find_homepage
+    expect(page).to have_current_path(find_path)
   end
 end

--- a/spec/system/find/homepage/quick_links/secondary_subjects_spec.rb
+++ b/spec/system/find/homepage/quick_links/secondary_subjects_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe "Secondary subjects quick link", service: :find do
       click_link_or_button "Find secondary courses"
       then_i_see_errors
     end
+
+    scenario "check for backlink presence and navigation on secondary page" do
+      click_link_or_button "Browse secondary courses"
+      then_i_see_backlink_to_find_homepage
+      click_link_or_button "Back"
+      then_i_am_on_the_find_homepage
+    end
   end
 
   def given_there_are_courses_with_secondary_subjects
@@ -58,23 +65,8 @@ RSpec.describe "Secondary subjects quick link", service: :find do
     click_link_or_button "Find secondary courses"
   end
 
-  def when_i_select_all_primary_courses
-    check "Primary"
-    check "Primary with English"
-    check "Primary with geography and history"
-    check "Primary with mathematics"
-    check "Primary with modern languages"
-    check "Primary with physical education"
-    check "Primary with science"
-    click_link_or_button "Find secondary courses"
-  end
-
   def then_i_see_only_see_chemistry_courses
     expect(page).to have_content("1 course found")
-  end
-
-  def then_i_see_all_primary_courses
-    expect(page).to have_content("4 courses found")
   end
 
   def then_i_see_errors
@@ -91,5 +83,13 @@ RSpec.describe "Secondary subjects quick link", service: :find do
 
   def then_i_see_all_secondary_courses
     expect(page).to have_content("4 courses found")
+  end
+
+  def then_i_see_backlink_to_find_homepage
+    expect(page).to have_link("Back", href: find_path)
+  end
+
+  def then_i_am_on_the_find_homepage
+    expect(page).to have_current_path(find_path)
   end
 end


### PR DESCRIPTION
## Context

On Find, there are currently no back links on the Primary and Secondary filter pages to return to the initial search page.

Trello: https://trello.com/c/9SQU1ORY/637-add-back-links-to-primary-and-secondary-filter-pages

## Changes proposed in this pull request

Added a govuk back link to the [Primary](https://find-teacher-training-courses.service.gov.uk/primary) and [Secondary](https://find-teacher-training-courses.service.gov.uk/secondary) pages which return the user to the Find homepage.

## Guidance to review

- check placement and functionality of the new back link.
- ensure tests are put together correctly and passing.

## Checklist

- [x] I have added the backlink to the Primary page.
- [x] I have added the backlink to the Secondary page.
- [x] I have checked accessibility: tabbing order and screen reader (VoiceOver).
- [x] I have added system tests for the backlink on Primary and Secondary pages.
