### PR TITLE
[Longform] Adding Salary details to main page in publish

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -312,6 +312,7 @@ class CourseDecorator < ApplicationDecorator
     placement_selection_criteria
     placement_school_activities
     support_and_mentorship
+    salary_details
     interview_process
     duration_per_school
     how_school_placements_work
@@ -472,10 +473,6 @@ class CourseDecorator < ApplicationDecorator
     return I18n.t("components.course.financial_incentives.bursary_and_scholarship", scholarship:, bursary_amount:) if bursary_amount.present? && scholarship.present?
 
     I18n.t("components.course.financial_incentives.bursary", amount: bursary_amount)
-  end
-
-  def salary_details
-    object.enrichment_attribute(:salary_details)
   end
 
   def personal_qualities

--- a/app/views/publish/courses/_v2_description_content.html.erb
+++ b/app/views/publish/courses/_v2_description_content.html.erb
@@ -24,7 +24,18 @@
        ) %>
   <% end %>
 
-  <%= render partial: "publish/courses/v2/fields/fees_and_financial_support", locals: { course: course, summary_list: summary_list } %>
+  <% if course.fee_based? %>
+    <%= render partial: "publish/courses/v2/fields/fees_and_financial_support", locals: { course: course, summary_list: summary_list } %>
+  <% else %>
+      <% enrichment_summary(
+      summary_list,
+      :course,
+      t("publish.providers.courses.description_content.salary_details_label"),
+      value_provided?(course.salary_details),
+      %w[salary_details],
+      action_path: salary_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code),
+    ) %>
+  <% end %>
 <% end %>
 
 <h2 class="govuk-heading-m">

--- a/config/locales/en/publish/providers/courses/description_content.yml
+++ b/config/locales/en/publish/providers/courses/description_content.yml
@@ -30,6 +30,7 @@ en:
           fee_international_label: Fee for non-UK citizens
           fee_international_optional_label: Fee for non-UK citizens (optional)
           financial_incentive_details_label: Financial support from the government
+          salary_details_label: Salary details
           gcse_label: GCSEs
           how_school_placements_work_hidden_text: details about how placements work
           how_school_placements_work_label: How placements work


### PR DESCRIPTION
## Context

This is a bug that is also in V1 prior to the longform changes. The row for salaried courses was missing. If this does not get fixed before the new cycle rolled over courses could not change their salaried section

## Changes proposed in this pull request

Adding salaried row to publish course as a row

## Guidance to review

Tested it already, just need a code review