### PR TITLE
Implement DataHub::UpdateSitesFromGias batch update

### DIFF
--- a/app/models/data_hub/update_sites_from_gias_process_summary.rb
+++ b/app/models/data_hub/update_sites_from_gias_process_summary.rb
@@ -1,0 +1,14 @@
+module DataHub
+  class UpdateSitesFromGiasProcessSummary < ProcessSummary
+    jsonb_accessor :short_summary,
+                   updated_total_count: :integer,
+                   updated_location_name: :integer,
+                   updated_latlon: :integer,
+                   updated_address3: :integer,
+                   error: :string,
+                   dry_run: :boolean
+
+    jsonb_accessor :full_summary,
+                   site_updates: [:jsonb, { array: true, default: [] }]
+  end
+end

--- a/app/services/data_hub/update_sites_from_gias/dry_run_site_updater.rb
+++ b/app/services/data_hub/update_sites_from_gias/dry_run_site_updater.rb
@@ -1,0 +1,9 @@
+module DataHub
+  module UpdateSitesFromGias
+    class DryRunSiteUpdater < SiteUpdater
+      def call
+        Result.new(site_id: site.id, changes: find_field_differences)
+      end
+    end
+  end
+end

--- a/app/services/data_hub/update_sites_from_gias/executor.rb
+++ b/app/services/data_hub/update_sites_from_gias/executor.rb
@@ -1,0 +1,60 @@
+module DataHub
+  module UpdateSitesFromGias
+    class Executor
+      BATCH_SIZE = 100
+
+      attr_reader :recruitment_cycle, :updater_class, :diff_query, :results
+
+      def initialize(recruitment_cycle:, updater_class: SiteUpdater, diff_query_class: SchoolsGiasDiffQuery)
+        @recruitment_cycle = recruitment_cycle
+        @updater_class = updater_class
+        @diff_query = diff_query_class.new(recruitment_cycle:)
+        @results = []
+      end
+
+      def execute
+        process_summary = DataHub::UpdateSitesFromGiasProcessSummary.start!
+
+        site_with_gias_difference do |site, gias_hash|
+          result = updater_class.new(site:, gias_school: gias_hash).call
+          results << result if result.changes.present?
+        end
+
+        summary_builder = SummaryBuilder.new(results)
+
+        process_summary.finish!(
+          short_summary: summary_builder.short_summary.merge(updater_class:),
+          full_summary: summary_builder.full_summary,
+        )
+
+        process_summary
+      rescue StandardError => e
+        process_summary&.fail!(e)
+        raise e
+      end
+
+    private
+
+      def site_with_gias_difference
+        diff_query.records_to_update.find_each(batch_size: BATCH_SIZE) do |site|
+          gias_hash = build_gias_hash(site)
+          yield(site, gias_hash)
+        end
+      end
+
+      def build_gias_hash(site)
+        {
+          name: site.gias_name,
+          address1: site.gias_address1,
+          address2: site.gias_address2,
+          address3: site.gias_address3,
+          town: site.gias_town,
+          county: site.gias_county,
+          postcode: site.gias_postcode,
+          latitude: site.gias_latitude,
+          longitude: site.gias_longitude,
+        }
+      end
+    end
+  end
+end

