### PR TITLE
Improved courses page - Merged 'Salary' and 'Fees and financial support sections

### DIFF
--- a/app/components/find/courses/contents_component/view.html.erb
+++ b/app/components/find/courses/contents_component/view.html.erb
@@ -3,12 +3,9 @@
   <% if course.training_locations? || preview? %>
     <li><%= govuk_link_to t(".where_you_will_train"), "#training-locations" %></li>
   <% end %>
-  <li><%= govuk_link_to t(".fees_and_financial_support"), "#section-financial-support" %></li>
+  <li><%= govuk_link_to (salaried? ? t(".salary_and_financial_support") : t(".fees_and_financial_support")), "#section-financial-support" %></li>
   <% if about_course.present? || preview? %>
     <li><%= govuk_link_to t(".course_details"), "#section-about" %></li>
-  <% end %>
-  <% if salaried? %>
-    <li><%= govuk_link_to t(".salary"), "#section-salary" %></li>
   <% end %>
   <% if interview_process.present? %>
     <li><%= govuk_link_to t(".interview_process"), "#section-interviews" %></li>
@@ -17,5 +14,7 @@
     <li><%= govuk_link_to t(".training_with_disabilities"), "#section-train-with-disabilities" %></li>
   <% end %>
   <li><%= govuk_link_to t(".support_and_advice"), "#section-advice" %></li>
-  <% if course.application_status_open? %> <li><%= govuk_link_to t(".apply"), "#section-apply" %></li> <% end %>
+  <% if course.application_status_open? %>
+    <li><%= govuk_link_to t(".apply"), "#section-apply" %></li>
+  <% end %>
 </ul>

--- a/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
+++ b/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
@@ -1,10 +1,13 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-financial-support">Fees and financial support</h2>
-
+  <h2 class="govuk-heading-l" id="section-financial-support">
+    <%= salaried? ? t(".salary_and_financial_support") : t(".fees_and_financial_support") %>
+  </h2>
+  <% if salaried? %>
+    <%= render partial: "find/courses/salary", locals: { course: @course } %>
+  <% end %>
   <% if has_fees? %>
     <%= render Find::Courses::FeesComponent::View.new(course) %>
   <% end %>
-
   <% if salaried? %>
     <%= render partial: "shared/courses/financial_support/salaried" %>
   <% elsif excluded_from_bursary? %>

--- a/app/views/find/courses/_salary.html.erb
+++ b/app/views/find/courses/_salary.html.erb
@@ -1,6 +1,3 @@
-<div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-salary">Salary</h2>
-  <% if course.salary_details.present? %>
-    <%= markdown(course.salary_details) %>
-  <% end %>
-</div>
+<% if course.salary_details.present? %>
+  <%= markdown(course.salary_details) %>
+<% end %>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -40,10 +40,6 @@
       <%= render partial: "find/courses/about_course", locals: { course: @course } %>
     <% end %>
 
-    <% if @course.salaried? %>
-      <%= render partial: "find/courses/salary", locals: { course: @course } %>
-    <% end %>
-
     <% if @course.published_interview_process.present? %>
       <%= render partial: "find/courses/interview_process", locals: { course: @course } %>
     <% end %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -33,10 +33,6 @@
 
     <%= render partial: "find/courses/about_course", locals: { course: } %>
 
-    <% if course.salaried? %>
-      <%= render partial: "find/courses/salary", locals: { course: } %>
-    <% end %>
-
     <% if course.interview_process.present? %>
       <%= render partial: "find/courses/interview_process", locals: { course: } %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,11 @@ en:
             This should be an honours degree (Third or above), or equivalent
           </span>
     courses:
+      financial_support:
+        fees_and_financial_support_component:
+          view:
+            fees_and_financial_support: Fees and financial support
+            salary_and_financial_support: Salary and financial support
       provider:
         heading: Contact %{provider_name}
       placements:

--- a/config/locales/find.yml
+++ b/config/locales/find.yml
@@ -126,7 +126,7 @@ en:
       find_out_more_student_loans: Find out more about student loans for teacher training.
       eligible_for_student_loan: You may be eligible for student loans to cover the cost of your tuition fee or to help with living costs.
       uk_citizens:
-        title: Financial Support for UK citizens
+        title: Financial support for UK citizens
         salaried_courses:
           title: How salaried courses work
           paid_salary: You will be paid a salary during this course. Financial support such as bursaries, scholarships and student loans is not available.
@@ -134,7 +134,7 @@ en:
           competitive: Places on salaried courses are limited and very competitive. Check your eligibility with the training provider and apply as soon as possible.
           find_out_more: Find out more about salaried courses.
       non_uk_citizens:
-        title: Financial Support for non-UK citizens
+        title: Financial support for non-UK citizens
         salaried_courses:
           title: "Non-UK citizens: applying for salaried courses"
           competitive: You can apply for a salaried teacher training course. However, these courses are limited in number and very competitive.
@@ -212,6 +212,7 @@ en:
           where_you_will_train: Where you will train
           training_with_disabilities: Training with disabilities
           fees_and_financial_support: Fees and financial support
+          salary_and_financial_support: Salary and financial support
           salary: Salary
           interview_process: Interview process
           support_and_advice: Support and advice


### PR DESCRIPTION
## Context

The ‘Salary’ section of the course pages is often empty, or contains very little information. The callout box in the ‘Fees and financial support’ section of salaried courses refers to salary, which is confusing. We need to merge the two sections, so that the provider free text about salary sits alongside the call out box that refers to salary.

Trello: https://trello.com/c/Yi1bM2cG

## Changes proposed in this pull request

- merged 'Salary' into 'Fees and financial support' section.
- removed standalone 'Salary' section.
- adapted `_salary` partial to remove title and any styling so it can be rendered within the `FeesAndFinancialSupportComponent`.
- adapted title of section to render either 'Salary and financial support' or 'Fees and financial support' depending on the context.
- updated contents list on page to dynamically render new section title.

**Salaried course:**
<img width="720" alt="Screenshot 2025-04-25 at 15 43 29" src="https://github.com/user-attachments/assets/d5a7fd55-3d35-4345-a1d9-d999697db368" />

**Non-Salaried course:**
<img width="766" alt="Screenshot 2025-04-25 at 15 43 50" src="https://github.com/user-attachments/assets/d0720942-8eef-4a44-8fc0-09a587545696" />

## Guidance to review

- Check a the different combinations of salaried and fee based courses to ensure the correct information is rendering depending on the context. 
- Check the preview page on Publish is rendering courses correctly as this page was also adapted e.g. http://publish.localhost:3001/publish/organisations/2AP/2025/courses/2VM4/preview#section-financial-support

## Checklist

- [x] I have merged the 'Salary' and 'Fees and financial support sections' and they are rendered correctly depending on the context. 
- [x] I have updated the contents at the top of the page to reflect the new section name(s) and removal of Salary section.
- [x] I have checked and updated any relevant tests. 

