### PR TITLE
Only render notification body if it exists

### DIFF
--- a/app/components/notification_banner.html.erb
+++ b/app/components/notification_banner.html.erb
@@ -8,8 +8,10 @@
     <p class="govuk-notification-banner__heading">
       <%= text %>
     </p>
-    <p class="govuk-body">
-      <%= text_body %>
-    </p>
+    <% if text_body.present? %>
+      <p class="govuk-body">
+        <%= text_body %>
+      </p>
+    <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

|Before|After|
|---|---|
|<img width="1181" height="427" alt="image" src="https://github.com/user-attachments/assets/328e9d4c-318f-4cb0-aeaa-3b681fe1cc6e" />|<img width="1151" height="415" alt="image" src="https://github.com/user-attachments/assets/f0724c17-fc77-4c2a-98aa-f3aea85c688f" />|

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
