### PR TITLE
Build when running in main

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -219,7 +219,7 @@ jobs:
   build:
     name: Build
     needs: [lint, analytics-checks, javascript-tests, rails-tests]
-    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
+    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')) }}
     outputs:
       docker_image: ${{ env.DOCKER_IMAGE }}
       image_tag: ${{ env.DOCKER_IMAGE_TAG }}
@@ -307,7 +307,6 @@ jobs:
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         uses: rtCamp/action-slack-notify@master
         env:
-          SLACK_CHANNEL: twd_findpub_tech
           SLACK_COLOR: "#ef5343"
           SLACK_ICON_EMOJI: ":github-logo:"
           SLACK_USERNAME: Publish Teacher Training


### PR DESCRIPTION
## Context

When optimising the CI pipeline, I forgot to think about the `main` branch deployments.

## Changes proposed in this pull request

- Run the `build` step on `main`, always.

## Guidance to review

\-

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
