### PR TITLE
Adding temp ingress for the find and api-publish

### DIFF
--- a/maintenance_page/manifests/production/ingress_temp_to_main2.yml
+++ b/maintenance_page/manifests/production/ingress_temp_to_main2.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: find-temp.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: find-temp.teacherservices.cloud
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: publish-production
+            port:
+              number: 80

--- a/maintenance_page/manifests/production/ingress_temp_to_main3.yml
+++ b/maintenance_page/manifests/production/ingress_temp_to_main3.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: api-publish-temp.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: api-publish-temp.teacherservices.cloud
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: publish-production
+            port:
+              number: 80

--- a/maintenance_page/manifests/qa/ingress_temp_to_main2.yml
+++ b/maintenance_page/manifests/qa/ingress_temp_to_main2.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: find-temp.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: find-temp.test.teacherservices.cloud
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: publish-qa
+            port:
+              number: 80

--- a/maintenance_page/manifests/qa/ingress_temp_to_main3.yml
+++ b/maintenance_page/manifests/qa/ingress_temp_to_main3.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: api-publish-temp.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: api-publish-temp.test.teacherservices.cloud
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: publish-qa
+            port:
+              number: 80

--- a/maintenance_page/scripts/failback.sh
+++ b/maintenance_page/scripts/failback.sh
@@ -18,8 +18,14 @@ kubectl -n ${NAMESPACE} apply -f maintenance_page/manifests/${CONFIG}/ingress_ex
 echo Reset internal ingress
 kubectl -n ${NAMESPACE} apply -f maintenance_page/manifests/${CONFIG}/ingress_internal_to_main.yml
 
-echo Delete temp ingress
+echo Delete temp ingress publish
 kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/manifests/${CONFIG}/ingress_temp_to_main.yml
+
+echo Delete temp ingress find
+kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/manifests/${CONFIG}/ingress_temp_to_main2.yml
+
+echo Delete temp ingress api-publish
+kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/manifests/${CONFIG}/ingress_temp_to_main3.yml
 
 echo Delete maintenance ingress
 kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/manifests/${CONFIG}/ingress_maintenance.yml

--- a/maintenance_page/scripts/failover.sh
+++ b/maintenance_page/scripts/failover.sh
@@ -33,8 +33,14 @@ kubectl apply -n ${NAMESPACE} -f maintenance_page/manifests/${CONFIG}/ingress_ex
 echo Configure internal ingress to point at the maintenance app
 kubectl apply -n ${NAMESPACE} -f maintenance_page/manifests/${CONFIG}/ingress_internal_to_maintenance.yml
 
-echo Create temp ingress
+echo Create temp ingress for publish
 kubectl apply -n ${NAMESPACE} -f maintenance_page/manifests/${CONFIG}/ingress_temp_to_main.yml
+
+echo Create temp ingress for find
+kubectl apply -n ${NAMESPACE} -f maintenance_page/manifests/${CONFIG}/ingress_temp_to_main2.yml
+
+echo Create temp ingress for api-publish
+kubectl apply -n ${NAMESPACE} -f maintenance_page/manifests/${CONFIG}/ingress_temp_to_main3.yml
 
 # Retrieve the teacherservices.cloud internal domain from the temp ingress manifest
 TEMP_URL=$(awk '/name:.*cloud/ {print $2}' ./maintenance_page/manifests/${CONFIG}/ingress_temp_to_main.yml)


### PR DESCRIPTION
## Context
There is a requirement for applications to be DR ready.

## Changes proposed in this pull request
Adding the temp ingress for the find and api-publish entry points



## Guidance to review

Review the ingress

## Link to Trello card
https://trello.com/c/dxDVXong/2237-publish-dr-test
## Checklist

- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [x]  Tested by running locally