### PR TITLE
Test suite passes when Cycle changes from 2025 to 2026

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -196,7 +196,6 @@ jobs:
         # Separate mutliple flags with a space
         feature-flags:
           - ""
-          - "SETTINGS__CURRENT_RECRUITMENT_CYCLE_YEAR=2026"
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -194,7 +194,9 @@ jobs:
         # Pass Settings compatible env vars to runs tests with
         # feature flag(s) enables
         # Separate mutliple flags with a space
-        feature-flags: [""]
+        feature-flags:
+          - ""
+          - "SETTINGS__CURRENT_RECRUITMENT_CYCLE_YEAR=2026"
 
     steps:
       - name: Checkout

--- a/app/lib/site_setting.rb
+++ b/app/lib/site_setting.rb
@@ -4,6 +4,10 @@ require "./config/initializers/redis"
 
 class SiteSetting
   def self.cycle_schedule
+    # ENV["ENABLE_SWITCHER"] allows us to selecctively enable the switcher in
+    # the test environemtn specifically so we can test this functionality
+    return :real if Rails.env.test? && ENV["ENABLE_SWITCHER"].blank?
+
     RedisClient.current.get("cycle_schedule")&.to_sym || :real
   end
 

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -35,13 +35,11 @@ class RecruitmentCycle < ApplicationRecord
   end
 
   scope :upcoming_cycles_open_to_publish, lambda {
-    where("application_start_date > ?", Date.current)
-     .where("? BETWEEN available_in_publish_from AND application_start_date", Date.current)
+    where("? BETWEEN available_in_publish_from AND application_start_date", Date.current)
   }
 
   scope :upcoming_cycles_open_to_support, lambda {
-    where("application_start_date > ?", Date.current)
-     .where("? BETWEEN available_for_support_users_from AND application_start_date", Date.current)
+    where("? BETWEEN available_for_support_users_from AND application_start_date", Date.current)
   }
 
   def previous

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -78,7 +78,7 @@ module Find
     def self.cycle_year_for_time(time)
       CYCLE_DATES.each do |year, dates|
         end_time = CYCLE_DATES[year + 1]&.dig(:find_opens) || dates[:find_closes]
-        return year if time.between?(dates[:find_opens], end_time - 1.second)
+        return year if time >= dates[:find_opens] && time < end_time
       end
       nil
     end

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -61,7 +61,7 @@ module Find
     def self.current_year
       now = Time.zone.now
 
-      current_year = cycle_year_from_time(now)
+      current_year = cycle_year_for_time(now)
 
       # If the cycle switcher has been set to 'find has reopened' then
       # we want to request next year's courses from the TTAPI
@@ -75,7 +75,7 @@ module Find
     # Returns the recruitment cycle year for a given time
     # Recruitment Cycles run from find opens to the find_opens in the next cycle
     # If there is no next cycle, the end of the last cycle is when find_closes
-    def self.cycle_year_from_time(time)
+    def self.cycle_year_for_time(time)
       CYCLE_DATES.each do |year, dates|
         end_time = CYCLE_DATES[year + 1]&.dig(:find_opens) || dates[:find_closes]
         return year if time.between?(dates[:find_opens], end_time - 1.second)

--- a/app/views/support/recruitment_cycles/index.html.erb
+++ b/app/views/support/recruitment_cycles/index.html.erb
@@ -22,10 +22,10 @@
       <% @recruitment_cycles.each do |recruitment_cycle| %>
         <% body.with_row do |row| %>
           <% row.with_cell text: govuk_link_to(recruitment_cycle.year, support_recruitment_cycle_path(recruitment_cycle)) %>
-          <% row.with_cell text: recruitment_cycle.application_start_date.strftime("%-d %B %Y") %>
-          <% row.with_cell text: recruitment_cycle.application_end_date.strftime("%-d %B %Y") %>
-          <% row.with_cell text: recruitment_cycle.available_for_support_users_from&.strftime("%-d %B %Y") %>
-          <% row.with_cell text: recruitment_cycle.available_in_publish_from&.strftime("%-d %B %Y") %>
+          <% row.with_cell text: recruitment_cycle.application_start_date.to_fs(:govuk_date) %>
+          <% row.with_cell text: recruitment_cycle.application_end_date.to_fs(:govuk_date) %>
+          <% row.with_cell text: recruitment_cycle.available_for_support_users_from&.to_fs(:govuk_date) %>
+          <% row.with_cell text: recruitment_cycle.available_in_publish_from&.to_fs(:govuk_date) %>
           <% row.with_cell text: govuk_tag(**rollover_status(target_cycle: recruitment_cycle)) %>
           <% row.with_cell do %>
             <%= recruitment_cycle_status_tag(recruitment_cycle) %>

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -80,7 +80,7 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
     post "/request-access", on: :member, to: "providers/access_requests#create"
     get "schools"
 
-    resources :recruitment_cycles, param: :year, constraints: { year: /2024|#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "", only: [:show] do
+    resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year - 1}|#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "", only: [:show] do
       get "/about", on: :member, to: "providers#about"
       put "/about", on: :member, to: "providers#update"
       get "/details", on: :member, to: "providers#details"

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -5,7 +5,7 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
 
   resources :feedbacks, only: %i[index show], path: "feedback", as: :feedback
 
-  resources :recruitment_cycle, only: %i[index], param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "" do
+  resources :recruitment_cycle, only: %i[index], param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year - 1}|#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "" do
     namespace :providers do
       namespace :onboarding do
         resource :contacts, only: %i[new create]

--- a/spec/components/support_title_bar_spec.rb
+++ b/spec/components/support_title_bar_spec.rb
@@ -7,7 +7,7 @@ describe SupportTitleBar do
 
   let(:current_user) { build(:user, :admin) }
 
-  context "when not during rollover" do
+  context "when not during rollover", travel: mid_cycle(2025) do
     before do
       render_inline(described_class.new(current_user:))
     end
@@ -21,9 +21,8 @@ describe SupportTitleBar do
     end
   end
 
-  context "when next cycle is available for support users" do
+  context "when next cycle is available for support users", travel: apply_opens(2024) do
     before do
-      create(:recruitment_cycle, :next, available_for_support_users_from: 1.day.ago)
       render_inline(described_class.new(current_user:))
     end
 

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -539,7 +539,7 @@ RSpec.describe API::Public::V1::ProvidersController do
             "provider_type" => provider.provider_type,
             "region_code" => provider.region_code,
             "train_with_disability" => provider.train_with_disability,
-            "train_with_us" => provider.train_with_us,
+            "train_with_us" => train_with_us,
             "website" => provider.website,
             "accredited_body" => provider.accredited?,
             "changed_at" => provider.changed_at.iso8601,
@@ -580,6 +580,14 @@ RSpec.describe API::Public::V1::ProvidersController do
 
         it "returns the correct attributes for the provider" do
           expect(json_response["data"]).to include(expected_data)
+        end
+      end
+
+      def train_with_us
+        if provider.recruitment_cycle.after_2025?
+          [provider.about_us.to_s, provider.value_proposition.to_s].compact_blank.join("\r\n\r\n")
+        else
+          provider.train_with_us
         end
       end
     end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -77,11 +77,7 @@ describe CourseDecorator do
     expect(decorated_course.length).to eq("1 year")
   end
 
