### PR TITLE
Enable One Login in Sandbox

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -25,4 +25,12 @@ dfe_signin:
   user_search_url: https://support.signin.education.gov.uk/users
 
 one_login:
-  enabled: false
+  enabled: true
+  # URL that the users are redirected to for signing in
+  idp_base_url: https://oidc.account.gov.uk
+  # URL we use to end the Onne Login session on behalf of the user
+  logout_url: https://oidc.account.gov.uk/logout
+  # URL user is redirected to after logging out of One Login
+  post_logout_url: https://find-teacher-training-courses.service.gov.uk/
+  # URL of the users profile
+  profile_url: https://home.account.gov.uk


### PR DESCRIPTION
## Context

As part of the launch of Candidate Accounts in production, we want to test that the One Login integration is working in production.

We can safely do this in Sandbox.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
