### PR TITLE
Longform: Add 'Copy course content' functionality to 'What you will do on school placements' and 'What you will study'

### DIFF
--- a/app/controllers/publish/courses/fields/school_placement_controller.rb
+++ b/app/controllers/publish/courses/fields/school_placement_controller.rb
@@ -14,7 +14,7 @@ module Publish
         # Page to edit school placements data that is stored in the course enrichment
         def edit
           @school_placement_form = Publish::Courses::Fields::SchoolPlacementForm.new(course_enrichment)
-          @copied_fields = copy_content_check(::Courses::Copy::SCHOOL_PLACEMENT_FIELDS)
+          @copied_fields = copy_content_check(::Courses::Copy::V2_SCHOOL_PLACEMENT_FIELDS)
           @v1_enrichment = course.enrichments.find_by(version: 1)
           @copied_fields_values = copied_fields_values if @copied_fields.present?
           @school_placement_form.valid? if show_errors_on_publish?

--- a/app/services/courses/copy.rb
+++ b/app/services/courses/copy.rb
@@ -23,6 +23,11 @@ module Courses
       "What you will do on school placements", "placement_school_activities"
     ].freeze
 
+    V2_SCHOOL_PLACEMENT_FIELDS = [
+      ["What you will do on school placements", "placement_school_activities"],
+      ["Support and mentorship", "support_and_mentorship"],
+    ].freeze
+
     INTERVIEW_PROCESS_FIELDS = [
       ["Interview process", "interview_process"],
     ].freeze

--- a/app/views/publish/courses/fields/school_placement/edit.html.erb
+++ b/app/views/publish/courses/fields/school_placement/edit.html.erb
@@ -64,6 +64,7 @@
 
     <div data-controller="input-preview">
         <%= f.govuk_text_area(:placement_school_activities,
+          value: @copied_fields_values&.dig("placement_school_activities"),
           data: {
             input_preview_target: "input",
             action: "input-preview#updatePreview",
@@ -75,6 +76,7 @@
           rows: 10) %>
 
         <%= f.govuk_text_area(:support_and_mentorship,
+          value: @copied_fields_values&.dig("support_and_mentorship"),
           data: {
             input_preview_target: "input",
             action: "input-preview#updatePreview",

--- a/app/views/publish/courses/fields/what_you_will_study/edit.html.erb
+++ b/app/views/publish/courses/fields/what_you_will_study/edit.html.erb
@@ -60,6 +60,7 @@
       ) %>
       <div data-controller="input-preview">
         <%= f.govuk_text_area(:theoretical_training_activities,
+          value: @copied_fields_values&.dig("theoretical_training_activities"),
           data: {
             input_preview_target: "input",
             action: "input-preview#updatePreview",
@@ -70,6 +71,7 @@
           rows: 5,
           max_words: 150) %>
         <%= f.govuk_text_area(:assessment_methods,
+          value: @copied_fields_values&.dig("assessment_methods"),
           data: {
             input_preview_target: "input",
             action: "input-preview#updatePreview",


### PR DESCRIPTION
## Context

Add ability to copy content from a previous course

## Changes proposed in this pull request

Update Copy fields and value fields for inouts

## Guidance to review

- Visit Publish
- Create a course which has the sections populated
- Visit another course and use the copy section button

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