-  context "recruitment cycles" do
-    before do
-      allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2019)
-    end
-
+  context "recruitment cycles", travel: mid_cycle(2022) do
     context "for a course in the current cycle" do
       it "knows which cycle it’s in" do
         expect(decorated_course.next_cycle?).to be(false)

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,8 +22,8 @@ FactoryBot.define do
     start_date { DateTime.new(provider.recruitment_cycle.year.to_i, 9, 1) }
     applications_open_from do
       Faker::Time.between(
-        from: DateTime.new(provider.recruitment_cycle.year.to_i - 1, 10, 1),
-        to: DateTime.new(provider.recruitment_cycle.year.to_i, 9, 29),
+        from: provider.recruitment_cycle.application_start_date,
+        to: provider.recruitment_cycle.application_end_date,
       )
     end
     degree_grade { :two_one }

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :recruitment_cycle do
     year { Settings.current_recruitment_cycle_year }
-    application_start_date { DateTime.new(year.to_i - 1, 10, 1) }
-    application_end_date { DateTime.new(year.to_i, 9, 30) }
+    application_start_date { Find::CycleTimetable.apply_opens(year) }
+    application_end_date { Find::CycleTimetable.apply_deadline(year) }
     available_in_publish_from { application_start_date.to_date - 1.month }
     available_for_support_users_from { available_in_publish_from - 1.week }
 

--- a/spec/features/find/switcher_cycles_spec.rb
+++ b/spec/features/find/switcher_cycles_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 feature "switcher cycle" do
   before do
     Timecop.freeze(2022, 10, 12)
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with("ENABLE_SWITCHER").and_return("1")
   end
 
   scenario "Navigate to /cycle" do

--- a/spec/features/publish/accepting_terms_spec.rb
+++ b/spec/features/publish/accepting_terms_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Accepting terms" do
+feature "Accepting terms", travel: mid_cycle do
   scenario "i can accept the terms and conditions" do
     given_i_am_a_user_who_has_not_accepted_the_terms
     when_i_visit_the_publish_service

--- a/spec/features/publish/accredited_partnership_spec.rb
+++ b/spec/features/publish/accredited_partnership_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Accredited partnership flow" do
+feature "Accredited partnership flow", travel: Find::CycleTimetable.mid_cycle do
   before do
     given_i_am_a_lead_school_provider_user
     and_i_visit_the_root_path

--- a/spec/features/publish/courses/add_ratifying_provider_when_publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/add_ratifying_provider_when_publishing_a_course_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Publishing a course when course ratifying provider is invalid" do
+feature "Publishing a course when course ratifying provider is invalid", travel: Find::CycleTimetable.mid_cycle do
   before do
     given_i_am_authenticated_as_a_provider_user
   end

--- a/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
+++ b/spec/features/publish/courses/editing_a_levels_tda_course_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Adding A levels to a teacher degree apprenticeship course" do
+feature "Adding A levels to a teacher degree apprenticeship course", travel: mid_cycle do
   scenario "adding a level requirements" do
     given_i_am_authenticated_as_a_provider_user
     and_i_have_a_teacher_degree_apprenticeship_course

--- a/spec/features/publish/courses/editing_course_about_this_course_from_preview_page_spec.rb
+++ b/spec/features/publish/courses/editing_course_about_this_course_from_preview_page_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "Editing about this course from the course preview page" do
-  scenario "I am redirected back to the preview page" do
+  scenario "I am redirected back to the preview page", travel: mid_cycle(2025) do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
 

--- a/spec/features/publish/courses/editing_course_about_this_course_spec.rb
+++ b/spec/features/publish/courses/editing_course_about_this_course_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "Editing about this course section" do
-  scenario "adding valid data" do
+  scenario "adding valid data", travel: mid_cycle(2025) do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_about_course_edit_page

--- a/spec/features/publish/courses/editing_course_schools_spec.rb
+++ b/spec/features/publish/courses/editing_course_schools_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Editing course schools" do
+feature "Editing course schools", travel: mid_cycle(2026) do
   before do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit

--- a/spec/features/publish/courses/editing_visa_sponsorship_deadline_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_deadline_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Editing visa sponsorship deadlines" do
+feature "Editing visa sponsorship deadlines", travel: mid_cycle do
   before do
     and_i_am_authenticated_as_a_lead_school_provider_user
   end

--- a/spec/features/publish/courses/new_tda_course_spec.rb
+++ b/spec/features/publish/courses/new_tda_course_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "Adding a teacher degree apprenticeship course" do
-  scenario "creating a degree awarding course from school direct provider" do
+  scenario "creating a degree awarding course from school direct provider", travel: mid_cycle(2025) do
     given_i_am_authenticated_as_a_school_direct_provider_user
     when_i_visit_the_courses_page
     and_i_click_on_add_course
@@ -46,7 +46,7 @@ feature "Adding a teacher degree apprenticeship course" do
     then_the_course_is_published
   end
 
-  scenario "creating a degree awarding course from scitt provider" do
+  scenario "creating a degree awarding course from scitt provider", travel: mid_cycle(2025) do
     given_i_am_authenticated_as_a_scitt_provider_user
     when_i_visit_the_courses_page
     and_i_click_on_add_course
@@ -84,7 +84,7 @@ feature "Adding a teacher degree apprenticeship course" do
     then_the_course_is_published
   end
 
-  scenario "when choosing primary course" do
+  scenario "when choosing primary course", travel: mid_cycle(2025) do
     given_i_am_authenticated_as_a_school_direct_provider_user
     when_i_visit_the_courses_page
     and_i_click_on_add_course

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Publishing courses" do
+feature "Publishing courses", travel: mid_cycle(2026) do
   before do
-    Timecop.travel(Find::CycleTimetable.mid_cycle)
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/editing_notification_preference_spec.rb
+++ b/spec/features/publish/editing_notification_preference_spec.rb
@@ -12,7 +12,7 @@ feature "Opting into notifications" do
     then_neither_radio_button_is_selected
   end
 
-  scenario "user sets notification preferences for the first time" do
+  scenario "user sets notification preferences for the first time", travel: mid_cycle do
     and_i_select_yes
     then_i_should_see_my_preferences_have_been_saved
     and_the_users_preference_is_set

--- a/spec/features/publish/managing_users_spec.rb
+++ b/spec/features/publish/managing_users_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Adding user to organisation as a provider user" do
+feature "Adding user to organisation as a provider user", travel: Find::CycleTimetable.mid_cycle do
   before do
     given_i_am_authenticated_as_a_provider_user
   end

--- a/spec/features/publish/primary_nav_spec.rb
+++ b/spec/features/publish/primary_nav_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Primary nav" do
+feature "Primary nav", travel: mid_cycle do
   scenario "view page as Anne - user with single provider" do
     and_i_am_authenticated_as_a_provider_user
     when_i_visit_the_courses_index_page

--- a/spec/features/publish/providers/schools/add_school_spec.rb
+++ b/spec/features/publish/providers/schools/add_school_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "provider_school_helper"
 
-feature "Adding a provider's schools" do
+feature "Adding a provider's schools", travel: mid_cycle(2026) do
   include ProviderSchoolHelper
   before do
     given_i_am_authenticated_as_a_provider_user

--- a/spec/features/publish/providers_index_spec.rb
+++ b/spec/features/publish/providers_index_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "Providers index" do
   after { travel_back }
 
-  scenario "view page as Mary - multi provider user" do
+  scenario "view page as Mary - multi provider user", travel: mid_cycle do
     given_we_are_not_in_rollover
     and_there_is_a_multi_provider_organisation
     and_i_am_authenticated_as_a_multi_provider_user
@@ -18,7 +18,7 @@ feature "Providers index" do
     i_should_see_the_provider_list
   end
 
-  scenario "view page as Colin - admin user" do
+  scenario "view page as Colin - admin user", travel: mid_cycle do
     given_we_are_not_in_rollover
     and_i_am_authenticated_as_an_admin_user
     and_there_are_providers
