### PR TITLE
900 bug wrong time stamp on visa sponsorship deadline

### DIFF
--- a/app/components/find/courses/apply_component/view.html.erb
+++ b/app/components/find/courses/apply_component/view.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-6" id="section-apply">
   <% if Find::CycleTimetable.mid_cycle? %>
     <% if application_status_open? %>
-      <p class="govuk-body govuk-!-margin-0">
+      <p class="govuk-body">
         <%= govuk_start_button(
               classes: "govuk-!-margin-0",
               text: "Apply for this course",

--- a/app/forms/publish/visa_sponsorship_application_deadline_date_form.rb
+++ b/app/forms/publish/visa_sponsorship_application_deadline_date_form.rb
@@ -49,7 +49,9 @@ module Publish
     end
 
     def set_date
-      @date = DateTime.new(year.to_i, month.to_i, day.to_i).end_of_day
+      @date = DateTime.new(year.to_i, month.to_i, day.to_i)
+                      .in_time_zone("London")
+                      .end_of_day
     end
 
     def within_range

--- a/app/services/courses/assign_visa_sponsorship_application_deadline_service.rb
+++ b/app/services/courses/assign_visa_sponsorship_application_deadline_service.rb
@@ -13,7 +13,8 @@ module Courses
     def execute(course)
       course.visa_sponsorship_application_deadline_at = if visa_sponsorship_application_deadline_required?(course)
                                                           DateTime.new(year.to_i, month.to_i, day.to_i)
-                                                                  .change(hour: 11, min: 59)
+                                                                  .in_time_zone("London")
+                                                                  .end_of_day
                                                         end
     rescue Date::Error
       course.visa_sponsorship_application_deadline_at = Struct.new(:year, :month, :day).new(year, month, day)

--- a/spec/features/publish/courses/new_visa_sponsorship_application_deadline_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_application_deadline_spec.rb
@@ -204,7 +204,7 @@ private
 
   def then_the_course_is_saved_with_the_new_deadline
     deadline = @provider.courses.reload.last.visa_sponsorship_application_deadline_at
-    expect(deadline).to eq @new_date.change(hour: 11, min: 59)
+    expect(deadline).to be_within(1.second).of @new_date.in_time_zone("London").end_of_day.utc
   end
 
   def and_i_complete_the_rest_of_the_form

--- a/spec/services/courses/creation_service_spec.rb
+++ b/spec/services/courses/creation_service_spec.rb
@@ -457,8 +457,8 @@ describe Courses::CreationService do
         end
 
         it "saves the visa sponsorship application deadline at from the params" do
-          deadline = DateTime.new(recruitment_cycle.year.to_i, 8, 1, 11, 59)
-          expect(subject.visa_sponsorship_application_deadline_at).to eq deadline
+          deadline = DateTime.new(recruitment_cycle.year.to_i, 8, 1).in_time_zone("London").end_of_day.utc
+          expect(subject.visa_sponsorship_application_deadline_at).to be_within(1.second).of deadline
         end
       end
     end


### PR DESCRIPTION
## Context

We are doing testing of the visa sponsorship application deadlines and come across a few little bugs. 

## Changes proposed in this pull request

First, just a formatting change, there wasn't any margin between the button and the text saying that there was a deadline. 
| Before | After |
| ------ | ------ |
| ![Screenshot 2025-05-02 at 17 09 56](https://github.com/user-attachments/assets/4e97bebf-3ffa-4c45-b1e1-75c80b1fa2aa) | ![image](https://github.com/user-attachments/assets/da753895-85bc-4f87-b0b7-06cd67d1449b) |

Next, a problem with time. 
- In one place, saving the time as 11:59 instead of 23:59.
- Everywhere, we were not including the intended time zone, which should be 11:59 local to London.

## Guidance to review


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
