### PR TITLE
Remove bug: Unexpected content when changing Modern Foreign language course in Publish

### DIFF
--- a/app/views/publish/courses/modern_languages/_form_fields.html.erb
+++ b/app/views/publish/courses/modern_languages/_form_fields.html.erb
@@ -1,7 +1,6 @@
 <%= render "publish/shared/error_wrapper", error_keys: [:modern_languages_subjects], data_qa: "course__modern_languages_subjects" do %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-    <%= render CaptionText.new(text: t("course.add_course")) %>
       <h1 class="govuk-fieldset__heading" data-qa="page-heading">
         <% if course.course_code %>
           <span class="govuk-caption-l"><%= course.name_and_code %></span>

--- a/app/views/publish/courses/modern_languages/edit.html.erb
+++ b/app/views/publish/courses/modern_languages/edit.html.erb
@@ -24,7 +24,6 @@
     <%= form_with model: course,
                   url: modern_languages_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
                   method: :put do |form| %>
-      <%= render "publish/shared/error_messages", error_keys: [:modern_languages_subjects] %>
 
       <%= render "publish/shared/course_creation_hidden_fields",
         form:,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -604,7 +604,7 @@ en:
               course_creation: "^Select a subject"
               duplicate: "^The second subject must be different to the first subject"
             modern_languages_subjects:
-              select_a_language: "^Select at least one language"
+              select_a_language: "Select at least one language"
             study_mode:
               blank: "^Select a study mode"
             applications_open_from:


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/nEFiztVI/779-bug-unexpected-content-when-changing-modern-foreign-language-course-in-publish

On the Modern Foreign Language course page in Publish there are a few things that need to be removed/edited:
1. There is an extra caption on the page saying 'Add course' which should not be there
2. There is a ^ symbol in both the error summary at the top and in the error message with the label
3.  There is an additional error message above the caption and H1 which should not be there

## Changes proposed in this pull request

- remove the ^ symbol from error message in locale file
- remove the rendering of `error_messages` partial on the page which appears to add an additional error message which is not needed. The error message now only appears in the error summary and with the form label when a user does not select at least one language
- remove `CaptionText` from `form_fields` partial so that 'Add course' is not displayed when changing an existing course

'Add course' has been removed from the language selection page:
<img width="621" alt="Screenshot 2025-07-02 at 13 05 47" src="https://github.com/user-attachments/assets/29b21809-010e-48f4-9f19-bcf7db26f89b" />

The additional error message above the main content has been removed as well as the ^ symbol:
<img width="864" alt="Screenshot 2025-07-02 at 13 06 21" src="https://github.com/user-attachments/assets/b9919732-ce0d-4a3a-9cb0-b3e1e0cdbe8e" />

## Guidance to review

- In Publish select a modern foreign language course from any provider
- Click on 'Basic details' tab
- On the subject row, click 'Change'
- Then click 'Update subject' on the next page
- QA: When changing an existing course, the caption on the Languages selection page should be of the course name and course code, and not display 'Add course'.
- QA: to check error messages, deselect all languages and click 'Save and publish changes'. When getting the error message, it should not contain the ^ symbol, and should only have the error message in the error summary and with the form label.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
