### PR TITLE
Add ability to view saved courses

### DIFF
--- a/app/assets/stylesheets/components/_button-link.scss
+++ b/app/assets/stylesheets/components/_button-link.scss
@@ -1,0 +1,19 @@
+// Make a button look like a link
+.app-button-link {
+  @include govuk-link-common;
+
+  &:not(:hover) {
+    text-decoration: underline;
+  }
+
+  font-size: inherit;
+
+  color: govuk-colour("blue");
+
+  text-decoration: underline;
+
+  cursor: pointer;
+
+  background: none;
+  border: none;
+}

--- a/app/assets/stylesheets/find/application.scss
+++ b/app/assets/stylesheets/find/application.scss
@@ -5,6 +5,7 @@
 
 @import "../components/accordion";
 @import "../components/autocomplete";
+@import "../components/button-link";
 @import "../components/filters";
 @import "../components/footer";
 @import "../components/header";
@@ -24,6 +25,7 @@
 @import "./components/promoted-link";
 @import "./components/quick-link-card";
 @import "./components/save-course-button";
+@import "./components/saved_course";
 @import "./components/search-results";
 @import "./components/text-ellipsis";
 @import "./components/toggle";

--- a/app/assets/stylesheets/find/components/_save-course-button.scss
+++ b/app/assets/stylesheets/find/components/_save-course-button.scss
@@ -24,7 +24,7 @@
     color: $govuk-link-colour;
 
     &:hover {
-      color: darken($govuk-link-colour, 15%);
+      color: govuk-colour("dark-grey");
     }
   }
 }

--- a/app/assets/stylesheets/find/components/_saved_course.scss
+++ b/app/assets/stylesheets/find/components/_saved_course.scss
@@ -1,0 +1,31 @@
+.app-saved-course__cell {
+  position: relative;
+
+  padding-top: 0;
+  padding-right: govuk-spacing(8);
+  padding-bottom: 0;
+}
+
+.app-saved-course__cell-link {
+  display: block;
+
+  color: inherit;
+
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+
+    background-color: govuk-colour("light-grey");
+  }
+}
+
+.app-saved-course__cell-content {
+  display: flex;
+
+  justify-content: space-between;
+
+  padding-top: govuk-spacing(4);
+  padding-bottom: govuk-spacing(4);
+  padding-left: govuk-spacing(2);
+}

--- a/app/controllers/find/candidates/saved_courses_controller.rb
+++ b/app/controllers/find/candidates/saved_courses_controller.rb
@@ -2,9 +2,10 @@ module Find
   module Candidates
     class SavedCoursesController < ApplicationController
       before_action :require_authentication
-      before_action :set_candidate
 
-      def index; end
+      def index
+        @saved_courses = @candidate.saved_courses
+      end
 
       def create
         course = Course.find(params[:course_id])
@@ -28,10 +29,6 @@ module Find
       end
 
     private
