### PR TITLE
Remove visa sponsorship deadline feature flag

### DIFF
--- a/app/components/find/courses/apply_component/view.rb
+++ b/app/components/find/courses/apply_component/view.rb
@@ -22,7 +22,7 @@ module Find
         end
 
         def show_application_deadline?
-          course.visa_sponsorship_application_deadline_at.present? && FeatureFlag.active?(:visa_sponsorship_deadline)
+          course.visa_sponsorship_application_deadline_at.present?
         end
 
         def application_deadline

--- a/app/controllers/publish/courses/visa_sponsorship_controller.rb
+++ b/app/controllers/publish/courses/visa_sponsorship_controller.rb
@@ -25,7 +25,7 @@ module Publish
 
       def redirect_to_after_update
         redirect_params = [provider.provider_code, recruitment_cycle.year, course.course_code]
-        if course.reload.no_visa_sponsorship? || !FeatureFlag.active?(:visa_sponsorship_deadline)
+        if course.reload.no_visa_sponsorship?
           flash[:success] = success_message
 
           redirect_to(

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -457,13 +457,11 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def show_sponsorship_deadline_required_row?
-    FeatureFlag.active?(:visa_sponsorship_deadline) &&
-      visa_sponsorship.in?(%i[can_sponsor_student_visa can_sponsor_skilled_worker_visa])
+    visa_sponsorship.in?(%i[can_sponsor_student_visa can_sponsor_skilled_worker_visa])
   end
 
   def show_sponsorship_deadline_date_row?
-    FeatureFlag.active?(:visa_sponsorship_deadline) &&
-      show_sponsorship_deadline_required_row? &&
+    show_sponsorship_deadline_required_row? &&
       visa_sponsorship_application_deadline_at.respond_to?(:to_fs)
   end
 

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -6,7 +6,6 @@ class FeatureFlags
       [:maintenance_mode, "Puts Find into maintenance mode", "Find and Publish team"],
       [:maintenance_banner, "Displays the maintenance mode banner", "Find and Publish team"],
       [:bursaries_and_scholarships_announced, "Display scholarship and bursary information", "Find and Publish team"],
-      [:visa_sponsorship_deadline, "Allow providers to add a deadline for those candidates require visa sponsorship"],
     ]
   end
 end

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -123,8 +123,6 @@ module Publish
     end
 
     def more_visa_information_required?
-      return false unless FeatureFlag.active?(:visa_sponsorship_deadline)
-
       # If they have changed course to allow sponsorship, we need to ask if a visa deadline is required
       (current_step.in?(%i[can_sponsor_skilled_worker_visa can_sponsor_student_visa]) &&
         course.visa_sponsorship != :no_sponsorship) ||

--- a/app/services/workflow_step_service.rb
+++ b/app/services/workflow_step_service.rb
@@ -144,7 +144,7 @@ private
   end
 
   def sponsorship_application_steps_to_remove
-    if !FeatureFlag.active?(:visa_sponsorship_deadline) || course.no_visa_sponsorship?
+    if course.no_visa_sponsorship?
       %i[visa_sponsorship_application_deadline_required visa_sponsorship_application_deadline_at]
     elsif visa_sponsorship_application_deadline_required_param == false
       [:visa_sponsorship_application_deadline_at]

--- a/spec/components/find/courses/apply_component/view_spec.rb
+++ b/spec/components/find/courses/apply_component/view_spec.rb
@@ -53,8 +53,6 @@ describe Find::Courses::ApplyComponent::View, type: :component do
     end
 
     context "when the course has a deadline for candidates who require visa sponsorship" do
