### PR TITLE
Refactor provider details for find and publish

### DIFF
--- a/app/views/find/courses/providers/show.html.erb
+++ b/app/views/find/courses/providers/show.html.erb
@@ -19,15 +19,5 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render Find::Courses::ContactDetailsComponent::View.new(@course) %>
-
-    <% if @course.provider.about_us.present? || @course.provider.value_proposition.present? %>
-        <%= render partial: "find/courses/v2/train_with_us", locals: { provider: @provider } %>
-    <% end %>
-
-    <% if @provider.train_with_us.present? || @course.about_accrediting_provider.present? %>
-      <%= render partial: "find/courses/about_the_provider", locals: { course: @course } %>
-    <% end %>
-  </div>
+  <%= render partial: "shared/provider/provider_details", locals: { course: @course } %>
 </div>

--- a/app/views/publish/courses/providers/show.html.erb
+++ b/app/views/publish/courses/providers/show.html.erb
@@ -20,9 +20,5 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render Find::Courses::ContactDetailsComponent::View.new(@course) %>
-
-    <%= render partial: "find/courses/about_the_provider", locals: { course: @course } %>
-  </div>
+  <%= render partial: "shared/provider/provider_details", locals: { course: @course } %>
 </div>

--- a/app/views/shared/provider/_provider_details.html.erb
+++ b/app/views/shared/provider/_provider_details.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-grid-column-two-thirds">
+  <%= render Find::Courses::ContactDetailsComponent::View.new(course) %>
+
+  <% is_v2 = (course.respond_to?(:version) ? (course.version&.to_i == 2) : (course.latest_enrichment&.version == 2)) %>
+  <% if is_v2 %>
+    <% if course.provider.about_us.present? || course.provider.value_proposition.present? %>
+        <%= render partial: "find/courses/v2/train_with_us", locals: { provider: course.provider } %>
+    <% end %>
+  <% else %>
+    <%= render partial: "find/courses/about_the_provider", locals: { course: course } %>
+  <% end %>
+</div>

--- a/spec/features/publish/provider_details_rendering_spec.rb
+++ b/spec/features/publish/provider_details_rendering_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Provider details rendering by version" do
+  scenario "renders v2 provider content when latest enrichment version is 2" do
+    provider = create(:provider, about_us: "About us v2", value_proposition: "Our offer v2")
+    course = create(:course, :secondary, provider:)
+    create(:course_enrichment, course:, status: :draft, version: 2)
+
+    given_i_am_authenticated(user: create(:user, providers: [provider]))
+
+    visit preview_publish_provider_recruitment_cycle_course_path(
+      course.provider.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code,
+    )
+
+    click_link_or_button(course.provider_name)
+
+    expect(page).to have_css("#section-why-train-with-us")
+    expect(page).to have_no_css("#section-about-provider")
+    expect(page).to have_content("Why train with us")
+    expect(page).to have_content("About us v2")
+    expect(page).to have_content("Our offer v2")
+  end
+
+  scenario "renders v1 provider content when latest enrichment version is 1" do
+    provider = create(:provider, train_with_us: "About us v1")
+    course = create(:course, :secondary, provider:)
+    create(:course_enrichment, course:, status: :draft, version: 1)
+
+    given_i_am_authenticated(user: create(:user, providers: [provider]))
+
+    visit preview_publish_provider_recruitment_cycle_course_path(
+      course.provider.provider_code,
+      course.recruitment_cycle_year,
+      course.course_code,
+    )
+
+    click_link_or_button(course.provider_name)
+
+    expect(page).to have_css("#section-about-provider")
+    expect(page).to have_no_css("#section-why-train-with-us")
+    expect(page).to have_content("About #{course.provider_name}")
+    expect(page).to have_content("About us v1")
+  end
+end


### PR DESCRIPTION
## Context

The content on the provider details pages was not rendering the correct input values when previewing a course. I also noticed the logic was also set up when viewing provider details in find would render both v1 and v2 content.

## Changes proposed in this pull request

Create a shared partial which can be used for both publish and find 

## Guidance to review

- View a v1 course in find and should show the v1 content for provider details
- Preview a v1 course in find and should show the v1 content for provider details
- View a v2 course in find and should show the v2 content for provider details
- Preview a v2 course in find and should show the v2 content for provider details

## Find 
<img width="1313" height="967" alt="Screenshot 2025-09-09 at 14 15 04" src="https://github.com/user-attachments/assets/7d2c5055-6550-4ed6-9f07-df644fe988b1" />

## Publish
<img width="1469" height="908" alt="Screenshot 2025-09-09 at 14 14 53" src="https://github.com/user-attachments/assets/0f5f3c1b-79d0-4554-bb1a-f3611d5e5e98" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
