### PR TITLE
Add excluded course param to search results

### DIFF
--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -53,7 +53,7 @@ module Find
         :subject_name,
         :university_degree_status,
         :applications_open,
-        { subjects: [], start_date: [], study_type: [], study_types: [], qualifications: [], qualification: [], funding: [] },
+        { subjects: [], start_date: [], study_type: [], study_types: [], qualifications: [], qualification: [], funding: [], excluded_courses: [] },
       ]
 
       permitted.delete(:applications_open) if FeatureFlag.active?(:hide_applications_open_date)

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -60,7 +60,7 @@ module Find
           qualifications: [],
           qualification: [],
           funding: [],
-          excluded_courses: %i[provider_code course_code] }, # No produced by the UI
+          excluded_courses: %i[provider_code course_code] },
       ]
 
       permitted.delete(:applications_open) if FeatureFlag.active?(:hide_applications_open_date)

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -53,7 +53,14 @@ module Find
         :subject_name,
         :university_degree_status,
         :applications_open,
-        { subjects: [], start_date: [], study_type: [], study_types: [], qualifications: [], qualification: [], funding: [], excluded_courses: %i[provider_code course_code] },
+        { subjects: [],
+          start_date: [],
+          study_type: [],
+          study_types: [],
+          qualifications: [],
+          qualification: [],
+          funding: [],
+          excluded_courses: %i[provider_code course_code] }, # No produced by the UI
       ]
 
       permitted.delete(:applications_open) if FeatureFlag.active?(:hide_applications_open_date)

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -53,7 +53,7 @@ module Find
         :subject_name,
         :university_degree_status,
         :applications_open,
-        { subjects: [], start_date: [], study_type: [], study_types: [], qualifications: [], qualification: [], funding: [], excluded_courses: [] },
+        { subjects: [], start_date: [], study_type: [], study_types: [], qualifications: [], qualification: [], funding: [], excluded_courses: %i[provider_code course_code] },
       ]
 
       permitted.delete(:applications_open) if FeatureFlag.active?(:hide_applications_open_date)

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -23,6 +23,7 @@ module Courses
     attribute :subject_code
     attribute :subject_name
     attribute :subjects
+    attribute :excluded_courses
 
     # Coordinates #
     attribute :country

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -52,6 +52,10 @@ module Courses
       @providers_cache = ProvidersCache.new
     end
 
+    def excluded_courses=(attributes)
+      super(attributes.is_a?(Hash) ? attributes.values : attributes)
+    end
+
     def search_params
       attributes
         .symbolize_keys

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -40,6 +40,7 @@ module Courses
       @scope = provider_scope
       @scope = optimisation_scope
       @scope = location_scope
+      @scope = excluded_courses_scope
 
       if @applied_scopes[:location].blank?
         @scope = default_ordering_scope
@@ -99,6 +100,16 @@ module Courses
       @applied_scopes[:subjects] = subject_codes
 
       @scope.joins(:subjects).where(subjects: { subject_code: subject_codes })
+    end
+
+    def excluded_courses_scope
+      return @scope if params[:excluded_courses].blank?
+
+      excluded_course_codes = params[:excluded_courses].compact_blank
+
+      @applied_scopes[:excluded_courses] = excluded_course_codes
+
+      @scope.where.not(course_code: excluded_course_codes)
     end
 
     def study_modes_scope

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -199,6 +199,14 @@ RSpec.describe Courses::SearchForm do
       end
     end
 
+    context "when excluded courses are provided" do
+      let(:form) { described_class.new(excluded_courses: %w[EX12]) }
+
+      it "returns the correct search params with excluded courses" do
+        expect(form.search_params).to eq({ excluded_courses: %w[EX12] })
+      end
+    end
+
     context "when location is provided" do
       let(:form) { described_class.new(location: "London NW9, UK", latitude: 51.53328, longitude: -0.1734435, radius: 10) }
 

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -200,10 +200,10 @@ RSpec.describe Courses::SearchForm do
     end
 
     context "when excluded courses are provided" do
-      let(:form) { described_class.new(excluded_courses: %w[EX12]) }
+      let(:form) { described_class.new(excluded_courses: [{ provider_code: "ABC", course_code: "C1" }]) }
 
       it "returns the correct search params with excluded courses" do
-        expect(form.search_params).to eq({ excluded_courses: %w[EX12] })
+        expect(form.search_params).to eq({ excluded_courses: [{ provider_code: "ABC", course_code: "C1" }] })
       end
     end
 

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -200,10 +200,20 @@ RSpec.describe Courses::SearchForm do
     end
 
     context "when excluded courses are provided" do
