### PR TITLE
[Longform] Seperation of V1 and V2 in find

### DIFF
--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -64,6 +64,7 @@ module Publish
 
     def preview
       fetch_course
+      @provider = provider
 
       authorize @course
     end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -405,6 +405,25 @@ class CourseDecorator < ApplicationDecorator
     current_published_enrichment[:about_course]
   end
 
+  def placement_selection_criteria
+    return unless current_published_enrichment
+
+    current_published_enrichment[:placement_selection_criteria]
+  end
+
+  def published_placement_school_activities
+    return unless current_published_enrichment
+
+    current_published_enrichment[:placement_school_activities]
+  end
+
+  def published_support_and_mentorship
+    return unless current_published_enrichment
+
+    current_published_enrichment[:support_and_mentorship]
+  end
+
+
   def published_interview_process
     return unless current_published_enrichment
 

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -441,12 +441,6 @@ class CourseDecorator < ApplicationDecorator
     current_published_enrichment[:how_school_placements_work]
   end
 
-  def train_with_disability
-    return unless current_published_enrichment
-
-    current_published_enrichment[:train_with_disability]
-  end
-
   def published_fee_uk_eu
     return unless current_published_enrichment
 

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -423,7 +423,6 @@ class CourseDecorator < ApplicationDecorator
     current_published_enrichment[:support_and_mentorship]
   end
 
-
   def published_interview_process
     return unless current_published_enrichment
 

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -417,6 +417,12 @@ class CourseDecorator < ApplicationDecorator
     current_published_enrichment[:placement_school_activities]
   end
 
+  def published_placement_school_activities
+    return unless current_published_enrichment
+
+    current_published_enrichment[:placement_school_activities]
+  end
+
   def published_support_and_mentorship
     return unless current_published_enrichment
 
@@ -439,6 +445,12 @@ class CourseDecorator < ApplicationDecorator
     return unless current_published_enrichment
 
     current_published_enrichment[:how_school_placements_work]
+  end
+
+  def train_with_disability
+    return unless current_published_enrichment
+
+    current_published_enrichment[:train_with_disability]
   end
 
   def published_fee_uk_eu

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -417,12 +417,6 @@ class CourseDecorator < ApplicationDecorator
     current_published_enrichment[:placement_school_activities]
   end
 
-  def published_placement_school_activities
-    return unless current_published_enrichment
-
-    current_published_enrichment[:placement_school_activities]
-  end
-
   def published_support_and_mentorship
     return unless current_published_enrichment
 

--- a/app/views/find/courses/_v1_components.html.erb
+++ b/app/views/find/courses/_v1_components.html.erb
@@ -4,9 +4,7 @@
 
 <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
 
-<% if course.published_about_course.present? %>
-    <%= render partial: "find/courses/about_course", locals: { course: course } %>
-<% end %>
+<%= render partial: "find/courses/about_course", locals: { course: course } %>
 
 <% if course.published_interview_process.present? || course.published_interview_location.present? %>
     <%= render partial: "find/courses/interview_process", locals: { course: course } %>

--- a/app/views/find/courses/_v1_components.html.erb
+++ b/app/views/find/courses/_v1_components.html.erb
@@ -1,0 +1,29 @@
+<%= render Find::Courses::ContentsComponent::View.new(@course) %>
+
+<%= render Find::Courses::AboutSchoolsComponent::View.new(@course, @coordinates, @distance_from_location, preview: preview?(params)) %>
+
+<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
+
+<% if @course.published_about_course.present? %>
+    <%= render partial: "find/courses/about_course", locals: { course: @course } %>
+<% end %>
+
+<% if @course.published_interview_process.present? || @course.published_interview_location.present? %>
+    <%= render partial: "find/courses/interview_process", locals: { course: @course } %>
+<% end %>
+
+<% if @provider.train_with_disability.present? %>
+    <h2 class="govuk-heading-m" id="section-train-with-disabilities">
+    <%= t("find.courses.show.training_with_disabilities") %>
+    </h2>
+
+    <p class="govuk-body govuk-!-margin-bottom-8">
+    <%= govuk_link_to(
+        t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
+        find_training_with_disabilities_path(
+        @course.provider_code,
+        @course.course_code,
+        ),
+    ) %>
+    </p>
+<% end %>

