### PR TITLE
Add content to the schools page when adding a course

### DIFF
--- a/app/helpers/publish/course_schools_helper.rb
+++ b/app/helpers/publish/course_schools_helper.rb
@@ -1,0 +1,17 @@
+module Publish
+  module CourseSchoolsHelper
+    def school_label_for(course)
+      t("publish.courses.schools.heading.#{course.salaried? ? 'salaried' : 'unsalaried'}")
+    end
+
+    def school_warning_text(course)
+      school_type = t("publish.courses.schools.#{course.salaried? ? 'salaried' : 'unsalaried'}").downcase
+      t("publish.courses.schools.new.warning_text", school_type: school_type)
+    end
+
+    def school_label_with_plural(course, count:)
+      prefix = t("publish.courses.schools.#{course.salaried? ? 'salaried' : 'unsalaried'}")
+      t("publish.courses.schools.label", count: count, prefix: prefix)
+    end
+  end
+end

--- a/app/helpers/publish/course_schools_helper.rb
+++ b/app/helpers/publish/course_schools_helper.rb
@@ -1,17 +1,21 @@
 module Publish
   module CourseSchoolsHelper
     def school_label_for(course)
-      t("publish.courses.schools.heading.#{course.salaried? ? 'salaried' : 'unsalaried'}")
+      t("publish.courses.schools.heading.#{course_type_key(course)}")
     end
 
     def school_warning_text(course)
-      school_type = t("publish.courses.schools.#{course.salaried? ? 'salaried' : 'unsalaried'}").downcase
+      school_type = t("publish.courses.schools.#{course_type_key(course)}").downcase
       t("publish.courses.schools.new.warning_text", school_type: school_type)
     end
 
     def school_label_with_plural(course, count:)
-      prefix = t("publish.courses.schools.#{course.salaried? ? 'salaried' : 'unsalaried'}")
+      prefix = t("publish.courses.schools.#{course_type_key(course)}")
       t("publish.courses.schools.label", count: count, prefix: prefix)
+    end
+
+    def course_type_key(course)
+      course.salaried? ? "salaried" : "unsalaried"
     end
   end
 end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -101,7 +101,7 @@
      end
 
      summary_list.with_row(html_attributes: { data: { qa: "course__schools" } }) do |row|
-       row.with_key { "School".pluralize(course.sites.length) }
+       row.with_key { school_label_with_plural(course, count: course.sites.length) }
        row.with_value do
          if course.sites.blank?
            raw("<span class=\"app-!-colour-muted\">None</span>")

--- a/app/views/publish/courses/confirmation.html.erb
+++ b/app/views/publish/courses/confirmation.html.erb
@@ -101,7 +101,7 @@
         <% end %>
 
         <% summary_list.with_row(html_attributes: { data: { qa: "course__schools" } }) do |row| %>
-          <% row.with_key { t(".school", count: course.sites.length) } %>
+          <% row.with_key { school_label_with_plural(course, count: course.sites.length) } %>
           <% row.with_value do %>
             <% if course.sites.nil? || course.sites.empty? %>
               <span class="app-!-colour-muted"><%= t(".none") %></span>

--- a/app/views/publish/courses/schools/edit.html.erb
+++ b/app/views/publish/courses/schools/edit.html.erb
@@ -1,4 +1,4 @@
-<% page_title = "Schools" %>
+<% page_title = school_label_for(course) %>
 <% content_for :page_title, title_with_error_prefix("#{page_title} – #{course.name_and_code}", @course_school_form.errors.present?) %>
 
 <% content_for :before_content do %>
@@ -18,7 +18,7 @@
 
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_check_boxes_fieldset :site_ids, legend:
-      { text: "#{render CaptionText.new(text: course.name_and_code)} Schools".html_safe, tag: "h1", size: "l" }, hint: { text: "Select all that apply" } do %>
+      { text: "#{render CaptionText.new(text: course.name_and_code)} #{school_label_for(course)}".html_safe, tag: "h1", size: "l" }, hint: { text: "Select all that apply" } do %>
        <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
           <%= f.govuk_check_box :site_ids,
               site.id,

