### PR TITLE
One Login header and candidate developer OAuth strategy

### DIFF
--- a/app/assets/stylesheets/find/application.scss
+++ b/app/assets/stylesheets/find/application.scss
@@ -1,6 +1,7 @@
 // Entry point for your Sass build
 @import "../govuk_style_setup";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
+@import "./one-login";
 
 @import "../components/accordion";
 @import "../components/autocomplete";

--- a/app/assets/stylesheets/find/one-login.scss
+++ b/app/assets/stylesheets/find/one-login.scss
@@ -1,0 +1,24 @@
+@import "govuk-one-login/service-header/dist/styles/service-header-no-imports";
+
+// If there's only one list-item, do not put a border on it
+.one-login-header__nav__list-item:only-of-type {
+  border: none;
+}
+
+// Make a button look like a link
+.one-login-header__button-link {
+  @include govuk-link-common;
+
+  &:not(:hover) {
+    text-decoration: none;
+  }
+
+  font-size: inherit;
+
+  color: govuk-colour("white");
+
+  cursor: pointer;
+
+  background: none;
+  border: none;
+}

--- a/app/components/govuk/one_login_header_component.html.erb
+++ b/app/components/govuk/one_login_header_component.html.erb
@@ -1,0 +1,68 @@
+<header class="cross-service-header" data-module="one-login-header">
+  <div class="one-login-header" data-one-login-header-nav>
+    <div class="one-login-header__container govuk-width-container">
+      <div class="one-login-header__logo">
+        <a href="https://www.gov.uk/" class="one-login-header__link one-login-header__link--homepage">
+          <svg
+            focusable="false"
+            role="img"
+            class="one-login-header__logotype"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 148 30"
+            height="30"
+            width="148"
+            aria-label="GOV.UK">
+            <title>GOV.UK</title>
+            <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+          </svg>
+        </a>
+      </div>
+      <button type="button"
+        aria-controls="one-login-header__nav"
+        aria-label="Show GOV.UK One Login menu"
+        data-open-class="cross-service-header__button--open"
+        data-label-for-show="Show GOV.UK One Login menu"
+        data-label-for-hide="Hide GOV.UK One Login menu"
+        aria-expanded="false"
+        class="cross-service-header__button cross-service-header__button--one-login js-x-header-toggle">
+        <span class="cross-service-header__button-content">One Login</span>
+        <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+            <circle cx="11" cy="11" r="11" fill="white" />
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8" />
+            <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8" />
+            <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2" />
+          </svg>
+        </span>
+      </button>
+      <nav aria-label="GOV.UK One Login" class="one-login-header__nav" data-open-class="one-login-header__nav--open" id="one-login-header__nav">
+        <ul class="one-login-header__nav__list">
+          <% if current_user %>
+            <li class="one-login-header__nav__list-item">
+              <a class="one-login-header__nav__link one-login-header__nav__link--one-login" href="https://home.account.gov.uk/">
+                <span class="one-login-header__nav__link-content">
+                  GOV.UK One Login
+                </span>
+                <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
+                  <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+                    <circle cx="11" cy="11" r="11" fill="white" />
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8" />
+                    <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8" />
+                    <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2" />
+                  </svg>
+                </span>
+              </a>
+            </li>
+            <li class="one-login-header__nav__list-item">
+              <%= sign_out_link %>
+            </li>
+          <% else %>
+            <li class="one-login-header__nav__list-item">
+              <%= sign_in_link %>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</header>

--- a/app/components/govuk/one_login_header_component.rb
+++ b/app/components/govuk/one_login_header_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Govuk
+  class OneLoginHeaderComponent < GovukComponent::HeaderComponent
+    attr_reader :current_user
+
+    # data-module="one-login-header" is used to initialize the js on mobile
+    def initialize(current_user:, html_attributes: { data: { module: "one-login-header" } })
+      super(html_attributes:)
+
+      @current_user = current_user
+    end
+
+    def sign_out_link
+      button_to("Sign out", find_sign_out_path, class: %w[
+        one-login-header__nav__link--one-login
+        one-login-header__button-link
+        one-login-header__nav__link
+      ], method: :delete)
+    end
+
+    def sign_in_link
+      button_to("Sign in", path, class: %w[
+        one-login-header__nav__link--one-login
+        one-login-header__button-link
+        one-login-header__nav__link
+      ], method: :post)
+    end
+
+    def path
+      "/auth/find-developer"
+    end
+  end
+end

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -1,19 +1,20 @@
 module Find
   module Authentication
     class SessionsController < ApplicationController
