### PR TITLE
Rolled over provider partnerships during rollover

### DIFF
--- a/app/queries/rollover_progress_query.rb
+++ b/app/queries/rollover_progress_query.rb
@@ -9,33 +9,37 @@ class RolloverProgressQuery
   end
 
   def remaining_to_rollover_count
-    total_eligible_providers_count - rolled_over_providers_count
+    eligible_providers_count - rolled_over_providers_count
   end
 
   delegate :count, to: :providers_without_published_courses, prefix: true
 
-  delegate :count, to: :total_eligible_providers, prefix: true
+  delegate :count, to: :eligible_providers, prefix: true
 
   delegate :count, to: :rolled_over_providers, prefix: true
 
-  delegate :count, to: :total_eligible_courses, prefix: true
+  delegate :count, to: :eligible_courses, prefix: true
 
   delegate :count, to: :rolled_over_courses, prefix: true
 
-  def rollover_percentage
-    return 0 if total_eligible_providers_count.zero? || rolled_over_providers_count.zero?
+  delegate :count, to: :eligible_partnerships, prefix: true
 
-    (rolled_over_providers_count.to_f / total_eligible_providers_count * 100).round(2)
+  delegate :count, to: :rolled_over_partnerships, prefix: true
+
+  def rollover_percentage
+    return 0 if eligible_providers_count.zero? || rolled_over_providers_count.zero?
+
+    (rolled_over_providers_count.to_f / eligible_providers_count * 100).round(2)
   end
 
   def providers_without_published_courses
-    @previous_target_cycle.providers.where.not(
-      id: total_eligible_providers.select(:id),
-    ).distinct
+    @previous_target_cycle.providers
+    .where.not(id: eligible_providers.select(:id))
+    .distinct
   end
 
-  def total_eligible_providers
-    @total_eligible_providers ||= @previous_target_cycle.providers.where(
+  def eligible_providers
+    @eligible_providers ||= @previous_target_cycle.providers.where(
       id: providers_with_own_rollable_courses.select(:id),
     ).or(
       @previous_target_cycle.providers.where(
@@ -44,12 +48,55 @@ class RolloverProgressQuery
     ).distinct
   end
 
-  def total_eligible_courses
+  def eligible_courses
     @previous_target_cycle
       .courses
       .joins(:latest_enrichment)
       .where(course_enrichment: { status: %i[published withdrawn] })
-      .where(provider_id: total_eligible_providers.select(:id)).distinct
+      .where(provider_id: eligible_providers.select(:id)).distinct
+  end
+
+  def eligible_partnerships
+    ProviderPartnership
+    .includes(:training_provider, :accredited_provider)
+    .where(
+      "accredited_provider_id IN (:ids) OR training_provider_id IN (:ids)",
+      ids: eligible_providers.select(:id),
+    )
+    .where.not(
+      training_provider_id: providers_without_published_courses.select(:id),
+    )
+    .where.not(
+      training_provider_id: previous_cycle_discarded_providers.select(:id),
+    )
+    .where.not(
+      accredited_provider_id: previous_cycle_discarded_providers.select(:id),
+    )
+  end
+
+  def rolled_over_partnerships
+    ProviderPartnership.includes(:training_provider, :accredited_provider).where(
+      "accredited_provider_id IN (:id) OR training_provider_id IN (:id)",
+      id: @target_cycle.providers.select(:id),
+    )
+  end
+
+  def partnerships_diff
+    previous_pairs = eligible_partnerships.map do |partnership|
+      [
+        partnership.training_provider.provider_code,
+        partnership.accredited_provider.provider_code,
+      ]
+    end
+
+    rolled_over_pairs = rolled_over_partnerships.map do |partnership|
+      [
+        partnership.training_provider.provider_code,
+        partnership.accredited_provider.provider_code,
+      ]
+    end
+
+    previous_pairs - rolled_over_pairs
   end
 
   def rolled_over_courses
@@ -74,5 +121,12 @@ private
       .joins(accredited_courses: :latest_enrichment)
       .where(course_enrichment: { status: %i[published withdrawn] })
       .distinct
+  end
+
+  def previous_cycle_discarded_providers
+    Provider
+      .unscoped
+      .where(recruitment_cycle_id: @previous_target_cycle.id)
+      .discarded
   end
 end

--- a/app/services/partnerships/copy_to_provider_service.rb
+++ b/app/services/partnerships/copy_to_provider_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Partnerships
+  class CopyToProviderService
+    def execute(provider:, rolled_over_provider:, new_recruitment_cycle:)
+      partnerships_count = 0
+
+      partnerships = ProviderPartnership.where(
+        "accredited_provider_id = :id OR training_provider_id = :id",
+        id: provider.id,
+      )
+      partnerships.find_each do |partnership|
+        new_accredited = find_provider_in_cycle(
+          partnership.accredited_provider.provider_code,
+          new_recruitment_cycle,
+        )
+        new_training = find_provider_in_cycle(
+          partnership.training_provider.provider_code,
+          new_recruitment_cycle,
+        )
+
+        next unless new_accredited && new_training
+        next unless partnership_involves_rolled_over?(new_accredited, new_training, rolled_over_provider)
+
+        create_partnership(new_accredited, new_training)
+        partnerships_count += 1
+      end
+
+      partnerships_count
+    end
+
+  private
+
+    def find_provider_in_cycle(provider_code, cycle)
+      cycle.providers.find_by(provider_code:)
+    end
+
+    def partnership_involves_rolled_over?(accredited, training, rolled_over)
+      accredited == rolled_over || training == rolled_over
+    end
+
+    def create_partnership(accredited, training)
+      ProviderPartnership.find_or_create_by(
+        accredited_provider: accredited,
+        training_provider: training,
+      )
+    end
+  end
+end

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -2,9 +2,10 @@
 
 module Providers
   class CopyToRecruitmentCycleService
-    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, force:)
+    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, copy_partnership_to_provider_service:, force:)
       @copy_course_to_provider_service = copy_course_to_provider_service
       @copy_site_to_provider_service = copy_site_to_provider_service