-      let(:form) { described_class.new(excluded_courses: [{ provider_code: "ABC", course_code: "C1" }]) }
+      context "when excluded courses are an array" do
+        let(:form) { described_class.new(excluded_courses: [{ provider_code: "ABC", course_code: "C1" }]) }
 
-      it "returns the correct search params with excluded courses" do
-        expect(form.search_params).to eq({ excluded_courses: [{ provider_code: "ABC", course_code: "C1" }] })
+        it "returns the correct search params with excluded courses" do
+          expect(form.search_params).to eq({ excluded_courses: [{ provider_code: "ABC", course_code: "C1" }] })
+        end
+      end
+
+      context "when excluded courses are hash" do
+        let(:form) { described_class.new(excluded_courses: { 0 => { provider_code: "ABC", course_code: "C1" } }) }
+
+        it "returns the correct search params with excluded courses" do
+          expect(form.search_params).to eq({ excluded_courses: [{ provider_code: "ABC", course_code: "C1" }] })
+        end
       end
     end
 

--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -593,14 +593,52 @@ RSpec.describe Courses::Query do
     end
 
     context "when searching excluding courses" do
-      let!(:course_to_exclude) { create(:course, :with_full_time_sites, course_code: "EX12", name: "Excluded Course") }
-      let!(:included_course) { create(:course, :with_full_time_sites, course_code: "IN34", name: "Included Course") }
-
-      let(:params) { { excluded_courses: %w[EX12] } }
+      let(:params) { { excluded_courses: { provider_code: "P12", course_code: "EX12" } } }
 
       it "excludes specified courses from the results" do
+        create(:course, :with_full_time_sites,
+               name: "Excluded Course",
+               course_code: "EX12",
+               provider: create(:provider, provider_code: "P12"))
+
+        included_course = create(:course, :with_full_time_sites,
+                                 name: "Included Course",
+                                 course_code: "IN34",
+                                 provider: create(:provider, provider_code: "P34"))
+
+        same_course_code_different_provider = create(:course, :with_full_time_sites,
+                                                     name: "Included Course with same course code but different provider",
+                                                     course_code: "EX12",
+                                                     provider: create(:provider, provider_code: "P99"))
+
         expect(results).to match_collection(
-          [included_course],
+          [included_course, same_course_code_different_provider],
+          attribute_names: %w[name],
+        )
+      end
+    end
+
+    context "when searching excluding courses array" do
+      let(:params) { { excluded_courses: [{ provider_code: "P12", course_code: "EX12" }] } }
+
+      it "excludes specified courses from the results" do
+        create(:course, :with_full_time_sites,
+               name: "Excluded Course",
+               course_code: "EX12",
+               provider: create(:provider, provider_code: "P12"))
+
+        included_course = create(:course, :with_full_time_sites,
+                                 name: "Included Course",
+                                 course_code: "IN34",
+                                 provider: create(:provider, provider_code: "P34"))
+
+        same_course_code_different_provider = create(:course, :with_full_time_sites,
+                                                     name: "Included Course with same course code but different provider",
+                                                     course_code: "EX12",
+                                                     provider: create(:provider, provider_code: "P99"))
+
+        expect(results).to match_collection(
+          [included_course, same_course_code_different_provider],
           attribute_names: %w[name],
         )
       end

--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -592,6 +592,20 @@ RSpec.describe Courses::Query do
       end
     end
 
+    context "when searching excluding courses" do
+      let!(:course_to_exclude) { create(:course, :with_full_time_sites, course_code: "EX12", name: "Excluded Course") }
+      let!(:included_course) { create(:course, :with_full_time_sites, course_code: "IN34", name: "Included Course") }
+
+      let(:params) { { excluded_courses: %w[EX12] } }
+
+      it "excludes specified courses from the results" do
+        expect(results).to match_collection(
+          [included_course],
+          attribute_names: %w[name],
+        )
+      end
+    end
+
     shared_examples "location search results" do |radius:|
       it "returns courses within a #{radius} mile radius" do
         params = { latitude: london.latitude, longitude: london.longitude, radius: }


### PR DESCRIPTION
## Context

The Apply service would like to direct Candidates to "recommended courses" which would exclude courses that they have previously applied to. 

## Changes proposed in this pull request

- Added the `excluded_courses` search param to the results page - this param is not used in the Find UI filters
- ~Controversially added a JSON response from the Results page.~

## Guidance to review

~The JSON response was put in to see how easy it could be. Ideally this would exist, allowing the Apply service to programatically check if there would be any results for a course recommendation query, before offering it to the Candidate.~

~This PR should act as a conversation on the possibilities/approach~

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