--- a/app/services/data_hub/update_sites_from_gias/schools_gias_diff_query.rb
+++ b/app/services/data_hub/update_sites_from_gias/schools_gias_diff_query.rb
@@ -1,0 +1,49 @@
+module DataHub
+  module UpdateSitesFromGias
+    class SchoolsGiasDiffQuery
+      SQL_FIELDS = [
+        %w[location_name name],
+        %w[address1 address1],
+        %w[address2 address2],
+        %w[address3 address3],
+        %w[town town],
+        %w[address4 county],
+        %w[postcode postcode],
+        %w[latitude latitude],
+        %w[longitude longitude],
+      ].freeze
+
+      FIELDS = %w[
+        name address1 address2 address3 town county postcode latitude longitude
+      ].freeze
+
+      def self.gias_select_aliases
+        FIELDS.map { |field| "gias_school.#{field} AS gias_#{field}" }
+      end
+
+      NORMALIZED_DIFFS = SQL_FIELDS.map do |site_field, gias_field|
+        if %w[latitude longitude].include?(site_field)
+          "site.#{site_field} IS DISTINCT FROM gias_school.#{gias_field}"
+        elsif site_field == "postcode"
+          "REPLACE(LOWER(TRIM(NULLIF(site.postcode, ''))), ' ', '') IS DISTINCT FROM REPLACE(LOWER(TRIM(NULLIF(gias_school.postcode, ''))), ' ', '')"
+        else
+          "LOWER(TRIM(NULLIF(site.#{site_field}, ''))) IS DISTINCT FROM LOWER(TRIM(NULLIF(gias_school.#{gias_field}, '')))"
+        end
+      end
+
+      def initialize(recruitment_cycle:)
+        @recruitment_cycle = recruitment_cycle
+      end
+
+      def records_to_update
+        @recruitment_cycle
+          .sites
+          .school
+          .kept
+          .joins("INNER JOIN gias_school ON site.urn = gias_school.urn")
+          .where(self.class::NORMALIZED_DIFFS.join(" OR "))
+          .select("site.*, #{self.class.gias_select_aliases.join(', ')}")
+      end
+    end
+  end
+end

--- a/app/services/data_hub/update_sites_from_gias/site_updater.rb
+++ b/app/services/data_hub/update_sites_from_gias/site_updater.rb
@@ -1,0 +1,73 @@
+module DataHub
+  module UpdateSitesFromGias
+    class SiteUpdater
+      FIELDS = {
+        location_name: :name,
+        address1: :address1,
+        address2: :address2,
+        address3: :address3,
+        town: :town,
+        address4: :county,
+        postcode: :postcode,
+        latitude: :latitude,
+        longitude: :longitude,
+      }.freeze
+
+      Result = Struct.new(:site_id, :changes, keyword_init: true)
+
+      def initialize(site:, gias_school:)
+        @site = site
+        @gias_school = gias_school
+      end
+
+      def call
+        differences = find_field_differences
+        return Result.new(site_id: site.id, changes: {}) if differences.empty?
+
+        site.transaction do
+          site.skip_geocoding = true
+          site.update_columns(differences.transform_values { |v| v[:after] })
+        end
+
+        Result.new(site_id: site.id, changes: differences)
+      end
+
+    private
+
+      attr_reader :site, :gias_school
+
+      def find_field_differences
+        FIELDS.each_with_object({}) do |(site_field, gias_field), diff_hash|
+          site_value = site.send(site_field)
+          gias_value = gias_school[gias_field]
+          if fields_differ?(site_field, site_value, gias_value)
+            diff_hash[site_field] = { before: site_value, after: gias_value }
+          end
+        end
+      end
+
+      def fields_differ?(field, site_value, gias_value)
+        case field
+        when :latitude, :longitude
+          floats_significantly_different?(site_value, gias_value)
+        when :postcode
+          normalize_postcode(site_value) != normalize_postcode(gias_value)
+        else
+          normalize_string(site_value) != normalize_string(gias_value)
+        end
+      end
+
+      def floats_significantly_different?(site_value, gias_value, epsilon = 0.00001)
+        (site_value.to_f - gias_value.to_f).abs > epsilon
+      end
+
+      def normalize_string(value)
+        value.to_s.downcase.strip.presence
+      end
+
+      def normalize_postcode(value)
+        value.to_s.downcase.strip.delete(" ").presence
+      end
+    end
+  end
+end

--- a/app/services/data_hub/update_sites_from_gias/summary_builder.rb
+++ b/app/services/data_hub/update_sites_from_gias/summary_builder.rb
@@ -1,0 +1,47 @@
+module DataHub
+  module UpdateSitesFromGias
+    class SummaryBuilder
+      ALL_FIELDS = %i[
+        location_name
+        address1
+        address2
+        address3
+        town
+        address4
+        postcode
+        latitude
+        longitude
+      ].freeze
+
+      def initialize(results)
+        @results = results
+      end
+
+      def short_summary
+        field_counts = ALL_FIELDS.index_with { |field| updated_count(field) }
+
+        {
+          updated_total_count: updated_results.count,
+        }.merge(field_counts)
+      end
+
+      def full_summary
+        {
+          site_updates: updated_results.map { |r| { id: r.site_id, changes: r.changes } },
+        }
+      end
+
+    private
+
+      attr_reader :results
+
+      def updated_results
+        @updated_results ||= results.select { |r| r.changes.present? }
+      end
+
+      def updated_count(field)
+        updated_results.count { |r| r.changes.key?(field) }
+      end
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -128,3 +128,9 @@
   - error
   - discarded_ids_lack_urn
   - discarded_invalid_urns
