### PR TITLE
Order rolledover courses in RolloverProgressQuery

### DIFF
--- a/app/queries/rollover_progress_query.rb
+++ b/app/queries/rollover_progress_query.rb
@@ -100,7 +100,7 @@ class RolloverProgressQuery
   end
 
   def rolled_over_courses
-    @target_cycle.courses.where("course.created_at < ?", @target_cycle.application_start_date)
+    @target_cycle.courses.where("course.created_at < ?", @target_cycle.application_start_date).order(created_at: :asc)
   end
 
   def rolled_over_providers


### PR DESCRIPTION
## Context

Flaky test:
The query doesn't guarantee the order so the test may fail if the actual order isn't the same as the expected order.

## Changes proposed in this pull request

Order the courses in the RolloverProgressQuery

## Guidance to review

Maybe there are other places this should be fixed.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
