### PR TITLE
Update find route to find_root

### DIFF
--- a/app/components/find/header/view.html.erb
+++ b/app/components/find/header/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_header(
-  homepage_url: find_path,
+  homepage_url: find_root_path,
   classes: "govuk-!-display-none-print app-header--full-border app-header--wide-logo #{environment_header_class}",
 ) do |header| %>
   <% header.with_product_name(name: service_name) %>

--- a/app/controllers/find/pages_controller.rb
+++ b/app/controllers/find/pages_controller.rb
@@ -21,7 +21,7 @@ module Find
   private
 
     def redirect_to_homepage_unless_in_maintenance_mode
-      redirect_to find_path unless FeatureFlag.active?(:maintenance_mode)
+      redirect_to find_root_path unless FeatureFlag.active?(:maintenance_mode)
     end
   end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -21,7 +21,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def find_url(provider = object.provider)
-    h.x_find_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
+    h.find_course_url(provider.provider_code, object.course_code)
   end
 
   def description
@@ -31,7 +31,7 @@ class CourseDecorator < ApplicationDecorator
   def on_find(provider = object.provider)
     if object.findable?
       if current_cycle_and_open?
-        h.govuk_link_to("Yes - view online", h.x_find_course_page_url(provider_code: provider.provider_code, course_code: object.course_code))
+        h.govuk_link_to("Yes - view online", h.find_course_url(provider.provider_code, object.course_code))
       else
         "No - live on #{l(Settings.next_cycle_open_date.to_date, format: :govuk_short)}"
       end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -14,14 +14,6 @@ module ViewHelper
     )
   end
 
-  def x_find_url(relative_path)
-    URI.join(Settings.find_url, relative_path).to_s
-  end
-
-  def x_find_course_page_url(provider_code:, course_code:)
-    x_find_url(find_course_path(provider_code, course_code))
-  end
-
   def bat_contact_email_address
     Settings.support_email
   end

--- a/app/views/find/courses/training_with_disabilities/show.html.erb
+++ b/app/views/find/courses/training_with_disabilities/show.html.erb
@@ -3,10 +3,7 @@
 <% end %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
