### PR TITLE
Temporary system spec fix to allow retry

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include ActiveJob::TestHelper, type: :request
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include SystemRetryHelper, type: :system
 
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
   config.before(:suite) do

--- a/spec/support/system_retry_helper.rb
+++ b/spec/support/system_retry_helper.rb
@@ -1,0 +1,16 @@
+module SystemRetryHelper
+  def with_retry(max_attempts: 4, exceptions: [Selenium::WebDriver::Error::StaleElementReferenceError], delay: 1)
+    attempts = 0
+    begin
+      yield
+    rescue *exceptions => e
+      attempts += 1
+      raise e if attempts >= max_attempts
+
+      pp "Retrying due to: #{e.class} - #{e.message} (attempt #{attempts}/#{max_attempts})"
+
+      sleep delay
+      retry
+    end
+  end
+end

--- a/spec/system/find/results_page/filtering/funding_type_spec.rb
+++ b/spec/system/find/results_page/filtering/funding_type_spec.rb
@@ -77,27 +77,35 @@ RSpec.describe "when I filter by funding type", :js, service: :find do
   end
 
   def then_i_see_only_salaried_courses
-    expect(results).to have_content("Chemistry (K592)")
-    expect(results).to have_no_content("Biology (S872)")
-    expect(results).to have_no_content("Computing (L364)")
+    with_retry do
+      expect(results).to have_content("Chemistry (K592)")
+      expect(results).to have_no_content("Biology (S872)")
+      expect(results).to have_no_content("Computing (L364)")
+    end
   end
 
   def then_i_see_only_fee_courses
-    expect(results).to have_content("Biology (S872)")
-    expect(results).to have_no_content("Chemistry (K592)")
-    expect(results).to have_no_content("Computing (L364)")
+    with_retry do
+      expect(results).to have_content("Biology (S872)")
+      expect(results).to have_no_content("Chemistry (K592)")
+      expect(results).to have_no_content("Computing (L364)")
+    end
   end
 
   def then_i_see_fee_and_salaried_courses
-    expect(results).to have_content("Biology (S872)")
-    expect(results).to have_content("Chemistry (K592)")
-    expect(results).to have_no_content("Computing (L364)")
+    with_retry do
+      expect(results).to have_content("Biology (S872)")
+      expect(results).to have_content("Chemistry (K592)")
+      expect(results).to have_no_content("Computing (L364)")
+    end
   end
 
   def then_i_see_only_apprenticeship_courses
-    expect(results).to have_content("Computing (L364)")
-    expect(results).to have_no_content("Chemistry (K592)")
-    expect(results).to have_no_content("Biology (S872)")
+    with_retry do
+      expect(results).to have_content("Computing (L364)")
+      expect(results).to have_no_content("Chemistry (K592)")
+      expect(results).to have_no_content("Biology (S872)")
+    end
   end
 
   def and_the_fee_filter_is_checked

--- a/spec/system/find/results_page/filtering/minimum_degree_spec.rb
+++ b/spec/system/find/results_page/filtering/minimum_degree_spec.rb
@@ -171,51 +171,63 @@ RSpec.describe "when I filter by minimum degree", :js, service: :find do
   end
 
   def then_courses_with_two_one_or_lower_degree_requirement_are_visible
-    expect(results).to have_content("Biology")
-    expect(results).to have_content("Chemistry")
-    expect(results).to have_content("Computing")
-    expect(results).to have_content("Dance")
-    expect(results).to have_no_content("Mathematics")
+    with_retry do
+      expect(results).to have_content("Biology")
+      expect(results).to have_content("Chemistry")
+      expect(results).to have_content("Computing")
+      expect(results).to have_content("Dance")
+      expect(results).to have_no_content("Mathematics")
+    end
   end
 
   def then_courses_with_two_two_or_lower_degree_requirement_are_visible
