### PR TITLE
Bundle omniauth_govuk_one_login from DFE-digital fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem "govuk_design_system_formbuilder", "~> 5.11"
 
 # DfE Sign-In
 gem "omniauth", "~> 2.1"
-gem "omniauth_govuk_one_login", github: "pauldougan/omniauth-govuk-one-login", ref: "aee3e10c5d4c6dbe855059198283ced16acec91f"
+gem "omniauth_govuk_one_login", github: "DFE-Digital/omniauth-govuk-one-login", tag: "v1.3.0"
 gem "omniauth_openid_connect", "~> 0.8"
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,16 @@ GIT
       jsonapi-rb (~> 0.5.0)
 
 GIT
+  remote: https://github.com/DFE-Digital/omniauth-govuk-one-login.git
+  revision: a875d09fb4dd6c9b6ba6155c496e9aa44dad72e6
+  tag: v1.3.0
+  specs:
+    omniauth_govuk_one_login (1.3.0)
+      faraday (~> 2.13)
+      jwt (~> 2.10)
+      omniauth (~> 2.1)
+
+GIT
   remote: https://github.com/DFE-Digital/open-api-rswag.git
   revision: b39fb1bdc9fef1c3beca52b0d0c61072c2597bae
   tag: v0.2.0
@@ -60,16 +70,6 @@ GIT
     open_api-rswag-ui (0.2.0)
       actionpack
       railties
-
-GIT
-  remote: https://github.com/pauldougan/omniauth-govuk-one-login.git
-  revision: aee3e10c5d4c6dbe855059198283ced16acec91f
-  ref: aee3e10c5d4c6dbe855059198283ced16acec91f
-  specs:
-    omniauth_govuk_one_login (1.3.0)
-      faraday (~> 2.13)
-      jwt (~> 2.10)
-      omniauth (~> 2.1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
## Context

We have forked the omniauth_govuk_one_login library from OPSS.
This means we are now hosting it ourselves in `DFE-Digital`
https://github.com/DFE-Digital/omniauth-govuk-one-login

We can sync the fork for updates provided by OPSS and the original author.

## Changes proposed in this pull request

Bundle our own version of `omniauth-govuk-one-login`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
https://trello.com/c/RaC22hLN/868-onelogin-make-the-gem-available-again

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
