### PR TITLE
Exclude non "prototype/" branches from prototype workflow runs

### DIFF
--- a/.github/workflows/build-and-deploy-prototype.yml
+++ b/.github/workflows/build-and-deploy-prototype.yml
@@ -3,7 +3,13 @@ concurrency: build_and_deploy_${{ github.ref_name }}
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+    branches:
+      - prototype/**
 
 permissions:
   contents: write

--- a/guides/prototype-branches.md
+++ b/guides/prototype-branches.md
@@ -1,6 +1,6 @@
 # Prototype branches
 
-We branch off the `main` branch of this repository to build prototype branches. Prototype branches should be prefixed with `prototype/`.
+We branch off the `main` branch of this repository to build prototype branches. Prototype branches must be prefixed with `prototype/` in order to be deployed.
 
 ## What are "prototype" branches?
 
@@ -18,7 +18,10 @@ The drawbacks, compared to Figma and the GOV.UK Prototype kit, are:
 
 ## Deploying prototype branches
 
-To deploy a prototype branch, open a PR and add the `prototype` label to it. The `prototype` label bypasses any code quality checks and directly deploys the review app, if possible.
+> [!IMPORTANT]
+> The deployment workflow will only trigger if the branch name is prefixed with `prototype/` and the `prototype` label has been attached.
+
+To deploy a prototype branch, open a PR and add the `prototype` label to it. The `prototype` label bypasses any code quality checks and directly deploys the review app, if possible. The code will redeploy itself on all new code pushes.
 
 Once deployment is successful, a comment will be posted to the PR linking to the relevant review app URLs.
 


### PR DESCRIPTION
## Context

All PRs are now triggering the prototype workflows and being immediately skipped.

![CleanShot 2025-05-15 at 15 08 06@2x](https://github.com/user-attachments/assets/47d11972-7264-4ae9-90c9-87c5d5f0f396)

This creates a lot of noise in the actions history.

## Changes proposed in this pull request

- Set the `build-and-deploy-prototype.yml` workflow to only trigger on pull requests for branches prefixed with `prototype/`.
- Update prototype documentation.

## Guidance to review

- Review the [updated documentation](https://github.com/DFE-Digital/publish-teacher-training/blob/dd/exclude-non-prototype-branches-from-prototype-workflow/guides/prototype-branches.md).
