### PR TITLE
Fix undefined method minimum_distance_to_search_location for an instance of Course (NoMethodError)

### DIFF
--- a/app/controllers/api/radius_quick_link_suggestions_controller.rb
+++ b/app/controllers/api/radius_quick_link_suggestions_controller.rb
@@ -22,7 +22,9 @@ module API
       radius_links_query = Courses::Query.call(params: params.merge(radius: MAX_RADIUS)).limit(MAX_COURSES_COUNT + 1)
 
       Courses::SearchForm::RADIUS_VALUES.filter_map do |radius|
-        count = radius_links_query.count { |course| course.minimum_distance_to_search_location.to_f <= radius }
+        count = radius_links_query.count do |course|
+          course.respond_to?(:minimum_distance_to_search_location) && course.minimum_distance_to_search_location.to_f <= radius
+        end
 
         { radius:, count: } if count.positive?
       end


### PR DESCRIPTION
## Context

We were getting this error in Sentry `undefined method 'minimum_distance_to_search_location' for an instance of Course (NoMethodError)`  from the RadiusQuickLinkSuggestionsController 

## Changes proposed in this pull request

`course.respond_to?(:minimum_distance_to_search_location)` checks whether the course object has a method or attribute called minimum_distance_to_search_location.

In this case, it's needed because:

- The minimum_distance_to_search_location is not a real attribute on the Course model.

- It's only added dynamically in the `Courses::Query.call` if the location_scope is applied — i.e., when both latitude and longitude are present in params.

- If it's not included, calling `course.minimum_distance_to_search_location` will raise a `NoMethodError`.

So this line ensures you're only accessing the attribute when it's actually available, avoiding the error.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
