### PR TITLE
Ignore some providers during register school import

### DIFF
--- a/app/services/data_hub/register_school_importer/provider_resolver.rb
+++ b/app/services/data_hub/register_school_importer/provider_resolver.rb
@@ -1,6 +1,9 @@
 module DataHub
   module RegisterSchoolImporter
     class ProviderResolver
+      HPITT_PROVIDERS = %w[1TF].freeze
+      IGNORED_PROVIDER_CODES = [HPITT_PROVIDERS].flatten
+
       def initialize(recruitment_cycle, parser)
         @recruitment_cycle = recruitment_cycle
         @parser = parser
@@ -9,6 +12,7 @@ module DataHub
       def resolve
         provider_code = @parser.provider_code
         return nil unless provider_code
+        return nil if IGNORED_PROVIDER_CODES.include?(provider_code)
 
         @recruitment_cycle.providers.find_by(provider_code:)
       end

--- a/spec/services/data_hub/register_school_importer/provider_resolver_spec.rb
+++ b/spec/services/data_hub/register_school_importer/provider_resolver_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe DataHub::RegisterSchoolImporter::ProviderResolver do
       end
     end
 
+    context "when provider_code is in the ignore list" do
+      let!(:provider) { create(:provider, recruitment_cycle: recruitment_cycle, provider_code: "1TF") }
+
+      before do
+        allow(parser).to receive(:provider_code).and_return("1TF")
+      end
+
+      it "returns nil" do
+        expect(subject.resolve).to be_nil
+      end
+    end
+
     context "when provider_code is nil" do
       before do
         allow(parser).to receive(:provider_code).and_return(nil)


### PR DESCRIPTION
## **Context**

As part of the work to add all placement schools from Register to Publish we have identified a provider who will be receiving many new schools. Top of the list. As the provider run both regular ITT, as well as High Potential ITT (HPITT) which is recruited off-service, we should not be adding HPITT only schools to their Publish account.

## **Guidance for Review**
- Verify that the ignore list is appropriate for this stage (currently hardcoded in the class).
