### PR TITLE
Change the rollover trigger

### DIFF
--- a/app/controllers/support/recruitment_cycles_controller.rb
+++ b/app/controllers/support/recruitment_cycles_controller.rb
@@ -63,7 +63,7 @@ module Support
     end
 
     def confirm_rollover
-      @review_rollover_form = ReviewRolloverForm.new(params.fetch(:support_review_rollover_form, {}).permit(:confirmation))
+      @review_rollover_form = ReviewRolloverForm.new(params.fetch(:support_review_rollover_form, {}).permit(:confirmation, :environment))
 
       if @review_rollover_form.valid?
         RolloverJob.perform_later(@recruitment_cycle.id)

--- a/app/controllers/support/recruitment_cycles_controller.rb
+++ b/app/controllers/support/recruitment_cycles_controller.rb
@@ -2,7 +2,7 @@
 
 module Support
   class RecruitmentCyclesController < ApplicationController
-    before_action :set_recruitment_cycle, :authorize_recruitment_cycle, only: %i[show edit update]
+    before_action :set_recruitment_cycle, :authorize_recruitment_cycle, only: %i[show edit update review_rollover]
 
     def index
       @recruitment_cycles = RecruitmentCycle.order(year: :desc)
@@ -31,6 +31,9 @@ module Support
 
     def show
       @rollover_progress = RolloverProgressQuery.new(target_cycle: @recruitment_cycle)
+    end
+
+    def review_rollover
     end
 
     def edit

--- a/app/forms/support/review_rollover_form.rb
+++ b/app/forms/support/review_rollover_form.rb
@@ -1,17 +1,23 @@
 module Support
   class ReviewRolloverForm < ApplicationForm
-    attr_accessor :confirmation
+    attr_accessor :confirmation, :environment
 
     CONFIRM_ROLLOVER = "confirm rollover".freeze
 
-    validates :confirmation, presence: true
-    validate :must_confirm_rollover
+    validates :confirmation, :environment, presence: true
+    validate :must_confirm_rollover, :must_confirm_environment
 
   private
 
     def must_confirm_rollover
       if confirmation.present? && confirmation != CONFIRM_ROLLOVER
         errors.add(:confirmation, :invalid_confirmation)
+      end
+    end
+
+    def must_confirm_environment
+      if environment.present? && environment != Settings.environment.name
+        errors.add(:environment, :invalid_environment)
       end
     end
   end

--- a/app/forms/support/review_rollover_form.rb
+++ b/app/forms/support/review_rollover_form.rb
@@ -1,0 +1,18 @@
+module Support
+  class ReviewRolloverForm < ApplicationForm
+    attr_accessor :confirmation
+
+    CONFIRM_ROLLOVER = "confirm rollover".freeze
+
+    validates :confirmation, presence: true
+    validate :must_confirm_rollover
+
+  private
+
+    def must_confirm_rollover
+      if confirmation.present? && confirmation != CONFIRM_ROLLOVER
+        errors.add(:confirmation, :invalid_confirmation)
+      end
+    end
+  end
+end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -90,6 +90,10 @@ class RecruitmentCycle < ApplicationRecord
     status == :upcoming
   end
 
+  def rollover_awaiting_start?
+    providers.count.zero?
+  end
+
   def year_range
     "#{year.to_i - 1} to #{year}"
   end

--- a/app/policies/recruitment_cycle_policy.rb
+++ b/app/policies/recruitment_cycle_policy.rb
@@ -38,4 +38,5 @@ class RecruitmentCyclePolicy
   def review_rollover?
     user.present?
   end
+  alias_method :confirm_rollover?, :review_rollover?
 end

--- a/app/policies/recruitment_cycle_policy.rb
+++ b/app/policies/recruitment_cycle_policy.rb
@@ -36,7 +36,7 @@ class RecruitmentCyclePolicy
   alias_method :update?, :edit?
 
   def review_rollover?
-    user.present?
+    user.present? && @recruitment_cycle.rollover_awaiting_start?
   end
   alias_method :confirm_rollover?, :review_rollover?
 end

--- a/app/policies/recruitment_cycle_policy.rb
+++ b/app/policies/recruitment_cycle_policy.rb
@@ -34,4 +34,8 @@ class RecruitmentCyclePolicy
     user.present? && @recruitment_cycle.upcoming?
   end
   alias_method :update?, :edit?
+
+  def review_rollover?
+    user.present?
+  end
 end

--- a/app/services/recruitment_cycle_creation_service.rb
+++ b/app/services/recruitment_cycle_creation_service.rb
@@ -8,13 +8,11 @@ class RecruitmentCycleCreationService
   attr_accessor :year, :application_start_date, :application_end_date, :available_in_publish_from
 
   def call
