### PR TITLE
Enable early access for support users during rollover (Part 3)

### DIFF
--- a/app/components/support_title_bar.rb
+++ b/app/components/support_title_bar.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class SupportTitleBar < ViewComponent::Base
+  attr_reader :current_user
+
+  def initialize(current_user:)
+    super
+
+    @current_user = current_user
+  end
+
 private
 
   def title
@@ -20,7 +28,7 @@ private
   end
 
   def rollover_active?
-    RecruitmentCycle.next_editable_cycles?
+    RolloverPeriod.active?(current_user:)
   end
 
   def recruitment_cycle_year

--- a/app/components/title_bar.rb
+++ b/app/components/title_bar.rb
@@ -43,7 +43,7 @@ private
   end
 
   def rollover_active?
-    RecruitmentCycle.next_editable_cycles?
+    RolloverPeriod.active?(current_user:)
   end
 
   def current_recruitment_cycle_year

--- a/app/controllers/publish/application_controller.rb
+++ b/app/controllers/publish/application_controller.rb
@@ -6,7 +6,7 @@ module Publish
     include SuccessMessage
 
     before_action :check_interrupt_redirects
-    before_action :clear_previous_cycle_year_in_session, unless: -> { RecruitmentCycle.next_editable_cycles? }
+    before_action :clear_previous_cycle_year_in_session, unless: -> { RecruitmentCycle.upcoming_cycles_open_to_publish? }
 
     # Protect every action of a provider
     before_action :authorize_provider

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -28,15 +28,9 @@ module Publish
     end
 
     def show
-      @cycle_year = session[:cycle_year] if session[:cycle_year].present?
+      @rollover_period = RolloverPeriod.new(current_user:)
 
-      if rollover_active?
-        if session[:cycle_year].present? && params[:switcher] != "true"
-          redirect_to publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
-        else
-          :show?
-        end
-      else
+      unless @rollover_period.active?
         redirect_to publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year)
       end
     end

--- a/app/controllers/support/recruitment_cycle_controller.rb
+++ b/app/controllers/support/recruitment_cycle_controller.rb
@@ -3,7 +3,9 @@
 module Support
   class RecruitmentCycleController < ApplicationController
     def index
-      redirect_to support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year) unless RecruitmentCycle.next_editable_cycles?
+      @rollover_period = RolloverPeriod.new(current_user:)
+
+      redirect_to support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year) unless @rollover_period.active?
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,7 +64,7 @@ module ApplicationHelper
   # rubocop:enable Rails/HelperInstanceVariable
 
   def dont_display_phase_banner_border?(user)
-    user && !user.admin? && user.providers.where(recruitment_cycle: RecruitmentCycle.current).one? && !RecruitmentCycle.next_editable_cycles?
+    user && !user.admin? && user.providers.where(recruitment_cycle: RecruitmentCycle.current).one? && !RecruitmentCycle.upcoming_cycles_open_to_publish?
   end
 
 private

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -42,7 +42,7 @@ module RecruitmentCycleHelper
   end
 
   def rollover_active?
-    RecruitmentCycle.next_editable_cycles?
+    RolloverPeriod.active?(current_user:)
   end
 
   def current_cycle_provider(provider)

--- a/app/helpers/title_bar_helper.rb
+++ b/app/helpers/title_bar_helper.rb
@@ -2,7 +2,7 @@
 
 module TitleBarHelper
   def render_title_bar?(current_user:, provider:)
