### PR TITLE
Candidate show in Support

### DIFF
--- a/app/controllers/support/candidates_controller.rb
+++ b/app/controllers/support/candidates_controller.rb
@@ -1,7 +1,21 @@
 module Support
   class CandidatesController < ApplicationController
+    before_action :set_candidate, only: %i[details saved_courses]
+
     def index
       @pagy, @candidates = pagy(Candidate.order(created_at: :desc))
+    end
+
+    def details; end
+
+    def saved_courses
+      @saved_courses = @candidate.saved_courses.order(created_at: :desc)
+    end
+
+  private
+
+    def set_candidate
+      @candidate = Candidate.find(params[:id])
     end
   end
 end

--- a/app/views/support/candidates/details.html.erb
+++ b/app/views/support/candidates/details.html.erb
@@ -1,0 +1,27 @@
+<%= render PageTitle.new(title: "support.candidates.details") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_candidates_path(page: params[:page])) %>
+<% end %>
+
+<h1 class="govuk-heading-l"><%= @candidate.email_address %></h1>
+
+<%= render TabNavigation.new(items: [
+  { name: t(".details"), url: details_support_candidate_path(@candidate), current: true },
+  { name: t(".saved_courses"), url: saved_courses_support_candidate_path(@candidate) },
+]) %>
+
+<%= govuk_summary_list do |list| %>
+  <% list.with_row do |row| %>
+    <% row.with_key text: t(".email_address") %>
+    <% row.with_value text: @candidate.email_address %>
+  <% end %>
+  <% list.with_row do |row| %>
+    <% row.with_key text: t(".created_at") %>
+    <% row.with_value text: @candidate.created_at.to_fs(:govuk_date_and_time) + " (#{time_ago_in_words(@candidate.created_at)} ago)" %>
+  <% end %>
+  <% list.with_row do |row| %>
+    <% row.with_key text: t(".last_logged_in") %>
+    <% row.with_value text: @candidate.sessions.last&.created_at&.to_fs(:govuk_date_and_time) || t(".never_logged_in") %>
+  <% end %>
+<% end %>

--- a/app/views/support/candidates/index.html.erb
+++ b/app/views/support/candidates/index.html.erb
@@ -12,7 +12,7 @@
   <% table.with_body do |body| %>
     <% @candidates.each do |candidate| %>
       <% body.with_row classes: %w[course-row] do |row| %>
-        <% row.with_cell text: candidate.email_address %>
+        <% row.with_cell text: govuk_link_to(candidate.email_address, details_support_candidate_path(candidate), class: "govuk-link") %>
         <% row.with_cell text: "#{candidate.created_at.to_fs(:govuk_date_and_time)} (#{time_ago_in_words(candidate.created_at)} ago)" %>
       <% end %>
     <% end %>

--- a/app/views/support/candidates/saved_courses.html.erb
+++ b/app/views/support/candidates/saved_courses.html.erb
@@ -1,0 +1,36 @@
+<%= render PageTitle.new(title: "support.candidates.saved_courses") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_candidates_path(page: params[:page])) %>
+<% end %>
+
+<h1 class="govuk-heading-l"><%= @candidate.email_address %></h1>
+
+<%= render TabNavigation.new(items: [
+  { name: t(".details"), url: details_support_candidate_path(@candidate) },
+  { name: t(".saved_courses"), url: saved_courses_support_candidate_path(@candidate), current: true },
+]) %>
+
+<% if @saved_courses.present? %>
+  <%= govuk_table do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell text: t(".course") %>
+        <% row.with_cell text: t(".provider") %>
+        <% row.with_cell text: t(".saved_at") %>
+      <% end %>
+    <% end %>
+    <% table.with_body do |body| %>
+      <% @saved_courses.each do |saved| %>
+        <% course = saved.try(:course) || saved %>
+        <% body.with_row do |row| %>
+          <% row.with_cell text: govuk_link_to(course.name_and_code, publish_provider_recruitment_cycle_course_url(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code)) %>
+          <% row.with_cell text: govuk_link_to(course.provider.provider_name, support_recruitment_cycle_provider_path(course.provider.recruitment_cycle_year, course.provider)) %>
+          <% row.with_cell text: saved.created_at.to_fs(:govuk_date_and_time) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <p class="govuk-body"><%= t(".no_saved_courses") %></p>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,7 +268,8 @@ en:
       show: "Recruitment cycles"
       change_cycle: "Change recruitment cycle"
     candidates:
