### PR TITLE
Add "available for support users" field to support interface

### DIFF
--- a/app/controllers/support/recruitment_cycles_controller.rb
+++ b/app/controllers/support/recruitment_cycles_controller.rb
@@ -21,6 +21,7 @@ module Support
           year: @support_recruitment_cycle_form.year,
           application_start_date: @support_recruitment_cycle_form.application_start_date,
           application_end_date: @support_recruitment_cycle_form.application_end_date,
+          available_for_support_users_from: @support_recruitment_cycle_form.available_for_support_users_from,
           available_in_publish_from: @support_recruitment_cycle_form.available_in_publish_from,
         )
 
@@ -35,6 +36,7 @@ module Support
         year: @recruitment_cycle.year,
         application_start_date: @recruitment_cycle.application_start_date,
         application_end_date: @recruitment_cycle.application_end_date,
+        available_for_support_users_from: @recruitment_cycle.available_for_support_users_from,
         available_in_publish_from: @recruitment_cycle.available_in_publish_from,
       )
     end
@@ -47,6 +49,7 @@ module Support
           year: @support_recruitment_cycle_form.year,
           application_start_date: @support_recruitment_cycle_form.application_start_date,
           application_end_date: @support_recruitment_cycle_form.application_end_date,
+          available_for_support_users_from: @support_recruitment_cycle_form.available_for_support_users_from,
           available_in_publish_from: @support_recruitment_cycle_form.available_in_publish_from,
         )
 
@@ -83,6 +86,7 @@ module Support
             year
             application_start_date
             application_end_date
+            available_for_support_users_from
             available_in_publish_from
           ],
         )

--- a/app/forms/support/recruitment_cycle_form.rb
+++ b/app/forms/support/recruitment_cycle_form.rb
@@ -15,6 +15,7 @@ module Support
               :available_in_publish_from,
               multiple_parameters_date: true
     validate :application_end_date_must_be_after_start_date
+    validate :available_for_support_users_from_must_be_before_available_in_publish_from
     validate :year_must_be_unique, if: -> { validation_context != :update }
 
     def initialize(params = {})
@@ -38,6 +39,21 @@ module Support
       return if year.blank?
 
       errors.add(:year, :taken) if RecruitmentCycle.exists?(year:)
+    end
+
+    def available_for_support_users_from_must_be_before_available_in_publish_from
+      return if available_for_support_users_from.blank? || available_in_publish_from.blank?
+
+      if available_for_support_users_from >= available_in_publish_from
+        errors.add(
+          :available_for_support_users_from,
+          :before_available_in_publish_from,
+        )
+        errors.add(
+          :available_in_publish_from,
+          :after_available_for_support_users_from,
+        )
+      end
     end
   end
 end

--- a/app/forms/support/recruitment_cycle_form.rb
+++ b/app/forms/support/recruitment_cycle_form.rb
@@ -5,10 +5,15 @@ module Support
     attribute :year, :string
     attribute :application_start_date, :multiple_parameters_date
     attribute :application_end_date, :multiple_parameters_date
+    attribute :available_for_support_users_from, :multiple_parameters_date
     attribute :available_in_publish_from, :multiple_parameters_date
 
     validates :year, presence: true, numericality: { only_integer: true }
-    validates :application_start_date, :application_end_date, :available_in_publish_from, multiple_parameters_date: true
+    validates :application_start_date,
+              :application_end_date,
+              :available_for_support_users_from,
+              :available_in_publish_from,
+              multiple_parameters_date: true
     validate :application_end_date_must_be_after_start_date
     validate :year_must_be_unique, if: -> { validation_context != :update }
 

--- a/app/services/recruitment_cycle_creation_service.rb
+++ b/app/services/recruitment_cycle_creation_service.rb
@@ -5,13 +5,18 @@ class RecruitmentCycleCreationService
 
   include ActiveModel::Model
 
