### PR TITLE
Bug: Error messages are wrong when trying to publish a course

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -124,7 +124,7 @@ class CourseEnrichment < ApplicationRecord
   validates :theoretical_training_activities, presence: true, on: :publish, if: -> { version == 2 }
   validates :theoretical_training_activities, words_count: { maximum: 150 }
 
-  validates :interview_process, words_count: { maximum: 200 }, if: -> { version == 2 }, on: :publish
+  validates :interview_process, words_count: { maximum: 200, message: :too_long }, if: -> { version == 2 }, on: :publish
 
   # v2 optional fields
   validates :theoretical_training_duration, words_count: { maximum: 50 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -694,6 +694,14 @@ en:
               blank: "^Enter details about the qualifications needed"
             course_length:
               blank: "^Enter a course length"
+            placement_selection_criteria:
+              blank: "^Enter how you decide which schools to place trainees in"
+            interview_process:
+              too_long: "^'What is the interview process?' must be 200 words or less"
+            duration_per_school:
+              blank: "^Enter how much time trainees will spend in each school"
+            placement_school_activities:
+              blank: "^Enter what will trainees do while in their placement schools"
             provider_about_us:
               blank: "^Tell candidates about your organisation"
               too_long: "Details about your organisation must be 100 words or fewer"
@@ -1008,7 +1016,7 @@ en:
         publish/course_interview_process_form:
           attributes:
             interview_process:
-              too_long: Reduce the word count for interview process
+              too_long: Interview process must be 250 words or less
         publish/fields/interview_process_form:
           attributes:
             interview_process:

--- a/spec/features/publish/courses/editing_course_interview_process_spec.rb
+++ b/spec/features/publish/courses/editing_course_interview_process_spec.rb
@@ -66,7 +66,7 @@ private
   end
 
   def then_i_see_an_error_message
-    expect(page).to have_content("Reduce the word count for interview process").twice
+    expect(page).to have_content("Interview process must be 250 words or less").twice
   end
 
   def and_i_enter_invalid_data

--- a/spec/features/publish/courses/v2_error_message_spec.rb
+++ b/spec/features/publish/courses/v2_error_message_spec.rb
@@ -17,19 +17,19 @@ feature "V2 Publishing a course with validation errors", type: :feature do
   end
 
   scenario "Placement selection criteria can't be blank error link navigates to the placement selection criteria field" do
-    click_link_in_error_summary("Placement selection criteria can't be blank")
+    click_link_in_error_summary("Enter how you decide which schools to place trainees in")
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{@course.course_code}/fields/where-you-will-train", ignore_query: true)
     expect(page).to have_content("Where you will train")
   end
 
   scenario "Duration per school can't be blank error link navigates to the duration per school field" do
-    click_link_in_error_summary("Duration per school can't be blank")
+    click_link_in_error_summary("Enter how much time trainees will spend in each school")
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{@course.course_code}/fields/where-you-will-train", ignore_query: true)
     expect(page).to have_content("Where you will train")
   end
 
   scenario "Placement school activities can't be blank error link navigates to the placement school activities field" do
-    click_link_in_error_summary("Placement school activities can't be blank")
+    click_link_in_error_summary("Enter what will trainees do while in their placement schools")
     expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle_year}/courses/#{@course.course_code}/fields/school-placement", ignore_query: true)
     expect(page).to have_content("What you will do on school placements")
   end

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe CourseEnrichment do
       it "is not valid to publish v2" do
         allow(FeatureFlag).to receive(:active?).with(:long_form_content).and_return(true)
         expect(record).not_to be_valid(:publish)
-        expect(record.errors[:placement_school_activities]).to include("can't be blank")
+        expect(record.errors[:placement_school_activities]).to include("^Enter what will trainees do while in their placement schools")
         expect(record.reload).to be_draft
       end
     end


### PR DESCRIPTION
## Context

Update error messages to match the fields they related too

## Changes proposed in this pull request

Update the error messages

## Guidance to review
Create a course and attempt to publish with errors, the error messages will match the fields names
<img width="1015" height="615" alt="Screenshot 2025-08-29 at 12 32 57" src="https://github.com/user-attachments/assets/a074ec78-796f-4eb4-859b-9437d9b55335" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
