### PR TITLE
Ensure that saving GiasSchool creates pg_search_vectors

### DIFF
--- a/app/models/gias_school.rb
+++ b/app/models/gias_school.rb
@@ -6,7 +6,7 @@ class GiasSchool < ApplicationRecord
 
   ESTABLISHMENT_OPEN_STATUS_CODE = "1"
 
-  validates :urn, :name, :address1, :town, :postcode, presence: true
+  validates :urn, :name, presence: true
   validates :urn, uniqueness: { case_sensitive: false }
 
   pg_search_scope :search,

--- a/lib/gias/importer.rb
+++ b/lib/gias/importer.rb
@@ -15,7 +15,13 @@ module Gias
 
       school_records = CSV.foreach(csv_path, headers: true).map(&:to_h)
 
-      GiasSchool.upsert_all(school_records, unique_by: :urn)
+      school_records.each do |school|
+        gs = GiasSchool.find_or_initialize_by(urn: school["urn"])
+        gs.assign_attributes(school)
+        if gs.changed?
+          gs.save!
+        end
+      end
 
       Log.log("Gias::Importer", "GIAS Data Imported!")
     end

--- a/spec/lib/gias/importer_spec.rb
+++ b/spec/lib/gias/importer_spec.rb
@@ -38,9 +38,56 @@ RSpec.describe Gias::Importer do
         postcode: "EC3A 5DE",
         website: "www.thealdgateschool.org",
         telephone: "02072831147",
-        searchable: "'100000':1 '123':7 'name':3,5 'ol':6 'ol123':8 'old':2,4,9 'town':10",
+        searchable: "'100000':1 '5de':9 'aldgate':3,6 'ec3a':8 'ec3a5de':10 'london':11 'school':4,7 'the':2,5",
         latitude: 51.513968813644965,
         longitude: -0.077530631715809 },
     )
+  end
+
+  context "when school hasn't changed" do
+    let!(:test_csv) do
+      StringIO.new(<<~CSV_DATA)
+        urn,name,type_code,group_code,status_code,phase_code,minimum_age,maximum_age,ukprn,address1,address2,address3,town,county,postcode,website,telephone,latitude,longitude
+        100000,The Aldgate School,02,4,1,2,3,11,10079319,St James's Passage,Duke's Place,"","","",EC3A 5DE,www.thealdgateschool.org,02072831147,51.513968813644965,-0.077530631715809
+      CSV_DATA
+    end
+
+    it "does not save the school again" do
+      freeze_time
+      now = Time.zone.now
+
+      described_class.call(test_csv)
+
+      school = GiasSchool.last
+
+      expect(school.reload).to have_attributes(
+        { urn: "100000",
+          name: "The Aldgate School",
+          type_code: "02",
+          group_code: "4",
+          status_code: "1",
+          phase_code: "2",
+          minimum_age: "3",
+          maximum_age: "11",
+          ukprn: "10079319",
+          address1: "St James's Passage",
+          address2: "Duke's Place",
+          address3: "",
+          town: "",
+          county: "",
+          postcode: "EC3A 5DE",
+          website: "www.thealdgateschool.org",
+          telephone: "02072831147",
+          searchable: "'100000':1 '5de':9 'aldgate':3,6 'ec3a':8 'ec3a5de':10 'school':4,7 'the':2,5",
+          latitude: 51.513968813644965,
+          longitude: -0.077530631715809 },
+      )
+
+      expect(GiasSchool.last.updated_at).to be_within(1.second).of(now)
+
+      travel_to 1.minute.from_now do
+        expect { described_class.call(test_csv) }.not_to(change { GiasSchool.last.updated_at })
+      end
+    end
   end
 end

--- a/spec/models/gias_school_spec.rb
+++ b/spec/models/gias_school_spec.rb
@@ -8,9 +8,6 @@ describe GiasSchool do
   it { is_expected.to be_valid }
   it { is_expected.to validate_presence_of(:urn) }
   it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_presence_of(:address1) }
-  it { is_expected.to validate_presence_of(:town) }
-  it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_uniqueness_of(:urn).case_insensitive }
 
   context "callbacks" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,7 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
   config.include ActiveJob::TestHelper, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
   config.before(:suite) do


### PR DESCRIPTION
## Context

Gias Schools are not searchable because when we save them, we aren't running the ActiveRecord Callbacks.

The CSV we receive has open schools with blank columns that we are currently validating the presence of.

## Changes proposed in this pull request

We decided to use `upsert_all` because it was fast. But this is in a background job, run at night, once a week.
We will save each GiasSchool with callbacks that has changed during the import.
Remove presence validation on columns that are nullable in the source CSV.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/5q1tqcZ8/725-gias-schools-are-not-searchable

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
