### PR TITLE
Specify the recruitment cycle when running automated rollover

### DIFF
--- a/app/jobs/rollover_job.rb
+++ b/app/jobs/rollover_job.rb
@@ -5,12 +5,12 @@ class RolloverJob < ApplicationJob
 
   BATCH_SIZE = 10
 
-  def perform
+  def perform(recruitment_cycle_id)
     relation = RecruitmentCycle.current_recruitment_cycle.providers
 
     BatchDelivery.new(relation:, stagger_over: 1.hour, batch_size: BATCH_SIZE).each do |batch_time, providers|
       providers.pluck(:provider_code).each do |provider_code|
-        RolloverProviderJob.perform_at(batch_time, provider_code)
+        RolloverProviderJob.perform_at(batch_time, provider_code, recruitment_cycle_id)
       end
     end
   end

--- a/app/jobs/rollover_provider_job.rb
+++ b/app/jobs/rollover_provider_job.rb
@@ -3,7 +3,11 @@
 class RolloverProviderJob
   include Sidekiq::Job
 
-  def perform(provider_code)
-    RolloverProviderService.call(provider_code:, force: false)
+  def perform(provider_code, new_recruitment_cycle_id)
+    RolloverProviderService.call(
+      provider_code:,
+      new_recruitment_cycle_id:,
+      force: false,
+    )
   end
 end

--- a/app/services/recruitment_cycle_creation_service.rb
+++ b/app/services/recruitment_cycle_creation_service.rb
@@ -10,12 +10,12 @@ class RecruitmentCycleCreationService
   end
 
   def call
-    RecruitmentCycle.create!(
+    recruitment_cycle = RecruitmentCycle.create!(
       year: @year,
       application_start_date: @application_start_date,
       application_end_date: @application_end_date,
     )
 
-    RolloverJob.perform_later
+    RolloverJob.perform_later(recruitment_cycle.id)
   end
 end

--- a/app/services/rollover_provider_service.rb
+++ b/app/services/rollover_provider_service.rb
@@ -3,9 +3,10 @@
 class RolloverProviderService
   include ServicePattern
 
-  def initialize(provider_code:, force:, course_codes: nil)
+  def initialize(provider_code:, force:, new_recruitment_cycle_id: nil, course_codes: nil)
     @provider_code = provider_code
     @course_codes = course_codes
+    @new_recruitment_cycle_id = new_recruitment_cycle_id
     @force = force
   end
 
@@ -37,7 +38,11 @@ private
   end
 
   def new_recruitment_cycle
-    @new_recruitment_cycle ||= RecruitmentCycle.next_recruitment_cycle
+    @new_recruitment_cycle ||= if @new_recruitment_cycle_id.present?
+                                 RecruitmentCycle.find(@new_recruitment_cycle_id)
+                               else
+                                 RecruitmentCycle.next_recruitment_cycle
+                               end
   end
 
   def provider

--- a/spec/jobs/rollover_provider_job_spec.rb
+++ b/spec/jobs/rollover_provider_job_spec.rb
@@ -4,12 +4,22 @@ require "rails_helper"
 
 RSpec.describe RolloverProviderJob do
   describe "#perform" do
-    let(:provider_code) { "ABC123" }
+    let(:new_recruitment_cycle) do
+      find_or_create(:recruitment_cycle, :next)
+    end
+    let(:provider) do
+      create(:provider)
+    end
 
-    it "calls the rollover service with correct parameters" do
-      expect(RolloverProviderService).to receive(:call).with(provider_code:, force: false)
+    it "copy courses from specific provider only" do
+      courses = create_list(:course, 5, :published, provider:)
+      create_list(:course, 5, :published, provider: create(:provider))
 
-      subject.perform(provider_code)
+      subject.perform(provider.provider_code, new_recruitment_cycle.id)
+
+      expect(new_recruitment_cycle.courses.pluck(:name, :course_code)).to eq(
+        courses.pluck(:name, :course_code),
+      )
     end
   end
 end

--- a/spec/services/rollover_provider_service_spec.rb
+++ b/spec/services/rollover_provider_service_spec.rb
@@ -46,5 +46,29 @@ describe RolloverProviderService do
 
       described_class.call(provider_code: provider.provider_code, course_codes:, force:)
     end
+
+    context "when a new_recruitment_cycle_id is provided" do
+      let(:custom_recruitment_cycle) do
+        find_or_create(
+          :recruitment_cycle,
+          year: 1.year.from_now.year,
+          application_start_date: DateTime.new(Date.current.year.to_i + 1, 10, 1),
+          application_end_date: DateTime.new(Date.current.year.to_i + 2, 9, 30),
+        )
+      end
+
+      it "uses the specified recruitment cycle" do
+        expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
+          provider:, new_recruitment_cycle: custom_recruitment_cycle, course_codes:,
+        )
+
+        described_class.call(
+          provider_code: provider.provider_code,
+          course_codes: course_codes,
+          force: force,
+          new_recruitment_cycle_id: custom_recruitment_cycle.id,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Originated from this PR comment:
https://github.com/DFE-Digital/publish-teacher-training/pull/5154#discussion_r2039199331

When running the rollover will be good to specify the recruitment cycle.