-    current_user.has_multiple_providers_in_current_recruitment_cycle? || RecruitmentCycle.next_editable_cycles? || (current_user.admin? &&
+    current_user.has_multiple_providers_in_current_recruitment_cycle? || RecruitmentCycle.upcoming_cycles_open_to_publish? || (current_user.admin? &&
     provider)
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -93,7 +93,7 @@ class Provider < ApplicationRecord
   end
 
   def rolled_over?
-    RecruitmentCycle.next_editable_cycles?
+    RecruitmentCycle.upcoming_cycles_open_to_publish?
   end
 
   # the providers that this provider is an accredited_provider for

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -26,17 +26,22 @@ class RecruitmentCycle < ApplicationRecord
     alias_method :next, :next_recruitment_cycle
   end
 
-  def self.next_editable_cycles?
-    next_editable_cycles.exists?
+  def self.upcoming_cycles_open_to_publish?
+    upcoming_cycles_open_to_publish.exists?
   end
 
-  def self.current_and_next_editable_cycles
-    where(year: Settings.current_recruitment_cycle_year).or(next_editable_cycles)
+  def self.current_and_upcoming_cycles_open_to_publish
+    where(year: Settings.current_recruitment_cycle_year).or(upcoming_cycles_open_to_publish)
   end
 
-  scope :next_editable_cycles, lambda {
+  scope :upcoming_cycles_open_to_publish, lambda {
     where("application_start_date > ?", Date.current)
      .where("? BETWEEN available_in_publish_from AND application_start_date", Date.current)
+  }
+
+  scope :upcoming_cycles_open_to_support, lambda {
+    where("application_start_date > ?", Date.current)
+     .where("? BETWEEN available_for_support_users_from AND application_start_date", Date.current)
   }
 
   def previous

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@
 class User < ApplicationRecord
   include Discard::Model
   include PgSearch::Model
-  include RecruitmentCycleHelper
 
   before_save :downcase_email, :strip_email_whitespace
 
@@ -59,7 +58,7 @@ class User < ApplicationRecord
     next_recruitment_cycle_provider_codes = providers_to_remove
                                             .filter_map { |provider| provider.provider_code if provider.recruitment_cycle.current? }
 
-    return unless rollover_active? && !RecruitmentCycle.next.nil? && next_recruitment_cycle_provider_codes.any?
+    return unless !RecruitmentCycle.next.nil? && next_recruitment_cycle_provider_codes.any?
 
     next_cycle_providers = RecruitmentCycle.next_recruitment_cycle.providers.where(provider_code: next_recruitment_cycle_provider_codes)
     self.providers = providers - next_cycle_providers

--- a/app/services/rollover_period.rb
+++ b/app/services/rollover_period.rb
@@ -1,0 +1,38 @@
+# RolloverPeriod determines if there are upcoming recruitment cycles available
+# for the given user, considering their role (admin/support or publish).
+# It provides methods to check if rollover is active and to
+# fetch the relevant cycles for the given user.
+#
+class RolloverPeriod
+  attr_reader :current_user
+
+  def self.active?(current_user:)
+    new(current_user:).active?
+  end
+
+  def initialize(current_user:)
+    @current_user = current_user
+  end
+
+  def active?
+    next_cycles_available_for_support_users? || next_cycles_available_for_publish_users?
+  end
+
+  def next_recruitment_cycles
+    if current_user.admin?
+      RecruitmentCycle.upcoming_cycles_open_to_support
+    else
+      RecruitmentCycle.upcoming_cycles_open_to_publish
+    end
+  end
+
+private
+
+  def next_cycles_available_for_support_users?
+    current_user.admin? && RecruitmentCycle.upcoming_cycles_open_to_support.exists?
+  end
+
+  def next_cycles_available_for_publish_users?
+    RecruitmentCycle.upcoming_cycles_open_to_publish?
+  end
+end

--- a/app/services/user_associations_service/create.rb
+++ b/app/services/user_associations_service/create.rb
@@ -3,7 +3,6 @@
 module UserAssociationsService
   class Create
     include RecruitmentCycleHelper
-
     attr_reader :provider, :user, :all_providers
 
     class << self
@@ -74,6 +73,10 @@ module UserAssociationsService
       user_notification_preferences.update(
         enable_notifications: user_notification_preferences.enabled,
       )
+    end
+
+    def rollover_active?
+      RecruitmentCycle.upcoming_cycles_open_to_publish?
     end
   end
 end

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -42,7 +42,7 @@
     <% end %>
 
     <div class="govuk-width-container">
-      <%= render SupportTitleBar.new %>
+      <%= render SupportTitleBar.new(current_user:) %>
       <%= yield :breadcrumbs %>
     </div>
 

--- a/app/views/publish/pages/performance_dashboard.html.erb
+++ b/app/views/publish/pages/performance_dashboard.html.erb
@@ -16,7 +16,7 @@
   <%= tabs.with_tab(label: "Users") do %>
     <%= render partial: "publish/pages/performance_dashboard/users_tab" %>
   <% end %>
-  <% if RecruitmentCycle.next_editable_cycles? %>
+  <% if RecruitmentCycle.upcoming_cycles_open_to_publish? %>
     <%= tabs.with_tab(label: "Rollover") do %>
       <%= render partial: "publish/pages/performance_dashboard/rollover_tab" %>
     <% end %>

--- a/app/views/publish/recruitment_cycles/_show_during_rollover.html.erb
+++ b/app/views/publish/recruitment_cycles/_show_during_rollover.html.erb
@@ -7,12 +7,14 @@
   ) %>
   </li>
 
-  <% RecruitmentCycle.next_editable_cycles.each do |recruitment_cycle| %>
-    <li>
-        <%= govuk_link_to(
-        recruitment_cycle.year_range,
-        publish_provider_recruitment_cycle_path(@provider.provider_code, recruitment_cycle.year),
-      ) %>
-    </li>
+  <% @rollover_period.next_recruitment_cycles.each do |next_recruitment_cycle| %>
+    <% if next_recruitment_cycle.providers.exists?(provider_code: @provider.provider_code) %>
+      <li>
+          <%= govuk_link_to(
+          next_recruitment_cycle.year_range,
+          publish_provider_recruitment_cycle_path(@provider.provider_code, next_recruitment_cycle.year),
+        ) %>
+      </li>
+    <% end %>
   <% end %>
 </ul>

--- a/app/views/support/recruitment_cycle/index.html.erb
+++ b/app/views/support/recruitment_cycle/index.html.erb
@@ -6,16 +6,17 @@
   <li>
     <%= govuk_link_to(
           "#{current_recruitment_cycle_period_text} - current",
-          support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year),
+          support_recruitment_cycle_providers_path(RecruitmentCycle.current.year),
           data: { qa: "provider__courses__current_cycle" },
         ) %>
   </li>
 