-      def new; end
-
-      def create
-        if (candidate = Candidate.find_or_create_by(params.permit(:email_address)))
-          start_new_session_for candidate
-          redirect_to find_root_path
+      def callback
+        email_address = omniauth.info.email
+        if (candidate = Candidate.find_or_create_by(email_address:))
+          start_new_session_for candidate, omniauth
+          flash[:success] = t(".sign_in")
+          redirect_to(session["return_to_after_authenticating"] || find_root_path, allow_remote_host: false)
         else
-          redirect_to find_root_path, alert: "Try another email address or password."
+          redirect_to find_root_path, flash: { warning: t(".authentication_error") }
         end
       end
 
       def destroy
         terminate_session
+        flash[:success] = t(".sign_out")
         redirect_to find_root_path
       end
 

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -16,6 +16,17 @@ module Find
         terminate_session
         redirect_to find_root_path
       end
+
+      # We render this action when an authentication error occurs
+      #
+      # request.env["omniauth.error"] # => #<JWT::EncodeError: The given key is a String. It has to be an OpenSSL::PKey::RSA instance>,
+      # request.env["omniauth.error.type"] # => :"The given key is a String. It has to be an OpenSSL::PKey::RSA instance",
+      # request.env["omniauth.error.strategy"] # => #<OmniAuth::Strategies::GovukOneLogin>
+      def failure
+        Sentry.capture_exception(request.env["omniauth.error"])
+
+        render "errors/omniauth"
+      end
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,4 +85,15 @@ private
       visually_hidden_text: action_visually_hidden_text,
     }
   end
+
+  def phase_colour
+    {
+      development: "grey",
+      production: "blue",
+      review: "purple",
+      sandbox: "purple",
+      staging: "red",
+      qa: "orange",
+    }.fetch(Settings.environment.name.to_sym, "grey")
+  end
 end

--- a/app/javascript/find/application.js
+++ b/app/javascript/find/application.js
@@ -1,6 +1,7 @@
 // Entry point for the build script in your package.json
 import jQuery from 'jquery'
 import { initAll } from 'govuk-frontend'
+import { initCrossServiceHeader } from './one-login-header'
 
 import { Application } from '@hotwired/stimulus'
 import FilterSearchController from './controllers/filter_search_controller'
@@ -25,3 +26,4 @@ window.jQuery = jQuery
 window.$ = jQuery
 
 initAll()
+initCrossServiceHeader()

