### PR TITLE
Providers can't publish a course

### DIFF
--- a/app/helpers/support/recruitment_cycles_helper.rb
+++ b/app/helpers/support/recruitment_cycles_helper.rb
@@ -1,0 +1,12 @@
+module Support
+  module RecruitmentCyclesHelper
+    def recruitment_cycle_status_tag(recruitment_cycle)
+      options = {
+        text: t("support.recruitment_cycles.index.status.#{recruitment_cycle.status}.text"),
+        colour: t("support.recruitment_cycles.index.status.#{recruitment_cycle.status}.colour"),
+      }
+
+      govuk_tag(**options)
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -343,7 +343,7 @@ class Course < ApplicationRecord
 
   validates :sites, presence: true, on: %i[publish new]
   validates :subjects, presence: true, on: :publish
-  validates :accrediting_provider, presence: true, on: :publish, unless: -> { self_accredited? }
+  validates :accrediting_provider, presence: true, on: :publish, unless: -> { self_accredited? || further_education_course? }
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish
   validate :validate_provider_visa_sponsorship_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -63,6 +63,16 @@ class RecruitmentCycle < ApplicationRecord
     end
   end
 
+  def status
+    @status ||= if current?
+                  :current
+                elsif application_start_date.future?
+                  :upcoming
+                else
+                  :inactive
+                end
+  end
+
   def year_range
     "#{year.to_i - 1} to #{year}"
   end

--- a/app/services/courses/creation_service.rb
+++ b/app/services/courses/creation_service.rb
@@ -35,7 +35,11 @@ module Courses
       update_study_mode(course)
       update_sites(course)
       update_study_sites(course)
-      course.accrediting_provider = course.provider.accredited_partners.first if course.provider.accredited_partners.length == 1
+
+      if !course.provider.accredited? && (course.provider.accredited_partners.length == 1)
+        course.accrediting_provider = course.provider.accredited_partners.first
+      end
+
       course.course_code = provider.next_available_course_code if next_available_course_code
 
       Publish::Courses::AssignTdaAttributesService.new(course).call if course.undergraduate_degree_with_qts?

--- a/app/views/support/recruitment_cycles/index.html.erb
+++ b/app/views/support/recruitment_cycles/index.html.erb
@@ -24,7 +24,7 @@
               <% row.with_cell text: recruitment_cycle.application_start_date.strftime("%-d %B %Y") %>
               <% row.with_cell text: recruitment_cycle.application_end_date.strftime("%-d %B %Y") %>
               <% row.with_cell do %>
-                <%= govuk_tag(text: (recruitment_cycle.current? ? t(".status_current") : t(".status_inactive")), colour: (recruitment_cycle.current? ? "green" : "grey")) %>
+                <%= recruitment_cycle_status_tag(recruitment_cycle) %>
               <% end %>
             <% end %>
           <% end %>

--- a/config/locales/en/support/recruitment_cycles.yml
+++ b/config/locales/en/support/recruitment_cycles.yml
@@ -4,8 +4,16 @@ en:
       index:
         page_title: Recruitment Cycles
         add_recruitment_cycle: Add recruitment cycle
-        status_current: Current
-        status_inactive: Past
+        status:
+          current:
+            text: Current
+            colour: green
+          inactive:
+            text: Past
+            colour: grey
+          upcoming:
+            text: Upcoming
+            colour: yellow
       new:
         page_title: Recruitment cycle details
         page_caption: Add recruitment cycle

--- a/spec/helpers/support/recruitment_cycles_helper_spec.rb
+++ b/spec/helpers/support/recruitment_cycles_helper_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "nokogiri"
+
+RSpec.describe Support::RecruitmentCyclesHelper do
+  describe "#recruitment_cycle_status_tag" do
+    subject(:tag_html) { helper.recruitment_cycle_status_tag(recruitment_cycle) }
+
+    let(:tag) { Nokogiri::HTML.fragment(tag_html).at_css("strong.govuk-tag") }
+
+    context "with current cycle" do
+      let(:recruitment_cycle) { build(:recruitment_cycle) }
+
+      it "returns green 'Current' tag" do
+        allow(recruitment_cycle).to receive(:current?).and_return(true)
+
+        expect(tag.text).to eq("Current")
+      end
+    end
+
+    context "with upcoming cycle" do
+      let(:recruitment_cycle) { build(:recruitment_cycle, :next) }
+
+      it "returns yellow 'Upcoming' tag" do
+        expect(tag.text).to eq("Upcoming")
+      end
+    end
+
+    context "with inactive cycle" do
+      let(:recruitment_cycle) { build(:recruitment_cycle, :previous) }
+
+      it "returns grey 'Past' tag" do
+        expect(tag.text).to eq("Past")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Card originated from an investigation on this support ticket.

One provider was unable to publish a course, but investigation reveals this is an issue affecting at least 14 providers and hundreds (265exactly) of courses.

The root cause is because the courses are missing accrediting provider partnerships, resulting in failed validations when course publishing.

One provider reported being unable to publish a course. The error message indicated the accrediting provider is not accredited or the partnership is missing.

Providers affected: 14

Published Courses affected: 265 published courses are currently invalid for re-publishing (update and publish again).
