### PR TITLE
Longform: Add 'Why train with us' to Find

### DIFF
--- a/app/components/find/courses/contact_details_component/view.html.erb
+++ b/app/components/find/courses/contact_details_component/view.html.erb
@@ -2,6 +2,8 @@
   <%= t(".heading", provider_name: course.provider_name) %>
 </h1>
 
+<h2 class="govuk-heading-l"><%= t(".contact_us") %></h1>
+
 <%= govuk_summary_list(actions: false, classes: ["govuk-summary-list--no-border"]) do |summary_list| %>
   <% summary_list.with_row do |row| %>
     <% if course.provider.decorate.website.present? %>

--- a/app/views/find/courses/providers/show.html.erb
+++ b/app/views/find/courses/providers/show.html.erb
@@ -22,6 +22,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render Find::Courses::ContactDetailsComponent::View.new(@course) %>
 
+    <% if @course.provider.about_us.present? || @course.provider.value_proposition.present? %>
+        <%= render partial: "find/courses/v2/train_with_us", locals: { provider: @provider } %>
+    <% end %>
+
     <% if @provider.train_with_us.present? || @course.about_accrediting_provider.present? %>
       <%= render partial: "find/courses/about_the_provider", locals: { course: @course } %>
     <% end %>

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -29,7 +29,8 @@
 </ul>
 
 <%# Why train with us below %>
-<% if @provider.value_proposition.present? %>
+<% if @provider.value_proposition.present? || @provider.about_us.present? %>
+  <%= render partial: "find/courses/v2/train_with_us", locals: { provider: @provider } %>
 <% end %>
 
 <%# Where you will train %>

--- a/app/views/find/courses/v2/_train_with_us.html.erb
+++ b/app/views/find/courses/v2/_train_with_us.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-why-train-with-us"><%= t(".heading") %> </h2>
+  <p class="govuk-body"><%= @provider.about_us %></p>
+  <p class="govuk-body"><%= @provider.value_proposition %></p>
+</div>

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -109,7 +109,8 @@ en:
           back: Back to %{course_name} (%{course_code})
       contact_details_component:
         view:
-          heading: Contact %{provider_name}
+          heading: About %{provider_name}
+          contact_us: Contact us
           contact_form: Contact form
           email_address: Email address
           send_email_to_contact: Send email to course contact

--- a/config/locales/en/find/courses/v2/train_with_us.yml
+++ b/config/locales/en/find/courses/v2/train_with_us.yml
@@ -1,0 +1,6 @@
+en:
+  find:
+    courses:
+      v2:
+        train_with_us:
+          heading: Why train with us


### PR DESCRIPTION
## Context

Update/Add Why train with us on provider and course page

## Changes proposed in this pull request

Add content and add new sections

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
