### PR TITLE
Update navigation links positions

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -62,3 +62,7 @@
 .govuk-service-navigation .govuk-service-navigation__container {
   justify-content: space-between;
 }
+
+.govuk-service-navigation__wrapper {
+  flex: none;
+}


### PR DESCRIPTION
## Context

Since this was merged https://github.com/DFE-Digital/publish-teacher-training/pull/5368 it has changed how the navigation elements are positioned

## Changes proposed in this pull request

Overrides the class to position the elements how they were before the merge above

## Guidance to review

Sign in as a user or via support and view the navigation links

BEFORE: 
<img width="1067" height="467" alt="Screenshot 2025-07-18 at 15 14 44" src="https://github.com/user-attachments/assets/23538122-8139-4a4b-93ce-5f4ddc4ce716" />

AFTER:
<img width="1066" height="393" alt="Screenshot 2025-07-18 at 15 14 38" src="https://github.com/user-attachments/assets/a3777e66-dce1-48f8-90f0-9fd3bf19844f" />

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