-  attr_accessor :year, :application_start_date, :application_end_date, :available_in_publish_from
+  attr_accessor :year,
+                :application_start_date,
+                :application_end_date,
+                :available_in_publish_from,
+                :available_for_support_users_from
 
   def call
     RecruitmentCycle.create!(
       year: @year,
       application_start_date: @application_start_date,
       application_end_date: @application_end_date,
+      available_for_support_users_from: @available_for_support_users_from,
       available_in_publish_from: @available_in_publish_from,
     )
   end

--- a/app/views/support/recruitment_cycles/_form.html.erb
+++ b/app/views/support/recruitment_cycles/_form.html.erb
@@ -24,6 +24,15 @@
     </div>
 
     <div class="govuk-form-group">
+      <%= f.govuk_date_field :available_for_support_users_from,
+                              class: "govuk-input--width-20",
+                              legend: { text: Support::RecruitmentCycleForm.human_attribute_name(:available_for_support_users_from), size: "s" },
+                              hint: {
+          text: Support::RecruitmentCycleForm.human_attribute_name(:available_for_support_users_from_description),
+        } %>
+    </div>
+
+    <div class="govuk-form-group">
       <%= f.govuk_date_field :available_in_publish_from,
                               class: "govuk-input--width-20",
                               legend: { text: Support::RecruitmentCycleForm.human_attribute_name(:available_in_publish_from), size: "s" },

--- a/app/views/support/recruitment_cycles/index.html.erb
+++ b/app/views/support/recruitment_cycles/index.html.erb
@@ -11,6 +11,7 @@
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:year) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:start_date) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:end_date) %>
+        <% row.with_cell text: RecruitmentCycle.human_attribute_name(:available_for_support_users_from) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:available_in_publish_from) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:rollover_progress) %>
         <% row.with_cell text: RecruitmentCycle.human_attribute_name(:status) %>
@@ -23,6 +24,7 @@
           <% row.with_cell text: govuk_link_to(recruitment_cycle.year, support_recruitment_cycle_path(recruitment_cycle)) %>
           <% row.with_cell text: recruitment_cycle.application_start_date.strftime("%-d %B %Y") %>
           <% row.with_cell text: recruitment_cycle.application_end_date.strftime("%-d %B %Y") %>
+          <% row.with_cell text: recruitment_cycle.available_for_support_users_from&.strftime("%-d %B %Y") %>
           <% row.with_cell text: recruitment_cycle.available_in_publish_from&.strftime("%-d %B %Y") %>
           <% row.with_cell text: govuk_tag(**rollover_status(target_cycle: recruitment_cycle)) %>
           <% row.with_cell do %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -37,9 +37,11 @@ en:
             available_in_publish_from:
               blank: Enter the date when courses will become available to users in Publish.
               invalid_date: Enter a valid date
+              after_available_for_support_users_from: Please choose a date after the courses become available to support users
             available_for_support_users_from:
               blank: Enter the date when courses will become available to support users (in Publish and Support).
               invalid_date: Enter a valid date
+              before_available_in_publish_from: Please choose a date before the courses become available in Publish
         support/review_rollover_form:
           attributes:
             confirmation:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -5,6 +5,8 @@ en:
         year: Recruitment cycle year
         application_start_date: Application start date
         application_end_date: Application end date
+        available_for_support_users_from: Available for support users from
+        available_for_support_users_from_description:  Date when courses will become available to support users (in Support and in Publish).
         available_in_publish_from: Available in publish from
         available_in_publish_from_description: Date when courses will become available to users in Publish.
       rollover_progress_query:
@@ -34,6 +36,9 @@ en:
               invalid_date: Enter a valid date
             available_in_publish_from:
               blank: Enter the date when courses will become available to users in Publish.
+              invalid_date: Enter a valid date
+            available_for_support_users_from:
+              blank: Enter the date when courses will become available to support users (in Publish and Support).
               invalid_date: Enter a valid date
         support/review_rollover_form:
           attributes:

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     application_start_date { DateTime.new(year.to_i - 1, 10, 1) }
     application_end_date { DateTime.new(year.to_i, 9, 30) }
     available_in_publish_from { application_start_date.to_date - 1.month }
+    available_for_support_users_from { available_in_publish_from - 1.week }
 
     trait :previous do
       year { (Settings.current_recruitment_cycle_year.to_i - 1).to_s }

