### PR TITLE
Where you will train displayed correctly in live and preview

### DIFF
--- a/app/controllers/publish/courses/fields/where_you_will_train_controller.rb
+++ b/app/controllers/publish/courses/fields/where_you_will_train_controller.rb
@@ -22,11 +22,19 @@ module Publish
           if @where_you_will_train_form.save!
             course_updated_message "Where you will train"
 
-            redirect_to publish_provider_recruitment_cycle_course_path(
-              provider.provider_code,
-              recruitment_cycle.year,
-              course.course_code,
-            )
+            if params["publish_fields_where_you_will_train_form"][:goto_preview] == "true"
+              redirect_to preview_publish_provider_recruitment_cycle_course_path(
+                provider_code: provider.provider_code,
+                recruitment_cycle_year: provider.recruitment_cycle_year,
+                code: course.course_code,
+              )
+            else
+              redirect_to publish_provider_recruitment_cycle_course_path(
+                provider.provider_code,
+                recruitment_cycle.year,
+                course.course_code,
+              )
+            end
 
           else
             @v1_enrichment = course.enrichments.find_by(version: 1)

--- a/app/helpers/find/where_you_will_train_helper.rb
+++ b/app/helpers/find/where_you_will_train_helper.rb
@@ -1,0 +1,11 @@
+module Find
+  module WhereYouWillTrainHelper
+    def published_where_you_will_train_present?(course)
+      course.published_placement_selection_criteria.present? && course.published_duration_per_school.present?
+    end
+
+    def where_you_will_train_present?(course)
+      course.placement_selection_criteria.present? && course.duration_per_school.present?
+    end
+  end
+end

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -5,7 +5,7 @@
     <li><%= govuk_link_to t("find.courses.show.why_train_with_us"), "#section-why-train-with-us" %></li>
   <% end %>
   <%# Where you will train %>
-  <% if course.placement_selection_criteria.present? || course.published_duration_per_school.present? || course.published_theoretical_training_location.present? || course.published_theoretical_training_duration.present? || preview?(params) %>
+  <% if published_where_you_will_train_present?(course) || preview?(params) %>
     <li><%= govuk_link_to t("find.courses.show.where_you_will_train"), "#section-placement-selection-criteria" %></li>
   <% end %>
   <%# What will you do on school placements %>
@@ -34,8 +34,8 @@
 <% end %>
 
 <%# Where you will train %>
-<% if course.published_placement_selection_criteria.present? || course.published_duration_per_school.present? || course.published_theoretical_training_location.present? || course.published_theoretical_training_duration.present? || preview?(params) %>
-  <%= render partial: "find/courses/v2/where_you_will_train", locals: { course: course } %>
+<% if published_where_you_will_train_present?(course) || preview?(params) %>
+    <%= render partial: "find/courses/v2/where_you_will_train", locals: { course: course } %>
 <% end %>
 
 <%# What you will do on school placements %>

--- a/app/views/find/courses/v2/_where_you_will_train.html.erb
+++ b/app/views/find/courses/v2/_where_you_will_train.html.erb
@@ -13,25 +13,43 @@
     <%= render Find::Courses::TrainingLocations::View.new(course:, coordinates: @coordinates, distance_from_location: @distance_from_location, preview: preview?(params)) %>
 
     <%= render Shared::Courses::SchoolPlacementsAdvice::View.new(course) %>
-    <% if course.published_placement_selection_criteria.present? || course.published_duration_per_school.present? || course.published_theoretical_training_location.present? || course.published_theoretical_training_duration.present? %>
-    <div data-qa="course__school_placement">
-        <% if course.published_placement_selection_criteria.present? %>
-            <%= markdown(course.published_placement_selection_criteria) %>
+    <% if preview?(course) %>
+      <div data-qa="course__school_placement">
+        <% if course.placement_selection_criteria.present? %>
+            <%= markdown(course.placement_selection_criteria) %>
         <% end %>
 
-        <% if course.published_duration_per_school.present? %>
-            <%= markdown(course.published_duration_per_school) %>
+        <% if course.duration_per_school.present? %>
+            <%= markdown(course.duration_per_school) %>
         <% end %>
 
-        <% if course.published_theoretical_training_location.present? %>
-            <%= markdown(course.published_theoretical_training_location) %>
+        <% if course.theoretical_training_location.present? %>
+            <%= markdown(course.theoretical_training_location) %>
         <% end %>
 
-        <% if course.published_theoretical_training_duration.present? %>
-            <%= markdown(course.published_theoretical_training_duration) %>
+        <% if course.theoretical_training_duration.present? %>
+            <%= markdown(course.theoretical_training_duration) %>
         <% end %>
-    </div>
+
+        <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :where_you_will_train, is_preview: !where_you_will_train_present?(course)) %>
+      </div>
     <% else %>
