### PR TITLE
Add newly added tag to course school selection pages

### DIFF
--- a/app/components/publish/school_newly_added_tag_component.rb
+++ b/app/components/publish/school_newly_added_tag_component.rb
@@ -1,0 +1,12 @@
+class Publish::SchoolNewlyAddedTagComponent < Publish::NewlyAddedTagComponent
+  def initialize(school:)
+    @school = school
+    @recruitment_cycle = school.recruitment_cycle
+
+    super()
+  end
+
+  def render?
+    @school.register_import? && @recruitment_cycle.rollover_period_2026?
+  end
+end

--- a/app/views/publish/courses/schools/edit.html.erb
+++ b/app/views/publish/courses/schools/edit.html.erb
@@ -26,7 +26,7 @@
        <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
           <%= f.govuk_check_box :site_ids,
               site.id,
-              label: { text: site.location_name },
+              label: { text: [site.location_name, render(Publish::SchoolNewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
               hint: { text: site.full_address },
               link_errors: index.zero? %>
        <% end %>

--- a/app/views/publish/courses/schools/new.html.erb
+++ b/app/views/publish/courses/schools/new.html.erb
@@ -27,7 +27,7 @@
             <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
               <%= form.govuk_check_box :sites_ids,
                     site.id,
-                    label: { text: site.location_name },
+                    label: { text: [site.location_name, render(Publish::SchoolNewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
                     hint: { text: site.full_address },
                     link_errors: index.zero? %>
             <% end %>

--- a/app/views/publish/providers/schools/_school.html.erb
+++ b/app/views/publish/providers/schools/_school.html.erb
@@ -2,9 +2,7 @@
   <th class="govuk-table__header name" scope="row">
     <%= govuk_link_to school.location_name, publish_provider_recruitment_cycle_school_path(@provider.provider_code, school.recruitment_cycle.year, school.id) %>
 
-    <% if school.register_import? && @recruitment_cycle.rollover_period_2026? %>
-      <%= render Publish::NewlyAddedTagComponent.new %>
-    <% end %>
+    <%= render Publish::SchoolNewlyAddedTagComponent.new(school:) %>
   </th>
 
   <td class="govuk-table__cell code">

--- a/spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb
+++ b/spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe "Publish - Courses: 'Newly added' tag for register import sites when selecting schools", service: :publish, type: :system do
+  include DfESignInUserHelper
+
+  let(:frozen_time) { Time.zone.local(2025, 6, 1, 12, 0, 0) }
+  let!(:recruitment_cycle) do
+    create(:recruitment_cycle, year: 2026, application_start_date: frozen_time + 2.months)
+  end
+  let(:provider) { create(:provider, provider_name: "Tag Provider", recruitment_cycle:) }
+  let!(:course) { create(:course, provider:) }
+
+  let!(:site_one) do
+    create(
+      :site,
+      provider:,
+      added_via: :register_import,
+      location_name: "Register Import School",
+      address1: "1 Import Road",
+    )
+  end
+
+  let!(:site_two) do
+    create(
+      :site,
+      provider:,
+      added_via: :publish_interface,
+      location_name: "UI Added School",
+      address1: "2 Publish Street",
+    )
+  end
+
+  let(:user) { create(:user, providers: [provider]) }
+
+  before do
+    travel_to frozen_time
+    sign_in_system_test(user:)
+  end
+
+  after { travel_back }
+
+  scenario "shows the 'Newly added' tag on school selection checkboxes only for register import, and not after rollover" do
+    when_i_visit_edit_course_schools_page
+
+    and_i_see_checkbox_with_tag("Register Import School", "Newly added")
+    and_i_see_checkbox_without_tag("UI Added School", "Newly added")
+
+    when_i_visit_new_course_schools_page
+
+    and_i_see_checkbox_with_tag("Register Import School", "Newly added")
+    and_i_see_checkbox_without_tag("UI Added School", "Newly added")
+
+    travel_to recruitment_cycle.application_start_date + 1.day
+    sign_in_system_test(user:)
+
+    when_i_visit_edit_course_schools_page
+    and_i_see_checkbox_without_tag("Register Import School", "Newly added")
+    and_i_see_checkbox_without_tag("UI Added School", "Newly added")
+
+    when_i_visit_new_course_schools_page
+    and_i_see_checkbox_without_tag("Register Import School", "Newly added")
+    and_i_see_checkbox_without_tag("UI Added School", "Newly added")
+  end
+
+  def when_i_visit_edit_course_schools_page
+    visit schools_publish_provider_recruitment_cycle_course_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: recruitment_cycle.year,
+      code: course.course_code,
+    )
+  end
+
+  def when_i_visit_new_course_schools_page
+    visit new_publish_provider_recruitment_cycle_courses_schools_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: recruitment_cycle.year,
+    )
+  end
+
+  def and_i_see_checkbox_with_tag(school_name, tag_text)
+    label = checkbox_label_for_school(school_name)
+
+    expect(label).to have_content(tag_text), "Expected '#{tag_text}' for checkbox label '#{school_name}', but did not find it. Label text: #{label.text}"
+  end
+
+  def and_i_see_checkbox_without_tag(school_name, tag_text)
+    label = checkbox_label_for_school(school_name)
+
+    expect(label).not_to have_content(tag_text), "Expected NOT to find '#{tag_text}' for checkbox label '#{school_name}', but tag was present. Label text: #{label.text}"
+  end
+
+  def checkbox_label_for_school(text)
+    page.find("label", text:)
+  end
+end


### PR DESCRIPTION
## Context

Add a "Newly added" tag to schools imported via register import on course school selection pages. 

This enhancement helps users identify which schools were recently added through the register import process during the 2026 rollover period.

## Screenshots

To see screenshots click on the trello card link.

## How to review

1. Run the rollover
2. Run the register import

Access 2026 on any provider and access the two pages below:

Access Publish and visit (replace with provider code / course_code

1. `/publish/organisations/#{provider_code}/2026/courses/#{course_code}/schools`

2. `/publish/organisations/#{provider_code}/2026/courses/schools/new?course%5Bage_range_in_years%5D=7_to_14&course%5Bcampaign_name%5D=&course%5Bfunding%5D=fee&course%5Bis_send%5D=true&course%5Blevel%5D=primary&course%5Bmaster_subject_id%5D=1&course%5Bqualification%5D=pgce_with_qts&course%5Bstudy_mode%5D%5B%5D=full_time&course%5Bsubjects_ids%5D%5B%5D=1`
