### PR TITLE
Correct the host of the One Login post logout url

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,7 +63,7 @@ one_login:
   # URL we use to end the Onne Login session on behalf of the user
   logout_url: https://oidc.integration.account.gov.uk/logout
   # URL user is redirected to after logging out of One Login
-  post_logout_url: https://qa.publish-teacher-training-courses.service.gov.uk/
+  post_logout_url: https://qa.find-teacher-training-courses.service.gov.uk
   # URL of the users profile
   profile_url: https://home.integration.account.gov.uk
   # YAML doesn't preserve newlines. Convert newlines to \n


### PR DESCRIPTION
## Context

When I created the default settings config for One Login, I put the wrong host in. The top level config only affects QA.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Correct the Post Logout URI that gets sent to One Login in an environment.

This doesn't affect Review so no point in deploying.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
