### PR TITLE
Fix training partners course export

### DIFF
--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -268,7 +268,7 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
       end
 
       scope module: :providers do
-        get "/training-providers-courses", on: :member, to: "training_providers/course_exports#index", as: "download_training_providers_courses"
+        get "/training-providers-courses", on: :member, to: "training_partners/course_exports#index", as: "download_training_providers_courses"
         resources :training_partners, path: "/training-partners", controller: "training_partners", only: [:index], param: :code do
           resources :courses, only: [:index], controller: "training_partners/courses"
         end

--- a/spec/requests/publish/training_partner_course_exports_spec.rb
+++ b/spec/requests/publish/training_partner_course_exports_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Publish::ProvidersController" do
+  include DfESignInUserHelper
+
+  describe "/publish/providers/suggest" do
+    context "when the user is authenticated" do
+      it "is successful" do
+        provider = create(:provider)
+        user = create(:user, providers: [provider])
+
+        login_user(user)
+        get "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/training-providers-courses.csv"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Providers are trying to use ‘download CSV file’ option under the training partners tab in Publish, but it is showing a 505 Internal Sever Error page.

The reason is because the route is pointing to a controller that was deleted.

## Guidance to review

1. Go to Publish (UCL as example)
2. Click on Training parterns tab
3. Click Download CSV

It should download on the review app. You can compare with QA too.