### PR TITLE
Add a notification banner that communicates the new date of rollover in Publish

### DIFF
--- a/app/components/notification_banner.html.erb
+++ b/app/components/notification_banner.html.erb
@@ -8,5 +8,8 @@
     <p class="govuk-notification-banner__heading">
       <%= text %>
     </p>
+    <p class="govuk-body">
+      <%= text_body %>
+    </p>
   </div>
 <% end %>

--- a/app/components/notification_banner.rb
+++ b/app/components/notification_banner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class NotificationBanner < ApplicationComponent
-  attr_reader :text, :title_id
+  attr_reader :text, :title_id, :text_body
 
   SUCCESS_TITLE = "Success"
   DEFAULT_TITLE = "Important"
@@ -14,6 +14,7 @@ class NotificationBanner < ApplicationComponent
   def initialize(
     title_text: nil,
     text: nil,
+    text_body: nil,
     type: nil,
     role: nil,
     title_id: nil,
@@ -24,6 +25,7 @@ class NotificationBanner < ApplicationComponent
     super(classes:, html_attributes:)
     @title_text = title_text
     @text = text
+    @text_body = text_body
     @type = type
     @role = role
     @title_id = title_id || "#{DEFAULT_CLASS}-title"

--- a/app/views/publish/authentication/sign_in/index.html.erb
+++ b/app/views/publish/authentication/sign_in/index.html.erb
@@ -1,5 +1,5 @@
 <%= render PageTitle.new(title: "sign_in.index") %>
-<%= render(NotificationBanner.new(text: "You can start rolling over your courses from early September.", text_body: "In early September, your courses will be ready to be rolled over to the 2025 to 2026 recruitment cycle. We will email you when you need to sign in to check and publish, or delete, your courses.")) %>
+<%= render(NotificationBanner.new(text: t("publish.rollover_notification.text"), text_body: t("publish.rollover_notification.text_body"))) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= render partial: "default_signin_content" %>

--- a/app/views/publish/authentication/sign_in/index.html.erb
+++ b/app/views/publish/authentication/sign_in/index.html.erb
@@ -1,5 +1,5 @@
 <%= render PageTitle.new(title: "sign_in.index") %>
-
+<%= render(NotificationBanner.new(text: "You can start rolling over your courses from early September.", text_body: "In early September, your courses will be ready to be rolled over to the 2025 to 2026 recruitment cycle. We will email you when you need to sign in to check and publish, or delete, your courses.")) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= render partial: "default_signin_content" %>

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
-<%= render(NotificationBanner.new(text: "You can start rolling over your courses from early September.", text_body: "In early September, your courses will be ready to be rolled over to the 2025 to 2026 recruitment cycle. We will email you when you need to sign in to check and publish, or delete, your courses.")) %>
+<%= render(NotificationBanner.new(text: t("publish.rollover_notification.text"), text_body: t("publish.rollover_notification.text_body"))) %>
 
 <h1 class="govuk-heading-l">Courses</h1>
 <%= render AddCourseButton.new(provider: @provider) %>

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
+<%= render(NotificationBanner.new(text: "You can start rolling over your courses from early September.", text_body: "In early September, your courses will be ready to be rolled over to the 2025 to 2026 recruitment cycle. We will email you when you need to sign in to check and publish, or delete, your courses.")) %>
 
 <h1 class="govuk-heading-l">Courses</h1>
 <%= render AddCourseButton.new(provider: @provider) %>

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -1,5 +1,8 @@
 en:
   publish:
+    rollover_notification:
+      text: "You can start rolling over your courses from early September."
+      text_body: "In early September, your courses will be ready to be rolled over to the 2025 to 2026 recruitment cycle. We will email you when you need to sign in to check and publish, or delete, your courses."
     authentication:
       magic_link:
         invalid_token: "Magic link could not be verified, please request a new one"


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/apMloMgz/840-publish-banner-a-notification-banner-that-communicates-the-new-date-of-rollover

Research with providers shows that they don’t see all comms that are communicated via email, for example that the date of rollover has changed.

## Changes proposed in this pull request
- add a notification banner that communicates the new date of rollover in Publish
- adapt `NotificationBanner` component to take in `text_body` with `class="govuk-body"` (non bold text), as this is needed to display the content correctly. 
- add notification banner to top of Publish Sign in page and Organisation page (Courses tab)

**Publish sign in page**
<img width="1057" height="509" alt="Screenshot 2025-07-10 at 15 21 17" src="https://github.com/user-attachments/assets/a6033306-4486-4b8b-85e9-ee870a383001" />

**Organisation page**
<img width="976" height="572" alt="Screenshot 2025-07-10 at 13 58 52" src="https://github.com/user-attachments/assets/1d85791d-087b-4426-bf08-f6989ade6720" />

## Guidance to review

- check notification banner on Publish sign in page 
- check 'Courses' page of different organisations to test banner is correct/present.

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