@@ -32,7 +32,7 @@ feature "Providers index" do
     i_should_see_the_change_organisation_link
   end
 
-  scenario "view page as Colin - admin user - during rollover" do
+  scenario "view page as Colin - admin user - during rollover", travel: find_opens do
     given_we_are_in_rollover
     and_there_are_providers
     and_today_is_before_next_cycle_available_for_support_users_date
@@ -132,21 +132,11 @@ feature "Providers index" do
   end
 
   def given_we_are_not_in_rollover
-    create(
-      :recruitment_cycle,
-      :next,
-      available_in_publish_from: 1.week.from_now,
-      available_for_support_users_from: 1.day.from_now,
-    )
+    find_or_create(:recruitment_cycle, :next)
   end
 
   def given_we_are_in_rollover
-    create(
-      :recruitment_cycle,
-      :next,
-      available_in_publish_from: 1.week.from_now,
-      available_for_support_users_from: 1.day.from_now,
-    )
+    create(:recruitment_cycle, :next)
   end
 
   def and_there_is_a_multi_provider_organisation

--- a/spec/forms/publish/course_school_form_spec.rb
+++ b/spec/forms/publish/course_school_form_spec.rb
@@ -14,7 +14,7 @@ module Publish
 
     subject { described_class.new(course, params:) }
 
-    describe "validations" do
+    describe "validations", travel: Find::CycleTimetable.mid_cycle(2026) do
       before { subject.valid? }
 
       it "validates :site_ids" do

--- a/spec/forms/support/recruitment_cycle_form_spec.rb
+++ b/spec/forms/support/recruitment_cycle_form_spec.rb
@@ -187,9 +187,11 @@ RSpec.describe Support::RecruitmentCycleForm do
 
     context "when year is not unique" do
       let(:params) { { year: } }
-      let(:year) { "2025" }
+      let(:year) { 2025 }
 
-      before { create(:recruitment_cycle, year:) }
+      before do
+        find_or_create(:recruitment_cycle, year:)
+      end
 
       it "is not valid" do
         expect(form).not_to be_valid

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -415,7 +415,7 @@ describe Course do
       end
 
       context "outside 2026 rollover period" do
-        let(:past_cycle) { RecruitmentCycle.find_by!(year: 2025) }
+        let(:past_cycle) { find_or_create(:recruitment_cycle, year: 2025) }
 
         it "does not add errors for sites on :publish" do
           course = create(:course, provider: build(:provider, recruitment_cycle: past_cycle))
@@ -687,7 +687,8 @@ describe Course do
 
       context "when next cycle is not available for publish users" do
         before do
-          create(:recruitment_cycle, :next, available_in_publish_from: 1.day.from_now)
+          create(:recruitment_cycle, :next)
+          Timecop.travel(1.day.until(RecruitmentCycle.next.available_in_publish_from))
         end
 
         it "returns false" do

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -2,15 +2,13 @@
 
 require "rails_helper"
 
-describe RecruitmentCycle do
+describe RecruitmentCycle, travel: mid_cycle(2025) do
   subject { current_cycle }
-
-  before { allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2023) }
 
   let(:current_cycle) { find_or_create(:recruitment_cycle) }
   let(:next_cycle) { find_or_create(:recruitment_cycle, :next) }
 
-  its(:to_s) { is_expected.to eq("2023/24") }
+  its(:to_s) { is_expected.to eq("2025/26") }
 
   it "is valid with valid attributes" do
     expect(subject).to be_valid

--- a/spec/queries/rollover_progress_query_spec.rb
+++ b/spec/queries/rollover_progress_query_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe RolloverProgressQuery, type: :model do
-  let!(:target_cycle) { create(:recruitment_cycle, year: "2026", application_start_date: Date.new(2025, 9, 1)) }
-  let!(:previous_target_cycle) { create(:recruitment_cycle, year: "2025", application_start_date: Date.new(2024, 9, 1)) }
+  let!(:target_cycle) { find_or_create(:recruitment_cycle, year: "2026") }
+  let!(:previous_target_cycle) { find_or_create(:recruitment_cycle, year: "2025") }
   let(:rollover_progress) { described_class.new(target_cycle:) }
 
   let(:provider_with_own_course) { create(:provider, recruitment_cycle: previous_target_cycle) }

--- a/spec/queries/rollover_progress_query_spec.rb
+++ b/spec/queries/rollover_progress_query_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe RolloverProgressQuery, type: :model do
-  let(:target_cycle) { create(:recruitment_cycle, year: "2026", application_start_date: Date.new(2025, 9, 1)) }
-  let(:previous_target_cycle) { RecruitmentCycle.current }
+  let!(:target_cycle) { create(:recruitment_cycle, year: "2026", application_start_date: Date.new(2025, 9, 1)) }
+  let!(:previous_target_cycle) { create(:recruitment_cycle, year: "2025", application_start_date: Date.new(2024, 9, 1)) }
   let(:rollover_progress) { described_class.new(target_cycle:) }
 
   let(:provider_with_own_course) { create(:provider, recruitment_cycle: previous_target_cycle) }
@@ -46,7 +46,8 @@ RSpec.describe RolloverProgressQuery, type: :model do
 
   describe "#initialize" do
     it "calculates previous_target_cycle" do
-      expect(rollover_progress.previous_target_cycle.attributes).to eq(previous_target_cycle.attributes)
+      # reloading the record because something in the test is setting the usec to be different from the value in the DB
+      expect(rollover_progress.previous_target_cycle.attributes).to eq(previous_target_cycle.reload.attributes)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,9 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+# Allows us to call `mid_cycle` in the highest context in the specs
+extend CycleTimetableHelpers # rubocop:disable Style/MixinUsage
+
 # Allows response.parsed_body to parse JSONAPI responses
 # Doesn't work by default with RSpec.
 # https://github.com/jsonapi-rb/jsonapi-rails/blob/master/lib/jsonapi/rails/railtie.rb#L47
@@ -57,6 +60,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # add `FactoryBot` methods
+  config.include CycleTimetableHelpers
   config.include FactoryBot::Syntax::Methods
   config.include RequestHelpers, type: :controller
   config.include ViewComponent::TestHelpers, type: :component
@@ -145,6 +149,25 @@ RSpec.configure do |config|
     Capybara.app_host = app_url(service:)
 
     driven_by Capybara.current_driver
+  end
+
+  config.before do |example|
+    if (time = example.metadata[:travel])
+      year = Find::CycleTimetable.cycle_year_from_time(time)
+      find_or_create(:recruitment_cycle, year:)
+      allow(Settings).to receive(:current_recruitment_cycle_year)
+        .and_return(year)
+    end
+  end
+
+  config.around do |example|
+    if (time = self.class.metadata[:travel] || example.metadata[:travel])
+      Timecop.travel(time) do
+        example.run
+      end
+    else
+      example.run
+    end
   end
 
 private

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -153,7 +153,7 @@ RSpec.configure do |config|
 
   config.before do |example|
     if (time = example.metadata[:travel])
-      year = Find::CycleTimetable.cycle_year_from_time(time)
+      year = Find::CycleTimetable.cycle_year_for_time(time)
       find_or_create(:recruitment_cycle, year:)
       allow(Settings).to receive(:current_recruitment_cycle_year)
         .and_return(year)

--- a/spec/requests/publish/authorization_spec.rb
+++ b/spec/requests/publish/authorization_spec.rb
@@ -19,7 +19,7 @@ describe "Provider authorization spec" do
         get publish_root_path
         expect(response).to redirect_to("/publish/organisations/A14")
         follow_redirect!
