### PR TITLE
Add preview and what you wrote last cycle on Fees and Financial Support page

### DIFF
--- a/app/forms/publish/fields/fees_and_financial_support_form.rb
+++ b/app/forms/publish/fields/fees_and_financial_support_form.rb
@@ -13,16 +13,9 @@ module Publish
 
       attr_accessor(*FIELDS)
 
-      validates :fee_schedule, words_count: { maximum: 50 }, if: :is_fee_based?
-      validates :additional_fees, words_count: { maximum: 50 }, if: :is_fee_based?
-
-      validates :financial_support,
-                words_count: { maximum: 250 },
-                if: -> { is_fee_based? && version.to_i == 1 }
-
-      validates :financial_support,
-                words_count: { maximum: 50 },
-                if: -> { is_fee_based? && version.to_i == 2 }
+      validates :fee_schedule, words_count: { maximum: 50, message: :too_long }
+      validates :additional_fees, words_count: { maximum: 50, message: :too_long }
+      validates :financial_support, words_count: { maximum: 50, message: :too_long }
 
       validates :fee_uk_eu, presence: true, if: :is_fee_based?
       validates :fee_uk_eu,

--- a/app/javascript/publish/courses/input_preview_controller.js
+++ b/app/javascript/publish/courses/input_preview_controller.js
@@ -37,11 +37,9 @@ export default class extends Controller {
     // Next, update each preview region with the combined content of its inputs.
     previewMap.forEach((inputs, key) => {
       // Determine the preview element corresponding to this key.
-      // If the key is 'shared', use the first preview target element.
-      // Otherwise, find the preview target with a matching data-preview-target attribute.
-      const previewEl = (key === 'shared')
-        ? this.previewTargets[0]
-        : this.previewTargets.find(p => p.dataset.previewTarget === key)
+      // Instead of assuming the first preview target is 'shared',
+      // explicitly find the preview element by its matching data-preview-target attribute.
+      const previewEl = this.previewTargets.find(p => p.dataset.previewTarget === key)
 
       // If no corresponding preview element exists, skip this group.
       if (!previewEl) return

--- a/app/views/publish/courses/fields/_dynamic_preview.html.erb
+++ b/app/views/publish/courses/fields/_dynamic_preview.html.erb
@@ -1,12 +1,20 @@
 <div class="app-preview-container--heading">
-    <span class="govuk-body"><strong><%= t(".preview_header") %></strong></span>
+  <span class="govuk-body"><strong><%= t(".preview_header") %></strong></span>
 </div>
 
 <div class="app-preview-container">
-    <p class="govuk-heading-m"><%= preview_heading %></p>
+  <p class="govuk-heading-m"><%= preview_heading %></p>
 
-    <% if @render_before_preview_body %>
-        <%= render partial: "publish/courses/fields/#{@render_before_preview_body}", locals: { locals: before_preview_locals } %>
-    <% end %>
-    <p class="govuk-body" data-input-preview-target="preview" data-preview-target="shared"><%= t(".preview_text") %></p>
+  <% if @render_before_preview_body %>
+    <%= render partial: "publish/courses/fields/#{@render_before_preview_body}",
+               locals: { locals: before_preview_locals } %>
+  <% end %>
+
+  <% if @render_fees %>
+    <%= render partial: "publish/courses/fields/fees" %>
+  <% end %>
+
+  <p class="govuk-body"
+      data-input-preview-target="preview"
+      data-preview-target="shared"><%= t(".preview_text") %></p>
 </div>

--- a/app/views/publish/courses/fields/_fees.html.erb
+++ b/app/views/publish/courses/fields/_fees.html.erb
@@ -1,0 +1,23 @@
+<dl class="govuk-summary-list govuk-!-margin-bottom-6">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= t(".uk_citizens") %>
+    </dt>
+    <dd class="govuk-summary-list__value"
+        data-input-preview-target="preview"
+        data-preview-target="currency1">
+      <%= t(".preview_text") %>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%= t(".non_uk_citizens") %>
+    </dt>
+    <dd class="govuk-summary-list__value"
+        data-input-preview-target="preview"
+        data-preview-target="currency2">
+      <%= t(".preview_text") %>
+    </dd>
+  </div>
+</dl>

--- a/app/views/publish/courses/fields/fees_and_financial_support/edit.html.erb
+++ b/app/views/publish/courses/fields/fees_and_financial_support/edit.html.erb
@@ -36,62 +36,71 @@
         <%= t(".heading") %>
       </h1>
 
-      <%= f.govuk_text_field(:fee_uk_eu,
-          form_group: { id: "fee-uk" },
-          label: { text: t(".fee_uk"), size: "s" },
-          value: @copied_fields_values&.dig("fee_uk_eu"),
-          prefix_text: "£",
-          width: 5,
-          data: { qa: "course_fee_uk_eu",
-                  input_preview_target: "input",
-                  action: "input-preview#updatePreview",
-                  preview_output_target: "currency1" }) %>
+      <% if @v1_enrichment %>
+        <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
+          texts: [
+            [t(".fee_uk"), number_to_currency(@v1_enrichment.fee_uk_eu).to_s],
+            [@course.can_sponsor_student_visa? ? t(".fee_international") : t(".fee_international_optional"), number_to_currency(@v1_enrichment.fee_international).to_s],
+            [t(".fee_schedule"), @v1_enrichment.fee_schedule],
+            [t(".additional_fees"), @v1_enrichment.additional_fees],
+            [t(".financial_support"), @v1_enrichment.financial_support],
+          ],
+        } %>
+      <% end %>
 
-      <%= f.govuk_text_field(:fee_international,
-          form_group: { id: "fee-international" },
-          label: { text: @course.can_sponsor_student_visa? ? t(".fee_international") : t(".fee_international_optional"), size: "s" },
-          value: @copied_fields_values&.dig("fee_international"),
-          prefix_text: "£",
-          width: 5,
-          data: {
-            qa: "course_fee_international",
-            input_preview_target: "input",
-            action: "input-preview#updatePreview",
-            preview_output_target: "currency2",
-        }) %>
+      <div data-controller="input-preview">
+        <%= f.govuk_text_field(:fee_uk_eu,
+            form_group: { id: "fee-uk" },
+            label: { text: t(".fee_uk"), size: "s" },
+            value: @copied_fields_values&.dig("fee_uk_eu"),
+            prefix_text: "£",
+            width: 5,
+            data: { input_preview_target: "input",
+                    action: "input-preview#updatePreview",
+                    preview_output_target: "currency1" }) %>
 
-      <%= f.govuk_text_area(:fee_schedule,
-          label: { text: t(".fee_schedule"), size: "s" },
-          value: @copied_fields_values&.dig("fee_schedule"),
-          rows: 5,
-          max_words: 50,
-          data: { qa: "course_fee_schedule",
-                  input_preview_target: "input",
-                  action: "input-preview#updatePreview",
-                  preview_output_target: "preview3" }) %>
+        <%= f.govuk_text_field(:fee_international,
+            form_group: { id: "fee-international" },
+            label: { text: @course.can_sponsor_student_visa? ? t(".fee_international") : t(".fee_international_optional"), size: "s" },
+            value: @copied_fields_values&.dig("fee_international"),
+            prefix_text: "£",
+            width: 5,
+            data: { input_preview_target: "input",
+                    action: "input-preview#updatePreview",
+                    preview_output_target: "currency2" }) %>
 
-      <%= f.govuk_text_area(:additional_fees,
-          label: { text: t(".additional_fees"), size: "s" },
-          value: @copied_fields_values&.dig("additional_fees"),
-          hint: { text: t(".additional_fees_hint"), size: "s" },
-          rows: 5,
-          max_words: 50,
-          data: { qa: "course_additional_fees",
-                  input_preview_target: "input",
-                  action: "input-preview#updatePreview",
-                  preview_output_target: "preview3" }) %>
+        <%= f.govuk_text_area(:fee_schedule,
+            label: { text: t(".fee_schedule"), size: "s" },
+            value: @copied_fields_values&.dig("fee_schedule"),
+            rows: 5,
+            max_words: 50,
+            data: { input_preview_target: "input",
+                    action: "input-preview#updatePreview",
+                    preview_output_target: "shared" }) %>
 
-      <%= f.govuk_text_area(:financial_support,
-          label: { text: t(".financial_support"), size: "s" },
-          value: @copied_fields_values&.dig("financial_support"),
-          hint: { text: t(".financial_support_hint"), size: "s" },
-          rows: 5,
-          max_words: @course_enrichment.version == 2 ? 50 : 250,
-          data: { qa: "course_financial_support",
-                  input_preview_target: "input",
-                  action: "input-preview#updatePreview",
-                  preview_output_target: "preview3" }) %>
+        <%= f.govuk_text_area(:additional_fees,
+            label: { text: t(".additional_fees"), size: "s" },
+            value: @copied_fields_values&.dig("additional_fees"),
+            hint: { text: t(".additional_fees_hint"), size: "s" },
+            rows: 5,
+            max_words: 50,
+            data: { input_preview_target: "input",
+                    action: "input-preview#updatePreview",
+                    preview_output_target: "shared" }) %>
 
+        <%= f.govuk_text_area(:financial_support,
+            label: { text: t(".financial_support"), size: "s" },
+            value: @copied_fields_values&.dig("financial_support"),
+            hint: { text: t(".financial_support_hint"), size: "s" },
+            rows: 5,
+            max_words: 50,
+            data: { input_preview_target: "input",
+                    action: "input-preview#updatePreview",
+                    preview_output_target: "shared" }) %>
+
+        <%= render partial: "publish/courses/fields/dynamic_preview", locals: { preview_heading: t(".preview_heading") } %>
+
+      </div>
       <%= f.govuk_submit t(".submit_button") %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1010,11 +1010,11 @@ en:
               less_than_or_equal_to: "Course fee for non-UK citizens must be less than or equal to £100,000"
               not_an_integer: "Course for fee non-UK citizens must not include pence, like 1000 or 1500"
             fee_schedule:
-              too_long: "Reduce the word count for fee schedule"
+              too_long: "Fee schedule must be 50 words or less"
             additional_fees:
-              too_long: "Reduce the word count for additional fees"
+              too_long: "Additional fees must be 50 words or less"
             financial_support:
-              too_long: "Reduce the word count for financial support"
+              too_long: "Financial support must be 50 words or less"
         publish/courses/fields/school_placement_form:
           attributes:
             placement_school_activities:

--- a/config/locales/en/publish/courses/fields/fees.yml
+++ b/config/locales/en/publish/courses/fields/fees.yml
@@ -1,0 +1,8 @@
+en:
+  publish:
+    courses:
+      fields:
+        fees:
+          uk_citizens: UK citizens
+          non_uk_citizens: Non-UK citizens
+          preview_text: The text you type above will show here.

--- a/config/locales/en/publish/courses/fields/fees_and_financial_support.yml
+++ b/config/locales/en/publish/courses/fields/fees_and_financial_support.yml
@@ -4,6 +4,7 @@ en:
       fields:
         fees_and_financial_support:
           edit:
+            preview_heading: Fees and financial support
             heading: Fees and financial support
             label: Fees and financial support
             page_title: Fees and financial support- %{course_name_and_code}

--- a/spec/system/publish/courses/long_form_content/financial_support_spec.rb
+++ b/spec/system/publish/courses/long_form_content/financial_support_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe "Publishing a course with long form content", service: :publish d
       financial_support: generate_text(251),
     )
 
-    expect(page).to have_content("Reduce the word count for fee schedule")
-    expect(page).to have_content("Reduce the word count for additional fees")
-    expect(page).to have_content("Reduce the word count for financial support")
+    expect(page).to have_content("Fee schedule must be 50 words or less")
+    expect(page).to have_content("Additional fees must be 50 words or less")
+    expect(page).to have_content("Financial support must be 50 words or less")
   end
 
   scenario "A user CAN see the new long form course content fields if the current cycle is 2026 or beyond" do


### PR DESCRIPTION
## Context

This adds the dynamic preview partial and what you wrote last cycle

## Changes proposed in this pull request

This adds the dynamic preview partial and what you wrote last cycle

## Guidance to review

- Visit Publish
- Add a course
- Edit the fees and financial support section
- See the preview change on the fly
- Click dropdown to see the what you wrote last cycle

<img width="715" height="884" alt="Screenshot 2025-08-13 at 15 19 16" src="https://github.com/user-attachments/assets/32202e93-05f1-46ba-be79-ddcaaf69ec1d" />


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
