### PR TITLE
[Longform] Why train with us

### DIFF
--- a/app/components/course_preview/missing_information_component.html.erb
+++ b/app/components/course_preview/missing_information_component.html.erb
@@ -1,2 +1,1 @@
-
 <%= govuk_inset_text { govuk_link_to(text, link) } %>

--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -39,7 +39,7 @@ module CoursePreview
     def train_with_disability_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true, anchor: "train-with-disability")
 
     def train_with_us_link
-      if FeatureFlag.active?(:long_form_content) || @recruitment_cycle.after_2025?
+      if FeatureFlag.active?(:long_form_content) || Current.recruitment_cycle.after_2025?
         edit_publish_provider_recruitment_cycle_why_train_with_us_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true)
       else
         about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true, anchor: "train-with-us")

--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -37,6 +37,13 @@ module CoursePreview
     def gcse_link = gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
     def how_school_placements_work_link = school_placements_publish_provider_recruitment_cycle_course_path(provider_code, recruitment_cycle_year, course_code, goto_preview: true)
     def train_with_disability_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true, anchor: "train-with-disability")
-    def train_with_us_link = about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true, anchor: "train-with-us")
+
+    def train_with_us_link
+      if FeatureFlag.active?(:long_form_content) || @recruitment_cycle.after_2025?
+        edit_publish_provider_recruitment_cycle_why_train_with_us_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true)
+      else
+        about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true, anchor: "train-with-us")
+      end
+    end
   end
 end

--- a/app/controllers/publish/providers/course_fields/why_train_with_us_controller.rb
+++ b/app/controllers/publish/providers/course_fields/why_train_with_us_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Publish
+  module Providers
+    module CourseFields
+      class WhyTrainWithUsController < ApplicationController
+        def edit
+          @train_with_us_form = WhyTrainWithUsForm.new(
+            provider,
+            redirect_params:,
+            course_code: params[:course_code],
+          )
+        end
+
+        def update
+          authorize provider, :update?
+
+          @train_with_us_form = WhyTrainWithUsForm.new(
+            provider,
+            params: provider_params,
+            redirect_params:,
+            course_code: params.dig(param_form_key, :course_code),
+          )
+
+          if @train_with_us_form.save!
+            redirect_to @train_with_us_form.update_success_path
+            flash[:success] = I18n.t("success.published") if redirect_params.all? { |_k, v| v.blank? }
+          else
+            @errors = @train_with_us_form.errors.messages
+            render :edit
+          end
+        end
+
+      private
+
+        def redirect_params
+          params.fetch(param_form_key, params).slice(
+            :goto_provider,
+          ).permit!.to_h
+        end
+
+        def param_form_key = :publish_why_train_with_us_form
+
+        def provider_params
+          params
+            .require(param_form_key)
+            .except(:course_code, :goto_provider)
+            .permit(
+              *WhyTrainWithUsForm::FIELDS,
+              accredited_partners: %i[provider_name provider_code description],
+            )
+        end
+      end
+    end
+  end
+end