--- a/spec/forms/support/recruitment_cycle_form_spec.rb
+++ b/spec/forms/support/recruitment_cycle_form_spec.rb
@@ -85,6 +85,9 @@ RSpec.describe Support::RecruitmentCycleForm do
           "available_in_publish_from(1i)" => "2050",
           "available_in_publish_from(2i)" => "03",
           "available_in_publish_from(3i)" => "09",
+          "available_for_support_users_from(1i)" => "2030",
+          "available_for_support_users_from(2i)" => "10",
+          "available_for_support_users_from(3i)" => "10",
         }
       end
 
@@ -123,6 +126,9 @@ RSpec.describe Support::RecruitmentCycleForm do
           "application_end_date(1i)" => "2025",
           "application_end_date(2i)" => "03",
           "application_end_date(3i)" => "50",
+          "available_for_support_users_from(1i)" => "2025",
+          "available_for_support_users_from(2i)" => "03",
+          "available_for_support_users_from(3i)" => "50",
         }
       end
 
@@ -130,6 +136,7 @@ RSpec.describe Support::RecruitmentCycleForm do
         expect(form).not_to be_valid
         expect(form.errors[:application_start_date]).to include("Enter a valid date")
         expect(form.errors[:application_end_date]).to include("Enter a valid date")
+        expect(form.errors[:available_for_support_users_from]).to include("Enter a valid date")
       end
     end
 
@@ -142,12 +149,15 @@ RSpec.describe Support::RecruitmentCycleForm do
           "application_end_date(1i)" => "2025",
           "application_end_date(2i)" => "03",
           "application_end_date(3i)" => "10",
+          "available_for_support_users_from(3i)" => "2025",
+          "available_for_support_users_from(2i)" => "10",
         }
       end
 
       it "is invalid" do
         expect(form).not_to be_valid
         expect(form.errors[:application_start_date]).to include("Enter an application start date")
+        expect(form.errors[:available_for_support_users_from]).to include("Enter the date when courses will become available to support users (in Publish and Support).")
       end
     end
 

--- a/spec/forms/support/recruitment_cycle_form_spec.rb
+++ b/spec/forms/support/recruitment_cycle_form_spec.rb
@@ -140,6 +140,30 @@ RSpec.describe Support::RecruitmentCycleForm do
       end
     end
 