-        expect(response).to redirect_to("/publish/organisations/A14/2025/courses")
+        expect(response).to redirect_to("/publish/organisations/A14/#{recruitment_cycle.year}/courses")
         follow_redirect!
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/publish/providers_controller_spec.rb
+++ b/spec/requests/publish/providers_controller_spec.rb
@@ -24,7 +24,7 @@ describe "Publish::ProvidersController" do
     end
   end
 
-  describe "/publish/providers/{authorized_provider_code}" do
+  describe "/publish/providers/{authorized_provider_code}", travel: mid_cycle do
     let(:provider) { user.providers.first }
 
     context "when the user is authenticated" do
@@ -32,6 +32,14 @@ describe "Publish::ProvidersController" do
         login_user(user)
         get "/publish/organisations/#{provider.provider_code}"
         expect(response).to redirect_to("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses")
+      end
+    end
+
+    context "when the user is authenticated during rollover period", travel: find_closes do
+      it "renders the cycle selector" do
+        login_user(user)
+        get "/publish/organisations/#{provider.provider_code}"
+        expect(response.parsed_body.text).to match("Recruitment cycles")
       end
     end
 

--- a/spec/requests/publish/providers_controller_spec.rb
+++ b/spec/requests/publish/providers_controller_spec.rb
@@ -37,6 +37,7 @@ describe "Publish::ProvidersController" do
 
     context "when the user is authenticated during rollover period", travel: find_closes do
       it "renders the cycle selector" do
+        find_or_create(:recruitment_cycle, :next)
         login_user(user)
         get "/publish/organisations/#{provider.provider_code}"
         expect(response.parsed_body.text).to match("Recruitment cycles")

--- a/spec/requests/support/copy_courses_spec.rb
+++ b/spec/requests/support/copy_courses_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Support::CopyCourses" do
   describe "GET new" do
     it "responds with 200" do
       login_user(user)
-      get "/support/2025/providers/#{source_provider.id}/copy_courses/new"
+      get "/support/#{RecruitmentCycle.current.year}/providers/#{source_provider.id}/copy_courses/new"
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/serializers/api/public/v1/serializable_provider_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_provider_spec.rb
@@ -19,7 +19,6 @@ describe API::Public::V1::SerializableProvider do
   it { is_expected.to have_attribute(:provider_type).with_value(provider.provider_type) }
   it { is_expected.to have_attribute(:region_code).with_value(provider.region_code) }
   it { is_expected.to have_attribute(:train_with_disability).with_value(provider.train_with_disability) }
-  it { is_expected.to have_attribute(:train_with_us).with_value(provider.train_with_us) }
   it { is_expected.to have_attribute(:website).with_value(provider.website) }
 
   it { is_expected.to have_attribute(:accredited_body).with_value(provider.accredited?) }
@@ -40,12 +39,21 @@ describe API::Public::V1::SerializableProvider do
   it { is_expected.to have_attribute(:can_sponsor_student_visa).with_value(provider.can_sponsor_student_visa) }
 
   context "2026 cycle" do
-    let(:recruitment_cycle) { create(:recruitment_cycle, :next) }
+    let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
     let(:provider) { create(:provider, about_us: "about us", value_proposition: "value proposition", recruitment_cycle:) }
+
+    it "returns updated train_with_us", travel: find_opens(2026) do
+      expect(subject).to have_attribute(:train_with_us).with_value("about us\r\n\r\nvalue proposition")
+    end
+  end
+
+  context "2025 cycle", travel: mid_cycle(2025) do
+    let!(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
+    let!(:provider) { create(:provider, about_us: "about us", value_proposition: "value proposition", recruitment_cycle:) }
 
     it "returns updated train_with_us" do
       Timecop.travel(Find::CycleTimetable.find_reopens) do
-        expect(subject).to have_attribute(:train_with_us).with_value("about us\r\n\r\nvalue proposition")
+        expect(subject).to have_attribute(:train_with_us).with_value(provider.train_with_us)
       end
     end
   end

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe Courses::CopyToProviderService do
 
   it "sets the visa_sponsorship_application_deadline_at to nil" do
     course.can_sponsor_student_visa = true
-    course.visa_sponsorship_application_deadline_at = 1.week.before(Find::CycleTimetable.find_closes)
+    course.visa_sponsorship_application_deadline_at = 1.week.before(course.recruitment_cycle.application_end_date)
+
     course.save!(validate: false)
 
     service.execute(course:, new_provider:)

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Courses::CopyToProviderService do
         course.applications_open_from = Date.new(provider.recruitment_cycle.year.to_i - 1, 10, 1)
       end
 
-      it "sets the new course's applications open from date correctly" do
+      it "sets the new course's applications open from date correctly", travel: mid_cycle do
         service.execute(course:, new_provider:)
 
         expect(new_course.applications_open_from).to eq(Find::CycleTimetable.apply_reopens.to_date)

--- a/spec/services/data_hub/update_sites_from_gias/schools_gias_diff_query_spec.rb
+++ b/spec/services/data_hub/update_sites_from_gias/schools_gias_diff_query_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe DataHub::UpdateSitesFromGias::SchoolsGiasDiffQuery do
   end
 
   it "ignores sites in other recruitment cycles" do
-    other_cycle = create(:recruitment_cycle, year: 2031)
+    other_cycle = create(:recruitment_cycle, :next)
     other_provider = create(:provider, recruitment_cycle: other_cycle)
     site = create(:site, provider: other_provider, urn: "99912", location_name: "OtherCycle")
     create(:gias_school, urn: "99912", name: "Different")

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -36,6 +36,38 @@ module Find
       end
     end
 
+    describe ".cycle_year_from_time" do
+      it "returns 2026 for a time in the middle of the 2026 cycle" do
+        time = Time.zone.local(2026, 1, 1, 12, 0, 0)
+        expect(described_class.cycle_year_from_time(time)).to eq(2026)
+      end
+
+      it "returns 2026 for the exact time find opens" do
+        time = Time.zone.local(2025, 9, 30, 9, 0, 0)
+        expect(described_class.cycle_year_from_time(time)).to eq(2026)
+      end
+
+      it "returns 2026 for a time just before find opens 2027" do
+        time = Time.zone.local(2026, 9, 29, 8, 59, 58)
+        expect(described_class.cycle_year_from_time(time)).to eq(2026)
+      end
+
+      it "returns 2027 for the exact time find opens" do
+        time = Time.zone.local(2026, 9, 29, 9, 0, 0)
+        expect(described_class.cycle_year_from_time(time)).to eq(2027)
+      end
+
+      it "returns nil for a time before any defined cycle" do
+        time = Time.zone.local(2019, 1, 1, 12, 0, 0)
+        expect(described_class.cycle_year_from_time(time)).to be_nil
+      end
+
+      it "returns nil for a time after the last defined cycle" do
+        time = Time.zone.local(2028, 1, 1, 12, 0, 0)
+        expect(described_class.cycle_year_from_time(time)).to be_nil
+      end
+    end
+
     describe ".next_year" do
       it "is 2022 if we are in the middle of the 2021 cycle" do
         Timecop.travel(Time.zone.local(2021, 1, 1, 12, 0, 0)) do

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -36,35 +36,35 @@ module Find
       end
     end
 
-    describe ".cycle_year_from_time" do
+    describe ".cycle_year_for_time" do
       it "returns 2026 for a time in the middle of the 2026 cycle" do
         time = Time.zone.local(2026, 1, 1, 12, 0, 0)
-        expect(described_class.cycle_year_from_time(time)).to eq(2026)
+        expect(described_class.cycle_year_for_time(time)).to eq(2026)
       end
 
       it "returns 2026 for the exact time find opens" do
         time = Time.zone.local(2025, 9, 30, 9, 0, 0)
-        expect(described_class.cycle_year_from_time(time)).to eq(2026)
+        expect(described_class.cycle_year_for_time(time)).to eq(2026)
       end
 
       it "returns 2026 for a time just before find opens 2027" do
         time = Time.zone.local(2026, 9, 29, 8, 59, 58)
-        expect(described_class.cycle_year_from_time(time)).to eq(2026)
+        expect(described_class.cycle_year_for_time(time)).to eq(2026)
       end
 
       it "returns 2027 for the exact time find opens" do
         time = Time.zone.local(2026, 9, 29, 9, 0, 0)
-        expect(described_class.cycle_year_from_time(time)).to eq(2027)
+        expect(described_class.cycle_year_for_time(time)).to eq(2027)
       end
 
       it "returns nil for a time before any defined cycle" do
         time = Time.zone.local(2019, 1, 1, 12, 0, 0)
-        expect(described_class.cycle_year_from_time(time)).to be_nil
+        expect(described_class.cycle_year_for_time(time)).to be_nil
       end
 
       it "returns nil for a time after the last defined cycle" do
         time = Time.zone.local(2028, 1, 1, 12, 0, 0)
-        expect(described_class.cycle_year_from_time(time)).to be_nil
+        expect(described_class.cycle_year_for_time(time)).to be_nil
       end
     end
 

--- a/spec/support/cycle_timetable_helpers.rb
+++ b/spec/support/cycle_timetable_helpers.rb
@@ -1,0 +1,23 @@
+# Include this in RSpec and we can call
+# context "when it is find opens in 2025", travel: find_opens(2025) do
+#
+# extending self makes the methods available outside the example and hooks
+module CycleTimetableHelpers
+  def self.included(base)
+    base.extend self
+  end
+
+  %i[find_opens apply_opens mid_cycle apply_deadline apply_closes find_closes find_reopens].each do |name|
+    define_method name do |year = nil|
+      if year
+        Find::CycleTimetable.send(name, year)
+      else
+        Find::CycleTimetable.send(name)
+      end
+    end
+  end
+
+  def first_deadline_banner
+    Find::CycleTimetable.send(:first_deadline_banner)
+  end
+end

--- a/spec/support/page_objects/publish/provider_courses_show.rb
+++ b/spec/support/page_objects/publish/provider_courses_show.rb
@@ -30,7 +30,7 @@ module PageObjects
       element :basic_details_link, "a.app-secondary-navigation__link", text: "Basic details"
       element :content_status, '[data-qa="course__content-status"]'
       element :rolled_over_course_link, '[data-qa="course__rolled-over-link"]'
-      element :publish_button, "button[type=submit]"
+      element :publish_button, "//button[text()='Publish course']" # Sometimes Rollover course button is on the page too
 
       def error_messages
         errors.map(&:text)

--- a/spec/system/find/courses/fields/financial_support_spec.rb
+++ b/spec/system/find/courses/fields/financial_support_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Viewing long form course content for fees and financial support"
   def then_i_see_the_long_form_content
     enrichment = @course.enrichments.first
 
-    expect(page).to have_content("The course fees for 2025 to 2026 are as follows:")
+    expect(page).to have_content("The course fees for #{@course.cycle_range} are as follows:")
     expect(page).to have_content("£2,500")
     expect(page).to have_content("£3,500")
     expect(page).to have_content(enrichment.fee_schedule)
@@ -59,6 +59,6 @@ RSpec.describe "Viewing long form course content for fees and financial support"
       course_code: "F314",
       provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
       subjects: [find_or_create(:secondary_subject, :art_and_design)],
-    )
+    ).decorate
   end
 end