--- a/app/javascript/find/one-login-header.js
+++ b/app/javascript/find/one-login-header.js
@@ -1,0 +1,101 @@
+/**
+ * A modified adaptation of the Design System header script
+ * Bundled into dist/scripts/init-service-header.js and dist/scripts/service-header.js
+ */
+function CrossServiceHeader ($module) {
+  this.$header = $module
+  this.$navigation =
+    $module && $module.querySelectorAll('[data-one-login-header-nav]')
+  this.$numberOfNavs = this.$navigation && this.$navigation.length
+
+  /**
+   * Handle menu button click
+   *
+   * When the menu button is clicked, change the visibility of the menu and then
+   * sync the accessibility state and menu button state
+   */
+  this.handleMenuButtonClick = function () {
+    this.isOpen = !this.isOpen
+    this.$menuOpenClass &&
+      this.$menu.classList.toggle(this.$menuOpenClass, this.isOpen)
+    this.$menuButtonOpenClass &&
+      this.$menuButton.classList.toggle(this.$menuButtonOpenClass, this.isOpen)
+    this.$menuButton.setAttribute('aria-expanded', this.isOpen)
+    if (this.$menuButtonCloseLabel && this.$menuButtonOpenLabel) {
+      this.$menuButton.setAttribute(
+        'aria-label',
+        this.isOpen ? this.$menuButtonCloseLabel : this.$menuButtonOpenLabel
+      )
+    }
+    if (this.$menuButtonCloseText && this.$menuButtonOpenText) {
+      this.$menuButton.innerHTML = this.isOpen
+        ? this.$menuButtonCloseText
+        : this.$menuButtonOpenText
+    }
+  }
+
+  /**
+   * Initialise header
+   *
+   * Check for the presence of the header, menu and menu button – if any are
+   * missing then there's nothing to do so return early.
+   */
+
+  if (!this.$header && !this.$numberOfNavs) {
+    return
+  }
+
+  /**
+   * The header navigation elements collapse into dropdowns on the mobile variation.
+   * This initialises the dropdown functionality for all navs that have a menu button which has:
+   * 1. a class of .js-x-header-toggle
+   * 2. an aria-controls attribute which can be mapped to the ID of the element
+   * that should be hidden on mobile
+   */
+  for (let i = 0; i < this.$numberOfNavs; i++) {
+    const $nav = this.$navigation[i]
+    $nav.$menuButton = $nav.querySelector('.js-x-header-toggle')
+
+    $nav.$menu =
+      $nav.$menuButton &&
+      $nav.querySelector('#' + $nav.$menuButton.getAttribute('aria-controls'))
+    $nav.menuItems = $nav.$menu && $nav.$menu.querySelectorAll('li')
+    if (!$nav.$menuButton || !$nav.$menu || $nav.menuItems.length < 2) {
+      return
+    }
+
+    $nav.classList.add('toggle-enabled')
+    $nav.$menuOpenClass = $nav.$menu && $nav.$menu.dataset.openClass
+    $nav.$menuButtonOpenClass =
+      $nav.$menuButton && $nav.$menuButton.dataset.openClass
+    $nav.$menuButtonOpenLabel =
+      $nav.$menuButton && $nav.$menuButton.dataset.labelForShow
+    $nav.$menuButtonCloseLabel =
+      $nav.$menuButton && $nav.$menuButton.dataset.labelForHide
+    $nav.$menuButtonOpenText =
+      $nav.$menuButton && $nav.$menuButton.dataset.textForShow
+    $nav.$menuButtonCloseText =
+      $nav.$menuButton && $nav.$menuButton.dataset.textForHide
+    $nav.isOpen = false
+
+    $nav.$menuButton.addEventListener(
+      'click',
+      this.handleMenuButtonClick.bind($nav)
+    )
+  }
+}
+
+function initCrossServiceHeader () {
+  const oneLoginHeader = document.querySelector(
+    "[data-module='one-login-header']"
+  )
+  if (oneLoginHeader && CrossServiceHeader) {
+    new CrossServiceHeader(oneLoginHeader) // eslint-disable-line
+  }
+}
+/**
+ * This gets appended to dist/scripts/service-header.js to make it
+ * import-able as a JS module
+ *
+ */
+export { CrossServiceHeader, initCrossServiceHeader }

--- a/app/lib/omni_auth/strategies/find_developer.rb
+++ b/app/lib/omni_auth/strategies/find_developer.rb
@@ -1,0 +1,32 @@
+module OmniAuth
+  module Strategies
+    class FindDeveloper < OmniAuth::Strategies::Developer
+      def request_phase
+        if Rails.env.production? || Rails.env.test?
+          super
+        else
+          mock_request_call
+        end
+      end
+
+      uid { 23 }
+
+      info do
+        {
+          sub: "dev-1",
+          name: "developer",
+          email: "candidateemail@example.com",
+        }
+      end
+
+      credentials do
+        {
+          token: "abc123",              # the OAuth access token
+          refresh_token: "xyz456",      # used to refresh the access token (optional)
+          expires_at: 1_650_000_000, # Unix timestamp for expiration (optional)
+          expires: true, # whether the token expires (boolean)
+        }
+      end
+    end
+  end
+end

