### PR TITLE
Set recruitment cycle check on longform content display

### DIFF
--- a/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
+++ b/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
@@ -6,7 +6,7 @@
     <%= render partial: "find/courses/salary", locals: { course: @course } %>
   <% end %>
   <% if has_fees? %>
-   <% if FeatureFlag.active?(:long_form_content) %>
+   <% if FeatureFlag.active?(:long_form_content) || course.provider.recruitment_cycle.after_2025? %>
     <%= render partial: "find/courses/v2/financial_support/fees_and_financials", locals: { course: @course } %>
    <% else %>
     <%= render Find::Courses::FeesComponent::View.new(course) %>

--- a/app/controllers/publish/courses/fields/base_controller.rb
+++ b/app/controllers/publish/courses/fields/base_controller.rb
@@ -16,7 +16,7 @@ module Publish
 
         # Redirects to the course page if the long form content feature flag is not active
         def redirect_to_course_if_feature_disabled
-          unless FeatureFlag.active?(:long_form_content)
+          unless FeatureFlag.active?(:long_form_content) || recruitment_cycle.after_2025?
             redirect_to publish_provider_recruitment_cycle_course_path(
               provider.provider_code,
               recruitment_cycle.year,

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -45,7 +45,7 @@ module ViewHelper
     fee_v2 = "#{field_base_url}/fees-and-financial-support".to_s
     fee_v1 = "#{base}/fees"
 
-    fees_url = FeatureFlag.active?(:long_form_content) ? fee_v2 : fee_v1
+    fees_url = FeatureFlag.active?(:long_form_content) || course.provider.recruitment_cycle.after_2025? ? fee_v2 : fee_v1
 
     if field.to_sym == :base
       base_errors_hash(provider_code, course)[message]

--- a/app/views/find/courses/_v1_components.html.erb
+++ b/app/views/find/courses/_v1_components.html.erb
@@ -7,21 +7,34 @@
 <%= render partial: "find/courses/about_course", locals: { course: course } %>
 
 <% if course.published_interview_process.present? || course.published_interview_location.present? %>
-    <%= render partial: "find/courses/interview_process", locals: { course: course } %>
+  <%= render partial: "find/courses/interview_process", locals: { course: course } %>
 <% end %>
 
-<% if @provider.train_with_disability.present? %>
-    <h2 class="govuk-heading-m" id="section-train-with-disabilities">
+<% if @provider.train_with_disability.present? || preview?(params) %>
+  <h2 class="govuk-heading-m" id="section-train-with-disabilities">
     <%= t("find.courses.show.training_with_disabilities") %>
-    </h2>
+  </h2>
 
+  <% if preview?(params) %>
     <p class="govuk-body govuk-!-margin-bottom-8">
     <%= govuk_link_to(
-            t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
-            find_training_with_disabilities_path(
-                course.provider_code,
-                course.course_code,
-              ),
-          ) %>
+      t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
+      training_with_disabilities_publish_provider_recruitment_cycle_course_path(
+        course.provider_code,
+        course.recruitment_cycle_year,
+        course.course_code,
+      ),
+    ) %>
     </p>
+  <% else %>
+    <p class="govuk-body govuk-!-margin-bottom-8">
+    <%= govuk_link_to(
+      t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
+      find_training_with_disabilities_path(
+        course.provider_code,
+        course.course_code,
+      ),
+    ) %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -1,31 +1,31 @@
 <h2 class="govuk-heading-m"><%= t("find.courses.show.contents_header") %></h2>
 <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