+      @copy_partnership_to_provider_service = copy_partnership_to_provider_service
       @force = force
     end
 
@@ -13,6 +14,7 @@ module Providers
       sites_count = 0
       study_sites_count = 0
       courses_count = 0
+      partnerships_count = 0
 
       if provider.rollable? || force
         ActiveRecord::Base.transaction do
@@ -34,6 +36,7 @@ module Providers
           sites_count = copy_sites_to_new_provider(provider, rolled_over_provider)
           study_sites_count = copy_study_sites_to_new_provider(provider, rolled_over_provider)
           courses_count = copy_courses_to_new_provider(rolled_over_provider, courses_to_copy(provider, course_codes))
+          partnerships_count = copy_partnerships_to_new_provider(provider, rolled_over_provider, new_recruitment_cycle)
         end
       end
 
@@ -42,6 +45,7 @@ module Providers
         sites: sites_count,
         study_sites: study_sites_count,
         courses: courses_count,
+        partnerships: partnerships_count,
       }
     end
 
@@ -111,6 +115,14 @@ module Providers
       end
 
       study_sites_count
+    end
+
+    def copy_partnerships_to_new_provider(provider, rolled_over_provider, new_recruitment_cycle)
+      @copy_partnership_to_provider_service.execute(
+        provider:,
+        rolled_over_provider:,
+        new_recruitment_cycle:,
+      )
     end
   end
 end

--- a/app/services/rollover_provider_service.rb
+++ b/app/services/rollover_provider_service.rb
@@ -61,6 +61,7 @@ private
     @copy_provider_to_recruitment_cycle ||= Providers::CopyToRecruitmentCycleService.new(
       copy_course_to_provider_service: copy_courses_to_provider_service,
       copy_site_to_provider_service: Sites::CopyToProviderService.new,
+      copy_partnership_to_provider_service: Partnerships::CopyToProviderService.new,
       force:,
     )
   end

