### PR TITLE
Handle uncaught exceptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests
   include Pundit::Authorization
   include Pagy::Backend
+  include Errorable
 
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 
@@ -15,9 +16,5 @@ private
     authenticate_or_request_with_http_basic do |username, password|
       BasicAuthenticable.authenticate(username, password)
     end
-  end
-
-  def render_not_found
-    render "errors/not_found", status: :not_found, formats: :html
   end
 end

--- a/app/controllers/concerns/errorable.rb
+++ b/app/controllers/concerns/errorable.rb
@@ -2,16 +2,38 @@
 
 module Errorable
   extend ActiveSupport::Concern
+  # **`rescue_from` are run bottom to top
+  included do
+    rescue_from StandardError, with: :internal_server_error
+    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+    rescue_from ActionController::UnknownFormat, with: :not_acceptable
+  end
 
   def not_found
-    render status: :not_found, template: "errors/not_found"
+    respond_to do |format|
+      format.any { render status: :not_found, formats: [:html], template: "errors/not_found" }
+    end
   end
+  alias_method :render_not_found, :not_found
 
   def forbidden
-    render status: :forbidden, template: "errors/forbidden"
+    respond_to do |format|
+      format.any { render status: :forbidden, formats: [:html], template: "errors/forbidden" }
+    end
   end
 
-  def internal_server_error
-    render status: :internal_server_error, template: "errors/internal_server_error"
+  def not_acceptable
+    respond_to do |format|
+      format.any { render status: :not_acceptable, formats: [:html], template: "errors/not_acceptable" }
+    end
+  end
+
+  def internal_server_error(error)
+    Sentry.capture_exception(error)
+    raise error if Rails.env.development? || Rails.env.test?
+
+    respond_to do |format|
+      format.any { render status: :internal_server_error, formats: [:html], template: "errors/internal_server_error" }
+    end
   end
 end

--- a/app/controllers/find/application_controller.rb
+++ b/app/controllers/find/application_controller.rb
@@ -5,6 +5,7 @@ module Find
     include Pagy::Backend
     include DfE::Analytics::Requests
     include Authentication
+    include Errorable
 
     layout "find"
 
@@ -12,8 +13,6 @@ module Find
 
     before_action :redirect_to_cycle_has_ended_if_find_is_down
     before_action :redirect_to_maintenance_page_if_flag_is_active
-
-    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
     def render_feedback_component
       @render_feedback_component = true
@@ -36,10 +35,6 @@ module Find
 
     def redirect_to_cycle_has_ended_if_find_is_down
       redirect_to find_cycle_has_ended_path if CycleTimetable.find_down?
-    end
-
-    def render_not_found
-      render "errors/not_found", status: :not_found
     end
   end
 end

--- a/app/controllers/find/errors_controller.rb
+++ b/app/controllers/find/errors_controller.rb
@@ -2,8 +2,5 @@
 
 module Find
   class ErrorsController < ApplicationController
-    include Errorable
-
-    layout "find"
   end
 end

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -4,7 +4,6 @@ module Publish
   class ProvidersController < ApplicationController
     include RecruitmentCycleHelper
     include GotoPreview
-    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
     def index
       authorize :provider, :index?

--- a/app/views/errors/not_acceptable.html.erb
+++ b/app/views/errors/not_acceptable.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "The requested format could not be processed" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">The format requested is not available</h1>
+    <% if request.path[/\..*/] %>
+    <p class="govuk-body">Try removing the "<%= request.path[/\..*/] %>" from the url.</p>
+    <% end %>
+    <p class="govuk-body">
+      Contact us by email to request access: <%= bat_contact_mail_to subject: "Publish teacher training courses access request" %>
+    </p>
+  </div>
+</div>

--- a/spec/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller_spec.rb
+++ b/spec/controllers/publish/courses/a_level_requirements/what_a_level_is_required_controller_spec.rb
@@ -42,9 +42,8 @@ module Publish
 
           context "when uuid is provided but not found" do
             it "raises ActiveRecord::RecordNotFound" do
-              expect {
-                get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code, uuid: "someuuid" }
-              }.to raise_error(ActiveRecord::RecordNotFound)
+              get :new, params: { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code, uuid: "someuuid" }
+              expect(response).to have_http_status :not_found
             end
           end
 