-    recruitment_cycle = RecruitmentCycle.create!(
+    RecruitmentCycle.create!(
       year: @year,
       application_start_date: @application_start_date,
       application_end_date: @application_end_date,
       available_in_publish_from: @available_in_publish_from,
     )
-
-    RolloverJob.perform_later(recruitment_cycle.id)
   end
 end

--- a/app/views/support/recruitment_cycles/review_rollover.html.erb
+++ b/app/views/support/recruitment_cycles/review_rollover.html.erb
@@ -6,86 +6,52 @@
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l"><%= t(".page_caption") %></span>
       <h1 class="govuk-heading-l"><%= @recruitment_cycle %></h1>
 
-        <%= govuk_summary_list do |summary_list| %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Name' } %>
-            <% row.with_value { 'Sarah Philips' } %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'name') %>
-          <% end %>
+      <%= form_with model: @review_rollover_form, url: confirm_rollover_support_recruitment_cycle_path(@recruitment_cycle), method: :post do |form| %>
+        <%= form.govuk_error_summary %>
 
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Date of birth' } %>
-            <% row.with_value { '5 January 1978' } %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'date of birth') %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Customer reference' } %>
-            <% row.with_value { 'Not provided' } %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'customer reference') %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Address' } %>
-            <% row.with_value do %>
-              <%= safe_join(["72 Guild Street", "London", "SE23 6FH"], tag.br) %>
-            <% end %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'address') %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Contact details' } %>
-            <% row.with_value do %>
-              <%= tag.p("07700 900457", class: "govuk-body") %>
-              <%= tag.p("sarah.phillips@example.com", class: "govuk-body") %>
-            <% end %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'contact details') %>
-          <% end %>
-        <% end %>
-
-        <h2 class="govuk-heading-m">Application details</h2>
-        <%= govuk_summary_list do |summary_list| %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Previous application number' } %>
-            <% row.with_value { '502135326' } %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'previous application number') %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Licence type' } %>
-            <% row.with_value { 'For personal use' } %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'licence type') %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Home address' } %>
-            <% row.with_value do %>
-              <%= safe_join(["72 Guild Street", "London", "SE23 6FH"], tag.br) %>
-            <% end %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'home address') %>
-          <% end %>
-
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { 'Licence period' } %>
-            <% row.with_value { 'Valid for 6 months' } %>
-            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'licence period') %>
-          <% end %>
-        <% end %>
-
-        <h2 class="govuk-heading-m">Now send your application</h2>
         <p class="govuk-body">
-          By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
+          <%= t(".intro", current_cycle: RecruitmentCycle.current.to_s, new_cycle: @recruitment_cycle.to_s) %>
         </p>
 
-        <%= form_with url: "/form-handler", method: :post, html: { novalidate: true } do |form| %>
-          <%= form.hidden_field :answers_checked, value: true %>
-          <%= govuk_button_to("Accept and send") %>
+        <div class="govuk-inset-text">
+          <%= t(".eligibility_intro_html") %>
+          <p class="govuk-body">
+            <%= t(".date_context_html", today: l(Date.current, format: :long)) %>
+          </p>
+          <p class="govuk-body">
+            <%= t(".available_in_publish_html", available_date: l(@recruitment_cycle.available_in_publish_from, format: :long)) %>
+          </p>
+      </div>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { t(".summary.providers") } %>
+            <% row.with_value(text: @rollover_progress_query.eligible_providers_count) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { t(".summary.courses") } %>
+            <% row.with_value(text: @rollover_progress_query.eligible_courses_count) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { t(".summary.partnerships") } %>
+            <% row.with_value(text: @rollover_progress_query.eligible_partnerships_count) %>
+          <% end %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { t(".summary.not_rolled_over") } %>
+            <% row.with_value(text: @rollover_progress_query.providers_without_published_courses_count) %>
+          <% end %>
         <% end %>
 
+        <h2 class="govuk-heading-m"><%= t(".confirm_heading") %></h2>
+        <p class="govuk-body">
+        <%= t(".confirm_body") %>
+        </p>
+
+        <%= form.govuk_text_field :confirmation, label: { text: "Type ‘#{Support::ReviewRolloverForm::CONFIRM_ROLLOVER}’ to confirm that you want to proceed", size: "m" }, width: 20 %>
+        <%= form.govuk_submit t("continue") %>
+      <% end %>
     </div>
-  </div>
 </div>

--- a/app/views/support/recruitment_cycles/review_rollover.html.erb
+++ b/app/views/support/recruitment_cycles/review_rollover.html.erb
@@ -7,22 +7,22 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
       <span class="govuk-caption-l"><%= t(".page_caption") %></span>
