### PR TITLE
Action minor feedback changes on schools outcome

### DIFF
--- a/app/assets/stylesheets/publish/application.scss
+++ b/app/assets/stylesheets/publish/application.scss
@@ -26,6 +26,7 @@
 @import "./components/code";
 @import "./components/secondary-navigation";
 @import "./components/dynamic_preview";
+@import "./components/newly_added_tag";
 
 .app-list--dash {
   padding-left: govuk-spacing(3);

--- a/app/assets/stylesheets/publish/components/_newly_added_tag.scss
+++ b/app/assets/stylesheets/publish/components/_newly_added_tag.scss
@@ -1,0 +1,16 @@
+.school-row {
+  .govuk-table__header.name {
+    display: flex;
+
+    flex-wrap: wrap;
+
+    gap: 0.50rem;
+    align-items: flex-start;
+
+    .newly-added-tag {
+      flex-shrink: 0;
+
+      margin-left: 0;
+    }
+  }
+}

--- a/app/components/publish/newly_added_tag_component.html.erb
+++ b/app/components/publish/newly_added_tag_component.html.erb
@@ -1,3 +1,3 @@
-<strong class="govuk-tag govuk-tag--green govuk-!-margin-left-1">
+<strong class="govuk-tag govuk-tag--green newly-added-tag">
   <%= t(".newly_added") %>
 </strong>

--- a/app/components/publish/providers/school_placements/outcome_explainer_component.html.erb
+++ b/app/components/publish/providers/school_placements/outcome_explainer_component.html.erb
@@ -18,5 +18,5 @@
 </div>
 
 <p class="govuk-body">
-  <%= t(".organisation_details_html", link: govuk_link_to("Organisation details ", details_publish_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @recruitment_cycle.year))) %>
+  <%= t(".organisation_details_html", link: govuk_link_to("Organisation details", details_publish_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @recruitment_cycle.year))) %>
 <p>

--- a/app/components/publish/schools/notification_banner_component.html.erb
+++ b/app/components/publish/schools/notification_banner_component.html.erb
@@ -9,6 +9,7 @@
         @provider.provider_code,
         @recruitment_cycle.year,
       ),
-      new_tab: true %>
+      target: "_blank",
+      rel: "noreferrer noopener" %>
   </p>
 <% end %>

--- a/config/locales/en/components/publish/outcome_explainer_component.yml
+++ b/config/locales/en/components/publish/outcome_explainer_component.yml
@@ -8,6 +8,6 @@ en:
           gias_url: https://get-information-schools.service.gov.uk/Search?SelectedTab=Establishments
           placement_school_text_html: You can attach placement schools to any of your courses from the ‘Basic details’ tab on each of %{link}.
           courses_link_text: your courses
-          location_searches_text: Your courses will not appear in candidates‘ location searches if you do not add placement schools to them.
+          location_searches_text: Your courses will not appear in candidates‘ location searches if you do not attach placement schools to them.
           organisation_details_html: You can choose whether to show or hide the placements from candidates in %{link}.
           find_out_more: Find out more about why you should add school placement locations.

--- a/config/locales/en/components/publish/schools/notification_banner_component.yml
+++ b/config/locales/en/components/publish/schools/notification_banner_component.yml
@@ -3,4 +3,4 @@ en:
     schools:
       notification_banner_component:
         title: 'The way schools are added to your account has changed.'
-        body: 'Find out more about how schools are added to your account.'
+        body: 'Find out more about how schools are added to your account (opens in new tab).'

--- a/config/locales/en/components/publish/schools_changed_banner_component.yml
+++ b/config/locales/en/components/publish/schools_changed_banner_component.yml
@@ -5,7 +5,7 @@ en:
       minimal_header: "The way schools are added to your account has changed."
       content_heading: "Changes to the schools in your account"
       minimal_heading: "You will no longer need to manually add all your schools to your account."
-      auto_upload: "We automatically upload all schools you are working with."
+      auto_upload: "You will no longer need to manually add all your schools to your account. We automatically upload all schools you are working with."
       added_register_html: >
         These are schools that are on <a class="govuk-link" href="%{url}">Register trainee teachers</a>.
       register_url: "https://www.register-trainee-teachers.service.gov.uk/"


### PR DESCRIPTION
# Changes

1. Schools landing page notification banner Replace paragraph:

```
We automatically upload all schools you are working with.
```

With:
```
You will no longer need to manually add all your schools to your account. We automatically upload all schools you are working with.
```

2. School landing page intro content Replace ‘add’:

Your courses will not appear in candidates‘ location searches if you do not add placement schools to them.

With ‘attach':

Your courses will not appear in candidates‘ location searches if you do not attach placement schools to them.

Remove extra space before full stop at the end of sentence:

You can choose whether to show or hide the placements from candidates in Organisation details .

3. Attached schools notification banner Change position of full stop from:

Find out more about how schools are added to your account. (opens in new tab)

To:

Find out more about how schools are added to your account (opens in new tab).

4. ‘Newly added’ tag on schools landing and attaching courses pages Fix padding when tag wraps. Remove left padding and add top padding:

## Guidance to review

1. Run rollover
2. Run register import (ask me or Simon how to run)