### PR TITLE
Update confirm course to apply page - bring into Find from Apply

### DIFF
--- a/app/assets/stylesheets/components/_button-link.scss
+++ b/app/assets/stylesheets/components/_button-link.scss
@@ -17,3 +17,13 @@
   background: none;
   border: none;
 }
+
+.app-cancel-button-container {
+  padding-left: 0;
+  margin-top: govuk-spacing(2);
+
+  @include govuk-media-query($until: desktop) {
+    padding-left: govuk-spacing(3);
+    margin-top: 0;
+  }
+}

--- a/app/components/find/courses/apply_component/view.html.erb
+++ b/app/components/find/courses/apply_component/view.html.erb
@@ -2,12 +2,21 @@
   <% if Find::CycleTimetable.mid_cycle? %>
     <% if application_status_open? %>
       <p class="govuk-body">
-        <%= govuk_start_button(
-              classes: "govuk-!-margin-0",
-              text: "Apply for this course",
-              href: preview ? apply_path : find_track_click_path(utm_content:, url: apply_path),
-            ) %>
+        <% if FeatureFlag.active?(:candidate_accounts) %>
+          <%= govuk_link_to(
+                t(".apply_to_course"),
+                find_confirm_apply_path(provider_code: course.provider_code, course_code: course.course_code),
+                class: "govuk-button govuk-!-margin-0",
+              ) %>
+        <% else %>
+          <%= govuk_start_button(
+                text: t(".apply_to_course"),
+                href: preview ? apply_path : find_track_click_path(utm_content:, url: apply_path),
+                classes: "govuk-!-margin-0",
+              ) %>
+        <% end %>
       </p>
+
       <% if show_application_deadline? %>
         <p class="govuk-body">
           <%= t(".visa_sponsorship_deadline_notice_html", application_deadline:) %>

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -10,20 +10,17 @@ module Find
 
     before_action :render_feedback_component, only: :show
     before_action :set_search_params, only: :show
+    before_action :set_course, only: %i[show confirm_apply]
 
     def show
-      @course = provider.courses.includes(
-        :enrichments,
-        subjects: [:financial_incentive],
-        site_statuses: [:site],
-      ).find_by!(course_code: params[:course_code]&.upcase).decorate
-
       distance_from_location if params[:location]
 
       @saved_course = @candidate&.saved_courses&.find_by(course_id: @course.id)
 
       render_not_found unless @course.is_published?
     end
+
+    def confirm_apply; end
 
     def distance_from_location
       @coordinates = Geolocation::CoordinatesQuery.new(params[:location]).call
@@ -89,6 +86,16 @@ module Find
         subjects: [],
         subject_codes: [], # Legacy
       )
+    end
+
+  private
+
+    def set_course
+      @course = provider.courses.includes(
+        :enrichments,
+        subjects: [:financial_incentive],
+        site_statuses: [:site],
+      ).find_by!(course_code: params[:course_code]&.upcase).decorate
     end
   end
 end