-      <h1 class="govuk-heading-l"><%= @recruitment_cycle %></h1>
+      <h1 class="govuk-heading-l"><%= @recruitment_cycle.year_range %></h1>
 
       <%= form_with model: @review_rollover_form, url: confirm_rollover_support_recruitment_cycle_path(@recruitment_cycle), method: :post do |form| %>
         <%= form.govuk_error_summary %>
 
         <p class="govuk-body">
-          <%= t(".intro", current_cycle: RecruitmentCycle.current.to_s, new_cycle: @recruitment_cycle.to_s) %>
+          <%= t(".intro", current_cycle: RecruitmentCycle.current.year_range, new_cycle: @recruitment_cycle.year_range) %>
         </p>
 
         <div class="govuk-inset-text">
           <%= t(".eligibility_intro_html") %>
           <p class="govuk-body">
-            <%= t(".date_context_html", today: l(Date.current, format: :long)) %>
+            <%= t(".date_context_html", today: l(Date.current)) %>
           </p>
           <p class="govuk-body">
-            <%= t(".available_in_publish_html", available_date: l(@recruitment_cycle.available_in_publish_from, format: :long)) %>
+            <%= t(".available_in_publish_html", available_date: l(@recruitment_cycle.available_in_publish_from)) %>
           </p>
       </div>
 

--- a/app/views/support/recruitment_cycles/review_rollover.html.erb
+++ b/app/views/support/recruitment_cycles/review_rollover.html.erb
@@ -1,0 +1,91 @@
+<% content_for :page_title, @recruitment_cycle.to_s %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(href: support_recruitment_cycles_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l"><%= t(".page_caption") %></span>
+      <h1 class="govuk-heading-l"><%= @recruitment_cycle %></h1>
+
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Name' } %>
+            <% row.with_value { 'Sarah Philips' } %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'name') %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Date of birth' } %>
+            <% row.with_value { '5 January 1978' } %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'date of birth') %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Customer reference' } %>
+            <% row.with_value { 'Not provided' } %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'customer reference') %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Address' } %>
+            <% row.with_value do %>
+              <%= safe_join(["72 Guild Street", "London", "SE23 6FH"], tag.br) %>
+            <% end %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'address') %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Contact details' } %>
+            <% row.with_value do %>
+              <%= tag.p("07700 900457", class: "govuk-body") %>
+              <%= tag.p("sarah.phillips@example.com", class: "govuk-body") %>
+            <% end %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'contact details') %>
+          <% end %>
+        <% end %>
+
+        <h2 class="govuk-heading-m">Application details</h2>
+        <%= govuk_summary_list do |summary_list| %>
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Previous application number' } %>
+            <% row.with_value { '502135326' } %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'previous application number') %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Licence type' } %>
+            <% row.with_value { 'For personal use' } %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'licence type') %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Home address' } %>
+            <% row.with_value do %>
+              <%= safe_join(["72 Guild Street", "London", "SE23 6FH"], tag.br) %>
+            <% end %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'home address') %>
+          <% end %>
+
+          <% summary_list.with_row do |row| %>
+            <% row.with_key { 'Licence period' } %>
+            <% row.with_value { 'Valid for 6 months' } %>
+            <% row.with_action(text: 'Change', href: '#', visually_hidden_text: 'licence period') %>
+          <% end %>
+        <% end %>
+
+        <h2 class="govuk-heading-m">Now send your application</h2>
+        <p class="govuk-body">
+          By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
+        </p>
+
+        <%= form_with url: "/form-handler", method: :post, html: { novalidate: true } do |form| %>
+          <%= form.hidden_field :answers_checked, value: true %>
+          <%= govuk_button_to("Accept and send") %>
+        <% end %>
+
+    </div>
+  </div>
+</div>

--- a/app/views/support/recruitment_cycles/review_rollover.html.erb
+++ b/app/views/support/recruitment_cycles/review_rollover.html.erb
@@ -6,52 +6,53 @@
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-      <span class="govuk-caption-l"><%= t(".page_caption") %></span>
-      <h1 class="govuk-heading-l"><%= @recruitment_cycle.year_range %></h1>
+    <span class="govuk-caption-l"><%= t(".page_caption") %></span>
+    <h1 class="govuk-heading-l"><%= @recruitment_cycle.year_range %></h1>
 
-      <%= form_with model: @review_rollover_form, url: confirm_rollover_support_recruitment_cycle_path(@recruitment_cycle), method: :post do |form| %>
-        <%= form.govuk_error_summary %>
+    <%= form_with model: @review_rollover_form, url: confirm_rollover_support_recruitment_cycle_path(@recruitment_cycle), local: true do |form| %>
+      <%= form.govuk_error_summary %>
 
