### PR TITLE
Temporary hotfix for locations

### DIFF
--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -63,7 +63,7 @@ module Find
           I18n.t(
             ".find.courses.training_locations.view.distance",
             distance: content_tag(:span, pluralize(distance_from_location, "mile"), class: "govuk-!-font-weight-bold"),
-            location: content_tag(:span, sanitize(coordinates[:formatted_address]), class: "govuk-!-font-weight-bold"),
+            location: content_tag(:span, sanitize(coordinates[:location]), class: "govuk-!-font-weight-bold"),
           ).html_safe
         end
 

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -24,7 +24,11 @@ module Find
     end
 
     def distance_from_location
-      @coordinates = Geolocation::CoordinatesQuery.new(params[:location]).call
+      @coordinates = {
+        location: params[:location],
+        **Geolocation::CoordinatesQuery.new(params[:location]).call,
+      }
+
       @distance_from_location ||= ::Courses::NearestSchoolQuery.new(
         courses: [@course],
         latitude: @coordinates[:latitude],

--- a/app/views/find/results/index.html.erb
+++ b/app/views/find/results/index.html.erb
@@ -113,7 +113,7 @@
           <% @results.each do |course| %>
             <%= render Courses::SummaryCardComponent.new(
               course:,
-              location: @search_params[:formatted_address] || @search_params[:location],
+              location: @search_params[:location],
               visa_sponsorship: @search_params[:can_sponsor_visa],
             ) %>
 


### PR DESCRIPTION
## Context

We have a [critical locations bug](https://trello.com/c/fmyMmM5r/598-bug-some-locations-dont-display-their-name-correctly-in-the-results-which-causes-the-inner-details-page-to-show-wrong-location-r) that displays distances incorrectly when linking them through to the course details pages.

We either:

1. Use Google's `place_id` to determine location coordinates and name.
2. Stop falling back for unmatched locations and use the `?location=` string directly in results and therefore links to courses.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