-    expect(results).to have_content("Chemistry")
-    expect(results).to have_content("Computing")
-    expect(results).to have_content("Dance")
-    expect(results).to have_no_content("Biology")
-    expect(results).to have_no_content("Mathematics")
+    with_retry do
+      expect(results).to have_content("Chemistry")
+      expect(results).to have_content("Computing")
+      expect(results).to have_content("Dance")
+      expect(results).to have_no_content("Biology")
+      expect(results).to have_no_content("Mathematics")
+    end
   end
 
   def then_courses_with_third_class_or_lower_degree_requirement_are_visible
-    expect(results).to have_content("Computing")
-    expect(results).to have_content("Dance")
-    expect(results).to have_no_content("Biology")
-    expect(results).to have_no_content("Chemistry")
-    expect(results).to have_no_content("Mathematics")
+    with_retry do
+      expect(results).to have_content("Computing")
+      expect(results).to have_content("Dance")
+      expect(results).to have_no_content("Biology")
+      expect(results).to have_no_content("Chemistry")
+      expect(results).to have_no_content("Mathematics")
+    end
   end
 
   def then_only_courses_with_ordinary_degree_requirement_are_visible
-    expect(results).to have_content("Dance")
-    expect(results).to have_no_content("Biology")
-    expect(results).to have_no_content("Chemistry")
-    expect(results).to have_no_content("Computing")
-    expect(results).to have_no_content("Mathematics")
+    with_retry do
+      expect(results).to have_content("Dance")
+      expect(results).to have_no_content("Biology")
+      expect(results).to have_no_content("Chemistry")
+      expect(results).to have_no_content("Computing")
+      expect(results).to have_no_content("Mathematics")
+    end
   end
 
   def then_only_undergraduate_courses_are_visible
-    expect(results).to have_content("Mathematics")
-    expect(results).to have_no_content("Biology")
-    expect(results).to have_no_content("Dance")
-    expect(results).to have_no_content("Chemistry")
-    expect(results).to have_no_content("Computing")
+    with_retry do
+      expect(results).to have_content("Mathematics")
+      expect(results).to have_no_content("Biology")
+      expect(results).to have_no_content("Dance")
+      expect(results).to have_no_content("Chemistry")
+      expect(results).to have_no_content("Computing")
+    end
   end
 
   def then_all_courses_are_visible
-    expect(results).to have_content("Biology")
-    expect(results).to have_content("Chemistry")
-    expect(results).to have_content("Computing")
-    expect(results).to have_content("Dance")
-    expect(results).to have_content("Mathematics")
+    with_retry do
+      expect(results).to have_content("Biology")
+      expect(results).to have_content("Chemistry")
+      expect(results).to have_content("Computing")
+      expect(results).to have_content("Dance")
+      expect(results).to have_content("Mathematics")
+    end
   end
 
   def and_i_see_that_four_courses_are_found

--- a/spec/system/find/results_page/filtering/start_date_spec.rb
+++ b/spec/system/find/results_page/filtering/start_date_spec.rb
@@ -72,23 +72,27 @@ RSpec.describe "when filtering by start date", :js, service: :find do
   end
 
   def then_i_see_only_courses_starting_in_september
-    expect(results).to have_content(@beginning_of_september_course.name)
-    expect(results).to have_content(@middle_of_september_course.name)
-    expect(results).to have_content(@end_of_september_course.name)
+    with_retry do
+      expect(results).to have_content(@beginning_of_september_course.name)
+      expect(results).to have_content(@middle_of_september_course.name)
+      expect(results).to have_content(@end_of_september_course.name)
 
-    expect(results).to have_no_content(@january_course.name)
-    expect(results).to have_no_content(@august_course.name)
-    expect(results).to have_no_content(@october_course.name)
+      expect(results).to have_no_content(@january_course.name)
+      expect(results).to have_no_content(@august_course.name)
+      expect(results).to have_no_content(@october_course.name)
+    end
   end
 
   def then_i_see_only_courses_not_starting_in_september
-    expect(results).to have_content(@january_course.name)
-    expect(results).to have_content(@august_course.name)
-    expect(results).to have_content(@october_course.name)
+    with_retry do
+      expect(results).to have_content(@january_course.name)
+      expect(results).to have_content(@august_course.name)
+      expect(results).to have_content(@october_course.name)
 