-    href: x_find_course_page_url(
-      provider_code: @course.provider_code,
-      course_code: @course.course_code,
-    ),
+    href: find_course_url(@course.provider_code, @course.course_code),
     text: t(
       ".back",
       course_name: @course.name,

--- a/app/views/find/primary_subjects/index.erb
+++ b/app/views/find/primary_subjects/index.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, title_with_error_prefix(t(".page_title"), @form.errors.present?) %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(find_path) %>
+  <%= govuk_back_link_to(find_root_path) %>
 <% end %>
 <%= form_with model: @form, url: find_primary_path, method: :post do |f| %>
   <%= f.hidden_field :utm_source, value: 'home' %>

--- a/app/views/find/secondary_subjects/index.erb
+++ b/app/views/find/secondary_subjects/index.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, title_with_error_prefix(t(".page_title"), @form.errors.present?) %>
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(find_path) %>
+  <%= govuk_back_link_to(find_root_path) %>
 <% end %>
 <%= form_with model: @form, url: find_secondary_path, method: :post do |f| %>
   <%= f.hidden_field :utm_source, value: 'home' %>

--- a/app/views/find/sitemaps/show.xml.builder
+++ b/app/views/find/sitemaps/show.xml.builder
@@ -3,16 +3,16 @@
 xml.instruct!
 xml.urlset "xmlns" => "http://www.google.com/schemas/sitemap/0.9", "xmlns:xhtml" => "http://www.w3.org/1999/xhtml" do
   xml.url do
-    xml.loc find_url
+    xml.loc find_root_url
   end
 
   xml.url do
-    xml.loc find_results_url.sub(%r{/find}, "")
+    xml.loc find_results_url
   end
 
   @courses.each do |course|
     xml.url do
-      xml.loc find_course_url(course.provider_code, course.course_code).sub(%r{/find}, "")
+      xml.loc find_course_url(course.provider_code, course.course_code)
       xml.lastmod course.changed_at.to_date.strftime("%Y-%m-%d")
     end
   end

--- a/app/views/publish/courses/course_button_panel/_published.html.erb
+++ b/app/views/publish/courses/course_button_panel/_published.html.erb
@@ -15,7 +15,7 @@
     <% if course.scheduled? %>
      <%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__preview-link" } %>
     <% else %>
-      <%= govuk_link_to x_find_course_page_url(provider_code: course.provider.provider_code, course_code: course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
+      <%= govuk_link_to find_course_url(course.provider_code, course.course_code), class: "govuk-!-margin-right-2", data: { qa: "course__is_findable" } do %>
       View on Find <span class="govuk-visually-hidden">teacher training courses</span>
       <% end %>
     <% end %>

--- a/app/views/support/settings/index.html.erb
+++ b/app/views/support/settings/index.html.erb
@@ -3,7 +3,7 @@
 <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
 
 <%= govuk_list([
-  govuk_link_to(t(".feature_flag"), x_find_url(find_feature_flags_path)),
+  govuk_link_to(t(".feature_flag"), find_feature_flags_url),
   govuk_link_to(t(".view_components"), support_view_components_path),
   govuk_link_to(t(".recruitment_cycles"), support_recruitment_cycles_path),
 ]) %>

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-scope via: :all do
-  match "/404", to: "find/errors#not_found"
-  match "/500", to: "find/errors#internal_server_error"
-  match "/403", to: "find/errors#forbidden"
-end
-
 namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host } do
   root to: "homepage#index"
 
@@ -46,4 +40,10 @@ namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host 
 
   resource :cookie_preferences, only: %i[show update], path: "/cookies", as: :cookies
   resource :sitemap, only: :show
+
+  scope via: :all do
+    match "/404", to: "errors#not_found"
+    match "/500", to: "errors#internal_server_error"
+    match "/403", to: "errors#forbidden"
+  end
 end

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-root to: "find/homepage#index", as: :find
-
 scope via: :all do
   match "/404", to: "find/errors#not_found"
   match "/500", to: "find/errors#internal_server_error"
   match "/403", to: "find/errors#forbidden"
 end
 
-namespace :find, path: "/" do
+namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host } do
+  root to: "homepage#index"
+
   get "track_click", to: "track#track_click"
 
   get "/accessibility", to: "pages#accessibility", as: :accessibility

--- a/spec/components/find/header/view_spec.rb
+++ b/spec/components/find/header/view_spec.rb
@@ -16,7 +16,7 @@ module Find
 
       it "links to the homepage" do
         render_inline(described_class.new(service_name: "Test Service"))
-        expect(page.has_link?(nil, href: find_path)).to be true
+        expect(page.has_link?(nil, href: find_root_path)).to be true
       end
     end
   end

--- a/spec/features/find/maintainance_page_spec.rb
+++ b/spec/features/find/maintainance_page_spec.rb
@@ -12,7 +12,7 @@ feature "Maintenance mode" do
       FeatureFlag.activate(:maintenance_mode)
       FeatureFlag.activate(:maintenance_banner)
 
-      visit find_path
+      visit find_root_path
 
       expect(page).to have_current_path find_maintenance_path
       expect(page).to have_no_content "This service will be unavailable on"
@@ -25,7 +25,7 @@ feature "Maintenance mode" do
 
       visit find_maintenance_path
 
-      expect(page).to have_current_path find_path
+      expect(page).to have_current_path find_root_path
     end
   end
 

--- a/spec/features/find/maintenance_banner_spec.rb
+++ b/spec/features/find/maintenance_banner_spec.rb
@@ -7,7 +7,7 @@ feature "Maintenance banner" do
     scenario "sends me to the maintenance page" do
       FeatureFlag.activate(:maintenance_banner)
 
-      visit find_path
+      visit find_root_path
 
       expect(page).to have_content "This service will be unavailable on"
     end
