### PR TITLE
Add independent control to show school placements in find

### DIFF
--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -76,7 +76,7 @@ module Find
         end
 
         def show_school_placements_link?
-          course.provider.selectable_school?
+          course.provider.show_school?
         end
       end
     end

--- a/app/controllers/find/placements_controller.rb
+++ b/app/controllers/find/placements_controller.rb
@@ -2,7 +2,7 @@
 
 module Find
   class PlacementsController < ApplicationController
-    before_action -> { render_not_found if provider.nil? || provider.selectable_school.blank? }
+    before_action -> { render_not_found if provider.nil? || provider.show_school.blank? }
 
     def index
       @course = provider.courses.includes(

--- a/app/controllers/publish/providers/school_placements_controller.rb
+++ b/app/controllers/publish/providers/school_placements_controller.rb
@@ -27,7 +27,7 @@ module Publish
     private
 
       def provider_params
-        params.expect(provider: [:selectable_school])
+        params.expect(provider: %i[selectable_school show_school])
       end
     end
   end

--- a/app/views/publish/courses/schools/new.html.erb
+++ b/app/views/publish/courses/schools/new.html.erb
@@ -1,11 +1,8 @@
-<% content_for :page_title, title_with_error_prefix("Schools", @errors && @errors.any?) %>
-
+<% content_for :page_title, title_with_error_prefix(course.salaried? ? "Employing schools" : "Placement schools", @errors && @errors.any?) %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
-
 <%= render "publish/shared/errors" %>
-
 <%= form_for course,
   url: continue_publish_provider_recruitment_cycle_courses_schools_path(@provider.provider_code, course.recruitment_cycle.year, course.course_code),
   method: :get do |form| %>
@@ -15,14 +12,25 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading" data-qa="page-heading">
             <%= render CaptionText.new(text: t("course.add_course")) %>
-            Schools
+            <%= course.salaried? ? "Employing schools" : "Placement schools" %>
           </h1>
         </legend>
+        <p class="govuk-body">
+          The more schools you select, the more searches your course will appear in.
+        </p>
+        <p class="govuk-body">
+          80% of searches are by location.
+        </p>
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            If you do not add all your 
+            <%= course.salaried? ? "employing schools" : "placement schools" %>, you may miss out on potential candidates.
+          </strong>
+        </div>
         <%= render "publish/shared/error_messages", error_keys: [:sites] %>
-
         <div class="govuk-form-group govuk-!-margin-top-2">
           <div class="govuk-hint">Select all that apply</div>
-
           <%= form.govuk_check_boxes_fieldset :sites_ids, legend: nil do %>
             <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
               <%= form.govuk_check_box :sites_ids,
@@ -32,13 +40,11 @@
                     link_errors: index.zero? %>
             <% end %>
           <% end %>
-
         </div>
       </fieldset>
     <% end %>
   <% end %>
 <% end %>
-
 <p class="govuk-body">
   <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 </p>

--- a/app/views/publish/courses/schools/new.html.erb
+++ b/app/views/publish/courses/schools/new.html.erb
@@ -1,8 +1,11 @@
-<% content_for :page_title, title_with_error_prefix(course.salaried? ? "Employing schools" : "Placement schools", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Schools", @errors && @errors.any?) %>
+
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
+
 <%= render "publish/shared/errors" %>
+
 <%= form_for course,
   url: continue_publish_provider_recruitment_cycle_courses_schools_path(@provider.provider_code, course.recruitment_cycle.year, course.course_code),
   method: :get do |form| %>
@@ -12,25 +15,14 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading" data-qa="page-heading">
             <%= render CaptionText.new(text: t("course.add_course")) %>
-            <%= course.salaried? ? "Employing schools" : "Placement schools" %>
+            Schools
           </h1>
         </legend>
-        <p class="govuk-body">
-          The more schools you select, the more searches your course will appear in.
-        </p>
-        <p class="govuk-body">
-          80% of searches are by location.
-        </p>
-        <div class="govuk-warning-text">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            If you do not add all your 
-            <%= course.salaried? ? "employing schools" : "placement schools" %>, you may miss out on potential candidates.
-          </strong>
-        </div>
         <%= render "publish/shared/error_messages", error_keys: [:sites] %>
+
         <div class="govuk-form-group govuk-!-margin-top-2">
           <div class="govuk-hint">Select all that apply</div>
+
           <%= form.govuk_check_boxes_fieldset :sites_ids, legend: nil do %>
             <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
               <%= form.govuk_check_box :sites_ids,
@@ -40,11 +32,13 @@
                     link_errors: index.zero? %>
             <% end %>
           <% end %>
+
         </div>
       </fieldset>
     <% end %>
   <% end %>
 <% end %>
+
 <p class="govuk-body">
   <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 </p>

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -1,6 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("About your organisation", @errors.present?) %>
 <%= content_for :before_content, render_breadcrumbs(:organisation_details) %>
-
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
@@ -22,11 +21,9 @@
     </div>
   </div>
 <% end %>
-
 <h1 class="govuk-heading-l">
   <%= t(".page_title") %>
 </h1>
-
 <h2 class="govuk-heading-m">
   <%= t(".about") %>
 </h2>
@@ -52,7 +49,6 @@
         action_visually_hidden_text: "details about training with disabilities and other needs",
       ) %>
     <% end %>
-
     <% unless @provider.provider_type == 'lead_school' %>
       <h2 class="govuk-heading-m"><%= t(".visa_sponsorship") %></h2>
       <%= govuk_summary_list do |summary_list| %>
@@ -65,7 +61,6 @@
              action_path: @provider.university? ? student_visa_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) : nil,
              action_visually_hidden_text: "if candidates can get Student visa sponsorship",
            ) %>
