### PR TITLE
Increase Capybara default max wait time to 10 seconds

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -124,6 +124,7 @@ RSpec.configure do |config|
 
   ActiveJob::Base.queue_adapter = :test
 
+  Capybara.default_max_wait_time = 10
   config.before(:each, type: :feature) do
     service = self.class.metadata[:service]
 


### PR DESCRIPTION
## Context

We're seeing a lot of stale element failures. Let's try change the Capybara config to help the tests pass.

Increase Capybara default max wait time to 10 seconds

If an element takes 3 seconds to appear, the test won't fail,
But if it fails for a good reason, it might take 10 seconds for it to fail.

Tradeoff.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
