### PR TITLE
[941] Set upper bound of visa sponsorship deadline to eq apply deadline

### DIFF
--- a/app/forms/publish/visa_sponsorship_application_deadline_date_form.rb
+++ b/app/forms/publish/visa_sponsorship_application_deadline_date_form.rb
@@ -82,7 +82,7 @@ module Publish
     end
 
     def last_valid_datetime
-      @last_valid_datetime ||= recruitment_cycle.application_end_date.end_of_day.change(hour: 18)
+      @last_valid_datetime ||= Find::CycleTimetable.date(:apply_deadline, recruitment_cycle.year.to_i)
     end
 
     def first_valid_datetime

--- a/spec/features/publish/courses/editing_visa_sponsorship_deadline_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_deadline_spec.rb
@@ -69,7 +69,10 @@ private
   end
 
   def and_i_add_a_date
-    @valid_date = accrediting_provider.recruitment_cycle.application_end_date - 1.day
+    @valid_date = Find::CycleTimetable.date(
+      :apply_deadline,
+      accrediting_provider.recruitment_cycle.year.to_i,
+    ) - 1.day
     fill_in "Year", with: @valid_date.year
     fill_in "Month", with: @valid_date.month
     fill_in "Day", with: @valid_date.day

--- a/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
@@ -123,7 +123,10 @@ feature "Editing visa sponsorship" do
   end
 
   def when_i_add_a_date_and_continue
-    @valid_date = accrediting_provider.recruitment_cycle.application_end_date - 1.day
+    @valid_date = Find::CycleTimetable.date(
+      :apply_deadline,
+      accrediting_provider.recruitment_cycle.year.to_i,
+    ) - 1.day
     fill_in "Year", with: @valid_date.year
     fill_in "Month", with: @valid_date.month
     fill_in "Day", with: @valid_date.day

--- a/spec/features/publish/courses/new_visa_sponsorship_application_deadline_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_application_deadline_spec.rb
@@ -134,7 +134,11 @@ private
 
   def then_i_see_the_out_of_range_error
     start_of_cycle = @provider.recruitment_cycle.application_start_date.end_of_day.change(hour: 9).to_fs(:govuk_date_and_time)
-    end_of_cycle = @provider.recruitment_cycle.application_end_date.end_of_day.change(hour: 18).to_fs(:govuk_date_and_time)
+    end_of_cycle = Find::CycleTimetable.date(
+      :apply_deadline,
+      @provider.recruitment_cycle.year.to_i,
+    ).to_fs(:govuk_date_and_time)
+
     error_message = "The date that applications which require visa sponsorship will close must be between #{start_of_cycle} and the end of the recruitment cycle, #{end_of_cycle}"
     then_i_see_an_error(error_message)
   end


### PR DESCRIPTION
## Context

I mistakenly assumed that the application end date was the apply deadline, but it is not. This means that potentially providers could set visa sponsorship application deadline dates _after_ applications have closed. (flagged by @tomas-stefano). Though in practice, no applications would be accepted after the apply deadline, and no providers have done so yet. 

## Changes proposed in this pull request

Sets the upper deadline for visa sponsorship application deadlines to match the apply deadline.

## Guidance to review
In the review app, try setting a visa sponsorship application deadline for a 2025 course after the apply deadline (16 September). You should receive an error.


## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