+  <% @rollover_period.next_recruitment_cycles.each do |next_recruitment_cycle| %>
     <li>
       <%= govuk_link_to(
-            next_recruitment_cycle_period_text.to_s,
-            support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year + 1),
-            data: { qa: "provider__courses__next_cycle" },
+            next_recruitment_cycle.year_range,
+            support_recruitment_cycle_providers_path(next_recruitment_cycle.year),
           ) %>
     </li>
-    </ul>
+  <% end %>
+</ul>

--- a/app/views/support/recruitment_cycles/show.html.erb
+++ b/app/views/support/recruitment_cycles/show.html.erb
@@ -57,6 +57,19 @@
         <% end %>
 
         <% summary_list.with_row do |row| %>
+          <% row.with_key text: RecruitmentCycle.human_attribute_name(:available_for_support_users_from) %>
+          <% row.with_value text: l(@recruitment_cycle.available_for_support_users_from, format: :long) %>
+          <% if policy(@recruitment_cycle).edit? %>
+            <% row.with_action(
+              text: t("change"),
+              href: edit_support_recruitment_cycle_path(@recruitment_cycle),
+              visually_hidden_text: RecruitmentCycle.human_attribute_name(:available_for_support_users_from),
+              classes: ["govuk-link--no-visited-state"],
+            ) %>
+          <% end %>
+        <% end %>
+
+        <% summary_list.with_row do |row| %>
           <% row.with_key text: RecruitmentCycle.human_attribute_name(:available_in_publish_from) %>
           <% row.with_value text: l(@recruitment_cycle.available_in_publish_from, format: :long) %>
           <% if policy(@recruitment_cycle).edit? %>