--- a/app/views/support/recruitment_cycles/show.html.erb
+++ b/app/views/support/recruitment_cycles/show.html.erb
@@ -68,10 +68,10 @@
         <div class="govuk-inset-text">
           <%= t(
                 ".rollover_status.inset_text_html",
-                total_eligible_providers_count: @rollover_progress.total_eligible_providers_count,
-                total_eligible_courses_count: @rollover_progress.total_eligible_courses_count,
-                providers_plus_one: @rollover_progress.total_eligible_providers_count + 1,
-                courses_plus_one: @rollover_progress.total_eligible_courses_count + 1,
+                total_eligible_providers_count: @rollover_progress.eligible_providers_count,
+                total_eligible_courses_count: @rollover_progress.eligible_courses_count,
+                providers_plus_one: @rollover_progress.eligible_providers_count + 1,
+                courses_plus_one: @rollover_progress.eligible_courses_count + 1,
               ) %>
         </div>
 
@@ -82,7 +82,7 @@
               <% row.with_value(
                                        text: rollover_providers_summary(
                                          previous_target_cycle: @rollover_progress.previous_target_cycle,
-                                         total_eligible_providers_count: @rollover_progress.total_eligible_providers_count,
+                                         total_eligible_providers_count: @rollover_progress.eligible_providers_count,
                                          rolled_over_providers_count: @rollover_progress.rolled_over_providers_count,
                                          rollover_percentage: @rollover_progress.rollover_percentage,
                                        ),
@@ -91,7 +91,12 @@
 
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:courses_summary)) %>
-              <% row.with_value(text: t(".rollover_status.courses_summary", total_eligible_courses_count: @rollover_progress.total_eligible_courses_count, rolled_over_courses_count: @rollover_progress.rolled_over_courses_count)) %>
+              <% row.with_value(text: t(".rollover_status.summary", total_eligible_count: @rollover_progress.eligible_courses_count, rolled_over_count: @rollover_progress.rolled_over_courses_count)) %>
+            <% end %>
+
+            <% summary_list.with_row do |row| %>
+              <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:partnerships_summary)) %>
+              <% row.with_value(text: t(".rollover_status.summary", total_eligible_count: @rollover_progress.eligible_partnerships_count, rolled_over_count: @rollover_progress.rolled_over_partnerships_count)) %>
             <% end %>
 
             <% summary_list.with_row do |row| %>

--- a/config/locales/en/support/recruitment_cycles.yml
+++ b/config/locales/en/support/recruitment_cycles.yml
@@ -32,7 +32,7 @@ en:
         rollover_status:
           no_previous_cycle: No previous cycle
           providers_summary: '%{rolled_over_providers_count} of %{total_eligible_providers_count} providers (%{rollover_percentage}%)'
-          courses_summary: '%{rolled_over_courses_count} of %{total_eligible_courses_count}'
+          summary: '%{rolled_over_count} of %{total_eligible_count}'
           inset_text_html: |
             The numbers below shown for "providers" and "courses" in the rollover summary reflect the status at the time the rollover automation was run.
             <br><br>

