### PR TITLE
Fix wrong content on course preview page

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -33,11 +33,15 @@ class CourseDecorator < ApplicationDecorator
       if current_cycle_and_open?
         h.govuk_link_to("View live course", h.find_course_url(provider.provider_code, object.course_code))
       else
-        "No - live on #{l(Settings.next_cycle_open_date.to_date, format: :govuk_short)}"
+        "No - live on #{govuk_short_ordinal(Settings.next_cycle_open_date)}"
       end
     else
       not_on_find
     end
+  end
+
+  def govuk_short_ordinal(date)
+    I18n.l(date, format: :govuk_short, ordinal: ActiveSupport::Inflector.ordinal(date.day))
   end
 
   def open_or_closed_for_applications

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,7 +138,7 @@ en:
     list_item_one: "* list item 1"
     list_item_one_show_as_html: >
       Will show as
-      <br> 
+      <br>
       <ul class="govuk-list govuk-list--bullet">
         <li>list item 1</li>
       </ul>
@@ -1276,7 +1276,7 @@ en:
     formats:
       default: "%-d %B %Y"
       short: "%B %Y"
-      govuk_short: "%-d %B"
+      govuk_short: "%-d%{ordinal} %B"
   time:
     formats:
       last_event: "%-d %B %Y at %l:%M%P"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -71,7 +71,7 @@ one_login:
   private_key: <%= ENV.fetch('ONE_LOGIN_PRIVATE_KEY', 'private_key').gsub("\n", '\n') %>
 
 current_recruitment_cycle_year: 2025
-next_cycle_open_date: 2025-10-1 # TBC
+next_cycle_open_date: 2025-09-30
 
 govuk_notify:
   api_key: please_change_me


### PR DESCRIPTION
## Context

Wrong content on course preview page, It should say ‘30th September’

Having the value hardcoded is not ideal, so longer term we should agree on a way to automate this

## Changes proposed in this pull request

Update the `Settings.next_cycle_open_date.to_date` value to be 30th September 

## Guidance to review

Create a scheduled course and ensure the date is 30th September  
<img width="648" height="55" alt="Screenshot 2025-08-26 at 13 33 29" src="https://github.com/user-attachments/assets/98df9e62-1a9f-4f68-9ee0-68bde42bb25f" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
