### PR TITLE
Undo Changes to prototype deployment

### DIFF
--- a/.github/workflows/build-and-deploy-prototype.yml
+++ b/.github/workflows/build-and-deploy-prototype.yml
@@ -2,7 +2,12 @@ name: Build and Deploy Prototype
 concurrency: build_and_deploy_${{ github.ref_name }}
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
 
 permissions:
   contents: write


### PR DESCRIPTION
## Context

The github action for prototypes was changed. The change meant that every deployment for prototypes had to be done manually. The issue is that if we do this certain values and triggers are not available such as `github.event.pull_request`. Because this action heavily leans on such events, it would require a rewrite of this action to make it manual.

This is currently not a priority of mine, I will add the rewrite of this to my ToDo, but it will most likely not get done before the new cycle.

## Changes proposed in this pull request

Undo previous changes to the prototype deployment

## Guidance to review

Please leave any comments or other options.

## Checklist

- [ ] Allow for prototypes to be deployed via pull request events
