### PR TITLE
Replace "Bernard" from test subjects

### DIFF
--- a/spec/features/publish/searching_for_a_school_spec.rb
+++ b/spec/features/publish/searching_for_a_school_spec.rb
@@ -41,7 +41,7 @@ private
   end
 
   def and_there_are_schools_in_the_database
-    @school = create(:gias_school, name: "Bernard", urn: "466415", postcode: "NW1 5WS", town: "Damonmouth")
+    @school = create(:gias_school, name: "Enda's", urn: "466415", postcode: "NW1 5WS", town: "Damonmouth")
     @school_two = create(:gias_school, name: "School Two")
     @school_three = create(:gias_school, name: "School Three")
   end

--- a/spec/features/publish/searching_for_a_study_site_spec.rb
+++ b/spec/features/publish/searching_for_a_study_site_spec.rb
@@ -108,7 +108,7 @@ feature "Searching for a study site from the GIAS list" do
   end
 
   def and_there_are_schools_in_the_database
-    @school = create(:gias_school, name: "Bernard")
+    @school = create(:gias_school, name: "Enda's")
     @school_two = create(:gias_school, name: "School Two")
     @school_three = create(:gias_school, name: "School Three")
   end


### PR DESCRIPTION
## Context

One of our test runs failed because we named a school Bernard, searched schools with that term, and another school was returned as well because it's address was generated as North Bernard.




## Changes proposed in this pull request

  Tests can become flaky if we use text that might be autogenerated by
  Faker. Try use text that won't match something generated by Faker

## Guidance to review

<img width="1419" height="336" alt="image" src="https://github.com/user-attachments/assets/1cdd0bd3-cdc5-4c89-ad0c-c0a7748b5f6d" />

https://github.com/DFE-Digital/publish-teacher-training/actions/runs/16821154975/job/47648183672?pr=5485

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