+  - updated_total_count
+  - updated_location_name
+  - updated_latlon
+  - updated_address3
+  - dry_run
+  - site_updates

--- a/lib/tasks/update_sites_from_gias.rake
+++ b/lib/tasks/update_sites_from_gias.rake
@@ -1,0 +1,28 @@
+namespace :update_sites_from_gias do
+  desc "Update sites from GIAS for a recruitment cycle (real run). Usage: rake data_hub:update_sites_from_gias:run YEAR=2025"
+  task :run, [:year] => :environment do |_t, args|
+    year = args[:year] || ENV["YEAR"]
+    raise "YEAR argument (or env) required, e.g. YEAR=2025" if year.blank?
+
+    recruitment_cycle = RecruitmentCycle.find_by!(year: year)
+    puts "[DataHub] Updating sites from GIAS for cycle #{year} (REAL RUN)"
+    summary = DataHub::UpdateSitesFromGias::Executor.new(recruitment_cycle:).execute
+    puts "[DataHub] Complete. Summary:"
+    pp summary.short_summary
+  end
+
+  desc "Dry run: Preview updates to sites from GIAS for a recruitment cycle (no DB changes). Usage: rake data_hub:update_sites_from_gias:dry_run YEAR=2025"
+  task :dry_run, [:year] => :environment do |_t, args|
+    year = args[:year] || ENV["YEAR"]
+    raise "YEAR argument (or env) required, e.g. YEAR=2025" if year.blank?
+
+    recruitment_cycle = RecruitmentCycle.find_by!(year: year)
+    puts "[DataHub] DRY RUN: Showing site updates from GIAS for cycle #{year}"
+    summary = DataHub::UpdateSitesFromGias::Executor.new(
+      recruitment_cycle:,
+      updater_class: DataHub::UpdateSitesFromGias::DryRunSiteUpdater,
+    ).execute
+    puts "[DataHub] Dry-run complete. Summary:"
+    pp summary.short_summary
+  end
+end

--- a/spec/services/data_hub/update_sites_from_gias/dry_run_site_updater_spec.rb
+++ b/spec/services/data_hub/update_sites_from_gias/dry_run_site_updater_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe DataHub::UpdateSitesFromGias::DryRunSiteUpdater do
+  subject(:result) { described_class.new(site:, gias_school:).call }
+
+  let(:site) { create(:site, location_name: "A", address1: "Old St", latitude: 1.23) }
+
+  let(:gias_school) do
+    {
+      name: "A",
+      address1: "New St",
+      address2: site.address2,
+      address3: site.address3,
+      town: site.town,
+      county: site.address4,
+      postcode: site.postcode,
+      latitude: 4.56,
+      longitude: site.longitude,
+    }
+  end
+
+  it "detects differences but does not update the site" do
+    expect { result }.not_to(change { [site.reload.address1, site.reload.latitude] })
+
+    expect(result.site_id).to eq(site.id)
+    expect(result.changes.keys).to match_array(%i[address1 latitude])
+    expect(result.changes[:address1]).to eq(before: "Old St", after: "New St")
+    expect(result.changes[:latitude]).to eq(before: 1.23, after: 4.56)
+  end
+
+  it "returns no changes if values are identical (including normalization)" do
+    gias = gias_school.merge(address1: "old st", latitude: 1.230001)
+    updater = described_class.new(site:, gias_school: gias)
+    expect(updater.call.changes).to eq({})
+    expect(site.reload.address1).to eq("Old St")
+  end
+end