-        <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :where_you_will_train, is_preview: preview?(params)) %>
+    <div data-qa="course__school_placement">
+      <% if course.published_placement_selection_criteria.present? %>
+          <%= markdown(course.published_placement_selection_criteria) %>
+      <% end %>
+
+      <% if course.published_duration_per_school.present? %>
+          <%= markdown(course.published_duration_per_school) %>
+      <% end %>
+
+      <% if course.published_theoretical_training_location.present? %>
+          <%= markdown(course.published_theoretical_training_location) %>
+      <% end %>
+
+      <% if course.published_theoretical_training_duration.present? %>
+          <%= markdown(course.published_theoretical_training_duration) %>
+      <% end %>
+    </div>
     <% end %>
 </div>

--- a/app/views/publish/courses/_v2_description_content.html.erb
+++ b/app/views/publish/courses/_v2_description_content.html.erb
@@ -68,12 +68,11 @@
 
 <h2 class="govuk-heading-m">
   <%= t("publish.providers.courses.description_content.course_about_heading") %>
-
-  <%= govuk_summary_list do |summary_list| %>
-    <%= render "publish/courses/v2/fields/where_you_will_train", course:, summary_list: summary_list %>
-  <% end %>
 </h2>
 
+<%= govuk_summary_list do |summary_list| %>
+  <%= render "publish/courses/v2/fields/where_you_will_train", course:, summary_list: summary_list %>
+<% end %>
 <%= govuk_summary_list do |summary_list| %>
   <% enrichment_summary(
     summary_list,

--- a/app/views/publish/courses/fields/where_you_will_train/edit.html.erb
+++ b/app/views/publish/courses/fields/where_you_will_train/edit.html.erb
@@ -112,6 +112,7 @@
           hint: -> { t(".theoretical_training_duration_hint") },
           max_words: 50,
           rows: 5) %>
+          <%= f.hidden_field :goto_preview, value: params[:goto_preview] %>
 
         <%= render partial: "publish/courses/fields/dynamic_preview", locals: { preview_heading: t(".preview_heading") } %>
       </div>

--- a/spec/system/publish/courses/previews/course_preview_where_you_will_train_spec.rb
+++ b/spec/system/publish/courses/previews/course_preview_where_you_will_train_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Course preview", service: :publish do
+  include Rails.application.routes.url_helpers
+
+  before do
+    Current.recruitment_cycle = find_or_create(:recruitment_cycle, year: 2026)
+  end
+
+  scenario "Adding missing Where you will train from course preview" do
+    given_i_am_authenticated(user: user_with_no_course_enrichments)
+    when_i_visit_the_publish_course_preview_page
+    and_i_click_link_or_button("Enter details about where you will train")
+    and_i_fill_in_the_where_will_you_train_inputs
+    and_i_submit_the_form
+    then_i_am_redirected_back_to_the_preview_page
+    and_i_see_the_where_you_will_train_content
+  end
+
+private
+
+  def user_with_no_course_enrichments
+    @provider = create(:provider, recruitment_cycle:)
+
+    @course = create(:course, :secondary, :with_accrediting_provider, provider:)
+
+    @provider.accredited_partnerships.create(accredited_provider: @course.accrediting_provider)
+
+    create(:user, providers: [@provider])
+  end
+
+  def when_i_visit_the_publish_course_preview_page
+    visit preview_publish_provider_recruitment_cycle_course_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      code: course.course_code,
+    )
+  end
+
+  def and_i_fill_in_the_where_will_you_train_inputs
+    fill_in "How do you decide which schools to place trainees in?", with: "text1"
+    fill_in "How much time will they spend in each school?", with: "text2"
+  end
+
+  def and_i_submit_the_form
+    click_button "Update where you will train"
+  end
+
+  def then_i_am_redirected_back_to_the_preview_page
+    expect(page).to have_current_path("/publish/organisations/#{@provider.provider_code}/2026/courses/#{@course.course_code}/preview")
+  end
+
+  def and_i_see_the_where_you_will_train_content
+    expect(page).to have_content("text1")
+    expect(page).to have_content("text2")
+  end
+
+  alias_method :and_i_click_link_or_button, :click_link_or_button
+
+  def provider
+    @provider ||= @current_user.providers.first
+  end
+
+  def recruitment_cycle
+    @recruitment_cycle ||= Current.recruitment_cycle
+  end
+
+  def course
+    @course ||= provider.courses.first
+  end
+
+  def accrediting_provider
+    @accrediting_provider ||= course.accrediting_provider
+  end
+end


### PR DESCRIPTION
## Context

  "Where you will train" is displayed in course preview and live in Find

  - If it is rendered on Find, show only the published values for the fields
  - If in preview, show the latest enrichment values regardless if they are published.
  - If none of the values are present, show the missing information component

We only need to check the presence of the required fields, we omit the optional ones.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