--- a/app/views/errors/omniauth.html.erb
+++ b/app/views/errors/omniauth.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_title, "Authentication error" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Authentication error</h1>
+    <p class="govuk-body">
+      There has been a problem authenticating this login. Please try again.
+    </p>
+    <p class="govuk-body">
+      If the problem persists, email<br>
+ <%= bat_contact_mail_to subject: "Authentication error" %>.
+    </p>
+  </div>
+</div>

--- a/app/views/find/authentication/sessions/new.html.erb
+++ b/app/views/find/authentication/sessions/new.html.erb
@@ -1,1 +1,0 @@
-You must login to view this page.

--- a/app/views/find/candidates/saved_courses/index.html.erb
+++ b/app/views/find/candidates/saved_courses/index.html.erb
@@ -1,1 +1,2 @@
+<%= content_for :page_title, title_with_error_prefix("Saved courses", flash[:error].present?) %>
 <%= "Hi #{@candidate.email_address} these are your saved courses" %>

--- a/app/views/find/courses/_save_button_login_link.html.erb
+++ b/app/views/find/courses/_save_button_login_link.html.erb
@@ -1,8 +1,0 @@
-<%= link_to new_find_sessions_path,
-            class: "save-course-button__button govuk-!-margin-0 govuk-!-padding-top-2" do %>
-  <%= image_tag "icon-save.svg", alt: t(".save_this_course"), width: 24, height: 24,
-                                 class: "govuk-!-margin-right-2 govuk-!-padding-top-0" %>
-  <span class="govuk-heading-s govuk-!-margin-0 save-course-button__text">
-    <%= t(".save_this_course") %>
-  </span>
-<% end %>

--- a/app/views/find/homepage/index.html.erb
+++ b/app/views/find/homepage/index.html.erb
@@ -1,18 +1,5 @@
 <%= content_for :page_title, title_with_error_prefix("Find courses by location or by training provider", flash[:error].present?) %>
 
-<% if FeatureFlag.active?(:candidate_accounts) %>
-  <p class="govuk-body"><%= candidate_session %></p>
-  <% if authenticated? %>
-    <h1 class="govuk-heading-m">You're logged in!</h1>
-
-    <%= button_to "Logout", find_sessions_path, method: :delete, local: true %>
-
-    <p class="govuk-body code"><%= Current.session.data %></p>
-  <% else %>
-    <%= button_to "Login", find_sessions_path, method: :post, params: { email_address: "test-candidate@example.com" } %>
-  <% end %>
-<% end %>
-
 <div class="app-homepage-search-container">
   <div class="app-homepage-search-content">
     <h1 class="govuk-heading-l">Find teacher training courses in England</h1>

--- a/app/views/find/saved_courses/_save_toggle.html.erb
+++ b/app/views/find/saved_courses/_save_toggle.html.erb
@@ -1,9 +1,5 @@
 <% if @saved_course %>
   <%= render partial: "find/courses/unsave_button", locals: { saved_course: @saved_course } %>
-
-<% elsif @candidate.present? %>
-  <%= render partial: "find/courses/save_button", locals: { course: @course } %>
-
 <% else %>
-  <%= render partial: "find/courses/save_button_login_link" %>
+  <%= render partial: "find/courses/save_button", locals: { course: @course } %>
 <% end %>

--- a/app/views/layouts/find.html.erb
+++ b/app/views/layouts/find.html.erb
@@ -32,16 +32,29 @@
 
     <%= render "layouts/add_js_enabled_class_to_body" %>
 
-    <%= render HeaderComponent.new(service_name: I18n.t("service_name.find"), current_user: Current.session&.sessionable) do |header| %>
-      <% header.with_phase_banner_text t(".feedback", link_to: govuk_link_to(t(".feedback_text"), new_find_feedback_path)) %>
+    <% if FeatureFlag.active?(:candidate_accounts) %>
+      <%= render Govuk::OneLoginHeaderComponent.new(current_user: Current.session&.sessionable) %>
+      <%= govuk_service_navigation(service_name: t("service_name.find"), service_url: "#") do |nav|
+            if authenticated?
+              nav.with_navigation_item(text: t(".primary_nav.courses_html"), href: find_root_path)
+              nav.with_navigation_item(text: t(".primary_nav.saved_courses_html"), href: find_candidate_saved_courses_path)
+            end
+          end %>
+    <% else %>
+      <%= render HeaderComponent.new(service_name: I18n.t("service_name.find")) do |header| %>
+        <% header.with_phase_banner_text t(".feedback", link_to: govuk_link_to(t(".feedback_text"), new_find_feedback_path)) %>
 