--- a/app/views/publish/courses/schools/new.html.erb
+++ b/app/views/publish/courses/schools/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix(course.salaried? ? "Employing schools" : "Placement schools", @errors && @errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(school_label_for(course), @errors && @errors.any?) %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
@@ -12,25 +12,24 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading" data-qa="page-heading">
             <%= render CaptionText.new(text: t("course.add_course")) %>
-            <%= course.salaried? ? "Employing schools" : "Placement schools" %>
+            <%= school_label_for(course) %>
           </h1>
         </legend>
         <p class="govuk-body">
-          The more schools you select, the more searches your course will appear in.
+          <%= t("publish.courses.schools.new.schools_selection") %>
         </p>
         <p class="govuk-body">
-          80% of searches are by location.
+          <%= t("publish.courses.schools.new.searches_by_location") %>
         </p>
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
           <strong class="govuk-warning-text__text">
-            If you do not add all your
-            <%= course.salaried? ? "employing schools" : "placement schools" %>, you may miss out on potential candidates.
+            <%= school_warning_text(course) %>
           </strong>
         </div>
         <%= render "publish/shared/error_messages", error_keys: [:sites] %>
         <div class="govuk-form-group govuk-!-margin-top-2">
-          <div class="govuk-hint">Select all that apply</div>
+          <div class="govuk-hint"><%= t("publish.courses.schools.new.selection") %></div>
           <%= form.govuk_check_boxes_fieldset :sites_ids, legend: nil do %>
             <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
               <%= form.govuk_check_box :sites_ids,

--- a/app/views/publish/courses/schools/new.html.erb
+++ b/app/views/publish/courses/schools/new.html.erb
@@ -1,11 +1,8 @@
-<% content_for :page_title, title_with_error_prefix("Schools", @errors && @errors.any?) %>
-
+<% content_for :page_title, title_with_error_prefix(course.salaried? ? "Employing schools" : "Placement schools", @errors && @errors.any?) %>
 <% content_for :before_content do %>
   <%= govuk_back_link_to(@back_link_path) %>
 <% end %>
-
 <%= render "publish/shared/errors" %>
-
 <%= form_for course,
   url: continue_publish_provider_recruitment_cycle_courses_schools_path(@provider.provider_code, course.recruitment_cycle.year, course.course_code),
   method: :get do |form| %>
@@ -15,14 +12,25 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading" data-qa="page-heading">
             <%= render CaptionText.new(text: t("course.add_course")) %>
-            Schools
+            <%= course.salaried? ? "Employing schools" : "Placement schools" %>
           </h1>
         </legend>
+        <p class="govuk-body">
+          The more schools you select, the more searches your course will appear in.
+        </p>
+        <p class="govuk-body">
+          80% of searches are by location.
+        </p>
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            If you do not add all your
+            <%= course.salaried? ? "employing schools" : "placement schools" %>, you may miss out on potential candidates.
+          </strong>
+        </div>
         <%= render "publish/shared/error_messages", error_keys: [:sites] %>
-
         <div class="govuk-form-group govuk-!-margin-top-2">
           <div class="govuk-hint">Select all that apply</div>
-
           <%= form.govuk_check_boxes_fieldset :sites_ids, legend: nil do %>
             <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
               <%= form.govuk_check_box :sites_ids,
@@ -32,13 +40,11 @@
                     link_errors: index.zero? %>
             <% end %>
           <% end %>
-
         </div>
       </fieldset>
     <% end %>
   <% end %>
 <% end %>
-
 <p class="govuk-body">
   <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 </p>

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -28,6 +28,20 @@ en:
         show:
           back: Back to %{course_name} (%{course_code})
           heading: About %{provider_name}
+      schools:
+        salaried: Employing
+        unsalaried: Placement
+        heading:
+          salaried: Employing schools
+          unsalaried: Placement schools
+        label:
+          one: "%{prefix} school"
+          other: "%{prefix} schools"
+        new:
+          schools_selection: The more schools you select, the more searches your course will appear in.
+          searches_by_location: 60% of searches are by location.
+          warning_text: "If you do not add all your %{school_type}, you may miss out on potential candidates."
+          selection: Select all that apply
     providers:
       details:
         page_title: Organisation details
@@ -104,10 +118,10 @@ en:
           summary_link: See what we include in this section
           guidance_html:
             <p class="govuk-body">Candidates find it helpful to know when fees are due, payment schedules, top up fees
-              and other costs like books and transport.</p>
+            and other costs like books and transport.</p>
             <p class="govuk-body">You can also tell them about any financial support your institution offers.</p>
             <p class="govuk-body">Do not include information about financial support available from the government
-              like student loans or bursaries.</p>
+            like student loans or bursaries.</p>
       interview_process:
         edit:
           interview_process_heading: Interview process (optional)
@@ -118,10 +132,10 @@ en:
           include_information_about_html:
             <p class="govuk-body">Include information about:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>how many interview candidates will have</li>
-              <li>the format of interviews, for example could they interview online</li>
-              <li>who will be interviewing them</li>
-              <li>any tests needed - if so, how they can prepare</li>
+            <li>how many interview candidates will have</li>
+            <li>the format of interviews, for example could they interview online</li>
+            <li>who will be interviewing them</li>
+            <li>any tests needed - if so, how they can prepare</li>
             </ul>
       school_placements:
         edit:
@@ -133,9 +147,9 @@ en:
             <p class="govuk-body">Give candidates information about the schools they will be training in</p>
             <p class="govuk-body">Tell them:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>how many placements they will have</li>
-              <li>how much time they will spend in each school</li>
-              <li>if mentors are available within the schools</li>
+            <li>how many placements they will have</li>
+            <li>how much time they will spend in each school</li>
+            <li>if mentors are available within the schools</li>
             </ul>
           where_you_will_train: Where you will train
           summary_text: See what we include in this section
@@ -149,18 +163,17 @@ en:
           candidates_say_section_html:
             <p class="govuk-body">Candidates say the most important information is:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>how and where they will spend their time</li>
-              <li>how the course is structured, for example which specific modules or areas are taught</li>
-              <li>how they will be supported, for example tutors and mentoring</li>
-              <li>the qualification and experience they will have at the end of the course</li>
+            <li>how and where they will spend their time</li>
+            <li>how the course is structured, for example which specific modules or areas are taught</li>
+            <li>how they will be supported, for example tutors and mentoring</li>
+            <li>the qualification and experience they will have at the end of the course</li>
             <ul>
-          remember_to_section_html:
-            <p class="govuk-body">Remember to:</p>
+          remember_to_section_html: <p class="govuk-body">Remember to:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>keep it brief and to the point, people struggle with long blocks of writing online</li>
-              <li>use bullet points, headings and paragraphs to make your writing easy to read</li>
-              <li>spell out acronyms the first time you use them, for example, ITT, NQT, SCITT</li>
-              <li>link to your organisation's website for people who want more detail about who you are and what you do</li>
+            <li>keep it brief and to the point, people struggle with long blocks of writing online</li>
+            <li>use bullet points, headings and paragraphs to make your writing easy to read</li>
+            <li>spell out acronyms the first time you use them, for example, ITT, NQT, SCITT</li>
+            <li>link to your organisation's website for people who want more detail about who you are and what you do</li>
             </ul>
           view_examples: View examples of great course summaries
       study_mode:

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -38,9 +38,9 @@ en:
           one: "%{prefix} school"
           other: "%{prefix} schools"
         new:
-          schools_selection: The more schools you select, the more searches your course will appear in.
+          schools_selection: The more schools you select, the more searches your course will appear in. You should only add schools that are relevent to this course.
           searches_by_location: 60% of searches are by location.
-          warning_text: "If you do not add all your %{school_type} schools, you may miss out on potential candidates."
+          warning_text: "If you do not add all relevant %{school_type} schools, you may miss out on potential candidates."
           selection: Select all that apply
     providers:
       details:

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -40,7 +40,7 @@ en:
         new:
           schools_selection: The more schools you select, the more searches your course will appear in.
           searches_by_location: 60% of searches are by location.
-          warning_text: "If you do not add all your %{school_type}, you may miss out on potential candidates."
+          warning_text: "If you do not add all your %{school_type} schools, you may miss out on potential candidates."
           selection: Select all that apply
     providers:
       details:

--- a/config/locales/en/publish/courses/confirmation.yml
+++ b/config/locales/en/publish/courses/confirmation.yml
@@ -8,9 +8,6 @@ en:
         subjects:
           one: Subject
           other: Subjects
-        school:
-          one: School
-          other: Schools
         study_site:
           one: Study site
           other: Study sites
@@ -45,4 +42,3 @@ en:
         ratifying_provider: ratifying provider
         visa_sponsorship_deadline_required_visually_hidden: visa sponsorship deadline required
         date_for_applications_requiring_visa_sponsorship_visually_hidden: date for applications requiring visa sponsorship
-

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -205,7 +205,7 @@ private
     expect_summary_list_to_include(key: "Qualification", value: "QTS with PGDE")
     expect_summary_list_to_include(key: "Funding type", value: "Salary (apprenticeship)")
     expect_summary_list_to_include(key: "Study pattern", value: "Full time or part time")
-    expect_summary_list_to_include(key: "School", value: site.location_name)
+    expect_summary_list_to_include(key: "Employing school", value: site.location_name)
     expect_summary_list_to_include(key: "Applications open date", value: "12 October #{Settings.current_recruitment_cycle_year.to_i - 1}")
     expect_summary_list_to_include(key: "Course start date", value: "October #{Settings.current_recruitment_cycle_year.to_i - 1}")
   end

--- a/spec/helpers/publish/course_schools_helper_spec.rb
+++ b/spec/helpers/publish/course_schools_helper_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Publish::CourseSchoolsHelper, type: :helper do
 
   describe "#school_warning_text" do
     it "returns the warning text for salaried courses" do
-      expect(helper.school_warning_text(salaried_course)).to eq("If you do not add all your employing schools, you may miss out on potential candidates.")
+      expect(helper.school_warning_text(salaried_course)).to eq("If you do not add all relevant employing schools, you may miss out on potential candidates.")
     end
 
     it "returns the warning text for unsalaried courses" do
-      expect(helper.school_warning_text(unsalaried_course)).to eq("If you do not add all your placement schools, you may miss out on potential candidates.")
+      expect(helper.school_warning_text(unsalaried_course)).to eq("If you do not add all relevant placement schools, you may miss out on potential candidates.")
     end
   end
 

--- a/spec/helpers/publish/course_schools_helper_spec.rb
+++ b/spec/helpers/publish/course_schools_helper_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Publish::CourseSchoolsHelper, type: :helper do
+  let(:salaried_course) { double("Course", salaried?: true) }
+  let(:unsalaried_course) { double("Course", salaried?: false) }
+
+  describe "#school_label_for" do
+    it "returns the correct label for salaried courses" do
+      expect(helper.school_label_for(salaried_course)).to eq("Employing schools")
+    end
+
+    it "returns the correct label for unsalaried courses" do
+      expect(helper.school_label_for(unsalaried_course)).to eq("Placement schools")
+    end
+  end
+
+  describe "#school_warning_text" do
+    it "returns the warning text for salaried courses" do
+      expect(helper.school_warning_text(salaried_course)).to eq("If you do not add all your employing schools, you may miss out on potential candidates.")
+    end
+
+    it "returns the warning text for unsalaried courses" do
+      expect(helper.school_warning_text(unsalaried_course)).to eq("If you do not add all your placement schools, you may miss out on potential candidates.")
+    end
+  end
+
+  describe "#school_label_with_plural" do
+    it "returns the correct label with pluralisation for salaried courses" do
+      expect(helper.school_label_with_plural(salaried_course, count: 1)).to eq("Employing school")
+      expect(helper.school_label_with_plural(salaried_course, count: 3)).to eq("Employing schools")
+    end
+
+    it "returns the correct label with pluralisation for unsalaried courses" do
+      expect(helper.school_label_with_plural(unsalaried_course, count: 1)).to eq("Placement school")
+      expect(helper.school_label_with_plural(unsalaried_course, count: 3)).to eq("Placement schools")
+    end
+  end
+end


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/XvfnwVdg/910-add-content-to-the-schools-page-when-adding-a-course

This ticket is to update the content on the Schools page when a provider adds a course (it is part of the parent ticket to [Add location controls at a course level](https://trello.com/c/FOWwybxi/350-add-location-controls-at-a-course-level))

## Changes proposed in this pull request

- update content on the Add a Course flow’s Schools page and Check Your Answers page.
- modify the Basic Details tab/page after course creation.
- conditionally render "Placement school(s)" or "Employing school(s)" labels based on whether the course is fee-based or salaried on the above pages.
- create a new helper (`Publish::CourseSchoolsHelper`) to handle dynamic labels and warning text.
- add specs for the new helper to ensure correct behaviour.

**Schools page (unsalaried course = Placement schools**)

<img width="1054" height="651" alt="Screenshot 2025-08-01 at 09 07 42" src="https://github.com/user-attachments/assets/3a9ff4ff-8994-4ca9-939f-f7bdb5789b59" />


**Schools page (salaried course = Employing schools**)

<img width="1107" height="652" alt="Screenshot 2025-08-01 at 09 07 56" src="https://github.com/user-attachments/assets/118048cf-fd3c-4d2d-9508-e31977387b11" />


## Guidance to review

- sign into Publish as a Provider and go through the 'Add a course' flow. 
- on the 'Funding type' step: selecting 'Salary' and 'Teaching apprenticeship - with salary' should go on to display 'Employing schools' on the Schools page and selecting 'Fee - no salary' should display 'Placement schools'. 
- once you reach the 'Check you answers page', the label for the list of schools should read either 'Placement schools' or 'Employing schools'.
- in addition, you can check the Schools label on the Basic details tab of any salaried or unsalaried course

## Checklist

- [x] I have moved hard-coded strings to locale files.
- [x] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