--- a/spec/services/data_hub/update_sites_from_gias/executor_spec.rb
+++ b/spec/services/data_hub/update_sites_from_gias/executor_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe DataHub::UpdateSitesFromGias::Executor do
+  let(:recruitment_cycle) { create(:recruitment_cycle, year: "2025") }
+  let(:provider) { create(:provider, recruitment_cycle: recruitment_cycle) }
+
+  let!(:site_one) do
+    create(:site, provider:, urn: "41333", location_name: "A", address1: "Old Addr")
+  end
+
+  let!(:gias_one) do
+    create(:gias_school, urn: "41333", name: "A", address1: "New Addr")
+  end
+
+  let!(:site_two) do
+    create(:site, provider:, urn: "41334", location_name: "B", latitude: 50.0, address1: "Addr")
+  end
+
+  let!(:gias_two) do
+    create(:gias_school, urn: "41334", name: "B", latitude: 51.5, address1: "Addr")
+  end
+
+  describe "real updater" do
+    subject(:summary) do
+      described_class.new(recruitment_cycle: recruitment_cycle).execute
+    end
+
+    it "updates only necessary fields and builds both summaries" do
+      expect { summary }
+        .to change { site_one.reload.address1 }
+        .from("Old Addr").to("New Addr")
+        .and change { site_two.reload.latitude }
+        .from(50.0).to(51.5)
+
+      full = summary.full_summary.deep_symbolize_keys
+      short = summary.short_summary.deep_symbolize_keys
+
+      expect(full[:site_updates].size).to eq(2)
+      expect(full[:site_updates].map { |x| x[:id] }).to contain_exactly(site_one.id, site_two.id)
+      expect(full[:site_updates].find { |u| u[:id] == site_one.id }[:changes].keys).to include(:address1)
+      expect(short[:address1]).to eq(1)
+      expect(short[:latitude]).to eq(1)
+      expect(short[:updated_total_count]).to eq(2)
+      expect(short[:updater_class]).to include("SiteUpdater")
+    end
+  end
+
+  describe "dry run updater" do
+    subject(:summary) do
+      described_class.new(
+        recruitment_cycle:,
+        updater_class: DataHub::UpdateSitesFromGias::DryRunSiteUpdater,
+      ).execute
+    end
+
+    it "does not persist changes but builds the correct summary" do
+      expect {
+        summary
+      }.not_to(change { [site_one.reload.address1, site_two.reload.latitude] })
+
+      full_summary = summary.full_summary.deep_symbolize_keys
+      short_summary = summary.short_summary.deep_symbolize_keys
+
+      ids = full_summary[:site_updates].map { |u| u[:id] }
+      expect(ids).to contain_exactly(site_one.id, site_two.id)
+      expect(short_summary[:updater_class]).to include("DryRun")
+    end
+  end
+
+  describe "summary keys" do
+    subject(:summary) do
+      described_class.new(recruitment_cycle: recruitment_cycle).execute
+    end
+
+    it "produces a full_summary with before/after for each changed field" do
+      full_summary = summary.full_summary.deep_symbolize_keys
+      change = full_summary[:site_updates].find { |u| u[:id] == site_one.id }[:changes]
+      expect(change.keys).to include(:address1)
+      expect(change[:address1]).to eq(before: "Old Addr", after: "New Addr")
+    end
+  end
+
+  describe "error handling" do
+    let(:bombing_updater_class) do
+      Class.new do
+        def initialize(site:, gias_school:); end
+        def call = raise("exploded!")
+      end
+    end
+
+    it "marks the summary as failed if an error is raised" do
+      expect {
+        described_class.new(
+          recruitment_cycle: recruitment_cycle,
+          updater_class: bombing_updater_class,
+        ).execute
+      }.to raise_error("exploded!")
+
+      expect(DataHub::UpdateSitesFromGiasProcessSummary.last.failed?).to be true
+    end
+  end
+end