-
         <% enrichment_summary(
              summary_list,
              :provider,
@@ -77,8 +72,18 @@
            ) %>
       <% end %>
     <% end %>
-
     <h2 class="govuk-heading-m"><%= t(".school_placements") %></h2>
+    <%= govuk_summary_list do |summary_list| %>
+      <% enrichment_summary(
+        summary_list,
+        :provider,
+        t(".show_school_label"),
+        @provider.show_school ? "Yes" : "No",
+        %w[show_school],
+        action_path: school_placements_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+        action_visually_hidden_text: "show school placement display",
+      ) %>
+    <% end %>
     <%= govuk_summary_list do |summary_list| %>
       <% enrichment_summary(
         summary_list,
@@ -87,7 +92,7 @@
         @provider.selectable_school ? "Yes" : "No",
         %w[selectable_school],
         action_path: school_placements_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
-        action_visually_hidden_text: "school placement display",
+        action_visually_hidden_text: "select a preferred school display",
       ) %>
     <% end %>
     <h2 class="govuk-heading-m"><%= t(".contact_details") %></h2>
@@ -101,7 +106,6 @@
         action_path: "#{contact_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#email",
         action_visually_hidden_text: "email address",
       ) %>
-
       <% enrichment_summary(
         summary_list,
         :provider,
@@ -111,7 +115,6 @@
         action_path: "#{contact_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#telephone",
         action_visually_hidden_text: "telephone number",
       ) %>
-
       <% enrichment_summary(
         summary_list,
         :provider,
@@ -121,7 +124,6 @@
         action_path: "#{contact_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#website",
         action_visually_hidden_text: "website",
       ) %>
-
       <% enrichment_summary(
         summary_list,
         :provider,
@@ -131,7 +133,6 @@
         action_path: "#{contact_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#ukprn",
         action_visually_hidden_text: "UKPRN",
       ) %>
-
       <% if @provider.provider_type == "lead_school" %>
         <% enrichment_summary(
           summary_list,
@@ -143,7 +144,6 @@
           action_visually_hidden_text: "URN",
         ) %>
       <% end %>
-
       <% enrichment_summary(
         summary_list,
         :provider,

--- a/app/views/publish/providers/school_placements/edit.html.erb
+++ b/app/views/publish/providers/school_placements/edit.html.erb
@@ -28,7 +28,7 @@
             legend: { text: t(".show_school_label") },
             hint: { text: t(".show_school_hint") },
           ) do %>
-        <%= f.govuk_radio_button :show_school, true, label: { text: "Yes"}, id: "provider-show-school-true-field", link_errors: true %>
+        <%= f.govuk_radio_button :show_school, true, label: { text: "Yes" }, id: "provider-show-school-true-field", link_errors: true %>
         <%= f.govuk_radio_button :show_school, false, label: { text: "No" }, id: "provider-show-school-false-field" %>
       <% end %>
       <%= f.govuk_radio_buttons_fieldset(

--- a/app/views/publish/providers/school_placements/edit.html.erb
+++ b/app/views/publish/providers/school_placements/edit.html.erb
@@ -1,10 +1,8 @@
-<% page_title = "School placements" %>
+<% page_title = t(".page_title") %>
 <% content_for :page_title, title_with_error_prefix(page_title, @provider.errors.present?) %>
-
 <% content_for :before_content do %>
   <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 <% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
@@ -13,23 +11,34 @@
       method: :put,
       local: true,
     ) do |f| %>
