### PR TITLE
Bug: "Why Train with us" markdown not rendering correctly

### DIFF
--- a/app/views/find/courses/v2/_train_with_us.html.erb
+++ b/app/views/find/courses/v2/_train_with_us.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-why-train-with-us"><%= t(".heading") %> </h2>
   <% if @provider.about_us.present? && @provider.value_proposition.present? %>
-    <p class="govuk-body"><%= @provider.about_us %></p>
-    <p class="govuk-body"><%= @provider.value_proposition %></p>
+    <p class="govuk-body"><%= markdown(@provider.about_us) %></p>
+    <p class="govuk-body"><%= markdown(@provider.value_proposition) %></p>
   <% else %>
     <%= render CoursePreview::MissingInformationComponent.new(course: @course, information_type: :train_with_us, is_preview: preview?(params)) %>
   <% end %>


### PR DESCRIPTION
## Context

URL of the page with the bug: https://qa.publish-teacher-training-courses.service.gov.uk/publish/organisations/2AT/2026/courses/2T84/preview

Description of the bug:  In preview 'Why Train with us' does not create a link when askes, so markdown seams to not have been added

Expected behaviour: Should convert part of the text to a link

Steps to replicate:  Add link into Why Train with us. Check Preview you'll see it's not parsed

**NOTE: This is fixed in the Find course show page as well as organisation details provider oage**

## Changes proposed in this pull request

Render the content using the `markdown` method to render the markdown content correctly

## Guidance to review

- Visit a provider and update the "Why Train with us" section, save changes and then view this within find to see the content correctly rendering

## Bedfore
<img width="475" height="355" alt="Screenshot 2025-08-26 at 14 26 21" src="https://github.com/user-attachments/assets/f47389d2-bc74-4697-b793-4b2373ce5e9b" />

## After
<img width="605" height="430" alt="Screenshot 2025-08-26 at 14 28 03" src="https://github.com/user-attachments/assets/6dd8b240-a90b-4813-8730-d31df505700f" />

<img width="767" height="538" alt="Screenshot 2025-08-26 at 14 21 57" src="https://github.com/user-attachments/assets/97c4bcb6-9c63-4554-8bd6-e8e7cd594ceb" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