--- a/spec/services/partnerships/copy_to_provider_service_spec.rb
+++ b/spec/services/partnerships/copy_to_provider_service_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+
+RSpec.describe Partnerships::CopyToProviderService do
+  let(:previous_cycle) { create(:recruitment_cycle) }
+  let(:target_cycle) { create(:recruitment_cycle, :next) }
+  let(:service) { described_class.new }
+
+  describe "#execute" do
+    let(:original_provider) { create(:provider, recruitment_cycle: previous_cycle, provider_code: "ORIG") }
+    let(:rolled_over_provider) { create(:provider, recruitment_cycle: target_cycle, provider_code: "ORIG") }
+
+    context "when partnership involves rolled-over provider as training provider" do
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "Accred") }
+      let!(:target_partner) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "Accred") }
+      let!(:partnership) do
+        create(:provider_partnership,
+               training_provider: original_provider,
+               accredited_provider: partner_provider)
+      end
+
+      it "creates partnership in target cycle" do
+        expect {
+          service.execute(
+            provider: original_provider,
+            rolled_over_provider: rolled_over_provider,
+            new_recruitment_cycle: target_cycle,
+          )
+        }.to change(ProviderPartnership, :count).by(1)
+
+        new_partnership = ProviderPartnership.last
+        expect(new_partnership.training_provider).to eq(rolled_over_provider)
+        expect(new_partnership.accredited_provider).to eq(target_partner)
+      end
+
+      it "returns correct count" do
+        result = service.execute(
+          provider: original_provider,
+          rolled_over_provider: rolled_over_provider,
+          new_recruitment_cycle: target_cycle,
+        )
+        expect(result).to eq(1)
+      end
+    end
+
+    context "when partnership involves rolled-over provider as accredited provider" do
+      let(:original_provider) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "Accr") }
+      let(:rolled_over_provider) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "Accr") }
+      let!(:partner_provider) { create(:provider, recruitment_cycle: previous_cycle, provider_code: "Train") }
+      let!(:target_partner) { create(:provider, recruitment_cycle: target_cycle, provider_code: "Train") }
+      let!(:partnership) do
+        create(:provider_partnership,
+               training_provider: partner_provider,
+               accredited_provider: original_provider)
+      end
+
+      it "creates partnership in target cycle" do
+        expect {
+          service.execute(
+            provider: original_provider,
+            rolled_over_provider: rolled_over_provider,
+            new_recruitment_cycle: target_cycle,
+          )
+        }.to change(ProviderPartnership, :count).by(1)
+
+        new_partnership = ProviderPartnership.last
+        expect(new_partnership.training_provider).to eq(target_partner)
+        expect(new_partnership.accredited_provider).to eq(rolled_over_provider)
+      end
+    end
+
+    context "when partnership doesn't involve rolled-over provider" do
+      let!(:other_provider_one) { create(:provider, recruitment_cycle: previous_cycle, provider_code: "OTH1") }
+      let!(:other_provider_two) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "OTH2") }
+      let!(:partnership) do
+        create(:provider_partnership,
+               training_provider: other_provider_one,
+               accredited_provider: other_provider_two)
+      end
+
+      it "does not create partnership" do
+        expect {
+          service.execute(
+            provider: original_provider,
+            rolled_over_provider: rolled_over_provider,
+            new_recruitment_cycle: target_cycle,
+          )
+        }.not_to change(ProviderPartnership, :count)
+      end
+    end
+
+    context "when partner provider doesn't exist in target cycle" do
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "MISS") }
+      let!(:partnership) do
+        create(:provider_partnership,
+               training_provider: original_provider,
+               accredited_provider: partner_provider)
+      end
+
+      it "does not create partnership" do
+        expect {
+          service.execute(
+            provider: original_provider,
+            rolled_over_provider: rolled_over_provider,
+            new_recruitment_cycle: target_cycle,
+          )
+        }.not_to change(ProviderPartnership, :count)
+      end
+    end
+
+    context "when partnership already exists in target cycle" do
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "PART") }
+      let!(:target_partner) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "PART") }
+      let!(:existing_partnership) do
+        create(:provider_partnership,
+               training_provider: rolled_over_provider,
+               accredited_provider: target_partner)
+      end
+
+      let!(:partnership) do
+        create(:provider_partnership,
+               training_provider: original_provider,
+               accredited_provider: partner_provider)
+      end
+
+      it "does not create duplicate partnership" do
+        expect {
+          service.execute(
+            provider: original_provider,
+            rolled_over_provider: rolled_over_provider,
+            new_recruitment_cycle: target_cycle,
+          )
+        }.not_to change(ProviderPartnership, :count)
+      end
+    end
+  end
+end