-
       <%= f.govuk_error_summary %>
-
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l"><%= @provider.provider_name %></span>
         <%= page_title %>
       </h1>
-
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          Changes to these preferences will not change courses you have already added.
+        </strong>
+      </div>
+      <p class="govuk-body">To change preferences of an existing course, go to the 'Basic details' tab of the course.</p>
+      <%= f.govuk_radio_buttons_fieldset(
+            :show_school,
+            legend: { text: t(".show_school_label") },
+            hint: { text: t(".show_school_hint") },
+          ) do %>
+        <%= f.govuk_radio_button :show_school, true, label: { text: "Yes"}, id: "provider-show-school-true-field", link_errors: true %>
+        <%= f.govuk_radio_button :show_school, false, label: { text: "No" }, id: "provider-show-school-false-field" %>
+      <% end %>
       <%= f.govuk_radio_buttons_fieldset(
             :selectable_school,
             legend: { text: t(".selectable_school_label") },
             hint: { text: t(".selectable_school_hint") },
           ) do %>
-        <%= f.govuk_radio_button :selectable_school, true, label: { text: "Yes" }, link_errors: true %>
-        <%= f.govuk_radio_button :selectable_school, false, label: { text: "No" } %>
+        <%= f.govuk_radio_button :selectable_school, true, label: { text: "Yes" }, id: "provider-selectable-school-true-field", link_errors: true %>
+        <%= f.govuk_radio_button :selectable_school, false, label: { text: "No" }, id: "provider-selectable-school-false-field" %>
       <% end %>
-
       <%= f.govuk_submit "Update school placement preferences" %>
     <% end %>
   </div>

--- a/app/views/publish/providers/school_placements/edit.html.erb
+++ b/app/views/publish/providers/school_placements/edit.html.erb
@@ -19,10 +19,10 @@
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
-          Changes to these preferences will not change courses you have already added.
+          <%= t(".warning_text") %>
         </strong>
       </div>
