### PR TITLE
Im/fix omniauth load error

### DIFF
--- a/app/lib/authentications/candidate_config.rb
+++ b/app/lib/authentications/candidate_config.rb
@@ -28,6 +28,10 @@ module Authentications
       end
     end
 
+    def config
+      yield self if block_given? && @provider.present?
+    end
+
   private
 
     def one_login?

--- a/app/lib/authentications/candidate_omni_auth.rb
+++ b/app/lib/authentications/candidate_omni_auth.rb
@@ -1,5 +1,5 @@
 module Authentications
-  class CandidateConfig
+  class CandidateOmniAuth
     attr_reader :provider
 
     def initialize

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../../app/services/publish/authentication_service"
-require_relative "../../app/lib/authentications/candidate_config"
+require_relative "../../app/lib/authentications/candidate_omni_auth"
 
 OmniAuth.config.logger = Rails.logger
 
@@ -43,8 +43,7 @@ else
 end
 
 # Find / Candidate inteface authentication
-Authentications::CandidateConfig.new.config do |config|
-
+Authentications::CandidateOmniAuth.new.config do |config|
   Rails.application.config.middleware.use OmniAuth::Builder do
     provider config.provider, config.options
   end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -43,7 +43,8 @@ else
 end
 
 # Find / Candidate inteface authentication
-Authentications::CandidateConfig.new.tap do |config|
+Authentications::CandidateConfig.new.config do |config|
+
   Rails.application.config.middleware.use OmniAuth::Builder do
     provider config.provider, config.options
   end

--- a/spec/lib/authentications/candidate_omni_auth_spec.rb
+++ b/spec/lib/authentications/candidate_omni_auth_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 module Authentications
-  RSpec.describe CandidateConfig do
-    let(:config) { described_class.new }
+  RSpec.describe CandidateOmniAuth do
+    subject { described_class.new }
 
     describe "#provider" do
       context "when Setting.one_login.enabled is false" do
@@ -11,7 +11,7 @@ module Authentications
         end
 
         it "sets provider to :find_developer" do
-          expect(config.provider).to eq(:find_developer)
+          expect(subject.provider).to eq(:find_developer)
         end
       end
 
@@ -21,7 +21,7 @@ module Authentications
         end
 
         it "sets provider to :govuk_one_login" do
-          expect(config.provider).to eq(:govuk_one_login)
+          expect(subject.provider).to eq(:govuk_one_login)
         end
       end
     end
@@ -40,7 +40,7 @@ module Authentications
             redirect_uri: "http://find.localhost/auth/one-login/callback",
             private_key: nil,
           }
-          expect(config.options).to eq(expected)
+          expect(subject.options).to eq(expected)
         end
       end
 
@@ -58,7 +58,40 @@ module Authentications
             callback_path: "/auth/find-developer/callback",
           }
 
-          expect(config.options).to eq(expected)
+          expect(subject.options).to eq(expected)
+        end
+      end
+    end
+
+    describe "#config" do
+      context "when Setting.one_login.enabled is false and env is not local" do
+        before do
+          allow(Settings.one_login).to receive(:enabled).and_return(false)
+          allow(Rails.env).to receive(:local?).and_return(false)
+        end
+
+        it "does not yield" do
+          expect { |b| subject.config(&b) }.not_to yield_control
+        end
+      end
+
+      context "when Setting.one_login.enabled is false and env is local" do
+        before do
+          allow(Settings.one_login).to receive(:enabled).and_return(false)
+        end
+
+        it "does yield" do
+          expect { |b| subject.config(&b) }.to yield_control
+        end
+      end
+
+      context "when Setting.one_login.enabled is true" do
+        before do
+          allow(Settings.one_login).to receive(:enabled).and_return(true)
+        end
+
+        it "sets provider to :govuk_one_login" do
+          expect(subject.provider).to eq(:govuk_one_login)
         end
       end
     end


### PR DESCRIPTION
## Context

When the applicaiton loads in production, there is no matching OmniAuth config for Candidate initialization.
This is preventing the deploy from succeeding in non-local environments

## Changes proposed in this pull request

Add #config method that yields the determined configuration _if_ there is a valid provider.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
