### PR TITLE
Disable One Login in staging and sandbox

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -23,3 +23,6 @@ dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   profile: https://profile.signin.education.gov.uk
   user_search_url: https://support.signin.education.gov.uk/users
+
+one_login:
+  enabled: false

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -24,6 +24,9 @@ dfe_signin:
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   user_search_url: https://pp-support.signin.education.gov.uk/users
 
+one_login:
+  enabled: false
+
 bg_jobs:
   save_statistic:
     cron: "0 0 * * *" # daily at midnight


### PR DESCRIPTION
## Context

One Login is disabled in Production but not Staging and Sandbox.
We haven't installed the configuration for these environments yet.

## Changes proposed in this pull request

Disable One Login in Staging and Sandbox

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
