### PR TITLE
Add ability to delete a saved course

### DIFF
--- a/app/components/flash_banner.html.erb
+++ b/app/components/flash_banner.html.erb
@@ -20,7 +20,7 @@
     <% elsif key == "success_with_body" %>
       <%= govuk_notification_banner(title_text: t("notification_banner.success"), success: true, html_attributes: { role: "alert" }) do |notification_banner| %>
         <% notification_banner.with_heading(text: value["title"]) %>
-        <p class="govuk-body" data-qa="flash__success__body"><%= value["body"] %></p>
+        <p class="govuk-body" data-qa="flash__success__body"><%= value["body"].html_safe %></p>
       <% end %>
     <% end %>
   <% end %>

--- a/app/controllers/find/candidates/saved_courses_controller.rb
+++ b/app/controllers/find/candidates/saved_courses_controller.rb
@@ -17,12 +17,37 @@ module Find
         end
       end
 
+      def undo
+        course = Course.find(params[:course_id])
+
+        if SaveCourseService.call(candidate: @candidate, course:)
+          redirect_to find_candidate_saved_courses_path
+        else
+          redirect_to find_candidate_saved_courses_path(course, error: t(".save_failed"))
+        end
+      end
+
       def destroy
         saved_course = @candidate.saved_courses.find(params[:id])
-        course = Course.find(saved_course.course_id)
+        course = saved_course.course
 
         if saved_course.destroy
-          redirect_to_course(course)
+          undo_link = view_context.render(
+            partial: "find/candidates/saved_courses/undo_link",
+            locals: { label: t(".undo"), undo_path: undo_find_candidate_saved_courses_path, course: },
+          )
+
+          flash[:success_with_body] = {
+            title: t(".success_message_title"),
+            body: t(
+              ".success_message_html",
+              provider_name: course.provider_name,
+              course_name_and_code: course.name_and_code,
+              undo_link: undo_link,
+            ),
+          }
+
+          redirect_to find_candidate_saved_courses_path
         else
           redirect_to_course(course, error: t(".unsave_failed"))
         end

--- a/app/views/find/candidates/saved_courses/_undo_link.html.erb
+++ b/app/views/find/candidates/saved_courses/_undo_link.html.erb
@@ -1,0 +1,4 @@
+<%= form_with url: undo_find_candidate_saved_courses_path, method: :post do |form| %>
+  <%= form.hidden_field :course_id, value: course.id %>
+  <%= form.submit t(".undo"), class: "app-button-link govuk-!-padding-left-0" %>
+<% end %>

--- a/config/locales/en/find/candidates/saved_courses.yml
+++ b/config/locales/en/find/candidates/saved_courses.yml
@@ -8,4 +8,10 @@ en:
         create:
           save_failed: Failed to save course
         destroy:
+          success_message_title: Saved course deleted
+          success_message_html: "%{provider_name} - %{course_name_and_code}. %{undo_link}"
           unsave_failed: Failed to unsave course
+          undo: Undo
+        undo_link:
+          undo: Undo
+          save_failed: Failed to undo course

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -41,7 +41,9 @@ namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host 
     end
 
     scope path: "candidate", module: "candidates", as: "candidate" do
-      resources :saved_courses, only: %i[index create destroy], path: "saved-courses"
+      resources :saved_courses, only: %i[index create destroy], path: "saved-courses" do
+        post :undo, on: :collection
+      end
     end
   end
 