+      <p class="govuk-body">
+        <%= t(".intro", current_cycle: RecruitmentCycle.current.year_range, new_cycle: @recruitment_cycle.year_range) %>
+      </p>
+
+      <div class="govuk-inset-text">
+        <%= t(".eligibility_intro_html") %>
         <p class="govuk-body">
-          <%= t(".intro", current_cycle: RecruitmentCycle.current.year_range, new_cycle: @recruitment_cycle.year_range) %>
+          <%= t(".date_context_html", today: l(Date.current)) %>
         </p>
-
-        <div class="govuk-inset-text">
-          <%= t(".eligibility_intro_html") %>
-          <p class="govuk-body">
-            <%= t(".date_context_html", today: l(Date.current)) %>
-          </p>
-          <p class="govuk-body">
-            <%= t(".available_in_publish_html", available_date: l(@recruitment_cycle.available_in_publish_from)) %>
-          </p>
+        <p class="govuk-body">
+          <%= t(".available_in_publish_html", available_date: l(@recruitment_cycle.available_in_publish_from)) %>
+        </p>
       </div>
 
-        <%= govuk_summary_list do |summary_list| %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { t(".summary.providers") } %>
-            <% row.with_value(text: @rollover_progress_query.eligible_providers_count) %>
-          <% end %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { t(".summary.courses") } %>
-            <% row.with_value(text: @rollover_progress_query.eligible_courses_count) %>
-          <% end %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { t(".summary.partnerships") } %>
-            <% row.with_value(text: @rollover_progress_query.eligible_partnerships_count) %>
-          <% end %>
-          <% summary_list.with_row do |row| %>
-            <% row.with_key { t(".summary.not_rolled_over") } %>
-            <% row.with_value(text: @rollover_progress_query.providers_without_published_courses_count) %>
-          <% end %>
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t(".summary.providers") } %>
+          <% row.with_value(text: @rollover_progress_query.eligible_providers_count) %>
         <% end %>
-
-        <h2 class="govuk-heading-m"><%= t(".confirm_heading") %></h2>
-        <p class="govuk-body">
-        <%= t(".confirm_body") %>
-        </p>
-
-        <%= form.govuk_text_field :confirmation, label: { text: "Type ‘#{Support::ReviewRolloverForm::CONFIRM_ROLLOVER}’ to confirm that you want to proceed", size: "m" }, width: 20 %>
-        <%= form.govuk_submit t("continue") %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t(".summary.courses") } %>
+          <% row.with_value(text: @rollover_progress_query.eligible_courses_count) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t(".summary.partnerships") } %>
+          <% row.with_value(text: @rollover_progress_query.eligible_partnerships_count) %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { t(".summary.not_rolled_over") } %>
+          <% row.with_value(text: @rollover_progress_query.providers_without_published_courses_count) %>
+        <% end %>
       <% end %>
-    </div>
+
+      <h2 class="govuk-heading-m"><%= t(".confirm_heading") %></h2>
+      <p class="govuk-body"><%= t(".confirm_body") %></p>
+
+      <%= form.govuk_text_field :confirmation, label: { text: "Type ‘#{Support::ReviewRolloverForm::CONFIRM_ROLLOVER}’ to confirm that you want to proceed", size: "m" }, width: 20, autocomplete: "off" %>
+
+      <%= form.govuk_text_field :environment, label: { text: "Type ‘#{Settings.environment.name}’ to confirm that you want to proceed", size: "m" }, width: 20, autocomplete: "off" %>
+
+      <%= form.govuk_submit t("continue") %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/support/recruitment_cycles/show.html.erb
+++ b/app/views/support/recruitment_cycles/show.html.erb
@@ -10,6 +10,12 @@
       <span class="govuk-caption-l"><%= t(".page_caption") %></span>
       <h1 class="govuk-heading-l"><%= @recruitment_cycle %></h1>
 
+      <% if @recruitment_cycle.providers.count.zero? %>
+        <p class="govuk-block">
+          <%= govuk_button_to "Review rollover", review_rollover_support_recruitment_cycle_path(@recruitment_cycle), method: :get %>
+        </p>
+      <% end %>
+
       <%= govuk_summary_list(actions: policy(@recruitment_cycle).edit?) do |summary_list| %>
         <% summary_list.with_row do |row| %>
           <% row.with_key text: RecruitmentCycle.human_attribute_name(:year) %>

--- a/app/views/support/recruitment_cycles/show.html.erb
+++ b/app/views/support/recruitment_cycles/show.html.erb
@@ -10,7 +10,7 @@
       <span class="govuk-caption-l"><%= t(".page_caption") %></span>
       <h1 class="govuk-heading-l"><%= @recruitment_cycle %></h1>
 