--- a/spec/system/find/courses/long_from_content/financial_support_spec.rb
+++ b/spec/system/find/courses/long_from_content/financial_support_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Viewing long form course content for fees and financial support"
   def then_i_see_the_long_form_content
     enrichment = @course.enrichments.first
 
-    expect(page).to have_content("The course fees for 2025 to 2026 are as follows:")
+    expect(page).to have_content("The course fees for #{@course.cycle_range} are as follows:")
     expect(page).to have_content("£2,500")
     expect(page).to have_content("£3,500")
     expect(page).to have_content(enrichment.fee_schedule)
@@ -59,6 +59,6 @@ RSpec.describe "Viewing long form course content for fees and financial support"
       course_code: "F314",
       provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
       subjects: [find_or_create(:secondary_subject, :art_and_design)],
-    )
+    ).decorate
   end
 end

--- a/spec/system/publish/courses/long_form_content/school_placement_spec.rb
+++ b/spec/system/publish/courses/long_form_content/school_placement_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Publishing a course with long form content on the school placement route", service: :publish, type: "system" do
+RSpec.describe "Publishing a course with long form content on the school placement route", service: :publish, type: :system do
   include DfESignInUserHelper
 
   let(:user) { create(:user) }
@@ -160,7 +160,7 @@ RSpec.describe "Publishing a course with long form content on the school placeme
   end
 
   def when_i_visit_the_school_placement_page
-    visit "/publish/organisations/#{@course.provider.provider_code}/#{@course.start_date.year}/courses/#{@course.course_code}/fields/school-placement"
+    visit "/publish/organisations/#{@course.provider.provider_code}/#{@course.recruitment_cycle.year}/courses/#{@course.course_code}/fields/school-placement"
     expect(page).to have_content("What you will do on school placements") if FeatureFlag.active?(:long_form_content)
   end
 

--- a/spec/system/publish/courses/long_form_content/what_you_will_study_spec.rb
+++ b/spec/system/publish/courses/long_form_content/what_you_will_study_spec.rb
@@ -44,14 +44,6 @@ RSpec.describe "Publishing a course with long form content", service: :publish d
     and_change_link_has_correct_route
   end
 
-  scenario "A user CANNOT see the new long form course content fields if the current cycle is before 2026" do
-    given_the_recruitment_cycle_year(2025)
-    given_there_is_a_draft_course(recruitment_cycle: RecruitmentCycle.current)
-    when_i_visit_the_course_page
-
-    expect(page).not_to have_content("What you will study")
-  end
-
   def given_there_is_a_draft_course(recruitment_cycle: RecruitmentCycle.current)
     provider_in_cycle = create(:provider, recruitment_cycle: recruitment_cycle)
     user.providers << provider_in_cycle

--- a/spec/system/publish/courses/schools/select_all_schools_spec.rb
+++ b/spec/system/publish/courses/schools/select_all_schools_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
     and_all_schools_should_be_assigned_to_the_course
   end
 
-  scenario "unselect all schools and update" do
+  scenario "unselect all schools and update", travel: mid_cycle(2026) do
     when_i_select_all_schools
     and_i_unselect_all_schools
     and_i_submit
@@ -114,7 +114,5 @@ RSpec.describe "Publish - Select all schools", :js, type: :system do
     @course = create(:course, provider:, sites:)
   end
 
-  attr_reader :course
-
-  attr_reader :provider
+  attr_reader :course, :provider
 end

--- a/spec/system/publish/load_the_service_spec.rb
+++ b/spec/system/publish/load_the_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Publish - Courses page", service: :publish do
+RSpec.describe "Publish - Courses page", service: :publish, travel: mid_cycle do
   include DfESignInUserHelper
 
   let(:provider) { create(:provider, provider_name: "System Provider") }

--- a/spec/system/publish/providers/added_removed_schools_banner_spec.rb
+++ b/spec/system/publish/providers/added_removed_schools_banner_spec.rb
@@ -1,15 +1,12 @@
 require "rails_helper"
 
