### PR TITLE
Add Index for Candidates in Support

### DIFF
--- a/app/controllers/support/candidates_controller.rb
+++ b/app/controllers/support/candidates_controller.rb
@@ -1,0 +1,7 @@
+module Support
+  class CandidatesController < ApplicationController
+    def index
+      @candidates = Candidate.order(created_at: :desc)
+    end
+  end
+end

--- a/app/controllers/support/candidates_controller.rb
+++ b/app/controllers/support/candidates_controller.rb
@@ -1,7 +1,7 @@
 module Support
   class CandidatesController < ApplicationController
     def index
-      @candidates = Candidate.order(created_at: :desc)
+      @pagy, @candidates = pagy(Candidate.order(created_at: :desc))
     end
   end
 end

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -34,8 +34,8 @@
     <%= govuk_skip_link %>
 
     <%= render HeaderComponent.new(service_name: I18n.t("service_name.support"), service_url: support_root_path, current_user:) do |header| %>
-      <% header.with_navigation_item t(".candidates"), support_candidates_path %>
       <% header.with_navigation_item t(".providers"), support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) %>
+      <% header.with_navigation_item t(".candidates"), support_candidates_path if FeatureFlag.active?(:candidate_accounts) %>
       <% header.with_navigation_item t(".users"), support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) %>
       <% header.with_navigation_item t(".feedbacks"), support_feedback_index_path %>
       <% header.with_navigation_item t(".settings"), support_settings_path %>

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -34,6 +34,7 @@
     <%= govuk_skip_link %>
 
     <%= render HeaderComponent.new(service_name: I18n.t("service_name.support"), service_url: support_root_path, current_user:) do |header| %>
+      <% header.with_navigation_item t(".candidates"), support_candidates_path %>
       <% header.with_navigation_item t(".providers"), support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) %>
       <% header.with_navigation_item t(".users"), support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) %>
       <% header.with_navigation_item t(".feedbacks"), support_feedback_index_path %>

--- a/app/views/support/candidates/index.html.erb
+++ b/app/views/support/candidates/index.html.erb
@@ -1,0 +1,20 @@
+<%= render PageTitle.new(title: "support.candidates.index") %>
+
+<h1 class="govuk-heading-l"><%= t("page_titles.candidates.index") %></h1>
+
+<%= govuk_table do |table| %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell text: "Email address" %>
+      <% row.with_cell text: "Created at" %>
+    <% end %>
+  <% end %>
+  <% table.with_body do |body| %>
+    <% @candidates.each do |candidate| %>
+      <% body.with_row classes: %w[course-row] do |row| %>
+        <% row.with_cell text: candidate.email_address %>
+        <% row.with_cell text: "#{candidate.created_at.to_fs(:govuk_date_and_time)} (#{time_ago_in_words(candidate.created_at)} ago)" %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/support/candidates/index.html.erb
+++ b/app/views/support/candidates/index.html.erb
@@ -18,3 +18,5 @@
     <% end %>
   <% end %>
 <% end %>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/support/candidates/index.html.erb
+++ b/app/views/support/candidates/index.html.erb
@@ -5,8 +5,8 @@
 <%= govuk_table do |table| %>
   <% table.with_head do |head| %>
     <% head.with_row do |row| %>
-      <% row.with_cell text: "Email address" %>
-      <% row.with_cell text: "Created at" %>
+      <% row.with_cell text: t(".email_address") %>
+      <% row.with_cell text: t(".created_at") %>
     <% end %>
   <% end %>
   <% table.with_body do |body| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,6 +250,8 @@ en:
     rollover:
       show: "Recruitment cycles"
       change_cycle: "Change recruitment cycle"
+    candidates:
+      index: "Candidates"
     users:
       index: "Users"
       new: "Personal details"
@@ -358,6 +360,8 @@ en:
               new: "Contact details"
             checks:
               show: "Check your answers"
+        candidates:
+          index: "Candidates"
         users:
           index: "Users"
           show: "User overview"

--- a/config/locales/en/layouts/support.yml
+++ b/config/locales/en/layouts/support.yml
@@ -1,6 +1,7 @@
 en:
   layouts:
     support:
+      candidates: Candidates
       providers: Providers
       users: Users
       settings: Settings

--- a/config/locales/en/support/candidates.yml
+++ b/config/locales/en/support/candidates.yml
@@ -1,0 +1,6 @@
+en:
+  support:
+    candidates:
+      index:
+        email_address: Email address
+        created_at: Created at

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -100,4 +100,5 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
       post :confirm_rollover
     end
   end
+  resources :candidates, only: %i[index]
 end

--- a/spec/system/support/candidates/list_candidates_spec.rb
+++ b/spec/system/support/candidates/list_candidates_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Support console Candidates index", service: :support do
+  let(:user) { create(:user, :admin) }
+
+  before { given_i_am_authenticated }
+
+  scenario "user sees candidates index" do
+    when_some_candidates_exist
+    and_i_visit_the_candidate_index
+    then_i_see_the_candidates_listed
+  end
+
+  def when_some_candidates_exist
+    @candidates = create_list(:candidate, 2)
+  end
+
+  def and_i_visit_the_candidate_index
+    visit support_candidates_path
+  end
+
+  def then_i_see_the_candidates_listed
+    expect(page).to have_content(@candidates[0].email_address)
+    expect(page).to have_content(@candidates[1].email_address)
+  end
+
+  def given_i_am_authenticated
+    sign_in_system_test(user:)
+  end
+end


### PR DESCRIPTION
## Context

List all the candidates that have logged into our service

## Changes proposed in this pull request

- Add an index in the Support Console for listing Candidates.
- The index is paginated

## Guidance to review

<img width="1202" height="583" alt="image" src="https://github.com/user-attachments/assets/17c4b70e-f0e4-4ebb-95a9-2bc5619c5e54" />




## Checklist

- [x] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