-      <% if authenticated? %>
-        <% header.with_navigation_item t(".primary_nav.courses_html"), find_root_path %>
-        <% header.with_navigation_item t(".primary_nav.saved_courses_html"), find_candidate_saved_courses_path %>
+        <% if authenticated? %>
+          <% header.with_navigation_item t(".primary_nav.courses_html"), find_root_path %>
+          <% header.with_navigation_item t(".primary_nav.saved_courses_html"), find_candidate_saved_courses_path %>
+        <% end %>
       <% end %>
     <% end %>
 
     <div class="govuk-width-container">
+      <% if FeatureFlag.active?(:candidate_accounts) %>
+        <%= render GovukComponent::PhaseBannerComponent.new(tag: { text: Settings.environment.name, colour: phase_colour }, text: t(".feedback", link_to: govuk_link_to(t(".feedback_text"), new_find_feedback_path)).html_safe) %>
+      <% end %>
       <%= yield :before_content %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= render Find::MaintenanceBannerComponent.new %>

--- a/app/views/layouts/find.html.erb
+++ b/app/views/layouts/find.html.erb
@@ -44,17 +44,6 @@
     <div class="govuk-width-container">
       <%= yield :before_content %>
       <main class="govuk-main-wrapper" id="main-content" role="main">
-        <% if flash[:success] %>
-          <%= govuk_notification_banner(
-            title_text: "Success",
-            success: true,
-            title_id: "success-message",
-            html_attributes: { role: "alert" },
-          ) do |notification_banner| %>
-            <% notification_banner.with_heading(text: flash[:success]) %>
-          <% end %>
-        <% end %>
-
         <%= render Find::MaintenanceBannerComponent.new %>
         <%= render Find::DeadlineBannerComponent.new(flash_empty: flash.reject { |flash| flash[0] == "start_wizard" }.empty?) unless request.url.include?("/results/filter/subject") %>
         <%= render Find::FinancialIncentivesBannerComponent.new %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -42,3 +42,15 @@ else
     provider :openid_connect, options
   end
 end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider(:find_developer,
+           name: "find-developer",
+           fields: %i[uid email],
+           uid_field: :uid,
+           path_prefix: "/auth",
+           callback_path: "/auth/find-developer/callback")
+  on_failure do |env|
+    Find::Authentication::SessionsController.action(:failure).call(env)
+  end
+end

--- a/config/locales/en/find/concerns/authentication.yml
+++ b/config/locales/en/find/concerns/authentication.yml
@@ -1,0 +1,5 @@
+en:
+  find:
+    concerns:
+      authentication:
+        unauthenticated_message: You must sign in to visit that page.

--- a/config/locales/en/find/sessions.yml
+++ b/config/locales/en/find/sessions.yml
@@ -1,0 +1,7 @@
+en:
+  find:
+    authentication:
+      sessions:
+        sign_out: You have been successfully signed out.
+        sign_in:  You have been successfully signed in.
+        authentication_error: Authentication failed

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -32,7 +32,10 @@ namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host 
 
   constraints ->(_req) { FeatureFlag.active?(:candidate_accounts) } do
     scope module: "authentication" do
-      resource :sessions, path: "auth/session", only: %i[new create destroy]
+      resource :sessions, path: "auth", only: %i[] do
+        get ":provider/callback", action: :callback
+      end
+      delete "/sign-out", to: "sessions#destroy"
     end
 
     scope path: "candidate", module: "candidates", as: "candidate" do

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@ministryofjustice/frontend": "2.0.0",
     "accessible-autocomplete": "^3.0.1",
     "dfe-autocomplete": "DFE-Digital/dfe-autocomplete#v0.2.1",
