### PR TITLE
Skip review apps on main

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -235,10 +235,18 @@ jobs:
     needs: [lint, analytics-checks, javascript-tests, rails-tests]
     if: |
       ${{
-        (
-          github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))
-        ) || (
-          failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype')
+        always() && (
+          (
+            needs.lint.result == 'success' &&
+            needs.analytics-checks.result == 'success' &&
+            needs.javascript-tests.result == 'success' &&
+            needs.rails-tests.result == 'success' &&
+            (
+              github.ref == 'refs/heads/main' ||
+              (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))
+            )
+          ) ||
+          github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype')
         )
       }}
     outputs:
@@ -340,15 +348,16 @@ jobs:
     environment:
       name: review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: [build]
     if: |
       ${{
+        always() &&
+        needs.build.result == 'success' && github.event_name == 'pull_request' &&
         (
-          github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')
-        ) || (
-          failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype')
+          contains(github.event.pull_request.labels.*.name, 'deploy') ||
+          contains(github.event.pull_request.labels.*.name, 'prototype')
         )
       }}
-    needs: [build]
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Context

The `deploy-review-app` is running on pushes to `main`. We should prevent this from happening.

## Changes proposed in this pull request

- Clean up the `build-and-deploy.yml` GitHub Action workflow, namely the following jobs:
  - `build`
  - `deploy-review-app`

## Guidance to review

- Check the new logic.
- See reference comment here: https://github.com/actions/runner/issues/491#issuecomment-850884422
- See the `prototype` labeled run result: https://github.com/DFE-Digital/publish-teacher-training/actions/runs/15018013495

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