--- a/spec/services/data_hub/update_sites_from_gias/schools_gias_diff_query_spec.rb
+++ b/spec/services/data_hub/update_sites_from_gias/schools_gias_diff_query_spec.rb
@@ -1,0 +1,165 @@
+require "rails_helper"
+
+RSpec.describe DataHub::UpdateSitesFromGias::SchoolsGiasDiffQuery do
+  subject(:diff_records) { described_class.new(recruitment_cycle: recruitment_cycle).records_to_update }
+
+  let(:recruitment_cycle) { RecruitmentCycle.current }
+  let(:provider) { create(:provider, recruitment_cycle: recruitment_cycle) }
+
+  def site_and_gias_pairs(overrides_site: {}, overrides_gias: {})
+    urn = "1#{rand(10_000..99_999)}"
+    base_name = overrides_site[:location_name] || overrides_gias[:name] || "Test School #{urn}"
+    site = create(
+      :site,
+      provider: provider,
+      urn: urn,
+      location_name: base_name,
+      address1: "Main Rd",
+      address2: "Block A",
+      address3: "Old Wing",
+      town: "Testtown",
+      address4: "Countyshire",
+      postcode: "BN1 1AA",
+      latitude: 12.34,
+      longitude: 56.78,
+      **overrides_site,
+    )
+    gias = create(
+      :gias_school,
+      urn: urn,
+      name: site.location_name,
+      address1: site.address1,
+      address2: site.address2,
+      address3: site.address3,
+      town: site.town,
+      county: site.address4,
+      postcode: site.postcode,
+      latitude: site.latitude,
+      longitude: site.longitude,
+      **overrides_gias,
+    )
+    [site, gias]
+  end
+
+  it "returns empty when there are no field differences" do
+    _, _gias = site_and_gias_pairs
+    expect(diff_records.pluck(:urn)).to eq([])
+  end
+
+  it "returns the site when only location_name is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { location_name: "AAA" },
+      overrides_gias: { name: "BBB" },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "returns the site when only address1 is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { address1: "Apples Lane" },
+      overrides_gias: { address1: "Oranges Lane" },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "returns the site when only address2 is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { address2: "Floor 7" },
+      overrides_gias: { address2: "Floor 8" },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "returns the site when only address3 is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { address3: "North Block" },
+      overrides_gias: { address3: "South Block" },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "returns the site when only town is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { town: "Northville" },
+      overrides_gias: { town: "Southville" },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "returns the site when only address4/county is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { address4: "County A" },
+      overrides_gias: { county: "County B" },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "returns the site when only postcode is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { postcode: "ZZ91 1ZZ" },
+      overrides_gias: { postcode: "ZZ91 2YY" },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "normalizes postcodes so 'BN1 1AA' == ' bn1 1aa '" do
+    _, _gias = site_and_gias_pairs(
+      overrides_site: { postcode: "BN1 1AA" },
+      overrides_gias: { postcode: " bn1   1aa " },
+    )
+    expect(diff_records.pluck(:urn)).to eq([])
+  end
+
+  it "returns the site when only latitude is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { latitude: 11.11 },
+      overrides_gias: { latitude: 12.12 },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "returns the site when only longitude is different" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { longitude: 99.99 },
+      overrides_gias: { longitude: 88.88 },
+    )
+    expect(diff_records.pluck(:urn)).to eq([site.urn])
+  end
+
+  it "ignores sites in other recruitment cycles" do
+    other_cycle = create(:recruitment_cycle, year: 2031)
+    other_provider = create(:provider, recruitment_cycle: other_cycle)
+    site = create(:site, provider: other_provider, urn: "99912", location_name: "OtherCycle")
+    create(:gias_school, urn: "99912", name: "Different")
+    expect(diff_records.pluck(:urn)).not_to include(site.urn)
+  end
+
+  it "ignores sites with no joined GIAS record" do
+    site = create(:site, provider: provider, urn: "12345", location_name: "OrphanSite")
+    expect(diff_records.pluck(:urn)).not_to include(site.urn)
+  end
+
+  it "returns only unique sites with one field difference" do
+    site1, _gias1 = site_and_gias_pairs(
+      overrides_site: { address1: "AA" },
+      overrides_gias: { address1: "BB" },
+    )
+    site2, _gias2 = site_and_gias_pairs(
+      overrides_site: { address2: "CC" },
+      overrides_gias: { address2: "DD" },
+    )
+    urns = diff_records.pluck(:urn)
+    expect(urns.uniq.size).to eq(urns.size)
+    expect(urns).to include(site1.urn, site2.urn)
+  end
+
+  it "yields GIAS fields as select aliases for a site with a difference" do
+    site, _gias = site_and_gias_pairs(
+      overrides_site: { latitude: 99.01 },
+      overrides_gias: { latitude: 44.44, address1: "FooAddr" },
+    )
+    record = diff_records.find_by(urn: site.urn)
+    expect(record.gias_latitude).to eq(44.44)
+    expect(record.gias_address1).to eq("FooAddr")
+  end
+end

