### PR TITLE
Display when there are no saved courses in the saved courses page

### DIFF
--- a/app/assets/stylesheets/find/application.scss
+++ b/app/assets/stylesheets/find/application.scss
@@ -22,6 +22,7 @@
 @import "./components/filter-search";
 @import "./components/filters";
 @import "./components/map";
+@import "./components/no_saved_courses_box";
 @import "./components/promoted-link";
 @import "./components/quick-link-card";
 @import "./components/save-course-button";

--- a/app/assets/stylesheets/find/components/_no_saved_courses_box.scss
+++ b/app/assets/stylesheets/find/components/_no_saved_courses_box.scss
@@ -1,0 +1,6 @@
+.no_saved-courses-box {
+  padding: govuk-spacing(6);
+
+  background-color: govuk-colour("light-grey");
+  border: 5px dashed $govuk-border-colour;
+}

--- a/app/views/find/candidates/saved_courses/index.html.erb
+++ b/app/views/find/candidates/saved_courses/index.html.erb
@@ -7,8 +7,17 @@
     </h1>
   </div>
 
-  <div class="govuk-grid-column-full">
-    <% if @saved_courses.any? %>
+  <% if @saved_courses.empty? %>
+    <div class="govuk-grid-column-full">
+      <div class="no_saved-courses-box">
+        <h2 class="govuk-heading-m"><%= t(".no_saved_courses") %></h2>
+        <p class="govuk-body">
+          <%= t(".empty_state_html", link: govuk_link_to(t(".find_saved_courses"), find_root_path)) %>
+        </p>
+      </div>
+    </div>
+  <% else %>
+    <div class="govuk-grid-column-full">
       <table class="govuk-table">
         <tbody class="govuk-table__body">
           <% @saved_courses.each do |saved_course| %>
@@ -16,8 +25,6 @@
           <% end %>
         </tbody>
       </table>
-    <% else %>
-      <p class="govuk-body"><%= t(".no_saved_courses") %></p>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/en/find/candidates/saved_courses.yml
+++ b/config/locales/en/find/candidates/saved_courses.yml
@@ -4,7 +4,9 @@ en:
       saved_courses:
         index:
           page_title: Saved courses
-          no_saved_courses: You have no saved courses.
+          no_saved_courses: You have no saved courses
+          find_saved_courses: Find a course
+          empty_state_html: "%{link} and start saving courses you may want to review and apply for later."
         create:
           save_failed: Failed to save course
         destroy:

--- a/spec/system/find/candidates/view_saved_courses_spec.rb
+++ b/spec/system/find/candidates/view_saved_courses_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe "Viewing my saved courses", service: :find do
   end
 
   def then_i_see_no_saved_courses_message
-    expect(page).to have_content("You have no saved courses.")
+    expect(page).to have_content("You have no saved courses")
+    expect(page).to have_link("Find a course", href: find_root_path)
+    expect(page).to have_content("and start saving courses you may want to review and apply for later.")
   end
 
   def then_i_view_my_saved_courses


### PR DESCRIPTION
## Context

As part of the candidate accounts work, we want to allow candidates to see when there are no saved courses on the saved courses page.

This ticket is to add content and styling to the page when there are no saved courses.

## Changes proposed in this pull request

Add a no saved courses state which is a custom html component which informs the user they have no saved courses

## Guidance to review

- Sign in 
- Go to saved courses page 
- If you have no saved courses you should see the below image

<img width="1200" height="744" alt="Screenshot 2025-07-23 at 17 49 02" src="https://github.com/user-attachments/assets/9ef23d36-2cc1-4c98-a8f5-5601faaa8f5e" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