--- a/spec/services/partnerships/copy_to_provider_service_spec.rb
+++ b/spec/services/partnerships/copy_to_provider_service_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Partnerships::CopyToProviderService do
-  let(:previous_cycle) { create(:recruitment_cycle) }
+  let(:current_cycle) { create(:recruitment_cycle) }
   let(:target_cycle) { create(:recruitment_cycle, :next) }
   let(:service) { described_class.new }
 
   describe "#execute" do
-    let(:original_provider) { create(:provider, recruitment_cycle: previous_cycle, provider_code: "ORIG") }
+    let(:original_provider) { create(:provider, recruitment_cycle: current_cycle, provider_code: "ORIG") }
     let(:rolled_over_provider) { create(:provider, recruitment_cycle: target_cycle, provider_code: "ORIG") }
 
     context "when partnership involves rolled-over provider as training provider" do
-      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "Accred") }
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "Accred") }
       let!(:target_partner) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "Accred") }
       let!(:partnership) do
         create(:provider_partnership,
@@ -43,9 +43,9 @@ RSpec.describe Partnerships::CopyToProviderService do
     end
 
     context "when partnership involves rolled-over provider as accredited provider" do
-      let(:original_provider) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "Accr") }
+      let(:original_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "Accr") }
       let(:rolled_over_provider) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "Accr") }