@@ -17,7 +17,7 @@ feature "Maintenance banner" do
     scenario "sends me to the homepage" do
       FeatureFlag.deactivate(:maintenance_banner)
 
-      visit find_path
+      visit find_root_path
 
       expect(page).to have_content "Find teacher training courses"
       expect(page).to have_no_content "This service will be unavailable on"

--- a/spec/requests/find/sitemaps_spec.rb
+++ b/spec/requests/find/sitemaps_spec.rb
@@ -37,13 +37,13 @@ module Find
           <?xml version="1.0" encoding="UTF-8"?>
           <urlset xmlns="http://www.google.com/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
             <url>
-              <loc>http://www.example.com/</loc>
+              <loc>http://find-teacher-training-courses.service.gov.uk/</loc>
             </url>
             <url>
-              <loc>http://www.example.com/results</loc>
+              <loc>http://find-teacher-training-courses.service.gov.uk/results</loc>
             </url>
             <url>
-              <loc>http://www.example.com/course/#{provider_code}/#{course_code}</loc>
+              <loc>http://find-teacher-training-courses.service.gov.uk/course/#{provider_code}/#{course_code}</loc>
               <lastmod>#{changed_at.to_date.strftime('%Y-%m-%d')}</lastmod>
             </url>
           </urlset>

--- a/spec/system/find/homepage/quick_links/primary_subjects_spec.rb
+++ b/spec/system/find/homepage/quick_links/primary_subjects_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Primary subjects quick link", service: :find do
   end
 
   def when_i_visit_the_find_homepage
-    visit find_path
+    visit find_root_path
   end
 
   def when_i_select_primary_with_english
@@ -79,10 +79,10 @@ RSpec.describe "Primary subjects quick link", service: :find do
   end
 
   def then_i_see_backlink_to_find_homepage
-    expect(page).to have_link("Back", href: find_path)
+    expect(page).to have_link("Back", href: find_root_path)
   end
 
   def then_i_am_on_the_find_homepage
-    expect(page).to have_current_path(find_path)
+    expect(page).to have_current_path(find_root_path)
   end
 end

--- a/spec/system/find/homepage/quick_links/secondary_subjects_spec.rb
+++ b/spec/system/find/homepage/quick_links/secondary_subjects_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Secondary subjects quick link", service: :find do
   end
 
   def when_i_visit_the_find_homepage
-    visit find_path
+    visit find_root_path
   end
 
   def when_i_select_chemistry
@@ -86,10 +86,10 @@ RSpec.describe "Secondary subjects quick link", service: :find do
   end
 
   def then_i_see_backlink_to_find_homepage
-    expect(page).to have_link("Back", href: find_path)
+    expect(page).to have_link("Back", href: find_root_path)
   end
 
   def then_i_am_on_the_find_homepage
-    expect(page).to have_current_path(find_path)
+    expect(page).to have_current_path(find_root_path)
   end
 end

--- a/spec/system/find/results_helper.rb
+++ b/spec/system/find/results_helper.rb
@@ -426,7 +426,7 @@ module ResultsHelper
   end
 
   def when_i_visit_the_homepage
-    visit find_path
+    visit find_root_path
   end
 
   def and_i_check_visa_sponsorship_filter_in_the_homepage
@@ -435,7 +435,7 @@ module ResultsHelper
   end
 
   def and_i_am_on_the_homepage
-    expect(page).to have_current_path(find_path)
+    expect(page).to have_current_path(find_root_path)
   end
 
   def and_i_am_on_the_results_page


### PR DESCRIPTION
## Context

The find `root` is defined outside of the `find` namespace. There is no reason for this to be the case.

## Changes proposed in this pull request

- Move the `find` root into the `find` namespace. Remove the `as` configuration and leave it as the default, `find_root`. `find_root_path`
- Add a host default to find to point find's url helpers to find's domain.
- Remove `x_find_url` helpers. We don't need these.

## Guidance to review

- Find works as it does.
- Publish links to Find also work as expected.
- Specs are all happy.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