--- a/spec/system/find/candidates/delete_a_saved_course_spec.rb
+++ b/spec/system/find/candidates/delete_a_saved_course_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe "Deleting a saved course", service: :find do
+  before do
+    FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_auth
+    given_a_published_course_exists
+  end
+
+  scenario "A signed-in candidate can delete a saved course" do
+    when_i_sign_in_as_a_candidate
+    when_i_view_a_course
+    then_i_save_the_course
+
+    then_the_course_is_saved
+
+    when_i_visit_my_saved_courses
+    then_i_see_my_saved_course
+    then_i_delete_a_saved_course
+  end
+
+  def then_i_delete_a_saved_course
+    click_link_or_button "Delete"
+    expect(page).to have_content("Saved course deleted")
+  end
+
+  def when_i_visit_my_saved_courses
+    visit find_candidate_saved_courses_path
+  end
+
+  def then_i_see_my_saved_course
+    expect(page).to have_content(@course.provider_name)
+    expect(page).to have_content(@course.name_and_code)
+    expect(page).to have_content("Delete")
+  end
+
+  def when_i_sign_in_as_a_candidate
+    visit "/"
+    click_link_or_button "Sign in"
+    expect(page).to have_content("You have been successfully signed in.")
+  end
+
+  def when_i_view_a_course
+    visit find_results_path
+    click_on_first_course
+  end
+
+  def when_i_visit_a_course_without_signing_in
+    visit "/"
+    visit find_results_path
+    click_on_first_course
+  end
+
+  def then_i_save_the_course
+    expect(page).to have_content("Save this course for later")
+    click_link_or_button("Save this course for later")
+  end
+
+  def then_the_course_is_saved
+    expect(page).to have_content("Course saved")
+  end
+
+  def then_i_am_prompted_to_sign_in
+    expect(page).to have_content("You must sign in to visit that page.")
+    expect(page).to have_current_path(find_root_path)
+  end
+
+  def click_on_first_course
+    page.first(".app-search-results").first("a").click
+  end
+
+  def given_a_published_course_exists
+    @course = create(
+      :course,
+      :with_full_time_sites,
+      :secondary,
+      :with_special_education_needs,
+      :published,
+      :open,
+      name: "Art and design (SEND)",
+      course_code: "F314",
+      provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
+      subjects: [find_or_create(:secondary_subject, :art_and_design)],
+    )
+  end
+end

--- a/spec/system/find/candidates/undo_deletion_of_saved_course_spec.rb
+++ b/spec/system/find/candidates/undo_deletion_of_saved_course_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Undo deletion of a saved course", service: :find do
+  before do
+    FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_auth
+    given_a_published_course_exists
+  end
+
+  scenario "A signed-in candidate can undo deleting a saved course" do
+    when_i_sign_in_as_a_candidate
+    when_i_view_a_course
+    then_i_save_the_course
+
+    then_the_course_is_saved
+
+    when_i_visit_my_saved_courses
+    then_i_see_my_saved_course
+    then_i_delete_a_saved_course
+    then_i_undo_the_deletion
+  end
+
+  def then_i_undo_the_deletion
+    click_link_or_button "Undo"
+    expect(page).to have_content(@course.provider_name)
+    expect(page).to have_content(@course.name_and_code)
+  end
+
+  def then_i_delete_a_saved_course
+    click_link_or_button "Delete"
+    expect(page).to have_content("Saved course deleted")
+  end
+
+  def when_i_visit_my_saved_courses
+    visit find_candidate_saved_courses_path
+  end
+
+  def then_i_see_my_saved_course
+    expect(page).to have_content(@course.provider_name)
+    expect(page).to have_content(@course.name_and_code)
+    expect(page).to have_content("Delete")
+  end
+
+  def when_i_sign_in_as_a_candidate
+    visit "/"
+    click_link_or_button "Sign in"
+    expect(page).to have_content("You have been successfully signed in.")
+  end
+
+  def when_i_view_a_course
+    visit find_results_path
+    click_on_first_course
+  end
+
+  def then_i_save_the_course
+    expect(page).to have_content("Save this course for later")
+    click_link_or_button("Save this course for later")
+  end
+
+  def then_the_course_is_saved
+    expect(page).to have_content("Course saved")
+  end
+
+  def click_on_first_course
+    page.first(".app-search-results").first("a").click
+  end
+
+  def given_a_published_course_exists
+    @course = create(
+      :course,
+      :with_full_time_sites,
+      :secondary,
+      :with_special_education_needs,
+      :published,
+      :open,
+      name: "Art and design (SEND)",
+      course_code: "F314",
+      provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
+      subjects: [find_or_create(:secondary_subject, :art_and_design)],
+    )
+  end
+end


### PR DESCRIPTION
## Context

As part of the candidate accounts work, we want to allow candidates to delete a course from the saved courses page.

## Changes proposed in this pull request

Add a flash banner to and setup deletion redirects, as well as the ability to undo a deletion

## Guidance to review
- Save a course
- Visit saved courses tab
- Delete a course 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
<img width="864" alt="Screenshot 2025-07-07 at 19 09 57" src="https://github.com/user-attachments/assets/6dee67d6-bced-497f-a890-2e8f37aa3706" />

