### PR TITLE
Split System tests and upload screenshots on failure

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -202,6 +202,13 @@ jobs:
           EXCLUDE_PATTERN: ${{ matrix.tests.exclude-pattern || ' ' }}
           FEATURE_FLAGS: ${{ matrix.feature-flags }}
 
+      - name: Upload screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test-screenshots
+          path: ${{ github.workspace }}/tmp/capybara/*
+
       # - name: Upload coverage results
       #   if: always()
       #   uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -167,8 +167,12 @@ jobs:
             include-pattern: spec/features/.*_spec.rb
             exclude-pattern: spec/features/(auth|find|publish|support)/.*_spec.rb
 
-          - name: System
+
+          - name: System - Find
+            include-pattern: spec/system/find/.*_spec.rb
+          - name: System - Other
             include-pattern: spec/system/.*_spec.rb
+            exclude-pattern: spec/system/find/.*_spec.rb
         # Pass Settings compatible env vars to runs tests with
         # feature flag(s) enables
         # Separate mutliple flags with a space


### PR DESCRIPTION
## Context

Use the [actions/upload-artifact](https://github.com/actions/upload-artifact) to upload screenshots of test failures


> Zip archives
> When an Artifact is uploaded, all the files are assembled into an immutable Zip archive. There is currently no way to download artifacts in a format other than a Zip or to download individual artifact contents.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

![image](https://github.com/user-attachments/assets/edec4725-6ba2-42a3-856e-939a16ed6420)

I tried this but it didn't work and I don't know how to debug it easily

```
        env:
          TEST_GROUP: ${{ matrix.tests.name }}

....

      - name: Upload screenshots
        if: ${{ failure() && startsWith(env.TEST_GROUP, 'System') }}
```

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
