### PR TITLE
Do not run build on opened if deploy label is present

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -233,7 +233,15 @@ jobs:
   build:
     name: Build
     needs: [lint, analytics-checks, javascript-tests, rails-tests]
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')) }}
+    if: |
+      github.ref == 'refs/heads/main' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          !contains(github.event.pull_request.labels.*.name, 'deploy') ||
+          (github.event.action == 'labeled' && github.event.label.name == 'deploy')
+        )
+      )
     outputs:
       docker_image: ${{ env.DOCKER_IMAGE }}
       image_tag: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,16 +19,15 @@ jobs:
   lint:
     name: Lint
     if: |
-      github.ref == 'refs/heads/main' ||
+      github.event_name != 'pull_request' ||
       (
         github.event_name == 'pull_request' &&
         (
           !contains(github.event.pull_request.labels.*.name, 'deploy') ||
           (github.event.action == 'labeled' && github.event.label.name == 'deploy')
         )
-      )
+      ) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'prototype'))
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'prototype')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,6 +18,15 @@ permissions:
 jobs:
   lint:
     name: Lint
+    if: |
+      github.ref == 'refs/heads/main' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          !contains(github.event.pull_request.labels.*.name, 'deploy') ||
+          (github.event.action == 'labeled' && github.event.label.name == 'deploy')
+        )
+      )
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'prototype')) }}
     strategy:
@@ -64,6 +73,15 @@ jobs:
 
   javascript-tests:
     name: JavaScript Tests
+    if: |
+      github.ref == 'refs/heads/main' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          !contains(github.event.pull_request.labels.*.name, 'deploy') ||
+          (github.event.action == 'labeled' && github.event.label.name == 'deploy')
+        )
+      )
     needs: [lint]
     runs-on: ubuntu-latest
 
@@ -92,6 +110,15 @@ jobs:
 
   analytics-checks:
     name: Analytics checks
+    if: |
+      github.ref == 'refs/heads/main' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          !contains(github.event.pull_request.labels.*.name, 'deploy') ||
+          (github.event.action == 'labeled' && github.event.label.name == 'deploy')
+        )
+      )
     needs: [lint]
     runs-on: ubuntu-latest
     env:
@@ -125,6 +152,15 @@ jobs:
 
   rails-tests:
     name: Rails Tests
+    if: |
+      github.ref == 'refs/heads/main' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          !contains(github.event.pull_request.labels.*.name, 'deploy') ||
+          (github.event.action == 'labeled' && github.event.label.name == 'deploy')
+        )
+      )
     needs: [lint]
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
  Currently, if you open a PR, and set the deploy label before opening
  actions will run the build workflow, then the build + deploy workflow.

  This is a massive waste of time.

  If the deploy label is there when a PR is opened, just run the build
  once

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
