### PR TITLE
[Longform] Fix for preview

### DIFF
--- a/app/views/find/courses/v2/_school_placement.html.erb
+++ b/app/views/find/courses/v2/_school_placement.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-l" id="section-school-placement"><%= t("find.courses.v2.school_placement.heading") %> </h2>
     <div data-qa="course__school_placement">
-        <% if course.published_placement_school_activities.present? %>
-            <%= markdown(course.published_placement_school_activities) %>
-            <% if course.published_support_and_mentorship.present? %>
-                <%= markdown(course.published_support_and_mentorship) %>
+        <% if course.placement_school_activities.present? %>
+            <%= markdown(course.placement_school_activities) %>
+            <% if course.support_and_mentorship.present? %>
+                <%= markdown(course.support_and_mentorship) %>
             <% end %>
         <% else %>
             <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :school_placement, is_preview: preview?(params)) %>

--- a/app/views/find/courses/v2/interview_process/_interview_process.html.erb
+++ b/app/views/find/courses/v2/interview_process/_interview_process.html.erb
@@ -15,8 +15,8 @@
       <% end %>
     <% end %>
 
-    <% if course.published_interview_process %>
-      <%= markdown(course.published_interview_process) %>
+    <% if course.interview_process.present? %>
+      <%= markdown(course.interview_process) %>
     <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :interview_process, is_preview: preview?(params)) %>
     <% end %>

--- a/app/views/find/courses/v2/what_you_will_study/_what_you_will_study.html.erb
+++ b/app/views/find/courses/v2/what_you_will_study/_what_you_will_study.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-l" id="section-what-you-will-study">
     <%= t(".heading") %>
   </h2>
-  <% if course.theoretical_training_activities.present? || course.assessment_methods %>
+  <% if course.theoretical_training_activities.present? || course.assessment_methods.present? %>
     <%= markdown(course.theoretical_training_activities) %>
     <%= markdown(course.assessment_methods) %>
   <% else %>


### PR DESCRIPTION
## Context

It turns out the preview was still not fixed. I went through the pages and fixed it, please view the screenshots now below.

<img width="1043" height="2416" alt="publish localhost_3001_publish_organisations_2AT_2025_courses_Y838_preview" src="https://github.com/user-attachments/assets/b05f9a0b-e1f2-426b-8438-09114973e5fe" />
<img width="1062" height="2257" alt="publish localhost_3001_publish_organisations_2AT_2025_courses_R324_preview" src="https://github.com/user-attachments/assets/43ccf4e7-fbff-42ff-a1d7-735f740a99b2" />

## Changes proposed in this pull request

Fixing of the course preview page in publish

## Guidance to review

Check the screenshot, if it looks ok to you, all good, if you have time, you can even go to the review app.

## Checklist

- [ ] Fix the link and content on the preview page