### PR TITLE
Pin `dfe-autocomplete` to v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@ministryofjustice/frontend": "2.0.0",
     "accessible-autocomplete": "^3.0.1",
-    "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete#v0.2.0",
+    "dfe-autocomplete": "DFE-Digital/dfe-autocomplete#v0.2.1",
     "govuk-frontend": "^5.9.0",
     "jquery": "^3.6.0",
     "lodash.debounce": "^4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,9 +950,9 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
-"dfe-autocomplete@github:DFE-Digital/dfe-autocomplete#v0.2.0":
-  version "0.0.1"
-  resolved "https://codeload.github.com/DFE-Digital/dfe-autocomplete/tar.gz/903b24cf60a2aecca659acedc1f1fcbd598e4a19"
+dfe-autocomplete@DFE-Digital/dfe-autocomplete#v0.2.1:
+  version "0.2.1"
+  resolved "https://codeload.github.com/DFE-Digital/dfe-autocomplete/tar.gz/966efa70f058585fdbc91e7217d678092db62303"
   dependencies:
     accessible-autocomplete "^3.0.1"
 


### PR DESCRIPTION
## Context

We want to ensure that `dfe-autocomplete` is always the correct version. A recent update to the `dfe-autocomplete` package updated the package version to align with the gem version.

## Changes proposed in this pull request

- Pin `dfe-autocomplete` to `v0.2.1`.

## Guidance to review

Everything works as expected.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
