### PR TITLE
Add available in publish from date in Publish

### DIFF
--- a/app/controllers/support/recruitment_cycles_controller.rb
+++ b/app/controllers/support/recruitment_cycles_controller.rb
@@ -20,6 +20,7 @@ module Support
           year: @support_recruitment_cycle_form.year,
           application_start_date: @support_recruitment_cycle_form.application_start_date,
           application_end_date: @support_recruitment_cycle_form.application_end_date,
+          available_in_publish_from: @support_recruitment_cycle_form.available_in_publish_from,
         )
 
         redirect_to support_recruitment_cycles_path, flash: { success: t(".added") }
@@ -33,6 +34,7 @@ module Support
         year: @recruitment_cycle.year,
         application_start_date: @recruitment_cycle.application_start_date,
         application_end_date: @recruitment_cycle.application_end_date,
+        available_in_publish_from: @recruitment_cycle.available_in_publish_from,
       )
     end
 
@@ -44,6 +46,7 @@ module Support
           year: @support_recruitment_cycle_form.year,
           application_start_date: @support_recruitment_cycle_form.application_start_date,
           application_end_date: @support_recruitment_cycle_form.application_end_date,
+          available_in_publish_from: @support_recruitment_cycle_form.available_in_publish_from,
         )
 
         redirect_to support_recruitment_cycle_path(@recruitment_cycle), flash: { success: t(".updated") }
@@ -57,9 +60,12 @@ module Support
     def recruitment_cycle_form_params
       params
         .expect(
-          support_recruitment_cycle_form: %i[year
-                                             application_start_date
-                                             application_end_date],
+          support_recruitment_cycle_form: %i[
+            year
+            application_start_date
+            application_end_date
+            available_in_publish_from
+          ],
         )
     end
 

--- a/app/forms/support/recruitment_cycle_form.rb
+++ b/app/forms/support/recruitment_cycle_form.rb
@@ -5,9 +5,10 @@ module Support
     attribute :year, :string
     attribute :application_start_date, :multiple_parameters_date
     attribute :application_end_date, :multiple_parameters_date
+    attribute :available_in_publish_from, :multiple_parameters_date
 
     validates :year, presence: true, numericality: { only_integer: true }
-    validates :application_start_date, :application_end_date, multiple_parameters_date: true
+    validates :application_start_date, :application_end_date, :available_in_publish_from, multiple_parameters_date: true
     validate :application_end_date_must_be_after_start_date
     validate :year_must_be_unique, if: -> { validation_context != :update }
 

--- a/app/services/recruitment_cycle_creation_service.rb
+++ b/app/services/recruitment_cycle_creation_service.rb
@@ -3,17 +3,16 @@
 class RecruitmentCycleCreationService
   include ServicePattern
 
-  def initialize(year:, application_start_date:, application_end_date:)
-    @year = year
-    @application_start_date = application_start_date
-    @application_end_date = application_end_date
-  end
+  include ActiveModel::Model
+
+  attr_accessor :year, :application_start_date, :application_end_date, :available_in_publish_from
 
   def call
     recruitment_cycle = RecruitmentCycle.create!(
       year: @year,
       application_start_date: @application_start_date,
       application_end_date: @application_end_date,
+      available_in_publish_from: @available_in_publish_from,
     )
 
     RolloverJob.perform_later(recruitment_cycle.id)

--- a/app/views/support/recruitment_cycles/_form.html.erb
+++ b/app/views/support/recruitment_cycles/_form.html.erb
@@ -23,6 +23,15 @@
                               legend: { text: Support::RecruitmentCycleForm.human_attribute_name(:application_end_date), size: "s" } %>
     </div>
 
+    <div class="govuk-form-group">
+      <%= f.govuk_date_field :available_in_publish_from,
+                              class: "govuk-input--width-20",
+                              legend: { text: Support::RecruitmentCycleForm.human_attribute_name(:available_in_publish_from), size: "s" },
+                              hint: {
+          text: Support::RecruitmentCycleForm.human_attribute_name(:available_in_publish_from_description),
+        } %>
+    </div>
+
     <%= f.govuk_submit t(".submit") %>
 
     <p class="govuk-body">