-RSpec.describe "Publish - Schools changes notification banner", service: :publish, type: :system do
+RSpec.describe "Publish - Schools changes notification banner", service: :publish, travel: mid_cycle(2025) do
   include DfESignInUserHelper
 
-  let(:frozen_time) { Time.zone.local(2025, 6, 1, 12, 0, 0) }
   let(:schools_page_path) do
     publish_provider_recruitment_cycle_schools_path(provider.provider_code, recruitment_cycle.year)
   end
-  let!(:recruitment_cycle) do
-    create(:recruitment_cycle, year: 2026, application_start_date: frozen_time + 2.months)
-  end
+  let!(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: 2026) }
   let(:provider) { create(:provider, provider_name: "Banner Provider", recruitment_cycle:) }
   let!(:site_one)   { create(:site, provider:, added_via: :register_import, location_name: "Added School 1") }
   let!(:site_two)   { create(:site, provider:, added_via: :register_import, location_name: "Added School 2") }
@@ -19,11 +16,8 @@ RSpec.describe "Publish - Schools changes notification banner", service: :publis
   let(:user) { create(:user, providers: [provider]) }
 
   before do
-    travel_to frozen_time
     sign_in_system_test(user:)
   end
-
-  after { travel_back }
 
   context "Provider has added and removed schools" do
     scenario "shows banner with both added and removed info" do

--- a/spec/system/publish/providers/courses/schools_rollover_validation_spec.rb
+++ b/spec/system/publish/providers/courses/schools_rollover_validation_spec.rb
@@ -1,12 +1,9 @@
 require "rails_helper"
 
-RSpec.describe "Publish - Schools validation during 2026 rollover", service: :publish, type: :system do
+RSpec.describe "Publish - Schools validation during 2026 rollover", service: :publish, travel: find_closes(2025) do
   include DfESignInUserHelper
 
-  let(:frozen_time) { Time.zone.local(2025, 9, 10, 12, 0, 0) }
-  let!(:recruitment_cycle) do
-    create(:recruitment_cycle, year: 2026, application_start_date: frozen_time - 15.days)
-  end
+  let!(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: 2026) }
   let!(:provider) { create(:provider, recruitment_cycle:, provider_code: "ABC") }
   let!(:accredited_provider) { create(:provider, :accredited_provider, recruitment_cycle:) }
   let!(:site_one) { create(:site, provider:, location_name: "School A") }
@@ -15,11 +12,8 @@ RSpec.describe "Publish - Schools validation during 2026 rollover", service: :pu
   let(:user)      { create(:user, providers: [provider]) }
 
   before do
-    travel_to frozen_time
     sign_in_system_test(user:)
   end
-
-  after { travel_back }
 
   scenario "Publishing from course page shows rollover school validation errors" do
     given_i_am_on_the_course_page

--- a/spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb
+++ b/spec/system/publish/providers/newly_added_tag_add_schools_to_a_course_page_spec.rb
@@ -1,12 +1,9 @@
 require "rails_helper"
 
-RSpec.describe "Publish - Courses: 'Newly added' tag for register import sites when selecting schools", service: :publish, type: :system do
+RSpec.describe "Publish - Courses: 'Newly added' tag for register import sites when selecting schools", service: :publish, travel: find_closes(2025) do
   include DfESignInUserHelper
 
-  let(:frozen_time) { Time.zone.local(2025, 6, 1, 12, 0, 0) }
-  let!(:recruitment_cycle) do
-    create(:recruitment_cycle, year: 2026, application_start_date: frozen_time + 2.months)
-  end
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: 2026) }
   let(:provider) { create(:provider, provider_name: "Tag Provider", recruitment_cycle:) }
   let!(:course) { create(:course, provider:) }
 
@@ -33,11 +30,8 @@ RSpec.describe "Publish - Courses: 'Newly added' tag for register import sites w
   let(:user) { create(:user, providers: [provider]) }
 
   before do
-    travel_to frozen_time
     sign_in_system_test(user:)
   end
-
-  after { travel_back }
 
   scenario "shows the 'Newly added' tag on school selection checkboxes only for register import, and not after rollover" do
     when_i_visit_edit_course_schools_page

--- a/spec/system/publish/providers/newly_added_tag_schools_page_spec.rb
+++ b/spec/system/publish/providers/newly_added_tag_schools_page_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
-RSpec.describe "Publish - Schools: 'Newly added' tag for register import sites", service: :publish, type: :system do
+RSpec.describe "Publish - Schools: 'Newly added' tag for register import sites", service: :publish, travel: find_closes(2025) do
   include DfESignInUserHelper
 
-  let(:frozen_time) { Time.zone.local(2025, 6, 1, 12, 0, 0) }
-  let!(:recruitment_cycle) do
-    create(:recruitment_cycle, year: 2026, application_start_date: frozen_time + 2.months)
-  end
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: 2026) }
+
   let(:provider) { create(:provider, provider_name: "Tag Provider", recruitment_cycle:) }
 
   let!(:site_one) do
@@ -31,14 +29,8 @@ RSpec.describe "Publish - Schools: 'Newly added' tag for register import sites",
 
   let(:user) { create(:user, providers: [provider]) }
 
-  before do
-    travel_to frozen_time
-    sign_in_system_test(user:)
-  end
-
-  after { travel_back }
-
   scenario "shows the 'Newly added' tag for register import only" do
+    sign_in_system_test(user:)
     when_i_visit_the_schools_page
 
     and_i_see_school_with_tag("Register Import School", "Newly added")

--- a/spec/system/publish/providers/providers_added_schools_spec.rb
+++ b/spec/system/publish/providers/providers_added_schools_spec.rb
@@ -48,19 +48,13 @@ RSpec.describe "Publish - Providers - Added Schools page", service: :publish, ty
     )
   end
 
-  context "when the 2026 cycle has not yet started" do
-    let(:frozen_time) { Time.zone.local(2025, 6, 1, 12, 0, 0) }
-    let!(:recruitment_cycle) do
-      create(:recruitment_cycle, year: 2026, application_start_date: frozen_time + 2.months)
-    end
+  context "when the 2026 cycle has not yet started", travel: find_closes(2025) do
+    let!(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: 2026) }
 
     before do
-      given_time_is_frozen
       and_provider_is_linked_to_recruitment_cycle
       and_user_is_signed_in
     end
-
-    after { travel_back }
 
     scenario "shows the added schools" do
       when_i_visit_the_added_schools_page
@@ -73,30 +67,22 @@ RSpec.describe "Publish - Providers - Added Schools page", service: :publish, ty
   end
 
   context "when the 2026 cycle has started" do
-    let(:frozen_time) { Time.zone.local(2025, 6, 1, 12, 0, 0) }
     let!(:recruitment_cycle) do
-      create(:recruitment_cycle, year: 2026, application_start_date: frozen_time - 1.month)
+      find_or_create(:recruitment_cycle, year: 2026, application_start_date: 2.months.after(find_opens(2026)))
     end
 
     before do
-      given_time_is_frozen
       and_provider_is_linked_to_recruitment_cycle
       and_user_is_signed_in
     end
 
-    after { travel_back }
-
-    scenario "returns a 404 page" do
+    scenario "returns a 404 page", travel: mid_cycle(2026) do
       when_i_visit_the_added_schools_page
       then_i_see_a_404_page
     end
   end
 
 private
-
-  def given_time_is_frozen
-    travel_to frozen_time
-  end
 
   def and_provider_is_linked_to_recruitment_cycle
     provider.update!(recruitment_cycle:)

