### PR TITLE
Add message_attribute option to word count validator

### DIFF
--- a/app/validators/words_count_validator.rb
+++ b/app/validators/words_count_validator.rb
@@ -2,14 +2,22 @@
 
 class WordsCountValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, string)
+    @attribute = attribute
     return if string.blank?
 
     return unless word_count(string) > options[:maximum]
 
     record.errors.add(
       attribute,
-      message: options[:message] || "Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}",
+      message:,
     )
+  end
+
+  def message
+    return options[:message] if options[:message].present?
+    return "Reduce the word count for #{options[:message_attribute]}" if options[:message_attribute].present?
+
+    "Reduce the word count for #{@attribute.to_s.humanize(capitalize: false)}"
   end
 
   def word_count(string)


### PR DESCRIPTION
## Context

We have an ask to make the WordCountValidator return error messages that don't conform to the existing implementation.

Currently, if the attribute has too many words, the error message is `"Reduce the word count for #{column_name}"`

We want to have the option of using a custom value in place of the `column_name`, such as the label of the input on the form.

## Changes proposed in this pull request

Add `message_attribute` seems a useful API to customize the WordCountValidator while keeping the standard error message format and to reduce the repetition of "Reduce the word count for "

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