--- a/app/views/find/courses/_v1_components.html.erb
+++ b/app/views/find/courses/_v1_components.html.erb
@@ -21,9 +21,9 @@
     <%= govuk_link_to(
             t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
             find_training_with_disabilities_path(
-            @course.provider_code,
-            @course.course_code,
-            ),
-        ) %>
+                @course.provider_code,
+                @course.course_code,
+              ),
+          ) %>
     </p>
 <% end %>

--- a/app/views/find/courses/_v1_components.html.erb
+++ b/app/views/find/courses/_v1_components.html.erb
@@ -19,11 +19,11 @@
 
     <p class="govuk-body govuk-!-margin-bottom-8">
     <%= govuk_link_to(
-        t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
-        find_training_with_disabilities_path(
-        @course.provider_code,
-        @course.course_code,
-        ),
-    ) %>
+            t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
+            find_training_with_disabilities_path(
+            @course.provider_code,
+            @course.course_code,
+            ),
+        ) %>
     </p>
 <% end %>

--- a/app/views/find/courses/_v1_components.html.erb
+++ b/app/views/find/courses/_v1_components.html.erb
@@ -1,15 +1,15 @@
-<%= render Find::Courses::ContentsComponent::View.new(@course) %>
+<%= render Find::Courses::ContentsComponent::View.new(course) %>
 
-<%= render Find::Courses::AboutSchoolsComponent::View.new(@course, @coordinates, @distance_from_location, preview: preview?(params)) %>
+<%= render Find::Courses::AboutSchoolsComponent::View.new(course, @coordinates, @distance_from_location, preview: preview?(params)) %>
 
-<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
+<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
 
-<% if @course.published_about_course.present? %>
-    <%= render partial: "find/courses/about_course", locals: { course: @course } %>
+<% if course.published_about_course.present? %>
+    <%= render partial: "find/courses/about_course", locals: { course: course } %>
 <% end %>
 
-<% if @course.published_interview_process.present? || @course.published_interview_location.present? %>
-    <%= render partial: "find/courses/interview_process", locals: { course: @course } %>
+<% if course.published_interview_process.present? || course.published_interview_location.present? %>
+    <%= render partial: "find/courses/interview_process", locals: { course: course } %>
 <% end %>
 
 <% if @provider.train_with_disability.present? %>
@@ -19,10 +19,10 @@
 
     <p class="govuk-body govuk-!-margin-bottom-8">
     <%= govuk_link_to(
-            t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
+            t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
             find_training_with_disabilities_path(
-                @course.provider_code,
-                @course.course_code,
+                course.provider_code,
+                course.course_code,
               ),
           ) %>
     </p>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -48,38 +48,10 @@
 
     <%= render Find::Courses::EntryRequirementsComponent::View.new(course: @course) %>
 
-    <%= render Find::Courses::ContentsComponent::View.new(@course) %>
-
-    <%= render Find::Courses::AboutSchoolsComponent::View.new(@course, @coordinates, @distance_from_location, preview: preview?(params)) %>
-
-    <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
-
-    <% if @course.published_about_course.present? %>
-      <%= render partial: "find/courses/about_course", locals: { course: @course } %>
-    <% end %>
-
-    <% if @course.published_interview_process.present? || @course.published_interview_location.present? %>
-      <% if FeatureFlag.active?(:long_form_content) %>
-        <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: @course } %>
-      <% else %>
-        <%= render partial: "find/courses/interview_process", locals: { course: @course } %>
-      <% end %>
-    <% end %>
-
-    <% if @provider.train_with_disability.present? %>
-      <h2 class="govuk-heading-m" id="section-train-with-disabilities">
-        <%= t(".training_with_disabilities") %>
-      </h2>
-
-      <p class="govuk-body govuk-!-margin-bottom-8">
-        <%= govuk_link_to(
-          t(".training_with_disabilities_link", provider_name: @course.provider_name),
-          find_training_with_disabilities_path(
-            @course.provider_code,
-            @course.course_code,
-          ),
-        ) %>
-      </p>
+    <% if FeatureFlag.active?(:long_form_content) %>
+      <%= render partial: "find/courses/v2/components" %>
+    <% else %>
+      <%= render partial: "find/courses/v1_components" %>
     <% end %>
 
     <% if @course.teacher_degree_apprenticeship? %>
