### PR TITLE
One Login backchannel logout

### DIFF
--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -1,6 +1,8 @@
 module Find
   module Authentication
     class SessionsController < ApplicationController
+      skip_before_action :verify_authenticity_token, only: %i[backchannel_logout]
+
       def callback
         candidate = Find::CandidateAuthenticator.new(oauth: omniauth).call
 

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -33,16 +33,12 @@ module Find
       end
 
       def backchannel_logout
-        return head :bad_request if params[:logout_token].blank?
+        response_status = BackchannelLogout.new(
+          params[:logout_token],
+          params[:provider],
+        ).call
 
-        uid = backchannel_logout_utility.get_sub(logout_token: params[:logout_token])
-
-        return head :bad_request if uid.blank?
-
-        authentication = ::Authentication.find_by!(subject_key: uid, provider: ::Authentication.provider_map(params[:provider]))
-
-        authentication.authenticable.sessions.destroy_all
-        head :ok
+        head response_status
       end
 
       def backchannel_logout_utility

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -39,7 +39,7 @@ module Find
 
         return head :bad_request if uid.blank?
 
-        authentication = ::Authentication.find_by!(subject_key: uid, provider: provider_map(params[:provider]))
+        authentication = ::Authentication.find_by!(subject_key: uid, provider: ::Authentication.provider_map(params[:provider]))
 
         authentication.authenticable.sessions.destroy_all
         head :ok

--- a/app/services/find/authentication/backchannel_logout.rb
+++ b/app/services/find/authentication/backchannel_logout.rb
@@ -1,0 +1,30 @@
+module Find
+  module Authentication
+    class BackchannelLogout
+      attr_reader :logout_token, :provider
+
+      def initialize(logout_token, provider)
+        @logout_token = logout_token
+        @provider = provider
+      end
+
+      # @return [Symbol] represents the response code for One Login Backchannel request
+      def call
+        return :bad_request if logout_token.blank? || uid.blank?
+
+        authentication = ::Authentication.find_by!(subject_key: uid, provider: ::Authentication.provider_map(provider))
+
+        authentication.authenticable.sessions.destroy_all
+
+        :ok
+      end
+
+      def uid
+        @uid ||= OmniAuth::GovukOneLogin::BackchannelLogoutUtility.new(
+          client_id: Settings.one_login.identifier,
+          idp_base_url: Settings.one_login.idp_base_url,
+        ).get_sub(logout_token:)
+      end
+    end
+  end
+end

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -37,6 +37,7 @@ namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host 
         get ":provider/callback", action: :callback
 
         get "/failure", to: "sessions#failure"
+        post ":provider/backchannel-logout", to: "sessions#backchannel_logout"
       end
       delete "/sign-out", to: "sessions#destroy"
     end

--- a/spec/requests/find/backchannel_logout_spec.rb
+++ b/spec/requests/find/backchannel_logout_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "/auth/one-login/backchannel-logout", service: :find do
+  context "when page parameter is invalid" do
+    before do
+      FeatureFlag.activate(:candidate_accounts)
+    end
+
+    it "returns 400 when params is empty" do
+      post "/auth/find-developer/backchannel-logout", params: {}
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    context "making request" do
+      before do
+        @utility = instance_double(OmniAuth::GovukOneLogin::BackchannelLogoutUtility)
+        allow(OmniAuth::GovukOneLogin::BackchannelLogoutUtility).to receive(:new).and_return(@utility)
+      end
+
+      let(:subject_key) { "UID" }
+
+      it "return 400 when UID is blank" do
+        allow(@utility).to receive(:get_sub).with(logout_token: anything).and_return("")
+        post "/auth/find-developer/backchannel-logout", params: { logout_token: "TOKEN" }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it "return 400 when authentication is not found" do
+        allow(@utility).to receive(:get_sub).with(logout_token: anything).and_return(subject_key)
+        post "/auth/find-developer/backchannel-logout", params: { logout_token: "TOKEN" }
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "return 400 when provider does not match the authentication" do
+        allow(@utility).to receive(:get_sub).with(logout_token: anything).and_return(subject_key)
+        auth = create(:authentication, subject_key:)
+        create(:session, sessionable: auth.authenticable)
+
+        post "/auth/other-provider/backchannel-logout", params: { logout_token: "TOKEN" }
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "return 200 when successful" do
+        allow(@utility).to receive(:get_sub).with(logout_token: anything).and_return(subject_key)
+        auth = create(:authentication, subject_key:)
+        create(:session, sessionable: auth.authenticable)
+
+        post "/auth/find-developer/backchannel-logout", params: { logout_token: "TOKEN" }
+
+        expect(auth.authenticable.sessions).to be_blank
+        expect(response).to have_http_status(:successful)
+      end
+    end
+  end
+end

--- a/spec/requests/find/backchannel_logout_spec.rb
+++ b/spec/requests/find/backchannel_logout_spec.rb
@@ -26,6 +26,7 @@ describe "/auth/one-login/backchannel-logout", service: :find do
         allow(@utility).to receive(:get_sub).with(logout_token: anything).and_return("")
         post "/auth/find-developer/backchannel-logout", params: { logout_token: "TOKEN" }
 
+        expect(@utility).to have_received(:get_sub)
         expect(response).to have_http_status(:bad_request)
       end
 
@@ -33,6 +34,7 @@ describe "/auth/one-login/backchannel-logout", service: :find do
         allow(@utility).to receive(:get_sub).with(logout_token: anything).and_return(subject_key)
         post "/auth/find-developer/backchannel-logout", params: { logout_token: "TOKEN" }
 
+        expect(@utility).to have_received(:get_sub)
         expect(response).to have_http_status(:not_found)
       end
 
@@ -43,6 +45,7 @@ describe "/auth/one-login/backchannel-logout", service: :find do
 
         post "/auth/other-provider/backchannel-logout", params: { logout_token: "TOKEN" }
 
+        expect(@utility).to have_received(:get_sub)
         expect(response).to have_http_status(:not_found)
       end
 
@@ -53,6 +56,7 @@ describe "/auth/one-login/backchannel-logout", service: :find do
 
         post "/auth/find-developer/backchannel-logout", params: { logout_token: "TOKEN" }
 
+        expect(@utility).to have_received(:get_sub)
         expect(auth.authenticable.sessions).to be_blank
         expect(response).to have_http_status(:successful)
       end


### PR DESCRIPTION
## Context

When a user signs out of One Login, One Login will send a request to our registered backchannel logout URL so that we can end the session of the users in Find.

## Changes proposed in this pull request

Implement the `OmniAuth::OneLoginStrategy::BackchannelLogoutUtility`

This module securely accepts a token from the One Login IDP with an instruction to sign out a specific user from Find when their session is ended in One Login.

## Guidance to review

According to the specification, the BackchannelLogout only gets sent when a user explicitly signs out, not when their session expires.

## Trello
https://trello.com/c/tBj00o4a/826-one-login-backchannel-logout

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
