### PR TITLE
Separate out prototype workflow from main development workflow

### DIFF
--- a/.github/workflows/build-and-deploy-prototype.yml
+++ b/.github/workflows/build-and-deploy-prototype.yml
@@ -1,0 +1,118 @@
+name: Build and Deploy Prototype
+concurrency: build_and_deploy_${{ github.ref_name }}
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: write
+  deployments: write
+  packages: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype') }}
+    outputs:
+      docker_image: ${{ env.DOCKER_IMAGE }}
+      image_tag: ${{ env.DOCKER_IMAGE_TAG }}
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: ghcr.io/dfe-digital/publish-teacher-training
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get values for current commit (Pull request)
+        if: github.event_name == 'pull_request'
+        run: |
+          # This is the actual PR branch
+          GIT_REF=${{ github.head_ref }}
+          GIT_BRANCH=${GIT_REF##*/}
+          echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+          # This is the latest commit on the actual PR branch
+          echo "DOCKER_IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Publish-Teacher-Training-Middleman
+        uses: docker/build-push-action@v6
+        with:
+          tags: ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
+          push: true
+          target: middleman
+          cache-from: |
+            type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:main
+            type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
+          build-args: BUILDKIT_INLINE_CACHE=1
+
+      - name: Build Publish-Teacher-Training
+        uses: docker/build-push-action@v6
+        with:
+          tags: |
+            ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+            ${{ env.DOCKER_IMAGE}}:${{ env.DOCKER_IMAGE_TAG }}
+          push: false
+          load: true
+          cache-from: |
+            type=registry,ref=${{ env.DOCKER_IMAGE}}:main
+            type=registry,ref=${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:main
+            type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            COMMIT_SHA=${{ env.DOCKER_IMAGE_TAG }}
+
+      - name: Push ${{ env.DOCKER_IMAGE }} images for review
+        run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
+
+  deploy-review-app:
+    name: Deployment To Review
+    environment:
+      name: review
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: [build]
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy App to Review
+        id: deploy_review
+        uses: ./.github/actions/deploy/
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          environment: review
+          pr-number: ${{ github.event.pull_request.number }}
+          sha: ${{ needs.build.outputs.image_tag }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          azure-storage-connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_SANITISED }}
+
+      - name: Post comment to Pull Request ${{ github.event.number }}
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: aks
+          message: |
+            ### Deployments
+
+            | App               | URL                                                                                      |
+            | ----------------- | ---------------------------------------------------------------------------------------- |
+            | Publish           | <https://publish-review-${{ github.event.number }}.test.teacherservices.cloud>           |
+            | Find              | <https://find-review-${{ github.event.number }}.test.teacherservices.cloud>              |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -234,22 +234,7 @@ jobs:
   build:
     name: Build
     needs: [lint, analytics-checks, javascript-tests, rails-tests]
-    if: |
-      ${{
-        !cancelled() && (
-          (
-            needs.lint.result == 'success' &&
-            needs.analytics-checks.result == 'success' &&
-            needs.javascript-tests.result == 'success' &&
-            needs.rails-tests.result == 'success' &&
-            (
-              github.ref == 'refs/heads/main' ||
-              (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))
-            )
-          ) ||
-          (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype'))
-        )
-      }}
+    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')) }}
     outputs:
       docker_image: ${{ env.DOCKER_IMAGE }}
       image_tag: ${{ env.DOCKER_IMAGE_TAG }}
@@ -258,28 +243,6 @@ jobs:
       DOCKER_IMAGE: ghcr.io/dfe-digital/publish-teacher-training
 
     steps:
-      - name: Print Event data
-        run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.event.pull_request.labels.*.name: ${{ toJSON(github.event.pull_request.labels.*.name) }}"
-          echo "github.event_name == 'pull_request': ${{ github.event_name == 'pull_request' }}"
-          echo ${{
-            (
-              (
-                needs.lint.result == 'success' &&
-                needs.analytics-checks.result == 'success' &&
-                needs.javascript-tests.result == 'success' &&
-                needs.rails-tests.result == 'success' &&
-                (
-                  github.ref == 'refs/heads/main' ||
-                  (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))
-                )
-              ) ||
-              (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype'))
-            )
-          }}
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -372,42 +335,11 @@ jobs:
       name: review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     needs: [build]
-    if: |
-      ${{
-        !cancelled() && (
-          needs.build.result == 'success' &&
-          github.event_name != 'push' &&
-          github.event_name == 'pull_request' &&
-          (
-            contains(github.event.pull_request.labels.*.name, 'deploy') ||
-            contains(github.event.pull_request.labels.*.name, 'prototype')
-          )
-        )
-      }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Print Event data
-        run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.event.pull_request.labels.*.name: ${{ toJSON(github.event.pull_request.labels.*.name) }}"
-          echo "github.event_name == 'push': ${{ github.event_name == 'push' }}"
-          echo "github.event_name == 'pull_request': ${{ github.event_name == 'pull_request' }}"
-          echo "(contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'prototype')): ${{ (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'prototype')) }}"
-          echo ${{
-            (
-              needs.build.result == 'success' &&
-              github.event_name != 'push' &&
-              github.event_name == 'pull_request' &&
-              (
-                contains(github.event.pull_request.labels.*.name, 'deploy') ||
-                contains(github.event.pull_request.labels.*.name, 'prototype')
-              )
-            )
-          }}
-
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - dd/skip-review-app-deployment-on-main
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - dd/skip-review-app-deployment-on-main
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
@@ -235,7 +236,7 @@ jobs:
     needs: [lint, analytics-checks, javascript-tests, rails-tests]
     if: |
       ${{
-        always() && (
+        !cancelled() && (
           (
             needs.lint.result == 'success' &&
             needs.analytics-checks.result == 'success' &&
@@ -246,7 +247,7 @@ jobs:
               (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))
             )
           ) ||
-          github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype')
+          (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype'))
         )
       }}
     outputs:
@@ -257,6 +258,28 @@ jobs:
       DOCKER_IMAGE: ghcr.io/dfe-digital/publish-teacher-training
 
     steps:
+      - name: Print Event data
+        run: |
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.ref: ${{ github.ref }}"
+          echo "github.event.pull_request.labels.*.name: ${{ toJSON(github.event.pull_request.labels.*.name) }}"
+          echo "github.event_name == 'pull_request': ${{ github.event_name == 'pull_request' }}"
+          echo ${{
+            (
+              (
+                needs.lint.result == 'success' &&
+                needs.analytics-checks.result == 'success' &&
+                needs.javascript-tests.result == 'success' &&
+                needs.rails-tests.result == 'success' &&
+                (
+                  github.ref == 'refs/heads/main' ||
+                  (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy'))
+                )
+              ) ||
+              (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'prototype'))
+            )
+          }}
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -351,17 +374,40 @@ jobs:
     needs: [build]
     if: |
       ${{
-        always() &&
-        needs.build.result == 'success' && github.event_name == 'pull_request' &&
-        (
-          contains(github.event.pull_request.labels.*.name, 'deploy') ||
-          contains(github.event.pull_request.labels.*.name, 'prototype')
+        !cancelled() && (
+          needs.build.result == 'success' &&
+          github.event_name != 'push' &&
+          github.event_name == 'pull_request' &&
+          (
+            contains(github.event.pull_request.labels.*.name, 'deploy') ||
+            contains(github.event.pull_request.labels.*.name, 'prototype')
+          )
         )
       }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Print Event data
+        run: |
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.ref: ${{ github.ref }}"
+          echo "github.event.pull_request.labels.*.name: ${{ toJSON(github.event.pull_request.labels.*.name) }}"
+          echo "github.event_name == 'push': ${{ github.event_name == 'push' }}"
+          echo "github.event_name == 'pull_request': ${{ github.event_name == 'pull_request' }}"
+          echo "(contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'prototype')): ${{ (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'prototype')) }}"
+          echo ${{
+            (
+              needs.build.result == 'success' &&
+              github.event_name != 'push' &&
+              github.event_name == 'pull_request' &&
+              (
+                contains(github.event.pull_request.labels.*.name, 'deploy') ||
+                contains(github.event.pull_request.labels.*.name, 'prototype')
+              )
+            )
+          }}
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Context

We're having difficulty conditionally starting at the `build` job for prototype workflows whilst also preventing `build` and `deploy-review-app` from running on `main` pushes _and_ when previous steps fail.

## Changes proposed in this pull request

- Split out the prototype PR workflow from the main development workflow.

## Guidance to review

When a PR is tagged as a prototype, it won't run the main development workflow and will just deploy a review app.

![CleanShot 2025-05-14 at 15 41 22@2x](https://github.com/user-attachments/assets/c3b0b821-02a3-45da-8eea-400810ad54f2)

It might also be worth adding the condition of flagging `prototype/` branches automatically as prototype PRs.
