### PR TITLE
Course enrichment references in controllers and views to use current …

### DIFF
--- a/app/controllers/publish/courses/fields/interview_process_controller.rb
+++ b/app/controllers/publish/courses/fields/interview_process_controller.rb
@@ -10,7 +10,6 @@ module Publish
         def edit
           @interview_process_form = Publish::Fields::InterviewProcessForm.new(course_enrichment)
           @copied_fields = copy_content_check(::Courses::Copy::V2_INTERVIEW_PROCESS_FIELDS)
-          @v1_enrichment = course.enrichments.find_by(version: 1)
 
           @copied_fields_values = copied_fields_values if @copied_fields.present?
 
@@ -25,7 +24,6 @@ module Publish
 
             redirect_to redirect_path
           else
-            @v1_enrichment = course.enrichments.find_by(version: 1)
             fetch_course_list_to_copy_from
             render :edit
           end

--- a/app/controllers/publish/courses/fields/school_placement_controller.rb
+++ b/app/controllers/publish/courses/fields/school_placement_controller.rb
@@ -15,7 +15,6 @@ module Publish
         def edit
           @school_placement_form = Publish::Courses::Fields::SchoolPlacementForm.new(course_enrichment)
           @copied_fields = copy_content_check(::Courses::Copy::V2_SCHOOL_PLACEMENT_FIELDS)
-          @v1_enrichment = course.enrichments.find_by(version: 1)
           @copied_fields_values = copied_fields_values if @copied_fields.present?
           @school_placement_form.valid? if show_errors_on_publish?
         end
@@ -37,7 +36,6 @@ module Publish
             )
 
           else
-            @v1_enrichment = course.enrichments.find_by(version: 1)
             fetch_course_list_to_copy_from
             render :edit
           end

--- a/app/controllers/publish/courses/fields/what_you_will_study_controller.rb
+++ b/app/controllers/publish/courses/fields/what_you_will_study_controller.rb
@@ -11,7 +11,6 @@ module Publish
           )
           @copied_fields = copy_content_check(::Courses::Copy::WHAT_YOU_WILL_STUDY_FIELDS)
           @copied_fields_values = copied_fields_values if @copied_fields.present?
-          @v1_enrichment = course.enrichments.find_by(version: 1)
 
           @what_you_will_study_form.valid? if show_errors_on_publish?
         end
@@ -28,7 +27,6 @@ module Publish
                                                                        course.course_code)
 
           else
-            @v1_enrichment = course.enrichments.find_by(version: 1)
             fetch_course_list_to_copy_from
             render :edit
           end

--- a/app/controllers/publish/courses/fields/where_you_will_train_controller.rb
+++ b/app/controllers/publish/courses/fields/where_you_will_train_controller.rb
@@ -9,7 +9,6 @@ module Publish
           @copied_fields = copy_content_check(::Courses::Copy::V2_WHERE_YOU_WILL_TRAIN_FIELDS)
 
           @copied_fields_values = copied_fields_values if @copied_fields.present?
-          @v1_enrichment = course.enrichments.find_by(version: 1)
           @where_you_will_train_form.valid? if show_errors_on_publish?
         end
 
@@ -35,9 +34,7 @@ module Publish
                 course.course_code,
               )
             end
-
           else
-            @v1_enrichment = course.enrichments.find_by(version: 1)
             fetch_course_list_to_copy_from
             render :edit
           end

--- a/app/views/publish/courses/fields/_last_cycle_recap.html.erb
+++ b/app/views/publish/courses/fields/_last_cycle_recap.html.erb
@@ -1,3 +1,4 @@
+<% if texts&.map{|val| val[1].present? }&.any? %>
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
@@ -6,6 +7,8 @@
   </summary>
   <div class="govuk-details__text">
     <% texts.each do |headline, text| %>
+      <% next if text.blank? %>
+
       <% if headline %>
         <p class="govuk-body">
           <strong><%= headline %></strong>
@@ -17,3 +20,4 @@
     <% end %>
   </div>
 </details>
+<% end %>

--- a/app/views/publish/courses/fields/fees_and_financial_support/edit.html.erb
+++ b/app/views/publish/courses/fields/fees_and_financial_support/edit.html.erb
@@ -36,17 +36,15 @@
         <%= t(".heading") %>
       </h1>
 
