### PR TITLE
Only show manually rollover button after is available to publish users

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -403,7 +403,7 @@ class Course < ApplicationRecord
   end
 
   def manually_rollable?
-    rollover_conditions = !rolled_over? && recruitment_cycle.next && recruitment_cycle == RecruitmentCycle.current
+    rollover_conditions = !rolled_over? && RecruitmentCycle.upcoming_cycles_open_to_publish? && recruitment_cycle == RecruitmentCycle.current
 
     rollover_conditions && %i[empty draft rolled_over].include?(content_status)
   end

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -64,6 +64,7 @@ feature "Course show" do
     scenario "published courses have a 'Scheduled' status" do
       given_there_is_a_next_recruitment_cycle
       given_i_am_authenticated_as_a_provider_user(course: build(:course))
+      and_there_is_the_provider_in_the_next_cycle
       when_i_visit_the_next_cycle_courses_page
       then_i_should_see_the_status_scheduled
     end
@@ -178,6 +179,8 @@ private
       year: next_year,
       application_start_date: Date.new(next_year - 1, 10, 1),
       application_end_date: Date.new(next_year, 9, 30),
+      available_for_support_users_from: 1.week.ago,
+      available_in_publish_from: 1.day.ago,
     )
   end
 
@@ -286,14 +289,19 @@ private
   end
 
   def given_i_am_authenticated_as_a_provider_user(course:)
-    given_i_am_authenticated(
-      user: create(
-        :user,
-        providers: [
-          create(:provider, sites: [build(:site)], courses: [course]),
-        ],
-      ),
+    @user = create(
+      :user,
+      providers: [
+        create(:provider, sites: [build(:site)], courses: [course]),
+      ],
     )
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_there_is_the_provider_in_the_next_cycle
+    provider = create(:provider, recruitment_cycle: RecruitmentCycle.next, provider_code: @user.providers.first.provider_code, courses: [build(:course, :published)])
+
+    @user.providers << provider
   end
 
   def when_i_visit_the_course_page

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -523,6 +523,46 @@ describe Course do
       end
     end
 
+    describe "#manually_rollable?" do
+      context "when next cycle is available for publish users" do
+        before do
+          create(:recruitment_cycle, :next, available_in_publish_from: 1.day.ago)
+        end
+
+        it "returns true" do
+          expect(create(:course)).to be_manually_rollable
+        end
+      end
+
+      context "when next cycle is available for publish users but course was already rolled over" do
+        let(:course) { create(:course) }
+
+        before do
+          next_recruitment_cycle = create(:recruitment_cycle, :next, available_in_publish_from: 1.day.ago)
+
+          create(
+            :course,
+            course_code: course.course_code,
+            provider: create(:provider, recruitment_cycle: next_recruitment_cycle, provider_code: course.provider.provider_code),
+          )
+        end
+
+        it "returns false" do
+          expect(course).not_to be_manually_rollable
+        end
+      end
+
+      context "when next cycle is not available for publish users" do
+        before do
+          create(:recruitment_cycle, :next, available_in_publish_from: 1.day.from_now)
+        end
+
+        it "returns false" do
+          expect(create(:course)).not_to be_manually_rollable
+        end
+      end
+    end
+
     describe "publishable?" do
       context "invalid enrichment" do
         let(:course) { create(:course, enrichments: [invalid_enrichment]) }


### PR DESCRIPTION


## Context

Do not show the button "Roll over course" for publish users if "today's date" is before the recruitment cycle date that is available for publish users.

## Changes proposed in this pull request

Only shows the button after the date is available for publish users.

<img width="606" alt="Screenshot 2025-07-01 at 11 51 12" src="https://github.com/user-attachments/assets/87b57bfc-3e86-41b3-a2a7-1703bda4ffed" />

## Guidance to review

1. Run the rollover
2. Enter as provider user 
3. Enter on a provider page **on the current 2025 cycle**
4. See a rolled over courses from the current cycle (this course can be rolled over to the next cycle)
5. The button "Rollover course" should only appear after the recruitment_cycle.available_in_publish_from date.
