### PR TITLE
Date field validation on 'applications open date' is not clear

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1092,6 +1092,8 @@ private
   def validate_applications_open_from
     if applications_open_from.blank? || applications_open_from.is_a?(Struct)
       errors.add(:applications_open_from, :blank)
+    elsif applications_open_from.year.to_s.length != 4
+      errors.add(:applications_open_from, "Year must include 4 numbers")
     elsif valid_date_range.exclude?(applications_open_from)
       errors.add(
         :applications_open_from,

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -8,6 +8,7 @@ module Support
     let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: Settings.current_recruitment_cycle_year, applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: Settings.current_recruitment_cycle_year, is_send: "true" } }
     let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: Settings.current_recruitment_cycle_year, applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
     let(:attributes_with_invalid_date_year) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2027", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "2000" } }
+    let(:attributes_with_two_digit_date_year) { { course_code: "T92", name: "Universitry of Oxfords", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "25" } }
     let(:blank_attributes) { { course_code: "", name: "", start_date_day: "", start_date_month: "", start_date_year: "", applications_open_from_day: "", applications_open_from_month: "", applications_open_from_year: "" } }
 
     subject { described_class.new(course) }
@@ -94,6 +95,17 @@ module Support
           expect(subject.errors.messages.count).to eq(2)
           expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the #{Settings.current_recruitment_cycle_year} cycle")
           expect(subject.errors.messages[:applications_open_from]).to include("The date when applications open must be between #{course.recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{course.recruitment_cycle.application_end_date.to_fs(:govuk_date)}")
+        end
+      end
+
+      context "form is assigned date year args with a 2 digit date" do
+        it "can promote and return errors including 2-digit year error" do
+          subject.assign_attributes(attributes_with_two_digit_date_year)
+          subject.save
+          subject.valid?
+
+          expect(subject.errors.messages.count).to eq(1)
+          expect(subject.errors.messages[:applications_open_from]).to include("Year must include 4 numbers")
         end
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -414,6 +414,14 @@ describe Course do
             expect(error).not_to be_empty
             expect(error.first).to include("The date when applications open must be between #{recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{recruitment_cycle.application_end_date.to_fs(:govuk_date)}")
           end
+
+          it "adds an error when the year only has 2 digits" do
+            course.applications_open_from = "01-01-25"
+            course.valid?(:new)
+            error = course.errors.messages[:applications_open_from]
+            expect(error).not_to be_empty
+            expect(error.first).to include("Year must include 4 numbers")
+          end
         end
 
         it "Requires at least one location" do


### PR DESCRIPTION
## Context

On the application open date if you enter the last two numbers of a date it causes an error but does not tell you how to fix it.

## Changes proposed in this pull request

Add validation to check that the year has a length of 4 digits

## Guidance to review

- Publish a course and on the `Applications open date` enter a year that only has 2 digits 

<img width="1158" alt="Screenshot 2025-05-06 at 15 37 49" src="https://github.com/user-attachments/assets/7bd325e1-6864-4bd6-8840-0979cce01a5f" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