-    expect(results).to have_no_content(@beginning_of_september_course.name)
-    expect(results).to have_no_content(@middle_of_september_course.name)
-    expect(results).to have_no_content(@end_of_september_course.name)
+      expect(results).to have_no_content(@beginning_of_september_course.name)
+      expect(results).to have_no_content(@middle_of_september_course.name)
+      expect(results).to have_no_content(@end_of_september_course.name)
+    end
   end
 
   def when_i_filter_by_all_start_date_options
@@ -97,12 +101,14 @@ RSpec.describe "when filtering by start date", :js, service: :find do
   end
 
   def then_i_see_all_courses_regardless_of_start_date
-    expect(results).to have_content(@january_course.name)
-    expect(results).to have_content(@august_course.name)
-    expect(results).to have_content(@october_course.name)
-    expect(results).to have_content(@beginning_of_september_course.name)
-    expect(results).to have_content(@middle_of_september_course.name)
-    expect(results).to have_content(@end_of_september_course.name)
+    with_retry do
+      expect(results).to have_content(@january_course.name)
+      expect(results).to have_content(@august_course.name)
+      expect(results).to have_content(@october_course.name)
+      expect(results).to have_content(@beginning_of_september_course.name)
+      expect(results).to have_content(@middle_of_september_course.name)
+      expect(results).to have_content(@end_of_september_course.name)
+    end
   end
 
   def and_i_see_that_six_courses_are_found

--- a/spec/system/find/results_page/filtering/subject_spec.rb
+++ b/spec/system/find/results_page/filtering/subject_spec.rb
@@ -83,7 +83,9 @@ RSpec.describe "when I filter by subject", :js, service: :find do
   end
 
   def when_i_clear_my_search_for_secondary_options
-    fill_in "filter-search-0-input", with: ""
+    with_retry do
+      page.find('[data-filter-search-target="searchInput"]').set("")
+    end
   end
 
   def when_i_filter_by_primary
@@ -108,17 +110,21 @@ RSpec.describe "when I filter by subject", :js, service: :find do
   end
 
   def then_i_see_only_primary_specific_courses
-    expect(results).to have_content("Primary (S872)")
-    expect(results).to have_no_content("Primary with english")
-    expect(results).to have_no_content("Primary with mathematics")
-    expect(results).to have_no_content("Primary with science")
+    with_retry do
+      expect(results).to have_content("Primary (S872)")
+      expect(results).to have_no_content("Primary with english")
+      expect(results).to have_no_content("Primary with mathematics")
+      expect(results).to have_no_content("Primary with science")
+    end
   end
 
   def then_i_see_primary_and_primary_with_science_courses
-    expect(results).to have_content("Primary (S872)")
-    expect(results).to have_content("Primary with science")
-    expect(results).to have_no_content("Primary with english")
-    expect(results).to have_no_content("Primary with mathematics")
+    with_retry do
+      expect(results).to have_content("Primary (S872)")
+      expect(results).to have_content("Primary with science")
+      expect(results).to have_no_content("Primary with english")
+      expect(results).to have_no_content("Primary with mathematics")
+    end
   end
 
   def and_the_primary_option_is_checked
@@ -130,10 +136,12 @@ RSpec.describe "when I filter by subject", :js, service: :find do
   end
 
   def then_i_see_mathematics_and_chemistry_courses
-    expect(results).to have_content("Mathematics")
-    expect(results).to have_content("Chemistry")
-    expect(results).to have_no_content("Biology")
-    expect(results).to have_no_content("Computing")
+    with_retry do
+      expect(results).to have_content("Mathematics")
+      expect(results).to have_content("Chemistry")
+      expect(results).to have_no_content("Biology")
+      expect(results).to have_no_content("Computing")
+    end
   end
 
   def and_the_mathematics_secondary_option_is_checked