-      <% if @v1_enrichment %>
-        <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
-          texts: [
-            [t(".fee_uk"), number_to_currency(@v1_enrichment.fee_uk_eu).to_s],
-            [@course.can_sponsor_student_visa? ? t(".fee_international") : t(".fee_international_optional"), number_to_currency(@v1_enrichment.fee_international).to_s],
-            [t(".fee_schedule"), @v1_enrichment.fee_schedule],
-            [t(".additional_fees"), @v1_enrichment.additional_fees],
-            [t(".financial_support"), @v1_enrichment.financial_support],
-          ],
-        } %>
-      <% end %>
+      <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
+        texts: [
+          [t(".fee_uk"), number_to_currency(@course.fee_uk_eu).to_s],
+          [@course.can_sponsor_student_visa? ? t(".fee_international") : t(".fee_international_optional"), number_to_currency(@course.fee_international).to_s],
+          [t(".fee_schedule"), @course.fee_schedule],
+          [t(".additional_fees"), @course.additional_fees],
+          [t(".financial_support"), @course.financial_support],
+        ],
+      } %>
 
       <%= render partial: "publish/courses/markdown_formatting" %>
 

--- a/app/views/publish/courses/fields/interview_process/edit.html.erb
+++ b/app/views/publish/courses/fields/interview_process/edit.html.erb
@@ -41,11 +41,9 @@
         <%= t(".page_title") %>
       </h1>
 
-      <% if @v1_enrichment %>
-        <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
-          texts: [["Interview process", @v1_enrichment.interview_process], ["Interview location", @v1_enrichment.interview_location]],
-        } %>
-      <% end %>
+      <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
+        texts: [["Interview process", @course.interview_process], ["Interview location", @course.interview_location]],
+      } %>
 
       <%= render partial: "publish/courses/markdown_formatting" %>
 

--- a/app/views/publish/courses/fields/school_placement/edit.html.erb
+++ b/app/views/publish/courses/fields/school_placement/edit.html.erb
@@ -42,11 +42,9 @@
         <%= t(".headline") %>
       </h1>
 
-      <% if @v1_enrichment %>
-        <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
-          texts: [["About this course", @v1_enrichment.about_course], ["How placements work", @v1_enrichment.how_school_placements_work]],
-        } %>
-      <% end %>
+      <%= render partial: "publish/courses/fields/last_cycle_recap", locals: {
+        texts: [["About this course", @course.about_course], ["How placements work", @course.how_school_placements_work]],
+      } %>
 
       <aside data-qa="course__related_sidebar">
       <%= render(

--- a/app/views/publish/courses/fields/what_you_will_study/edit.html.erb
+++ b/app/views/publish/courses/fields/what_you_will_study/edit.html.erb
@@ -36,17 +36,17 @@
         <span class="govuk-caption-l"><%= @course.name_and_code %></span>
         <%= t(".page_title") %>
       </h1>
-      <% if @v1_enrichment %>
-        <%= render(
-    partial: "publish/courses/fields/last_cycle_recap",
-    locals: {
-      texts: [
-        [t(".about_this_course"), @v1_enrichment&.about_course],
-        [t(".how_placements_work"), @v1_enrichment&.how_school_placements_work],
-      ],
-    },
-  ) %>
-      <% end %>
+
+      <%= render(
+        partial: "publish/courses/fields/last_cycle_recap",
+        locals: {
+          texts: [
+            [t(".about_this_course"), @course&.about_course],
+            [t(".how_placements_work"), @course&.how_school_placements_work],
+          ],
+        },
+      ) %>
+
       <%= render(
         partial: "publish/courses/markdown_formatting",
         locals: {

--- a/app/views/publish/courses/fields/where_you_will_train/edit.html.erb
+++ b/app/views/publish/courses/fields/where_you_will_train/edit.html.erb
@@ -36,17 +36,15 @@
         <%= t(".heading") %>
       </h1>
 
-      <% if @v1_enrichment %>
-        <%= render(
-          partial: "publish/courses/fields/last_cycle_recap",
-          locals: {
-            texts: [
-              [t(".about_this_course"), @v1_enrichment&.about_course],
-              [t(".how_placements_work"), @v1_enrichment&.how_school_placements_work],
-            ],
-          },
-        ) %>
-      <% end %>
+      <%= render(
+        partial: "publish/courses/fields/last_cycle_recap",
+        locals: {
+          texts: [
+            [t(".about_this_course"), @course&.about_course],
+            [t(".how_placements_work"), @course&.how_school_placements_work],
+          ],
+        },
+      ) %>
 
       <%= render(
         partial: "publish/courses/markdown_formatting",


### PR DESCRIPTION
## Context

Course enrichment references in controllers and views have been updated to use current_course data instead of `v1` enrichment.  
This change is needed because rolled-over V1 enrichments are updated to V2 enrichments when they are first edited, which causes the "last cycle" section to disappear after the first update.

## Changes proposed in this pull request

- Replace references to `v1` enrichment instance variable and use the current @course instead to show this data, since this data will be copied from the past cycle and won't be deleted.
- Moved logic into the last cycle partial that checks if text exists and skips sections where it is nil