--- a/app/forms/publish/why_train_with_us_form.rb
+++ b/app/forms/publish/why_train_with_us_form.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Publish
+  class WhyTrainWithUsForm < BaseProviderForm
+    include Rails.application.routes.url_helpers
+
+    validates :value_proposition, presence: { message: "Enter details about training with you" }, if: :value_proposition_changed?
+    validates :about_us, presence: { message: "Enter details about your organisation" }, if: :about_us_changed?
+
+    validates :value_proposition, words_count: { maximum: 100, message: "Reduce the word count for your value proposition" }
+    validates :about_us, words_count: { maximum: 100, message: "Reduce the word count for about us" }
+
+    def initialize(model, params: {}, redirect_params: {}, course_code: nil)
+      super(model, params:)
+      @redirect_params = redirect_params
+      @course_code = course_code
+    end
+
+    FIELDS = %i[
+      about_us
+      value_proposition
+    ].freeze
+
+    attr_accessor(*FIELDS)
+    attr_reader :redirect_params, :course_code
+
+    def update_success_path
+      case redirection_key
+      when "goto_provider"
+        provider_publish_provider_recruitment_cycle_course_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year,
+          course_code,
+        )
+      else
+        details_publish_provider_recruitment_cycle_path(
+          provider.provider_code,
+          provider.recruitment_cycle_year,
+        )
+      end
+    end
+    alias_method :back_path, :update_success_path
+
+  private
+
+    def value_proposition_changed?
+      changed?(:value_proposition)
+    end
+
+    def about_us_changed?
+      changed?(:about_us)
+    end
+
+    def changed?(attribute)
+      public_send(attribute) != provider.public_send(attribute)
+    end
+
+    def compute_fields
+      provider.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+
+    def new_attributes
+      params
+    end
+
+    def redirection_key
+      redirect_params.select { |_k, v| v == "true" }&.keys&.first
+    end
+  end
+end

--- a/app/forms/publish/why_train_with_us_form.rb
+++ b/app/forms/publish/why_train_with_us_form.rb
@@ -4,11 +4,11 @@ module Publish
   class WhyTrainWithUsForm < BaseProviderForm
     include Rails.application.routes.url_helpers
 
-    validates :value_proposition, presence: { message: "Enter details about training with you" }, if: :value_proposition_changed?
-    validates :about_us, presence: { message: "Enter details about your organisation" }, if: :about_us_changed?
+    validates :about_us, presence: true, if: :about_us_changed?
+    validates :value_proposition, presence: true, if: :value_proposition_changed?
 
-    validates :value_proposition, words_count: { maximum: 100, message: "Reduce the word count for your value proposition" }
-    validates :about_us, words_count: { maximum: 100, message: "Reduce the word count for about us" }
+    validates :about_us, words_count: { maximum: 100, message: :too_many_words }
+    validates :value_proposition, words_count: { maximum: 100, message: :too_many_words }
 
     def initialize(model, params: {}, redirect_params: {}, course_code: nil)
       super(model, params:)
@@ -17,8 +17,8 @@ module Publish
     end
 
     FIELDS = %i[
-      about_us
       value_proposition
+      about_us
     ].freeze
 
     attr_accessor(*FIELDS)

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -114,4 +114,8 @@ class RecruitmentCycle < ApplicationRecord
   def after_2021?
     year.to_i >= 2022
   end
+
+  def after_2025?
+    year.to_i > 2025
+  end
 end

--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -16,7 +16,6 @@ module API
                    :provider_type,
                    :region_code,
                    :train_with_disability,
-                   :train_with_us,
                    :website,
                    :latitude,
                    :longitude,
@@ -25,6 +24,14 @@ module API
                    :can_sponsor_skilled_worker_visa,
                    :can_sponsor_student_visa,
                    :selectable_school
+
+        attribute :train_with_us do
+          if @object.recruitment_cycle.after_2025?
+            [@object.about_us.to_s, @object.value_proposition.to_s].compact_blank.join("\r\n\r\n")
+          else
+            @object.train_with_us
+          end
+        end
 
         attribute :accredited_body do
           @object.accredited?

