### PR TITLE
Fix the rubocop-govuk git blame ignore commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,7 @@
-fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf # https://github.com/DFE-Digital/publish-teacher-training/commit/fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf
-30dc154189ec222a157a8ddf806b7fdc454c93a2 # https://github.com/DFE-Digital/publish-teacher-training/commit/30dc154189ec222a157a8ddf806b7fdc454c93a2
+# Prefer single-quoted strings (.rb)
+# https://github.com/DFE-Digital/publish-teacher-training/commit/fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf
+fa9bb3bdd1f105043ccdad8cbde124c0fa776cbf
+
+# Adopt GOV.UK's RuboCop configuration
+# https://github.com/DFE-Digital/publish-teacher-training/commit/e1832eb7e84a4dadf2f63ffa747558cefdca57ef
+e1832eb7e84a4dadf2f63ffa747558cefdca57ef


### PR DESCRIPTION
## Context

The commit SHA for the "Adopt GOV.UK's RuboCop configuration" is incorrect.

## Changes proposed in this pull request

- Fix the rubocop-govuk git blame ignore commit SHA
- Also rearrange the `.git-blame-ignore-revs` file and add the commit title as a comment for reference.

## Guidance to review

Commits should be ignored correctly now.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