-      <% if @recruitment_cycle.providers.count.zero? %>
+      <% if @recruitment_cycle.rollover_awaiting_start? && params[:confirmed].blank? %>
         <p class="govuk-block">
           <%= govuk_button_to "Review rollover", review_rollover_support_recruitment_cycle_path(@recruitment_cycle), method: :get %>
         </p>
@@ -70,49 +70,49 @@
         <% end %>
       <% end %>
 
-      <% if @rollover_progress.previous_target_cycle.present? %>
+      <% if @rollover_progress_query.previous_target_cycle.present? && !@recruitment_cycle.rollover_awaiting_start? %>
         <div class="govuk-inset-text">
           <%= t(
                 ".rollover_status.inset_text_html",
-                total_eligible_providers_count: @rollover_progress.eligible_providers_count,
-                total_eligible_courses_count: @rollover_progress.eligible_courses_count,
-                providers_plus_one: @rollover_progress.eligible_providers_count + 1,
-                courses_plus_one: @rollover_progress.eligible_courses_count + 1,
+                total_eligible_providers_count: @rollover_progress_query.eligible_providers_count,
+                total_eligible_courses_count: @rollover_progress_query.eligible_courses_count,
+                providers_plus_one: @rollover_progress_query.eligible_providers_count + 1,
+                courses_plus_one: @rollover_progress_query.eligible_courses_count + 1,
               ) %>
         </div>
 
-        <%= govuk_summary_card(classes: %w[recruitment-cycle-summary-card], title: RecruitmentCycle.human_attribute_name(:rollover_progress)) do |card| %>
+        <%= govuk_summary_card(classes: %w[recruitment-cycle-summary-card], title: RecruitmentCycle.human_attribute_name(:rollover_progress_query)) do |card| %>
           <%= card.with_summary_list(actions: false, classes: ["govuk-summary-list--no-border"]) do |summary_list| %>
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:providers_summary)) %>
               <% row.with_value(
                                        text: rollover_providers_summary(
-                                         previous_target_cycle: @rollover_progress.previous_target_cycle,
-                                         total_eligible_providers_count: @rollover_progress.eligible_providers_count,
-                                         rolled_over_providers_count: @rollover_progress.rolled_over_providers_count,
-                                         rollover_percentage: @rollover_progress.rollover_percentage,
+                                         previous_target_cycle: @rollover_progress_query.previous_target_cycle,
+                                         total_eligible_providers_count: @rollover_progress_query.eligible_providers_count,
+                                         rolled_over_providers_count: @rollover_progress_query.rolled_over_providers_count,
+                                         rollover_percentage: @rollover_progress_query.rollover_percentage,
                                        ),
                                      ) %>
             <% end %>
 
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:courses_summary)) %>
-              <% row.with_value(text: t(".rollover_status.summary", total_eligible_count: @rollover_progress.eligible_courses_count, rolled_over_count: @rollover_progress.rolled_over_courses_count)) %>
+              <% row.with_value(text: t(".rollover_status.summary", total_eligible_count: @rollover_progress_query.eligible_courses_count, rolled_over_count: @rollover_progress_query.rolled_over_courses_count)) %>
             <% end %>
 
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:partnerships_summary)) %>
-              <% row.with_value(text: t(".rollover_status.summary", total_eligible_count: @rollover_progress.eligible_partnerships_count, rolled_over_count: @rollover_progress.rolled_over_partnerships_count)) %>
+              <% row.with_value(text: t(".rollover_status.summary", total_eligible_count: @rollover_progress_query.eligible_partnerships_count, rolled_over_count: @rollover_progress_query.rolled_over_partnerships_count)) %>
             <% end %>
 
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:remaining_to_rollover)) %>
-              <% row.with_value(text: @rollover_progress.remaining_to_rollover_count) %>
+              <% row.with_value(text: @rollover_progress_query.remaining_to_rollover_count) %>
             <% end %>
 
             <% summary_list.with_row do |row| %>
               <% row.with_key(text: RolloverProgressQuery.human_attribute_name(:providers_without_published_courses)) %>
-              <% row.with_value(text: @rollover_progress.providers_without_published_courses_count) %>
+              <% row.with_value(text: @rollover_progress_query.providers_without_published_courses_count) %>
             <% end %>
           <% end %>
         <% end %>
@@ -127,11 +127,11 @@
           <% end %>
 
           <%= table.with_body do |body| %>
-            <% @rollover_progress.providers_without_published_courses.order(provider_name: :asc).each do |provider| %>
+            <% @rollover_progress_query.providers_without_published_courses.order(provider_name: :asc).each do |provider| %>
               <%= body.with_row do |row| %>
                 <%= row.with_cell(text: provider.provider_code) %>
                 <%= row.with_cell do %>