--- a/spec/requests/find/errors_spec.rb
+++ b/spec/requests/find/errors_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Testing Errors render", service: :find, type: :request do
+  describe "not_acceptable - GET /results.*" do
+    before do
+      create(:course, :secondary)
+    end
+
+    it "returns html response when json format is not found" do
+      get "/results.json"
+
+      expect(response).to have_http_status(:not_acceptable)
+      expect(response.body).to include("The format requested is not available")
+    end
+  end
+
+  describe "not_found - GET /courses/not/found" do
+    it "returns html response when json format is not found" do
+      get "/course/not/found"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body.text.squish).to include("Page not found If you typed a web address, check it is correct. If you pasted the web address, check you copied the entire address.")
+    end
+  end
+
+  describe "internal_server_error" do
+    it "returns html response when json format is not found" do
+      allow(Sentry).to receive(:capture_exception)
+      allow(Rails.env).to receive(:test?).and_return(false) # allow error to render template
+      allow(RecruitmentCycle).to receive(:current).and_raise(StandardError)
+
+      get "/course/not/found"
+
+      expect(Sentry).to have_received(:capture_exception).with(StandardError)
+      expect(response).to have_http_status(:internal_server_error)
+      expect(response.parsed_body.text.squish).to include("Sorry, there’s a problem with the service Try again later.")
+    end
+  end
+end

--- a/spec/requests/publish/errors_spec.rb
+++ b/spec/requests/publish/errors_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Testing Errors render", service: :publish, type: :request do
+  describe "GET /publish/organisations/:provider_code/courses/:course_code.json" do
+    include DfESignInUserHelper
+
+    let(:provider) { create(:provider) }
+    let(:course) { create(:course, :secondary, provider:) }
+    let(:recruitment_cycle_year) { provider.recruitment_cycle.year }
+
+    before do
+      user = create(:user, providers: [provider])
+      login_user(user)
+    end
+
+    describe "not_acceptable - GET /publish/organisations/.../J522.json" do
+      it "renders not acceptable html" do
+        get "/publish/organisations/#{provider.provider_code}/#{recruitment_cycle_year}/courses/#{course.course_code}.json"
+
+        expect(response).to have_http_status(:not_acceptable)
+        expect(response.body).to include("The format requested is not available")
+      end
+    end
+
+    describe "not_found - GET /publish/organisations/.../wertyu.json" do
+      it "returns html response when json format is not found" do
+        get "/publish/organisations/#{provider.provider_code}/#{recruitment_cycle_year}/courses/wertyu.json"
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body.text.squish).to include("Page not found If you typed a web address, check it is correct. If you pasted the web address, check you copied the entire address.")
+      end
+    end
+
+    describe "internal_server_error" do
+      it "returns html response when json format is not found" do
+        allow(Rails.env).to receive(:test?).and_return(false) # allow error to render template
+        # Only way I can find to reliably trigger error in controller context
+        allow(RecruitmentCycle).to receive(:find_by!).and_raise(StandardError)
+        allow(Sentry).to receive(:capture_exception)
+
+        get "/publish/organisations/#{provider.provider_code}/#{recruitment_cycle_year}/courses/#{course.course_code}"
+
+        expect(Sentry).to have_received(:capture_exception).with(StandardError)
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.parsed_body.text.squish).to include("Sorry, there’s a problem with the service Try again later.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

When a request is made to our app with an unexpected extension, we try to render a not found template, but the request is asking for a format that we don't provide.

Like, `find.com/x/y/z.json` will effectively try to render `404.json`. We crash when we can't find the matching template.

## Changes proposed in this pull request

`include Errorable` in `Find::ApplicationController` and `ApplicationController` so it's available througout our controllers.
Move all `rescue_from` macros into the Errorable concern
Add 406 / not_acceptable error handling.
Add tests for 404, 406, 500 in Find and Publish


## Guidance to review

https://find-review-5359.test.teacherservices.cloud/results.json

![image](https://github.com/user-attachments/assets/3942c8d8-6cbc-429a-9328-7f1e4d877554)



We get a lot of these

![image](https://github.com/user-attachments/assets/e691b68f-a021-4c5c-8f2a-b1592e06c549)


This also fixes this

https://qa.publish-teacher-training-courses.service.gov.uk/publish/organisations/asdfasdf/2025/courses/J522

![image](https://github.com/user-attachments/assets/4ee5cb43-507d-4238-b39a-7a07666cb64e)

## Trello
https://trello.com/c/lFjkMINF/813-uncaught-exception-not-reported-to-sentry?filter=label:Bug%20%F0%9F%90%9E

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
