### PR TITLE
Use SemanticLogger.tagged to log session_id and request_id

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,16 +2,10 @@
 
 class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests
-
   include Pundit::Authorization
   include Pagy::Backend
 
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
-  before_action :log_session
-
-  def log_session
-    Rails.logger.push_tags({ session_id: session.id })
-  end
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 

--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -7,12 +7,6 @@ module Find
 
     layout "find"
 
-    before_action :log_session
-
-    def log_session
-      Rails.logger.push_tags({ session_id: session.id })
-    end
-
     default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
     before_action :redirect_to_cycle_has_ended_if_find_is_down

--- a/app/middleware/request_logging_tags.rb
+++ b/app/middleware/request_logging_tags.rb
@@ -1,0 +1,17 @@
+class RequestLoggingTags
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = ActionDispatch::Request.new(env)
+    session_id = request.session&.id&.public_id || "-"
+
+    SemanticLogger.tagged(
+      request_id: request.request_id,
+      session_id: session_id,
+    ) do
+      @app.call(env)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_view/railtie"
 require "active_support/core_ext/integer/time"
 require "view_component/compile_cache"
 require "govuk/components"
+require_relative "../app/middleware/request_logging_tags"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -68,7 +69,10 @@ module ManageCoursesBackend
     config.exceptions_app = routes
     config.active_job.queue_adapter = :sidekiq
 
-    config.log_tags = [:request_id]
+    config.log_tags = []
     config.log_level = Settings.log_level
+
+    # Insert the middlware at the end of the stack
+    config.middleware.use RequestLoggingTags
   end
 end


### PR DESCRIPTION
## Context

Rails.logger.tags are piling up and not being cleared after each request.

I've decided to use a different way of logging values. Instead of the `config.log_tags` I've added a custom middleware to log request_id and session_id. This needs to go in middleware otherwise not every relevant log line will be tagged.

Piling up request ids:
![image](https://github.com/user-attachments/assets/76b22820-59a5-44ee-b0c7-147c4f15783c)

## Changes proposed in this pull request

![image](https://github.com/user-attachments/assets/cf4c7091-4cbc-4d86-ad92-9694b0d99cce)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
