### PR TITLE
Move up the course applications closed notification

### DIFF
--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -1,5 +1,3 @@
-<%= render Find::Courses::ApplyComponent::View.new(course, preview: preview?(params), utm_content: "apply_course_button_top") if course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
-
 <h2 class="govuk-heading-l">
   <%= t(".course_summary") %>
 </h2>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -22,11 +22,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render Find::Courses::SummaryComponent::View.new(@course) %>
-
     <% if @course.application_status_closed? %>
       <%= render partial: "find/courses/course_closed" %>
     <% end %>
+
+    <%= render Find::Courses::ApplyComponent::View.new(@course, preview: preview?(params), utm_content: "apply_course_button_top") if @course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
+
+    <%= render Find::Courses::SummaryComponent::View.new(@course) %>
 
     <%= render Find::Courses::EntryRequirementsComponent::View.new(course: @course) %>
 

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -72,6 +72,6 @@
       <%= render partial: "find/courses/course_closed" %>
     <% end %>
 
-    <%= render Find::Courses::ApplyComponent::View.new(@course, utm_content: "apply_course_button_bottom") if @course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
+    <%= render Find::Courses::ApplyComponent::View.new(@course, preview: preview?(params), utm_content: "apply_course_button_bottom") if @course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
   </div>
 </div>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -54,6 +54,6 @@
 
     <%= render partial: "find/courses/advice", locals: { course: } %>
 
-    <%= render Find::Courses::ApplyComponent::View.new(course, preview: true) unless course.application_status_open? %>
+    <%= render Find::Courses::ApplyComponent::View.new(course, preview: true) if course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
   </div>
 </div>

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -270,12 +270,7 @@ private
   def has_apply_for_course_buttons
     expected_url = "/publish/organisations/#{course.provider.provider_code}/#{course.provider.recruitment_cycle.year}/courses/#{course.course_code}/apply"
 
-    links = publish_course_preview_page.all("a", text: "Apply for this course", exact_text: true)
-    expect(links.size).to eq(2)
-
-    links.each do |link|
-      expect(link[:href]).to eq(expected_url)
-    end
+    expect(page).to have_link("Apply for this course", href: expected_url, count: 2)
   end
 
   def user_with_custom_address_requested_via_zendesk


### PR DESCRIPTION
## Context

The "applications closed" message is not in the same location as the top "Apply" button. We want to align the position of the "applications closed" message to be in the same place as the top "Apply" button.

## Changes proposed in this pull request

- Move up the "applications closed" partial.

## Guidance to review

| Before | After |
| ------ | ----- |
| ![CleanShot 2025-05-20 at 11 42 23](https://github.com/user-attachments/assets/2ba3c1d6-6dfb-4d87-8cd9-deaddd5f5c93) | ![CleanShot 2025-05-20 at 11 42 07](https://github.com/user-attachments/assets/820fcecc-557f-414a-848e-82e2044c0adc) |