--- a/spec/components/support_title_bar_spec.rb
+++ b/spec/components/support_title_bar_spec.rb
@@ -5,13 +5,15 @@ require "rails_helper"
 describe SupportTitleBar do
   alias_method :component, :page
 
-  context "not during rollover" do
+  let(:current_user) { build(:user, :admin) }
+
+  context "when not during rollover" do
     before do
-      render_inline(described_class.new)
+      render_inline(described_class.new(current_user:))
     end
 
     it "does not render the provided title" do
-      expect(component).to have_no_text("Recruitment cycle #{Settings.current_recruitment_cycle_year}")
+      expect(component).to have_no_text("Recruitment cycle #{RecruitmentCycle.current.year}")
     end
 
     it "does not render the recruitment cycle link" do
@@ -19,17 +21,18 @@ describe SupportTitleBar do
     end
   end
 
-  context "during rollover" do
+  context "when next cycle is available for support users" do
     before do
-      allow(RecruitmentCycle).to receive(:next_editable_cycles?).and_return(true)
-      render_inline(described_class.new)
+      create(:recruitment_cycle, :next, available_for_support_users_from: 1.day.ago)
+      render_inline(described_class.new(current_user:))
     end
 
     it "renders the provided title" do
-      expect(component).to have_text("Recruitment cycle #{Settings.current_recruitment_cycle_year}")
+      expect(component).to have_text("Recruitment cycle #{RecruitmentCycle.current.year}")
     end
 
     it "renders the recruitment cycle link" do
+      expect(component).to have_text("Change recruitment cycle")
       expect(component.has_link?("Change recruitment cycle", href: "/support")).to be true
     end
   end

--- a/spec/components/title_bar_spec.rb
+++ b/spec/components/title_bar_spec.rb
@@ -10,7 +10,7 @@ describe TitleBar do
 
   context "single org users" do
     before do
-      allow(RecruitmentCycle).to receive(:next_editable_cycles?).and_return(false)
+      allow(RecruitmentCycle).to receive(:upcoming_cycles_open_to_publish?).and_return(false)
       render_inline(described_class.new(title:, current_user:, provider: provider_code))
     end
 
@@ -25,7 +25,7 @@ describe TitleBar do
 
   context "single org users during rollover" do
     before do
-      allow(RecruitmentCycle).to receive(:next_editable_cycles?).and_return(true)
+      allow(RecruitmentCycle).to receive(:upcoming_cycles_open_to_publish?).and_return(true)
       render_inline(described_class.new(title:, current_user:, provider: provider_code))
     end
 


### PR DESCRIPTION
## Context

During the course rollover process, support users need the ability to access next cycle course data in both the Support and Publish interfaces **before** it becomes available to general Publish users.

This requires a new date field in the recruitment cycle: "Available for Support Users Date".

Support users: Can see next cycle courses **in both Support and Publish interfaces** from this date.

Publish users: Can only see next cycle courses after the standard "Available in Publish From" date.

## Changes proposed in this pull request

This PR adds the links when they are available depending on the dates and the types of the user.

## Guidance to review

1. Visit support
2. Click Settings > Recruitment Cycles > Add recruitment cycle
3. Add 2026 cycle
4. Add the dates that the next cycle will be available for support users and publish users
5. If both in the future, nothing is available for anyone
6. Update the support users date to yesterday
7. Now next cycle is available to support users
8. Login as a publish user
9. The next cycle still not available for publish users
10. Update both dates again to be in the past
11. Login as a publish user again
12. Now next cycle is available
