### PR TITLE
Content update on the other languages input

### DIFF
--- a/app/helpers/find/subjects_helper.rb
+++ b/app/helpers/find/subjects_helper.rb
@@ -1,0 +1,5 @@
+module Find::SubjectsHelper
+  def subject_display_name(subject)
+    subject.name == "Modern languages (other)" ? "Other modern languages" : subject.name
+  end
+end

--- a/app/views/find/secondary_subjects/index.erb
+++ b/app/views/find/secondary_subjects/index.erb
@@ -13,7 +13,8 @@
       <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
 
       <% @secondary_subject_options.group_by(&:subject_group).each do |subject_group_name, subjects| %>
-        <%= f.govuk_collection_check_boxes :subjects, subjects, :code, :name, :financial_info, legend: { text: subject_group_name } %>
+      <% label_lambda = ->(s) { subject_display_name(s) } %>
+      <%= f.govuk_collection_check_boxes :subjects, subjects, :code, label_lambda, :financial_info %>
       <% end %>
 
       <%= f.govuk_submit t(".find_courses_button") %>

--- a/spec/helpers/find/subjects_helper_spec.rb
+++ b/spec/helpers/find/subjects_helper_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Find::SubjectsHelper, type: :helper do
+  describe "#subject_display_name" do
+    context "when subject name is 'Modern languages (other)'" do
+      it "returns 'Other modern languages'" do
+        subject = build(:secondary_subject, subject_name: "Modern languages (other)")
+        expect(helper.subject_display_name(subject)).to eq("Other modern languages")
+      end
+    end
+
+    context "when subject name is different" do
+      it "returns the original subject name" do
+        subject = build(:secondary_subject, subject_name: "Biology")
+        expect(helper.subject_display_name(subject)).to eq("Biology")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/WegbvqMi/493-content-update-on-the-other-languages-input-bug-party-1-2025-content-design-feedback

Content update on the other languages input (Bug party 1 - 2025 Content / Design Feedback): The content for Modern languages (other) should be updated to Other modern languages on '[browse secondary subjects](https://qa.find-teacher-training-courses.service.gov.uk/secondary)' page.

## Changes proposed in this pull request
- The label name is coming from the Subject table - changing it here would likely affect other logic within the app; for this reason, I have initially changed the label name in the view only.
- Change label name of "Modern languages (other)" to "Other modern languages" on 'Browse secondary courses' page
- create helper method to adapt label name in the view (browse secondary courses page)
- create spec test for helper

![Screenshot 2025-05-29 at 11 25 07](https://github.com/user-attachments/assets/f80d7ee3-7c24-4cab-9c74-260a5a955ab3)

## Guidance to review

- do we just want to change the name on the browse secondary course name?
- if a helper the best approach here if we just want to change the label in the view?
- do we need to change to 'Other modern languages' everywhere? If so should we change the name in the Subject table?

## Checklist

- [ ] I have changed the label name in the view
- [ ] I have created any relevant tests
- [ ] I have checked this is correct from a code/design POV
