### PR TITLE
Candidate can Sign In via One Login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem "govuk_design_system_formbuilder", "~> 5.10"
 
 # DfE Sign-In
 gem "omniauth", "~> 2.1"
-gem "omniauth_govuk_one_login"
+gem "omniauth_govuk_one_login", github: "pauldougan/omniauth-govuk-one-login", ref: "aee3e10c5d4c6dbe855059198283ced16acec91f"
 gem "omniauth_openid_connect", "~> 0.8"
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,7 @@ gem "govuk_design_system_formbuilder", "~> 5.10"
 
 # DfE Sign-In
 gem "omniauth", "~> 2.1"
+gem "omniauth_govuk_one_login"
 gem "omniauth_openid_connect", "~> 0.8"
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,16 @@ GIT
       actionpack
       railties
 
+GIT
+  remote: https://github.com/pauldougan/omniauth-govuk-one-login.git
+  revision: aee3e10c5d4c6dbe855059198283ced16acec91f
+  ref: aee3e10c5d4c6dbe855059198283ced16acec91f
+  specs:
+    omniauth_govuk_one_login (1.3.0)
+      faraday (~> 2.13)
+      jwt (~> 2.10)
+      omniauth (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -466,10 +476,6 @@ GEM
     omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    omniauth_govuk_one_login (1.3.0)
-      faraday (~> 2.13)
-      jwt (~> 2.10)
-      omniauth (~> 2.1)
     omniauth_openid_connect (0.8.0)
       omniauth (>= 1.9, < 3)
       openid_connect (~> 2.2)
@@ -849,7 +855,7 @@ DEPENDENCIES
   oj
   omniauth (~> 2.1)
   omniauth-rails_csrf_protection (~> 1.0)
-  omniauth_govuk_one_login
+  omniauth_govuk_one_login!
   omniauth_openid_connect (~> 0.8)
   open_api-rswag-api (= 0.2.0)!
   open_api-rswag-specs (= 0.2.0)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -466,6 +466,10 @@ GEM
     omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    omniauth_govuk_one_login (1.3.0)
+      faraday (~> 2.13)
+      jwt (~> 2.10)
+      omniauth (~> 2.1)
     omniauth_openid_connect (0.8.0)
       omniauth (>= 1.9, < 3)
       openid_connect (~> 2.2)
@@ -845,6 +849,7 @@ DEPENDENCIES
   oj
   omniauth (~> 2.1)
   omniauth-rails_csrf_protection (~> 1.0)
+  omniauth_govuk_one_login
   omniauth_openid_connect (~> 0.8)
   open_api-rswag-api (= 0.2.0)!
   open_api-rswag-specs (= 0.2.0)!

--- a/app/components/govuk/one_login_header_component.rb
+++ b/app/components/govuk/one_login_header_component.rb
@@ -28,7 +28,11 @@ module Govuk
     end
 
     def path
-      "/auth/find-developer"
+      if Settings.one_login.enabled
+        "/auth/one-login"
+      else
+        "/auth/find-developer"
+      end
     end
   end
 end

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -18,31 +18,11 @@ module Find
         redirect_to find_root_path
       end
 
-      # We render this action when an authentication error occurs
-      #
-      # request.env["omniauth.error"] # => #<JWT::EncodeError: The given key is a String. It has to be an OpenSSL::PKey::RSA instance>,
-      # request.env["omniauth.error.type"] # => :"The given key is a String. It has to be an OpenSSL::PKey::RSA instance",
-      # request.env["omniauth.error.strategy"] # => #<OmniAuth::Strategies::GovukOneLogin>
       def failure
-        exception = request.env["omniauth.error"]
-        strategy = request.env["omniauth.error.strategy"]
-        error_type = request.env["omniauth.error.type"]
-
-        if exception
-          Sentry.capture_exception(exception, extra: {
-            provider: strategy&.name,
-            error_type: error_type,
-          })
-        elsif error_type
-          Sentry.capture_message("OmniAuth failure without exception", extra: {
-            error_type:,
-          })
-        elsif params[:message]
-          Sentry.capture_message("OmniAuth failure without exception", extra: {
-            error_type: params[:message],
-            provider: params[:provider],
-          })
-        end
+        Sentry.capture_message("One Login failure", extra: {
+          error_type: params[:message],
+          provider: params[:provider],
+        })
 
         render "errors/omniauth"
       end

--- a/app/javascript/find/one-login-header.js
+++ b/app/javascript/find/one-login-header.js
@@ -90,7 +90,7 @@ function initCrossServiceHeader () {
     "[data-module='one-login-header']"
   )
   if (oneLoginHeader && CrossServiceHeader) {
-    new CrossServiceHeader(oneLoginHeader) // eslint-disable-line
+    new CrossServiceHeader(oneLoginHeader); // eslint-disable-line
   }
 }
 /**

--- a/app/lib/authentications/candidate_config.rb
+++ b/app/lib/authentications/candidate_config.rb
@@ -1,0 +1,63 @@
+module Authentications
+  class CandidateConfig
+    attr_reader :provider
+
+    def initialize
+      @provider = set_provider
+    end
+
+    def options
+      if one_login?
+        {
+          name: :"one-login",
+          client_id: Settings.one_login.identifier,
+          idp_base_url: Settings.one_login.idp_base_url,
+          # scope: "openid,email", # default
+          # vtr: ["Cl.Cm"], # default
+          redirect_uri:,
+          private_key:,
+        }
+      elsif Rails.env.local?
+        {
+          name: "find-developer",
+          fields: %i[uid email],
+          uid_field: :uid,
+          path_prefix: "/auth",
+          callback_path: "/auth/find-developer/callback",
+        }
+      end
+    end
+
+  private
+
+    def one_login?
+      Settings.one_login.enabled
+    end
+
+    def set_provider
+      if Settings.one_login.enabled
+        :govuk_one_login
+      elsif Rails.env.local?
+        :find_developer
+      end
+    end
+
+    def redirect_uri
+      # Generate callback URL for any environment
+      host = URI(Settings.find_url).host
+      port = Rails.env.development? && "3001"
+      path = "/auth/one-login/callback"
+      protocol = Rails.env.local? ? URI::HTTP : URI::HTTPS
+      protocol.build(host:, port:, path:).to_s
+    end
+
+    def private_key
+      # Load private key from environment variable
+      OpenSSL::PKey::RSA.new(Settings.one_login.private_key.gsub('\n', "\n"))
+    rescue StandardError => e
+      Sentry.capture_exception(e)
+      Rails.logger.error(e)
+      nil
+    end
+  end
+end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -56,6 +56,7 @@ if Settings.one_login.enabled
   begin
     private_key = OpenSSL::PKey::RSA.new(Settings.one_login.private_key.gsub('\n', "\n"))
   rescue StandardError => e
+    Sentry.capture_exception(e)
     Rails.logger.error(e)
   end
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -42,8 +42,17 @@ else
 end
 
 if Settings.one_login.enabled
-  URI.parse(Settings.one_login.idp_base_url)
-  one_login_redirect_uri = URI.join("http://find.localhost:3001/auth/one-login/callback")
+  # Generate callback URL for any environment
+  host = URI(Settings.find_url).host
+  port = Rails.env.development? && "3001"
+  path = "/auth/one-login/callback"
+  one_login_redirect_uri = if Rails.env.local?
+                             URI::HTTP.build(host:, port:, path:)
+                           else
+                             URI::HTTPS.build(host:, port:, path:)
+                           end
+
+  # Load private key from environment variable
   begin
     private_key = OpenSSL::PKey::RSA.new(Settings.one_login.private_key.gsub('\n', "\n"))
   rescue StandardError => e

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -71,11 +71,6 @@ if Settings.one_login.enabled
 
   Rails.application.config.middleware.use OmniAuth::Builder do
     provider :govuk_one_login, options
-
-    # will call `Users::OmniauthController#failure` if there are any errors during the login process
-    on_failure do |env|
-      Find::Authentication::SessionsController.action(:failure).call(env)
-    end
   end
 elsif Rails.env.in?(%w[development test])
   Rails.application.config.middleware.use OmniAuth::Builder do
@@ -85,8 +80,5 @@ elsif Rails.env.in?(%w[development test])
              uid_field: :uid,
              path_prefix: "/auth",
              callback_path: "/auth/find-developer/callback")
-    on_failure do |env|
-      Find::Authentication::SessionsController.action(:failure).call(env)
-    end
   end
 end

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -34,6 +34,8 @@ namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host 
     scope module: "authentication" do
       resource :sessions, path: "auth", only: %i[] do
         get ":provider/callback", action: :callback
+
+        get "/failure", to: "sessions#failure"
       end
       delete "/sign-out", to: "sessions#destroy"
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,6 +54,18 @@ authentication:
   # mode: magic_link  # when dfe_signin is down
   # mode: persona     # none critical systems, ie localhost
 
+one_login:
+  enabled: true
+  # Integration client id in One Login
+  identifier: <%= ENV.fetch('ONE_LOGIN_CLIENT_ID', 'client_id') %>
+  # URL that the users are redirected to for signing in
+  idp_base_url: https://oidc.integration.account.gov.uk/
+  # URL of the users profile
+  profile_url: https://home.oidc.integration.account.gov.uk
+  # YAML doesn't preserve newlines. Convert newlines to \n
+  # Then convert them back to newlines for OpenSSL
+  private_key: <%= ENV.fetch('ONE_LOGIN_PRIVATE_KEY', 'private_key').gsub("\n", '\n') %>
+
 current_recruitment_cycle_year: 2025
 next_cycle_open_date: 2025-10-1 # TBC
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -28,6 +28,13 @@ dfe_signin:
   profile: https://profile.signin.education.gov.uk
   user_search_url: https://support.signin.education.gov.uk/users
 
+one_login:
+  enabled: false
+  # URL that the users are redirected to for signing in
+  idp_base_url: https://oidc.account.gov.uk
+  # URL of the users profile
+  profile_url: https://home.oidc.account.gov.uk
+
 bg_jobs:
   save_statistic:
     cron: "0 0 * * *" # daily at midnight

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -30,4 +30,7 @@ basic_auth:
   username: admin
   password: password
 
+one_login:
+  enabled: false
+
 STATE_CHANGE_SLACK_URL: https://example.com/webhook

--- a/spec/lib/authentications/candidate_config_spec.rb
+++ b/spec/lib/authentications/candidate_config_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+module Authentications
+  RSpec.describe CandidateConfig do
+    let(:config) { described_class.new }
+
+    describe "#provider" do
+      context "when Setting.one_login.enabled is false" do
+        before do
+          allow(Settings.one_login).to receive(:enabled).and_return(false)
+        end
+
+        it "sets provider to :find_developer" do
+          expect(config.provider).to eq(:find_developer)
+        end
+      end
+
+      context "when Setting.one_login.enabled is true" do
+        before do
+          allow(Settings.one_login).to receive(:enabled).and_return(true)
+        end
+
+        it "sets provider to :govuk_one_login" do
+          expect(config.provider).to eq(:govuk_one_login)
+        end
+      end
+    end
+
+    describe "#options" do
+      context "when one_login" do
+        before do
+          allow(Settings.one_login).to receive(:enabled).and_return(true)
+        end
+
+        it "sets provider to :govuk_one_login" do
+          expected = {
+            name: :"one-login",
+            client_id: Settings.one_login.identifier,
+            idp_base_url: Settings.one_login.idp_base_url,
+            redirect_uri: "http://find.localhost/auth/one-login/callback",
+            private_key: nil,
+          }
+          expect(config.options).to eq(expected)
+        end
+      end
+
+      context "when find_developer" do
+        before do
+          allow(Settings.one_login).to receive(:enabled).and_return(false)
+        end
+
+        it "sets provider to :govuk_one_login" do
+          expected = {
+            name: "find-developer",
+            fields: %i[uid email],
+            uid_field: :uid,
+            path_prefix: "/auth",
+            callback_path: "/auth/find-developer/callback",
+          }
+
+          expect(config.options).to eq(expected)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/find/authentication_error_spec.rb
+++ b/spec/requests/find/authentication_error_spec.rb
@@ -3,23 +3,23 @@
 require "rails_helper"
 
 RSpec.describe "Authentication error", service: :find, type: :request do
-  include OmniAuth::Test
-
   before do
     create(:find_developer_candidate)
+    FeatureFlag.activate(:candidate_accounts)
 
     CandidateAuthHelper.mock_error_auth
   end
 
   describe "POST /auth/find-developer/callback" do
     it "triggers an error and renders the error page" do
-      allow(Sentry).to receive(:capture_exception)
-      allow(OmniAuth.config.failure_raise_out_environments).to receive(:include?).and_return(true)
+      allow(Sentry).to receive(:capture_message)
 
-      post "/auth/find-developer/callback", params: {}
+      post "/auth/find-developer/callback"
+      follow_redirect!
+
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Authentication error")
-      expect(Sentry).to have_received(:capture_exception)
+      expect(Sentry).to have_received(:capture_message)
     end
   end
 end


### PR DESCRIPTION
## Context

_Yesterday, July 1st, version all versions of the `omniauth-govuk-one-login` gem were yanked from RubyGems. I'm investeigating what is happening with this gem. For now, we're pulling the library in from the GitHub repo._

`Settings.one_login.enabled` must be true, for candidates can log in at `/auth/one-login`
If `Settings.one_login.enabled` is false, then candidates can log in at `/auth/find-developer`
This should never be true in Production.

|Environment| Settings.one_login.enabled|Details|
|---|---|---|
|Production|Yes|Obvious|
|Test|No|We cannot stub every request in system tests|
|Development|Can be|If you are testing the integration you can enable it. There will be documentation|
|Review|Can be|If you are testing the integration you can enable it. There will be documentation|


### Instructions will be added to documentation as part of this outcome

_This is informational only, this is all setup for the review app._

1. Create an integration environment [here](https://admin.sign-in.service.gov.uk/)
2. Create a key pair
3. Put the public key in the admin tool
4. Set the private key in the application with `export ONE_LOGIN_PRIVATE_KEY="$(cat private_key.pem)"`
5. Add redirect url to `http://find.localhost:3001/auth/one-login/callback` in the admin tool

### Update to how we handle errors.

Remove the `on_failure` callback and instead rely on OmniAuth redirecting errors to `/auth/failure` with a query string including `?message=some_error_happened&provider=one-login`



### Testing
This is the part I have spent most time on. I'm not totally sure how much I need to test.
OmniAuth doesn't really have a method for testing the strategy with you're application.

OmniAuth allows you to generate an error response which will render the `/auth/failure` endpoint with relevant params.
This is the best I think we can hope for. I've changed the error handling to depend directly on this functionality because I feel I couldn't test the `on_failure` callback as well as I'd like.


## Changes proposed in this pull request

Allow users to sign in to Find as a Candidate authenticated by One Login.


## What this is not
 - Logout of One login
 - Recognise email changed for the user on login
 - check if user is already logged into One Login

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello

https://trello.com/c/3S0Q1nV9/823-sign-up-sign-in-with-one-login

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