-      let!(:partner_provider) { create(:provider, recruitment_cycle: previous_cycle, provider_code: "Train") }
+      let!(:partner_provider) { create(:provider, recruitment_cycle: current_cycle, provider_code: "Train") }
       let!(:target_partner) { create(:provider, recruitment_cycle: target_cycle, provider_code: "Train") }
       let!(:partnership) do
         create(:provider_partnership,
@@ -69,8 +69,8 @@ RSpec.describe Partnerships::CopyToProviderService do
     end
 
     context "when partnership doesn't involve rolled-over provider" do
-      let!(:other_provider_one) { create(:provider, recruitment_cycle: previous_cycle, provider_code: "OTH1") }
-      let!(:other_provider_two) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "OTH2") }
+      let!(:other_provider_one) { create(:provider, recruitment_cycle: current_cycle, provider_code: "OTH1") }
+      let!(:other_provider_two) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "OTH2") }
       let!(:partnership) do
         create(:provider_partnership,
                training_provider: other_provider_one,
@@ -89,7 +89,7 @@ RSpec.describe Partnerships::CopyToProviderService do
     end
 
     context "when partner provider doesn't exist in target cycle" do
-      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "MISS") }
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "MISS") }
       let!(:partnership) do
         create(:provider_partnership,
                training_provider: original_provider,
@@ -108,7 +108,7 @@ RSpec.describe Partnerships::CopyToProviderService do
     end
 
     context "when partnership already exists in target cycle" do
-      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: previous_cycle, provider_code: "PART") }
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "PART") }
       let!(:target_partner) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "PART") }
       let!(:existing_partnership) do
         create(:provider_partnership,

--- a/spec/services/partnerships/copy_to_provider_service_spec.rb
+++ b/spec/services/partnerships/copy_to_provider_service_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Partnerships::CopyToProviderService do
   let(:service) { described_class.new }
 
   describe "#execute" do
-    let(:original_provider) { create(:provider, recruitment_cycle: current_cycle, provider_code: "ORIG") }
-    let(:rolled_over_provider) { create(:provider, recruitment_cycle: target_cycle, provider_code: "ORIG") }
+    let(:original_provider) { create(:provider, recruitment_cycle: current_cycle, provider_code: "ORI") }
+    let(:rolled_over_provider) { create(:provider, recruitment_cycle: target_cycle, provider_code: "ORI") }
 
     context "when partnership involves rolled-over provider as training provider" do
-      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "Accred") }
-      let!(:target_partner) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "Accred") }
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "Acc") }
+      let!(:target_partner) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "Acc") }
       let!(:partnership) do
         create(:provider_partnership,
                training_provider: original_provider,
@@ -43,10 +43,10 @@ RSpec.describe Partnerships::CopyToProviderService do
     end
 
     context "when partnership involves rolled-over provider as accredited provider" do
-      let(:original_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "Accr") }
-      let(:rolled_over_provider) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "Accr") }
-      let!(:partner_provider) { create(:provider, recruitment_cycle: current_cycle, provider_code: "Train") }
-      let!(:target_partner) { create(:provider, recruitment_cycle: target_cycle, provider_code: "Train") }
+      let(:original_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "Acc") }
+      let(:rolled_over_provider) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "Acc") }
+      let!(:partner_provider) { create(:provider, recruitment_cycle: current_cycle, provider_code: "Tra") }
+      let!(:target_partner) { create(:provider, recruitment_cycle: target_cycle, provider_code: "Tra") }
       let!(:partnership) do
         create(:provider_partnership,
                training_provider: partner_provider,
@@ -69,8 +69,8 @@ RSpec.describe Partnerships::CopyToProviderService do
     end
 
     context "when partnership doesn't involve rolled-over provider" do
-      let!(:other_provider_one) { create(:provider, recruitment_cycle: current_cycle, provider_code: "OTH1") }
-      let!(:other_provider_two) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "OTH2") }
+      let!(:other_provider_one) { create(:provider, recruitment_cycle: current_cycle, provider_code: "OT1") }
+      let!(:other_provider_two) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "OT2") }
       let!(:partnership) do
         create(:provider_partnership,
                training_provider: other_provider_one,
@@ -89,7 +89,7 @@ RSpec.describe Partnerships::CopyToProviderService do
     end
 
     context "when partner provider doesn't exist in target cycle" do
-      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "MISS") }
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "MIS") }
       let!(:partnership) do
         create(:provider_partnership,
                training_provider: original_provider,
@@ -108,8 +108,8 @@ RSpec.describe Partnerships::CopyToProviderService do
     end
 
     context "when partnership already exists in target cycle" do
-      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "PART") }
-      let!(:target_partner) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "PART") }
+      let!(:partner_provider) { create(:provider, :accredited_provider, recruitment_cycle: current_cycle, provider_code: "PAR") }
+      let!(:target_partner) { create(:provider, :accredited_provider, recruitment_cycle: target_cycle, provider_code: "PAR") }
       let!(:existing_partnership) do
         create(:provider_partnership,
                training_provider: rolled_over_provider,

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -36,10 +36,12 @@ describe Providers::CopyToRecruitmentCycleService do
     end
     let(:mocked_copy_course_service) { double(execute: nil) }
     let(:mocked_copy_site_service) { double(execute: nil) }
+    let(:mocked_copy_partnership_service) { double(execute: nil) }
     let(:service) do
       described_class.new(
         copy_course_to_provider_service: mocked_copy_course_service,
         copy_site_to_provider_service: mocked_copy_site_service,
+        copy_partnership_to_provider_service: mocked_copy_partnership_service,
         force:,
       )
     end
@@ -106,6 +108,19 @@ describe Providers::CopyToRecruitmentCycleService do
 
         expect(mocked_copy_course_service).to have_received(:execute).with(course:, new_provider:)
       end
+
+      it "copies over the partnerships" do
+        service.execute(provider:, new_recruitment_cycle:)
+
+        expect(
+          mocked_copy_partnership_service,
+        ).to have_received(:execute)
+          .with(
+            provider:,
+            rolled_over_provider: new_provider,
+            new_recruitment_cycle:,
+          )
+      end
     end
 
     it "assigns the new provider to organisation" do
@@ -156,6 +171,7 @@ describe Providers::CopyToRecruitmentCycleService do
     it "returns a hash of the counts of copied objects" do
       allow(mocked_copy_course_service).to receive(:execute).and_return(double)
       allow(mocked_copy_site_service).to receive(:execute).and_return(double)
+      allow(mocked_copy_partnership_service).to receive(:execute).and_return(1)
 
       output = service.execute(provider:, new_recruitment_cycle:)
 
@@ -164,6 +180,7 @@ describe Providers::CopyToRecruitmentCycleService do
         sites: 1,
         study_sites: 1,
         courses: 1,
+        partnerships: 1,
       )
     end
 

