### PR TITLE
Add Current.recruitment_cycle

### DIFF
--- a/app/controllers/publish/application_controller.rb
+++ b/app/controllers/publish/application_controller.rb
@@ -25,7 +25,7 @@ module Publish
     end
 
     def recruitment_cycle
-      @recruitment_cycle ||= RecruitmentCycle.find_by!(year: cycle_year)
+      @recruitment_cycle ||= Current.recruitment_cycle = RecruitmentCycle.find_by!(year: cycle_year)
     end
 
     def cycle_year

--- a/app/controllers/support/application_controller.rb
+++ b/app/controllers/support/application_controller.rb
@@ -18,7 +18,7 @@ module Support
     end
 
     def recruitment_cycle
-      @recruitment_cycle ||= RecruitmentCycle.find_by(year: params.fetch(:recruitment_cycle_year))
+      @recruitment_cycle ||= Current.recruitment_cycle = RecruitmentCycle.find_by(year: params.fetch(:recruitment_cycle_year))
     end
   end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,8 +1,12 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :session, :user
+  attribute :session, :user, :recruitment_cycle
   delegate :sessionable, to: :session, allow_nil: true
 
   def user
     session&.sessionable
+  end
+
+  def recruitment_cycle
+    attributes[:recruitment_cycle] || RecruitmentCycle.current_recruitment_cycle
   end
 end


### PR DESCRIPTION
## Context

We often have to discover what the current recruitment cycle is, by using `@recruitment_cycle` , passing the recruitment cycle as an argument into components, etc.

It would be good to have a single source of truth about recruitment cycle. It's a fairly global attribute in the application so maybe suitable for CurrentAttribute.

## Changes proposed in this pull request

  This will be set on every request.
  It will be available inside Components too

  If you test a component in isolation, and the component uses Current,
  you'll need to initialize it

  ```ruby
  before { Current.recruitment_cycle = .... }
  ```


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
