### PR TITLE
Skip linting and testing for prototype deployments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,6 +19,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'prototype')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -233,7 +233,14 @@ jobs:
   build:
     name: Build
     needs: [lint, analytics-checks, javascript-tests, rails-tests]
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')) }}
+    if: |
+      ${{
+        (
+          github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))
+        ) || (
+          failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype')
+        )
+      }}
     outputs:
       docker_image: ${{ env.DOCKER_IMAGE }}
       image_tag: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -340,7 +340,14 @@ jobs:
     environment:
       name: review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
+    if: |
+      ${{
+        (
+          github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')
+        ) || (
+          failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype')
+        )
+      }}
     needs: [build]
     runs-on: ubuntu-latest
     env:

--- a/guides/prototype-branches.md
+++ b/guides/prototype-branches.md
@@ -1,0 +1,28 @@
+# Prototype branches
+
+We branch off the `main` branch of this repository to build prototype branches. Prototype branches should be prefixed with `prototype/`.
+
+## What are "prototype" branches?
+
+Prototype branches are forks of the code that are built primarily by the team's Interaction Designer. Their purpose is to provide a near-to live service experience for experimental and upcoming designs.
+
+The benefits of using the Rails codebase to prototype are:
+
+- It already provides a foundation for the service's existing functionality. There is no need to build the results page, for example.
+- As developers are already familiar with the language and codebase, they are available to assist with development and troubleshooting.
+
+The drawbacks, compared to Figma and the GOV.UK Prototype kit, are:
+
+- Branches need to be compatible to merge with the `main` branch in order to be deployable. This means that conflicts need to be resolved.
+- As developers are not familiar with the tooling, language nor codebase, the Interaction Designer will receive limited support from the internal team.
+
+## Deploying prototype branches
+
+To deploy a prototype branch, open a PR and add the `prototype` label to it. The `prototype` label bypasses any code quality checks and directly deploys the review app, if possible.
+
+Once deployment is successful, a comment will be posted to the PR linking to the relevant review app URLs.
+
+### Example PRs
+
+- [prototype/provider-performance](https://github.com/DFE-Digital/publish-teacher-training/pull/5066)
+- [prototype/structure-course-information](https://github.com/DFE-Digital/publish-teacher-training/pull/5221)


### PR DESCRIPTION
## Context

We need a way to rapidly deploy review apps for Prototypes.

"Prototypes" are UI-focused branches that are primarily built by the team's Interaction Designer. Their purpose is to provide realistic service functionality for User Research and user testing sessions.

## Changes proposed in this pull request

- Add new condition for the `lint` step. It will not run for PRs with the `prototype` label.
- Add new condition for the `build` and `deploy-review-app` steps to run for PRs with the `prototype` label.

## Guidance to review

- Review the GitHub Action run: https://github.com/DFE-Digital/publish-teacher-training/actions/runs/14992818313
- Only the `build` and `deploy-review-app` steps should run.
- Review the [Prototype branches](https://github.com/DFE-Digital/publish-teacher-training/blob/dd/allow-deployments-for-prototypes/guides/prototype-branches.md) documentation.
