### PR TITLE
Longform content just depends on the feature flag

### DIFF
--- a/app/components/course_preview/missing_information_component.rb
+++ b/app/components/course_preview/missing_information_component.rb
@@ -45,7 +45,7 @@ module CoursePreview
     def provider_train_with_disability_link = edit_publish_provider_recruitment_cycle_disability_support_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true)
 
     def train_with_us_link
-      if FeatureFlag.active?(:long_form_content) || Current.recruitment_cycle.after_2025?
+      if FeatureFlag.active?(:long_form_content)
         edit_publish_provider_recruitment_cycle_why_train_with_us_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true)
       else
         about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_provider: true, anchor: "train-with-us")
@@ -53,7 +53,7 @@ module CoursePreview
     end
 
     def train_with_disability_link
-      if FeatureFlag.active?(:long_form_content) || Current.recruitment_cycle.after_2025?
+      if FeatureFlag.active?(:long_form_content)
         edit_publish_provider_recruitment_cycle_disability_support_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true)
       else
         about_publish_provider_recruitment_cycle_path(provider_code, recruitment_cycle_year, course_code:, goto_training_with_disabilities: true, anchor: "train-with-disability")

--- a/app/controllers/publish/courses/fields/base_controller.rb
+++ b/app/controllers/publish/courses/fields/base_controller.rb
@@ -16,7 +16,7 @@ module Publish
 
         # Redirects to the course page if the long form content feature flag is not active
         def redirect_to_course_if_feature_disabled
-          unless FeatureFlag.active?(:long_form_content) || recruitment_cycle.after_2025?
+          unless FeatureFlag.active?(:long_form_content)
             redirect_to publish_provider_recruitment_cycle_course_path(
               provider.provider_code,
               recruitment_cycle.year,

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -45,7 +45,7 @@ module ViewHelper
     fee_v2 = "#{field_base_url}/fees-and-financial-support".to_s
     fee_v1 = "#{base}/fees"
 
-    fees_url = FeatureFlag.active?(:long_form_content) || course.provider.recruitment_cycle.after_2025? ? fee_v2 : fee_v1
+    fees_url = FeatureFlag.active?(:long_form_content) ? fee_v2 : fee_v1
 
     if field.to_sym == :base
       base_errors_hash(provider_code, course)[message]

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -25,7 +25,7 @@
 
     <%= render Find::Courses::EntryRequirementsComponent::View.new(course:) %>
 
-    <% if FeatureFlag.active?(:long_form_content) || @provider.recruitment_cycle.after_2025? %>
+    <% if FeatureFlag.active?(:long_form_content) %>
       <%= render partial: "find/courses/v2/components" %>
     <% else %>
       <%= render partial: "find/courses/v1_components" %>

--- a/app/views/publish/courses/show.html.erb
+++ b/app/views/publish/courses/show.html.erb
@@ -38,7 +38,7 @@
 <section class="app-section" id="description">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <% if FeatureFlag.active?(:long_form_content) || @recruitment_cycle.after_2025? %>
+      <% if FeatureFlag.active?(:long_form_content) %>
         <%= render partial: "v2_description_content" %>
       <% else %>
         <%= render partial: "description_content" %>

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -33,7 +33,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_summary_list do |summary_list| %>
-      <% if FeatureFlag.active?(:long_form_content) || Current.recruitment_cycle.after_2025? %>
+      <% if FeatureFlag.active?(:long_form_content) %>
           <% enrichment_summary(
           summary_list,
           :provider,


### PR DESCRIPTION
## Context

  We planned to have longform content only apply to courses in the 2026
  cycle but due to a lack of time we were forced to apply it to 2025
  courses as well.

  This commit removes all the conditionals on recruitment cycle with
  respect to long form content.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
