### PR TITLE
Find::CycleTimetable.mid_cycle is `find_opens + 2.months`

### DIFF
--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -112,8 +112,8 @@ module Find
       date(:apply_opens, next_year)
     end
 
-    def self.mid_cycle
-      date(:find_opens, current_year) + 1.day
+    def self.mid_cycle(year = current_year)
+      date(:find_opens, year) + 2.months
     end
 
     def self.preview_mode?


### PR DESCRIPTION
## Context

  We've introduced the concept of the rollover period. The current
  Find::CycleTimetable definition of "Mid cycle" falls within the
  provisional period of "rollover period". My idea of mid cycle is after
  the rollover period.


## Changes proposed in this pull request

  This PR sets the `mid_cycle` to a date after find opens beyond the
  rollover period.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
