### PR TITLE
Handle email change for candidate accounts

### DIFF
--- a/app/controllers/concerns/find/authentication.rb
+++ b/app/controllers/concerns/find/authentication.rb
@@ -45,14 +45,14 @@ module Find
         user.sessions.create!(session_key: candidate_session, id_token: oauth.credentials.id_token, user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
           Current.session = session
         end
-        user.authentications.find_or_create_by(authenticable: user, provider: provider_map(oauth.provider), subject_key: oauth.uid)
       end
     end
 
     def provider_map(provider)
       {
         "find-developer" => "developer",
-      }[provider]
+        "one-login" => "govuk_one_login",
+      }[provider.to_s]
     end
 
     def request_authentication

--- a/app/controllers/concerns/find/authentication.rb
+++ b/app/controllers/concerns/find/authentication.rb
@@ -48,13 +48,6 @@ module Find
       end
     end
 
-    def provider_map(provider)
-      {
-        "find-developer" => "developer",
-        "one-login" => "govuk_one_login",
-      }[provider.to_s]
-    end
-
     def request_authentication
       session["return_to_after_authenticating"] = request.url
 

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -3,8 +3,23 @@ module Find
     class SessionsController < ApplicationController
       def callback
         email_address = omniauth.info.email
-        if (candidate = Candidate.find_or_create_by(email_address:))
-          start_new_session_for candidate, omniauth
+        authentication = ::Authentication.find_by(subject_key: omniauth.uid)
+
+        if authentication.present?
+          candidate = authentication.authenticable
+          unless candidate.email_address.casecmp?(email_address)
+            candidate.update(email_address:)
+          end
+        else
+          Candidate.transaction do
+            candidate = Candidate.create(email_address:)
+
+            candidate.authentications.build(provider: provider_map(omniauth.provider), subject_key: omniauth.uid)
+            candidate.save!
+          end
+        end
+
+        if start_new_session_for candidate, omniauth
           flash[:success] = t(".sign_in")
           redirect_to(session["return_to_after_authenticating"] || find_root_path, allow_remote_host: false)
         else

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -6,6 +6,13 @@ class Authentication < ApplicationRecord
   validates :authenticable, :provider, :subject_key, presence: true
   validate :unique_authenticable_with_provider
 
+  def self.provider_map(provider)
+    {
+      "find-developer" => "developer",
+      "one-login" => "govuk_one_login",
+    }[provider.to_s]
+  end
+
 private
 
   def unique_authenticable_with_provider

--- a/app/services/find/candidate_authenticator.rb
+++ b/app/services/find/candidate_authenticator.rb
@@ -9,25 +9,46 @@ module Find
     # 1. Find existing Candidate via provider authentication
     # 2. Update Candidate email if it has changed
     # 3. Create a new candidate if one does not exist yet
+    # @return Candidate
     def call
-      email_address = oauth.info.email
-      authentication = ::Authentication.find_by(subject_key: oauth.uid)
-
       if authentication.present?
-        candidate = authentication.authenticable
+        sign_in!
+      else
+        sign_up!
+      end
+    end
+
+  private
+
+    # @return Candidate
+    def sign_up!
+      candidate = nil
+      Candidate.transaction do
+        candidate = Candidate.create(email_address:)
+
+        provider = ::Authentication.provider_map(oauth.provider)
+        candidate.authentications.build(provider:, subject_key: oauth.uid)
+        candidate.save!
+      end
+      candidate
+    end
+
+    # @return Candidate
+    def sign_in!
+      authentication.authenticable.tap do |candidate|
         unless candidate.email_address.casecmp?(email_address)
           candidate.update(email_address:)
         end
-      else
-        Candidate.transaction do
-          candidate = Candidate.create(email_address:)
-
-          provider = ::Authentication.provider_map(oauth.provider)
-          candidate.authentications.build(provider:, subject_key: oauth.uid)
-          candidate.save!
-        end
       end
-      candidate
+    end
+
+    # @return Authentication
+    def authentication
+      @authentication ||= ::Authentication.find_by(subject_key: oauth.uid)
+    end
+
+    def email_address
+      oauth.info.email
     end
   end
 end

--- a/app/services/find/candidate_authenticator.rb
+++ b/app/services/find/candidate_authenticator.rb
@@ -1,0 +1,33 @@
+module Find
+  class CandidateAuthenticator
+    attr_reader :oauth
+
+    def initialize(oauth:)
+      @oauth = oauth
+    end
+
+    # 1. Find existing Candidate via provider authentication
+    # 2. Update Candidate email if it has changed
+    # 3. Create a new candidate if one does not exist yet
+    def call
+      email_address = oauth.info.email
+      authentication = ::Authentication.find_by(subject_key: oauth.uid)
+
+      if authentication.present?
+        candidate = authentication.authenticable
+        unless candidate.email_address.casecmp?(email_address)
+          candidate.update(email_address:)
+        end
+      else
+        Candidate.transaction do
+          candidate = Candidate.create(email_address:)
+
+          provider = ::Authentication.provider_map(oauth.provider)
+          candidate.authentications.build(provider:, subject_key: oauth.uid)
+          candidate.save!
+        end
+      end
+      candidate
+    end
+  end
+end

--- a/spec/factories/authentications.rb
+++ b/spec/factories/authentications.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     authenticable { create(:candidate) }
     subject_key { "urn:fdc:gov.uk:2022:FxfvtauQJr_igWuhWM1VammyaszsOfndSyGsgmibajM" }
     traits_for_enum :provider
