### PR TITLE
Add spacing between Settings menu items

### DIFF
--- a/app/views/support/settings/index.html.erb
+++ b/app/views/support/settings/index.html.erb
@@ -6,4 +6,4 @@
   govuk_link_to(t(".feature_flag"), support_feature_flags_path),
   govuk_link_to(t(".view_components"), support_view_components_path),
   govuk_link_to(t(".recruitment_cycles"), support_recruitment_cycles_path),
-]) %>
+], spaced: true) %>


### PR DESCRIPTION
## Context

The Settings menu can be a bit cramped up. With more items, the cramped-ness will increase.

## Changes proposed in this pull request

- Add spacing between Settings menu items.

## Guidance to review

| Before | After |
| ------ | ----- |
| ![CleanShot 2025-05-20 at 16 31 32](https://github.com/user-attachments/assets/2ead6265-a043-4163-871d-f73c45a70f0a) | ![CleanShot 2025-05-20 at 16 30 52](https://github.com/user-attachments/assets/5cfc94ee-7c1d-4acd-8281-04c083eefca7) |