### PR TITLE
[Bug] Exempt discarded schools from uniqueness validation

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -33,6 +33,7 @@ class Site < ApplicationRecord
   }
 
   validates :location_name, uniqueness: { scope: %i[provider_id site_type],
+                                          conditions: -> { where(discarded_at: nil) },
                                           message: lambda { |object, _data|
                                             "This #{object.site_type.humanize.downcase} has already been added"
                                           } }


### PR DESCRIPTION
## Context

We received a ticket from a provider regarding an issue with school data. An old school record was discarded due to a missing URN. When the provider attempted to re-add the school with the correct URN, it failed.  

The failure occurred because the old school wasn’t actually deleted—only discarded—and our `location_name` uniqueness constraint caused a validation error. Tomas quickly identified the issue and proposed a solution, which this PR implements.

## Changes proposed in this pull request

- Add a new condition to exempt discarded schools from the uniqueness validation

This solves:
https://trello.com/c/kvCq7hpL/959-missing-school-in-publish