--- a/spec/system/find/results_page/filtering_helper.rb
+++ b/spec/system/find/results_page/filtering_helper.rb
@@ -43,10 +43,12 @@ module FilteringHelper
   end
 
   def then_i_see_only_mathematics_courses
-    expect(results).to have_content("Mathematics (4RTU)")
-    expect(results).to have_no_content("Biology")
-    expect(results).to have_no_content("Chemistry")
-    expect(results).to have_no_content("Computing")
+    with_retry do
+      expect(results).to have_content("Mathematics (4RTU)")
+      expect(results).to have_no_content("Biology")
+      expect(results).to have_no_content("Chemistry")
+      expect(results).to have_no_content("Computing")
+    end
   end
 
   def and_i_click_search

--- a/spec/system/find/results_page/filtering_spec.rb
+++ b/spec/system/find/results_page/filtering_spec.rb
@@ -161,16 +161,20 @@ RSpec.describe "Search Results", :js, service: :find do
   end
 
   def then_i_see_only_courses_that_sponsor_visa
-    expect(results).to have_content("Biology (S872")
-    expect(results).to have_content("Chemistry (K592)")
-    expect(results).to have_content("Computing (L364)")
-    expect(results).to have_no_content("Dance (C115)")
+    with_retry do
+      expect(results).to have_content("Biology (S872")
+      expect(results).to have_content("Chemistry (K592)")
+      expect(results).to have_content("Computing (L364)")
+      expect(results).to have_no_content("Dance (C115)")
+    end
   end
 
   def then_i_see_only_part_time_courses
-    expect(results).to have_content("Chemistry (K592)")
-    expect(results).to have_content("Computing (L364)")
-    expect(results).to have_no_content("Biology (S872)")
+    with_retry do
+      expect(results).to have_content("Chemistry (K592)")
+      expect(results).to have_content("Computing (L364)")
+      expect(results).to have_no_content("Biology (S872)")
+    end
   end
 
   def and_the_part_time_filter_is_checked
@@ -178,9 +182,11 @@ RSpec.describe "Search Results", :js, service: :find do
   end
 
   def then_i_see_only_full_time_courses
-    expect(results).to have_content("Biology (S872)")
-    expect(results).to have_content("Computing (L364)")
-    expect(results).to have_no_content("Chemistry (K592)")
+    with_retry do
+      expect(results).to have_content("Biology (S872)")
+      expect(results).to have_content("Computing (L364)")
+      expect(results).to have_no_content("Chemistry (K592)")
+    end
   end
 
   def and_the_full_time_filter_is_checked
@@ -188,18 +194,22 @@ RSpec.describe "Search Results", :js, service: :find do
   end
 
   def then_i_see_all_courses_containing_all_study_types
-    expect(results).to have_content("Biology (S872)")
-    expect(results).to have_content("Computing (L364)")
-    expect(results).to have_content("Chemistry (K592)")
+    with_retry do
+      expect(results).to have_content("Biology (S872)")
+      expect(results).to have_content("Computing (L364)")
+      expect(results).to have_content("Chemistry (K592)")
+    end
   end
 
   def then_i_see_only_qts_only_courses
-    expect(results).to have_content("Biology (S872)")
-    expect(results).to have_no_content("Chemistry (K592)")
-    expect(results).to have_no_content("Computing (L364)")
-    expect(results).to have_no_content("Dance (C115)")
-    expect(results).to have_no_content("Physics (3CXN)")
-    expect(results).to have_no_content("Mathemathics (4RTU)")
+    with_retry do
+      expect(results).to have_content("Biology (S872)")
+      expect(results).to have_no_content("Chemistry (K592)")
+      expect(results).to have_no_content("Computing (L364)")
+      expect(results).to have_no_content("Dance (C115)")
+      expect(results).to have_no_content("Physics (3CXN)")
+      expect(results).to have_no_content("Mathemathics (4RTU)")
+    end
   end
 
   def and_the_qts_only_filter_is_checked
@@ -207,12 +217,14 @@ RSpec.describe "Search Results", :js, service: :find do
   end
 
   def then_i_see_only_qts_with_pgce_or_pgde_courses
