### PR TITLE
Add rate limiting via front door

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -414,29 +414,29 @@ jobs:
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
           terraform-base: terraform/custom_domains/infrastructure
 
-  # deploy_domains_env:
-  #   name: Deploy Domains to ${{ matrix.domain_environment }} environment
-  #   runs-on: ubuntu-latest
-  #   if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-  #   concurrency: deploy_${{ matrix.domain_environment }}
-  #   needs: [deploy_domains_infra]
-  #   strategy:
-  #     max-parallel: 1
-  #     matrix:
-  #       domain_environment: [qa, staging, sandbox, production]
-  #   environment:
-  #     name: production
-  #   permissions:
-  #     id-token: write
+  deploy_domains_env:
+    name: Deploy Domains to ${{ matrix.domain_environment }} environment
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_${{ matrix.domain_environment }}
+    needs: [deploy_domains_infra]
+    strategy:
+      max-parallel: 1
+      matrix:
+        domain_environment: [qa, staging, sandbox, production]
+    environment:
+      name: production
+    permissions:
+      id-token: write
 
-  #   steps:
-  #     - name: Deploy Domains Environment
-  #       uses: DFE-Digital/github-actions/deploy-domains-env@master
-  #       with:
-  #         azure-client-id: ${{ secrets.AZURE_CLIENT_ID  }}
-  #         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID   }}
-  #         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
-  #         environment: ${{ matrix.domain_environment }}
-  #         healthcheck: healthcheck
-  #         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-  #         terraform-base: terraform/custom_domains/environment_domains
+    steps:
+      - name: Deploy Domains Environment
+        uses: DFE-Digital/github-actions/deploy-domains-env@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          environment: ${{ matrix.domain_environment }}
+          healthcheck: healthcheck
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+          terraform-base: terraform/custom_domains/environment_domains

--- a/terraform/custom_domains/environment_domains/main.tf
+++ b/terraform/custom_domains/environment_domains/main.tf
@@ -13,6 +13,9 @@ module "domains" {
   cached_paths          = try(each.value.cached_paths, [])
   exclude_cnames        = try(each.value.exclude_cnames, [])
   redirect_rules        = try(each.value.redirect_rules, null)
+  allow_aks             = try(var.allow_aks, false)
+  block_ip              = try(var.block_ip, false)
+  rate_limit_max        = try(var.rate_limit_max, false)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.

--- a/terraform/custom_domains/environment_domains/variables.tf
+++ b/terraform/custom_domains/environment_domains/variables.tf
@@ -7,3 +7,18 @@ variable "multiple_hosted_zones" {
   type = bool
   default = false
 }
+
+variable "allow_aks" {
+  type = bool
+  default = false
+}
+
+variable "block_ip" {
+  type = bool
+  default = false
+}
+
+variable "rate_limit_max" {
+  type = number
+  default = null
+}

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json
@@ -40,5 +40,8 @@
         "to-domain": "find-teacher-training-courses.service.gov.uk"
       }]
     }
-  }
+  },
+  "rate_limit_max": 1500,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_qa.tfvars.json
@@ -33,5 +33,8 @@
       "null_host_header": true,
       "redirect_rules": []
     }
-  }
+  },
+  "rate_limit_max": 1500,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_sandbox.tfvars.json
@@ -33,5 +33,8 @@
       "null_host_header": true,
       "redirect_rules": []
     }
-  }
+  },
+  "rate_limit_max": 1500,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/find_staging.tfvars.json
@@ -33,5 +33,8 @@
       "null_host_header": true,
       "redirect_rules": []
     }
-  }
+  },
+  "rate_limit_max": 1500,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_production.tfvars.json
@@ -20,5 +20,8 @@
         "to-domain": "www.publish-teacher-training-courses.service.gov.uk"
       }]
     }
-  }
+  },
+  "rate_limit_max": 1500,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_qa.tfvars.json
@@ -15,5 +15,8 @@
       "origin_hostname": "publish-qa.test.teacherservices.cloud",
       "null_host_header": true
     }
-  }
+  },
+  "rate_limit_max": 1500,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_sandbox.tfvars.json
@@ -15,5 +15,8 @@
       "origin_hostname": "publish-sandbox.teacherservices.cloud",
       "null_host_header": true
     }
-  }
+  },
+  "rate_limit_max": 1500,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/publish_staging.tfvars.json
@@ -15,5 +15,8 @@
       "origin_hostname": "publish-staging.test.teacherservices.cloud",
       "null_host_header": true
     }
-  }
+  },
+  "rate_limit_max": 1500,
+  "allow_aks": true,
+  "block_ip": true
 }


### PR DESCRIPTION
## Context

Add rate limiting via Azure Front Door 
- currently set at 1500 reqs per 5 minute period, and this has been active for production for months (applied manually)
- allows all AKS originated traffic
- sets a dummy block IP rule that can be enabled if required

## Changes proposed in this pull request

Add rate limit terraform variables and settings

## Guidance to review

make env domains-plan
Currently applied to several environments (prod/qa)

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