@@ -87,7 +59,7 @@
     <% else %>
       <%= render partial: "find/courses/advice", locals: { course: @course } %>
     <% end %>
-
+  
     <% if @course.application_status_closed? %>
       <%= render partial: "find/courses/course_closed" %>
     <% end %>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -49,9 +49,9 @@
     <%= render Find::Courses::EntryRequirementsComponent::View.new(course: @course) %>
 
     <% if FeatureFlag.active?(:long_form_content) %>
-      <%= render partial: "find/courses/v2/components" %>
+      <%= render partial: "find/courses/v2/components", locals: { course: @course } %>
     <% else %>
-      <%= render partial: "find/courses/v1_components" %>
+      <%= render partial: "find/courses/v1_components", locals: { course: @course } %>
     <% end %>
 
     <% if @course.teacher_degree_apprenticeship? %>

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -59,7 +59,7 @@
     <% else %>
       <%= render partial: "find/courses/advice", locals: { course: @course } %>
     <% end %>
-  
+
     <% if @course.application_status_closed? %>
       <%= render partial: "find/courses/course_closed" %>
     <% end %>

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -5,23 +5,23 @@
       <li><%= govuk_link_to t("find.courses.show.why_train_with_us"), "#section-why-train-with-us" %></li>
     <% end %>
     <%# Where you will train %>
-    <% if @course.placement_selection_criteria %>
+    <% if course.placement_selection_criteria %>
       <li><%= govuk_link_to t("find.courses.show.placement_selection_criteria"), "#section-placement-selection-criteria" %></li>
     <% end %>
     <%# What will you do on school placements %>
-    <% if @course.published_placement_school_activities %>
+    <% if course.published_placement_school_activities %>
       <li><%= govuk_link_to t("find.courses.show.what_will_you_do_on_school_placements"), "#section-school-placement" %></li>
     <% end %>
     <%# What you will study %>
-    <% if @course.theoretical_training_activities.present? %>
+    <% if course.theoretical_training_activities.present? %>
       <li><%= govuk_link_to t("find.courses.show.theoretical_training"), "#section-theoretical-training" %></li>
     <% end %>
     <%# Interview process %>
-    <% if @course.published_interview_process.present? || course.published_interview_location.present? %>
+    <% if course.published_interview_process.present? || course.published_interview_location.present? %>
       <li><%= govuk_link_to t("find.courses.show.interview_process"), "#section-interviews" %></li>
     <% end %>
     <%# Fees and financial support %>
-    <li><%= govuk_link_to (@course.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
+    <li><%= govuk_link_to (course.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
     <%# Training with disabilities %>
     <% if @provider.train_with_disability.present? %>
       <li><%= govuk_link_to t("find.courses.show.training_with_disabilities"), "#section-train-with-disabilities" %></li>
@@ -33,25 +33,25 @@
 <% end %>
 
 <%# Where you will train %>
-<% if @course.placement_selection_criteria.present? %>
+<% if course.placement_selection_criteria.present? %>
 <% end %>
 
 <%# What you will do on school placements %>
-<% if @course.published_placement_school_activities.present? %>
-    <%= render partial: "find/courses/v2/school_placement", locals: { course: @course } %>
+<% if course.published_placement_school_activities.present? %>
+    <%= render partial: "find/courses/v2/school_placement", locals: { course: course } %>
 <% end %>
 
 <%# What you will study %>
-<% if @course.theoretical_training_activities.present? %>
+<% if course.theoretical_training_activities.present? %>
 <% end %>
 
 <%# Interview process %>
-<% if @course.published_interview_process.present? || @course.published_interview_location.present? %>
-    <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: @course } %>
+<% if course.published_interview_process.present? || course.published_interview_location.present? %>
+    <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: course } %>
 <% end %>
 
 <%# Financial support %>
-<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
+<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
 
 <%# Training with disabilities %>
 <% if @provider.train_with_disability.present? %>
