### PR TITLE
Find developer is enabled when one-login is disabled except production

### DIFF
--- a/app/lib/authentications/candidate_omni_auth.rb
+++ b/app/lib/authentications/candidate_omni_auth.rb
@@ -17,7 +17,7 @@ module Authentications
           redirect_uri:,
           private_key:,
         }
-      elsif Rails.env.local?
+      elsif !Rails.env.production?
         {
           name: "find-developer",
           fields: %i[uid email],
@@ -41,7 +41,7 @@ module Authentications
     def set_provider
       if Settings.one_login.enabled
         :govuk_one_login
-      elsif Rails.env.local?
+      elsif !Rails.env.production?
         :find_developer
       end
     end

--- a/spec/lib/authentications/candidate_omni_auth_spec.rb
+++ b/spec/lib/authentications/candidate_omni_auth_spec.rb
@@ -64,10 +64,10 @@ module Authentications
     end
 
     describe "#config" do
-      context "when Setting.one_login.enabled is false and env is not local" do
+      context "when Setting.one_login.enabled is false and env is production" do
         before do
           allow(Settings.one_login).to receive(:enabled).and_return(false)
-          allow(Rails.env).to receive(:local?).and_return(false)
+          allow(Rails.env).to receive(:production?).and_return(true)
         end
 
         it "does not yield" do
@@ -75,9 +75,10 @@ module Authentications
         end
       end
 
-      context "when Setting.one_login.enabled is false and env is local" do
+      context "when Setting.one_login.enabled is false and env is not production" do
         before do
           allow(Settings.one_login).to receive(:enabled).and_return(false)
+          allow(Rails.env).to receive(:production?).and_return(false)
         end
 
         it "does yield" do


### PR DESCRIPTION
## Context

  One Login should be enabled in any environment that Settings.one_login.enabled is true.
  FindDeveloper should replace One Login if Settings.one_login.enabled is false.
  Production should *never* have FindDeveloper enabled

#### What about QA and other environments?

  FindDeveloper logs the user in with a specific email, resolving to a specific user. Is this ok in QA, Staging, Sandbox?

## Changes proposed in this pull request

If for any reason we disable One Login in a lower environment, we want the Find Developer strategy to be enabled.

## Guidance to review

Is there any environment other than Production that we should not enable the FindDeveloper Strategy?

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
