### PR TITLE
Remove references to `Settings.find_valid_referers`

### DIFF
--- a/app/helpers/find/view_helper.rb
+++ b/app/helpers/find/view_helper.rb
@@ -13,18 +13,21 @@ module Find
     def permitted_referrer?
       return false if request.referer.blank?
 
-      request.referer.include?(request.host_with_port) ||
-        Settings.find_valid_referers.any? { |url| request.referer.start_with?(url) }
+      [*Settings.find_hosts, *Settings.publish_hosts].include?(referer.host)
     end
 
     def course_back_link
-      referer = URI(request.referer)
       if referer.request_uri =~ %r{^/results}
-
         request.referer
       elsif referer && session[:results_path] =~ %r{^/results}
         session[:results_path]
       end
+    end
+
+  private
+
+    def referer
+      URI.parse(request.referer)
     end
   end
 end


### PR DESCRIPTION
## Context

There was a lingering reference to `Settings.find_valid_referers`. We can safely remove it.

## Changes proposed in this pull request

- Remove `Settings.find_valid_referers` reference.
- Update code to use Find and Publish hosts instead.

## Guidance to review

- Navigate to a course details page from searching.
- Click on some links and click back. All should be fine.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