+    "govuk-one-login/service-header": "govuk-one-login/service-header#v3.0.1",
     "govuk-frontend": "^5.10.2",
     "jquery": "^3.6.0",
     "lodash.debounce": "^4.0.8",

--- a/spec/factories/candidates.rb
+++ b/spec/factories/candidates.rb
@@ -7,4 +7,8 @@ FactoryBot.define do
       sessions { build_list(:session, 1) }
     end
   end
+
+  factory :find_developer_candidate, parent: :candidate do
+    email_address { "candidateemail@example.com" }
+  end
 end

--- a/spec/requests/find/authentication_error_spec.rb
+++ b/spec/requests/find/authentication_error_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Authentication error", service: :find, type: :request do
+  include OmniAuth::Test
+
+  before do
+    create(:find_developer_candidate)
+
+    CandidateAuthHelper.mock_error_auth
+  end
+
+  describe "POST /auth/find-developer/callback" do
+    it "triggers an error and renders the error page" do
+      allow(Sentry).to receive(:capture_exception)
+      allow(OmniAuth.config.failure_raise_out_environments).to receive(:include?).and_return(true)
+
+      post "/auth/find-developer/callback", params: {}
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Authentication error")
+      expect(Sentry).to have_received(:capture_exception)
+    end
+  end
+end

--- a/spec/requests/find/sign_in_spec.rb
+++ b/spec/requests/find/sign_in_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "/auth/find-developer", service: :find do
+  context "when page parameter is invalid" do
+    before do
+      FeatureFlag.activate(:candidate_accounts)
+      CandidateAuthHelper.mock_auth
+    end
+
+    it "responds successfully" do
+      post "/auth/find-developer"
+      follow_redirect!
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it "redirects user to the original url accessed before signing in" do
+      get "/candidate/saved-courses"
+      follow_redirect! # redirect to homepage (sets the session redirect url)
+
+      post "/auth/find-developer"
+      follow_redirect! # redirect to callback url
+      follow_redirect! # redirect to saved-courses url set in the session
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.title).to eq("Saved courses - Find teacher training courses - GOV.UK")
+    end
+  end
+end

--- a/spec/support/candidate_auth_helper.rb
+++ b/spec/support/candidate_auth_helper.rb
@@ -1,0 +1,33 @@
+module CandidateAuthHelper
+module_function
+
+  def mock_auth
+    OmniAuth.config.mock_auth[:"find-developer"] = OmniAuth::AuthHash.new(
+      {
+        "provider" => "dfe",
+        "uid" => "sign_in_user_id",
+        "info" => {
+          "name" => "candidate test",
+          "email" => "candidateemail@example.com",
+        },
+        "credentials" => {
+          "id_token" => "id_token",
+          "token" => "CANDIDATE_SIGN_IN_TOKEN",
+          "expires_in" => 3600,
+          "scope" => "email openid",
+        },
+        "extra" => {
+          "raw_info" => {
+            "email" => "candidateemail@example.com",
+            "sub" => "sign_in_user_id",
+          },
+        },
+      },
+    )
+  end
+
+  # This auth will fail! and exception in OmniAuth and trigger the failure flow
+  def mock_error_auth
+    OmniAuth.config.mock_auth[:"find-developer"] = :fail
+  end
+end

--- a/spec/system/find/authentication_error_spec.rb
+++ b/spec/system/find/authentication_error_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Candidate Authentication Error" do
+  before do
+    FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_error_auth
+  end
+
+  scenario "Authentication error page when login fails" do
+    when_i_visit_the_find_homepage
+    when_i_click_login
+    then_i_see_an_error_message
+  end
+
+  def when_i_visit_the_find_homepage
+    visit "/"
+  end
+
+  def when_i_click_login
+    click_link_or_button "Sign in"
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content("Authentication error")
+    expect(page).to have_content("There has been a problem authenticating this login. Please try again.")
+  end
+end

