### PR TITLE
Param passed to internal_server_error handler is optional

### DIFF
--- a/app/controllers/concerns/errorable.rb
+++ b/app/controllers/concerns/errorable.rb
@@ -28,9 +28,14 @@ module Errorable
     end
   end
 
-  def internal_server_error(error)
-    Sentry.capture_exception(error)
-    raise error if Rails.env.development? || Rails.env.test?
+  # This method is called when /500.xxx is requested
+  # an in that case, no error is passed to the
+  # method
+  def internal_server_error(error = nil)
+    if error
+      Sentry.capture_exception(error)
+      raise error if Rails.env.development? || Rails.env.test?
+    end
 
     respond_to do |format|
       format.any { render status: :internal_server_error, formats: [:html], template: "errors/internal_server_error" }


### PR DESCRIPTION
## Context

When our application receives a request directly to `/500`, no error is passed and this triggers an `ArgumentError`.

## Changes proposed in this pull request

  The argument is optional because when `/500.php`, for example, is
  requested directly, no error is passed to the method

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/0GwRzRnI/876-error-rescuing-error

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
