### PR TITLE
Increase main_app memory limit to 1.5Gi in QA configuration

### DIFF
--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -8,7 +8,8 @@
   "resource_group_name": "s189t01-ptt-qa-rg",
   "main_app": {
     "main": {
-      "replicas": 2
+      "replicas": 2,
+      "max_memory": "1.5Gi"
     }
   },
   "worker_apps": {


### PR DESCRIPTION
## Context

* Increase QA main_app memory limit to 1.5Gi.
* This change is in response to observed memory usage during recent register school import rake task, which peaked at approximately 557Mi locally. 
* Setting the memory limit to 1.5Gi provides a safe buffer for fluctuations and ensures reliable operation during heavy workloads.

## Why?

Helps prevent OOMKilled pod failures during imports.