--- a/app/views/find/courses/confirm_apply.html.erb
+++ b/app/views/find/courses/confirm_apply.html.erb
@@ -1,0 +1,52 @@
+<%= content_for :page_title, t(".apply_to_course") %>
+
+<%= content_for(:before_content) do %>
+  <%= govuk_back_link(
+    text: t(".back_link_text", course_name_and_code: @course.name_and_code),
+    href: find_course_path(provider_code: @course.provider_code, course_code: @course.course_code),
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t(".apply_to_course") %>
+    </h1>
+
+    <%= govuk_inset_text do %>
+      <p class="govuk-!-font-weight-bold govuk-body-m govuk-!-margin-bottom-0"><%= @course.provider_name %></p>
+      <p class="govuk-!-font-weight-bold govuk-!-font-size-24 govuk-!-margin-top-0"><%= @course.name_and_code %></p>
+    <% end %>
+
+    <p class="govuk-body"><%= t(".continue_text") %></p>
+    <p class="govuk-body"><%= t(".need_to_sign_in") %></p>
+    <p class="govuk-body"><%= t(".save_application") %></p>
+    <p class="govuk-body govuk-!-font-weight-bold"><%= t(".start_application") %></p>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
+        <%= govuk_start_button(
+              text: t(".start_now"),
+              href: find_track_click_path(
+                utm_content: "confirm_apply_course_button",
+                url: find_apply_path(
+                  provider_code: @course.provider.provider_code,
+                  course_code: @course.course_code,
+                ),
+              ),
+            ) %>
+      </div>
+
+      <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop app-cancel-button-container">
+        <%= govuk_link_to(
+              t(".cancel"),
+              find_course_path(
+                provider_code: @course.provider_code,
+                course_code: @course.course_code,
+              ),
+              class: "govuk-link govuk-body",
+            ) %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/components/find/courses/apply_component.yml
+++ b/config/locales/en/components/find/courses/apply_component.yml
@@ -5,3 +5,4 @@ en:
         view:
           not_accepting_applications: This course is not accepting applications at the moment. You can contact the provider for more information.
           visa_sponsorship_deadline_notice_html: Non-UK citizens, apply by <b>%{application_deadline}</b>
+          apply_to_course: Apply for this course

--- a/config/locales/en/find/courses/confirm_apply.yml
+++ b/config/locales/en/find/courses/confirm_apply.yml
@@ -1,0 +1,12 @@
+en:
+  find:
+    courses:
+      confirm_apply:
+        apply_to_course: Apply for this course
+        back_link_text: Back to %{course_name_and_code}
+        continue_text: Continue to the Apply for teacher training website to apply for this course.
+        need_to_sign_in: "You’ll need to sign in to use this service. If you do not already have sign in details, you’ll be able to create them."
+        save_application: You can save your application and come back to it at any time.
+        start_application: Start your application on the Apply for teacher training website.
+        start_now: Start now
+        cancel: Cancel and return to the course page

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -13,6 +13,7 @@ namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host 
   get "/course/:provider_code/:course_code/apply", to: "courses#apply", as: :apply
   get "/course/:provider_code/:course_code/git/:git_path", to: "courses#git_redirect", as: :get_into_teaching_redirect
   get "/course/:provider_code/:course_code/provider/website", to: "courses#provider_website", as: :provider_website
+  get "/course/:provider_code/:course_code/confirm-apply", to: "courses#confirm_apply", as: :confirm_apply
 
   get "/geolocation-suggestions", to: "geolocation_suggestions#index"
 

--- a/spec/system/find/courses/apply_for_course_spec.rb
+++ b/spec/system/find/courses/apply_for_course_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "Saving a course", service: :find do
+  before do
+    FeatureFlag.activate(:candidate_accounts)
+    CandidateAuthHelper.mock_auth
+    given_a_published_course_exists
+  end
+
+  scenario "A signed-in candidate can save a course" do
+    when_i_view_a_course
+    when_i_click_apply_for_this_course
+
+    then_i_see_the_confirm_apply_page
+  end
+
+  def when_i_view_a_course
+    visit find_results_path
+    click_on_first_course
+  end
+
+  def when_i_visit_a_course_without_signing_in
+    visit "/"
+    visit find_results_path
+    click_on_first_course
+  end
+
+  def click_on_first_course
+    page.first(".app-search-results").first("a").click
+  end
+
+  def when_i_click_apply_for_this_course
+    page.find("a", text: "Apply for this course", match: :first).click
+  end
+
+  def then_i_see_the_confirm_apply_page
+    expect(page).to have_content("Back to #{@course.name_and_code}")
+    expect(page).to have_content("Apply for this course")
+    expect(page).to have_content("Continue to the Apply for teacher training website to apply for this course.")
+
+    expected_href = find_track_click_path(
+      utm_content: "confirm_apply_course_button",
+      url: find_apply_path(provider_code: @course.provider.provider_code, course_code: @course.course_code),
+    )
+
+    expect(page).to have_link("Start now", href: expected_href)
+  end
+
+  def given_a_published_course_exists
+    @course = create(
+      :course,
+      :with_full_time_sites,
+      :secondary,
+      :with_special_education_needs,
+      :published,
+      :open,
+      name: "Art and design (SEND)",
+      course_code: "F314",
+      provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
+      subjects: [find_or_create(:secondary_subject, :art_and_design)],
+    )
+  end
+end


### PR DESCRIPTION
## Context

As part of the candidate accounts work, we want to update the confirm course page and move it from Apply to Find, to improve the journey for candidates from Find to Apply.

## Changes proposed in this pull request

Update the flow when applying for a course. We now have a page which lets the user know they are going to Apply

## Guidance to review

Apply for a course, you should see the new intermediary page


<img width="1118" alt="Screenshot 2025-07-09 at 16 15 24" src="https://github.com/user-attachments/assets/eb57e9e1-a734-402e-97df-fc5021dae580" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
