### PR TITLE
Fix prototype deployments

### DIFF
--- a/.github/workflows/build-and-deploy-prototype.yml
+++ b/.github/workflows/build-and-deploy-prototype.yml
@@ -8,8 +8,6 @@ on:
       - reopened
       - synchronize
       - labeled
-    branches:
-      - prototype/**
 
 permissions:
   contents: write


### PR DESCRIPTION
## Context

Unfortunately, GitHub doesn't natively provide a method of conditionally triggering workflows based on the source branch.

Given a workflow trigger of:

```yaml
on:
  pull_request:
    branches:
      - prototype/**
```

This will run the workflow on pull requests _into_ the `prototype/**` branches, not _from_.

Therefore, we need to run this workflow on all branches and skip the jobs below based on conditions tied to the source branch.

## Changes proposed in this pull request

- Remove `branches` restrictions from the `build-and-deploy-prototype.yml` workflow.

## Guidance to review

- Read the Context above.
