### PR TITLE
[Longform] Adding preview and last cycl to where you will train page publish

### DIFF
--- a/app/controllers/publish/courses/fields/where_you_will_train_controller.rb
+++ b/app/controllers/publish/courses/fields/where_you_will_train_controller.rb
@@ -9,6 +9,7 @@ module Publish
           @copied_fields = copy_content_check(::Courses::Copy::V2_WHERE_YOU_WILL_TRAIN_FIELDS)
 
           @copied_fields_values = copied_fields_values if @copied_fields.present?
+          @v1_enrichment = course.enrichments.find_by(version: 1)
           @where_you_will_train_form.valid? if show_errors_on_publish?
         end
 
@@ -28,6 +29,7 @@ module Publish
             )
 
           else
+            @v1_enrichment = course.enrichments.find_by(version: 1)
             fetch_course_list_to_copy_from
             render :edit
           end

--- a/app/views/publish/courses/fields/where_you_will_train/edit.html.erb
+++ b/app/views/publish/courses/fields/where_you_will_train/edit.html.erb
@@ -36,38 +36,85 @@
         <%= t(".heading") %>
       </h1>
 
+      <% if @v1_enrichment %>
+        <%= render(
+          partial: "publish/courses/fields/last_cycle_recap",
+          locals: {
+            texts: [
+              [t(".about_this_course"), @v1_enrichment&.about_course],
+              [t(".how_placements_work"), @v1_enrichment&.how_school_placements_work],
+            ],
+          },
+        ) %>
+      <% end %>
+
+      <%= render(
+        partial: "publish/courses/markdown_formatting",
+        locals: {
+          course: @course,
+          page_path: fields_what_you_will_study_publish_provider_recruitment_cycle_course_path(
+            @provider.provider_code,
+            @course.recruitment_cycle_year,
+            @course.course_code,
+          ),
+        },
+      ) %>
       <%= t(".description_html") %>
 
-      <%= f.govuk_text_area(:placement_selection_criteria,
-        value: @copied_fields_values&.dig("placement_selection_criteria") ||
-          @where_you_will_train_form.placement_selection_criteria,
-        label: { text: t(".placement_selection_criteria_label"), size: "s" },
-        hint: -> { t(".placement_selection_criteria_hint") },
-        max_words: 50,
-        rows: 5) %>
+      <div data-controller="input-preview">
+        <%= f.govuk_text_area(:placement_selection_criteria,
+          value: @copied_fields_values&.dig("placement_selection_criteria") ||
+            @where_you_will_train_form.placement_selection_criteria,
+          data: {
+            input_preview_target: "input",
+            action: "input-preview#updatePreview",
+            preview_output_target: "shared",
+          },
+          label: { text: t(".placement_selection_criteria_label"), size: "s" },
+          hint: -> { t(".placement_selection_criteria_hint") },
+          max_words: 50,
+          rows: 5) %>
 
-      <%= f.govuk_text_area(:duration_per_school,
-        value: @copied_fields_values&.dig("duration_per_school") ||
-          @where_you_will_train_form.duration_per_school,
-        label: { text: t(".duration_per_school_label"), size: "s" },
-        max_words: 50,
-        rows: 5) %>
+        <%= f.govuk_text_area(:duration_per_school,
+          value: @copied_fields_values&.dig("duration_per_school") ||
+            @where_you_will_train_form.duration_per_school,
+          data: {
+            input_preview_target: "input",
+            action: "input-preview#updatePreview",
+            preview_output_target: "shared",
+          },
+          label: { text: t(".duration_per_school_label"), size: "s" },
+          max_words: 50,
+          rows: 5) %>
 
-      <%= f.govuk_text_area(:theoretical_training_location,
-        value: @copied_fields_values&.dig("theoretical_training_location") ||
-          @where_you_will_train_form.theoretical_training_location,
-        label: { text: t(".theoretical_training_location_label", suffix: "(optional)"), size: "s" },
-        hint: -> { t(".theoretical_training_location_hint") },
-        max_words: 50,
-        rows: 5) %>
+        <%= f.govuk_text_area(:theoretical_training_location,
+          value: @copied_fields_values&.dig("theoretical_training_location") ||
+            @where_you_will_train_form.theoretical_training_location,
+          data: {
+            input_preview_target: "input",
+            action: "input-preview#updatePreview",
+            preview_output_target: "shared",
+          },
+          label: { text: t(".theoretical_training_location_label", suffix: "(optional)"), size: "s" },
+          hint: -> { t(".theoretical_training_location_hint") },
+          max_words: 50,
+          rows: 5) %>
 
-      <%= f.govuk_text_area(:theoretical_training_duration,
-        value: @copied_fields_values&.dig("theoretical_training_duration") ||
-          @where_you_will_train_form.theoretical_training_duration,
-        label: { text: t(".theoretical_training_duration_label", suffix: "(optional)"), size: "s" },
-        hint: -> { t(".theoretical_training_duration_hint") },
-        max_words: 50,
-        rows: 5) %>
+        <%= f.govuk_text_area(:theoretical_training_duration,
+          value: @copied_fields_values&.dig("theoretical_training_duration") ||
+            @where_you_will_train_form.theoretical_training_duration,
+          data: {
+            input_preview_target: "input",
+            action: "input-preview#updatePreview",
+            preview_output_target: "shared",
+          },
+          label: { text: t(".theoretical_training_duration_label", suffix: "(optional)"), size: "s" },
+          hint: -> { t(".theoretical_training_duration_hint") },
+          max_words: 50,
+          rows: 5) %>
+
+        <%= render partial: "publish/courses/fields/dynamic_preview", locals: { preview_heading: t(".preview_heading") } %>
+      </div>
 
       <%= f.govuk_submit t(".submit_button") %>
     <% end %>

--- a/config/locales/en/publish/courses/fields/where_you_will_train.yml
+++ b/config/locales/en/publish/courses/fields/where_you_will_train.yml
@@ -16,4 +16,7 @@ en:
             theoretical_training_location_hint: For example at a training location, university or online
             theoretical_training_duration_label: How much time will they spend in theoretical training? (optional)
             theoretical_training_duration_hint: For example, one day of theoretical training each week
+            about_this_course: About this course
+            how_placements_work: How placements work
+            preview_heading: Where you will train
             submit_button: Update where you will train


### PR DESCRIPTION
## Context

We want to be able to use a preview to see how the text will look in published state. We also want to read what was written last cycle.

## Changes proposed in this pull request

Adding functionality, please view checklist

## Guidance to review

Look at page, look at code

## Checklist

- [ ] Adding preview box to where you will train on publish
- [ ] Adding last cycle text to where you will train on publish
- [ ] Adding markdown information box into where you will train on publish