-    expect(results).to have_content("Chemistry (K592)")
-    expect(results).to have_content("Computing (L364)")
-    expect(results).to have_no_content("Biology (S872)")
-    expect(results).to have_no_content("Dance (C115)")
-    expect(results).to have_no_content("Physics (3CXN)")
-    expect(results).to have_no_content("Mathemathics (4RTU)")
+    with_retry do
+      expect(results).to have_content("Chemistry (K592)")
+      expect(results).to have_content("Computing (L364)")
+      expect(results).to have_no_content("Biology (S872)")
+      expect(results).to have_no_content("Dance (C115)")
+      expect(results).to have_no_content("Physics (3CXN)")
+      expect(results).to have_no_content("Mathemathics (4RTU)")
+    end
   end
 
   def and_the_qts_with_pgce_or_pgde_filter_is_checked
@@ -220,19 +232,23 @@ RSpec.describe "Search Results", :js, service: :find do
   end
 
   def then_i_see_only_courses_with_special_education_needs
-    expect(results).to have_content("Biology SEND (S872")
-    expect(results).to have_content("Chemistry SEND (K592)")
-    expect(results).to have_content("Computing SEND (L364)")
-    expect(results).to have_no_content("Dance (C115)")
-    expect(results).to have_no_content("Physics (3CXN)")
+    with_retry do
+      expect(results).to have_content("Biology SEND (S872")
+      expect(results).to have_content("Chemistry SEND (K592)")
+      expect(results).to have_content("Computing SEND (L364)")
+      expect(results).to have_no_content("Dance (C115)")
+      expect(results).to have_no_content("Physics (3CXN)")
+    end
   end
 
   def then_i_see_only_courses_that_are_open_for_applications
-    expect(results).to have_content("Biology (S872)")
-    expect(results).to have_content("Chemistry (K592)")
-    expect(results).to have_content("Computing (L364)")
-    expect(results).to have_no_content("Dance (C115)")
-    expect(results).to have_no_content("Physics (3CXN)")
+    with_retry do
+      expect(results).to have_content("Biology (S872)")
+      expect(results).to have_content("Chemistry (K592)")
+      expect(results).to have_content("Computing (L364)")
+      expect(results).to have_no_content("Dance (C115)")
+      expect(results).to have_no_content("Physics (3CXN)")
+    end
   end
 
   def and_the_visa_sponsorship_filter_is_checked

--- a/spec/system/find/results_page/ordering_spec.rb
+++ b/spec/system/find/results_page/ordering_spec.rb
@@ -224,6 +224,8 @@ RSpec.describe "Search results ordering", :js, service: :find do
 private
 
   def result_titles
-    page.all(".govuk-summary-card__title").map { |element| element.text.split("\n").join(" ") }
+    with_retry do
+      page.all(".govuk-summary-card__title").map { |element| element.text.split("\n").join(" ") }
+    end
   end
 end

--- a/spec/system/find/results_page/subject_and_location_spec.rb
+++ b/spec/system/find/results_page/subject_and_location_spec.rb
@@ -186,13 +186,15 @@ RSpec.describe "Search results by subject and location", :js, service: :find do
   end
 
   def then_i_only_see_courses_within_a_10_mile_radius
-    expect(results).to have_content(@london_primary_course.name_and_code)
-    expect(results).to have_content(@london_mathematics_course.name_and_code)
+    with_retry do
+      expect(results).to have_content(@london_primary_course.name_and_code)
+      expect(results).to have_content(@london_mathematics_course.name_and_code)
 
-    expect(results).to have_no_content(@romford_primary_course.name_and_code)
-    expect(results).to have_no_content(@romford_mathematics_course.name_and_code)
-    expect(results).to have_no_content(@watford_primary_course.name_and_code)
-    expect(results).to have_no_content(@watford_mathematics_course.name_and_code)
+      expect(results).to have_no_content(@romford_primary_course.name_and_code)
+      expect(results).to have_no_content(@romford_mathematics_course.name_and_code)
+      expect(results).to have_no_content(@watford_primary_course.name_and_code)
+      expect(results).to have_no_content(@watford_mathematics_course.name_and_code)
+    end
   end
 
   def and_the_10_mile_radius_is_selected