--- a/spec/system/publish/providers/providers_removed_schools_spec.rb
+++ b/spec/system/publish/providers/providers_removed_schools_spec.rb
@@ -48,19 +48,16 @@ RSpec.describe "Publish - Providers - Removed Schools page", service: :publish, 
     )
   end
 
-  context "when rollover period has not yet finished" do
-    let(:frozen_time) { Time.zone.local(2025, 6, 1, 12, 0, 0) }
+  context "when rollover period has not yet finished", travel: Find::CycleTimetable.find_closes(2025) do
     let!(:recruitment_cycle) do
-      create(:recruitment_cycle, year: 2026, application_start_date: frozen_time + 2.months)
+      find_or_create(:recruitment_cycle, year: 2026)
     end
 
     before do
-      given_time_is_frozen
+      allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
       and_provider_is_linked_to_recruitment_cycle
       and_user_is_signed_in
     end
-
-    after { travel_back }
 
     scenario "shows the removed schools" do
       when_i_visit_the_removed_schools_page
@@ -71,19 +68,15 @@ RSpec.describe "Publish - Providers - Removed Schools page", service: :publish, 
     end
   end
 
-  context "when rollover period ended" do
-    let(:frozen_time) { Time.zone.local(2025, 6, 1, 12, 0, 0) }
+  context "when rollover period ended", travel: Find::CycleTimetable.mid_cycle(2026) do
     let!(:recruitment_cycle) do
-      create(:recruitment_cycle, year: 2026, application_start_date: frozen_time - 1.month)
+      find_or_create(:recruitment_cycle, year: 2026)
     end
 
     before do
-      given_time_is_frozen
       and_provider_is_linked_to_recruitment_cycle
       and_user_is_signed_in
     end
-
-    after { travel_back }
 
     scenario "returns a 404 page" do
       when_i_visit_the_removed_schools_page
@@ -92,10 +85,6 @@ RSpec.describe "Publish - Providers - Removed Schools page", service: :publish, 
   end
 
 private
-
-  def given_time_is_frozen
-    travel_to frozen_time
-  end
 
   def and_provider_is_linked_to_recruitment_cycle
     provider.update!(recruitment_cycle:)

--- a/spec/system/support/feedbacks_spec.rb
+++ b/spec/system/support/feedbacks_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Support console feedback view", service: :support do
       then_i_see_recent_feedback_entries
     end
 
-    scenario "check for backlink presence and navigation on feedback page" do
+    scenario "check for backlink presence and navigation on feedback page", travel: mid_cycle do
       then_i_see_backlink_to_support_homepage
       click_link_or_button "Back"
       then_i_am_on_the_support_homepage

--- a/spec/system/support/load_the_service_spec.rb
+++ b/spec/system/support/load_the_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Support", service: :publish do
     sign_in_system_test(user:)
   end
 
-  it "shows the support page" do
+  it "shows the support page", travel: mid_cycle do
     visit "/publish/organisations"
     click_on("Support console")
     expect(page).to have_current_path(%r{/support})

--- a/spec/system/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/system/support/providers/courses/editing_a_course_spec.rb
@@ -2,13 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Edit provider course details" do
-  around do |example|
-    Timecop.freeze(2021, 8, 1, 12) do
-      example.run
-    end
-  end
-
+RSpec.describe "Edit provider course details", travel: mid_cycle do
   before do
     given_i_am_authenticated_as_an_admin_user
     and_there_is_a_provider_with_courses
@@ -135,7 +129,7 @@ private
   end
 
   def valid_date_month
-    @valid_date_month ||= "6"
+    @valid_date_month ||= "9"
   end
 
   def invalid_date_month
@@ -233,7 +227,7 @@ private
 
   def and_it_contains_invalid_value_errors
     expect(support_provider_course_edit_page.error_summary.text).to include("Course code is already taken")
-    expect(support_provider_course_edit_page.error_summary.text).to include("June #{Settings.current_recruitment_cycle_year + 3} is not in the #{Settings.current_recruitment_cycle_year} cycle")
+    expect(support_provider_course_edit_page.error_summary.text).to include("September #{Settings.current_recruitment_cycle_year + 3} is not in the #{Settings.current_recruitment_cycle_year} cycle")
   end
 
   def and_it_contains_start_date_format_error

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Support index" do
-  after { travel_back }
-
   scenario "viewing support cycles page during rollover", travel: find_closes do
     given_we_have_a_next_cycle
     and_there_are_two_recruitment_cycles
@@ -40,12 +38,7 @@ RSpec.describe "Support index" do
   end
 
   def given_we_have_a_next_cycle
-    create(
-      :recruitment_cycle,
-      :next,
-      available_in_publish_from: 1.week.from_now,
-      available_for_support_users_from: 1.day.from_now,
-    )
+    find_or_create(:recruitment_cycle, :next)
   end
 
   def and_there_are_two_recruitment_cycles
@@ -99,10 +92,10 @@ RSpec.describe "Support index" do
   end
 
   def and_today_is_before_next_cycle_available_for_support_users_date
-    travel_to(RecruitmentCycle.next.available_for_support_users_from - 1.day)
+    travel_to(1.day.before(RecruitmentCycle.next.available_for_support_users_from))
   end
 
   def and_today_is_after_next_cycle_available_for_support_users_date
-    travel_to(RecruitmentCycle.next.available_for_support_users_from + 1.day)
+    travel_to(1.day.since(RecruitmentCycle.next.available_for_support_users_from))
   end
 end

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Support index" do
   after { travel_back }
 
-  scenario "viewing support cycles page during rollover" do
+  scenario "viewing support cycles page during rollover", travel: find_closes do
     given_we_have_a_next_cycle
     and_there_are_two_recruitment_cycles
     and_today_is_before_next_cycle_available_for_support_users_date
@@ -27,7 +27,7 @@ RSpec.describe "Support index" do
     i_should_be_on_the_next_cycle_page
   end
 
-  scenario "viewing providers page when not in rollover" do
+  scenario "viewing providers page when not in rollover", travel: mid_cycle do
     given_we_have_a_next_cycle
     and_there_are_two_recruitment_cycles
     and_i_am_authenticated_as_an_admin_user

--- a/spec/system/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/system/support/providers/users/adding_user_to_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Adding user to provider as an admin" do
+RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   before do
     given_i_am_authenticated_as_an_admin_user
     and_there_is_a_provider

--- a/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Adding a new recruitment cycle", service: :publish, travel: mid_
 
   before do
     # The test suite auto creates the current cycle, need to delete in 2026
-    RecruitmentCycle.find_by(year: 2026).destroy
+    RecruitmentCycle.find_by(year: 2026)&.destroy
     sign_in_system_test(user:)
   end
 

--- a/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/add_recruitment_cycle_spec.rb
@@ -2,15 +2,14 @@
 
 require "spec_helper"
 
-RSpec.describe "Adding a new recruitment cycle", service: :publish do
+RSpec.describe "Adding a new recruitment cycle", service: :publish, travel: mid_cycle(2025) do
   include DfESignInUserHelper
   let(:provider) { create(:provider) }
   let(:user) { create(:user, :admin, providers: [provider]) }
 
   before do
-    Timecop.travel(Time.zone.local(2025, 1, 1))
-
-    driven_by(:rack_test)
+    # The test suite auto creates the current cycle, need to delete in 2026
+    RecruitmentCycle.find_by(year: 2026).destroy
     sign_in_system_test(user:)
   end
 

--- a/spec/system/support/settings/recruitment_cycles/edit_recruitment_cycle_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/edit_recruitment_cycle_spec.rb
@@ -2,15 +2,12 @@
 
 require "spec_helper"
 