--- a/app/views/support/recruitment_cycles/index.html.erb
+++ b/app/views/support/recruitment_cycles/index.html.erb
@@ -11,6 +11,7 @@
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:year) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:start_date) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:end_date) %>
+        <% row.with_cell text: RecruitmentCycle.human_attribute_name(:available_in_publish_from) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:rollover_progress) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:status) %>
       <% end %>
@@ -22,6 +23,7 @@
           <% row.with_cell text: govuk_link_to(recruitment_cycle.year, support_recruitment_cycle_path(recruitment_cycle)) %>
           <% row.with_cell text: recruitment_cycle.application_start_date.strftime("%-d %B %Y") %>
           <% row.with_cell text: recruitment_cycle.application_end_date.strftime("%-d %B %Y") %>
+          <% row.with_cell text: recruitment_cycle.available_in_publish_from&.strftime("%-d %B %Y") %>
           <% row.with_cell text: render(RolloverProgressComponent.new(current_cycle: RecruitmentCycle.current, target_cycle: recruitment_cycle)) %>
           <% row.with_cell do %>
             <%= recruitment_cycle_status_tag(recruitment_cycle) %>

--- a/app/views/support/recruitment_cycles/show.html.erb
+++ b/app/views/support/recruitment_cycles/show.html.erb
@@ -51,6 +51,19 @@
         <% end %>
 
         <% summary_list.with_row do |row| %>
+          <% row.with_key text: RecruitmentCycle.human_attribute_name(:available_in_publish_from) %>
+          <% row.with_value text: l(@recruitment_cycle.available_in_publish_from, format: :long) %>
+          <% if policy(@recruitment_cycle).edit? %>
+            <% row.with_action(
+              text: t("change"),
+              href: edit_support_recruitment_cycle_path(@recruitment_cycle),
+              visually_hidden_text: RecruitmentCycle.human_attribute_name(:available_in_publish_from),
+              classes: ["govuk-link--no-visited-state"],
+            ) %>
+          <% end %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
           <% row.with_key text: RecruitmentCycle.human_attribute_name(:rollover_progress) %>
           <% row.with_value text: render(RolloverProgressComponent.new(current_cycle: RecruitmentCycle.current, target_cycle: @recruitment_cycle)) %>
         <% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -5,6 +5,8 @@ en:
         year: Recruitment cycle year
         application_start_date: Application start date
         application_end_date: Application end date
+        available_in_publish_from: Available in publish from
+        available_in_publish_from_description: Date when courses will become available to users in Publish.
     errors:
       models:
         support/recruitment_cycle_form:
@@ -20,4 +22,7 @@ en:
             application_end_date:
               blank: Enter an application end date
               application_end_date_after_start_date: End date must be after the application start date
+              invalid_date: Enter a valid date
+            available_in_publish_from:
+              blank: Enter the date when courses will become available to users in Publish.
               invalid_date: Enter a valid date

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -7,3 +7,4 @@ en:
         end_date: End date
         rollover_progress: Rollover progress
         status: Status
+        available_in_publish_from: Available in Publish

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     year { Settings.current_recruitment_cycle_year }
     application_start_date { DateTime.new(year.to_i - 1, 10, 1) }
     application_end_date { DateTime.new(year.to_i, 9, 30) }
+    available_in_publish_from { application_start_date.to_date - 1.month }
 
     trait :previous do
       year { (Settings.current_recruitment_cycle_year.to_i - 1).to_s }

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -173,7 +173,12 @@ private
 
   def given_there_is_a_next_recruitment_cycle
     next_year = RecruitmentCycle.current.year.to_i + 1
-    RecruitmentCycle.create(year: next_year, application_start_date: Date.new(next_year - 1, 10, 1), application_end_date: Date.new(next_year, 9, 30))
+    create(
+      :recruitment_cycle,
+      year: next_year,
+      application_start_date: Date.new(next_year - 1, 10, 1),
+      application_end_date: Date.new(next_year, 9, 30),
+    )
   end
 
   def when_i_click_the_rollover_course_button

