### PR TITLE
Scope gias file to the process id to prevent collision

### DIFF
--- a/lib/gias/downloader.rb
+++ b/lib/gias/downloader.rb
@@ -9,7 +9,7 @@ module Gias
       yesterday = Time.zone.yesterday.strftime("%Y%m%d")
       filename = "edubasealldata#{yesterday}.csv"
       url = URI("#{PATH}/#{filename}")
-      csv_path = "tmp/gias_school.csv"
+      csv_path = "tmp/gias_school-#{Process.pid}.csv"
 
       Log.log("Gias::Downloader", "Downloading the new gias file for #{Time.zone.yesterday}", level: :info)
 

--- a/spec/lib/gias/downloader_spec.rb
+++ b/spec/lib/gias/downloader_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe Gias::Downloader do
     end
   end
 
+  let!(:file_name) { "tmp/gias_school-#{Process.pid}.csv" }
+
   it "downloads the file" do
-    FileUtils.rm_f("tmp/gias_school.csv")
-    expect { described_class.call }.to change { File.exist?("tmp/gias_school.csv") }.from(false).to(true)
+    FileUtils.rm_f(file_name)
+    expect { described_class.call }.to change { File.exist?(file_name) }.from(false).to(true)
   ensure
-    FileUtils.rm_f("tmp/gias_school.csv")
+    FileUtils.rm_f(file_name)
   end
 
   it "raises DownloadError when request is not success" do

--- a/spec/lib/gias/importer_spec.rb
+++ b/spec/lib/gias/importer_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Gias::Importer do
     end
 
     it "does not save the school again" do
-      freeze_time do
+      Timecop.freeze do
         now = Time.zone.now
 
         described_class.call(test_csv)
@@ -86,7 +86,7 @@ RSpec.describe Gias::Importer do
         expect(GiasSchool.last.updated_at).to be_within(1.second).of(now)
       end
 
-      travel_to 1.minute.from_now do
+      Timecop.travel 1.minute.from_now do
         expect { described_class.call(test_csv) }.not_to(change { GiasSchool.last.updated_at })
       end
     end

--- a/spec/lib/gias/transformer_spec.rb
+++ b/spec/lib/gias/transformer_spec.rb
@@ -5,9 +5,10 @@ require "spec_helper"
 RSpec.describe Gias::Transformer do
   subject { described_class.call(downloaded_csv.open) }
 
+  let(:file_name) { "tmp/gias_school-#{Process.pid}.csv" }
   let(:downloaded_csv) do
-    FileUtils.cp(file_fixture("lib/gias/downloaded.csv"), "tmp/gias_school.csv")
-    File.new("tmp/gias_school.csv")
+    FileUtils.cp(file_fixture("lib/gias/downloaded.csv"), file_name)
+    File.new(file_name)
   end
 
   it "when northing or easting is not present does not create a row and logs error" do
@@ -24,11 +25,11 @@ RSpec.describe Gias::Transformer do
 
     expect(Gias::Log).to have_received(:log).with("Gias::Transformer", "Starting transformation of GIAS schools download...")
 
-    expect(File.exist?("tmp/gias_school.csv")).to be(false)
+    expect(File.exist?(file_name)).to be(false)
     expect(expected_csv).to eq(actual_csv)
   ensure
     inline_csv&.delete
-    FileUtils.rm_f("tmp/gias_school.csv")
+    FileUtils.rm_f(file_name)
   end
 
   it "filters out the columns we do not use" do
@@ -40,7 +41,7 @@ RSpec.describe Gias::Transformer do
     actual_csv = described_class.call(downloaded_csv)
     expect(actual_csv.read).to eq(expected_csv)
   ensure
-    FileUtils.rm_f("tmp/gias_school.csv")
+    FileUtils.rm_f(file_name)
     actual_csv&.delete
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "database_cleaner"
 require "spec_helper"
+require_relative "./support/system_retry_helper"
 
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
## Context

GIAS downloader tests are flaky because if the tests run in parallel, and one test creates a file and another expects it to be deleted, there is a collision.

## Changes proposed in this pull request

When the GIAS job downloads a new CSV, we will save it with the process ID in the name. This will prevent multiple concurrent tests stepping on eachothers test files.

If the GIAS processing spans more than one process, we'll have a problem. But I think that will be obvious and picked up at the time.

## Guidance to review

Is this insane?

## Trello

https://trello.com/c/D3l4VC1E/778-gias-job-flakey-test

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
