### PR TITLE
Add rubocop-govuk lint changes to git blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,2 @@
 fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf # https://github.com/DFE-Digital/publish-teacher-training/commit/fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf
+30dc154189ec222a157a8ddf806b7fdc454c93a2 # https://github.com/DFE-Digital/publish-teacher-training/commit/30dc154189ec222a157a8ddf806b7fdc454c93a2


### PR DESCRIPTION
## Context

We recently made a large linting change to adopt the GOV.UK ruby code styles. This causes a lot of our git blame calls to be less useful.

## Changes proposed in this pull request

- Add 30dc154189ec222a157a8ddf806b7fdc454c93a2 to ignored commits

## Guidance to review

- View [app/forms/publish/visa_sponsorship_application_deadline_date_form.rb](https://github.com/DFE-Digital/publish-teacher-training/blob/main/app/forms/publish/visa_sponsorship_application_deadline_date_form.rb), there should be no git blame references to the `rubocop-govuk` changes.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
