### PR TITLE
Remove the usage of feature flag api summary content - part 1

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -130,11 +130,7 @@ module API
         end
 
         attribute :summary do
-          if FeatureService.enabled?(:api_summary_content_change)
-            @object.summary
-          else
-            @object.description
-          end
+          @object.summary
         end
 
         attribute :subject_codes do

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -19,12 +19,8 @@ RSpec.describe API::Public::V1::CoursesController do
       end
     end
 
-    context "when course summary feature flag is on" do
-      before do
-        allow(Settings.features).to receive(:api_summary_content_change).and_return(true)
-      end
-
-      it "returns new summary content" do
+    context "when course summary" do
+      it "returns summary content" do
         pgce_with_qts = create(:course, :resulting_in_pgce_with_qts)
         pgde_with_qts = create(:course, :resulting_in_pgde_with_qts)
         provider.courses << [pgce_with_qts, pgde_with_qts]
@@ -38,28 +34,6 @@ RSpec.describe API::Public::V1::CoursesController do
         end
 
         expect(actual).to contain_exactly("QTS with PGCE full time", "QTS with PGDE full time")
-      end
-    end
-
-    context "when course summary feature flag is off" do
-      before do
-        allow(Settings.features).to receive(:api_summary_content_change).and_return(false)
-      end
-
-      it "returns old summary content" do
-        pgce_with_qts = create(:course, :resulting_in_pgce_with_qts)
-        pgde_with_qts = create(:course, :resulting_in_pgde_with_qts)
-        provider.courses << [pgce_with_qts, pgde_with_qts]
-
-        get :index, params: {
-          recruitment_cycle_year: recruitment_cycle.year,
-        }
-
-        actual = json_response["data"].map do |data|
-          data["attributes"]["summary"]
-        end
-
-        expect(actual).to contain_exactly("PGCE with QTS full time", "PGDE with QTS full time")
       end
     end
 


### PR DESCRIPTION
## Context

Now we will always display the course.summary in API so we can remove the feature flag.

This is part 1 that only removes the code.

After this PR is deployed we can merge part 2: https://github.com/DFE-Digital/publish-teacher-training/pull/5258

## Guidance to review

1. ASK the API on `/api/public/v1/recruitment_cycles/:recruitment_cycle_year/courses`
2. See the `summary` and you should see many "QTS with PGCE" or "QTS with PGDE" or just "QTS".