-      before { FeatureFlag.activate(:visa_sponsorship_deadline) }
-
       it "renders the deadline" do
         deadline = 2.days.from_now.change(hour: 11, min: 59)
         course = build(

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -41,6 +41,7 @@ feature "course confirmation" do
       and_i_select_funding_type(:fee)
       and_i_click_continue
       and_i_should_see_the_title_as("Student visas")
+      and_i_select_no_student_visa
       and_i_click_continue
       then_i_should_be_on_the_confirmation_page
     end
@@ -50,6 +51,7 @@ feature "course confirmation" do
       and_i_select_funding_type(:apprenticeship)
       and_i_click_continue
       and_i_should_see_the_title_as("Skilled Worker visas")
+      and_i_select_no_skilled_worker_visa
       and_i_click_continue
       then_i_should_be_on_the_confirmation_page
     end
@@ -59,6 +61,7 @@ feature "course confirmation" do
       and_i_select_funding_type(:salary)
       and_i_click_continue
       and_i_should_see_the_title_as("Skilled Worker visas")
+      and_i_select_no_skilled_worker_visa
       and_i_click_continue
       then_i_should_be_on_the_confirmation_page
     end
@@ -231,5 +234,13 @@ private
 
   def then_i_am_met_with_the_publish_course_confirmation_page
     expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/confirmation")
+  end
+
+  def and_i_select_no_student_visa
+    choose "course_can_sponsor_student_visa_false"
+  end
+
+  def and_i_select_no_skilled_worker_visa
+    choose "course_can_sponsor_skilled_worker_visa_false"
   end
 end

--- a/spec/features/publish/courses/editing_apprenticeship_spec.rb
+++ b/spec/features/publish/courses/editing_apprenticeship_spec.rb
@@ -3,89 +3,45 @@
 require "rails_helper"
 
 feature "Editing apprenticeship" do
-  context "visa sponsorship feature flag is activated" do
-    before do
-      FeatureFlag.activate(:visa_sponsorship_deadline)
-      and_i_am_authenticated_as_accredited_provider_provider_user
-    end
+  before do
+    and_i_am_authenticated_as_accredited_provider_provider_user
+  end
 
-    context "apprenticeship to non apprenticeship course" do
-      scenario "i am taken to the Student visa step" do
-        given_there_is_apprenticeship_course
-        when_i_visit_the_publish_courses_apprenticeship_edit_page
-        when_i_select(:fee)
-        and_i_continue
-        then_i_should_be_on_the_student_visa_edit_page
-        when_i_go_back
-        then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
-        when_i_select(:fee)
-        and_i_continue
-        then_i_should_be_on_the_student_visa_edit_page
-        when_i_update_the_student_visa_to_be_sponsored
-        then_i_should_be_on_the_visa_deadline_required_page
-        when_i_select_no_deadline
-        then_i_see_the_no_deadline_success_message
-      end
-    end
-
-    context "non apprenticeship to apprenticeship course" do
-      scenario "i am taken to the skilled worker visa step" do
-        given_there_is_fee_course
-        when_i_visit_the_publish_courses_apprenticeship_edit_page
-        when_i_select(:apprenticeship)
-        and_i_continue
-        then_i_should_be_on_the_publish_courses_skilled_worker_visa_sponsorship_edit_page
-        when_i_go_back
-        then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
-        when_i_select(:apprenticeship)
-        and_i_continue
-        then_i_should_be_on_the_publish_courses_skilled_worker_visa_sponsorship_edit_page
-        when_i_update_the_skilled_worker_visa_to_be_sponsored
-        then_i_should_be_on_the_visa_deadline_required_page
-        when_i_select_no_deadline
-        then_i_see_the_no_deadline_success_message
-      end
+  context "apprenticeship to non apprenticeship course" do
+    scenario "i am taken to the Student visa step" do
+      given_there_is_apprenticeship_course
+      when_i_visit_the_publish_courses_apprenticeship_edit_page
+      when_i_select(:fee)
+      and_i_continue
+      then_i_should_be_on_the_student_visa_edit_page
+      when_i_go_back
+      then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
+      when_i_select(:fee)
+      and_i_continue
+      then_i_should_be_on_the_student_visa_edit_page
+      when_i_update_the_student_visa_to_be_sponsored
+      then_i_should_be_on_the_visa_deadline_required_page
+      when_i_select_no_deadline
+      then_i_see_the_no_deadline_success_message
     end
   end
 
-  context "visa sponsorship feature flag is deactivated" do
-    before do
-      FeatureFlag.deactivate(:visa_sponsorship_deadline)
-      and_i_am_authenticated_as_accredited_provider_provider_user
-    end
-
-    context "apprenticeship to non apprenticeship course" do
-      scenario "i am taken to the Student visa step" do
-        given_there_is_apprenticeship_course
-        when_i_visit_the_publish_courses_apprenticeship_edit_page
-        when_i_select(:fee)
-        and_i_continue
-        then_i_should_be_on_the_student_visa_edit_page
-        when_i_go_back
-        then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
-        when_i_select(:fee)
-        and_i_continue
-        then_i_should_be_on_the_student_visa_edit_page
-        when_i_update_the_student_visa_to_be_sponsored
-        then_i_should_see_a_success_message_for("Student")
-      end
-    end
-
-    context "non apprenticeship to apprenticeship course" do
-      scenario "i am taken to the skilled worker visa step" do
-        given_there_is_fee_course
-        when_i_visit_the_publish_courses_apprenticeship_edit_page
-        when_i_select(:apprenticeship)
-        and_i_continue
-        then_i_should_be_on_the_publish_courses_skilled_worker_visa_sponsorship_edit_page
-        when_i_go_back
-        then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
-        when_i_select(:apprenticeship)
-        and_i_continue
-        then_i_should_be_on_the_publish_courses_skilled_worker_visa_sponsorship_edit_page
-        when_i_update_the_skilled_worker_visa_to_be_sponsored
-        then_i_should_see_a_success_message_for("Skilled Worker")
-      end
+  context "non apprenticeship to apprenticeship course" do
+    scenario "i am taken to the skilled worker visa step" do
+      given_there_is_fee_course
+      when_i_visit_the_publish_courses_apprenticeship_edit_page
+      when_i_select(:apprenticeship)
+      and_i_continue
+      then_i_should_be_on_the_publish_courses_skilled_worker_visa_sponsorship_edit_page
+      when_i_go_back
+      then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
+      when_i_select(:apprenticeship)
+      and_i_continue
+      then_i_should_be_on_the_publish_courses_skilled_worker_visa_sponsorship_edit_page
+      when_i_update_the_skilled_worker_visa_to_be_sponsored
+      then_i_should_be_on_the_visa_deadline_required_page
+      when_i_select_no_deadline
+      then_i_see_the_no_deadline_success_message
     end
   end
 

--- a/spec/features/publish/courses/editing_funding_type_spec.rb
+++ b/spec/features/publish/courses/editing_funding_type_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 feature "Editing funding type" do
   context "with visa sponsorship deadline feature flag activated" do
     before do
-      FeatureFlag.activate(:visa_sponsorship_deadline)
       and_i_am_authenticated_as_a_lead_school_provider_user
     end
 
@@ -57,73 +56,6 @@ feature "Editing funding type" do
         then_i_should_be_on_the_visa_deadline_required_page
         when_i_select_no_deadline
         then_i_see_the_no_deadline_success_message
-        and_the_course_should_have_updated_to_fee_and_sponsor_student_visa
-
-        when_i_update_funding_type_back_to_salaried_and_skilled_worker_to_sponsored
-        then_the_previously_updated_student_visa_should_be_false
-      end
-
-      scenario "i cancel after changing funding type and changes are not retained" do
-        given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
-        when_i_visit_the_publish_courses_funding_type_edit_page
-        when_i_select_a_funding_type(:fee)
-        and_i_continue
-        and_i_cancel
-        then_the_course_should_should_still_be_salaried
-      end
-    end
-  end
-
-  context "with visa sponsorship deadline feature flag deactivated" do
-    before do
-      FeatureFlag.deactivate(:visa_sponsorship_deadline)
-      and_i_am_authenticated_as_a_lead_school_provider_user
-    end
-
-    context "fee paying to salaried course" do
-      scenario "i am taken to the skilled worker visa step" do
-        given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
-        when_i_visit_the_publish_courses_funding_type_edit_page
-        when_i_select_a_funding_type(:salary)
-        and_i_continue
-        then_i_should_be_on_the_publish_courses_skilled_worker_visa_sponsorship_edit_page
-        when_i_go_back
-        then_i_should_be_on_the_publish_courses_funding_type_edit_page
-        when_i_select_a_funding_type(:salary)
-        and_i_continue
-        then_i_should_be_on_the_publish_courses_skilled_worker_visa_sponsorship_edit_page
-        when_i_update_the_skilled_worker_visa_to_be_sponsored
-        then_i_should_see_a_success_message_for("Skilled Worker")
-        and_the_course_should_have_updated_to_salaried_and_sponsor_skilled_worker_visa
-
-        when_i_update_funding_type_back_to_fee_paying_and_student_visa_to_sponsored
-        then_the_previously_updated_skilled_worker_visa_should_be_false
-      end
-
-      scenario "i cancel after changing funding type and changes are not retained" do
-        given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
-        when_i_visit_the_publish_courses_funding_type_edit_page
-        when_i_select_a_funding_type(:salary)
-        and_i_continue
-        and_i_cancel
-        then_the_course_should_should_still_be_fee_paying
-      end
-    end
-
-    context "salaried to fee paying course" do
-      scenario "i am taken to the student visa step" do
-        given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
-        when_i_visit_the_publish_courses_funding_type_edit_page
-        when_i_select_a_funding_type(:fee)
-        and_i_continue
-        then_i_should_be_on_the_student_visa_edit_page
-        when_i_go_back
-        then_i_should_be_on_the_publish_courses_funding_type_edit_page
-        when_i_select_a_funding_type(:fee)
-        and_i_continue
-        then_i_should_be_on_the_student_visa_edit_page
-        when_i_update_the_student_visa_to_be_sponsored
-        then_i_should_see_a_success_message_for("Student")
         and_the_course_should_have_updated_to_fee_and_sponsor_student_visa
 
         when_i_update_funding_type_back_to_salaried_and_skilled_worker_to_sponsored

--- a/spec/features/publish/courses/editing_visa_sponsorship_deadline_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_deadline_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 feature "Editing visa sponsorship deadlines" do
   before do
-    FeatureFlag.activate(:visa_sponsorship_deadline)
     and_i_am_authenticated_as_a_lead_school_provider_user
   end
 

--- a/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 feature "Editing visa sponsorship" do
   before do
-    FeatureFlag.activate(:visa_sponsorship_deadline)
     and_i_am_authenticated_as_a_lead_school_provider_user
   end
 

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -186,6 +186,7 @@ feature "Adding a teacher degree apprenticeship course" do
     when_i_click_continue
     and_i_click_continue
     and_i_choose_to_sponsor_a_student_visa
+    and_i_choose_no_visa_deadline
     when_i_click_on_add_a_course
     then_i_see_the_correct_attributes_in_the_database_for_fee_paying
   end
@@ -209,6 +210,7 @@ feature "Adding a teacher degree apprenticeship course" do
     and_i_click_continue
 
     and_i_choose_to_sponsor_a_skilled_worker_visa
+    and_i_choose_no_visa_deadline
     when_i_click_on_add_a_course
     then_i_see_the_correct_attributes_in_the_database_for_salaried
   end
@@ -571,6 +573,11 @@ feature "Adding a teacher degree apprenticeship course" do
 
   def and_i_choose_to_sponsor_a_student_visa
     choose "Yes"
+    and_i_click_continue
+  end
+
+  def and_i_choose_no_visa_deadline
+    choose "No"
     and_i_click_continue
   end
 

--- a/spec/features/publish/courses/new_visa_sponsorship_application_deadline_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_application_deadline_spec.rb
@@ -3,10 +3,6 @@
 require "rails_helper"
 
 feature "Entering a deadline for candidates who need visa sponsorship" do
-  before do
-    FeatureFlag.activate(:visa_sponsorship_deadline)
-  end
-
   scenario "navigation" do
     given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
     and_i_am_creating_a_new_course_that_allows_visa_sponsorship

--- a/spec/features/publish/courses/new_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_spec.rb
@@ -16,6 +16,7 @@ feature "visa sponsorship (add course summary page)" do
       then_i_should_see_the_student_visas_title
 
       when_i_choose_yes_for_student_visa
+      and_i_select_no_student_visa
       and_i_click_continue
       then_i_should_be_back_on_the_publish_course_confirmation_page
     end
@@ -27,6 +28,7 @@ feature "visa sponsorship (add course summary page)" do
       then_i_should_see_the_skilled_worker_visas_title
 
       when_i_choose_yes_for_skilled_worker_visa
+      and_i_select_no_skillled_worker_visa
       and_i_click_continue
       then_i_should_be_back_on_the_publish_course_confirmation_page
     end
@@ -106,5 +108,13 @@ private
 
   def then_i_should_be_back_on_the_publish_course_confirmation_page
     expect(page).to have_text("Check your answers")
+  end
+
+  def and_i_select_no_student_visa
+    choose "course_can_sponsor_student_visa_false"
+  end
+
+  def and_i_select_no_skillled_worker_visa
+    choose "course_can_sponsor_skilled_worker_visa_false"
   end
 end

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -8,7 +8,6 @@ feature "new course" do
     # and ensure that the correct page gets displayed at the end
     # with the correct course being created
     given_i_am_authenticated_as_a_provider_user_in_the_next_cycle
-    and_the_visa_sponsor_deadline_feature_flag_is_on
     when_i_visit_the_courses_page
     and_i_click_on_add_course
     then_i_can_create_the_course
@@ -46,10 +45,6 @@ private
         ],
       ),
     )
