### PR TITLE
Use recruitment_cycle.application_start_date if flag set

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -12,11 +12,7 @@ module API
             class: API::Public::V1::SerializerService.call,
           }
 
-          if should_strip_applications_open_from?
-            strip_hidden_fields_from_response!(**render_opts)
-          else
-            render(**render_opts)
-          end
+          render(**render_opts)
         rescue ActiveRecord::StatementInvalid
           render json: {
             status: 400,
@@ -25,21 +21,6 @@ module API
         end
 
       private
-
-        def should_strip_applications_open_from?
-          FeatureFlag.active?(:hide_applications_open_date)
-        end
-
-        def strip_hidden_fields_from_response!(**render_opts)
-          rendered = render_to_string(**render_opts)
-          json = JSON.parse(rendered, symbolize_names: true)
-
-          json[:data].each do |course|
-            course[:attributes].delete(:applications_open_from)
-          end
-
-          render json: json
-        end
 
         def cached_course_count
           year = permitted_params[:recruitment_cycle_year] || RecruitmentCycle.current.year

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -62,7 +62,11 @@ module API
         end
 
         attribute :applications_open_from do
-          @object.applications_open_from&.iso8601
+          if FeatureFlag.active?(:hide_applications_open_date)
+            @object.recruitment_cycle&.application_start_date&.iso8601
+          else
+            @object.applications_open_from&.iso8601
+          end
         end
 
         attribute :changed_at do

--- a/spec/serializers/api/public/v1/serializable_course_hide_applications_open_from_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_hide_applications_open_from_spec.rb
@@ -3,17 +3,29 @@
 require "rails_helper"
 
 RSpec.describe API::Public::V1::SerializableCourse do
-  subject { JSON.parse(resource.as_jsonapi.to_json) }
+  subject(:json) { JSON.parse(resource.as_jsonapi.to_json) }
 
   let(:enrichment) { build(:course_enrichment, :published) }
   let(:course) { create(:course, :with_accrediting_provider, enrichments: [enrichment], funding: "apprenticeship") }
   let(:resource) { described_class.new(object: course) }
 
-  before do
+  it "returns applications_open_from from the recruitment cycle when the flag is on" do
     FeatureFlag.activate(:hide_applications_open_date)
+
+    expect(json["attributes"]).to have_key("applications_open_from")
+
+    expect(json["attributes"]["applications_open_from"]).to eq(
+      course.recruitment_cycle.application_start_date.iso8601,
+    )
   end
 
-  it "does not include applications_open_from field" do
-    expect(subject).not_to have_key("applications_open_from")
+  it "returns the course applications_open_from when the flag is off" do
+    FeatureFlag.deactivate(:hide_applications_open_date)
+
+    expect(json["attributes"]).to have_key("applications_open_from")
+
+    expect(json["attributes"]["applications_open_from"]).to eq(
+      course.applications_open_from.iso8601,
+    )
   end
 end


### PR DESCRIPTION
## Context

After chatting with Apply we decided to not strip the value as that would cause issues downstream. So we went with a pragmatic approach of using the `recruitment_cycle. application_start_date` as we are no longer using the `course. application_start_date` values anymore on Find and Publish. This change allows Apply to keep using this field which contains a sensible value.

## Changes proposed in this pull request

Remove the code that removed the value, and replace it with `@object.recruitment_cycle&.application_start_date&.to_date&.iso8601` to allow nothing to break downstream

## Guidance to review

- Hit the API with the flag off
- Hit the API with the flag on 
- Compare the values to the course and current recruitment cycle to see the values change 

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