--- a/spec/system/find/candidates/save_a_course_spec.rb
+++ b/spec/system/find/candidates/save_a_course_spec.rb
@@ -1,30 +1,31 @@
 require "rails_helper"
 
-RSpec.describe "Saving a course", :js, service: :find do
+RSpec.describe "Saving a course", service: :find do
   before do
     FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_auth
     given_a_published_course_exists
   end
 
   scenario "A signed-in candidate can save a course" do
-    when_i_log_in_as_a_candidate
+    when_i_sign_in_as_a_candidate
     when_i_view_a_course
     then_i_save_the_course
 
     then_the_course_is_saved
   end
 
-  scenario "An unauthenticated visitor is prompted to log in when trying to save a course" do
-    when_i_visit_a_course_without_logging_in
+  scenario "An unauthenticated visitor is prompted to sign in when trying to save a course" do
+    when_i_visit_a_course_without_signing_in
     then_i_save_the_course
 
-    then_i_am_prompted_to_log_in
+    then_i_am_prompted_to_sign_in
   end
 
-  def when_i_log_in_as_a_candidate
+  def when_i_sign_in_as_a_candidate
     visit "/"
-    click_link_or_button "Login"
-    expect(page).to have_content("You're logged in!")
+    click_link_or_button "Sign in"
+    expect(page).to have_content("You have been successfully signed in.")
   end
 
   def when_i_view_a_course
@@ -32,7 +33,7 @@ RSpec.describe "Saving a course", :js, service: :find do
     click_on_first_course
   end
 
-  def when_i_visit_a_course_without_logging_in
+  def when_i_visit_a_course_without_signing_in
     visit "/"
     visit find_results_path
     click_on_first_course
@@ -47,9 +48,9 @@ RSpec.describe "Saving a course", :js, service: :find do
     expect(page).to have_content("Course saved")
   end
 
-  def then_i_am_prompted_to_log_in
-    expect(page).to have_content("You must login to view this page")
-    expect(page).to have_current_path(new_find_sessions_path)
+  def then_i_am_prompted_to_sign_in
+    expect(page).to have_content("You must sign in to visit that page.")
+    expect(page).to have_current_path(find_root_path)
   end
 
   def click_on_first_course

--- a/spec/system/find/candidates/saved_courses_spec.rb
+++ b/spec/system/find/candidates/saved_courses_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe "View pages" do
   before do
     FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_auth
   end
 
   scenario "As a Candidate, I can visit my saved courses" do
     when_i_visit_the_find_homepage
-    then_i_see_a_login_button
 
     when_i_click_login
     then_i_see_that_i_am_logged_in
@@ -26,16 +26,12 @@ RSpec.describe "View pages" do
     visit "/"
   end
 
-  def then_i_see_a_login_button
-    expect(page).to have_button("Login")
-  end
-
   def when_i_click_login
-    click_link_or_button "Login"
+    click_link_or_button "Sign in"
   end
 
   def then_i_see_that_i_am_logged_in
-    expect(page).to have_content("You're logged in!")
+    expect(page).to have_content("You have been successfully signed in.")
   end
 
   def then_i_can_see_the_primary_navigation_links
@@ -63,6 +59,7 @@ RSpec.describe "View pages" do
   def then_i_cant_visit_saved_courses_page_without_logging_in
     visit find_candidate_saved_courses_path
 
-    expect(page).to have_current_path(new_find_sessions_path)
+    expect(page).to have_current_path(find_root_path)
+    expect(page).to have_content("You must sign in to visit that page.")
   end
 end

--- a/spec/system/find/signin_spec.rb
+++ b/spec/system/find/signin_spec.rb
@@ -1,15 +1,16 @@
 require "rails_helper"
 
-RSpec.describe "View pages" do
+RSpec.describe "Candidate Sign in" do
   before do
     FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_auth
   end
 
   scenario "As a Candidate, I can log into and out of Find" do
     when_i_visit_the_find_homepage
-    then_i_see_a_login_button
 
     when_i_click_login
+
     then_i_see_that_i_am_logged_in
 
     when_i_click_logout