-    provider { :govuk_one_login }
+    provider { :developer }
   end
 end

--- a/spec/factories/candidates.rb
+++ b/spec/factories/candidates.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
 
   factory :find_developer_candidate, parent: :candidate do
     email_address { "candidateemail@example.com" }
+    authentications { build_list(:authentication, 1, subject_key: "sign_in_user_id") }
   end
 end

--- a/spec/services/find/candidate_authenticator_spec.rb
+++ b/spec/services/find/candidate_authenticator_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Find
+  describe CandidateAuthenticator do
+    let(:oauth) do
+      CandidateAuthHelper.mock_auth
+    end
+
+    subject { described_class.new(oauth:) }
+
+    describe ".call" do
+      context "when no candidate exists yet" do
+        it "creates a new Candidate and Authentication" do
+          expect { subject.call }.to change(Candidate, :count).by(1).and(change(::Authentication, :count).by(1))
+        end
+      end
+
+      context "when candidate already exists" do
+        before { create(:find_developer_candidate) }
+
+        it "creates a new Candidate and Authentication" do
+          expect { subject.call }.to not_change(Candidate, :count).and(not_change(::Authentication, :count))
+        end
+      end
+
+      context "when candidate email changes" do
+        let(:oauth) do
+          CandidateAuthHelper.mock_auth(email_address: "different@example.com")
+        end
+
+        let!(:candidate) { create(:find_developer_candidate) }
+
+        it "updates the existing Candidate email address" do
+          expect { subject.call }.to change { candidate.reload.email_address }.to("different@example.com")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/candidate_auth_helper.rb
+++ b/spec/support/candidate_auth_helper.rb
@@ -1,14 +1,14 @@
 module CandidateAuthHelper
 module_function
 
-  def mock_auth
+  def mock_auth(email_address: "candidateemail@example.com")
     OmniAuth.config.mock_auth[:"find-developer"] = OmniAuth::AuthHash.new(
       {
         "provider" => "find-developer",
         "uid" => "sign_in_user_id",
         "info" => {
           "name" => "candidate test",
-          "email" => "candidateemail@example.com",
+          "email" => email_address,
         },
         "credentials" => {
           "id_token" => "id_token",
@@ -18,7 +18,7 @@ module_function
         },
         "extra" => {
           "raw_info" => {
-            "email" => "candidateemail@example.com",
+            "email" => email_address,
             "sub" => "sign_in_user_id",
           },
         },

--- a/spec/support/candidate_auth_helper.rb
+++ b/spec/support/candidate_auth_helper.rb
@@ -4,7 +4,7 @@ module_function
   def mock_auth
     OmniAuth.config.mock_auth[:"find-developer"] = OmniAuth::AuthHash.new(
       {
-        "provider" => "dfe",
+        "provider" => "find-developer",
         "uid" => "sign_in_user_id",
         "info" => {
           "name" => "candidate test",

--- a/spec/system/find/results_page/ordering_spec.rb
+++ b/spec/system/find/results_page/ordering_spec.rb
@@ -224,8 +224,6 @@ RSpec.describe "Search results ordering", :js, service: :find do
 private
 
   def result_titles
-    with_retry do
-      page.all(".govuk-summary-card__title").map { |element| element.text.split("\n").join(" ") }
-    end
+    page.all(".govuk-summary-card__title", minimum: 5).map { |element| element.text.split("\n").join(" ") }
   end
 end

--- a/spec/system/find/signin_with_different_email_spec.rb
+++ b/spec/system/find/signin_with_different_email_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Candidate Sign in" do
+  before do
+    FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_auth(email_address: new_email_address)
+  end
+
+  scenario "As a Candidate, I can log into and out of Find" do
+    when_i_visit_the_find_homepage
+
+    when_i_click_login
+
+    then_i_see_that_i_am_logged_in
+
+    when_i_click_logout
+    then_i_see_that_i_am_logged_out
+    and_the_candidate_email_address_is_updated
+  end
+
+  def when_i_visit_the_find_homepage
+    visit "/"
+  end
+
+  def when_i_click_login
+    click_link_or_button "Sign in"
+  end
+
+  def then_i_see_that_i_am_logged_in
+    expect(page).to have_content("You have been successfully signed in.")
+  end
+
+  def when_i_click_logout
+    click_link_or_button "Sign out"
+  end
+
+  def then_i_see_that_i_am_logged_out
+    expect(page).to have_no_content("You have been successfully signed in.")
+    expect(page).to have_content("You have been successfully signed out.")
+    expect(page).to have_button("Sign in")
+  end
+
+  def and_the_candidate_email_address_is_updated
+    expect(Candidate.last.email_address).to eq(new_email_address)
+  end
+
+  def new_email_address
+    @new_email_address = "updated@example.com"
+  end
+end


### PR DESCRIPTION
## Context

A Candidate user can change their email address in One Login.
If they do that, we want to be able to authenticate them correctly and update their email address in our system.

## Changes proposed in this pull request

Upon authentication, find the Authentication matching the subject_key of the One Login authentication hash.
Find the associated candidate. If the email does not match the auth hash, then update the email address.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello 

https://trello.com/c/52YVeMdS/825-one-login-account-can-change-email-and-keep-same-candidate-account

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