-
-      def set_candidate
-        @candidate = Current.user
-      end
 
       def redirect_to_course(course, error: nil)
         options = {

--- a/app/helpers/find/view_helper.rb
+++ b/app/helpers/find/view_helper.rb
@@ -9,7 +9,9 @@ module Find
     end
 
     def course_back_link
-      if referer.request_uri =~ %r{^/results}
+      if referer.request_uri =~ %r{^/candidate/saved-courses}
+        find_candidate_saved_courses_path
+      elsif referer.request_uri =~ %r{^/results}
         request.referer
       elsif referer && session[:results_path] =~ %r{^/results}
         session[:results_path]

--- a/app/views/find/candidates/saved_courses/_saved_course_row.html.erb
+++ b/app/views/find/candidates/saved_courses/_saved_course_row.html.erb
@@ -1,0 +1,40 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell app-saved-course__cell">
+    <% if saved_course.course.is_withdrawn? %>
+      <div class="app-saved-course__cell-content">
+        <div>
+          <strong>
+            <span>
+              <%= saved_course.course.provider_name %>
+            </span>
+          </strong>
+          <span class="govuk-!-padding-left-2"><%= saved_course.course.decorate.status_tag %></span><br>
+          <span class="govuk-body-s"><%= saved_course.course.name_and_code %></span>
+        </div>
+        <%= button_to t(".delete"),
+                      find_candidate_saved_course_path(saved_course),
+                      method: :delete,
+                      class: "app-button-link" %>
+      </div>
+    <% else %>
+      <%= govuk_link_to find_course_path(provider_code: saved_course.course.provider_code, course_code: saved_course.course.course_code),
+                        class: "app-saved-course__cell-link" do %>
+        <div class="app-saved-course__cell-content">
+          <div>
+            <strong>
+              <span class="govuk-link">
+                <%= saved_course.course.provider_name %>
+              </span>
+            </strong>
+            <span class="govuk-!-padding-left-2"><%= saved_course.course.decorate.status_tag %></span><br>
+            <span class="govuk-body-s"><%= saved_course.course.name_and_code %></span>
+          </div>
+          <%= button_to t(".delete"),
+                        find_candidate_saved_course_path(saved_course),
+                        method: :delete,
+                        class: "app-button-link" %>
+        </div>
+      <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/find/candidates/saved_courses/index.html.erb
+++ b/app/views/find/candidates/saved_courses/index.html.erb
@@ -1,2 +1,23 @@
-<%= content_for :page_title, title_with_error_prefix("Saved courses", flash[:error].present?) %>
-<%= "Hi #{@candidate.email_address} these are your saved courses" %>
+<%= content_for :page_title, title_with_error_prefix(t(".page_title"), flash[:error].present?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t(".page_title") %>
+    </h1>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <% if @saved_courses.any? %>
+      <table class="govuk-table">
+        <tbody class="govuk-table__body">
+          <% @saved_courses.each do |saved_course| %>
+            <%= render partial: "find/candidates/saved_courses/saved_course_row", locals: { saved_course: } %>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="govuk-body"><%= t(".no_saved_courses") %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -3,7 +3,7 @@
 <% if permitted_referrer? && course_back_link %>
   <%= content_for(:before_content) do %>
     <%= govuk_back_link(
-      text: t("find.courses.show.back_to_search"),
+      text: course_back_link == find_candidate_saved_courses_path ? t("find.courses.show.back_to_saved_courses") : t("find.courses.show.back_to_search"),
       href: course_back_link,
     ) %>
   <% end %>

--- a/config/locales/en/find/candidates/saved_course_row.yml
+++ b/config/locales/en/find/candidates/saved_course_row.yml
@@ -1,0 +1,6 @@
+en:
+  find:
+    candidates:
+      saved_courses:
+        saved_course_row:
+          delete: Delete

--- a/config/locales/en/find/candidates/saved_courses.yml
+++ b/config/locales/en/find/candidates/saved_courses.yml
@@ -2,6 +2,9 @@ en:
   find:
     candidates:
       saved_courses:
+        index:
+          page_title: Saved courses
+          no_saved_courses: You have no saved courses.
         create:
           save_failed: Failed to save course
         destroy:

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -135,5 +135,6 @@ en:
         not_consider_a_level_equivalency: We will not consider candidates who need to take A level equivalency tests.
       show:
         back_to_search: Back to search results
+        back_to_saved_courses: Back to saved courses
         training_with_disabilities: Training with disabilities
         training_with_disabilities_link: Find out about training with disabilities and other needs at %{provider_name}.

--- a/spec/system/find/candidates/view_saved_courses_spec.rb
+++ b/spec/system/find/candidates/view_saved_courses_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Viewing my saved courses", service: :find do
+  before do
+    FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_auth
+    given_a_published_course_exists
+  end
+
+  scenario "A candidate can view their saved courses" do
+    when_i_log_in_as_a_candidate
+    when_i_have_saved_courses
+
+    then_i_visit_my_saved_courses
+
+    then_i_view_my_saved_courses
+    then_the_back_link_takes_me_back_to_the_saved_courses_page
+  end
+
+  scenario "A candidate can view the saved courses page with no saved courses" do
+    when_i_log_in_as_a_candidate
+    then_i_visit_my_saved_courses
+
+    then_i_see_no_saved_courses_message
+  end
+
+  def then_i_see_no_saved_courses_message
+    expect(page).to have_content("You have no saved courses.")
+  end
+
+  def then_i_view_my_saved_courses
+    within(all(".govuk-table__row").first) do
+      expect(page).to have_content(@course.provider.provider_name)
+      expect(page).to have_content(@course.name)
+      expect(page).to have_content(@course.course_code)
+      expect(page).to have_content("Delete")
+
+      expect(page).to have_link(
+        @course.provider.provider_name,
+        href: find_course_path(
+          provider_code: @course.provider_code,
+          course_code: @course.course_code,
+        ),
+      )
+    end
+  end
+
+  def then_the_back_link_takes_me_back_to_the_saved_courses_page
+    click_link_or_button @course.provider.provider_name
+    expect(page).to have_link("Back to saved courses", href: find_candidate_saved_courses_path)
+  end
+
+  def when_i_log_in_as_a_candidate
+    visit "/"
+    click_link_or_button "Sign in"
+    expect(page).to have_content("You have been successfully signed in.")
+  end
+
+  def then_i_visit_my_saved_courses
+    click_link_or_button "Saved courses"
+  end
+
+  def when_i_have_saved_courses
+    candidate = Candidate.first
+    @saved_courses = create(:saved_course, course: @course, candidate: candidate)
+  end
+
+  def given_a_published_course_exists
+    @course = create(
+      :course,
+      :with_full_time_sites,
+      :secondary,
+      :with_special_education_needs,
+      :published,
+      :open,
+      name: "Art and design (SEND)",
+      course_code: "F314",
+      provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
+      subjects: [find_or_create(:secondary_subject, :art_and_design)],
+    )
+  end
+end


### PR DESCRIPTION
## Context

This PR attends to two tickets: 

https://trello.com/c/gcBvVWee/704-3-7-add-ability-to-view-saved-courses
https://trello.com/c/XuTzCdPl/706-5-7-add-ability-to-see-when-a-saved-course-is-closed-or-withdrawn

Figma: https://www.figma.com/proto/MI3inIeITiJWfp1irGNnI6/Find?page-id=235%3A9866&node-id=791-5203&p=f&viewport=242%2C-320%2C0.14&t=DLgQdPKYAdrWZp69-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=235%3A9867

## Changes proposed in this pull request

By visits `candidate/saved-courses` we can now see a list of saved courses. With a link to the course, as well as tags indicating if a course is withdrawn or closed. The Delete functionality works but is not the final implementation, this is covered in another ticket. In addition the back link on the show courses page will change text and take the user back to the saved courses page if they originally came from there to view the course.

## Guidance to review
<img width="1012" alt="Screenshot 2025-06-27 at 10 32 08" src="https://github.com/user-attachments/assets/4d953035-6832-413d-abf1-daa57b3e0145" />

Save some courses. Then visit the saved courses page to view all saved courses


