### PR TITLE
Remove `plpgsql` from azure extensions

### DIFF
--- a/terraform/aks/locals.tf
+++ b/terraform/aks/locals.tf
@@ -3,7 +3,7 @@ locals {
   review_additional_hostnames = var.app_environment == "review" ? ["find-${local.app_name_suffix}.${var.cluster}.teacherservices.cloud"] : ["find-${local.app_name_suffix}.${var.cluster}.development.teacherservices.cloud"]
   db_setup_command            = ["/bin/sh", "-c", "bundle exec rails db:setup && bundle exec rails server -b 0.0.0.0"]
   worker_startup_command      = ["/bin/sh", "-c", "bundle exec sidekiq -c 5 -C config/sidekiq.yml"]
-  postgres_extensions         = ["PG_BUFFERCACHE", "PG_STAT_STATEMENTS", "BTREE_GIN", "BTREE_GIST", "CITEXT", "PLPGSQL", "UUID-OSSP", "POSTGIS"]
+  postgres_extensions         = ["PG_BUFFERCACHE", "PG_STAT_STATEMENTS", "BTREE_GIN", "BTREE_GIST", "CITEXT", "UUID-OSSP", "POSTGIS"]
   app_secrets = {
     DATABASE_URL     = module.postgres.url
     REDIS_CACHE_URL  = module.redis_cache.url


### PR DESCRIPTION
## Context

Azure has removed `plphsql` from their list of extensions. This is causing our terraform deployments to fail.

List of Azure Postgres extensions: https://learn.microsoft.com/en-us/azure/postgresql/extensions/concepts-extensions-versions

## Changes proposed in this pull request

- Remove `plpgsql` from azure extensions in terraform

## Guidance to review

- Refer to https://github.com/DFE-Digital/register-early-career-teachers-public/pull/484 for example reference.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
