### PR TITLE
Add what you wrote last cycle and formatting links

### DIFF
--- a/app/views/publish/providers/course_fields/why_train_with_us/edit.html.erb
+++ b/app/views/publish/providers/course_fields/why_train_with_us/edit.html.erb
@@ -24,6 +24,12 @@
 
         <%= t(".page_intro_html") %>
 
+        <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
+          texts: [["Why train with us", @provider.train_with_us]],
+        } %>
+
+        <%= render partial: "publish/courses/markdown_formatting" %>
+
         <%= f.govuk_text_area(:about_us,
           data: {
             input_preview_target: "input",


### PR DESCRIPTION
## Context

We missed adding What you wrote last cycle and help formatting drop down linls

## Changes proposed in this pull request

Add the partials 

## Guidance to review

Visit an organisations details page with flag off and update the about us train_with_us section and save. Then turn flag on and visit the same page and you should see the content previously used for V1 

<img width="791" height="959" alt="Screenshot 2025-08-28 at 15 06 13" src="https://github.com/user-attachments/assets/e6f27f16-21c5-4e24-87ee-fe8f417b6ef6" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
