### PR TITLE
Long form bug party: update missing information link text on Find

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -420,13 +420,13 @@ en:
         what_you_will_study:
           text: "Enter details about what you will study"
         school_placement:
-          text: "Enter details about school placements"
+          text: "Enter details about what you will do on school placements"
         interview_process:
           text: "Enter details about the interview process"
         fees_and_financials:
           text: "Enter details about fees and financial support"
         where_you_will_train:
-          text: "Enter details about how placements work"
+          text: "Enter details about where you will train"
   value_not_entered: "Not entered"
   a_level_grades:
     minimum_grade: Grade %{minimum_grade}


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/VCJIujuD/994-bug-the-links-on-the-find-preview-need-to-be-updated

When I click 'Preview course', the wording of two two links needs to be updated.
They should read 'Enter details about where you will train' and 'Enter details about what you will do on school placements'.

## Changes proposed in this pull request

- update missing information link text

<img width="700" height="439" alt="Screenshot 2025-08-19 at 16 06 43" src="https://github.com/user-attachments/assets/d379cae3-6b6e-48c3-96a6-a4f8f444cb84" />

## Guidance to review

- ensure feature flag for long_form_content is active 
- sign in as a provider on Publish and find a draft course with no content in the 'Where you will train' and 'How school placements work' (or add a new course).
- click preview course to check preview page has the right missing link text

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