--- a/spec/services/data_hub/update_sites_from_gias/site_updater_spec.rb
+++ b/spec/services/data_hub/update_sites_from_gias/site_updater_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+RSpec.describe DataHub::UpdateSitesFromGias::SiteUpdater do
+  subject(:updater) { described_class.new(site: site, gias_school: gias_school) }
+
+  let(:site_attrs) do
+    {
+      location_name: "Broadway Academy",
+      address1: "123 Main St",
+      address2: "Suite 2",
+      address3: "Old Block",
+      town: "Birmingham",
+      address4: "West Midlands",
+      postcode: "B20 3DP",
+      latitude: 52.12345,
+      longitude: -1.98765,
+    }
+  end
+  let!(:site) { create(:site, site_attrs) }
+  let(:gias_school) { gias_hash_for(site_attrs, gias_overrides) }
+  let(:gias_overrides) { {} }
+
+  def gias_hash_for(site_hash, overrides = {})
+    {
+      name: site_hash[:location_name],
+      address1: site_hash[:address1],
+      address2: site_hash[:address2],
+      address3: site_hash[:address3],
+      town: site_hash[:town],
+      county: site_hash[:address4],
+      postcode: site_hash[:postcode],
+      latitude: site_hash[:latitude],
+      longitude: site_hash[:longitude],
+    }.merge(overrides)
+  end
+
+  context "when some fields are different" do
+    let(:gias_overrides) do
+      {
+        address2: "Suite 2B",
+        address3: "Old Block Renamed",
+      }
+    end
+
+    it "detects changed fields and only updates those" do
+      result = updater.call
+
+      expect(result.site_id).to eq(site.id)
+      expect(result.changes.keys).to match_array(%i[address2 address3])
+      expect(result.changes).to eq(
+        address2: { before: "Suite 2", after: "Suite 2B" },
+        address3: { before: "Old Block", after: "Old Block Renamed" },
+      )
+
+      site.reload
+      expect(site.address2).to eq "Suite 2B"
+      expect(site.address3).to eq "Old Block Renamed"
+      # unchanged fields remain
+      expect(site.location_name).to eq "Broadway Academy"
+    end
+  end
+
+  context "when all fields are identical, after normalization" do
+    let(:gias_overrides) do
+      {
+        name: "broadway academy ",
+        address1: "123   Main St",
+        address2: "Suite 2",
+        address3: "Old Block",
+        town: "Birmingham",
+        county: "WEST MIDLANDS",
+        postcode: " B20   3dp",
+        latitude: 52.12345000,
+        longitude: -1.9876500,
+      }
+    end
+
+    it "does not update anything if values equivalent" do
+      expect { updater.call }.not_to(change { site.reload.updated_at })
+      expect(updater.call.changes).to eq({})
+    end
+  end
+
+  context "when only latitude or longitude differ by < 0.00001" do
+    let(:gias_overrides) { { latitude: 52.123451, longitude: -1.987649 } }
+
+    it "treats as unchanged (due to epsilon threshold)" do
+      expect(updater.call.changes).to eq({})
+    end
+  end
+
+  context "when latitude or longitude differ by > 0.00001" do
+    let(:gias_overrides) { { latitude: 52.12400, longitude: -2.00001 } }
+
+    it "detects as changed" do
+      result = updater.call
+      expect(result.changes.keys).to match_array(%i[latitude longitude])
+      expect(result.changes[:latitude][:after]).to eq(52.12400)
+      expect(result.changes[:longitude][:after]).to eq(-2.00001)
+    end
+  end
+
+  context "when site has nil and gias has value" do
+    let!(:site) { create(:site, site_attrs.merge(address2: nil)) }
+    let(:gias_overrides) { { address2: "Suite 2B" } }
+
+    it "detects nil vs value as a change" do
+      result = updater.call
+
+      expect(result.changes.keys).to include(:address2)
+      expect(result.changes[:address2][:before]).to be_nil
+      expect(result.changes[:address2][:after]).to eq("Suite 2B")
+    end
+  end
+
+  context "when gias_postcode differs only by internal spaces and casing" do
+    let!(:site) { create(:site, site_attrs.merge(postcode: "B20 3DP")) }
+    let(:gias_overrides) { { postcode: " b20 3dp " } }
+
+    it "treats postcodes as the same (normalization tested)" do
+      expect(updater.call.changes).not_to have_key(:postcode)
+    end
+  end
+
+  context "when gias has blank string and site has nil" do
+    let!(:site) { create(:site, site_attrs.merge(address4: nil)) }
+    let(:gias_overrides) { { county: "" } }
+
+    it "does not treat nil and blank as a difference after normalization" do
+      expect(updater.call.changes).not_to have_key(:address4)
+    end
+  end
+end

