### PR TITLE
Confirm 2026, add 2027 cycle dates

### DIFF
--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -47,7 +47,14 @@ module Find
         apply_opens: Time.zone.local(2025, 10, 8, 9), # CONFIRMED
         first_deadline_banner: Time.zone.local(2026, 7, 12, 9), # TBC
         apply_deadline: Time.zone.local(2026, 9, 16, 18), # CONFIRMED
-        find_closes: Time.zone.local(2026, 9, 30, 23, 59, 59), # TBC
+        find_closes: Time.zone.local(2026, 9, 30, 23, 59, 59), # CONFIRMED
+      },
+      2027 => {
+        find_opens: Time.zone.local(2026, 10, 1, 9), # CONFIRMED
+        apply_opens: Time.zone.local(2026, 10, 8, 9), # CONFIRMED
+        first_deadline_banner: Time.zone.local(2027, 7, 12, 9), # TBC
+        apply_deadline: Time.zone.local(2027, 9, 21, 18), # CONFIRMED
+        find_closes: Time.zone.local(2027, 10, 4, 23, 59, 59), # TBC
       },
     }.freeze
 


### PR DESCRIPTION
## Context

The cycle dates for the next, next cycle (which will become the next cycle in a few months) have been confirmed with policy and updated in Apply. 

## Changes proposed in this pull request

Bring the dates recorded in this file in-line with the dates on apply

## Guidance to review

Cross reference the changes with the dates on apply
[2026](https://www.apply-for-teacher-training.service.gov.uk/publications/recruitment-cycle-timetables/2026)
[2027](https://www.apply-for-teacher-training.service.gov.uk/publications/recruitment-cycle-timetables/2027)

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