@@ -62,10 +62,10 @@
     <p class="govu
     k-body govuk-!-margin-bottom-8">
     <%= govuk_link_to(
-            t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
+            t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
             find_training_with_disabilities_path(
-            @course.provider_code,
-            @course.course_code,
+            course.provider_code,
+            course.course_code,
           ),
           ) %>
     </p>

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -32,7 +32,7 @@
 <% if @provider.value_proposition.present? %>
 <% end %>
 
-<% # Where you will train %>
+<%# Where you will train %>
 <% if @course.placement_selection_criteria.present? %>
 <% end %>
 
@@ -42,7 +42,7 @@
 <% end %>
 
 <%# What you will study %>
-<% if @course.theoretical_training_activities.present?  %>
+<% if @course.theoretical_training_activities.present? %>
 <% end %>
 
 <%# Interview process %>
@@ -62,11 +62,11 @@
     <p class="govu
     k-body govuk-!-margin-bottom-8">
     <%= govuk_link_to(
-        t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
-        find_training_with_disabilities_path(
-        @course.provider_code,
-        @course.course_code,
-        ),
-    ) %>
+            t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
+            find_training_with_disabilities_path(
+            @course.provider_code,
+            @course.course_code,
+            ),
+        ) %>
     </p>
 <% end %>

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -66,7 +66,7 @@
             find_training_with_disabilities_path(
             @course.provider_code,
             @course.course_code,
-            ),
-        ) %>
+          ),
+          ) %>
     </p>
 <% end %>

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -1,0 +1,73 @@
+<h2 class="govuk-heading-m"><%= t("find.courses.show.contents_header") %></h2>
+<ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
+    <%# Why train with us %>
+    <% if @provider&.value_proposition.present? %>
+      <li><%= govuk_link_to t("find.courses.show.why_train_with_us"), "#section-why-train-with-us" %></li>
+    <% end %>
+    <%# Where you will train %>
+    <% if @course.placement_selection_criteria %>
+      <li><%= govuk_link_to t("find.courses.show.placement_selection_criteria"), "#section-placement-selection-criteria" %></li>
+    <% end %>
+    <%# What will you do on school placements %>
+    <% if @course.published_placement_school_activities %>
+      <li><%= govuk_link_to t("find.courses.show.what_will_you_do_on_school_placements"), "#section-school-placement" %></li>
+    <% end %>
+    <%# What you will study %>
+    <% if @course.theoretical_training_activities.present? %>
+      <li><%= govuk_link_to t("find.courses.show.theoretical_training"), "#section-theoretical-training" %></li>
+    <% end %>
+    <%# Interview process %>
+    <% if @course.published_interview_process.present? || course.published_interview_location.present? %>
+      <li><%= govuk_link_to t("find.courses.show.interview_process"), "#section-interviews" %></li>
+    <% end %>
+    <%# Fees and financial support %>
+    <li><%= govuk_link_to (@course&.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
+    <%# Training with disabilities %>
+    <% if @provider.train_with_disability.present? %>
+      <li><%= govuk_link_to t("find.courses.show.training_with_disabilities"), "#section-train-with-disabilities" %></li>
+    <% end %>
+</ul>
+
+<%# Why train with us below %>
+<% if @provider.value_proposition.present? %>
+<% end %>
+
+<% # Where you will train %>
+<%# if @course.placement_selection_criteria.present? %>
+
+<%# end %>
+
+<%# What you will do on school placements %>
+<% if @course.published_placement_school_activities.present? %>
+    <%= render partial: "find/courses/v2/school_placement", locals: { course: @course } %>
+<% end %>
+
+<%# What you will study %>
+<% if @course.theoretical_training_activities.present?  %>
+<% end %>
+
+<%# Interview process %>
+<% if @course.published_interview_process.present? || @course.published_interview_location.present? %>
+    <%# render partial: "find/courses/v2/interview_process/interview_process", locals: { course: @course } %>
+<% end %>
+
+<%# Financial support %>
+<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(@course) %>
+
+<%# Training with disabilities %>
+<% if @provider.train_with_disability.present? %>
+    <h2 class="govuk-heading-m" id="section-train-with-disabilities">
+    <%= t("find.courses.show.training_with_disabilities") %>
+    </h2>
+
+    <p class="govu
+    k-body govuk-!-margin-bottom-8">
+    <%= govuk_link_to(
+        t("find.courses.show.training_with_disabilities_link", provider_name: @course.provider_name),
+        find_training_with_disabilities_path(
+        @course.provider_code,
+        @course.course_code,
+        ),
+    ) %>
+    </p>
+<% end %>

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -21,7 +21,7 @@
       <li><%= govuk_link_to t("find.courses.show.interview_process"), "#section-interviews" %></li>
     <% end %>
     <%# Fees and financial support %>
-    <li><%= govuk_link_to (@course&.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
+    <li><%= govuk_link_to (@course.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
     <%# Training with disabilities %>
     <% if @provider.train_with_disability.present? %>
       <li><%= govuk_link_to t("find.courses.show.training_with_disabilities"), "#section-train-with-disabilities" %></li>
@@ -33,9 +33,8 @@
 <% end %>
 
 <% # Where you will train %>
-<%# if @course.placement_selection_criteria.present? %>
-
-<%# end %>
+<% if @course.placement_selection_criteria.present? %>
+<% end %>
 
 <%# What you will do on school placements %>
 <% if @course.published_placement_school_activities.present? %>
@@ -48,7 +47,7 @@
 
 <%# Interview process %>
 <% if @course.published_interview_process.present? || @course.published_interview_location.present? %>
-    <%# render partial: "find/courses/v2/interview_process/interview_process", locals: { course: @course } %>
+    <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: @course } %>
 <% end %>
 
 <%# Financial support %>

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -59,8 +59,7 @@
     <%= t("find.courses.show.training_with_disabilities") %>
     </h2>
 
-    <p class="govu
-    k-body govuk-!-margin-bottom-8">
+    <p class="govuk-body govuk-!-margin-bottom-8">
     <%= govuk_link_to(
             t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
             find_training_with_disabilities_path(

--- a/app/views/find/courses/v2/_school_placement.html.erb
+++ b/app/views/find/courses/v2/_school_placement.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-!-margin-bottom-8">
+    <h2 class="govuk-heading-l" id="section-school-placement"><%= t(".heading") %> </h2>
+    <div data-qa="course__school_placement">
+        <% if course.published_placement_school_activities.present? %>
+            <%= markdown(course.published_placement_school_activities) %>
+            <% if course.published_support_and_mentorship.present? %>
+                <%= markdown(course.published_support_and_mentorship) %>
+            <% end %>
+        <% else %>
+            <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :school_placement, is_preview: preview?(params)) %>
+        <% end %>
+    </div>
+</div>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -31,6 +31,23 @@
       <%= render partial: "find/courses/v1_components" %>
     <% end %>
 
+    <% if @provider.train_with_disability.nil? %>
+        <h2 class="govuk-heading-m" id="section-train-with-disabilities">
+          <%= t(".training_with_disabilities") %>
+        </h2>
+
+        <p class="govuk-body govuk-!-margin-bottom-8">
+          <%= govuk_link_to(
+            t(".training_with_disabilities_link", provider_name: course.provider_name),
+            training_with_disabilities_publish_provider_recruitment_cycle_course_path(
+              course.provider_code,
+              course.recruitment_cycle_year,
+              course.course_code,
+            ),
+          ) %>
+        </p>
+    <% end %>
+
     <%= render partial: "find/courses/advice", locals: { course: } %>
 
     <%= render Find::Courses::ApplyComponent::View.new(course, preview: true) if course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -25,36 +25,11 @@
 
     <%= render Find::Courses::EntryRequirementsComponent::View.new(course:) %>
 
-    <%= render Find::Courses::ContentsComponent::View.new(course) %>
-
-    <%= render Find::Courses::AboutSchoolsComponent::View.new(course, nil, nil, preview: preview?(params)) %>
-
-    <%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
-
-    <%= render partial: "find/courses/about_course", locals: { course: } %>
-
-    <% if course.interview_process.present? || course.interview_location.present? %>
-      <% if FeatureFlag.active?(:long_form_content) %>
-        <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: } %>
-      <% else %>
-        <%= render partial: "find/courses/interview_process", locals: { course: } %>
-      <% end %>
+    <% if FeatureFlag.active?(:long_form_content) %>
+      <%= render partial: "find/courses/v2/components" %>
+    <% else %>
+      <%= render partial: "find/courses/v1_components" %>
     <% end %>
-
-    <h2 class="govuk-heading-m" id="section-train-with-disabilities">
-      <%= t(".training_with_disabilities") %>
-    </h2>
-
-    <p class="govuk-body govuk-!-margin-bottom-8">
-      <%= govuk_link_to(
-        t(".training_with_disabilities_link", provider_name: course.provider_name),
-        training_with_disabilities_publish_provider_recruitment_cycle_course_path(
-          course.provider_code,
-          course.recruitment_cycle_year,
-          course.course_code,
-        ),
-      ) %>
-    </p>
 
     <%= render partial: "find/courses/advice", locals: { course: } %>
 

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -136,5 +136,13 @@ en:
       show:
         back_to_search: Back to search results
         back_to_saved_courses: Back to saved courses
+        contents_header: Contents
         training_with_disabilities: Training with disabilities
         training_with_disabilities_link: Find out about training with disabilities and other needs at %{provider_name}.
+        why_train_with_us: Why train with us
+        where_you_will_train: Where you will train
+        what_will_you_do_on_school_placements: What you will do on school placements
+        what_you_will_study: What you will study
+        interview_process: Interview process
+        salary_and_financial_support: Salary and financial support
+        fees_and_financial_support: Fees and financial support

--- a/config/locales/en/find/courses/v2/school_placement.yml
+++ b/config/locales/en/find/courses/v2/school_placement.yml
@@ -1,0 +1,6 @@
+en:
+  find:
+    courses:
+      v2:
+        school_placement:
+          heading: "What you will do on school placements"

--- a/spec/system/find/courses/long_from_content/school_placement_spec.rb
+++ b/spec/system/find/courses/long_from_content/school_placement_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Viewing long form course content for school placement", service: :find do
+  before do
+    FeatureFlag.activate(:long_form_content)
+    given_a_published_course_exists
+  end
+
+  scenario "A user can see the Fees and financial support long from content" do
+    when_i_visit_a_course
+    then_i_see_the_school_placement_section
+    then_i_see_the_long_form_content
+  end
+
+  def when_i_visit_a_course
+    visit find_results_path
+    click_on_first_course
+  end
+
+  def click_on_first_course
+    page.first(".app-search-results").first("a").click
+  end
+
+  def then_i_see_the_school_placement_section
+    expect(page).to have_content("What you will do on school placements")
+  end
+
+  def then_i_see_the_long_form_content
+    enrichment = @course.enrichments.first
+    expect(page).to have_content(enrichment.placement_school_activities)
+    expect(page).to have_content(enrichment.support_and_mentorship)
+  end
+
+  def given_a_published_course_exists
+    @course = create(
+      :course,
+      :with_full_time_sites,
+      :secondary,
+      :with_special_education_needs,
+      :published,
+      :open,
+      enrichments: [
+        build(
+          :course_enrichment,
+          :published,
+          :v2,
+          fee_uk_eu: 2500,
+          fee_international: 3500,
+          fee_schedule: "Fee schedule",
+          additional_fees: "Additional fees",
+          financial_support: "Support of finances",
+        ),
+      ],
+      name: "Art and design (SEND)",
+      course_code: "F314",
+      provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
+      subjects: [find_or_create(:secondary_subject, :art_and_design)],
+    )
+  end
+end


### PR DESCRIPTION
## Context

Currently we do not have a structure to separate V1 from V2 in find, this PR should offer guidance to every dev working on this so that we engineer this solution in a similar fashion.


## Changes proposed in this pull request

introduction of new partials, specifically displaying content for V1 and V2 (Pre and post long form content go live).

It also has changes to the course page preview in publish. Both sides will share the same partials and components to keep it dry and consistent.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] separate V1 and V2 logic in the find/course/show
- [ ] HAve the same logic in the publish course preview
- [ ] Adding school placement field data to find course page