+    context "when available_for_support_users_from is not before available_in_publish_from" do
+      let(:params) do
+        {
+          "available_for_support_users_from(1i)" => "2026",
+          "available_for_support_users_from(2i)" => "05",
+          "available_for_support_users_from(3i)" => "01",
+          "available_in_publish_from(1i)" => "2026",
+          "available_in_publish_from(2i)" => "04",
+          "available_in_publish_from(3i)" => "01",
+        }
+      end
+
+      it "is invalid" do
+        form = described_class.new(params)
+        expect(form).not_to be_valid
+        expect(form.errors[:available_for_support_users_from]).to include(
+          "Please choose a date before the courses become available in Publish",
+        )
+        expect(form.errors[:available_in_publish_from]).to include(
+          "Please choose a date after the courses become available to support users",
+        )
+      end
+    end
+
     context "when dates are incomplete" do
       let(:params) do
         {

--- a/spec/services/recruitment_cycle_creation_service_spec.rb
+++ b/spec/services/recruitment_cycle_creation_service_spec.rb
@@ -6,15 +6,19 @@ describe RecruitmentCycleCreationService do
   describe ".call" do
     subject(:service) do
       described_class.call(
-        year: year,
-        application_start_date: application_start_date,
-        application_end_date: application_end_date,
+        year:,
+        application_start_date:,
+        application_end_date:,
+        available_for_support_users_from:,
+        available_in_publish_from:,
       )
     end
 
     let(:year) { 2030 }
     let(:application_start_date) { Date.new(2031, 9, 1) }
     let(:application_end_date) { Date.new(2032, 9, 1) }
+    let(:available_for_support_users_from) { Date.new(2032, 6, 1) }
+    let(:available_in_publish_from) { Date.new(2032, 7, 1) }
 
     context "when creation succeeds" do
       it "creates a recruitment cycle with correct attributes" do
@@ -24,6 +28,8 @@ describe RecruitmentCycleCreationService do
         expect(recruitment_cycle.year.to_i).to eq(year)
         expect(recruitment_cycle.application_start_date).to eq(application_start_date)
         expect(recruitment_cycle.application_end_date).to eq(application_end_date)
+        expect(recruitment_cycle.available_for_support_users_from).to eq(available_for_support_users_from)
+        expect(recruitment_cycle.available_in_publish_from).to eq(available_in_publish_from)
       end
     end
 

--- a/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish do
     expect(page).to have_text("Enter an application start date")
     expect(page).to have_text("Enter an application end date")
     expect(page).to have_text("Enter the date when courses will become available to users in Publish")
+    expect(page).to have_text("Enter the date when courses will become available to support users (in Publish and Support)")
   end
 
   def when_i_fill_in_valid_recruitment_cycle_details
@@ -62,6 +63,10 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish do
     fill_in "support_recruitment_cycle_form[available_in_publish_from(3i)]", with: "04"
     fill_in "support_recruitment_cycle_form[available_in_publish_from(2i)]", with: "09"
     fill_in "support_recruitment_cycle_form[available_in_publish_from(1i)]", with: "2025"
+
+    fill_in "support_recruitment_cycle_form[available_for_support_users_from(3i)]", with: "01"
+    fill_in "support_recruitment_cycle_form[available_for_support_users_from(2i)]", with: "09"
+    fill_in "support_recruitment_cycle_form[available_for_support_users_from(1i)]", with: "2025"
   end
 
   def and_i_submit_the_form
@@ -79,5 +84,6 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish do
     expect(recruitment_cycle.application_start_date).to eq(Date.new(2025, 10, 4))
     expect(recruitment_cycle.application_end_date).to eq(Date.new(2026, 10, 4))
     expect(recruitment_cycle.available_in_publish_from).to eq(Date.new(2025, 9, 4))
+    expect(recruitment_cycle.available_for_support_users_from).to eq(Date.new(2025, 9, 1))
   end
 end

--- a/spec/system/support/settings/recruitment_cycles/edit_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/edit_recruitment_cycle_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe "Editing a recruitment cycle", service: :publish do
 
   def and_i_change_the_available_in_publish_from_date
     within_fieldset "Available in publish from" do
-      fill_in "Day", with: "14"
-      fill_in "Month", with: "08"
+      fill_in "Day", with: RecruitmentCycle.current.available_for_support_users_from.day + 1
+      fill_in "Month", with: RecruitmentCycle.current.available_for_support_users_from.month
     end
   end
 
@@ -114,8 +114,8 @@ RSpec.describe "Editing a recruitment cycle", service: :publish do
     expect(@upcoming_cycle.application_start_date.month).to eq(9)
     expect(@upcoming_cycle.application_end_date.day).to eq(5)
     expect(@upcoming_cycle.application_end_date.month).to eq(10)
-    expect(@upcoming_cycle.available_in_publish_from.day).to eq(14)
-    expect(@upcoming_cycle.available_in_publish_from.month).to eq(8)
+    expect(@upcoming_cycle.available_in_publish_from.day).to eq(RecruitmentCycle.current.available_for_support_users_from.day + 1)
+    expect(@upcoming_cycle.available_in_publish_from.month).to eq(RecruitmentCycle.current.available_for_support_users_from.month)
     expect(page).to have_content(@upcoming_cycle.year)
     expect(page).to have_content(I18n.l(@upcoming_cycle.application_start_date, format: :long))
     expect(page).to have_content(I18n.l(@upcoming_cycle.application_end_date, format: :long))


### PR DESCRIPTION
## Context

During the course rollover process, support users need the ability to access next cycle course data in both the Support and Publish interfaces before it becomes available to general Publish users.

This PR adds this field to be set via support interface when creating a new cycle.

## Guidance to review

1. Enter on Support
2. Settings > Recruitment cycles -> Add recruitment cycle
3. Set the dates

**For now this work is only setup the field and not using. This will be part 3 (next PR!).;**