--- a/spec/services/data_hub/update_sites_from_gias/summary_builder_spec.rb
+++ b/spec/services/data_hub/update_sites_from_gias/summary_builder_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe DataHub::UpdateSitesFromGias::SummaryBuilder do
+  subject(:builder) { described_class.new(results) }
+
+  let(:results) do
+    [
+      double(
+        site_id: 1,
+        changes: {
+          address2: { before: "X", after: "Y" },
+          address3: { before: "A", after: "B" },
+        },
+      ),
+      double(
+        site_id: 2,
+        changes: {
+          location_name: { before: "A", after: "B" },
+          latitude: { before: 1, after: 2 },
+        },
+      ),
+      double(
+        site_id: 3,
+        changes: {
+          postcode: { before: "P1", after: "P2" },
+          longitude: { before: 10.1, after: 10.2 },
+          town: { before: "Old", after: "New" },
+        },
+      ),
+      double(
+        site_id: 4,
+        changes: {},
+      ),
+    ]
+  end
+
+  it "builds the short summary with accurate field counts" do
+    summary = builder.short_summary
+    expect(summary[:updated_total_count]).to eq(3)
+    expect(summary[:address2]).to eq(1)
+    expect(summary[:address3]).to eq(1)
+    expect(summary[:location_name]).to eq(1)
+    expect(summary[:latitude]).to eq(1)
+    expect(summary[:postcode]).to eq(1)
+    expect(summary[:longitude]).to eq(1)
+    expect(summary[:town]).to eq(1)
+    expect(summary[:address1]).to eq(0)
+  end
+
+  it "includes every expected field in the short summary" do
+    fields = %i[
+      location_name address1 address2 address3 town address4 postcode latitude longitude
+    ]
+    fields.each { |field| expect(builder.short_summary).to have_key(field) }
+  end
+
+  it "only includes updated sites in full summary" do
+    site_ids = builder.full_summary[:site_updates].map { |hash| hash[:id] }
+    expect(site_ids).to contain_exactly(1, 2, 3)
+    expect(site_ids).not_to include(4)
+  end
+end


### PR DESCRIPTION
## Context

This PR introduces a new DataHub script for batch updating Site records from GIAS, addressing the need to:

* Detect and update Site records with any field differing from their joined GIAS record for a given recruitment cycle.

* Support both real-run (persisting updates) and dry-run (no DB updates, for preview/audit) via dependency-injected updater strategies, following prior DataHub service patterns.

Provide auditability via process summaries: per-field counts, before/after per-row hashes, and clear reporting.

## How to review/test

To use in console:

### Real run:

```ruby
cycle = RecruitmentCycle.find_by(year: "2025")
DataHub::UpdateSitesFromGias::Executor.new(recruitment_cycle: cycle).execute
```

### Dry run:

```ruby
DataHub::UpdateSitesFromGias::Executor.new(recruitment_cycle: cycle, updater_class: DataHub::UpdateSitesFromGias::DryRunSiteUpdater).execute
```

## Reviewer guidance

1. After running the real one take a look on the summary:
```ruby
DataHub::UpdateSitesFromGiasProcessSummary.last
```