-  end
-
-  def and_the_visa_sponsor_deadline_feature_flag_is_on
-    FeatureFlag.activate(:visa_sponsorship_deadline)
   end
 
   def when_i_visit_the_courses_page

--- a/spec/services/workflow_step_service_spec.rb
+++ b/spec/services/workflow_step_service_spec.rb
@@ -9,10 +9,6 @@ describe WorkflowStepService do
 
   let(:params) { {} }
 
-  before do
-    FeatureFlag.activate(:visa_sponsorship_deadline)
-  end
-
   describe "#call" do
     context "when course.is_school_direct? && when course.provider.accredited_partners.length == 0 && course.no_visa_sponsorship?" do
       let(:provider) { build(:provider) }

--- a/spec/system/support/settings/feature_flags/view_feature_flags_spec.rb
+++ b/spec/system/support/settings/feature_flags/view_feature_flags_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Viewing feature flags" do
       "Puts Find into maintenance mode",
       "Displays the maintenance mode banner",
       "Display scholarship and bursary information",
-      "Allow providers to add a deadline for those candidates require visa sponsorship",
     ].each do |feature_flag_text|
       expect(page).to have_content(feature_flag_text)
     end


### PR DESCRIPTION
## Context

This feature flag is not necessary anymore. The visa sponsorship deadline feature is permanent.

## Changes proposed in this pull request

Removed `visa_sponsorship_deadline` feature flag where it's used

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