-      index: "Candidates"
+      index: Candidates
+      show: Candidates
     users:
       index: "Users"
       new: "Personal details"
@@ -378,7 +379,9 @@ en:
             checks:
               show: "Check your answers"
         candidates:
-          index: "Candidates"
+          index: Candidates
+          details: View a candidate
+          saved_courses: Saved Courses
         users:
           index: "Users"
           show: "User overview"

--- a/config/locales/en/support/candidates.yml
+++ b/config/locales/en/support/candidates.yml
@@ -4,3 +4,17 @@ en:
       index:
         email_address: Email address
         created_at: Created at
+      details:
+        email_address: Email address
+        created_at: Created at
+        last_logged_in: Last login date
+        never_logged_in: Never logged in
+        details: Details
+        saved_courses: Saved courses
+      saved_courses:
+        details: Details
+        saved_courses: Saved courses
+        saved_at: Saved at
+        no_saved_courses: This candidate hasn’t saved any courses yet.
+        course: Course
+        provider: Provider

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -100,5 +100,10 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
       post :confirm_rollover
     end
   end
-  resources :candidates, only: %i[index]
+  resources :candidates, only: %i[index] do
+    member do
+      get :details
+      get :saved_courses
+    end
+  end
 end

--- a/spec/system/support/candidates/details_candidate_spec.rb
+++ b/spec/system/support/candidates/details_candidate_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Support console Candidates details" do
+  let(:user) { create(:user, :admin) }
+
+  before { given_i_am_authenticated }
+
+  scenario "user sees candidates details" do
+    when_a_candidates_exist
+    and_i_visit_the_candidate_details
+    then_i_see_the_details_of_the_candidate
+  end
+
+  def when_a_candidates_exist
+    @candidate = create(:candidate)
+  end
+
+  def and_i_visit_the_candidate_details
+    visit details_support_candidate_path(@candidate)
+  end
+
+  def then_i_see_the_details_of_the_candidate
+    expect(page).to have_content(@candidate.email_address)
+    expect(page).to have_content(@candidate.created_at.to_fs(:govuk_date_and_time))
+    expect(page).to have_content("Never logged in")
+  end
+
+  def given_i_am_authenticated
+    sign_in_system_test(user:)
+  end
+end

--- a/spec/system/support/candidates/saved_courses_candidate_spec.rb
+++ b/spec/system/support/candidates/saved_courses_candidate_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Support console Candidates saved courses" do
+  let(:user) { create(:user, :admin) }
+
+  before { given_i_am_authenticated }
+
+  scenario "user sees candidates details" do
+    when_a_candidates_exist
+    and_i_visit_the_candidate_details
+    then_i_see_the_saved_courses_of_the_candidate
+  end
+
+  def when_a_candidates_exist
+    @candidate = create(:candidate)
+
+    course = create(:course)
+    @saved_course = create(:saved_course, candidate: @candidate, course:)
+  end
+
+  def and_i_visit_the_candidate_details
+    visit saved_courses_support_candidate_path(@candidate)
+  end
+
+  def then_i_see_the_saved_courses_of_the_candidate
+    expect(page).to have_content(@saved_course.course.name)
+    expect(page).to have_content(@saved_course.course.course_code)
+    expect(page).to have_content(@saved_course.course.provider_name)
+    expect(page).to have_content(@saved_course.created_at.to_fs(:govuk_date_and_time))
+  end
+
+  def given_i_am_authenticated
+    sign_in_system_test(user:)
+  end
+end


### PR DESCRIPTION
## Context

Provide more info about candidates for support users 

## Changes proposed in this pull request

- Add details tab
- Add saved courses tab

## Guidance to review

Sign in as a support user and navigate to the candidates tab. You should see all candidates as well as the links to view more in-depth detail about the candidate 

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
