### PR TITLE
Add temp hosts to valid Production and QA hosts

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -5,15 +5,18 @@ environment:
 find_url: https://find-teacher-training-courses.service.gov.uk
 find_hosts:
   - find-teacher-training-courses.service.gov.uk
+  - find-temp.teacherservices.cloud
 
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 publish_hosts:
   - www.publish-teacher-training-courses.service.gov.uk
   - publish-production.teacherservices.cloud
+  - publish-temp.teacherservices.cloud
 
 api_url: https://api.publish-teacher-training-courses.service.gov.uk
 api_hosts:
   - api.publish-teacher-training-courses.service.gov.uk
+  - api-publish-temp.teacherservices.cloud
 
 base_url: https://www.publish-teacher-training-courses.service.gov.uk
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -6,16 +6,18 @@ find_url: https://qa.find-teacher-training-courses.service.gov.uk
 find_hosts:
   - qa.find-teacher-training-courses.service.gov.uk
   # - find-qa.test.teacherservices.cloud
+  - find-temp.test.teacherservices.cloud
 
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 publish_hosts:
   - qa.publish-teacher-training-courses.service.gov.uk
   - publish-qa.test.teacherservices.cloud
+  - publish-temp.test.teacherservices.cloud
 
 api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 api_hosts:
   - qa.api.publish-teacher-training-courses.service.gov.uk
-  # - publish-api-qa.test.teacherservices.cloud
+  - api-publish-temp.test.teacherservices.cloud
 
 base_url: https://qa.publish-teacher-training-courses.service.gov.uk
 


### PR DESCRIPTION
## Context

Since we added the ability to configure multiple valid hosts, we can now add the additional temp URLs.

> The temp ingress for both prod and qa env are below.
> 
> **Production**
> - publish-temp.teacherservices.cloud
> - find-temp.teacherservices.cloud
> - api-publish-temp.teacherservices.cloud
> 
> **QA**
> - publish-temp.test.teacherservices.cloud
> - find-temp.test.teacherservices.cloud
> - api-publish-temp.test.teacherservices.cloud

## Changes proposed in this pull request

- Add temp URLs to production and QA settings.

## Guidance to review

- Review https://github.com/DFE-Digital/publish-teacher-training/pull/5202

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