--- a/app/views/publish/providers/course_fields/why_train_with_us/edit.html.erb
+++ b/app/views/publish/providers/course_fields/why_train_with_us/edit.html.erb
@@ -1,0 +1,50 @@
+<% page_title = t(".page_title") %>
+<% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @train_with_us_form,
+      url: publish_provider_recruitment_cycle_why_train_with_us_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      method: :put,
+    ) do |f| %>
+
+      <% content_for :before_content do %>
+        <%= govuk_back_link_to(@train_with_us_form.back_path) %>
+      <% end %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+        <%= page_title %>
+      </h1>
+
+      <%= t(".page_intro_html") %>
+
+      <%= f.govuk_text_area(:about_us,
+        form_group: { id: "about-us" },
+        label: { text: t(".about_us_label", provider_name: @provider.provider_name), size: "s" },
+        hint: -> { t(".about_us_hint") },
+        max_words: 100,
+        rows: 15) %>
+
+      <%= f.govuk_text_area(:value_proposition,
+        form_group: { id: "train-with-us" },
+        label: { text: t(".train_with_us_label"), size: "s" },
+        hint: lambda {
+          t(".train_with_us_hint_html")
+        },
+        max_words: 100,
+        rows: 15) %>
+      <%= f.hidden_field(:goto_provider, value: goto_provider_value(param_form_key: f.object_name.to_sym, params:)) %>
+      <%= f.hidden_field(:course_code, value: params[:course_code] || params.dig(f.object_name.to_sym, :course_code)) %>
+
+      <%= f.govuk_submit t(".submit") %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), @train_with_us_form.back_path) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -33,7 +33,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_summary_list do |summary_list| %>
-      <% if FeatureFlag.active?(:long_form_content) || @recruitment_cycle.after_2025? %>
+      <% if FeatureFlag.active?(:long_form_content) || Current.recruitment_cycle.after_2025? %>
         <% enrichment_summary(
         summary_list,
         :provider,

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -33,7 +33,18 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_summary_list do |summary_list| %>
-      <% enrichment_summary(
+      <% if FeatureFlag.active?(:long_form_content) || @recruitment_cycle.after_2025? %>
+        <% enrichment_summary(
+        summary_list,
+        :provider,
+        "Why train with us",
+        value_provided?(markdown(@provider.about_us) + markdown(@provider.value_proposition)),
+        %w[about_us value_proposition],
+        action_path: edit_publish_provider_recruitment_cycle_why_train_with_us_path(@provider.provider_code, @provider.recruitment_cycle_year),
+        action_visually_hidden_text: "details about training with your organisation",
+      ) %>
+      <% else %>
+        <% enrichment_summary(
         summary_list,
         :provider,
         "Training with your organisation",
@@ -42,6 +53,8 @@
         action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#train-with-us",
         action_visually_hidden_text: "details about training with your organisation",
       ) %>
+      <% end %>
+
       <% enrichment_summary(
         summary_list,
         :provider,

--- a/config/locales/en/publish/providers/course_fields/why_train_with_us.yml
+++ b/config/locales/en/publish/providers/course_fields/why_train_with_us.yml
@@ -1,0 +1,20 @@
+en:
+  publish:
+    providers:
+      course_fields:
+        why_train_with_us:
+          edit:
+            page_title: "Why train with us"
+            page_intro_html: |
+              <p class="govuk-body">This information appears at the top of every course page.</p>
+              <p class="govuk-body">Be as specific as possible. This will help candidates work out if they want to train with you.</p>
+
+            about_us_label:  "What kind of organisation is %{provider_name}?"
+            about_us_hint: "Are you a large or small organisation? Do you work in a particular area? How many schools do you work with?"
+            train_with_us_label:  "Why should candidates choose to train with you?"
+            train_with_us_hint_html: |
+              <span>Focus on what makes you different from other providers.</span>
+              <br>
+              <br>
+              <span>You can include past achievements, for example student successes or Ofsted ratings. Be specific with your claims, and support them with evidence</span>
+            submit: Update why train with us

--- a/config/locales/en/publish/why_train_with_us_form.yml
+++ b/config/locales/en/publish/why_train_with_us_form.yml
@@ -1,0 +1,12 @@
+en:
+  activemodel:
+    errors:
+      models:
+        publish/why_train_with_us_form:
+          attributes:
+            about_us:
+              blank: Enter what kind of organisation you are
+              too_many_words: "'What kind of organisation is yours?' must be 100 words or less"
+            value_proposition:
+              blank: Enter why candidates should choose to train with you
+              too_many_words: "'Why should candidates choose to train with you?' must be 100 words or less"

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -299,6 +299,10 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
           resources :courses, only: [:index], controller: "training_partners/courses"
         end
 
+        scope module: :course_fields do
+          resource :why_train_with_us, only: %i[edit update], path: "why-train-with-us"
+        end
+
         resources :accredited_partnerships, param: :accredited_provider_code, only: %i[index destroy show], path: "accredited-partnerships", controller: "accredited_partnerships" do
           member do
             get :delete

--- a/spec/features/publish/edit_provider_details_2026_spec.rb
+++ b/spec/features/publish/edit_provider_details_2026_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "About Your Organisation section" do
+feature "Why Train With Us section in 2026 cyle +" do
   scenario "Provider user edits provider details" do
     given_i_am_a_provider_user_as_a_provider_user
     when_i_visit_the_details_page
@@ -12,7 +12,7 @@ feature "About Your Organisation section" do
   end
 
   def given_i_am_a_provider_user_as_a_provider_user
-    @recruitment_cycle = find_or_create(:recruitment_cycle, year: 2025)
+    @recruitment_cycle = create(:recruitment_cycle, :next)
     @provider = create(:provider, recruitment_cycle: @recruitment_cycle)
     course = create(:course, :with_accrediting_provider, provider: @provider)
 
@@ -30,23 +30,26 @@ feature "About Your Organisation section" do
   end
 
   def then_i_can_edit_info_about_training_with_us
-    publish_provider_details_show_page.train_with_us_link.click
-    expect(page).to have_current_path publish_provider_details_edit_page.url(
+    visit("/publish/organisations/#{@provider.provider_code}/#{@recruitment_cycle.year}/details")
+    page.click_link "Change details about training with your organisation"
+
+    expect(page).to have_current_path edit_publish_provider_recruitment_cycle_why_train_with_us_path(
       provider_code: @provider.provider_code,
       recruitment_cycle_year: @provider.recruitment_cycle_year,
     )
 
-    publish_provider_details_edit_page.training_with_you_field.set ""
-    publish_provider_details_edit_page.save_and_publish.click
+    page.find("#publish-why-train-with-us-form-about-us-field").set ""
+
+    page.click_button "Update why train with us"
     within publish_provider_details_edit_page.error_summary do
-      expect(page).to have_content "Enter details about training with you"
+      expect(page).to have_content "Enter what kind of organisation you are"
     end
 
-    publish_provider_details_edit_page.training_with_you_field.set "Updated: Training with you"
-    publish_provider_details_edit_page.save_and_publish.click
+    page.find("#publish-why-train-with-us-form-about-us-field-error").set "Updated: Training with you"
+    page.click_button "Update why train with us"
 
     expect(page).to have_content "Your changes have been published"
-    within_summary_row "Training with your organisation" do
+    within_summary_row "Why train with us" do
       expect(page).to have_content "Updated: Training with you"
     end
   end

--- a/spec/forms/publish/why_train_with_us_form_spec.rb
+++ b/spec/forms/publish/why_train_with_us_form_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  describe WhyTrainWithUsForm, type: :model do
+    include Rails.application.routes.url_helpers
+    let(:params) do
+      {
+        about_us:,
+        value_proposition:,
+      }
+    end
+    let(:about_us) { "about_us" }
+    let(:value_proposition) { "value_proposition" }
+    let(:provider) { create(:provider) }
+    let(:redirect_params) { { "goto_provider" => "true" } }
+    let(:course_code) { create(:course) }
+
+    subject { described_class.new(provider, params:, redirect_params:, course_code:) }
+
+    context "validations" do
+      it { is_expected.to validate_presence_of(:about_us).with_message("Enter what kind of organisation you are") }
+      it { is_expected.to validate_presence_of(:value_proposition).with_message("Enter why candidates should choose to train with you") }
+
+      context "traing_with_us word count is invalid" do
+        let(:about_us) { Faker::Lorem.sentence(word_count: 101) }
+
+        it "is not valid when traing_with_us is over 100 words" do
+          expect(subject.valid?).to be_falsey
+          expect(subject.errors[:about_us]).to include("'What kind of organisation is yours?' must be 100 words or less")
+        end
+      end
+
+      context "value_proposition word count is invalid" do
+        let(:value_proposition) { Faker::Lorem.sentence(word_count: 101) }
+
+        it "is not valid when value_proposition is over 100 words" do
+          expect(subject.valid?).to be_falsey
+          expect(subject.errors[:value_proposition]).to include("'Why should candidates choose to train with you?' must be 100 words or less")
+        end
+      end
+    end
+
+    describe "#update_success_path" do
+      context "when goto_provider is true" do
+        let(:redirect_params) { { "goto_provider" => "true" } }
+
+        it "returns the goto_provider path" do
+          expect(subject.update_success_path).to eq(
+            provider_publish_provider_recruitment_cycle_course_path(
+              provider.provider_code,
+              provider.recruitment_cycle_year,
+              course_code,
+            ),
+          )
+        end
+      end
+
+      context "when there is no redirect_params" do
+        let(:redirect_params) { {} }
+
+        it "returns the details path" do
+          expect(subject.update_success_path).to eq(
+            details_publish_provider_recruitment_cycle_path(
+              provider.provider_code,
+              provider.recruitment_cycle_year,
+            ),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/api/public/v1/serializable_provider_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_provider_spec.rb
@@ -38,4 +38,15 @@ describe API::Public::V1::SerializableProvider do
   it { is_expected.to have_attribute(:email).with_value(provider.email) }
   it { is_expected.to have_attribute(:can_sponsor_skilled_worker_visa).with_value(provider.can_sponsor_skilled_worker_visa) }
   it { is_expected.to have_attribute(:can_sponsor_student_visa).with_value(provider.can_sponsor_student_visa) }
+
+  context "2026 cycle" do
+    let(:recruitment_cycle) { create(:recruitment_cycle, :next) }
+    let(:provider) { create(:provider, about_us: "about us", value_proposition: "value proposition", recruitment_cycle:) }
+
+    it "returns updated train_with_us" do
+      Timecop.travel(Find::CycleTimetable.find_reopens) do
+        expect(subject).to have_attribute(:train_with_us).with_value("about us\r\n\r\nvalue proposition")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Information is stored on the Provider model that is shared across all the providers courses in Find. This PR updates the details that a provider displays when describing to a candidate what their organisation is.

This information is available on every course the provider runs or accredits.
**These changes will be visible starting in the 2026 recruitment cycle.**

## Changes proposed in this pull request

Change from using the `train_with_us` column to using two columns `about_us` and `value_proposition`.

The Provider is required to fill in both these inputs.

### API
`train_with_us` is available in the API. I've concatenated the two fields and made them available through the API on that attribute.

|Provider console|API response|
|---|---|
|<img width="1156" height="624" alt="image" src="https://github.com/user-attachments/assets/855dad2b-b899-47aa-9192-c391d84373c9" />|<img width="1920" height="749" alt="image" src="https://github.com/user-attachments/assets/0c162be9-513e-4dbf-8960-857a6b5352b1" />|

### Provider Organisation Details

|Before|After|
|---|---|
|<img width="1220" height="846" alt="image" src="https://github.com/user-attachments/assets/a6279506-be35-44d3-9496-f9363d2049c7" />|<img width="1200" height="794" alt="image" src="https://github.com/user-attachments/assets/70ecb810-6911-4fbc-8d7f-f2f9a4c7848a" />|

### Editing Train with us

<img width="802" height="857" alt="image" src="https://github.com/user-attachments/assets/a57f7950-3237-4519-852e-415b0e7b8814" />


## Guidance to review

**The old train with us is still visible in the Training with disabilities eidt page, this will be updated in the next PR.**

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