-RSpec.describe "Editing a recruitment cycle", service: :publish do
+RSpec.describe "Editing a recruitment cycle", service: :publish, travel: mid_cycle(2025) do
   include DfESignInUserHelper
   let(:provider) { create(:provider) }
   let(:user) { create(:user, :admin, providers: [provider]) }
 
   before do
-    Timecop.travel(Time.zone.local(2025, 1, 1))
-
-    driven_by(:rack_test)
     sign_in_system_test(user:)
 
     given_there_are_recruitment_cycles
@@ -40,9 +37,9 @@ RSpec.describe "Editing a recruitment cycle", service: :publish do
   end
 
   def given_there_are_recruitment_cycles
-    @previous_cycle = create(:recruitment_cycle, :previous)
+    @previous_cycle = find_or_create(:recruitment_cycle, :previous)
     @current_cycle = RecruitmentCycle.current
-    @upcoming_cycle = create(:recruitment_cycle, :next)
+    @upcoming_cycle = find_or_create(:recruitment_cycle, :next)
   end
 
   def given_i_visit_support_settings
@@ -97,8 +94,8 @@ RSpec.describe "Editing a recruitment cycle", service: :publish do
 
   def and_i_change_the_available_in_publish_from_date
     within_fieldset "Available in publish from" do
-      fill_in "Day", with: RecruitmentCycle.current.available_for_support_users_from.day + 1
-      fill_in "Month", with: RecruitmentCycle.current.available_for_support_users_from.month
+      fill_in "Day", with: RecruitmentCycle.current.available_for_support_users_from.succ.day
+      fill_in "Month", with: RecruitmentCycle.current.available_for_support_users_from.succ.month
     end
   end
 
@@ -114,8 +111,8 @@ RSpec.describe "Editing a recruitment cycle", service: :publish do
     expect(@upcoming_cycle.application_start_date.month).to eq(9)
     expect(@upcoming_cycle.application_end_date.day).to eq(5)
     expect(@upcoming_cycle.application_end_date.month).to eq(10)
-    expect(@upcoming_cycle.available_in_publish_from.day).to eq(RecruitmentCycle.current.available_for_support_users_from.day + 1)
-    expect(@upcoming_cycle.available_in_publish_from.month).to eq(RecruitmentCycle.current.available_for_support_users_from.month)
+    expect(@upcoming_cycle.available_in_publish_from.day).to eq(RecruitmentCycle.current.available_for_support_users_from.succ.day)
+    expect(@upcoming_cycle.available_in_publish_from.month).to eq(RecruitmentCycle.current.available_for_support_users_from.succ.month)
     expect(page).to have_content(@upcoming_cycle.year)
     expect(page).to have_content(I18n.l(@upcoming_cycle.application_start_date, format: :long))
     expect(page).to have_content(I18n.l(@upcoming_cycle.application_end_date, format: :long))

--- a/spec/system/support/settings/recruitment_cycles/view_recruitment_cycles_spec.rb
+++ b/spec/system/support/settings/recruitment_cycles/view_recruitment_cycles_spec.rb
@@ -6,12 +6,9 @@ RSpec.describe "Viewing recruitment cycles", service: :publish do
   include DfESignInUserHelper
   let(:provider) { create(:provider) }
   let(:user) { create(:user, :admin, providers: [provider]) }
-  let!(:previous_recruitment_cycle) { create(:recruitment_cycle, year: "2024") }
+  let!(:previous_recruitment_cycle) { find_or_create(:recruitment_cycle, :previous) }
 
   before do
-    Timecop.travel(Time.zone.local(2025, 1, 1))
-
-    driven_by(:rack_test)
     sign_in_system_test(user:)
   end
 
@@ -34,9 +31,9 @@ RSpec.describe "Viewing recruitment cycles", service: :publish do
     first_row = first(:css, ".govuk-table tbody tr", visible: true)
 
     within(first_row) do
-      expect(page).to have_text("2025")
-      expect(page).to have_text("1 October 2024")
-      expect(page).to have_text("30 September 2025")
+      expect(page).to have_text(RecruitmentCycle.current.year)
+      expect(page).to have_text(RecruitmentCycle.current.application_start_date.to_fs(:govuk_date))
+      expect(page).to have_text(RecruitmentCycle.current.application_end_date.to_fs(:govuk_date))
       expect(page).to have_css(".govuk-tag.govuk-tag--green", text: "Current")
     end
   end
@@ -46,8 +43,8 @@ RSpec.describe "Viewing recruitment cycles", service: :publish do
 
     within(second_row) do
       expect(page).to have_text("2024")
-      expect(page).to have_text("1 October 2023")
-      expect(page).to have_text("30 September 2024")
+      expect(page).to have_text(previous_recruitment_cycle.application_start_date.to_fs(:govuk_date))
+      expect(page).to have_text(previous_recruitment_cycle.application_end_date.to_fs(:govuk_date))
       expect(page).to have_css(".govuk-tag.govuk-tag--grey", text: "Past")
     end
   end


### PR DESCRIPTION
## Context

The publish service code base is built around the concept of a Recruitment Cycle.

Recruitment Cycles have transitions and intervals. The application behaviour can a lot after a transition from one interval to anoter. For example, when apply closes, the apply button on courses in find are all automatcally disabled / replaced with a notice.

If we write a test in the middle of the cycle asserting that we expect to see the apply button, it will pass, but when we are running the test after apply closes, that test will fail becuase the test suite by default recognises the Cycle timetable and knows not to render the apply button.

This is why we use Timecop to stub the current time in the application. We want to be able to pretend we are inthe rollover period in the test suite so we can test how the appplication behaves when it really is in the rollover period.

Sometimes when we write tests, we forget that the thing we're writnig tests for  will change behviour in a different interval of the cycle. Of ten this happens towards the end of the cycle when find closes and rollover begins. Becuase we don't test every feature under every time period, we can find we have a lot of failing tests when the time period changes significantly.

Another reason we see a lot of failing tests at the end/beginning of a cycle is that we test to make wide raching changes to the system to be launched in the new cycle. Tests that were written for the standard, existing behaviour will pass in the previous periods but now in the new cycle for the same period they will fail. 

These are the main issues that this PR is dealing with.

## Changes proposed in this pull request

- Expand the API of the `Find::CycleTimetable` period methods to accept a year representing the recruitment cycle.
  - change ` def self.apply_opens` to `def self.apply_opens(year)` so we can get the time for apply opens in any cycle year
- Lock down tests to specific periods, and even specific periods in specific cycles.
- Add `.cycle_year_for_time` so we can calculate what recruitment cycle any given time is in.
- The availability of `.cycle_year_for_time` could be used to replace the Setting :current_recruitment_cycle_year. We can determine what cycle year we are in based on the current time of the application.
- Initialize the recruitment cycle factory dates with the CycleTimetable dates for the "current_year". This allows us to change the "current_year" and the CycleTimetable will automatically initialize the factory with the correct dates for the given year.
- Disable `SiteSetting` completely in the test environment. This means it doesn't interfere with the CycleTimetable and doesn't need to reach out to redis for a value. In test we manipulate the "current period" using tools other than `SiteSetting` so it is not necessary in the test environment. It's only used in non-prod envs like review apps and qa.
- Extend `rails_helper` by creating a `CycleTimetableHelpers` module and including (and extending) it in RSpec. This  makes `mid_cycle(year)`, `find_closes(year)` etc, available without having to call `Find::CycleTimetable.mid_cycle(2025)`. Extending the module makes those methods available outside the example group like in the metadata of an example/example group.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