-      <p class="govuk-body">To change preferences of an existing course, go to the 'Basic details' tab of the course.</p>
+      <p class="govuk-body"><%= t(".change_preferences") %></p>
       <%= f.govuk_radio_buttons_fieldset(
             :show_school,
             legend: { text: t(".show_school_label") },

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -163,6 +163,7 @@ shared:
   provider:
     - accredited
     - selectable_school
+    - show_school
     - id
     - address4
     - provider_name

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -32,10 +32,11 @@ en:
       details:
         page_title: Organisation details
         about: About your organisation
-        school_placements: School placements
+        school_placements: Preferences for schools
         contact_details: Contact details
         visa_sponsorship: Visa sponsorship
-        selectable_school_label: Show locations and allow candidates to select a preferred school
+        show_school_label: Show schools to candidates
+        selectable_school_label: Let candidates select a preferred school
       courses:
         accredited_provider:
           show:
@@ -104,10 +105,10 @@ en:
           summary_link: See what we include in this section
           guidance_html:
             <p class="govuk-body">Candidates find it helpful to know when fees are due, payment schedules, top up fees
-              and other costs like books and transport.</p>
+            and other costs like books and transport.</p>
             <p class="govuk-body">You can also tell them about any financial support your institution offers.</p>
             <p class="govuk-body">Do not include information about financial support available from the government
-              like student loans or bursaries.</p>
+            like student loans or bursaries.</p>
       interview_process:
         edit:
           interview_process_heading: Interview process (optional)
@@ -118,24 +119,26 @@ en:
           include_information_about_html:
             <p class="govuk-body">Include information about:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>how many interview candidates will have</li>
-              <li>the format of interviews, for example could they interview online</li>
-              <li>who will be interviewing them</li>
-              <li>any tests needed - if so, how they can prepare</li>
+            <li>how many interview candidates will have</li>
+            <li>the format of interviews, for example could they interview online</li>
+            <li>who will be interviewing them</li>
+            <li>any tests needed - if so, how they can prepare</li>
             </ul>
       school_placements:
         edit:
-          page_title: How placements work - %{course_name_and_code}
+          page_title: Preferences for schools
           submit_button: Update how placements work
-          selectable_school_label: Do you want to show placement schools to candidates?
-          selectable_school_hint: Candidates will see a list of placement schools on your course pages and be able to select a preference when they apply.
+          selectable_school_label: Do you want to let candidates select a preferred school?
+          selectable_school_hint: Candidates will be able to select a preferred school when applying.
+          show_school_label: Do you want to show schools to candidates?
+          show_school_hint: Candidates will see the list of potential schools on the course page.
           guidance_text_html:
             <p class="govuk-body">Give candidates information about the schools they will be training in</p>
             <p class="govuk-body">Tell them:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>how many placements they will have</li>
-              <li>how much time they will spend in each school</li>
-              <li>if mentors are available within the schools</li>
+            <li>how many placements they will have</li>
+            <li>how much time they will spend in each school</li>
+            <li>if mentors are available within the schools</li>
             </ul>
           where_you_will_train: Where you will train
           summary_text: See what we include in this section
@@ -149,18 +152,17 @@ en:
           candidates_say_section_html:
             <p class="govuk-body">Candidates say the most important information is:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>how and where they will spend their time</li>
-              <li>how the course is structured, for example which specific modules or areas are taught</li>
-              <li>how they will be supported, for example tutors and mentoring</li>
-              <li>the qualification and experience they will have at the end of the course</li>
+            <li>how and where they will spend their time</li>
+            <li>how the course is structured, for example which specific modules or areas are taught</li>
+            <li>how they will be supported, for example tutors and mentoring</li>
+            <li>the qualification and experience they will have at the end of the course</li>
             <ul>
-          remember_to_section_html:
-            <p class="govuk-body">Remember to:</p>
+          remember_to_section_html: <p class="govuk-body">Remember to:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>keep it brief and to the point, people struggle with long blocks of writing online</li>
-              <li>use bullet points, headings and paragraphs to make your writing easy to read</li>
-              <li>spell out acronyms the first time you use them, for example, ITT, NQT, SCITT</li>
-              <li>link to your organisation's website for people who want more detail about who you are and what you do</li>
+            <li>keep it brief and to the point, people struggle with long blocks of writing online</li>
+            <li>use bullet points, headings and paragraphs to make your writing easy to read</li>
+            <li>spell out acronyms the first time you use them, for example, ITT, NQT, SCITT</li>
+            <li>link to your organisation's website for people who want more detail about who you are and what you do</li>
             </ul>
           view_examples: View examples of great course summaries
       study_mode:

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -127,6 +127,8 @@ en:
       school_placements:
         edit:
           page_title: Preferences for schools
+          warning_text: Changes to these preferences will not change courses you have already added.
+          change_preferences: To change preferences of an existing course, go to the 'Basic details' tab of the course.
           submit_button: Update how placements work
           selectable_school_label: Do you want to let candidates select a preferred school?
           selectable_school_hint: Candidates will be able to select a preferred school when applying.

--- a/db/migrate/20250714140702_add_show_school_placements_on_provider.rb
+++ b/db/migrate/20250714140702_add_show_school_placements_on_provider.rb
@@ -1,0 +1,5 @@
+class AddShowSchoolPlacementsOnProvider < ActiveRecord::Migration[8.0]
+  def change
+    add_column :provider, :show_school, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -368,6 +368,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_21_145533) do
     t.text "address3"
     t.boolean "selectable_school", default: false, null: false
     t.boolean "accredited", default: false, null: false
+    t.boolean "show_school", default: false, null: false
     t.index ["accredited"], name: "index_provider_on_accredited"
     t.index ["can_sponsor_student_visa"], name: "index_provider_on_can_sponsor_student_visa"
     t.index ["changed_at"], name: "index_provider_on_changed_at", unique: true

--- a/spec/components/find/courses/training_locations/view_spec.rb
+++ b/spec/components/find/courses/training_locations/view_spec.rb
@@ -56,13 +56,12 @@ describe Find::Courses::TrainingLocations::View, type: :component do
   end
 
   describe "#placements_url" do
-    let(:provider) { create(:provider, selectable_school:) }
+    let(:provider) { create(:provider, show_school:) }
     let(:course) { create(:course, provider:) }
-    let(:selectable_school) { false }
 
-    context "when preview is true and provider is not selectable_school" do
+    context "when preview is true and provider does not show schools" do
       let(:preview) { true }