-                  <% if @rollover_progress.target_cycle.upcoming? %>
+                  <% if @rollover_progress_query.target_cycle.upcoming? %>
                     <%= govuk_link_to provider.provider_name,
                       support_recruitment_cycle_provider_path(provider.recruitment_cycle_year, provider) %>
                   <% else %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -40,3 +40,6 @@ en:
             confirmation:
               invalid_confirmation: &rollover_confirmation_message "You must type 'confirm rollover' to proceed."
               blank: *rollover_confirmation_message
+            environment:
+              invalid_environment: &rollover_environment_message "You must type the environment name to proceed."
+              blank: *rollover_environment_message

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -35,3 +35,8 @@ en:
             available_in_publish_from:
               blank: Enter the date when courses will become available to users in Publish.
               invalid_date: Enter a valid date
+        support/review_rollover_form:
+          attributes:
+            confirmation:
+              invalid_confirmation: &rollover_confirmation_message "You must type 'confirm rollover' to proceed."
+              blank: *rollover_confirmation_message

--- a/config/locales/en/support/recruitment_cycles.yml
+++ b/config/locales/en/support/recruitment_cycles.yml
@@ -50,7 +50,7 @@ en:
           providers: "Providers to be rolled over"
           courses: "Courses to be rolled over"
           partnerships: "Partnerships to be rolled over"
-          not_rolled_over: "Providers that will NOT be rolled over"
+          not_rolled_over: "Providers that will not be rolled over"
         confirm_heading: "Confirm rollover"
         confirm_body: "By submitting this confirmation you are agreeing that, to the best of your knowledge, the details above are correct and you wish to proceed with the rollover."
       confirm_rollover:

--- a/config/locales/en/support/recruitment_cycles.yml
+++ b/config/locales/en/support/recruitment_cycles.yml
@@ -42,3 +42,16 @@ en:
       review_rollover:
         page_title: Review rollover
         page_caption: Review rollover
+        intro: "You are about to confirm and initiate the rollover process for the %{new_cycle} recruitment cycle. This means that all eligible providers, courses, schools, study sites and partnerships from the current cycle (%{current_cycle}) will be carried over into the new cycle (%{new_cycle})"
+        eligibility_intro_html: <strong>Eligibility for rollover:</strong> Only providers with <strong>published</strong> or <strong>withdrawn</strong> courses will be rolled over to the next recruitment cycle.
+        date_context_html: After confirmation, all records from the current cycle will be rolled over with today's date (%{today}).
+        available_in_publish_html: Rolled-over courses will be available to edit in Publish from <strong>%{available_date}</strong>.
+        summary:
+          providers: "Providers to be rolled over"
+          courses: "Courses to be rolled over"
+          partnerships: "Partnerships to be rolled over"
+          not_rolled_over: "Providers that will NOT be rolled over"
+        confirm_heading: "Confirm rollover"
+        confirm_body: "By submitting this confirmation you are agreeing that, to the best of your knowledge, the details above are correct and you wish to proceed with the rollover."
+      confirm_rollover:
+        rollover_confirmed: Rollover started. This process may take up to 1 hour to complete.

--- a/config/locales/en/support/recruitment_cycles.yml
+++ b/config/locales/en/support/recruitment_cycles.yml
@@ -39,3 +39,6 @@ en:
             At that point, there were <strong>%{total_eligible_providers_count} providers</strong> and <strong>%{total_eligible_courses_count} courses</strong> eligible for rollover.
             <br><br>
             If you see higher numbers displayed later (for example, "%{providers_plus_one} of %{total_eligible_providers_count} providers" or "%{courses_plus_one} of %{total_eligible_courses_count} courses"), this means that after the automated rollover process completed, additional providers or courses were manually added — either by support staff or by provider users manually rolling over specific courses — before the start of the new cycle.
+      review_rollover:
+        page_title: Review rollover
+        page_caption: Review rollover

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -97,6 +97,7 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
   resources :recruitment_cycles do
     member do
       get :review_rollover
+      post :confirm_rollover
     end
   end
 end

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -94,5 +94,9 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
   end
   resource :environment_confirmations, path: "confirm-environment", only: %i[new create]
   resources :view_components, only: %i[index]
-  resources :recruitment_cycles
+  resources :recruitment_cycles do
+    member do
+      get :review_rollover
+    end
+  end
 end

