### PR TITLE
Remove unnecessary Find namespaces

### DIFF
--- a/app/controllers/find/courses/accrediting_providers_controller.rb
+++ b/app/controllers/find/courses/accrediting_providers_controller.rb
@@ -2,7 +2,7 @@
 
 module Find
   module Courses
-    class AccreditingProvidersController < Find::ApplicationController
+    class AccreditingProvidersController < ApplicationController
       def show
         @course = provider.courses.includes(
           :enrichments,

--- a/app/controllers/find/courses/providers_controller.rb
+++ b/app/controllers/find/courses/providers_controller.rb
@@ -2,7 +2,7 @@
 
 module Find
   module Courses
-    class ProvidersController < Find::ApplicationController
+    class ProvidersController < ApplicationController
       before_action -> { render_not_found if provider.nil? }
 
       def show

--- a/app/controllers/find/courses/training_with_disabilities_controller.rb
+++ b/app/controllers/find/courses/training_with_disabilities_controller.rb
@@ -2,7 +2,7 @@
 
 module Find
   module Courses
-    class TrainingWithDisabilitiesController < Find::ApplicationController
+    class TrainingWithDisabilitiesController < ApplicationController
       before_action -> { render_not_found if provider.nil? }
       before_action -> { render_not_found if provider.train_with_disability.blank? }
 

--- a/app/controllers/find/homepage_controller.rb
+++ b/app/controllers/find/homepage_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Find
-  class HomepageController < Find::ApplicationController
+  class HomepageController < ApplicationController
     def index
       @search_courses_form = ::Courses::SearchForm.new
     end

--- a/app/controllers/find/primary_subjects_controller.rb
+++ b/app/controllers/find/primary_subjects_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Find
-  class PrimarySubjectsController < Find::ApplicationController
-    include Find::FinancialIncentiveHelper
+  class PrimarySubjectsController < ApplicationController
+    include FinancialIncentiveHelper
 
     before_action :initialize_form
 
@@ -22,7 +22,7 @@ module Find
   private
 
     def initialize_form
-      @form = Find::Subjects::PrimaryForm.new(subject_params)
+      @form = Subjects::PrimaryForm.new(subject_params)
     end
 
     def subject_params

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Find
-  class ResultsController < Find::ApplicationController
+  class ResultsController < ApplicationController
     after_action :store_result_fullpath_for_backlinks, :send_analytics_event, only: [:index]
 
     def index
@@ -19,7 +19,7 @@ module Find
   private
 
     def send_analytics_event
-      Find::Analytics::SearchResultsEvent.new(
+      Analytics::SearchResultsEvent.new(
         request:,
         total: @courses_count,
         page: @pagy.page,

--- a/app/controllers/find/secondary_subjects_controller.rb
+++ b/app/controllers/find/secondary_subjects_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Find
-  class SecondarySubjectsController < Find::ApplicationController
-    include Find::FinancialIncentiveHelper
+  class SecondarySubjectsController < ApplicationController
+    include FinancialIncentiveHelper
 
     before_action :initialize_form
 
@@ -22,7 +22,7 @@ module Find
   private
 
     def initialize_form
-      @form = Find::Subjects::SecondaryForm.new(subject_params)
+      @form = Subjects::SecondaryForm.new(subject_params)
     end
 
     SecondarySubjectInput = Struct.new(:code, :name, :financial_info, :subject_group, keyword_init: true)

--- a/app/controllers/find/track_controller.rb
+++ b/app/controllers/find/track_controller.rb
@@ -6,7 +6,7 @@ module Find
       utm_content = params[:utm_content]
       url = params[:url]
 
-      Find::Analytics::ClickEvent.new(utm_content:, url:, request:).send_event
+      Analytics::ClickEvent.new(utm_content:, url:, request:).send_event
 
       redirect_to url, allow_other_host: true
     end


### PR DESCRIPTION
## Context

When referencing ruby classes from within a module, Ruby attempts to find class references from within the same module first, before bubbling up to the next module levels.

```ruby
module Find
  Analytics # Looks for `Find::Analytics`. If not found, only then does it look for `Analytics`.
end
```

## Changes proposed in this pull request

- Remove superfluous `Find` namespace from `Find` module nested class calls.

## Guidance to review

- Review that tests pass and app works - specifically the Find service.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
