### PR TITLE
Bug: Success message should say 'Your course has been scheduled' not 'Your course has been published'

### DIFF
--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -80,7 +80,7 @@ module Publish
       authorize @course
 
       if ::Courses::PublishService.new(course: @course, user: @current_user).call
-        flash[:success] = "Your course has been published."
+        flash[:success] = render_flash_message_content
 
         redirect_to publish_provider_recruitment_cycle_course_path(
           @provider.provider_code,
@@ -101,6 +101,10 @@ module Publish
     end
 
   private
+
+    def render_flash_message_content
+      @course.scheduled? ? "Your course has been scheduled." : "Your course has been published."
+    end
 
     def course_params
       if params.key? :course

--- a/spec/system/publish/providers/courses/schools_rollover_validation_spec.rb
+++ b/spec/system/publish/providers/courses/schools_rollover_validation_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Publish - Schools validation during 2026 rollover", service: :pu
   end
 
   def then_course_is_published
-    expect(page).to have_content("Your course has been published.")
+    expect(page).to have_content("Your course has been scheduled.")
     expect(course.reload.is_published?).to be(true)
   end
 end


### PR DESCRIPTION
## Context

When a course is scheduled to be published the success message still said `Your course has been published`, which is confusing for users. The change is to allow the success message to say `Your course has been scheduled` if the `@course.scheduled?` is true

## Changes proposed in this pull request

Add `render_flash_message_content` to render the success message depending on the course status.

## Guidance to review

Visit publish publish a course you will see `Your course has been published`
Run roll over and set a date in the future for applications to be published and when you "publish a course" it will say `Your course has been scheduled`
## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