--- a/spec/forms/support/review_rollover_form_spec.rb
+++ b/spec/forms/support/review_rollover_form_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Support::ReviewRolloverForm, type: :model do
+  subject { described_class.new(confirmation:) }
+
+  context "when confirmation is blank" do
+    let(:confirmation) { "" }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:confirmation]).to include("You must type 'confirm rollover' to proceed.")
+    end
+  end
+
+  context "when confirmation is incorrect" do
+    let(:confirmation) { "something else" }
+
+    it "is invalid with custom message" do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:confirmation]).to include("You must type 'confirm rollover' to proceed.")
+    end
+  end
+
+  context "when confirmation is correct" do
+    let(:confirmation) { "confirm rollover" }
+
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/forms/support/review_rollover_form_spec.rb
+++ b/spec/forms/support/review_rollover_form_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Support::ReviewRolloverForm, type: :model do
-  subject { described_class.new(confirmation:) }
+  subject { described_class.new(confirmation:, environment:) }
+
+  let(:confirmation) { "" }
+  let(:environment) { "" }
 
   context "when confirmation is blank" do
     let(:confirmation) { "" }
@@ -21,8 +24,27 @@ RSpec.describe Support::ReviewRolloverForm, type: :model do
     end
   end
 
-  context "when confirmation is correct" do
+  context "when environment is blank" do
+    let(:environment) { "" }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:environment]).to include("You must type the environment name to proceed.")
+    end
+  end
+
+  context "when environment is incorrect" do
+    let(:confirmation) { "something else" }
+
+    it "is invalid with custom message" do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:environment]).to include("You must type the environment name to proceed.")
+    end
+  end
+
+  context "when confirmation and environment is correct" do
     let(:confirmation) { "confirm rollover" }
+    let(:environment) { "test" }
 
     it "is valid" do
       expect(subject).to be_valid