@@ -222,13 +224,15 @@ RSpec.describe "Search results by subject and location", :js, service: :find do
   alias_method :and_i_set_the_radius_to_10_miles, :when_i_set_the_radius_to_10_miles
 
   def then_i_see_courses_up_to_15_miles_distance
-    expect(results).to have_content(@london_primary_course.name_and_code)
-    expect(results).to have_content(@london_mathematics_course.name_and_code)
-    expect(results).to have_content(@romford_primary_course.name_and_code)
-    expect(results).to have_content(@romford_mathematics_course.name_and_code)
+    with_retry do
+      expect(results).to have_content(@london_primary_course.name_and_code)
+      expect(results).to have_content(@london_mathematics_course.name_and_code)
+      expect(results).to have_content(@romford_primary_course.name_and_code)
+      expect(results).to have_content(@romford_mathematics_course.name_and_code)
 
-    expect(results).to have_no_content(@watford_primary_course.name_and_code)
-    expect(results).to have_no_content(@watford_mathematics_course.name_and_code)
+      expect(results).to have_no_content(@watford_primary_course.name_and_code)
+      expect(results).to have_no_content(@watford_mathematics_course.name_and_code)
+    end
   end
 
   def when_i_increase_the_radius_to_20_miles
@@ -236,12 +240,14 @@ RSpec.describe "Search results by subject and location", :js, service: :find do
   end
 
   def then_i_see_courses_up_to_20_miles_distance
-    expect(results).to have_content(@london_primary_course.name_and_code)
-    expect(results).to have_content(@london_mathematics_course.name_and_code)
-    expect(results).to have_content(@romford_primary_course.name_and_code)
-    expect(results).to have_content(@romford_mathematics_course.name_and_code)
-    expect(results).to have_content(@watford_primary_course.name_and_code)
-    expect(results).to have_content(@watford_mathematics_course.name_and_code)
+    with_retry do
+      expect(results).to have_content(@london_primary_course.name_and_code)
+      expect(results).to have_content(@london_mathematics_course.name_and_code)
+      expect(results).to have_content(@romford_primary_course.name_and_code)
+      expect(results).to have_content(@romford_mathematics_course.name_and_code)
+      expect(results).to have_content(@watford_primary_course.name_and_code)
+      expect(results).to have_content(@watford_mathematics_course.name_and_code)
+    end
   end
 
   def and_select_primary_subject
@@ -255,12 +261,14 @@ RSpec.describe "Search results by subject and location", :js, service: :find do
   end
 
   def then_i_see_only_courses_within_selected_location_and_primary_subject_within_a_10_mile_radius
-    expect(results).to have_content(@london_primary_course.name_and_code)
-    expect(results).to have_no_content(@london_mathematics_course.name_and_code)
-    expect(results).to have_no_content(@romford_primary_course.name_and_code)
-    expect(results).to have_no_content(@romford_mathematics_course.name_and_code)
-    expect(results).to have_no_content(@watford_primary_course.name_and_code)
-    expect(results).to have_no_content(@watford_mathematics_course.name_and_code)
+    with_retry do
+      expect(results).to have_content(@london_primary_course.name_and_code)
+      expect(results).to have_no_content(@london_mathematics_course.name_and_code)
+      expect(results).to have_no_content(@romford_primary_course.name_and_code)
+      expect(results).to have_no_content(@romford_mathematics_course.name_and_code)
+      expect(results).to have_no_content(@watford_primary_course.name_and_code)
+      expect(results).to have_no_content(@watford_mathematics_course.name_and_code)
+    end
   end
 
   def when_i_search_for_math
@@ -268,23 +276,27 @@ RSpec.describe "Search results by subject and location", :js, service: :find do
   end
 
   def then_i_see_only_mathematics_courses
