### PR TITLE
Increase QA worker memory

### DIFF
--- a/terraform/aks/workspace_variables/qa.tfvars.json
+++ b/terraform/aks/workspace_variables/qa.tfvars.json
@@ -14,7 +14,8 @@
   },
   "worker_apps": {
     "worker": {
-      "replicas": 1
+      "replicas": 1,
+      "max_memory": "1.2Gi"
     }
   },
   "enable_find": true,


### PR DESCRIPTION
## Context

QA and review apps are being restarted during rollover.

And we are losing jobs. Increasing to test rollover on QA and see if is the root cause of it
