### PR TITLE
CI linting should always run on main branch

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,15 +20,18 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     # Run if:
-    # - It's not a PR
+    # - It's main branch
     # - It is a PR, don't run if it has a prototype label
     # - It is a PR, don't run on opened if it has a deploy label
     if: |
-        github.event_name == 'pull_request' &&
-        !contains(github.event.pull_request.labels.*.name, 'prototype') &&
+        github.ref == 'refs/heads/main' ||
         (
-          github.event.action != 'opened' ||
-          !contains(github.event.pull_request.labels.*.name, 'deploy')
+          github.event_name == 'pull_request' &&
+          !contains(github.event.pull_request.labels.*.name, 'prototype') &&
+          (
+            github.event.action != 'opened' ||
+            !contains(github.event.pull_request.labels.*.name, 'deploy')
+          )
         )
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Context

I changed when the lint job runs in our CI workflows recently to prevent it running on the pull_request opened event if and when the label deploy was added to prevent the build running on "opened" and "labeled".

I did not sepcify that lint should always happen on the main branch and now the build isn't running when we merge PRs.

## Changes proposed in this pull request

Always run lint job in CI on the main branch

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