-    <%# Why train with us %>
-    <% if @provider&.value_proposition.present? || preview?(params) %>
-      <li><%= govuk_link_to t("find.courses.show.why_train_with_us"), "#section-why-train-with-us" %></li>
-    <% end %>
-    <%# Where you will train %>
-    <% if course.placement_selection_criteria.present? || course.published_duration_per_school.present? || course.published_theoretical_training_location.present? || course.published_theoretical_training_duration.present? || preview?(params) %>
-      <li><%= govuk_link_to t("find.courses.show.where_you_will_train"), "#section-placement-selection-criteria" %></li>
-    <% end %>
-    <%# What will you do on school placements %>
-    <% if course.published_placement_school_activities || preview?(params) %>
-      <li><%= govuk_link_to t("find.courses.show.what_will_you_do_on_school_placements"), "#section-school-placement" %></li>
-    <% end %>
-    <%# What you will study %>
-    <% if course.theoretical_training_activities.present? || preview?(params) %>
-      <li><%= govuk_link_to t("find.courses.show.what_you_will_study"), "#section-what-you-will-study" %></li>
-    <% end %>
-    <%# Interview process %>
-    <% if course.published_interview_process.present? || course.published_interview_location.present? || preview?(params) %>
-      <li><%= govuk_link_to t("find.courses.show.interview_process"), "#section-interviews" %></li>
-    <% end %>
-    <%# Fees and financial support %>
-    <li><%= govuk_link_to (course.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
-    <%# Training with disabilities %>
-    <% if @provider.train_with_disability.present? || preview?(params) %>
-      <li><%= govuk_link_to t("find.courses.show.training_with_disabilities"), "#section-train-with-disabilities" %></li>
-    <% end %>
+  <%# Why train with us %>
+  <% if @provider&.value_proposition.present? || preview?(params) %>
+    <li><%= govuk_link_to t("find.courses.show.why_train_with_us"), "#section-why-train-with-us" %></li>
+  <% end %>
+  <%# Where you will train %>
+  <% if course.placement_selection_criteria.present? || course.published_duration_per_school.present? || course.published_theoretical_training_location.present? || course.published_theoretical_training_duration.present? || preview?(params) %>
+    <li><%= govuk_link_to t("find.courses.show.where_you_will_train"), "#section-placement-selection-criteria" %></li>
+  <% end %>
+  <%# What will you do on school placements %>
+  <% if course.published_placement_school_activities || preview?(params) %>
+    <li><%= govuk_link_to t("find.courses.show.what_will_you_do_on_school_placements"), "#section-school-placement" %></li>
+  <% end %>
+  <%# What you will study %>
+  <% if course.theoretical_training_activities.present? || preview?(params) %>
+    <li><%= govuk_link_to t("find.courses.show.what_you_will_study"), "#section-what-you-will-study" %></li>
+  <% end %>
+  <%# Interview process %>
+  <% if course.published_interview_process.present? || course.published_interview_location.present? || preview?(params) %>
+    <li><%= govuk_link_to t("find.courses.show.interview_process"), "#section-interviews" %></li>
+  <% end %>
+  <%# Fees and financial support %>
+  <li><%= govuk_link_to (course.salaried? ? t("find.courses.show.salary_and_financial_support") : t("find.courses.show.fees_and_financial_support")), "#section-financial-support" %></li>
+  <%# Training with disabilities %>
+  <% if @provider.train_with_disability.present? || preview?(params) %>
+    <li><%= govuk_link_to t("find.courses.show.training_with_disabilities"), "#section-train-with-disabilities" %></li>
+  <% end %>
 </ul>
 
 <%# Why train with us below %>
@@ -35,22 +35,22 @@
 
 <%# Where you will train %>
 <% if course.published_placement_selection_criteria.present? || course.published_duration_per_school.present? || course.published_theoretical_training_location.present? || course.published_theoretical_training_duration.present? || preview?(params) %>
-    <%= render partial: "find/courses/v2/where_you_will_train", locals: { course: course } %>
+  <%= render partial: "find/courses/v2/where_you_will_train", locals: { course: course } %>
 <% end %>
 
 <%# What you will do on school placements %>
 <% if course.published_placement_school_activities.present? || preview?(params) %>
-    <%= render partial: "find/courses/v2/school_placement", locals: { course: course } %>
+  <%= render partial: "find/courses/v2/school_placement", locals: { course: course } %>
 <% end %>
 
 <%# What you will study %>
 <% if course.theoretical_training_activities.present? || preview?(params) %>
-    <%= render partial: "find/courses/v2/what_you_will_study/what_you_will_study", locals: { course: @course } %>
+  <%= render partial: "find/courses/v2/what_you_will_study/what_you_will_study", locals: { course: @course } %>
 <% end %>
 
 <%# Interview process %>
 <% if course.published_interview_process.present? || course.published_interview_location.present? || preview?(params) %>
-    <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: course } %>
+  <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: course } %>
 <% end %>
 
 <%# Financial support %>
