### PR TITLE
Sanitize the candidate table backup sql

### DIFF
--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -9,3 +9,8 @@ UPDATE "user"
            sign_in_user_id=null
        WHERE email NOT LIKE '%@digital.education.gov.uk'
              AND email NOT LIKE '%@education.gov.uk';
+
+UPDATE "candidate"
+       SET email=concat('anonimized-candidate-',id,'@example.com')
+       WHERE email NOT LIKE '%@digital.education.gov.uk'
+             AND email NOT LIKE '%@education.gov.uk';


### PR DESCRIPTION
## Context

We added a Candidate model and table that contains the candidate email address. We want to sanitize this data when we backup for non-prod environments.

## Changes proposed in this pull request

Sanitize the candidate table in backup

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