--- a/spec/policies/recruitment_cycle_policy_spec.rb
+++ b/spec/policies/recruitment_cycle_policy_spec.rb
@@ -7,10 +7,9 @@ describe RecruitmentCyclePolicy do
 
   let(:current_recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
+  let(:user) { create(:user) }
 
   describe "scope" do
-    let(:user) { create(:user) }
-
     it "limits the providers to those the user is assigned to" do
       current_recruitment_cycle
       next_recruitment_cycle
@@ -21,21 +20,29 @@ describe RecruitmentCyclePolicy do
   end
 
   permissions :index? do
-    let(:user) { create(:user) }
-
     it { is_expected.to permit(user, RecruitmentCycle) }
   end
 
   # rubocop:disable RSpec/RepeatedExample
   permissions :show? do
-    let(:user) { create(:user) }
-
     it { is_expected.to permit(user, current_recruitment_cycle) }
     it { is_expected.to permit(user, next_recruitment_cycle) }
   end
 
   permissions :edit? do
-    let(:user) { create(:user) }
+    it { is_expected.not_to permit(user, current_recruitment_cycle) }
+    it { is_expected.to permit(user, next_recruitment_cycle) }
+  end
+
+  permissions :review_rollover? do
+    let!(:provider) { create(:provider, recruitment_cycle: current_recruitment_cycle) }
+
+    it { is_expected.not_to permit(user, current_recruitment_cycle) }
+    it { is_expected.to permit(user, next_recruitment_cycle) }
+  end
+
+  permissions :confirm_rollover? do
+    let!(:provider) { create(:provider, recruitment_cycle: current_recruitment_cycle) }
 
     it { is_expected.not_to permit(user, current_recruitment_cycle) }
     it { is_expected.to permit(user, next_recruitment_cycle) }

--- a/spec/services/recruitment_cycle_creation_service_spec.rb
+++ b/spec/services/recruitment_cycle_creation_service_spec.rb
@@ -25,15 +25,6 @@ describe RecruitmentCycleCreationService do
         expect(recruitment_cycle.application_start_date).to eq(application_start_date)
         expect(recruitment_cycle.application_end_date).to eq(application_end_date)
       end
-
-      it "enqueues the rollover job with the recruitment cycle ID" do
-        allow(RolloverJob).to receive(:perform_later)
-
-        service
-
-        RecruitmentCycle.find_by(year: year)
-        expect(RolloverJob).to have_received(:perform_later)
-      end
     end
 
     context "when creation fails" do
@@ -46,14 +37,6 @@ describe RecruitmentCycleCreationService do
 
         expect { service }.to raise_error(ActiveRecord::RecordInvalid)
         expect(RecruitmentCycle.count).to eq(0)
-      end
-
-      it "does not enqueue the rollover job" do
-        allow(RolloverJob).to receive(:perform_later)
-
-        expect { service }.to raise_error(ActiveRecord::RecordInvalid)
-
-        expect(RolloverJob).not_to have_received(:perform_later)
       end
     end
   end

--- a/spec/system/support/settings/recruitment_cycles/confirm_rollover_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/confirm_rollover_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Confirm rollover", service: :publish do
     and_i_click_continue
     then_i_see_an_error_message
     and_i_write_the_wrong_confirmation_message
+    and_i_write_the_wrong_environment_name
     and_i_click_continue
     then_i_see_an_error_message
 
@@ -55,14 +56,20 @@ RSpec.describe "Confirm rollover", service: :publish do
 
   def then_i_see_an_error_message
     expect(page).to have_content("You must type 'confirm rollover' to proceed.")
+    expect(page).to have_content("You must type the environment name to proceed.")
   end
 
   def and_i_write_the_wrong_confirmation_message
     fill_in "Type ‘confirm rollover’ to confirm that you want to proceed", with: "wrong message"
   end
 
+  def and_i_write_the_wrong_environment_name
+    fill_in "Type ‘test’ to confirm that you want to proceed", with: "wrong message"
+  end
+
   def when_i_confirm_the_rollover
     fill_in "Type ‘confirm rollover’ to confirm that you want to proceed", with: "confirm rollover"
+    fill_in "Type ‘test’ to confirm that you want to proceed", with: "test"
   end
 
   def then_rollover_is_started

--- a/spec/system/support/settings/recruitment_cycles/confirm_rollover_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/confirm_rollover_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Confirm rollover", service: :publish do
+  include DfESignInUserHelper
+  let(:provider) { create(:provider) }
+  let(:user) { create(:user, :admin, providers: [provider]) }
+  let!(:current_recruitment_cycle) { create(:recruitment_cycle) }
+  let!(:next_recruitment_cycle) { create(:recruitment_cycle, :next) }
+
+  before do
+    Timecop.travel(Time.zone.local(2025, 1, 1))
+
+    driven_by(:rack_test)
+    sign_in_system_test(user:)
+  end
+
+  scenario "when confirming the rollover to run" do
+    given_i_visit_support_settings
+    when_i_click_recruitment_cycles
+    and_i_click_next_cycle
+
+    when_i_click_to_review_rollover_information
+    and_i_click_continue
+    then_i_see_an_error_message
+    and_i_write_the_wrong_confirmation_message
+    and_i_click_continue
+    then_i_see_an_error_message
+
+    when_i_confirm_the_rollover
+    and_i_click_continue
+    then_rollover_is_started
+  end
+
+  def given_i_visit_support_settings
+    visit support_settings_path
+  end
+
+  def when_i_click_recruitment_cycles
+    click_link_or_button "Recruitment Cycles"
+  end
+
+  def and_i_click_next_cycle
+    click_link_or_button next_recruitment_cycle.year
+  end
+
+  def when_i_click_to_review_rollover_information
+    click_link_or_button "Review rollover"
+  end
+
+  def and_i_click_continue
+    click_link_or_button "Continue"
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content("You must type 'confirm rollover' to proceed.")
+  end
+
+  def and_i_write_the_wrong_confirmation_message
+    fill_in "Type ‘confirm rollover’ to confirm that you want to proceed", with: "wrong message"
+  end
+
+  def when_i_confirm_the_rollover
+    fill_in "Type ‘confirm rollover’ to confirm that you want to proceed", with: "confirm rollover"
+  end
+
+  def then_rollover_is_started
+    expect(page).to have_content("Rollover started. This process may take up to 1 hour to complete.")
+
+    rollover_job = ActiveJob::Base.queue_adapter.enqueued_jobs.find { |job| job["job_class"] == "RolloverJob" }
+    expect(rollover_job).to be_present
+    expect(rollover_job["arguments"]).to contain_exactly(next_recruitment_cycle.id)
+  end
+end

--- a/spec/system/support/settings/recruitment_cycles/confirm_rollover_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/confirm_rollover_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Confirm rollover", service: :publish do
 
   def then_rollover_is_started
     expect(page).to have_content("Rollover started. This process may take up to 1 hour to complete.")
+    expect(page).not_to have_content("Review rollover")
 
     rollover_job = ActiveJob::Base.queue_adapter.enqueued_jobs.find { |job| job["job_class"] == "RolloverJob" }
     expect(rollover_job).to be_present


### PR DESCRIPTION
## Context

This PR enhances the support interface for confirming recruitment cycle rollover. 

It improves user guidance, eligibility explanation, summary statistics, and only after confirmation the rollover will be run.

## Changes proposed in this pull request

* Confirmation Form: Users must type confirm rollover to proceed, with custom error messages for blank or incorrect input.

![screencapture-publish-localhost-support-recruitment-cycles-40-review-rollover-2025-06-17-12_11_53](https://github.com/user-attachments/assets/18b6b79d-e542-49ed-9516-e465394343e6)


I fill these tomorrow morning.

## Guidance to review

1. Visit the support interface, navigate to a future recruitment cycle, and review the rollover confirmation flow.
2. Confirm that eligibility, summary, and timing information is clear.
3. Test both valid and invalid confirmation submissions.
4. Ensure the flash message and job enqueueing behave as expected.
5. Visit /sidekiq to see rollover running.

