### PR TITLE
Require system_retry_helper correctly

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "database_cleaner"
 require "spec_helper"
-require_relative "./support/system_retry_helper"
 
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
@@ -13,8 +12,9 @@ require "rspec/rails"
 require "capybara/rspec"
 require "capybara/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
+require_relative "./support/system_retry_helper.rb"
 
-# Pull in all the files in spec/support automatically.
+# Pull in all the files in spec/strategies automatically.
 Dir["./spec/strategies/**/*.rb"].each { |file| require file }
 
 Faker::Config.locale = "en-GB"


### PR DESCRIPTION
## Context

I didn't commit the `.rb` on the end of the spec support file `require_relative`

This is required for some test runners that don't load the test files the same way as `bundle exec rspec` does.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