@@ -20,24 +21,21 @@ RSpec.describe "View pages" do
     visit "/"
   end
 
-  def then_i_see_a_login_button
-    expect(page).to have_button("Login")
-  end
-
   def when_i_click_login
-    click_link_or_button "Login"
+    click_link_or_button "Sign in"
   end
 
   def then_i_see_that_i_am_logged_in
-    expect(page).to have_content("You're logged in!")
+    expect(page).to have_content("You have been successfully signed in.")
   end
 
   def when_i_click_logout
-    click_link_or_button "Logout"
+    click_link_or_button "Sign out"
   end
 
   def then_i_see_that_i_am_logged_out
-    expect(page).to have_no_content("You're logged in!")
-    expect(page).to have_button("Login")
+    expect(page).to have_no_content("You have been successfully signed in.")
+    expect(page).to have_content("You have been successfully signed out.")
+    expect(page).to have_button("Sign in")
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,6 +579,11 @@
     loupe "^3.1.4"
     tinyrainbow "^2.0.0"
 
+a-sync-waterfall@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz#75b6b6aa72598b497a125e7a2770f14f4c8a1fa7"
+  integrity sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==
+
 accessible-autocomplete@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz#8ddf4934d0b4ba6acb28de486dd505e062cdc86e"
@@ -782,6 +787,11 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
+asap@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
@@ -951,6 +961,11 @@ colord@^2.9.3:
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
   integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
+
+commander@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1932,10 +1947,17 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-govuk-frontend@^5.0.0, govuk-frontend@^5.10.2:
+govuk-frontend@^5.0.0, govuk-frontend@^5.10.2, govuk-frontend@^5.9.0:
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.10.2.tgz#616465463a4aa333b01714f90aed5926ad066e6d"
   integrity sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==
+
+govuk-one-login/service-header@govuk-one-login/service-header#v3.0.1:
+  version "3.0.1"
+  resolved "https://codeload.github.com/govuk-one-login/service-header/tar.gz/12e31a02ad0c2b3a10e25d305b5e9a2bc541ab19"
+  dependencies:
+    govuk-frontend "^5.9.0"
+    nunjucks "^3.2.4"
 
 graceful-fs@^4.1.15:
   version "4.2.11"
@@ -2749,6 +2771,15 @@ normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+nunjucks@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.4.tgz#f0878eef528ce7b0aa35d67cc6898635fd74649e"
+  integrity sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==
+  dependencies:
+    a-sync-waterfall "^1.0.0"
+    asap "^2.0.3"
+    commander "^5.1.0"
 
 nwsapi@^2.2.16:
   version "2.2.18"


### PR DESCRIPTION
## Context

Candidates will be able to login with OAuth. We need to setup the UI and the OAuth flow for candidate sign in.

This PR will establish a dummy sign in path for non-prod environments.

## One Login Header
govuk-frontend has deprecated navigation items in the GovUk Header.
However, One Login relies on links being present in the Govuk Header. This is because One Login is cross service.

One Login has developed their own GovUK header. https://github.com/govuk-one-login/service-header

They are currently recommending copying JS files into the service using it.

## Find Developer OmniAuth strategy

Add "find_developer" Omniauth strategy.

DfE Sign in defines a `:developer` strategy already. We want independent developer strategies for each host.
By defining separate providers we can avoid collisions when both are enabled (review apps, development).
We can avoid running requests through both Middleware in both hosts.


## Changes proposed in this pull request

- yarn add `govuk-one-login/service-header`
  - Copy and adapt the HTML.
  - import the css
  - initialize the JS for mobile UI when the menu drops down when signed in
- Create `OneLoginHeaderComponent` to wrap the `one-login/service-header`
- Add a dummy developer strategy for signing in as a candidate in QA/development environments.
- This strategy uses the full OAuth flow of request and callback where other implementations just send a request to the callback endpoint.

## Guidance to review

Test Desktop and Mobile.
Test menu dropdown on mobile when signed in.
[Test both with and without Candidate Accounts feature flag enabled.](https://publish-review-5347.test.teacherservices.cloud/support/feature-flags)

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
