### PR TITLE
Save register import as added field on schools

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -27,6 +27,11 @@ class Site < ApplicationRecord
     study_site: 1,
   }
 
+  enum :added_via, {
+    publish_interface: "publish_interface",
+    register_import: "register_import",
+  }
+
   validates :location_name, uniqueness: { scope: %i[provider_id site_type],
                                           message: lambda { |object, _data|
                                             "This #{object.site_type.humanize.downcase} has already been added"

--- a/app/services/data_hub/register_school_importer/school_creator.rb
+++ b/app/services/data_hub/register_school_importer/school_creator.rb
@@ -41,6 +41,7 @@ module DataHub
       def create!(site, gias_school)
         site.assign_attributes(gias_school.school_attributes)
         site.site_type = Site.site_types[:school]
+        site.added_via = Site.added_via[:register_import]
 
         if gias_school.latitude.present? && gias_school.longitude.present?
           site.latitude  = gias_school.latitude

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -253,6 +253,15 @@ describe Site do
     end
   end
 
+  describe "added via" do
+    it "defines a string enum for added_via" do
+      expect(described_class.added_via).to eq({
+        "publish_interface" => "publish_interface",
+        "register_import" => "register_import",
+      })
+    end
+  end
+
   describe "site type" do
     let(:site) { build(:site) }
 

--- a/spec/services/data_hub/register_school_importer/school_creator_spec.rb
+++ b/spec/services/data_hub/register_school_importer/school_creator_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe DataHub::RegisterSchoolImporter::SchoolCreator do
         expect(site).not_to be_nil
         expect(site.location_name).to eq("Test School")
         expect(site.site_type).to eq("school")
+        expect(site.added_via).to eq("register_import")
       end
     end
 
@@ -97,6 +98,7 @@ RSpec.describe DataHub::RegisterSchoolImporter::SchoolCreator do
         site = provider.reload.sites.find_by(urn:)
         expect(site.latitude).to eq(52.6)
         expect(site.longitude).to eq(-1.2)
+        expect(site.added_via).to eq("register_import")
       end
     end
 


### PR DESCRIPTION
## Context

We want to track how each Site record was created, allowing for better auditing and filtering based on the source of the school (e.g. manual UI vs. register import). 

This is especially important now that Register School Imports are happening at scale.

## What’s Changed

- Added a string-based `added_via` enum to the Site model, with possible values: `"publish_interface"` and `"register_import"`
- By default, `added_via` is `"publish_interface"` for sites created through the standard interface
- When importing via RegisterSchoolImporter, `added_via` is set to `"register_import"`
- Updated `SchoolCreator#create!` to assign the enum value for all imported sites
- Enhanced specs for both Site and SchoolCreator:
  - Tested the enum mapping
  - Verified that `added_via` is set as expected on newly-imported sites through register import

## Why?

- Enables easy reporting on provenance of schools, which will help to show all added schools in Publish interface

## How to test/review

- Run `bin/rspec` to verify model and creator specs pass
- Try running a register import: newly-created sites should have `added_via: "register_import"` (` CSV_PATH=~/Downloads/register_of_placement_schools_v2.csv YEAR=2025 bin/rails register_schools:import`)
- Manually create a site (UI/console/factory): it should default to `"publish_interface"`
