### PR TITLE
Increase worker memory in production

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -14,7 +14,8 @@
   },
   "worker_apps": {
     "worker": {
-      "replicas": 2
+      "replicas": 2,
+      "max_memory": "1.5Gi"
     }
   },
   "enable_find": true,


### PR DESCRIPTION
## Context

For the rollover in QA I had to increase memory to make rollover sync everything and not restart during and loose jobs, so I am doing the same in production on this commit.

## Trello

https://trello.com/c/iALtfriy/1021-increase-memory-on-production-in-order-to-run-rollover-and-register-school-import