### PR TITLE
Do not run build on PR open when deploy label is present

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,17 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'prototype')) }}
+    # Run if:
+    # - It's not a PR
+    # - It is a PR, don't run if it has a prototype label
+    # - It is a PR, don't run on opened if it has a deploy label
+    if: |
+        github.event_name == 'pull_request' &&
+        !contains(github.event.pull_request.labels.*.name, 'prototype') &&
+        (
+          github.event.action != 'opened' ||
+          !contains(github.event.pull_request.labels.*.name, 'deploy')
+        )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Context

When you create a PR, and you know you want it to be deployed to a review app, before creating the PR you will add the deploy label.

This actually triggers two builds.
1. github.event.action = 'opened'
2. github.event.labled

The 'opened' workflow will run lint, tests, and build the image.
The 'labeled' workflow will run lint, tests, build and deploy.

If we create a PR with the deploy label, we want to skip the build for 'opened'.

![image](https://github.com/user-attachments/assets/7a76bd6e-4630-4031-85e7-48c518f3d9a9)


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The opened workflow is skipped
![image](https://github.com/user-attachments/assets/e40b0235-75dd-431e-8923-3cb74ce7c01b)

Skipped
![image](https://github.com/user-attachments/assets/64d28f95-b1ca-416c-bc4d-6b8a4b6fe803)


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
