### PR TITLE
GOV.UK Rebrand

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template ">
+<html lang="en" class="govuk-template govuk-template--rebranded">
   <head>
     <meta charset="UTF-8">
 

--- a/app/views/layouts/find.html.erb
+++ b/app/views/layouts/find.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<html lang="en" class="govuk-template govuk-template--rebranded">
   <head>
     <meta charset="UTF-8">
 

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template ">
+<html lang="en" class="govuk-template govuk-template--rebranded">
   <head>
     <meta charset="UTF-8">
 


### PR DESCRIPTION
## Context

There is an upcoming GOV.UK Rebrand.

## Changes proposed in this pull request

- Enable the new rebrand by adding the `govuk-template--rebranded` css class.

## Guidance to review

- The new GOV.UK Rebrand must have gone live.
- The designs have been approved from our design team.