@@ -58,17 +58,30 @@
 
 <%# Training with disabilities %>
 <% if @provider.train_with_disability.present? || preview?(params) %>
-    <h2 class="govuk-heading-m" id="section-train-with-disabilities">
+  <h2 class="govuk-heading-m" id="section-train-with-disabilities">
     <%= t("find.courses.show.training_with_disabilities") %>
-    </h2>
+  </h2>
 
+  <% if preview?(params) %>
     <p class="govuk-body govuk-!-margin-bottom-8">
     <%= govuk_link_to(
-            t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
-            find_training_with_disabilities_path(
-            course.provider_code,
-            course.course_code,
-          ),
-          ) %>
+      t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
+      training_with_disabilities_publish_provider_recruitment_cycle_course_path(
+        course.provider_code,
+        course.recruitment_cycle_year,
+        course.course_code,
+      ),
+    ) %>
     </p>
+  <% else %>
+    <p class="govuk-body govuk-!-margin-bottom-8">
+    <%= govuk_link_to(
+      t("find.courses.show.training_with_disabilities_link", provider_name: course.provider_name),
+      find_training_with_disabilities_path(
+        course.provider_code,
+        course.course_code,
+      ),
+    ) %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -31,23 +31,6 @@
       <%= render partial: "find/courses/v1_components" %>
     <% end %>
 
-    <% if @provider.train_with_disability.nil? %>
-        <h2 class="govuk-heading-m" id="section-train-with-disabilities">
-          <%= t(".training_with_disabilities") %>
-        </h2>
-
-        <p class="govuk-body govuk-!-margin-bottom-8">
-          <%= govuk_link_to(
-            t(".training_with_disabilities_link", provider_name: course.provider_name),
-            training_with_disabilities_publish_provider_recruitment_cycle_course_path(
-              course.provider_code,
-              course.recruitment_cycle_year,
-              course.course_code,
-            ),
-          ) %>
-        </p>
-    <% end %>
-
     <%= render partial: "find/courses/advice", locals: { course: } %>
 
     <%= render Find::Courses::ApplyComponent::View.new(course, preview: true) if course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -25,7 +25,7 @@
 
     <%= render Find::Courses::EntryRequirementsComponent::View.new(course:) %>
 
-    <% if FeatureFlag.active?(:long_form_content) %>
+    <% if FeatureFlag.active?(:long_form_content) || @provider.recruitment_cycle.after_2025? %>
       <%= render partial: "find/courses/v2/components" %>
     <% else %>
       <%= render partial: "find/courses/v1_components" %>

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -211,14 +211,13 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
         get "/fields/where-you-will-train", on: :member, to: "courses/fields/where_you_will_train#edit"
         patch "/fields/where-you-will-train", on: :member, to: "courses/fields/where_you_will_train#update"
 
+        get "/fields/what-you-will-study", on: :member, to: "courses/fields/what_you_will_study#edit"
+        patch "/fields/what-you-will-study", on: :member, to: "courses/fields/what_you_will_study#update"
+
         get "/fees", on: :member, to: "courses/fees#edit"
         patch "/fees", on: :member, to: "courses/fees#update"
         get "/salary", on: :member, to: "courses/salary#edit"
         patch "/salary", on: :member, to: "courses/salary#update"
-        constraints ->(_req) { FeatureFlag.active?(:long_form_content) } do
-          get "/fields/what-you-will-study", on: :member, to: "courses/fields/what_you_will_study#edit"
-          patch "/fields/what-you-will-study", on: :member, to: "courses/fields/what_you_will_study#update"
-        end
 
         get "/withdraw", on: :member, to: "courses/withdrawals#edit"
         patch "/withdraw", on: :member, to: "courses/withdrawals#update"


### PR DESCRIPTION
## Context
We can't just depend on the feature flag to display longform content
  changes, we need to be able to display both versions simultaneously## Context

## Changes proposed in this pull request

- Check for the current recruitment cycle when displaying content based on long form content
- Fix bug with duplicate Training with Disabilites in course preview when feature flags are enabled
- REmove version constraint on where you will train route - base controller handles this now.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