--- a/spec/forms/support/recruitment_cycle_form_spec.rb
+++ b/spec/forms/support/recruitment_cycle_form_spec.rb
@@ -82,6 +82,9 @@ RSpec.describe Support::RecruitmentCycleForm do
           "application_end_date(1i)" => "2051",
           "application_end_date(2i)" => "03",
           "application_end_date(3i)" => "10",
+          "available_in_publish_from(1i)" => "2050",
+          "available_in_publish_from(2i)" => "03",
+          "available_in_publish_from(3i)" => "09",
         }
       end
 

--- a/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish do
     when_i_fill_in_valid_recruitment_cycle_details
     and_i_submit_the_form
     then_i_see_the_success_message
+    and_the_recruitment_cycle_is_created
   end
 
   def given_i_visit_support_settings
@@ -46,6 +47,7 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish do
     expect(page).to have_text("Enter a year")
     expect(page).to have_text("Enter an application start date")
     expect(page).to have_text("Enter an application end date")
+    expect(page).to have_text("Enter the date when courses will become available to users in Publish")
   end
 
   def when_i_fill_in_valid_recruitment_cycle_details
@@ -56,6 +58,10 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish do
     fill_in "support_recruitment_cycle_form[application_end_date(3i)]", with: "04"
     fill_in "support_recruitment_cycle_form[application_end_date(2i)]", with: "10"
     fill_in "support_recruitment_cycle_form[application_end_date(1i)]", with: "2026"
+
+    fill_in "support_recruitment_cycle_form[available_in_publish_from(3i)]", with: "04"
+    fill_in "support_recruitment_cycle_form[available_in_publish_from(2i)]", with: "09"
+    fill_in "support_recruitment_cycle_form[available_in_publish_from(1i)]", with: "2025"
   end
 
   def and_i_submit_the_form
@@ -64,5 +70,14 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish do
 
   def then_i_see_the_success_message
     expect(page).to have_text("Recruitment cycle added")
+  end
+
+  def and_the_recruitment_cycle_is_created
+    recruitment_cycle = RecruitmentCycle.find_by(year: "2026")
+    expect(recruitment_cycle).to be_present
+
+    expect(recruitment_cycle.application_start_date).to eq(Date.new(2025, 10, 4))
+    expect(recruitment_cycle.application_end_date).to eq(Date.new(2026, 10, 4))
+    expect(recruitment_cycle.available_in_publish_from).to eq(Date.new(2025, 9, 4))
   end
 end

--- a/spec/system/support/settings/recruitment_cycles/edit_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/edit_recruitment_cycle_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Editing a recruitment cycle", service: :publish do
     when_i_click_change
     and_i_change_the_application_start_date
     and_i_change_the_application_end_date
+    and_i_change_the_available_in_publish_from_date
     and_i_click_continue
 
     then_i_see_the_recruitment_cycle_updated_successfully
@@ -94,6 +95,13 @@ RSpec.describe "Editing a recruitment cycle", service: :publish do
     end
   end
 
+  def and_i_change_the_available_in_publish_from_date
+    within_fieldset "Available in publish from" do
+      fill_in "Day", with: "14"
+      fill_in "Month", with: "08"
+    end
+  end
+
   def and_i_click_continue
     click_link_or_button "Continue"
   end
@@ -106,6 +114,8 @@ RSpec.describe "Editing a recruitment cycle", service: :publish do
     expect(@upcoming_cycle.application_start_date.month).to eq(9)
     expect(@upcoming_cycle.application_end_date.day).to eq(5)
     expect(@upcoming_cycle.application_end_date.month).to eq(10)
+    expect(@upcoming_cycle.available_in_publish_from.day).to eq(14)
+    expect(@upcoming_cycle.available_in_publish_from.month).to eq(8)
     expect(page).to have_content(@upcoming_cycle.year)
     expect(page).to have_content(I18n.l(@upcoming_cycle.application_start_date, format: :long))
     expect(page).to have_content(I18n.l(@upcoming_cycle.application_end_date, format: :long))


### PR DESCRIPTION


## Context

Add the field "available in publish from" date field to recruitment cycle support. Also added on index and show actions.

## Guidance to review

1. Can you add a new cycle and add the available from field?
2. Can you edit the cycles and change the available from field?
3. Does it show in index and show actions?
