### PR TITLE
Updated labels on the course page to match the results page

### DIFF
--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -222,7 +222,7 @@ en:
           heading: Entry requirements
           visa_sponsorship: Visa sponsorship
           gcses: GCSEs
-          degree: Degree
+          degree: Degree required
           or_equivalent_qualification: or equivalent qualification
           equivalency_tests: Equivalency tests
           degree_subject_requirements: Degree subject requirements
@@ -242,10 +242,10 @@ en:
           no_fee: There is no fee
           course_summary: Course summary
           course_length: Course length
-          age_range: Age range
+          age_range: Age group
           date_can_apply: Date you can apply from
           start_date: Start date
-          qualification: Qualification
+          qualification: Qualification awarded
           provider: Provider
           accredited_by: Accredited by
           for_uk_citizens: for UK citizens

--- a/spec/components/find/courses/entry_requirements_component/view_spec.rb
+++ b/spec/components/find/courses/entry_requirements_component/view_spec.rb
@@ -407,7 +407,7 @@ describe Find::Courses::EntryRequirementsComponent::View, type: :component do
       component = described_class.new(course: course.decorate)
       render_inline(component)
 
-      expect(component.qualification_required).to eq("Degree")
+      expect(component.qualification_required).to eq("Degree required")
     end
 
     context "when teacher_degree_apprenticeship" do

--- a/spec/components/find/courses/sumary_component/view_spec.rb
+++ b/spec/components/find/courses/sumary_component/view_spec.rb
@@ -14,8 +14,8 @@ module Find
           expect(result.text).to include(
             "Fee or salary",
             "Course length",
-            "Age range",
-            "Qualification",
+            "Age group",
+            "Qualification awarded",
             "Provider",
             "Date you can apply from",
             "Start date",


### PR DESCRIPTION
## Context

The content on the course page doesn’t match the content on the results page. The content on the results page was iterated based on user research.

Trello: https://trello.com/c/9tD0TgTb/613-bug-content-on-course-page-doesnt-match-results-page

## Changes proposed in this pull request

- updated content for course page in `find.yml` which is used in the 'Course summary' and 'Entry requirements' section of the course page:
Updated label `Age range` to `Age group`
Updated label `Qualification` to `Qualification awarded`
Updated label `Degree` to `Degree required`
- adapted spec tests to reflect new content.

<img width="723" alt="Screenshot 2025-04-23 at 20 03 49" src="https://github.com/user-attachments/assets/6732f68a-2993-4483-aae4-85937d597abb" />


## Guidance to review

- check label names on course page are correct and match up with results page.

## Checklist

- [x] Updated content in locale files.
- [x] Adapted the corresponding tests.
