### PR TITLE
Error message when entering "other age range" is not clear

### DIFF
--- a/app/services/courses/validate_custom_age_range_service.rb
+++ b/app/services/courses/validate_custom_age_range_service.rb
@@ -2,34 +2,42 @@
 
 module Courses
   class ValidateCustomAgeRangeService
-    def execute(age_range_in_years, course)
-      valid_age_range_regex = /^(?<from>\d{1,2})_to_(?<to>\d{1,2})$/
+    AGE_RANGE_REGEX = /^(?<from>\d{1,2})_to_(?<to>\d{1,2})$/
+    MIN_FROM_AGE = 3
+    MAX_FROM_AGE = 15
+    MIN_TO_AGE = 7
+    MAX_TO_AGE = 19
+    MIN_AGE_SPAN = 4
 
-      if valid_age_range_regex.match(age_range_in_years)
-        from_age = get_ages(age_range_in_years, valid_age_range_regex)["from"]
-        to_age = get_ages(age_range_in_years, valid_age_range_regex)["to"]
-        if from_age_invalid?(from_age) || to_age_invalid?(to_age)
-          course.errors.add(:age_range_in_years, "^Age range must be a school age")
-        elsif to_age - from_age < 4
-          course.errors.add(:age_range_in_years, "^Age range must cover at least 4 years")
-        end
-      else
+    def execute(age_range_in_years, course)
+      ages = parse_age_range(age_range_in_years)
+
+      if ages.nil?
         course.errors.add(:age_range_in_years, "^Enter an age range")
+        return
+      end
+
+      from_age, to_age = ages.values_at("from", "to")
+
+      if invalid_from_age?(from_age) || invalid_to_age?(to_age)
+        course.errors.add(:age_range_in_years, "^Age range must cover #{MIN_AGE_SPAN} or more school years")
+      elsif (to_age - from_age) < MIN_AGE_SPAN
+        course.errors.add(:age_range_in_years, "^Age range must cover at least #{MIN_AGE_SPAN} years")
       end
     end
 
   private
 
-    def get_ages(age_range_in_years, valid_age_range_regex)
-      valid_age_range_regex.match(age_range_in_years)&.named_captures&.transform_values(&:to_i)
+    def parse_age_range(age_range)
+      AGE_RANGE_REGEX.match(age_range)&.named_captures&.transform_values(&:to_i)
     end
 
-    def from_age_invalid?(from_age)
-      from_age < 3 || from_age > 15
+    def invalid_from_age?(age)
+      age < MIN_FROM_AGE || age > MAX_FROM_AGE
     end
 
-    def to_age_invalid?(to_age)
-      to_age < 7 || to_age > 19
+    def invalid_to_age?(age)
+      age < MIN_TO_AGE || age > MAX_TO_AGE
     end
   end
 end

--- a/spec/services/courses/validate_custom_age_range_service_spec.rb
+++ b/spec/services/courses/validate_custom_age_range_service_spec.rb
@@ -31,7 +31,7 @@ describe Courses::ValidateCustomAgeRangeService do
 
     context "with a from value that does not fall within the valid age range" do
       let(:age_range_in_years) { "1_to_15" }
-      let(:error_message) { "^Age range must be a school age" }
+      let(:error_message) { "^Age range must cover 4 or more school years" }
 
       it "returns an error" do
         expect(course.errors.messages_for(:age_range_in_years)).to contain_exactly error_message
@@ -40,7 +40,7 @@ describe Courses::ValidateCustomAgeRangeService do
 
     context "with a to value that does not fall within the valid age range" do
       let(:age_range_in_years) { "7_to_20" }
-      let(:error_message) { "^Age range must be a school age" }
+      let(:error_message) { "^Age range must cover 4 or more school years" }
 
       it "returns an error stating valid age ranges must be 4 years or greater" do
         expect(course.errors.messages_for(:age_range_in_years)).to contain_exactly error_message


### PR DESCRIPTION
## Context

When creating a course on publish, if you manually enter another age range the range must be at least four years. If it is less than four years it is currently showing an unhelpful error message.

## Changes proposed in this pull request

- Update error message
- Refactor `ValidateCustomAgeRangeService` 

## Guidance to review

- Visit publush
- Create a course
- When adding age range enter `Another age range` of 15 to 17 to see the new error 

<img width="972" alt="Screenshot 2025-05-07 at 13 47 18" src="https://github.com/user-attachments/assets/d793f120-a5fa-427c-b5af-f15872e06c06" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
