### PR TITLE
An existing authentication should not trigger unique validation error

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -18,7 +18,7 @@ private
   def unique_authenticable_with_provider
     return if authenticable.nil?
 
-    if self.class.exists?(authenticable:, provider:)
+    if self.class.where.not(id:).exists?(authenticable:, provider:)
       errors.add(:authenticable, :unique)
     end
   end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -2,16 +2,20 @@ require "rails_helper"
 
 RSpec.describe Authentication, type: :model do
   let(:auth) { create(:authentication, :developer) }
+  let(:candidate) { create(:candidate, :logged_in) }
 
   it "is associated with an authenticable" do
     expect(auth.authenticable).to be_a(Candidate)
   end
 
   it "authenticable is unique given provider" do
-    candidate = create(:candidate, :logged_in)
-
     authentication = candidate.authentications.last.dup
     expect(authentication).not_to be_valid
     expect(authentication.errors.full_messages).to include("Authenticable should be unique to the given provider")
+  end
+
+  it "is valid" do
+    authentication = candidate.authentications.first
+    expect(authentication).to be_valid
   end
 end


### PR DESCRIPTION
## Context

  When an authentication is created, when we check if it is valid,
  we should exclude itself from duplication checks

## Changes proposed in this pull request

Check if an Authentication is unique by excluding itself from the check

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Trello
[Unique Authentication validation bug](https://trello.com/c/x6JMQsxL/912-unique-authentication-validation-bug)

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