-      let(:selectable_school) { false }
+      let(:show_school) { false }
 
       it "renders link to the publish path for provider" do
         expect(subject).to have_no_link(
@@ -76,8 +75,8 @@ describe Find::Courses::TrainingLocations::View, type: :component do
       end
     end
 
-    context "when preview is false and provider has selectable_school enabled" do
-      let(:selectable_school) { true }
+    context "when preview is false and provider has show_school enabled" do
+      let(:show_school) { true }
 
       it "renders a link to the find path" do
         expect(subject).to have_link("View list of school placements",

--- a/spec/controllers/find/placements_controller_spec.rb
+++ b/spec/controllers/find/placements_controller_spec.rb
@@ -9,7 +9,7 @@ module Find
     end
 
     describe "#placements" do
-      context "when provider is not pressent" do
+      context "when provider is not present" do
         it "renders the not found page" do
           get :index, params: {
             provider_code: "ABC",
@@ -20,9 +20,9 @@ module Find
         end
       end
 
-      context "when provider sets school_placement as not selectable" do
+      context "when provider does not show schools" do
         it "renders the not found page" do
-          provider = create(:provider, selectable_school: false)
+          provider = create(:provider, show_school: false)
           course = create(:course, :published, provider:)
 
           get :index, params: {
@@ -48,9 +48,9 @@ module Find
         end
       end
 
-      context "when course is published and school placement is selectable" do
+      context "when course is published and provider shows schools" do
         it "respond successfully" do
-          provider = create(:provider, selectable_school: true)
+          provider = create(:provider, show_school: true)
           course = create(:course, :published, provider:)
 
           get :index, params: {

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -37,6 +37,7 @@ FactoryBot.define do
     can_sponsor_skilled_worker_visa { [true, false].sample }
     synonyms { Faker::Lorem.words(number: 0..3) }
     selectable_school { true }
+    show_school { true }
 
     trait :with_name do
       provider_name { "Test Name" }

--- a/spec/features/find/course/viewing_a_course_spec.rb
+++ b/spec/features/find/course/viewing_a_course_spec.rb
@@ -57,23 +57,29 @@ feature "Viewing a findable course" do
     create(:recruitment_cycle, :next)
     Timecop.travel(Find::CycleTimetable.find_opens) do
       given_there_is_a_findable_course
-      and_the_provider_does_not_have_selectable_schools
+      and_the_provider_does_not_have_viewable_schools
       when_i_visit_the_course_page
       then_i_see_no_school_placements_link
     end
   end
 
-  scenario "user sees selectable school placements" do
+  scenario "user sees viewable school placements" do
     create(:recruitment_cycle, :next)
     Timecop.travel(Find::CycleTimetable.find_opens) do
       given_there_is_a_findable_course
-      and_the_provider_has_selectable_schools
+      and_the_provider_has_viewable_schools
       when_i_visit_the_course_page
       when_i_click("View list of school placements")
       then_i_should_be_on_the_school_placements_page
       when_i_click("Back to #{@course.name} (#{course.course_code})")
       then_i_should_be_on_the_course_page
     end
+  end
+
+  scenario "provider has selectable school enabled" do
+    given_there_is_a_findable_course
+    and_the_provider_has_selectable_schools
+    then_the_provider_should_have_selectable_schools
   end
 
   scenario "user views provider and accredited_provider" do
@@ -449,11 +455,19 @@ private
     expect(find_course_show_page).to have_no_link("View list of school placements")
   end
 
-  def and_the_provider_does_not_have_selectable_schools
-    @provider.update(selectable_school: false)
+  def and_the_provider_does_not_have_viewable_schools
+    @provider.update(show_school: false)
+  end
+
+  def and_the_provider_has_viewable_schools
+    @provider.update(show_school: true)
   end
 
   def and_the_provider_has_selectable_schools
-    @provider.update(selectable_school: true)
+    @course.provider.update(selectable_school: true)
+  end
+
+  def then_the_provider_should_have_selectable_schools
+    expect(@course.provider).to be_selectable_school
   end
 end

--- a/spec/features/publish/edit_provider_details_spec.rb
+++ b/spec/features/publish/edit_provider_details_spec.rb
@@ -8,11 +8,11 @@ feature "About Your Organisation section" do
     when_i_visit_the_details_page
     then_i_can_edit_info_about_training_with_us
     then_i_can_edit_info_about_disabilities_and_other_needs
-    then_i_can_edit_school_placements
+    then_i_can_edit_school_placement_preferences
   end
 
   def given_i_am_a_provider_user_as_a_provider_user
-    @provider = create(:provider)
+    @provider = create(:provider, show_school: true, selectable_school: true)
     course = create(:course, :with_accrediting_provider, provider: @provider)
 
     @provider.accredited_partnerships.create(accredited_provider: course.accrediting_provider)
@@ -62,16 +62,38 @@ feature "About Your Organisation section" do
     end
   end
 
-  def then_i_can_edit_school_placements
+  def then_i_can_edit_school_placement_preferences
+    then_i_can_toggle_show_school
+    then_i_can_toggle_selectable_school
+  end
+
+  def then_i_can_toggle_show_school
+    within(publish_provider_details_show_page.show_school) do
+      expect(page).to have_content("Yes")
+    end
+
+    publish_provider_details_show_page.show_school_change_link.click
+    expect(page.find_by_id("provider-show-school-true-field")).to be_checked
+
+    page.find("input#provider-show-school-false-field").click
+    page.click_on("Update school placement preferences")
+
+    within(publish_provider_details_show_page.show_school) do
+      expect(page).to have_content("No")
+    end
+  end
+
+  def then_i_can_toggle_selectable_school
     within(publish_provider_details_show_page.selectable_school) do
       expect(page).to have_content("Yes")
     end
+
     publish_provider_details_show_page.selectable_school_change_link.click
     expect(page.find_by_id("provider-selectable-school-true-field")).to be_checked
-    page.find("input#provider-selectable-school-field").click
+
+    page.find("input#provider-selectable-school-false-field").click
     page.click_on("Update school placement preferences")
 
-    publish_provider_details_show_page.selectable_school.click
     within(publish_provider_details_show_page.selectable_school) do
       expect(page).to have_content("No")
     end

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -138,7 +138,7 @@ feature "Course show" do
     create(:recruitment_cycle, :next)
     Timecop.travel(Find::CycleTimetable.find_opens) do
       given_i_am_authenticated(user: user_with_fee_based_course)
-      provider.update(selectable_school: false)
+      provider.update(show_school: false)
       when_i_visit_the_publish_course_preview_page
       then_i_see_no_school_placements_link
     end

--- a/spec/support/page_objects/publish/provider_details_show.rb
+++ b/spec/support/page_objects/publish/provider_details_show.rb
@@ -14,6 +14,8 @@ module PageObjects
       element :email_link, "[data-qa=enrichment__email] a"
       element :selectable_school, "[data-qa=enrichment__selectable_school]"
       element :selectable_school_change_link, "[data-qa=enrichment__selectable_school] a"
+      element :show_school, "[data-qa=enrichment__show_school]"
+      element :show_school_change_link, "[data-qa=enrichment__show_school] a"
     end
   end
 end


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/ArUdkr7S/891-add-independent-control-to-show-school-placements-in-find

We previously added the ability for providers to turn on displaying placement schools and preferred school selection in "Organisation details".​ However, some providers would like more control over the settings.​

This ticket is to update the controls at an organisational level. 

## Changes proposed in this pull request

- New database column at Provider level: `show_school`
- Use the new column to show/hide school list in Find (the logic for the `selectable_school` field remains unchanged)
- Update the schools page content and add new radio button/question
- Update the 'Organisation Details' page with 'Preferences for schools' summary
- Update feature/controller specs to support new field

**Add additional question / radio button to Schools page and adapt content**

<img width="984" height="669" alt="Screenshot 2025-07-18 at 15 46 44" src="https://github.com/user-attachments/assets/3102222f-7cdb-428b-8210-6bbf81f59d7c" />

**Update the organisational details page**

<img width="971" height="222" alt="Screenshot 2025-07-18 at 15 48 01" src="https://github.com/user-attachments/assets/3e8e6be9-d5a3-4142-8277-9d3282378775" />

**Using new show_school field/question in Publish to show/hide the list of schools to candidates in Find**

https://github.com/user-attachments/assets/42bf391a-d57a-47f1-954f-45140ccd2cf0

## Guidance to review

The main thing is to test that the new `show_school` field, show/hides the 'View list of placement schools' link on the course page. 
- In Publish, sign in as Colin and select 'Abacus Belsize Primary School'
- click the 'Organisation Details' tab and scroll down to 'Preferences for schools'
- under 'Show schools to candidates' click 'Change' and select 'yes' for the first question ('Do you want to show schools to candidates?')
- navigate to Find and view courses for Abacus Belsize Primary School. Select a course.
- scroll down to the 'Where you will train' section and under 'Nearest placement school' there should be a link to 'View list of placement schools' link. Click the link to ensure list of placements schools are displayed on the next page. 
(you can play around and toggle between answering yes and no in Publish and see what effect it has on the display for the 'View list of placement schools' in Find)

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
