### PR TITLE
Add callout to GIT Funding and support if you're disabled page

### DIFF
--- a/app/views/find/courses/training_with_disabilities/show.html.erb
+++ b/app/views/find/courses/training_with_disabilities/show.html.erb
@@ -22,5 +22,12 @@
         find_provider_path(@course.provider_code, @course.course_code),
       ) %>
     </p>
+
+    <%= govuk_inset_text classes: "app-callout app-callout--orange app-callout--min-height govuk-!-margin-top-0" do %>
+      <h3><%= t(".funding_and_support") %></h3>
+
+      <p><%= t(".neurodivergent_html", link: govuk_link_to(t(".neurodivergent_link_text"), find_track_click_path(utm_content: "training_disabilities_neurodivergent", url: t(".neurodivergent_link")))) %>.</p>
+      <p><%= t(".adjustments_html", link: govuk_link_to(t(".adjustments_link_text"), find_track_click_path(utm_content: "training_disabilities_adjustments", url: t(".adjustments_link")))) %>.</p>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en/find/courses/training_with_disabilities.yml
+++ b/config/locales/en/find/courses/training_with_disabilities.yml
@@ -1,0 +1,12 @@
+en:
+  find:
+    courses:
+      training_with_disabilities:
+        show:
+          funding_and_support: Funding and support
+          neurodivergent_html: If you're neurodivergent, have a long-term physical or mental health condition, or have any other accessibility needs, %{link}
+          neurodivergent_link_text: find out what funding and support you can get
+          neurodivergent_link: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
+          adjustments_html: Training providers can also make adjustments so you can attend an interview and complete your teacher training. %{link}
+          adjustments_link_text: Find out more about adjustments to help you apply and train to teach
+          adjustments_link: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/accessibility-adjustments


### PR DESCRIPTION
## Context

User research from GIT has suggested that people do not know what pages exist to help support disabled users. We also do not link to any pages to support disabled users. So at the point of need we should add a link to GITs help for funding and support for our users.

## Changes proposed in this pull request

Add new call out box to provide support information

## Guidance to review

- Visit a course 
- Scroll down to `training with disabilities` section and select the link to find out more
- You should see the new call out box

<img width="834" alt="Screenshot 2025-05-12 at 19 04 12" src="https://github.com/user-attachments/assets/ff113a00-38d7-49e2-9d2d-15c3ac634f67" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