-    expect(results).to have_content(@london_mathematics_course.name_and_code)
-    expect(results).to have_content(@romford_mathematics_course.name_and_code)
-    expect(results).to have_content(@watford_mathematics_course.name_and_code)
+    with_retry do
+      expect(results).to have_content(@london_mathematics_course.name_and_code)
+      expect(results).to have_content(@romford_mathematics_course.name_and_code)
+      expect(results).to have_content(@watford_mathematics_course.name_and_code)
 
-    expect(results).to have_no_content(@london_primary_course.name_and_code)
-    expect(results).to have_no_content(@romford_primary_course.name_and_code)
-    expect(results).to have_no_content(@watford_primary_course.name_and_code)
+      expect(results).to have_no_content(@london_primary_course.name_and_code)
+      expect(results).to have_no_content(@romford_primary_course.name_and_code)
+      expect(results).to have_no_content(@watford_primary_course.name_and_code)
+    end
   end
 
   def then_i_see_mathematics_courses_in_15_miles_from_london_that_sponsors_visa
-    expect(results).to have_content(@london_mathematics_course.name_and_code)
+    with_retry do
+      expect(results).to have_content(@london_mathematics_course.name_and_code)
 
-    expect(results).to have_no_content(@romford_mathematics_course.name_and_code)
-    expect(results).to have_no_content(@watford_mathematics_course.name_and_code)
-    expect(results).to have_no_content(@london_primary_course.name_and_code)
-    expect(results).to have_no_content(@romford_primary_course.name_and_code)
-    expect(results).to have_no_content(@watford_primary_course.name_and_code)
+      expect(results).to have_no_content(@romford_mathematics_course.name_and_code)
+      expect(results).to have_no_content(@watford_mathematics_course.name_and_code)
+      expect(results).to have_no_content(@london_primary_course.name_and_code)
+      expect(results).to have_no_content(@romford_primary_course.name_and_code)
+      expect(results).to have_no_content(@watford_primary_course.name_and_code)
+    end
   end
 
   def when_i_search_for_a_provider
@@ -301,12 +313,14 @@ RSpec.describe "Search results by subject and location", :js, service: :find do
   end
 
   def then_i_see_only_courses_from_that_provider
-    expect(results).to have_content("First university")
+    with_retry do
+      expect(results).to have_content("First university")
 
-    providers = Provider.where.not(provider_name: "First university")
+      providers = Provider.where.not(provider_name: "First university")
 
-    providers.each do |provider|
-      expect(results).to have_no_content(provider.provider_name)
+      providers.each do |provider|
+        expect(results).to have_no_content(provider.provider_name)
+      end
     end
   end
 

--- a/spec/system/find/results_page/tracking_spec.rb
+++ b/spec/system/find/results_page/tracking_spec.rb
@@ -146,7 +146,9 @@ RSpec.describe "Search results tracking", :js, service: :find do
   end
 
   def when_i_apply_filters_using_the_bottom_button
-    page.all("button", text: "Apply filters").last.click
+    with_retry do
+      page.all("button", text: "Apply filters").last.click
+    end
   end
 
   def then_search_result_is_tracked_with_applied_filters_with_bottom_applied_filter

--- a/spec/system/find/results_page/view_course_spec.rb
+++ b/spec/system/find/results_page/view_course_spec.rb
@@ -75,7 +75,9 @@ RSpec.describe "Search results - view a course", :js, service: :find do
   end
 
   def when_i_click_on_the_first_result
-    page.first(".app-search-results").first("a").click
+    with_retry do
+      page.first(".app-search-results").first("a").click
+    end
   end
 
   def when_i_click_on_the_provider_link


### PR DESCRIPTION
We have been facing issues with out system specs with JS enabled with this error `Selenium::WebDriver::Error::StaleElementReferenceError` after some investigation I pinpointed the expectations which are causing the issues and have implemented a temporary fix using `with_retry`, this allows us to retry if the expectation fails with that exception. 

### We will chat as a team around the longer term solution. Maybe moving to Playwright