### PR TITLE
Revert clever build and deploy workflow optimisation

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,20 +19,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    # Run if:
-    # - It's main branch
-    # - It is a PR, don't run if it has a prototype label
-    # - It is a PR, don't run on opened if it has a deploy label
-    if: |
-        github.ref == 'refs/heads/main' ||
-        (
-          github.event_name == 'pull_request' &&
-          !contains(github.event.pull_request.labels.*.name, 'prototype') &&
-          (
-            github.event.action != 'opened' ||
-            !contains(github.event.pull_request.labels.*.name, 'deploy')
-          )
-        )
+    if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'prototype')) }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Context

We tried to optimise the running of the build and deploy job. It resulted in workflows being cancelled and the checks feature on the PR being broken.

<img width="1019" height="657" alt="image" src="https://github.com/user-attachments/assets/3dfedc1f-2cf0-4bf1-b137-f67747643db8" />


## Changes proposed in this pull request

Go back to naive workflow running to avoid cancelled jobs and orphaned checks statuses.

This also means the 
1. Opening a PR with the deploy label means the app will need to build twice to deploy once

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