--- a/spec/services/rollover_provider_service_spec.rb
+++ b/spec/services/rollover_provider_service_spec.rb
@@ -18,6 +18,7 @@ describe RolloverProviderService do
     allow(Providers::CopyToRecruitmentCycleService).to receive(:new).with(
       copy_course_to_provider_service:,
       copy_site_to_provider_service: instance_of(Sites::CopyToProviderService),
+      copy_partnership_to_provider_service: instance_of(Partnerships::CopyToProviderService),
       force:,
     ).and_return(copy_provider_to_recruitment_cycle_service)
   end

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -18,6 +18,7 @@ describe RolloverService do
     allow(Providers::CopyToRecruitmentCycleService).to receive(:new).with(
       copy_course_to_provider_service:,
       copy_site_to_provider_service: instance_of(Sites::CopyToProviderService),
+      copy_partnership_to_provider_service: instance_of(Partnerships::CopyToProviderService),
       force:,
     ).and_return(copy_provider_to_recruitment_cycle_service)
   end


### PR DESCRIPTION
## Context

The partnerships was a new work added this year so this is not included during the rollover.

This PR adds to the rollver script the partnerships records.

Also added the rollover progress numbers to eh recruitment cycle page:

Now we can see the number of partnerships created in the page.

**There are some discarded providers which has partnerships so I have to exclude them from numbers in rollover progress summary card.**

## Gotcha 1 - Partnership creation

During the rollover process, we need to create provider records one by one. Each provider may have partnerships (as a training provider or an accredited provider) that also need to be created. However, a partnership can only be created if **both** providers involved (training and accredited) already exist in the database.

- When processing a single provider, it's possible that the corresponding partner provider (the other side of the partnership) hasn't been created yet.
- This means we can't create the partnership immediately if one of the providers is missing.
- As a result, some partnerships are delayed until both providers exist.

To handle this, I added the following query:

```ruby
partnerships = ProviderPartnership.where(
  "accredited_provider_id = :id OR training_provider_id = :id",
  id: provider.id,
)
```

- This query fetches all partnerships where the current provider is either the training provider or the accredited provider.
- When processing each provider, we attempt to create partnerships.
- If the partner provider does not exist yet, the partnership creation is skipped for now.
- Once both providers have been created (as the rollover proceeds), the partnership will be created on a subsequent pass.
- Since providers are created one by one, and partnerships depend on both providers, it's expected that some partnerships will only be created after both sides exist.
- By always checking for partnerships involving the current provider, we ensure that as soon as both providers exist, the partnership can be created if it doesn't already exist.
- This approach guarantees eventual consistency: all partnerships will be created once all relevant providers are present.

**Example Flow**

1. **Provider A is created.**
   - Provider B (partner) does not exist yet.
   - Partnership between A and B is skipped for now.

2. **Provider B is created later.**
   - Now both A and B exist.
   - The code checks for partnerships involving B (using the query above).
   - Partnership between A and B is created if not already present.

*Summary
- Providers are created one at a time.
- Partnerships are only created when both providers exist.
- The query ensures we check for all relevant partnerships as each provider is processed.
- All partnerships will eventually be created by the end of the rollover, ensuring data integrity and consistency.

## Gotcha 2 - Discarded providers and partnerships

There are some training providers that aren't eligible for rollover (meaning they don't have published/withdrawn courses) so the partnerships for these training providers won't be rolled over.

## Guidance to review

1. Run the rollover by creating a recruitment cycle
2. Find one accredited provider
3. Check under partnerships tab in publish in both cycles
4. Find one training provider
5. Check under partnerships tab in publish in both cycles
