### PR TITLE
Time.zone.now and CycleTimetable determines the cycle year

### DIFF
--- a/app/components/support_title_bar.rb
+++ b/app/components/support_title_bar.rb
@@ -13,9 +13,9 @@ private
 
   def title
     if current_recruitment_cycle?
-      "Recruitment cycle #{current_recruitment_cycle_year} to #{next_recruitment_cycle_year} - current"
+      "Recruitment cycle #{previous_recruitment_cycle_year} to #{current_recruitment_cycle_year} - current"
     else
-      "Recruitment cycle #{current_recruitment_cycle_year + 1} to #{next_recruitment_cycle_year + 1}"
+      "Recruitment cycle #{current_recruitment_cycle_year} to #{next_recruitment_cycle_year}"
     end
   end
 
@@ -36,19 +36,23 @@ private
   end
 
   def current_recruitment_cycle?
-    recruitment_cycle_year == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+    recruitment_cycle_year == Find::CycleTimetable.current_year
   end
 
   def next_recruitment_cycle?
-    recruitment_cycle_year == Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
+    recruitment_cycle_year == Find::CycleTimetable.next_year
+  end
+
+  def previous_recruitment_cycle_year
+    Find::CycleTimetable.previous_year
   end
 
   def current_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1
+    Find::CycleTimetable.current_year
   end
 
   def next_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+    Find::CycleTimetable.next_year
   end
 
   def support_index_page

--- a/app/components/support_title_bar.rb
+++ b/app/components/support_title_bar.rb
@@ -36,19 +36,19 @@ private
   end
 
   def current_recruitment_cycle?
-    recruitment_cycle_year == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+    recruitment_cycle_year == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
   end
 
   def next_recruitment_cycle?
-    recruitment_cycle_year == Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
+    recruitment_cycle_year == Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
   end
 
   def current_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1
+    Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1
   end
 
   def next_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+    Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
   end
 
   def support_index_page

--- a/app/components/support_title_bar.rb
+++ b/app/components/support_title_bar.rb
@@ -36,19 +36,19 @@ private
   end
 
   def current_recruitment_cycle?
-    recruitment_cycle_year == Settings.current_recruitment_cycle_year
+    recruitment_cycle_year == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
   end
 
   def next_recruitment_cycle?
-    recruitment_cycle_year == Settings.current_recruitment_cycle_year + 1
+    recruitment_cycle_year == Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
   end
 
   def current_recruitment_cycle_year
-    Settings.current_recruitment_cycle_year - 1
+    Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1
   end
 
   def next_recruitment_cycle_year
-    Settings.current_recruitment_cycle_year
+    Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
   end
 
   def support_index_page

--- a/app/components/title_bar.rb
+++ b/app/components/title_bar.rb
@@ -31,11 +31,11 @@ private
   end
 
   def current_recruitment_cycle?
-    recruitment_cycle_year == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+    recruitment_cycle_year == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
   end
 
   def next_recruitment_cycle?
-    recruitment_cycle_year == Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
+    recruitment_cycle_year == Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
   end
 
   def recruitment_cycle_year
@@ -47,11 +47,11 @@ private
   end
 
   def current_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1
+    Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1
   end
 
   def next_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+    Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
   end
 
   def recruitment_label

--- a/app/components/title_bar.rb
+++ b/app/components/title_bar.rb
@@ -31,11 +31,11 @@ private
   end
 
   def current_recruitment_cycle?
-    recruitment_cycle_year == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+    recruitment_cycle_year == Find::CycleTimetable.current_year
   end
 
   def next_recruitment_cycle?
-    recruitment_cycle_year == Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
+    recruitment_cycle_year == Find::CycleTimetable.next_year
   end
 
   def recruitment_cycle_year
@@ -46,19 +46,23 @@ private
     RolloverPeriod.active?(current_user:)
   end
 
+  def previous_recruitment_cycle_year
+    Find::CycleTimetable.previous_year
+  end
+
   def current_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1
+    Find::CycleTimetable.current_year
   end
 
   def next_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+    Find::CycleTimetable.current_year
   end
 
   def recruitment_label
     if current_recruitment_cycle?
-      "- #{current_recruitment_cycle_year} to #{next_recruitment_cycle_year} - current"
+      "- #{previous_recruitment_cycle_year} to #{current_recruitment_cycle_year} - current"
     elsif next_recruitment_cycle?
-      "- #{current_recruitment_cycle_year + 1} to #{next_recruitment_cycle_year + 1}"
+      "- #{current_recruitment_cycle_year} to #{next_recruitment_cycle_year}"
     end
   end
 end

--- a/app/components/title_bar.rb
+++ b/app/components/title_bar.rb
@@ -31,11 +31,11 @@ private
   end
 
   def current_recruitment_cycle?
-    recruitment_cycle_year == Settings.current_recruitment_cycle_year
+    recruitment_cycle_year == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
   end
 
   def next_recruitment_cycle?
-    recruitment_cycle_year == Settings.current_recruitment_cycle_year + 1
+    recruitment_cycle_year == Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
   end
 
   def recruitment_cycle_year
@@ -47,11 +47,11 @@ private
   end
 
   def current_recruitment_cycle_year
-    Settings.current_recruitment_cycle_year - 1
+    Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1
   end
 
   def next_recruitment_cycle_year
-    Settings.current_recruitment_cycle_year
+    Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
   end
 
   def recruitment_label

--- a/app/controllers/publish/application_controller.rb
+++ b/app/controllers/publish/application_controller.rb
@@ -29,7 +29,7 @@ module Publish
     end
 
     def cycle_year
-      @cycle_year ||= params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
+      @cycle_year ||= params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
     end
 
     def show_errors_on_publish?
@@ -46,7 +46,7 @@ module Publish
     end
 
     def clear_previous_cycle_year_in_session
-      return if session[:cycle_year].to_i == Settings.current_recruitment_cycle_year
+      return if session[:cycle_year].to_i == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
 
       session[:cycle_year] = nil
     end

--- a/app/controllers/publish/application_controller.rb
+++ b/app/controllers/publish/application_controller.rb
@@ -29,7 +29,7 @@ module Publish
     end
 
     def cycle_year
-      @cycle_year ||= params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+      @cycle_year ||= params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
     end
 
     def show_errors_on_publish?
@@ -46,7 +46,7 @@ module Publish
     end
 
     def clear_previous_cycle_year_in_session
-      return if session[:cycle_year].to_i == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+      return if session[:cycle_year].to_i == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
 
       session[:cycle_year] = nil
     end

--- a/app/controllers/publish/application_controller.rb
+++ b/app/controllers/publish/application_controller.rb
@@ -29,7 +29,7 @@ module Publish
     end
 
     def cycle_year
-      @cycle_year ||= params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+      @cycle_year ||= params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.current_year
     end
 
     def show_errors_on_publish?
@@ -46,7 +46,7 @@ module Publish
     end
 
     def clear_previous_cycle_year_in_session
-      return if session[:cycle_year].to_i == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+      return if session[:cycle_year].to_i == Find::CycleTimetable.current_year
 
       session[:cycle_year] = nil
     end

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -52,7 +52,7 @@ module Publish
   private
 
     def cycle_year
-      session[:cycle_year] || params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+      session[:cycle_year] || params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
     end
 
     def user

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -52,7 +52,7 @@ module Publish
   private
 
     def cycle_year
-      session[:cycle_year] || params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+      session[:cycle_year] || params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.current_year
     end
 
     def user

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -52,7 +52,7 @@ module Publish
   private
 
     def cycle_year
-      session[:cycle_year] || params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
+      session[:cycle_year] || params[:recruitment_cycle_year] || params[:year] || Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
     end
 
     def user

--- a/app/controllers/support/recruitment_cycle_controller.rb
+++ b/app/controllers/support/recruitment_cycle_controller.rb
@@ -5,7 +5,7 @@ module Support
     def index
       @rollover_period = RolloverPeriod.new(current_user:)
 
-      redirect_to support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year) unless @rollover_period.active?
+      redirect_to support_recruitment_cycle_providers_path(Find::CycleTimetable.cycle_year_from_time(Time.zone.now)) unless @rollover_period.active?
     end
   end
 end

--- a/app/controllers/support/recruitment_cycle_controller.rb
+++ b/app/controllers/support/recruitment_cycle_controller.rb
@@ -5,7 +5,7 @@ module Support
     def index
       @rollover_period = RolloverPeriod.new(current_user:)
 
-      redirect_to support_recruitment_cycle_providers_path(Find::CycleTimetable.cycle_year_from_time(Time.zone.now)) unless @rollover_period.active?
+      redirect_to support_recruitment_cycle_providers_path(Find::CycleTimetable.cycle_year_for_time(Time.zone.now)) unless @rollover_period.active?
     end
   end
 end

--- a/app/controllers/support/recruitment_cycle_controller.rb
+++ b/app/controllers/support/recruitment_cycle_controller.rb
@@ -5,7 +5,7 @@ module Support
     def index
       @rollover_period = RolloverPeriod.new(current_user:)
 
-      redirect_to support_recruitment_cycle_providers_path(Find::CycleTimetable.cycle_year_for_time(Time.zone.now)) unless @rollover_period.active?
+      redirect_to support_recruitment_cycle_providers_path(Find::CycleTimetable.current_year) unless @rollover_period.active?
     end
   end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -229,7 +229,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def current_cycle?
-    course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year
+    course.recruitment_cycle.year.to_i == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
   end
 
   def current_cycle_and_open?
@@ -237,7 +237,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def next_cycle?
-    course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year + 1
+    course.recruitment_cycle.year.to_i == Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
   end
 
   def use_financial_support_placeholder?
@@ -472,7 +472,7 @@ class CourseDecorator < ApplicationDecorator
     bursary_amount = number_to_currency(financial_incentive&.bursary_amount)
     scholarship = number_to_currency(financial_incentive&.scholarship)
 
-    return I18n.t("components.course.financial_incentives.not_yet_available") if (course.recruitment_cycle_year.to_i > Settings.current_recruitment_cycle_year) || !FeatureFlag.active?(:bursaries_and_scholarships_announced)
+    return I18n.t("components.course.financial_incentives.not_yet_available") if (course.recruitment_cycle_year.to_i > Find::CycleTimetable.cycle_year_from_time(Time.zone.now)) || !FeatureFlag.active?(:bursaries_and_scholarships_announced)
     return I18n.t("components.course.financial_incentives.none") if financial_incentive.nil?
 
     return I18n.t("components.course.financial_incentives.bursary_and_scholarship", scholarship:, bursary_amount:) if bursary_amount.present? && scholarship.present?

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -229,7 +229,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def current_cycle?
-    course.recruitment_cycle.year.to_i == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+    course.recruitment_cycle.year.to_i == Find::CycleTimetable.current_year
   end
 
   def current_cycle_and_open?
@@ -237,7 +237,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def next_cycle?
-    course.recruitment_cycle.year.to_i == Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
+    course.recruitment_cycle.year.to_i == Find::CycleTimetable.current_year + 1
   end
 
   def use_financial_support_placeholder?
@@ -472,7 +472,7 @@ class CourseDecorator < ApplicationDecorator
     bursary_amount = number_to_currency(financial_incentive&.bursary_amount)
     scholarship = number_to_currency(financial_incentive&.scholarship)
 
-    return I18n.t("components.course.financial_incentives.not_yet_available") if (course.recruitment_cycle_year.to_i > Find::CycleTimetable.cycle_year_for_time(Time.zone.now)) || !FeatureFlag.active?(:bursaries_and_scholarships_announced)
+    return I18n.t("components.course.financial_incentives.not_yet_available") if (course.recruitment_cycle_year.to_i > Find::CycleTimetable.current_year) || !FeatureFlag.active?(:bursaries_and_scholarships_announced)
     return I18n.t("components.course.financial_incentives.none") if financial_incentive.nil?
 
     return I18n.t("components.course.financial_incentives.bursary_and_scholarship", scholarship:, bursary_amount:) if bursary_amount.present? && scholarship.present?

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -229,7 +229,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def current_cycle?
-    course.recruitment_cycle.year.to_i == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+    course.recruitment_cycle.year.to_i == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
   end
 
   def current_cycle_and_open?
@@ -237,7 +237,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def next_cycle?
-    course.recruitment_cycle.year.to_i == Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
+    course.recruitment_cycle.year.to_i == Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
   end
 
   def use_financial_support_placeholder?
@@ -472,7 +472,7 @@ class CourseDecorator < ApplicationDecorator
     bursary_amount = number_to_currency(financial_incentive&.bursary_amount)
     scholarship = number_to_currency(financial_incentive&.scholarship)
 
-    return I18n.t("components.course.financial_incentives.not_yet_available") if (course.recruitment_cycle_year.to_i > Find::CycleTimetable.cycle_year_from_time(Time.zone.now)) || !FeatureFlag.active?(:bursaries_and_scholarships_announced)
+    return I18n.t("components.course.financial_incentives.not_yet_available") if (course.recruitment_cycle_year.to_i > Find::CycleTimetable.cycle_year_for_time(Time.zone.now)) || !FeatureFlag.active?(:bursaries_and_scholarships_announced)
     return I18n.t("components.course.financial_incentives.none") if financial_incentive.nil?
 
     return I18n.t("components.course.financial_incentives.bursary_and_scholarship", scholarship:, bursary_amount:) if bursary_amount.present? && scholarship.present?

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -64,6 +64,6 @@ private
   end
 
   def is_current_cycle(cycle_year)
-    Find::CycleTimetable.cycle_year_from_time(Time.zone.now) == cycle_year.to_i
+    Find::CycleTimetable.cycle_year_for_time(Time.zone.now) == cycle_year.to_i
   end
 end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -64,6 +64,6 @@ private
   end
 
   def is_current_cycle(cycle_year)
-    Find::CycleTimetable.cycle_year_for_time(Time.zone.now) == cycle_year.to_i
+    Find::CycleTimetable.current_year == cycle_year.to_i
   end
 end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -64,6 +64,6 @@ private
   end
 
   def is_current_cycle(cycle_year)
-    Settings.current_recruitment_cycle_year == cycle_year.to_i
+    Find::CycleTimetable.cycle_year_from_time(Time.zone.now) == cycle_year.to_i
   end
 end

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -2,19 +2,19 @@
 
 module RecruitmentCycleHelper
   def current_recruitment_cycle_period_text
-    "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}"
+    "#{Find::CycleTimetable.previous_year} to #{Find::CycleTimetable.current_year}"
   end
 
   def next_recruitment_cycle_period_text
-    "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1}"
+    "#{Find::CycleTimetable.current_year} to #{Find::CycleTimetable.next_year}"
   end
 
   def next_academic_cycle_period_text
-    "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 2}"
+    "#{Find::CycleTimetable.next_year} to #{Find::CycleTimetable.next_year + 1}"
   end
 
   def previous_recruitment_cycle_period_text
-    "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}"
+    "#{Find::CycleTimetable.next_year} to #{Find::CycleTimetable.current_year}"
   end
 
   def hint_text_for_mid_cycle
@@ -38,7 +38,7 @@ module RecruitmentCycleHelper
   end
 
   def current_recruitment_cycle?(provider)
-    provider.recruitment_cycle_year.to_i == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+    provider.recruitment_cycle_year.to_i == Find::CycleTimetable.current_year
   end
 
   def rollover_active?

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -2,19 +2,19 @@
 
 module RecruitmentCycleHelper
   def current_recruitment_cycle_period_text
-    "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}"
+    "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}"
   end
 
   def next_recruitment_cycle_period_text
-    "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1}"
+    "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1}"
   end
 
   def next_academic_cycle_period_text
-    "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 2}"
+    "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 2}"
   end
 
   def previous_recruitment_cycle_period_text
-    "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}"
+    "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}"
   end
 
   def hint_text_for_mid_cycle
@@ -38,7 +38,7 @@ module RecruitmentCycleHelper
   end
 
   def current_recruitment_cycle?(provider)
-    provider.recruitment_cycle_year.to_i == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+    provider.recruitment_cycle_year.to_i == Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
   end
 
   def rollover_active?

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -2,19 +2,19 @@
 
 module RecruitmentCycleHelper
   def current_recruitment_cycle_period_text
-    "#{Settings.current_recruitment_cycle_year - 1} to #{Settings.current_recruitment_cycle_year}"
+    "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}"
   end
 
   def next_recruitment_cycle_period_text
-    "#{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}"
+    "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1}"
   end
 
   def next_academic_cycle_period_text
-    "#{Settings.current_recruitment_cycle_year + 1} to #{Settings.current_recruitment_cycle_year + 2}"
+    "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 2}"
   end
 
   def previous_recruitment_cycle_period_text
-    "#{Settings.current_recruitment_cycle_year - 1} to #{Settings.current_recruitment_cycle_year}"
+    "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}"
   end
 
   def hint_text_for_mid_cycle
@@ -38,7 +38,7 @@ module RecruitmentCycleHelper
   end
 
   def current_recruitment_cycle?(provider)
-    provider.recruitment_cycle_year.to_i == Settings.current_recruitment_cycle_year
+    provider.recruitment_cycle_year.to_i == Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
   end
 
   def rollover_active?

--- a/app/lib/cycle_year_constraint.rb
+++ b/app/lib/cycle_year_constraint.rb
@@ -1,0 +1,17 @@
+class CycleYearConstraint
+  def matches?(request)
+    permitted_years = [
+      Find::CycleTimetable.previous_year,
+      Find::CycleTimetable.current_year,
+      Find::CycleTimetable.next_year,
+    ]
+
+    possible_year_params = [
+      request.params[:recruitment_cycle_year],
+      request.params[:cycle_year],
+      request.params[:year],
+    ].find(&:present?)
+
+    possible_year_params.to_i.in?(permitted_years)
+  end
+end

--- a/app/models/concerns/courses/edit_options/start_date_concern.rb
+++ b/app/models/concerns/courses/edit_options/start_date_concern.rb
@@ -34,7 +34,7 @@ module Courses
           if instance_of?(Course) && persisted?
             available_options
           else
-            starting_index = available_options.find_index "#{Date::MONTHNAMES[DateTime.now.month]} #{DateTime.now.year}"
+            starting_index = available_options.find_index "#{Date::MONTHNAMES[DateTime.now.month]} #{Find::CycleTimetable.current_year}"
 
             available_options[starting_index..available_options.size]
           end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -366,7 +366,7 @@ class Provider < ApplicationRecord
   end
 
   def from_next_recruitment_cycle
-    Provider.joins(:recruitment_cycle).where(recruitment_cycle: { year: Settings.current_recruitment_cycle_year.succ.to_s }).find_by(provider_code:)
+    Provider.joins(:recruitment_cycle).where(recruitment_cycle: { year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now).succ.to_s }).find_by(provider_code:)
   end
 
 private

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -366,7 +366,7 @@ class Provider < ApplicationRecord
   end
 
   def from_next_recruitment_cycle
-    Provider.joins(:recruitment_cycle).where(recruitment_cycle: { year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now).succ.to_s }).find_by(provider_code:)
+    Provider.joins(:recruitment_cycle).where(recruitment_cycle: { year: Find::CycleTimetable.next_year.to_s }).find_by(provider_code:)
   end
 
 private

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -366,7 +366,7 @@ class Provider < ApplicationRecord
   end
 
   def from_next_recruitment_cycle
-    Provider.joins(:recruitment_cycle).where(recruitment_cycle: { year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now).succ.to_s }).find_by(provider_code:)
+    Provider.joins(:recruitment_cycle).where(recruitment_cycle: { year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now).succ.to_s }).find_by(provider_code:)
   end
 
 private

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -12,11 +12,11 @@ class RecruitmentCycle < ApplicationRecord
 
   class << self
     def current_recruitment_cycle!
-      find_by!(year: Settings.current_recruitment_cycle_year)
+      find_by!(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
     end
 
     def current_recruitment_cycle
-      find_by(year: Settings.current_recruitment_cycle_year)
+      find_by(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
     end
     alias_method :current, :current_recruitment_cycle
 
@@ -31,7 +31,7 @@ class RecruitmentCycle < ApplicationRecord
   end
 
   def self.current_and_upcoming_cycles_open_to_publish
-    where(year: Settings.current_recruitment_cycle_year).or(upcoming_cycles_open_to_publish)
+    where(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)).or(upcoming_cycles_open_to_publish)
   end
 
   scope :upcoming_cycles_open_to_publish, lambda {

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -12,11 +12,11 @@ class RecruitmentCycle < ApplicationRecord
 
   class << self
     def current_recruitment_cycle!
-      find_by!(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+      find_by!(year: Find::CycleTimetable.current_year)
     end
 
     def current_recruitment_cycle
-      find_by(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+      find_by(year: Find::CycleTimetable.current_year)
     end
     alias_method :current, :current_recruitment_cycle
 

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -12,11 +12,11 @@ class RecruitmentCycle < ApplicationRecord
 
   class << self
     def current_recruitment_cycle!
-      find_by!(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+      find_by!(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
     end
 
     def current_recruitment_cycle
-      find_by(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+      find_by(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
     end
     alias_method :current, :current_recruitment_cycle
 
@@ -31,7 +31,7 @@ class RecruitmentCycle < ApplicationRecord
   end
 
   def self.current_and_upcoming_cycles_open_to_publish
-    where(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)).or(upcoming_cycles_open_to_publish)
+    where(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)).or(upcoming_cycles_open_to_publish)
   end
 
   scope :upcoming_cycles_open_to_publish, lambda {

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -12,11 +12,11 @@ class RecruitmentCycle < ApplicationRecord
 
   class << self
     def current_recruitment_cycle!
-      find_by!(year: Find::CycleTimetable.current_year)
+      find_by!(year: Find::CycleTimetable.current_year.to_s)
     end
 
     def current_recruitment_cycle
-      find_by(year: Find::CycleTimetable.current_year)
+      find_by(year: Find::CycleTimetable.current_year.to_s)
     end
     alias_method :current, :current_recruitment_cycle
 
@@ -31,7 +31,7 @@ class RecruitmentCycle < ApplicationRecord
   end
 
   def self.current_and_upcoming_cycles_open_to_publish
-    where(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)).or(upcoming_cycles_open_to_publish)
+    where(year: Find::CycleTimetable.current_year).or(upcoming_cycles_open_to_publish)
   end
 
   scope :upcoming_cycles_open_to_publish, lambda {

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -215,7 +215,7 @@ module Courses
 
       @applied_scopes[:start_date] = params[:start_date]
 
-      current_recruitment_cycle_year = Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+      current_recruitment_cycle_year = Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
       september_range = Date.new(current_recruitment_cycle_year, 9, 1)..Date.new(current_recruitment_cycle_year, 9, 30)
 
       case params[:start_date]

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -215,7 +215,7 @@ module Courses
 
       @applied_scopes[:start_date] = params[:start_date]
 
-      current_recruitment_cycle_year = Settings.current_recruitment_cycle_year
+      current_recruitment_cycle_year = Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
       september_range = Date.new(current_recruitment_cycle_year, 9, 1)..Date.new(current_recruitment_cycle_year, 9, 30)
 
       case params[:start_date]

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -215,7 +215,7 @@ module Courses
 
       @applied_scopes[:start_date] = params[:start_date]
 
-      current_recruitment_cycle_year = Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+      current_recruitment_cycle_year = Find::CycleTimetable.current_year
       september_range = Date.new(current_recruitment_cycle_year, 9, 1)..Date.new(current_recruitment_cycle_year, 9, 30)
 
       case params[:start_date]

--- a/app/views/find/results/filters/_all.html.erb
+++ b/app/views/find/results/filters/_all.html.erb
@@ -104,7 +104,7 @@
   <% end %>
 
   <%= form.govuk_check_boxes_fieldset :start_date, legend: { text: t(".start_date_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-    <%= form.govuk_check_box :start_date, "september", label: { text: t(".start_date_options.september", recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)), size: "s" }, include_hidden: false %>
+    <%= form.govuk_check_box :start_date, "september", label: { text: t(".start_date_options.september", recruitment_cycle_year: Find::CycleTimetable.current_year), size: "s" }, include_hidden: false %>
     <%= form.govuk_check_box :start_date, "all_other_dates", label: { text: t(".start_date_options.all_other_dates", size: "s") }, include_hidden: false %>
   <% end %>
 

--- a/app/views/find/results/filters/_all.html.erb
+++ b/app/views/find/results/filters/_all.html.erb
@@ -104,7 +104,7 @@
   <% end %>
 
   <%= form.govuk_check_boxes_fieldset :start_date, legend: { text: t(".start_date_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-    <%= form.govuk_check_box :start_date, "september", label: { text: t(".start_date_options.september", recruitment_cycle_year: Settings.current_recruitment_cycle_year), size: "s" }, include_hidden: false %>
+    <%= form.govuk_check_box :start_date, "september", label: { text: t(".start_date_options.september", recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)), size: "s" }, include_hidden: false %>
     <%= form.govuk_check_box :start_date, "all_other_dates", label: { text: t(".start_date_options.all_other_dates", size: "s") }, include_hidden: false %>
   <% end %>
 

--- a/app/views/find/results/filters/_all.html.erb
+++ b/app/views/find/results/filters/_all.html.erb
@@ -104,7 +104,7 @@
   <% end %>
 
   <%= form.govuk_check_boxes_fieldset :start_date, legend: { text: t(".start_date_html"), size: "s" }, class: "app-filter__group govuk-checkboxes--small", multiple: false, form_group: { class: "app-filter__group" } do %>
-    <%= form.govuk_check_box :start_date, "september", label: { text: t(".start_date_options.september", recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)), size: "s" }, include_hidden: false %>
+    <%= form.govuk_check_box :start_date, "september", label: { text: t(".start_date_options.september", recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)), size: "s" }, include_hidden: false %>
     <%= form.govuk_check_box :start_date, "all_other_dates", label: { text: t(".start_date_options.all_other_dates", size: "s") }, include_hidden: false %>
   <% end %>
 

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -34,9 +34,9 @@
     <%= govuk_skip_link %>
 
     <%= render HeaderComponent.new(service_name: I18n.t("service_name.support"), service_url: support_root_path, current_user:) do |header| %>
-      <% header.with_navigation_item t(".providers"), support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) %>
+      <% header.with_navigation_item t(".providers"), support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Find::CycleTimetable.cycle_year_from_time(Time.zone.now)) %>
       <% header.with_navigation_item t(".candidates"), support_candidates_path if FeatureFlag.active?(:candidate_accounts) %>
-      <% header.with_navigation_item t(".users"), support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year) %>
+      <% header.with_navigation_item t(".users"), support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Find::CycleTimetable.cycle_year_from_time(Time.zone.now)) %>
       <% header.with_navigation_item t(".feedbacks"), support_feedback_index_path %>
       <% header.with_navigation_item t(".settings"), support_settings_path %>
       <% header.with_phase_banner_text t(".phase_banner_text", feedback_link: govuk_link_to("feedback", "#", new_tab: true)) %>

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -34,9 +34,9 @@
     <%= govuk_skip_link %>
 
     <%= render HeaderComponent.new(service_name: I18n.t("service_name.support"), service_url: support_root_path, current_user:) do |header| %>
-      <% header.with_navigation_item t(".providers"), support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Find::CycleTimetable.cycle_year_for_time(Time.zone.now)) %>
+      <% header.with_navigation_item t(".providers"), support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Find::CycleTimetable.current_year) %>
       <% header.with_navigation_item t(".candidates"), support_candidates_path if FeatureFlag.active?(:candidate_accounts) %>
-      <% header.with_navigation_item t(".users"), support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Find::CycleTimetable.cycle_year_for_time(Time.zone.now)) %>
+      <% header.with_navigation_item t(".users"), support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Find::CycleTimetable.current_year) %>
       <% header.with_navigation_item t(".feedbacks"), support_feedback_index_path %>
       <% header.with_navigation_item t(".settings"), support_settings_path %>
       <% header.with_phase_banner_text t(".phase_banner_text", feedback_link: govuk_link_to("feedback", "#", new_tab: true)) %>
@@ -47,7 +47,7 @@
       <%= yield :breadcrumbs %>
     </div>
 
-    <%= render partial: "publish/shared/navigation_bar" %>
+    <%#= render partial: "publish/shared/navigation_bar" %>
 
     <div class="govuk-width-container">
       <%= yield :before_content %>

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -34,9 +34,9 @@
     <%= govuk_skip_link %>
 
     <%= render HeaderComponent.new(service_name: I18n.t("service_name.support"), service_url: support_root_path, current_user:) do |header| %>
-      <% header.with_navigation_item t(".providers"), support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Find::CycleTimetable.cycle_year_from_time(Time.zone.now)) %>
+      <% header.with_navigation_item t(".providers"), support_recruitment_cycle_providers_path(params[:recruitment_cycle_year] || Find::CycleTimetable.cycle_year_for_time(Time.zone.now)) %>
       <% header.with_navigation_item t(".candidates"), support_candidates_path if FeatureFlag.active?(:candidate_accounts) %>
-      <% header.with_navigation_item t(".users"), support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Find::CycleTimetable.cycle_year_from_time(Time.zone.now)) %>
+      <% header.with_navigation_item t(".users"), support_recruitment_cycle_users_path(params[:recruitment_cycle_year] || Find::CycleTimetable.cycle_year_for_time(Time.zone.now)) %>
       <% header.with_navigation_item t(".feedbacks"), support_feedback_index_path %>
       <% header.with_navigation_item t(".settings"), support_settings_path %>
       <% header.with_phase_banner_text t(".phase_banner_text", feedback_link: govuk_link_to("feedback", "#", new_tab: true)) %>

--- a/app/views/publish/recruitment_cycles/_show_during_rollover.html.erb
+++ b/app/views/publish/recruitment_cycles/_show_during_rollover.html.erb
@@ -2,7 +2,7 @@
   <li>
     <%= govuk_link_to(
     "#{current_recruitment_cycle_period_text} - current",
-    publish_provider_recruitment_cycle_path(@provider.provider_code, Find::CycleTimetable.cycle_year_for_time(Time.zone.now)),
+    publish_provider_recruitment_cycle_path(@provider.provider_code, Find::CycleTimetable.current_year),
     data: { qa: "provider__courses__current_cycle" },
   ) %>
   </li>

--- a/app/views/publish/recruitment_cycles/_show_during_rollover.html.erb
+++ b/app/views/publish/recruitment_cycles/_show_during_rollover.html.erb
@@ -2,7 +2,7 @@
   <li>
     <%= govuk_link_to(
     "#{current_recruitment_cycle_period_text} - current",
-    publish_provider_recruitment_cycle_path(@provider.provider_code, Find::CycleTimetable.cycle_year_from_time(Time.zone.now)),
+    publish_provider_recruitment_cycle_path(@provider.provider_code, Find::CycleTimetable.cycle_year_for_time(Time.zone.now)),
     data: { qa: "provider__courses__current_cycle" },
   ) %>
   </li>

--- a/app/views/publish/recruitment_cycles/_show_during_rollover.html.erb
+++ b/app/views/publish/recruitment_cycles/_show_during_rollover.html.erb
@@ -2,7 +2,7 @@
   <li>
     <%= govuk_link_to(
     "#{current_recruitment_cycle_period_text} - current",
-    publish_provider_recruitment_cycle_path(@provider.provider_code, Settings.current_recruitment_cycle_year),
+    publish_provider_recruitment_cycle_path(@provider.provider_code, Find::CycleTimetable.cycle_year_from_time(Time.zone.now)),
     data: { qa: "provider__courses__current_cycle" },
   ) %>
   </li>

--- a/app/views/publish/shared/_aside_information_box.html.erb
+++ b/app/views/publish/shared/_aside_information_box.html.erb
@@ -5,9 +5,9 @@
 
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-    <h2 class="govuk-heading-s">Your courses for the <%= "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1}" %> cycle</h2>
+    <h2 class="govuk-heading-s">Your courses for the <%= "#{Find::CycleTimetable.current_year} to #{Find::CycleTimetable.next_year}" %> cycle</h2>
     <p class="govuk-body">
-      Courses you publish for the <%= "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1}" %> cycle will be made available on <%= t("service_name.find") %> for candidates to view.
+      Courses you publish for the <%= "#{Find::CycleTimetable.current_year} to #{Find::CycleTimetable.next_year}" %> cycle will be made available on <%= t("service_name.find") %> for candidates to view.
     </p>
 
     <h2 class="govuk-heading-s">Support and guidance</h2>

--- a/app/views/publish/shared/_aside_information_box.html.erb
+++ b/app/views/publish/shared/_aside_information_box.html.erb
@@ -5,9 +5,9 @@
 
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-    <h2 class="govuk-heading-s">Your courses for the <%= "#{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}" %> cycle</h2>
+    <h2 class="govuk-heading-s">Your courses for the <%= "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1}" %> cycle</h2>
     <p class="govuk-body">
-      Courses you publish for the <%= "#{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}" %> cycle will be made available on <%= t("service_name.find") %> for candidates to view.
+      Courses you publish for the <%= "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1}" %> cycle will be made available on <%= t("service_name.find") %> for candidates to view.
     </p>
 
     <h2 class="govuk-heading-s">Support and guidance</h2>

--- a/app/views/publish/shared/_aside_information_box.html.erb
+++ b/app/views/publish/shared/_aside_information_box.html.erb
@@ -5,9 +5,9 @@
 
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-    <h2 class="govuk-heading-s">Your courses for the <%= "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1}" %> cycle</h2>
+    <h2 class="govuk-heading-s">Your courses for the <%= "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1}" %> cycle</h2>
     <p class="govuk-body">
-      Courses you publish for the <%= "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1}" %> cycle will be made available on <%= t("service_name.find") %> for candidates to view.
+      Courses you publish for the <%= "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1}" %> cycle will be made available on <%= t("service_name.find") %> for candidates to view.
     </p>
 
     <h2 class="govuk-heading-s">Support and guidance</h2>

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -80,7 +80,7 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
     post "/request-access", on: :member, to: "providers/access_requests#create"
     get "schools"
 
-    resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year - 1}|#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "", only: [:show] do
+    resources :recruitment_cycles, param: :year, constraints: CycleYearConstraint.new, path: "", only: [:show] do
       get "/about", on: :member, to: "providers#about"
       put "/about", on: :member, to: "providers#update"
       get "/details", on: :member, to: "providers#details"

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -5,7 +5,7 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
 
   resources :feedbacks, only: %i[index show], path: "feedback", as: :feedback
 
-  resources :recruitment_cycle, only: %i[index], param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year - 1}|#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "" do
+  resources :recruitment_cycle, only: %i[index], param: :year, constraints: CycleYearConstraint.new, path: "" do
     namespace :providers do
       namespace :onboarding do
         resource :contacts, only: %i[new create]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ Provider.destroy_all
 User.destroy_all
 RecruitmentCycle.destroy_all
 
-current_recruitment_year = Settings.current_recruitment_cycle_year
+current_recruitment_year = Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
 current_recruitment_cycle = RecruitmentCycle.create(year: current_recruitment_year, application_start_date: Date.new(current_recruitment_year.to_i - 1, 10, 9), application_end_date: Date.new(current_recruitment_year.to_i, 9, 30))
 next_recruitment_cycle = RecruitmentCycle.create(year: (current_recruitment_year.to_i + 1).to_s, application_start_date: Date.new(current_recruitment_year.to_i, 10, 8), application_end_date: Date.new(current_recruitment_year.to_i + 1, 9, 30))
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ Provider.destroy_all
 User.destroy_all
 RecruitmentCycle.destroy_all
 
-current_recruitment_year = Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+current_recruitment_year = Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
 current_recruitment_cycle = RecruitmentCycle.create(year: current_recruitment_year, application_start_date: Date.new(current_recruitment_year.to_i - 1, 10, 9), application_end_date: Date.new(current_recruitment_year.to_i, 9, 30))
 next_recruitment_cycle = RecruitmentCycle.create(year: (current_recruitment_year.to_i + 1).to_s, application_start_date: Date.new(current_recruitment_year.to_i, 10, 8), application_end_date: Date.new(current_recruitment_year.to_i + 1, 9, 30))
 

--- a/spec/components/add_course_button_preview.rb
+++ b/spec/components/add_course_button_preview.rb
@@ -42,7 +42,7 @@ class AddCourseButtonPreview < ViewComponent::Preview
     end
 
     def recruitment_cycle_year
-      Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+      Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
     end
 
     def accredited?

--- a/spec/components/add_course_button_preview.rb
+++ b/spec/components/add_course_button_preview.rb
@@ -42,7 +42,7 @@ class AddCourseButtonPreview < ViewComponent::Preview
     end
 
     def recruitment_cycle_year
-      Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+      Find::CycleTimetable.current_year
     end
 
     def accredited?

--- a/spec/components/add_course_button_preview.rb
+++ b/spec/components/add_course_button_preview.rb
@@ -42,7 +42,7 @@ class AddCourseButtonPreview < ViewComponent::Preview
     end
 
     def recruitment_cycle_year
-      Settings.current_recruitment_cycle_year
+      Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
     end
 
     def accredited?

--- a/spec/components/gcse_row_content_preview.rb
+++ b/spec/components/gcse_row_content_preview.rb
@@ -2,7 +2,7 @@
 
 class GcseRowContentPreview < ViewComponent::Preview
   def incomplete
-    course = Course.new(course_code: "C0D3", provider: Provider.new(provider_code: "E2E", recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))))
+    course = Course.new(course_code: "C0D3", provider: Provider.new(provider_code: "E2E", recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.current_year)))
 
     render(GcseRowContent.new(course: course.decorate))
   end

--- a/spec/components/gcse_row_content_preview.rb
+++ b/spec/components/gcse_row_content_preview.rb
@@ -2,7 +2,7 @@
 
 class GcseRowContentPreview < ViewComponent::Preview
   def incomplete
-    course = Course.new(course_code: "C0D3", provider: Provider.new(provider_code: "E2E", recruitment_cycle: RecruitmentCycle.new(year: Settings.current_recruitment_cycle_year)))
+    course = Course.new(course_code: "C0D3", provider: Provider.new(provider_code: "E2E", recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))))
 
     render(GcseRowContent.new(course: course.decorate))
   end

--- a/spec/components/gcse_row_content_preview.rb
+++ b/spec/components/gcse_row_content_preview.rb
@@ -2,7 +2,7 @@
 
 class GcseRowContentPreview < ViewComponent::Preview
   def incomplete
-    course = Course.new(course_code: "C0D3", provider: Provider.new(provider_code: "E2E", recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))))
+    course = Course.new(course_code: "C0D3", provider: Provider.new(provider_code: "E2E", recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))))
 
     render(GcseRowContent.new(course: course.decorate))
   end

--- a/spec/components/providers/provider_list/view_preview.rb
+++ b/spec/components/providers/provider_list/view_preview.rb
@@ -4,15 +4,15 @@ module Providers
   module ProviderList
     class ViewPreview < ViewComponent::Preview
       def with_scitt_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "scitt", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Settings.current_recruitment_cycle_year))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "scitt", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)))))
       end
 
       def with_lead_school_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "lead_school", accredited: false, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Settings.current_recruitment_cycle_year))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "lead_school", accredited: false, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)))))
       end
 
       def with_university_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "university", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Settings.current_recruitment_cycle_year))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "university", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)))))
       end
     end
   end

--- a/spec/components/providers/provider_list/view_preview.rb
+++ b/spec/components/providers/provider_list/view_preview.rb
@@ -4,15 +4,15 @@ module Providers
   module ProviderList
     class ViewPreview < ViewComponent::Preview
       def with_scitt_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "scitt", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "scitt", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)))))
       end
 
       def with_lead_school_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "lead_school", accredited: false, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "lead_school", accredited: false, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)))))
       end
 
       def with_university_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "university", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "university", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)))))
       end
     end
   end

--- a/spec/components/providers/provider_list/view_preview.rb
+++ b/spec/components/providers/provider_list/view_preview.rb
@@ -4,15 +4,15 @@ module Providers
   module ProviderList
     class ViewPreview < ViewComponent::Preview
       def with_scitt_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "scitt", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "scitt", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.current_year))))
       end
 
       def with_lead_school_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "lead_school", accredited: false, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "lead_school", accredited: false, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.current_year))))
       end
 
       def with_university_provider
-        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "university", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)))))
+        render(ProviderList::View.new(provider: Provider.new(id: "1", provider_name: "University A", provider_code: "AA01", provider_type: "university", accredited: true, updated_at: Time.zone.now, recruitment_cycle: RecruitmentCycle.new(year: Find::CycleTimetable.current_year))))
       end
     end
   end

--- a/spec/controllers/api/accredited_provider_suggestions_controller_spec.rb
+++ b/spec/controllers/api/accredited_provider_suggestions_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe API::AccreditedProviderSuggestionsController do
       before do
         get :index, params: {
           query: "cl",
-          recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+          recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
         }
       end
 
@@ -27,7 +27,7 @@ RSpec.describe API::AccreditedProviderSuggestionsController do
       before do
         get :index, params: {
           query: "cla",
-          recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+          recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
         }
       end
 

--- a/spec/controllers/api/accredited_provider_suggestions_controller_spec.rb
+++ b/spec/controllers/api/accredited_provider_suggestions_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe API::AccreditedProviderSuggestionsController do
       before do
         get :index, params: {
           query: "cl",
-          recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+          recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
         }
       end
 
@@ -27,7 +27,7 @@ RSpec.describe API::AccreditedProviderSuggestionsController do
       before do
         get :index, params: {
           query: "cla",
-          recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+          recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
         }
       end
 

--- a/spec/controllers/api/accredited_provider_suggestions_controller_spec.rb
+++ b/spec/controllers/api/accredited_provider_suggestions_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe API::AccreditedProviderSuggestionsController do
       before do
         get :index, params: {
           query: "cl",
-          recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+          recruitment_cycle_year: Find::CycleTimetable.current_year,
         }
       end
 
@@ -27,7 +27,7 @@ RSpec.describe API::AccreditedProviderSuggestionsController do
       before do
         get :index, params: {
           query: "cla",
-          recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+          recruitment_cycle_year: Find::CycleTimetable.current_year,
         }
       end
 

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
       parameter name: :filter,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/CourseFilter" },

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Settings.current_recruitment_cycle_year
+                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
       parameter name: :filter,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/CourseFilter" },

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+                example: Find::CycleTimetable.current_year
       parameter name: :filter,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/CourseFilter" },

--- a/spec/docs/providers/courses/locations_spec.rb
+++ b/spec/docs/providers/courses/locations_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/courses/locations_spec.rb
+++ b/spec/docs/providers/courses/locations_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Settings.current_recruitment_cycle_year
+                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/courses/locations_spec.rb
+++ b/spec/docs/providers/courses/locations_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+                example: Find::CycleTimetable.current_year
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -18,7 +18,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,
@@ -97,7 +97,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -18,7 +18,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Settings.current_recruitment_cycle_year
+                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,
@@ -97,7 +97,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Settings.current_recruitment_cycle_year
+                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -18,7 +18,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+                example: Find::CycleTimetable.current_year
       parameter name: :provider_code,
                 in: :path,
                 type: :string,
@@ -97,7 +97,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+                example: Find::CycleTimetable.current_year
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/locations_spec.rb
+++ b/spec/docs/providers/locations_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/locations_spec.rb
+++ b/spec/docs/providers/locations_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Settings.current_recruitment_cycle_year
+                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers/locations_spec.rb
+++ b/spec/docs/providers/locations_spec.rb
@@ -13,7 +13,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+                example: Find::CycleTimetable.current_year
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -16,7 +16,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+                example: Find::CycleTimetable.current_year
       parameter name: :sort,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Sort" },
@@ -80,7 +80,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
+                example: Find::CycleTimetable.current_year
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -16,7 +16,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Settings.current_recruitment_cycle_year
+                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
       parameter name: :sort,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Sort" },
@@ -80,7 +80,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Settings.current_recruitment_cycle_year
+                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -16,7 +16,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
       parameter name: :sort,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Sort" },
@@ -80,7 +80,7 @@ describe "API" do
                 type: :string,
                 required: true,
                 description: 'The starting year of the recruitment cycle. Also accepts "current" for the current recruitment cycle. Defaults to current recruitment cycle if invalid year (eg "1066") is provided',
-                example: Find::CycleTimetable.cycle_year_from_time(Time.zone.now)
+                example: Find::CycleTimetable.cycle_year_for_time(Time.zone.now)
       parameter name: :provider_code,
                 in: :path,
                 type: :string,

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -2,18 +2,18 @@
 
 FactoryBot.define do
   factory :recruitment_cycle do
-    year { Find::CycleTimetable.cycle_year_for_time(Time.zone.now) }
+    year { Find::CycleTimetable.current_year }
     application_start_date { Find::CycleTimetable.apply_opens(year) }
     application_end_date { Find::CycleTimetable.apply_deadline(year) }
     available_in_publish_from { application_start_date.to_date - 1.month }
     available_for_support_users_from { available_in_publish_from - 1.week }
 
     trait :previous do
-      year { (Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i - 1).to_s }
+      year { Find::CycleTimetable.previous_year }
     end
 
     trait :next do
-      year { (Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i + 1).to_s }
+      year { Find::CycleTimetable.next_year }
     end
   end
 end

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -2,18 +2,18 @@
 
 FactoryBot.define do
   factory :recruitment_cycle do
-    year { Find::CycleTimetable.cycle_year_from_time(Time.zone.now) }
+    year { Find::CycleTimetable.cycle_year_for_time(Time.zone.now) }
     application_start_date { Find::CycleTimetable.apply_opens(year) }
     application_end_date { Find::CycleTimetable.apply_deadline(year) }
     available_in_publish_from { application_start_date.to_date - 1.month }
     available_for_support_users_from { available_in_publish_from - 1.week }
 
     trait :previous do
-      year { (Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i - 1).to_s }
+      year { (Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i - 1).to_s }
     end
 
     trait :next do
-      year { (Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i + 1).to_s }
+      year { (Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i + 1).to_s }
     end
   end
 end

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -2,18 +2,18 @@
 
 FactoryBot.define do
   factory :recruitment_cycle do
-    year { Settings.current_recruitment_cycle_year }
+    year { Find::CycleTimetable.cycle_year_from_time(Time.zone.now) }
     application_start_date { Find::CycleTimetable.apply_opens(year) }
     application_end_date { Find::CycleTimetable.apply_deadline(year) }
     available_in_publish_from { application_start_date.to_date - 1.month }
     available_for_support_users_from { available_in_publish_from - 1.week }
 
     trait :previous do
-      year { (Settings.current_recruitment_cycle_year.to_i - 1).to_s }
+      year { (Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i - 1).to_s }
     end
 
     trait :next do
-      year { (Settings.current_recruitment_cycle_year.to_i + 1).to_s }
+      year { (Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i + 1).to_s }
     end
   end
 end

--- a/spec/features/find/switcher_cycles_spec.rb
+++ b/spec/features/find/switcher_cycles_spec.rb
@@ -7,6 +7,8 @@ feature "switcher cycle" do
     Timecop.freeze(2022, 10, 12)
     allow(ENV).to receive(:[])
     allow(ENV).to receive(:[]).with("ENABLE_SWITCHER").and_return("1")
+    find_or_create(:recruitment_cycle, year: 2023)
+    find_or_create(:recruitment_cycle, year: 2024)
   end
 
   scenario "Navigate to /cycle" do

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -142,7 +142,7 @@ private
   end
 
   def then_i_should_be_on_the_confirmation_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/confirmation", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/confirmation", ignore_query: true)
   end
 
   def and_i_select_some_languages
@@ -173,7 +173,7 @@ private
   def when_i_visit_the_publish_course_confirmation_page
     publish_course_confirmation_page.load(
       provider_code: provider.provider_code,
-      recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+      recruitment_cycle_year: Find::CycleTimetable.current_year,
       query: confirmation_params(provider),
     )
   end
@@ -206,7 +206,7 @@ private
     expect_summary_list_to_include(key: "Funding type", value: "Salary (apprenticeship)")
     expect_summary_list_to_include(key: "Study pattern", value: "Full time or part time")
     expect_summary_list_to_include(key: "Employing school", value: site.location_name)
-    expect_summary_list_to_include(key: "Course start date", value: "October #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i - 1}")
+    expect_summary_list_to_include(key: "Course start date", value: "October #{Find::CycleTimetable.next_year}")
   end
 
   def expect_summary_list_to_include(key:, value:)
@@ -224,7 +224,7 @@ private
   end
 
   def and_i_am_met_with_the_publish_courses_new_schools_page
-    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/schools/new")
+    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/schools/new")
   end
 
   def and_i_update_the_schools
@@ -232,7 +232,7 @@ private
   end
 
   def then_i_am_met_with_the_publish_course_confirmation_page
-    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/confirmation")
+    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/confirmation")
   end
 
   def and_i_select_no_student_visa

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -142,7 +142,7 @@ private
   end
 
   def then_i_should_be_on_the_confirmation_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/confirmation", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/confirmation", ignore_query: true)
   end
 
   def and_i_select_some_languages
@@ -173,7 +173,7 @@ private
   def when_i_visit_the_publish_course_confirmation_page
     publish_course_confirmation_page.load(
       provider_code: provider.provider_code,
-      recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+      recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
       query: confirmation_params(provider),
     )
   end
@@ -206,7 +206,7 @@ private
     expect_summary_list_to_include(key: "Funding type", value: "Salary (apprenticeship)")
     expect_summary_list_to_include(key: "Study pattern", value: "Full time or part time")
     expect_summary_list_to_include(key: "Employing school", value: site.location_name)
-    expect_summary_list_to_include(key: "Course start date", value: "October #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i - 1}")
+    expect_summary_list_to_include(key: "Course start date", value: "October #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i - 1}")
   end
 
   def expect_summary_list_to_include(key:, value:)
@@ -224,7 +224,7 @@ private
   end
 
   def and_i_am_met_with_the_publish_courses_new_schools_page
-    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/schools/new")
+    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/schools/new")
   end
 
   def and_i_update_the_schools
@@ -232,7 +232,7 @@ private
   end
 
   def then_i_am_met_with_the_publish_course_confirmation_page
-    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/confirmation")
+    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/confirmation")
   end
 
   def and_i_select_no_student_visa

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -142,7 +142,7 @@ private
   end
 
   def then_i_should_be_on_the_confirmation_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/confirmation", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/confirmation", ignore_query: true)
   end
 
   def and_i_select_some_languages
@@ -173,7 +173,7 @@ private
   def when_i_visit_the_publish_course_confirmation_page
     publish_course_confirmation_page.load(
       provider_code: provider.provider_code,
-      recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+      recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
       query: confirmation_params(provider),
     )
   end
@@ -206,7 +206,7 @@ private
     expect_summary_list_to_include(key: "Funding type", value: "Salary (apprenticeship)")
     expect_summary_list_to_include(key: "Study pattern", value: "Full time or part time")
     expect_summary_list_to_include(key: "Employing school", value: site.location_name)
-    expect_summary_list_to_include(key: "Course start date", value: "October #{Settings.current_recruitment_cycle_year.to_i - 1}")
+    expect_summary_list_to_include(key: "Course start date", value: "October #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i - 1}")
   end
 
   def expect_summary_list_to_include(key:, value:)
@@ -224,7 +224,7 @@ private
   end
 
   def and_i_am_met_with_the_publish_courses_new_schools_page
-    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/schools/new")
+    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/schools/new")
   end
 
   def and_i_update_the_schools
@@ -232,7 +232,7 @@ private
   end
 
   def then_i_am_met_with_the_publish_course_confirmation_page
-    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/confirmation")
+    expect(page.current_url).to include("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/confirmation")
   end
 
   def and_i_select_no_student_visa

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -66,7 +66,7 @@ feature "Editing course application status" do
   end
 
   def then_i_am_on_the_application_status_confirm_page
-    expect(page).to have_current_path("/publish/organisations/#{course.provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/application_status")
+    expect(page).to have_current_path("/publish/organisations/#{course.provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/application_status")
   end
 
   def and_i_click_open_course

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -66,7 +66,7 @@ feature "Editing course application status" do
   end
 
   def then_i_am_on_the_application_status_confirm_page
-    expect(page).to have_current_path("/publish/organisations/#{course.provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/application_status")
+    expect(page).to have_current_path("/publish/organisations/#{course.provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/application_status")
   end
 
   def and_i_click_open_course

--- a/spec/features/publish/courses/editing_application_status_spec.rb
+++ b/spec/features/publish/courses/editing_application_status_spec.rb
@@ -66,7 +66,7 @@ feature "Editing course application status" do
   end
 
   def then_i_am_on_the_application_status_confirm_page
-    expect(page).to have_current_path("/publish/organisations/#{course.provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/application_status")
+    expect(page).to have_current_path("/publish/organisations/#{course.provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/application_status")
   end
 
   def and_i_click_open_course

--- a/spec/features/publish/courses/editing_apprenticeship_spec.rb
+++ b/spec/features/publish/courses/editing_apprenticeship_spec.rb
@@ -52,7 +52,7 @@ private
   end
 
   def then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/funding-type")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/funding-type")
   end
 
   def and_i_am_authenticated_as_accredited_provider_provider_user

--- a/spec/features/publish/courses/editing_apprenticeship_spec.rb
+++ b/spec/features/publish/courses/editing_apprenticeship_spec.rb
@@ -52,7 +52,7 @@ private
   end
 
   def then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/funding-type")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/funding-type")
   end
 
   def and_i_am_authenticated_as_accredited_provider_provider_user

--- a/spec/features/publish/courses/editing_apprenticeship_spec.rb
+++ b/spec/features/publish/courses/editing_apprenticeship_spec.rb
@@ -52,7 +52,7 @@ private
   end
 
   def then_i_should_be_on_the_publish_courses_apprenticeship_edit_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/funding-type")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/funding-type")
   end
 
   def and_i_am_authenticated_as_accredited_provider_provider_user

--- a/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
@@ -102,7 +102,7 @@ private
   end
 
   def when_i_visit_the_edit_course_subject_page
-    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), course_code: course.course_code)
+    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), course_code: course.course_code)
   end
 
   def when_i_select_a_subject(subject_type)
@@ -126,29 +126,29 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/details")
   end
 
   def then_i_return_to_the_edit_course_subject_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/subjects")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/subjects")
   end
 
   def then_i_return_to_the_edit_engineers_teach_physics_with_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{course_subject_ids}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{course_subject_ids}")
   end
 
   def then_i_am_met_with_the_publish_courses_edit_engineers_teach_physics_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{params_with_subject}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{params_with_subject}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_edit_engineers_teach_physics_with_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{modern_languages_with_form_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{modern_languages_with_form_params}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_edit_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/modern-languages?#{modern_languages_subject_ids}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/modern-languages?#{modern_languages_subject_ids}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
@@ -102,7 +102,7 @@ private
   end
 
   def when_i_visit_the_edit_course_subject_page
-    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, course_code: course.course_code)
+    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), course_code: course.course_code)
   end
 
   def when_i_select_a_subject(subject_type)
@@ -126,29 +126,29 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/details")
   end
 
   def then_i_return_to_the_edit_course_subject_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/subjects")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/subjects")
   end
 
   def then_i_return_to_the_edit_engineers_teach_physics_with_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/engineers_teach_physics?#{course_subject_ids}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{course_subject_ids}")
   end
 
   def then_i_am_met_with_the_publish_courses_edit_engineers_teach_physics_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/engineers_teach_physics?#{params_with_subject}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{params_with_subject}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_edit_engineers_teach_physics_with_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/engineers_teach_physics?#{modern_languages_with_form_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{modern_languages_with_form_params}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_edit_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/modern-languages?#{modern_languages_subject_ids}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/modern-languages?#{modern_languages_subject_ids}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/editing_engineers_teach_physics_spec.rb
@@ -102,7 +102,7 @@ private
   end
 
   def when_i_visit_the_edit_course_subject_page
-    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), course_code: course.course_code)
+    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, course_code: course.course_code)
   end
 
   def when_i_select_a_subject(subject_type)
@@ -126,29 +126,29 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/details")
   end
 
   def then_i_return_to_the_edit_course_subject_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/subjects")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/subjects")
   end
 
   def then_i_return_to_the_edit_engineers_teach_physics_with_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{course_subject_ids}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/engineers_teach_physics?#{course_subject_ids}")
   end
 
   def then_i_am_met_with_the_publish_courses_edit_engineers_teach_physics_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{params_with_subject}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/engineers_teach_physics?#{params_with_subject}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_edit_engineers_teach_physics_with_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/engineers_teach_physics?#{modern_languages_with_form_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/engineers_teach_physics?#{modern_languages_with_form_params}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_edit_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/modern-languages?#{modern_languages_subject_ids}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/modern-languages?#{modern_languages_subject_ids}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/editing_funding_type_spec.rb
+++ b/spec/features/publish/courses/editing_funding_type_spec.rb
@@ -80,7 +80,7 @@ private
   end
 
   def then_i_should_be_on_the_publish_courses_funding_type_edit_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/funding-type")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/funding-type")
   end
 
   def and_i_am_authenticated_as_a_lead_school_provider_user

--- a/spec/features/publish/courses/editing_funding_type_spec.rb
+++ b/spec/features/publish/courses/editing_funding_type_spec.rb
@@ -80,7 +80,7 @@ private
   end
 
   def then_i_should_be_on_the_publish_courses_funding_type_edit_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/funding-type")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/funding-type")
   end
 
   def and_i_am_authenticated_as_a_lead_school_provider_user

--- a/spec/features/publish/courses/editing_funding_type_spec.rb
+++ b/spec/features/publish/courses/editing_funding_type_spec.rb
@@ -80,7 +80,7 @@ private
   end
 
   def then_i_should_be_on_the_publish_courses_funding_type_edit_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/funding-type")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/funding-type")
   end
 
   def and_i_am_authenticated_as_a_lead_school_provider_user

--- a/spec/features/publish/courses/editing_modern_languages_spec.rb
+++ b/spec/features/publish/courses/editing_modern_languages_spec.rb
@@ -60,7 +60,7 @@ private
 
   def when_i_visit_the_edit_course_modern_languages_page(with_invalid_query: false)
     query = edit_course_modern_languages_page_with_query(invalid: with_invalid_query)
-    publish_courses_modern_languages_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), course_code: course.course_code, query:)
+    publish_courses_modern_languages_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, course_code: course.course_code, query:)
   end
 
   def and_i_click_continue
@@ -93,7 +93,7 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/details")
   end
 
   def then_i_am_redirected_to_course_details_page

--- a/spec/features/publish/courses/editing_modern_languages_spec.rb
+++ b/spec/features/publish/courses/editing_modern_languages_spec.rb
@@ -60,7 +60,7 @@ private
 
   def when_i_visit_the_edit_course_modern_languages_page(with_invalid_query: false)
     query = edit_course_modern_languages_page_with_query(invalid: with_invalid_query)
-    publish_courses_modern_languages_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, course_code: course.course_code, query:)
+    publish_courses_modern_languages_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), course_code: course.course_code, query:)
   end
 
   def and_i_click_continue
@@ -93,7 +93,7 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/details")
   end
 
   def then_i_am_redirected_to_course_details_page

--- a/spec/features/publish/courses/editing_modern_languages_spec.rb
+++ b/spec/features/publish/courses/editing_modern_languages_spec.rb
@@ -60,7 +60,7 @@ private
 
   def when_i_visit_the_edit_course_modern_languages_page(with_invalid_query: false)
     query = edit_course_modern_languages_page_with_query(invalid: with_invalid_query)
-    publish_courses_modern_languages_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), course_code: course.course_code, query:)
+    publish_courses_modern_languages_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), course_code: course.course_code, query:)
   end
 
   def and_i_click_continue
@@ -93,7 +93,7 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/details")
   end
 
   def then_i_am_redirected_to_course_details_page

--- a/spec/features/publish/courses/editing_subject_spec.rb
+++ b/spec/features/publish/courses/editing_subject_spec.rb
@@ -107,7 +107,7 @@ private
   end
 
   def when_i_visit_the_edit_course_subject_page
-    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), course_code: course.course_code)
+    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, course_code: course.course_code)
   end
 
   def when_i_select_a_primary_subject(subject_type)
@@ -143,14 +143,14 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/details")
   end
 
   def then_i_am_met_with_the_modern_languages_page(extra_subject = nil)
     expect(page).to have_current_path(
       [
         "/publish/organisations/#{provider.provider_code}/",
-        "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/",
+        "#{Find::CycleTimetable.current_year}/",
         "courses/#{course.course_code}/modern-languages?",
         params_with_subject(extra_subject).to_s,
       ].join,

--- a/spec/features/publish/courses/editing_subject_spec.rb
+++ b/spec/features/publish/courses/editing_subject_spec.rb
@@ -107,7 +107,7 @@ private
   end
 
   def when_i_visit_the_edit_course_subject_page
-    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), course_code: course.course_code)
+    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), course_code: course.course_code)
   end
 
   def when_i_select_a_primary_subject(subject_type)
@@ -143,14 +143,14 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/details")
   end
 
   def then_i_am_met_with_the_modern_languages_page(extra_subject = nil)
     expect(page).to have_current_path(
       [
         "/publish/organisations/#{provider.provider_code}/",
-        "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/",
+        "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/",
         "courses/#{course.course_code}/modern-languages?",
         params_with_subject(extra_subject).to_s,
       ].join,

--- a/spec/features/publish/courses/editing_subject_spec.rb
+++ b/spec/features/publish/courses/editing_subject_spec.rb
@@ -107,7 +107,7 @@ private
   end
 
   def when_i_visit_the_edit_course_subject_page
-    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, course_code: course.course_code)
+    publish_courses_subjects_edit_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), course_code: course.course_code)
   end
 
   def when_i_select_a_primary_subject(subject_type)
@@ -143,14 +143,14 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/details")
   end
 
   def then_i_am_met_with_the_modern_languages_page(extra_subject = nil)
     expect(page).to have_current_path(
       [
         "/publish/organisations/#{provider.provider_code}/",
-        "#{Settings.current_recruitment_cycle_year}/",
+        "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/",
         "courses/#{course.course_code}/modern-languages?",
         params_with_subject(extra_subject).to_s,
       ].join,

--- a/spec/features/publish/courses/new_age_range_spec.rb
+++ b/spec/features/publish/courses/new_age_range_spec.rb
@@ -37,7 +37,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_age_range_page
-    publish_courses_new_age_range_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: age_range_params)
+    publish_courses_new_age_range_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: age_range_params)
   end
 
   def when_i_select_an_age_range
@@ -62,7 +62,7 @@ private
   end
 
   def then_i_am_met_with_the_course_outcome_page(age_range)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/outcome/new#{selected_params(age_range)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/outcome/new#{selected_params(age_range)}")
     expect(page).to have_content("Qualification")
   end
 

--- a/spec/features/publish/courses/new_age_range_spec.rb
+++ b/spec/features/publish/courses/new_age_range_spec.rb
@@ -37,7 +37,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_age_range_page
-    publish_courses_new_age_range_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: age_range_params)
+    publish_courses_new_age_range_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: age_range_params)
   end
 
   def when_i_select_an_age_range
@@ -62,7 +62,7 @@ private
   end
 
   def then_i_am_met_with_the_course_outcome_page(age_range)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/outcome/new#{selected_params(age_range)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/outcome/new#{selected_params(age_range)}")
     expect(page).to have_content("Qualification")
   end
 

--- a/spec/features/publish/courses/new_age_range_spec.rb
+++ b/spec/features/publish/courses/new_age_range_spec.rb
@@ -37,7 +37,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_age_range_page
-    publish_courses_new_age_range_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: age_range_params)
+    publish_courses_new_age_range_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: age_range_params)
   end
 
   def when_i_select_an_age_range
@@ -62,7 +62,7 @@ private
   end
 
   def then_i_am_met_with_the_course_outcome_page(age_range)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/outcome/new#{selected_params(age_range)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/outcome/new#{selected_params(age_range)}")
     expect(page).to have_content("Qualification")
   end
 

--- a/spec/features/publish/courses/new_course_outcome_spec.rb
+++ b/spec/features/publish/courses/new_course_outcome_spec.rb
@@ -39,7 +39,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_outcome_page
-    publish_courses_new_outcome_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: outcome_params)
+    publish_courses_new_outcome_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: outcome_params)
   end
 
   def when_i_select_an_outcome(outcome)
@@ -55,7 +55,7 @@ private
   end
 
   def then_i_am_met_with_the_funding_type_page(outcome)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/funding-type/new#{selected_params(outcome)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/funding-type/new#{selected_params(outcome)}")
     expect(page).to have_content("Funding type")
   end
 

--- a/spec/features/publish/courses/new_course_outcome_spec.rb
+++ b/spec/features/publish/courses/new_course_outcome_spec.rb
@@ -39,7 +39,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_outcome_page
-    publish_courses_new_outcome_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: outcome_params)
+    publish_courses_new_outcome_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: outcome_params)
   end
 
   def when_i_select_an_outcome(outcome)
@@ -55,7 +55,7 @@ private
   end
 
   def then_i_am_met_with_the_funding_type_page(outcome)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/funding-type/new#{selected_params(outcome)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/funding-type/new#{selected_params(outcome)}")
     expect(page).to have_content("Funding type")
   end
 

--- a/spec/features/publish/courses/new_course_outcome_spec.rb
+++ b/spec/features/publish/courses/new_course_outcome_spec.rb
@@ -39,7 +39,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_outcome_page
-    publish_courses_new_outcome_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: outcome_params)
+    publish_courses_new_outcome_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: outcome_params)
   end
 
   def when_i_select_an_outcome(outcome)
@@ -55,7 +55,7 @@ private
   end
 
   def then_i_am_met_with_the_funding_type_page(outcome)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/funding-type/new#{selected_params(outcome)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/funding-type/new#{selected_params(outcome)}")
     expect(page).to have_content("Funding type")
   end
 

--- a/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
@@ -71,7 +71,7 @@ private
   end
 
   def when_i_visit_the_new_course_subject_page(level)
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: level_params(level))
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: level_params(level))
   end
 
   def and_i_select_a_subject(subject_type)
@@ -99,42 +99,42 @@ private
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_subject(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/engineers-teach-physics/new?#{params_with_subject(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page_with_etp(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_etp(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/engineers-teach-physics/new?#{params_with_etp(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page_with_no_etp(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_no_etp(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/engineers-teach-physics/new?#{params_with_no_etp(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_with_languages_page(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{modern_language_params_with_subject(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/engineers-teach-physics/new?#{modern_language_params_with_subject(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_age_range_page(level, subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new?#{params_with_etp(level, subject_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/age-range/new?#{params_with_etp(level, subject_type)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_age_range_page_with_latin(level, subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new?#{form_params_with_latin(level, subject_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/age-range/new?#{form_params_with_latin(level, subject_type)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
     expect(page).to have_content("Languages")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
@@ -71,7 +71,7 @@ private
   end
 
   def when_i_visit_the_new_course_subject_page(level)
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: level_params(level))
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: level_params(level))
   end
 
   def and_i_select_a_subject(subject_type)
@@ -99,42 +99,42 @@ private
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_subject(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_subject(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page_with_etp(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_etp(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_etp(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page_with_no_etp(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_no_etp(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_no_etp(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_with_languages_page(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{modern_language_params_with_subject(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{modern_language_params_with_subject(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_age_range_page(level, subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new?#{params_with_etp(level, subject_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new?#{params_with_etp(level, subject_type)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_age_range_page_with_latin(level, subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new?#{form_params_with_latin(level, subject_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new?#{form_params_with_latin(level, subject_type)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
     expect(page).to have_content("Languages")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
+++ b/spec/features/publish/courses/new_engineers_teach_physics_spec.rb
@@ -71,7 +71,7 @@ private
   end
 
   def when_i_visit_the_new_course_subject_page(level)
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: level_params(level))
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: level_params(level))
   end
 
   def and_i_select_a_subject(subject_type)
@@ -99,42 +99,42 @@ private
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/engineers-teach-physics/new?#{params_with_subject(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_subject(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page_with_etp(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/engineers-teach-physics/new?#{params_with_etp(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_etp(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_page_with_no_etp(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/engineers-teach-physics/new?#{params_with_no_etp(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{params_with_no_etp(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_engineers_teach_physics_with_languages_page(_level, _subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/engineers-teach-physics/new?#{modern_language_params_with_subject(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/engineers-teach-physics/new?#{modern_language_params_with_subject(:secondary, :physics)}")
     expect(page).to have_content("Engineers Teach Physics")
   end
 
   def then_i_am_met_with_the_age_range_page(level, subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/age-range/new?#{params_with_etp(level, subject_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new?#{params_with_etp(level, subject_type)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_age_range_page_with_latin(level, subject_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/age-range/new?#{form_params_with_latin(level, subject_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new?#{form_params_with_latin(level, subject_type)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
     expect(page).to have_content("Languages")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/modern-languages/new?#{modern_languages_with_form_params(:secondary, :physics)}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/new_funding_type_spec.rb
+++ b/spec/features/publish/courses/new_funding_type_spec.rb
@@ -48,7 +48,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_funding_type_page
-    publish_courses_new_funding_type_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: funding_type_params)
+    publish_courses_new_funding_type_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: funding_type_params)
   end
 
   def when_i_select_funding_type(funding_type)
@@ -80,7 +80,7 @@ private
   end
 
   def then_i_am_met_with_the_full_or_part_time_page(funding_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/full-part-time/new#{selected_params(funding_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/full-part-time/new#{selected_params(funding_type)}")
     expect(page).to have_content("Study pattern")
   end
 

--- a/spec/features/publish/courses/new_funding_type_spec.rb
+++ b/spec/features/publish/courses/new_funding_type_spec.rb
@@ -48,7 +48,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_funding_type_page
-    publish_courses_new_funding_type_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: funding_type_params)
+    publish_courses_new_funding_type_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: funding_type_params)
   end
 
   def when_i_select_funding_type(funding_type)
@@ -80,7 +80,7 @@ private
   end
 
   def then_i_am_met_with_the_full_or_part_time_page(funding_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/full-part-time/new#{selected_params(funding_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/full-part-time/new#{selected_params(funding_type)}")
     expect(page).to have_content("Study pattern")
   end
 

--- a/spec/features/publish/courses/new_funding_type_spec.rb
+++ b/spec/features/publish/courses/new_funding_type_spec.rb
@@ -48,7 +48,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_funding_type_page
-    publish_courses_new_funding_type_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: funding_type_params)
+    publish_courses_new_funding_type_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: funding_type_params)
   end
 
   def when_i_select_funding_type(funding_type)
@@ -80,7 +80,7 @@ private
   end
 
   def then_i_am_met_with_the_full_or_part_time_page(funding_type)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/full-part-time/new#{selected_params(funding_type)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/full-part-time/new#{selected_params(funding_type)}")
     expect(page).to have_content("Study pattern")
   end
 

--- a/spec/features/publish/courses/new_level_spec.rb
+++ b/spec/features/publish/courses/new_level_spec.rb
@@ -58,7 +58,7 @@ private
   end
 
   def and_i_visit_the_new_course_level_page
-    publish_courses_new_level_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    publish_courses_new_level_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def given_i_select_primary_level
@@ -96,17 +96,17 @@ private
   end
 
   def then_i_am_met_with_the_primary_subjects_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/subjects/new#{primary_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/subjects/new#{primary_level_selected_params}")
     expect(page).to have_content("Subject")
   end
 
   def then_i_am_met_with_the_secondary_subjects_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/subjects/new#{secondary_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/subjects/new#{secondary_level_selected_params}")
     expect(page).to have_content("Subject")
   end
 
   def then_i_am_met_with_the_course_outcome_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/outcome/new#{further_education_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/outcome/new#{further_education_level_selected_params}")
     expect(page).to have_content("Qualification")
   end
 

--- a/spec/features/publish/courses/new_level_spec.rb
+++ b/spec/features/publish/courses/new_level_spec.rb
@@ -58,7 +58,7 @@ private
   end
 
   def and_i_visit_the_new_course_level_page
-    publish_courses_new_level_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    publish_courses_new_level_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def given_i_select_primary_level
@@ -96,17 +96,17 @@ private
   end
 
   def then_i_am_met_with_the_primary_subjects_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/subjects/new#{primary_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/subjects/new#{primary_level_selected_params}")
     expect(page).to have_content("Subject")
   end
 
   def then_i_am_met_with_the_secondary_subjects_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/subjects/new#{secondary_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/subjects/new#{secondary_level_selected_params}")
     expect(page).to have_content("Subject")
   end
 
   def then_i_am_met_with_the_course_outcome_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/outcome/new#{further_education_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/outcome/new#{further_education_level_selected_params}")
     expect(page).to have_content("Qualification")
   end
 

--- a/spec/features/publish/courses/new_level_spec.rb
+++ b/spec/features/publish/courses/new_level_spec.rb
@@ -58,7 +58,7 @@ private
   end
 
   def and_i_visit_the_new_course_level_page
-    publish_courses_new_level_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    publish_courses_new_level_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def given_i_select_primary_level
@@ -96,17 +96,17 @@ private
   end
 
   def then_i_am_met_with_the_primary_subjects_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/subjects/new#{primary_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/subjects/new#{primary_level_selected_params}")
     expect(page).to have_content("Subject")
   end
 
   def then_i_am_met_with_the_secondary_subjects_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/subjects/new#{secondary_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/subjects/new#{secondary_level_selected_params}")
     expect(page).to have_content("Subject")
   end
 
   def then_i_am_met_with_the_course_outcome_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/outcome/new#{further_education_level_selected_params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/outcome/new#{further_education_level_selected_params}")
     expect(page).to have_content("Qualification")
   end
 

--- a/spec/features/publish/courses/new_modern_languages_spec.rb
+++ b/spec/features/publish/courses/new_modern_languages_spec.rb
@@ -49,7 +49,7 @@ private
 
   def when_i_visit_the_new_course_modern_languages_page(with_invalid_query: false)
     query = new_course_modern_languages_page_with_query(invalid: with_invalid_query)
-    publish_courses_new_modern_languages_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query:)
+    publish_courses_new_modern_languages_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query:)
   end
 
   def and_i_click_continue
@@ -83,7 +83,7 @@ private
 
   def then_i_am_met_with_the_age_range_page(with_invalid_params: false)
     params = selected_params(with_subjects: with_invalid_params)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new#{params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new#{params}")
     expect(page).to have_content("Age range")
   end
 

--- a/spec/features/publish/courses/new_modern_languages_spec.rb
+++ b/spec/features/publish/courses/new_modern_languages_spec.rb
@@ -49,7 +49,7 @@ private
 
   def when_i_visit_the_new_course_modern_languages_page(with_invalid_query: false)
     query = new_course_modern_languages_page_with_query(invalid: with_invalid_query)
-    publish_courses_new_modern_languages_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query:)
+    publish_courses_new_modern_languages_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query:)
   end
 
   def and_i_click_continue
@@ -83,7 +83,7 @@ private
 
   def then_i_am_met_with_the_age_range_page(with_invalid_params: false)
     params = selected_params(with_subjects: with_invalid_params)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new#{params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/age-range/new#{params}")
     expect(page).to have_content("Age range")
   end
 

--- a/spec/features/publish/courses/new_modern_languages_spec.rb
+++ b/spec/features/publish/courses/new_modern_languages_spec.rb
@@ -49,7 +49,7 @@ private
 
   def when_i_visit_the_new_course_modern_languages_page(with_invalid_query: false)
     query = new_course_modern_languages_page_with_query(invalid: with_invalid_query)
-    publish_courses_new_modern_languages_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query:)
+    publish_courses_new_modern_languages_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query:)
   end
 
   def and_i_click_continue
@@ -83,7 +83,7 @@ private
 
   def then_i_am_met_with_the_age_range_page(with_invalid_params: false)
     params = selected_params(with_subjects: with_invalid_params)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/age-range/new#{params}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new#{params}")
     expect(page).to have_content("Age range")
   end
 

--- a/spec/features/publish/courses/new_primary_subject_spec.rb
+++ b/spec/features/publish/courses/new_primary_subject_spec.rb
@@ -28,7 +28,7 @@ private
   end
 
   def when_i_visit_the_new_primary_course_subject_page
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: primary_subject_params)
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: primary_subject_params)
   end
 
   def when_i_select_a_primary_subject(subject_type)
@@ -44,7 +44,7 @@ private
   end
 
   def then_i_am_met_with_the_age_range_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/age-range/new?#{params_with_subject}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new?#{params_with_subject}")
     expect(page).to have_content("Age range")
   end
 

--- a/spec/features/publish/courses/new_primary_subject_spec.rb
+++ b/spec/features/publish/courses/new_primary_subject_spec.rb
@@ -28,7 +28,7 @@ private
   end
 
   def when_i_visit_the_new_primary_course_subject_page
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: primary_subject_params)
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: primary_subject_params)
   end
 
   def when_i_select_a_primary_subject(subject_type)
@@ -44,7 +44,7 @@ private
   end
 
   def then_i_am_met_with_the_age_range_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new?#{params_with_subject}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/age-range/new?#{params_with_subject}")
     expect(page).to have_content("Age range")
   end
 

--- a/spec/features/publish/courses/new_primary_subject_spec.rb
+++ b/spec/features/publish/courses/new_primary_subject_spec.rb
@@ -28,7 +28,7 @@ private
   end
 
   def when_i_visit_the_new_primary_course_subject_page
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: primary_subject_params)
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: primary_subject_params)
   end
 
   def when_i_select_a_primary_subject(subject_type)
@@ -44,7 +44,7 @@ private
   end
 
   def then_i_am_met_with_the_age_range_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new?#{params_with_subject}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new?#{params_with_subject}")
     expect(page).to have_content("Age range")
   end
 

--- a/spec/features/publish/courses/new_ratifying_provider_spec.rb
+++ b/spec/features/publish/courses/new_ratifying_provider_spec.rb
@@ -33,7 +33,7 @@ private
   end
 
   def when_i_visit_the_new_ratifying_providers_page
-    publish_courses_new_ratifying_provider_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: accredited_provider_params)
+    publish_courses_new_ratifying_provider_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: accredited_provider_params)
   end
 
   def when_i_select_an_accredited_provider
@@ -49,7 +49,7 @@ private
   end
 
   def then_i_am_met_with_the_applications_open_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/start-date/new", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/start-date/new", ignore_query: true)
     expect(page).to have_content("Add course Course start date")
   end
 

--- a/spec/features/publish/courses/new_ratifying_provider_spec.rb
+++ b/spec/features/publish/courses/new_ratifying_provider_spec.rb
@@ -33,7 +33,7 @@ private
   end
 
   def when_i_visit_the_new_ratifying_providers_page
-    publish_courses_new_ratifying_provider_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: accredited_provider_params)
+    publish_courses_new_ratifying_provider_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: accredited_provider_params)
   end
 
   def when_i_select_an_accredited_provider
@@ -49,7 +49,7 @@ private
   end
 
   def then_i_am_met_with_the_applications_open_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/start-date/new", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/start-date/new", ignore_query: true)
     expect(page).to have_content("Add course Course start date")
   end
 

--- a/spec/features/publish/courses/new_ratifying_provider_spec.rb
+++ b/spec/features/publish/courses/new_ratifying_provider_spec.rb
@@ -33,7 +33,7 @@ private
   end
 
   def when_i_visit_the_new_ratifying_providers_page
-    publish_courses_new_ratifying_provider_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: accredited_provider_params)
+    publish_courses_new_ratifying_provider_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: accredited_provider_params)
   end
 
   def when_i_select_an_accredited_provider
@@ -49,7 +49,7 @@ private
   end
 
   def then_i_am_met_with_the_applications_open_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/start-date/new", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/start-date/new", ignore_query: true)
     expect(page).to have_content("Add course Course start date")
   end
 

--- a/spec/features/publish/courses/new_schools_spec.rb
+++ b/spec/features/publish/courses/new_schools_spec.rb
@@ -32,7 +32,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_schools_page
-    publish_courses_new_schools_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: schools_params)
+    publish_courses_new_schools_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: schools_params)
   end
 
   def when_i_select_a_school
@@ -49,7 +49,7 @@ private
   end
 
   def then_i_am_met_with_the_accredited_provider_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/ratifying-provider/new", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/ratifying-provider/new", ignore_query: true)
     expect(page).to have_content("Accredited provider")
   end
 

--- a/spec/features/publish/courses/new_schools_spec.rb
+++ b/spec/features/publish/courses/new_schools_spec.rb
@@ -32,7 +32,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_schools_page
-    publish_courses_new_schools_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: schools_params)
+    publish_courses_new_schools_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: schools_params)
   end
 
   def when_i_select_a_school
@@ -49,7 +49,7 @@ private
   end
 
   def then_i_am_met_with_the_accredited_provider_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/ratifying-provider/new", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/ratifying-provider/new", ignore_query: true)
     expect(page).to have_content("Accredited provider")
   end
 

--- a/spec/features/publish/courses/new_schools_spec.rb
+++ b/spec/features/publish/courses/new_schools_spec.rb
@@ -32,7 +32,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_schools_page
-    publish_courses_new_schools_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: schools_params)
+    publish_courses_new_schools_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: schools_params)
   end
 
   def when_i_select_a_school
@@ -49,7 +49,7 @@ private
   end
 
   def then_i_am_met_with_the_accredited_provider_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/ratifying-provider/new", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/ratifying-provider/new", ignore_query: true)
     expect(page).to have_content("Accredited provider")
   end
 

--- a/spec/features/publish/courses/new_secondary_subject_spec.rb
+++ b/spec/features/publish/courses/new_secondary_subject_spec.rb
@@ -70,7 +70,7 @@ private
   end
 
   def when_i_visit_the_new_course_subject_page
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: secondary_subject_params)
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: secondary_subject_params)
   end
 
   def when_i_select_one_subject(subject_type)
@@ -104,12 +104,12 @@ private
   end
 
   def then_i_am_met_with_the_age_range_page(master, subordinate = nil)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new?#{params_with_subject(master, subordinate)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new?#{params_with_subject(master, subordinate)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/modern-languages/new?#{params_with_subject(:modern_languages)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/modern-languages/new?#{params_with_subject(:modern_languages)}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/new_secondary_subject_spec.rb
+++ b/spec/features/publish/courses/new_secondary_subject_spec.rb
@@ -70,7 +70,7 @@ private
   end
 
   def when_i_visit_the_new_course_subject_page
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: secondary_subject_params)
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: secondary_subject_params)
   end
 
   def when_i_select_one_subject(subject_type)
@@ -104,12 +104,12 @@ private
   end
 
   def then_i_am_met_with_the_age_range_page(master, subordinate = nil)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/age-range/new?#{params_with_subject(master, subordinate)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/age-range/new?#{params_with_subject(master, subordinate)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/modern-languages/new?#{params_with_subject(:modern_languages)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/modern-languages/new?#{params_with_subject(:modern_languages)}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/new_secondary_subject_spec.rb
+++ b/spec/features/publish/courses/new_secondary_subject_spec.rb
@@ -70,7 +70,7 @@ private
   end
 
   def when_i_visit_the_new_course_subject_page
-    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: secondary_subject_params)
+    publish_courses_new_subjects_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: secondary_subject_params)
   end
 
   def when_i_select_one_subject(subject_type)
@@ -104,12 +104,12 @@ private
   end
 
   def then_i_am_met_with_the_age_range_page(master, subordinate = nil)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/age-range/new?#{params_with_subject(master, subordinate)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/age-range/new?#{params_with_subject(master, subordinate)}")
     expect(page).to have_content("Age range")
   end
 
   def then_i_am_met_with_the_modern_languages_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/modern-languages/new?#{params_with_subject(:modern_languages)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/modern-languages/new?#{params_with_subject(:modern_languages)}")
     expect(page).to have_content("Languages")
   end
 

--- a/spec/features/publish/courses/new_start_date_spec.rb
+++ b/spec/features/publish/courses/new_start_date_spec.rb
@@ -23,11 +23,11 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_start_date_page
-    publish_courses_new_start_date_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: start_date_params(provider))
+    publish_courses_new_start_date_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: start_date_params(provider))
   end
 
   def when_i_select_january
-    publish_courses_new_start_date_page.choose("January #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i + 1}")
+    publish_courses_new_start_date_page.choose("January #{Find::CycleTimetable.next_year}")
   end
 
   def and_i_click_continue
@@ -39,7 +39,7 @@ private
   end
 
   def then_i_am_met_with_the_confirmation_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/confirmation", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/confirmation", ignore_query: true)
     expect(page).to have_content("Check your answers")
   end
 end

--- a/spec/features/publish/courses/new_start_date_spec.rb
+++ b/spec/features/publish/courses/new_start_date_spec.rb
@@ -23,11 +23,11 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_start_date_page
-    publish_courses_new_start_date_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: start_date_params(provider))
+    publish_courses_new_start_date_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: start_date_params(provider))
   end
 
   def when_i_select_january
-    publish_courses_new_start_date_page.choose("January #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i + 1}")
+    publish_courses_new_start_date_page.choose("January #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i + 1}")
   end
 
   def and_i_click_continue
@@ -39,7 +39,7 @@ private
   end
 
   def then_i_am_met_with_the_confirmation_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/confirmation", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/confirmation", ignore_query: true)
     expect(page).to have_content("Check your answers")
   end
 end

--- a/spec/features/publish/courses/new_start_date_spec.rb
+++ b/spec/features/publish/courses/new_start_date_spec.rb
@@ -23,11 +23,11 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_start_date_page
-    publish_courses_new_start_date_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: start_date_params(provider))
+    publish_courses_new_start_date_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: start_date_params(provider))
   end
 
   def when_i_select_january
-    publish_courses_new_start_date_page.choose("January #{Settings.current_recruitment_cycle_year.to_i + 1}")
+    publish_courses_new_start_date_page.choose("January #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i + 1}")
   end
 
   def and_i_click_continue
@@ -39,7 +39,7 @@ private
   end
 
   def then_i_am_met_with_the_confirmation_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/confirmation", ignore_query: true)
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/confirmation", ignore_query: true)
     expect(page).to have_content("Check your answers")
   end
 end

--- a/spec/features/publish/courses/new_study_mode_spec.rb
+++ b/spec/features/publish/courses/new_study_mode_spec.rb
@@ -49,7 +49,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_study_mode_page
-    publish_courses_new_study_mode_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: study_mode_params)
+    publish_courses_new_study_mode_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: study_mode_params)
   end
 
   def when_i_select_a_study_mode(study_mode)
@@ -66,7 +66,7 @@ private
   end
 
   def then_i_am_met_with_the_schools_page(study_mode)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/schools/new#{selected_params(study_mode)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/schools/new#{selected_params(study_mode)}")
     expect(page).to have_content("Schools")
   end
 

--- a/spec/features/publish/courses/new_study_mode_spec.rb
+++ b/spec/features/publish/courses/new_study_mode_spec.rb
@@ -49,7 +49,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_study_mode_page
-    publish_courses_new_study_mode_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Settings.current_recruitment_cycle_year, query: study_mode_params)
+    publish_courses_new_study_mode_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), query: study_mode_params)
   end
 
   def when_i_select_a_study_mode(study_mode)
@@ -66,7 +66,7 @@ private
   end
 
   def then_i_am_met_with_the_schools_page(study_mode)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/schools/new#{selected_params(study_mode)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/schools/new#{selected_params(study_mode)}")
     expect(page).to have_content("Schools")
   end
 

--- a/spec/features/publish/courses/new_study_mode_spec.rb
+++ b/spec/features/publish/courses/new_study_mode_spec.rb
@@ -49,7 +49,7 @@ private
   end
 
   def when_i_visit_the_publish_courses_new_study_mode_page
-    publish_courses_new_study_mode_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), query: study_mode_params)
+    publish_courses_new_study_mode_page.load(provider_code: provider.provider_code, recruitment_cycle_year: Find::CycleTimetable.current_year, query: study_mode_params)
   end
 
   def when_i_select_a_study_mode(study_mode)
@@ -66,7 +66,7 @@ private
   end
 
   def then_i_am_met_with_the_schools_page(study_mode)
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/schools/new#{selected_params(study_mode)}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/schools/new#{selected_params(study_mode)}")
     expect(page).to have_content("Schools")
   end
 

--- a/spec/features/publish/courses/new_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_spec.rb
@@ -57,7 +57,7 @@ private
   def when_i_visit_the_publish_course_confirmation_page
     publish_course_confirmation_page.load(
       provider_code: provider.provider_code,
-      recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+      recruitment_cycle_year: Find::CycleTimetable.current_year,
       query: confirmation_params(provider),
     )
   end

--- a/spec/features/publish/courses/new_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_spec.rb
@@ -57,7 +57,7 @@ private
   def when_i_visit_the_publish_course_confirmation_page
     publish_course_confirmation_page.load(
       provider_code: provider.provider_code,
-      recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+      recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
       query: confirmation_params(provider),
     )
   end

--- a/spec/features/publish/courses/new_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/new_visa_sponsorship_spec.rb
@@ -57,7 +57,7 @@ private
   def when_i_visit_the_publish_course_confirmation_page
     publish_course_confirmation_page.load(
       provider_code: provider.provider_code,
-      recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+      recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
       query: confirmation_params(provider),
     )
   end

--- a/spec/features/publish/managing_study_sites_spec.rb
+++ b/spec/features/publish/managing_study_sites_spec.rb
@@ -97,7 +97,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def and_i_am_on_the_study_sites_show_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites/#{site.id}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites/#{site.id}")
   end
   alias_method :then_i_am_on_the_study_site_show_page, :and_i_am_on_the_study_sites_show_page
 
@@ -130,7 +130,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def then_i_am_on_the_index_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites")
   end
 
   def and_i_click_add_study_site
@@ -138,7 +138,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def and_i_am_on_the_study_sites_check_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites/check")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites/check")
   end
 
   def and_i_click_the_link_to_enter_a_school_manually
@@ -200,7 +200,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def then_i_am_on_the_study_sites_delete_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites/#{site.id}/delete")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites/#{site.id}/delete")
   end
 
   def when_i_click_cancel

--- a/spec/features/publish/managing_study_sites_spec.rb
+++ b/spec/features/publish/managing_study_sites_spec.rb
@@ -97,7 +97,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def and_i_am_on_the_study_sites_show_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites/#{site.id}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites/#{site.id}")
   end
   alias_method :then_i_am_on_the_study_site_show_page, :and_i_am_on_the_study_sites_show_page
 
@@ -130,7 +130,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def then_i_am_on_the_index_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites")
   end
 
   def and_i_click_add_study_site
@@ -138,7 +138,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def and_i_am_on_the_study_sites_check_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites/check")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites/check")
   end
 
   def and_i_click_the_link_to_enter_a_school_manually
@@ -200,7 +200,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def then_i_am_on_the_study_sites_delete_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites/#{site.id}/delete")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites/#{site.id}/delete")
   end
 
   def when_i_click_cancel

--- a/spec/features/publish/managing_study_sites_spec.rb
+++ b/spec/features/publish/managing_study_sites_spec.rb
@@ -97,7 +97,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def and_i_am_on_the_study_sites_show_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites/#{site.id}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/study-sites/#{site.id}")
   end
   alias_method :then_i_am_on_the_study_site_show_page, :and_i_am_on_the_study_sites_show_page
 
@@ -130,7 +130,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def then_i_am_on_the_index_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/study-sites")
   end
 
   def and_i_click_add_study_site
@@ -138,7 +138,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def and_i_am_on_the_study_sites_check_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites/check")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/study-sites/check")
   end
 
   def and_i_click_the_link_to_enter_a_school_manually
@@ -200,7 +200,7 @@ feature "Managing a provider's study_sites" do
   end
 
   def then_i_am_on_the_study_sites_delete_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites/#{site.id}/delete")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/study-sites/#{site.id}/delete")
   end
 
   def when_i_click_cancel

--- a/spec/features/publish/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/publish/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -59,7 +59,7 @@ private
 
   def when_i_visit_the_accredited_provider_search_page
     visit search_publish_provider_recruitment_cycle_accredited_providers_path(
-      recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+      recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
       provider_code: provider.provider_code,
     )
   end
@@ -83,7 +83,7 @@ private
   def then_i_am_taken_to_the_index_page
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_accredited_partnerships_path(
-        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
         provider_code: provider.provider_code,
       ),
     )
@@ -142,7 +142,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_search_page
     expect(page).to have_current_path(
       search_publish_provider_recruitment_cycle_accredited_providers_path(
-        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
         provider_code: provider.provider_code,
       ),
     )
@@ -151,7 +151,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_search_page_with_confirmation
     expect(page).to have_current_path(
       search_publish_provider_recruitment_cycle_accredited_providers_path(
-        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
         provider_code: provider.provider_code,
         accredited_provider_id: @accredited_provider.id,
         goto_confirmation: true,
@@ -162,7 +162,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_description_page
     expect(page).to have_current_path(
       new_publish_provider_recruitment_cycle_accredited_partnership_path(
-        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
         provider_code: provider.provider_code,
         goto_confirmation: true,
       ),
@@ -176,7 +176,7 @@ private
   def then_i_am_taken_back_to_the_confirm_page
     expect(page).to have_current_path(
       check_publish_provider_recruitment_cycle_accredited_partnerships_path(
-        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
         provider_code: provider.provider_code,
         accredited_provider_id: @accredited_provider.id,
       ),

--- a/spec/features/publish/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/publish/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -59,7 +59,7 @@ private
 
   def when_i_visit_the_accredited_provider_search_page
     visit search_publish_provider_recruitment_cycle_accredited_providers_path(
-      recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+      recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
       provider_code: provider.provider_code,
     )
   end
@@ -83,7 +83,7 @@ private
   def then_i_am_taken_to_the_index_page
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_accredited_partnerships_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
         provider_code: provider.provider_code,
       ),
     )
@@ -142,7 +142,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_search_page
     expect(page).to have_current_path(
       search_publish_provider_recruitment_cycle_accredited_providers_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
         provider_code: provider.provider_code,
       ),
     )
@@ -151,7 +151,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_search_page_with_confirmation
     expect(page).to have_current_path(
       search_publish_provider_recruitment_cycle_accredited_providers_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
         provider_code: provider.provider_code,
         accredited_provider_id: @accredited_provider.id,
         goto_confirmation: true,
@@ -162,7 +162,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_description_page
     expect(page).to have_current_path(
       new_publish_provider_recruitment_cycle_accredited_partnership_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
         provider_code: provider.provider_code,
         goto_confirmation: true,
       ),
@@ -176,7 +176,7 @@ private
   def then_i_am_taken_back_to_the_confirm_page
     expect(page).to have_current_path(
       check_publish_provider_recruitment_cycle_accredited_partnerships_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
         provider_code: provider.provider_code,
         accredited_provider_id: @accredited_provider.id,
       ),

--- a/spec/features/publish/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
+++ b/spec/features/publish/providers/accredited_provider_search/searching_for_an_accredited_provider_spec.rb
@@ -59,7 +59,7 @@ private
 
   def when_i_visit_the_accredited_provider_search_page
     visit search_publish_provider_recruitment_cycle_accredited_providers_path(
-      recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+      recruitment_cycle_year: Find::CycleTimetable.current_year,
       provider_code: provider.provider_code,
     )
   end
@@ -83,7 +83,7 @@ private
   def then_i_am_taken_to_the_index_page
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_accredited_partnerships_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.current_year,
         provider_code: provider.provider_code,
       ),
     )
@@ -142,7 +142,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_search_page
     expect(page).to have_current_path(
       search_publish_provider_recruitment_cycle_accredited_providers_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.current_year,
         provider_code: provider.provider_code,
       ),
     )
@@ -151,7 +151,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_search_page_with_confirmation
     expect(page).to have_current_path(
       search_publish_provider_recruitment_cycle_accredited_providers_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.current_year,
         provider_code: provider.provider_code,
         accredited_provider_id: @accredited_provider.id,
         goto_confirmation: true,
@@ -162,7 +162,7 @@ private
   def then_i_am_taken_to_the_accredited_provider_description_page
     expect(page).to have_current_path(
       new_publish_provider_recruitment_cycle_accredited_partnership_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.current_year,
         provider_code: provider.provider_code,
         goto_confirmation: true,
       ),
@@ -176,7 +176,7 @@ private
   def then_i_am_taken_back_to_the_confirm_page
     expect(page).to have_current_path(
       check_publish_provider_recruitment_cycle_accredited_partnerships_path(
-        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+        recruitment_cycle_year: Find::CycleTimetable.current_year,
         provider_code: provider.provider_code,
         accredited_provider_id: @accredited_provider.id,
       ),

--- a/spec/features/publish/providers/schools/add_school_spec.rb
+++ b/spec/features/publish/providers/schools/add_school_spec.rb
@@ -67,7 +67,7 @@ feature "Adding a provider's schools", travel: mid_cycle(2026) do
   end
 
   def then_i_am_on_the_school_search_page
-    expect(page).to have_current_path(search_publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_code: provider.provider_code))
+    expect(page).to have_current_path(search_publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code))
   end
 
   def when_i_search_with_an_empty_query

--- a/spec/features/publish/providers/schools/add_school_spec.rb
+++ b/spec/features/publish/providers/schools/add_school_spec.rb
@@ -67,7 +67,7 @@ feature "Adding a provider's schools", travel: mid_cycle(2026) do
   end
 
   def then_i_am_on_the_school_search_page
-    expect(page).to have_current_path(search_publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code))
+    expect(page).to have_current_path(search_publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code))
   end
 
   def when_i_search_with_an_empty_query

--- a/spec/features/publish/providers/schools/add_school_spec.rb
+++ b/spec/features/publish/providers/schools/add_school_spec.rb
@@ -67,7 +67,7 @@ feature "Adding a provider's schools", travel: mid_cycle(2026) do
   end
 
   def then_i_am_on_the_school_search_page
-    expect(page).to have_current_path(search_publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code))
+    expect(page).to have_current_path(search_publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code))
   end
 
   def when_i_search_with_an_empty_query

--- a/spec/features/publish/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/features/publish/providers/schools/creating_multiple_schools_spec.rb
@@ -119,7 +119,7 @@ feature "Multiple schools" do
   end
 
   def then_i_am_redirected_to_the_school_index
-    expect(page).to have_current_path(publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code))
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code))
   end
 
   def and_i_see_that_all_schools_are_created
@@ -193,16 +193,16 @@ feature "Multiple schools" do
   end
 
   def and_i_am_redirected_to_the_multiple_school_check_page
-    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
+    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
     expect(page).to have_text "Check your answers"
   end
 
   def when_i_visit_the_multiple_schools_new_page
-    visit new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
+    visit new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
   end
 
   def when_i_visit_a_provider_schools_page
-    visit publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
+    visit publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
   end
 
   def and_i_have_one_existing_school
@@ -268,11 +268,11 @@ feature "Multiple schools" do
   end
 
   def when_i_am_redirected_to_the_schools_page
-    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
+    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
   end
 
   def and_i_am_on_the_enter_urns_page
-    expect(page).to have_current_path new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
+    expect(page).to have_current_path new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
   end
 
   alias_method :and_i_click_back, :when_i_click_back

--- a/spec/features/publish/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/features/publish/providers/schools/creating_multiple_schools_spec.rb
@@ -119,7 +119,7 @@ feature "Multiple schools" do
   end
 
   def then_i_am_redirected_to_the_school_index
-    expect(page).to have_current_path(publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_code: provider.provider_code))
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code))
   end
 
   def and_i_see_that_all_schools_are_created
@@ -193,16 +193,16 @@ feature "Multiple schools" do
   end
 
   def and_i_am_redirected_to_the_multiple_school_check_page
-    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_multiple_check_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_code: provider.provider_code)
+    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
     expect(page).to have_text "Check your answers"
   end
 
   def when_i_visit_the_multiple_schools_new_page
-    visit new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_code: provider.provider_code)
+    visit new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
   end
 
   def when_i_visit_a_provider_schools_page
-    visit publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_code: provider.provider_code)
+    visit publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
   end
 
   def and_i_have_one_existing_school
@@ -268,11 +268,11 @@ feature "Multiple schools" do
   end
 
   def when_i_am_redirected_to_the_schools_page
-    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_code: provider.provider_code)
+    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
   end
 
   def and_i_am_on_the_enter_urns_page
-    expect(page).to have_current_path new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_code: provider.provider_code)
+    expect(page).to have_current_path new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_code: provider.provider_code)
   end
 
   alias_method :and_i_click_back, :when_i_click_back

--- a/spec/features/publish/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/features/publish/providers/schools/creating_multiple_schools_spec.rb
@@ -119,7 +119,7 @@ feature "Multiple schools" do
   end
 
   def then_i_am_redirected_to_the_school_index
-    expect(page).to have_current_path(publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code))
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code))
   end
 
   def and_i_see_that_all_schools_are_created
@@ -193,16 +193,16 @@ feature "Multiple schools" do
   end
 
   def and_i_am_redirected_to_the_multiple_school_check_page
-    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
+    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
     expect(page).to have_text "Check your answers"
   end
 
   def when_i_visit_the_multiple_schools_new_page
-    visit new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
+    visit new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
   end
 
   def when_i_visit_a_provider_schools_page
-    visit publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
+    visit publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
   end
 
   def and_i_have_one_existing_school
@@ -268,11 +268,11 @@ feature "Multiple schools" do
   end
 
   def when_i_am_redirected_to_the_schools_page
-    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
+    expect(page).to have_current_path publish_provider_recruitment_cycle_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
   end
 
   def and_i_am_on_the_enter_urns_page
-    expect(page).to have_current_path new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_code: provider.provider_code)
+    expect(page).to have_current_path new_publish_provider_recruitment_cycle_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_code: provider.provider_code)
   end
 
   alias_method :and_i_click_back, :when_i_click_back

--- a/spec/features/publish/providers_index_spec.rb
+++ b/spec/features/publish/providers_index_spec.rb
@@ -87,7 +87,7 @@ feature "Providers index" do
   end
 
   def i_should_see_the_recruitment_cycle_text
-    expect(publish_title_bar_page.recruitment_cycle_text).to have_text("#{Settings.current_recruitment_cycle_year.to_i - 1} to #{Settings.current_recruitment_cycle_year} - current")
+    expect(publish_title_bar_page.recruitment_cycle_text).to have_text("#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} - current")
   end
 
   def and_today_is_before_next_cycle_available_for_support_users_date
@@ -115,7 +115,7 @@ feature "Providers index" do
   end
 
   def when_i_click_on_the_current_cycle_link
-    click_link_or_button "#{Settings.current_recruitment_cycle_year.to_i - 1} to #{Settings.current_recruitment_cycle_year} - current"
+    click_link_or_button "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} - current"
   end
 
   def i_should_be_on_the_recruitment_cycle_switcher_page
@@ -123,7 +123,7 @@ feature "Providers index" do
   end
 
   def i_should_be_on_the_courses_index_page_in_the_same_recruitment_cycle
-    expect(page).to have_current_path("/publish/organisations/#{current_user.providers.first.provider_code}/#{Settings.current_recruitment_cycle_year}/courses")
+    expect(page).to have_current_path("/publish/organisations/#{current_user.providers.first.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses")
     expect(page).to have_text "Courses"
   end
 
@@ -158,7 +158,7 @@ feature "Providers index" do
     publish_providers_index_page.search_input.set "Really big school (A01)"
     publish_providers_index_page.search_button.click
     expect(publish_provider_courses_index_page).to be_displayed
-    expect(publish_provider_courses_index_page.current_url).to end_with("A01/#{Settings.current_recruitment_cycle_year}/courses")
+    expect(publish_provider_courses_index_page.current_url).to end_with("A01/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses")
   end
 
   def i_should_see_the_pagination_link
@@ -200,7 +200,7 @@ feature "Providers index" do
   end
 
   def i_should_be_on_the_organisations_list
-    expect(page).to have_current_path("/?recruitment_cycle_year=#{Settings.current_recruitment_cycle_year}")
+    expect(page).to have_current_path("/?recruitment_cycle_year=#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}")
     expect(page).to have_text "Organisations"
   end
 

--- a/spec/features/publish/providers_index_spec.rb
+++ b/spec/features/publish/providers_index_spec.rb
@@ -87,7 +87,7 @@ feature "Providers index" do
   end
 
   def i_should_see_the_recruitment_cycle_text
-    expect(publish_title_bar_page.recruitment_cycle_text).to have_text("#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} - current")
+    expect(publish_title_bar_page.recruitment_cycle_text).to have_text("#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} - current")
   end
 
   def and_today_is_before_next_cycle_available_for_support_users_date
@@ -115,7 +115,7 @@ feature "Providers index" do
   end
 
   def when_i_click_on_the_current_cycle_link
-    click_link_or_button "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} - current"
+    click_link_or_button "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} - current"
   end
 
   def i_should_be_on_the_recruitment_cycle_switcher_page
@@ -123,7 +123,7 @@ feature "Providers index" do
   end
 
   def i_should_be_on_the_courses_index_page_in_the_same_recruitment_cycle
-    expect(page).to have_current_path("/publish/organisations/#{current_user.providers.first.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses")
+    expect(page).to have_current_path("/publish/organisations/#{current_user.providers.first.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses")
     expect(page).to have_text "Courses"
   end
 
@@ -158,7 +158,7 @@ feature "Providers index" do
     publish_providers_index_page.search_input.set "Really big school (A01)"
     publish_providers_index_page.search_button.click
     expect(publish_provider_courses_index_page).to be_displayed
-    expect(publish_provider_courses_index_page.current_url).to end_with("A01/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses")
+    expect(publish_provider_courses_index_page.current_url).to end_with("A01/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses")
   end
 
   def i_should_see_the_pagination_link
@@ -200,7 +200,7 @@ feature "Providers index" do
   end
 
   def i_should_be_on_the_organisations_list
-    expect(page).to have_current_path("/?recruitment_cycle_year=#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}")
+    expect(page).to have_current_path("/?recruitment_cycle_year=#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}")
     expect(page).to have_text "Organisations"
   end
 

--- a/spec/features/publish/providers_index_spec.rb
+++ b/spec/features/publish/providers_index_spec.rb
@@ -87,7 +87,7 @@ feature "Providers index" do
   end
 
   def i_should_see_the_recruitment_cycle_text
-    expect(publish_title_bar_page.recruitment_cycle_text).to have_text("#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} - current")
+    expect(publish_title_bar_page.recruitment_cycle_text).to have_text("#{Find::CycleTimetable.previous_year} to #{Find::CycleTimetable.current_year} - current")
   end
 
   def and_today_is_before_next_cycle_available_for_support_users_date
@@ -115,7 +115,7 @@ feature "Providers index" do
   end
 
   def when_i_click_on_the_current_cycle_link
-    click_link_or_button "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} - current"
+    click_link_or_button "#{Find::CycleTimetable.previous_year} to #{Find::CycleTimetable.current_year} - current"
   end
 
   def i_should_be_on_the_recruitment_cycle_switcher_page
@@ -123,7 +123,7 @@ feature "Providers index" do
   end
 
   def i_should_be_on_the_courses_index_page_in_the_same_recruitment_cycle
-    expect(page).to have_current_path("/publish/organisations/#{current_user.providers.first.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses")
+    expect(page).to have_current_path("/publish/organisations/#{current_user.providers.first.provider_code}/#{Find::CycleTimetable.current_year}/courses")
     expect(page).to have_text "Courses"
   end
 
@@ -158,7 +158,7 @@ feature "Providers index" do
     publish_providers_index_page.search_input.set "Really big school (A01)"
     publish_providers_index_page.search_button.click
     expect(publish_provider_courses_index_page).to be_displayed
-    expect(publish_provider_courses_index_page.current_url).to end_with("A01/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses")
+    expect(publish_provider_courses_index_page.current_url).to end_with("A01/#{Find::CycleTimetable.current_year}/courses")
   end
 
   def i_should_see_the_pagination_link
@@ -200,7 +200,7 @@ feature "Providers index" do
   end
 
   def i_should_be_on_the_organisations_list
-    expect(page).to have_current_path("/?recruitment_cycle_year=#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}")
+    expect(page).to have_current_path("/?recruitment_cycle_year=#{Find::CycleTimetable.current_year}")
     expect(page).to have_text "Organisations"
   end
 

--- a/spec/features/publish/searching_for_a_school_spec.rb
+++ b/spec/features/publish/searching_for_a_school_spec.rb
@@ -81,7 +81,7 @@ private
   end
 
   def then_i_should_be_taken_to_the_add_school_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/schools/check?school_id=#{@school_two.id}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/schools/check?school_id=#{@school_two.id}")
   end
 
   def and_i_search_with_an_invalid_query

--- a/spec/features/publish/searching_for_a_school_spec.rb
+++ b/spec/features/publish/searching_for_a_school_spec.rb
@@ -81,7 +81,7 @@ private
   end
 
   def then_i_should_be_taken_to_the_add_school_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/schools/check?school_id=#{@school_two.id}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/schools/check?school_id=#{@school_two.id}")
   end
 
   def and_i_search_with_an_invalid_query

--- a/spec/features/publish/searching_for_a_school_spec.rb
+++ b/spec/features/publish/searching_for_a_school_spec.rb
@@ -81,7 +81,7 @@ private
   end
 
   def then_i_should_be_taken_to_the_add_school_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/schools/check?school_id=#{@school_two.id}")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/schools/check?school_id=#{@school_two.id}")
   end
 
   def and_i_search_with_an_invalid_query

--- a/spec/features/publish/searching_for_a_study_site_spec.rb
+++ b/spec/features/publish/searching_for_a_study_site_spec.rb
@@ -45,7 +45,7 @@ feature "Searching for a study site from the GIAS list" do
 
   def then_i_should_be_taken_to_the_add_study_site_page
     URI(current_url).then do |uri|
-      expect(uri.path).to eq("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/study-sites/new")
+      expect(uri.path).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites/new")
       expect(uri.query).to eq("school_id=#{@school_two.id}")
     end
   end

--- a/spec/features/publish/searching_for_a_study_site_spec.rb
+++ b/spec/features/publish/searching_for_a_study_site_spec.rb
@@ -45,7 +45,7 @@ feature "Searching for a study site from the GIAS list" do
 
   def then_i_should_be_taken_to_the_add_study_site_page
     URI(current_url).then do |uri|
-      expect(uri.path).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/study-sites/new")
+      expect(uri.path).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites/new")
       expect(uri.query).to eq("school_id=#{@school_two.id}")
     end
   end

--- a/spec/features/publish/searching_for_a_study_site_spec.rb
+++ b/spec/features/publish/searching_for_a_study_site_spec.rb
@@ -45,7 +45,7 @@ feature "Searching for a study site from the GIAS list" do
 
   def then_i_should_be_taken_to_the_add_study_site_page
     URI(current_url).then do |uri|
-      expect(uri.path).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/study-sites/new")
+      expect(uri.path).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/study-sites/new")
       expect(uri.query).to eq("school_id=#{@school_two.id}")
     end
   end

--- a/spec/features/publish/viewing_a_course_details_spec.rb
+++ b/spec/features/publish/viewing_a_course_details_spec.rb
@@ -99,8 +99,7 @@ private
   end
 
   def and_the_new_cycle_has_started
-    allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2026)
-    Timecop.travel(1.day.after(find_opens(2025)))
+    Timecop.travel(1.day.after(find_opens(2026)))
     # Changing the time will log the user out
     # /lib/publish/authentication/user_session.rb:34
     visit_auth_sign_in_page

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -431,7 +431,7 @@ private
   end
 
   def next_recruitment_cycle_year
-    Settings.current_recruitment_cycle_year + 1
+    Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
   end
 
   def when_i_visit_the_next_cycle_courses_page

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -431,7 +431,7 @@ private
   end
 
   def next_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
+    Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
   end
 
   def when_i_visit_the_next_cycle_courses_page

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -431,7 +431,7 @@ private
   end
 
   def next_recruitment_cycle_year
-    Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
+    Find::CycleTimetable.next_year
   end
 
   def when_i_visit_the_next_cycle_courses_page

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 module Support
   describe EditCourseForm do
-    let(:course) { create(:course, course_code: "T92", name: "Universitry of Oxfords", start_date: Date.new(Settings.current_recruitment_cycle_year, 9, 1)) }
-    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: Settings.current_recruitment_cycle_year, applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: Settings.current_recruitment_cycle_year, is_send: "true" } }
-    let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: Settings.current_recruitment_cycle_year, applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
+    let(:course) { create(:course, course_code: "T92", name: "Universitry of Oxfords", start_date: Date.new(Find::CycleTimetable.cycle_year_from_time(Time.zone.now), 9, 1)) }
+    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), is_send: "true" } }
+    let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
     let(:attributes_with_invalid_date_year) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2027", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "2000" } }
     let(:attributes_with_two_digit_date_year) { { course_code: "T92", name: "Universitry of Oxfords", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "25" } }
     let(:blank_attributes) { { course_code: "", name: "", start_date_day: "", start_date_month: "", start_date_year: "", applications_open_from_day: "", applications_open_from_month: "", applications_open_from_year: "" } }
@@ -93,7 +93,7 @@ module Support
           subject.valid?
 
           expect(subject.errors.messages.count).to eq(2)
-          expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the #{Settings.current_recruitment_cycle_year} cycle")
+          expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} cycle")
           expect(subject.errors.messages[:applications_open_from]).to include("The date when applications open must be between #{course.recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{course.recruitment_cycle.application_end_date.to_fs(:govuk_date)}")
         end
       end
@@ -114,7 +114,7 @@ module Support
       context "form is assigned valid date args" do
         it "returns a date object" do
           subject.assign_attributes(valid_attributes)
-          expect(subject.start_date).to eq(Date.new(Settings.current_recruitment_cycle_year.to_i, 9, 2))
+          expect(subject.start_date).to eq(Date.new(Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i, 9, 2))
         end
       end
 
@@ -132,7 +132,7 @@ module Support
           expect(output).not_to be_instance_of(Date)
           expect(output.day).to eq("222")
           expect(output.month).to eq("90")
-          expect(output.year).to eq(Settings.current_recruitment_cycle_year)
+          expect(output.year).to eq(Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
         end
       end
 

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 module Support
   describe EditCourseForm do
-    let(:course) { create(:course, course_code: "T92", name: "Universitry of Oxfords", start_date: Date.new(Find::CycleTimetable.cycle_year_from_time(Time.zone.now), 9, 1)) }
-    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), is_send: "true" } }
-    let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
+    let(:course) { create(:course, course_code: "T92", name: "Universitry of Oxfords", start_date: Date.new(Find::CycleTimetable.cycle_year_for_time(Time.zone.now), 9, 1)) }
+    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), is_send: "true" } }
+    let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
     let(:attributes_with_invalid_date_year) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2027", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "2000" } }
     let(:attributes_with_two_digit_date_year) { { course_code: "T92", name: "Universitry of Oxfords", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "25" } }
     let(:blank_attributes) { { course_code: "", name: "", start_date_day: "", start_date_month: "", start_date_year: "", applications_open_from_day: "", applications_open_from_month: "", applications_open_from_year: "" } }
@@ -93,7 +93,7 @@ module Support
           subject.valid?
 
           expect(subject.errors.messages.count).to eq(2)
-          expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} cycle")
+          expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} cycle")
           expect(subject.errors.messages[:applications_open_from]).to include("The date when applications open must be between #{course.recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{course.recruitment_cycle.application_end_date.to_fs(:govuk_date)}")
         end
       end
@@ -114,7 +114,7 @@ module Support
       context "form is assigned valid date args" do
         it "returns a date object" do
           subject.assign_attributes(valid_attributes)
-          expect(subject.start_date).to eq(Date.new(Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i, 9, 2))
+          expect(subject.start_date).to eq(Date.new(Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i, 9, 2))
         end
       end
 
@@ -132,7 +132,7 @@ module Support
           expect(output).not_to be_instance_of(Date)
           expect(output.day).to eq("222")
           expect(output.month).to eq("90")
-          expect(output.year).to eq(Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+          expect(output.year).to eq(Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
         end
       end
 

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 module Support
   describe EditCourseForm do
-    let(:course) { create(:course, course_code: "T92", name: "Universitry of Oxfords", start_date: Date.new(Find::CycleTimetable.cycle_year_for_time(Time.zone.now), 9, 1)) }
-    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), is_send: "true" } }
-    let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
+    let(:course) { create(:course, course_code: "T92", name: "Universitry of Oxfords", start_date: Date.new(Find::CycleTimetable.current_year, 9, 1)) }
+    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: Find::CycleTimetable.current_year, applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: Find::CycleTimetable.current_year, is_send: "true" } }
+    let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: Find::CycleTimetable.current_year, applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
     let(:attributes_with_invalid_date_year) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2027", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "2000" } }
     let(:attributes_with_two_digit_date_year) { { course_code: "T92", name: "Universitry of Oxfords", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "25" } }
     let(:blank_attributes) { { course_code: "", name: "", start_date_day: "", start_date_month: "", start_date_year: "", applications_open_from_day: "", applications_open_from_month: "", applications_open_from_year: "" } }
@@ -93,7 +93,7 @@ module Support
           subject.valid?
 
           expect(subject.errors.messages.count).to eq(2)
-          expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} cycle")
+          expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the #{Find::CycleTimetable.current_year} cycle")
           expect(subject.errors.messages[:applications_open_from]).to include("The date when applications open must be between #{course.recruitment_cycle.application_start_date.to_fs(:govuk_date)} and #{course.recruitment_cycle.application_end_date.to_fs(:govuk_date)}")
         end
       end
@@ -114,7 +114,7 @@ module Support
       context "form is assigned valid date args" do
         it "returns a date object" do
           subject.assign_attributes(valid_attributes)
-          expect(subject.start_date).to eq(Date.new(Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i, 9, 2))
+          expect(subject.start_date).to eq(Date.new(Find::CycleTimetable.current_year.to_i, 9, 2))
         end
       end
 
@@ -132,7 +132,7 @@ module Support
           expect(output).not_to be_instance_of(Date)
           expect(output.day).to eq("222")
           expect(output.month).to eq("90")
-          expect(output.year).to eq(Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+          expect(output.year).to eq(Find::CycleTimetable.current_year)
         end
       end
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -15,11 +15,11 @@ describe ViewHelper do
     end
 
     it "returns enrichment error URL for base error" do
-      expect(enrichment_error_url(provider_code: "A1", course:, field: "base", message: "Select if student visas can be sponsored")).to eq("/publish/organisations/A1/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/student-visa")
+      expect(enrichment_error_url(provider_code: "A1", course:, field: "base", message: "Select if student visas can be sponsored")).to eq("/publish/organisations/A1/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/student-visa")
     end
 
     it "returns the course applications open date url for the error" do
-      expect(enrichment_error_url(provider_code: provider.provider_code, course:, field: "applications_open_from")).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/applications-open")
+      expect(enrichment_error_url(provider_code: provider.provider_code, course:, field: "applications_open_from")).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/applications-open")
     end
   end
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -15,11 +15,11 @@ describe ViewHelper do
     end
 
     it "returns enrichment error URL for base error" do
-      expect(enrichment_error_url(provider_code: "A1", course:, field: "base", message: "Select if student visas can be sponsored")).to eq("/publish/organisations/A1/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/student-visa")
+      expect(enrichment_error_url(provider_code: "A1", course:, field: "base", message: "Select if student visas can be sponsored")).to eq("/publish/organisations/A1/#{Find::CycleTimetable.current_year}/student-visa")
     end
 
     it "returns the course applications open date url for the error" do
-      expect(enrichment_error_url(provider_code: provider.provider_code, course:, field: "applications_open_from")).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/courses/#{course.course_code}/applications-open")
+      expect(enrichment_error_url(provider_code: provider.provider_code, course:, field: "applications_open_from")).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/applications-open")
     end
   end
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -15,11 +15,11 @@ describe ViewHelper do
     end
 
     it "returns enrichment error URL for base error" do
-      expect(enrichment_error_url(provider_code: "A1", course:, field: "base", message: "Select if student visas can be sponsored")).to eq("/publish/organisations/A1/#{Settings.current_recruitment_cycle_year}/student-visa")
+      expect(enrichment_error_url(provider_code: "A1", course:, field: "base", message: "Select if student visas can be sponsored")).to eq("/publish/organisations/A1/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/student-visa")
     end
 
     it "returns the course applications open date url for the error" do
-      expect(enrichment_error_url(provider_code: provider.provider_code, course:, field: "applications_open_from")).to eq("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/applications-open")
+      expect(enrichment_error_url(provider_code: provider.provider_code, course:, field: "applications_open_from")).to eq("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/courses/#{course.course_code}/applications-open")
     end
   end
 

--- a/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
@@ -73,7 +73,7 @@ describe Courses::EditOptions::StartDateConcern do
     end
 
     around do |example|
-      Timecop.freeze(Time.zone.local(Settings.current_recruitment_cycle_year, month, 1)) do
+      Timecop.freeze(Time.zone.local(Find::CycleTimetable.cycle_year_from_time(Time.zone.now), month, 1)) do
         example.run
       end
     end

--- a/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
@@ -73,7 +73,7 @@ describe Courses::EditOptions::StartDateConcern do
     end
 
     around do |example|
-      Timecop.freeze(Time.zone.local(Find::CycleTimetable.cycle_year_from_time(Time.zone.now), month, 1)) do
+      Timecop.freeze(Time.zone.local(Find::CycleTimetable.cycle_year_for_time(Time.zone.now), month, 1)) do
         example.run
       end
     end

--- a/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
@@ -73,7 +73,7 @@ describe Courses::EditOptions::StartDateConcern do
     end
 
     around do |example|
-      Timecop.freeze(Time.zone.local(Find::CycleTimetable.cycle_year_for_time(Time.zone.now), month, 1)) do
+      Timecop.freeze(Time.zone.local(Find::CycleTimetable.current_year, month, 1)) do
         example.run
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -155,8 +155,6 @@ RSpec.configure do |config|
     if (time = example.metadata[:travel])
       year = Find::CycleTimetable.cycle_year_for_time(time)
       find_or_create(:recruitment_cycle, year:)
-      allow(Settings).to receive(:current_recruitment_cycle_year)
-        .and_return(year)
     end
   end
 

--- a/spec/smoke/api/v1/courses_spec.rb
+++ b/spec/smoke/api/v1/courses_spec.rb
@@ -9,7 +9,7 @@ describe "V1 Public API Smoke Tests", :aggregate_failures, :smoke do
 
   context "courses" do
     describe "GET /api/public/v1/recruitment_cycles/:recruitment_year/courses" do
-      let(:recruitment_year) { Find::CycleTimetable.cycle_year_for_time(Time.zone.now) }
+      let(:recruitment_year) { Find::CycleTimetable.current_year }
       let(:url) { "#{base_url}/api/public/v1/recruitment_cycles/#{recruitment_year}/courses?page[per_page]=1" }
 
       it "returns HTTP success" do

--- a/spec/smoke/api/v1/courses_spec.rb
+++ b/spec/smoke/api/v1/courses_spec.rb
@@ -9,7 +9,7 @@ describe "V1 Public API Smoke Tests", :aggregate_failures, :smoke do
 
   context "courses" do
     describe "GET /api/public/v1/recruitment_cycles/:recruitment_year/courses" do
-      let(:recruitment_year) { Find::CycleTimetable.current_year }
+      let(:recruitment_year) { Find::CycleTimetable.cycle_year_for_time(Time.zone.now) }
       let(:url) { "#{base_url}/api/public/v1/recruitment_cycles/#{recruitment_year}/courses?page[per_page]=1" }
 
       it "returns HTTP success" do

--- a/spec/smoke/api/v1/courses_spec.rb
+++ b/spec/smoke/api/v1/courses_spec.rb
@@ -9,7 +9,7 @@ describe "V1 Public API Smoke Tests", :aggregate_failures, :smoke do
 
   context "courses" do
     describe "GET /api/public/v1/recruitment_cycles/:recruitment_year/courses" do
-      let(:recruitment_year) { Find::CycleTimetable.cycle_year_from_time(Time.zone.now) }
+      let(:recruitment_year) { Find::CycleTimetable.cycle_year_for_time(Time.zone.now) }
       let(:url) { "#{base_url}/api/public/v1/recruitment_cycles/#{recruitment_year}/courses?page[per_page]=1" }
 
       it "returns HTTP success" do

--- a/spec/smoke/api/v1/courses_spec.rb
+++ b/spec/smoke/api/v1/courses_spec.rb
@@ -9,7 +9,7 @@ describe "V1 Public API Smoke Tests", :aggregate_failures, :smoke do
 
   context "courses" do
     describe "GET /api/public/v1/recruitment_cycles/:recruitment_year/courses" do
-      let(:recruitment_year) { Settings.current_recruitment_cycle_year }
+      let(:recruitment_year) { Find::CycleTimetable.cycle_year_from_time(Time.zone.now) }
       let(:url) { "#{base_url}/api/public/v1/recruitment_cycles/#{recruitment_year}/courses?page[per_page]=1" }
 
       it "returns HTTP success" do

--- a/spec/smoke/api/v1/providers_spec.rb
+++ b/spec/smoke/api/v1/providers_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper_smoke"
 describe "V1 Public API Smoke Tests", :aggregate_failures, :smoke do
   subject(:response) { HTTParty.get(url) }
 
-  let(:recruitment_year) { Settings.current_recruitment_cycle_year }
+  let(:recruitment_year) { Find::CycleTimetable.cycle_year_from_time(Time.zone.now) }
   let(:base_url) { Settings.api_url }
 
   context "providers" do

--- a/spec/smoke/api/v1/providers_spec.rb
+++ b/spec/smoke/api/v1/providers_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper_smoke"
 describe "V1 Public API Smoke Tests", :aggregate_failures, :smoke do
   subject(:response) { HTTParty.get(url) }
 
-  let(:recruitment_year) { Find::CycleTimetable.current_year }
+  let(:recruitment_year) { Find::CycleTimetable.cycle_year_for_time(Time.zone.now) }
   let(:base_url) { Settings.api_url }
 
   context "providers" do

--- a/spec/smoke/api/v1/providers_spec.rb
+++ b/spec/smoke/api/v1/providers_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper_smoke"
 describe "V1 Public API Smoke Tests", :aggregate_failures, :smoke do
   subject(:response) { HTTParty.get(url) }
 
-  let(:recruitment_year) { Find::CycleTimetable.cycle_year_for_time(Time.zone.now) }
+  let(:recruitment_year) { Find::CycleTimetable.current_year }
   let(:base_url) { Settings.api_url }
 
   context "providers" do

--- a/spec/smoke/api/v1/providers_spec.rb
+++ b/spec/smoke/api/v1/providers_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper_smoke"
 describe "V1 Public API Smoke Tests", :aggregate_failures, :smoke do
   subject(:response) { HTTParty.get(url) }
 
-  let(:recruitment_year) { Find::CycleTimetable.cycle_year_from_time(Time.zone.now) }
+  let(:recruitment_year) { Find::CycleTimetable.cycle_year_for_time(Time.zone.now) }
   let(:base_url) { Settings.api_url }
 
   context "providers" do

--- a/spec/spec_helper_smoke.rb
+++ b/spec/spec_helper_smoke.rb
@@ -8,5 +8,8 @@ require "config"
 require "httparty"
 require "active_support"
 require "active_support/time"
+require "active_support/core_ext/time/zones"
+Time.zone = "Europe/London"
+load "app/services/find/cycle_timetable.rb"
 
 Config.load_and_set_settings(Config.setting_files("config", ENV.fetch("RAILS_ENV", nil)))

--- a/spec/support/feature_helpers/new_course_param_helper.rb
+++ b/spec/support/feature_helpers/new_course_param_helper.rb
@@ -75,7 +75,7 @@ module FeatureHelpers
         "course[is_send]" => "0",
         "course[level]" => "secondary",
         "course[qualification]" => "pgde_with_qts",
-        "course[start_date]" => "October #{provider.recruitment_cycle_year.to_i - 1}",
+        "course[start_date]" => "October #{provider.recruitment_cycle_year.to_i + 1}",
         "course[study_mode][]" => "full_time_or_part_time",
         "course[subjects_ids][]" => "30",
         "course[sites_ids][]" => provider.sites.first.id,

--- a/spec/system/publish/auth/persona_spec.rb
+++ b/spec/system/publish/auth/persona_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Authentication with Personas" do
   end
 
   def when_i_go_to_support
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def then_i_am_given_the_option_to_sign_in_with_a_persona

--- a/spec/system/publish/auth/persona_spec.rb
+++ b/spec/system/publish/auth/persona_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Authentication with Personas" do
   end
 
   def when_i_go_to_support
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def then_i_am_given_the_option_to_sign_in_with_a_persona

--- a/spec/system/publish/auth/persona_spec.rb
+++ b/spec/system/publish/auth/persona_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Authentication with Personas" do
   end
 
   def when_i_go_to_support
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def then_i_am_given_the_option_to_sign_in_with_a_persona

--- a/spec/system/publish/auth/provider_user_signs_in_spec.rb
+++ b/spec/system/publish/auth/provider_user_signs_in_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "Authentication" do
   end
 
   def and_i_cannot_access_the_support_interface
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
-    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
     expect(page.status_code).to eq(403)
     expect(page.find("h1")).to have_content("You are not permitted to see this page")
   end

--- a/spec/system/publish/auth/provider_user_signs_in_spec.rb
+++ b/spec/system/publish/auth/provider_user_signs_in_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "Authentication" do
   end
 
   def and_i_cannot_access_the_support_interface
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
-    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.current_year)
+    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.current_year)
     expect(page.status_code).to eq(403)
     expect(page.find("h1")).to have_content("You are not permitted to see this page")
   end

--- a/spec/system/publish/auth/provider_user_signs_in_spec.rb
+++ b/spec/system/publish/auth/provider_user_signs_in_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "Authentication" do
   end
 
   def and_i_cannot_access_the_support_interface
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
-    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
     expect(page.status_code).to eq(403)
     expect(page.find("h1")).to have_content("You are not permitted to see this page")
   end

--- a/spec/system/publish/auth/support_user_signs_in_spec.rb
+++ b/spec/system/publish/auth/support_user_signs_in_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Authentication" do
   end
 
   def when_i_visit_the_support_interface
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def then_i_am_expected_to_sign_in
@@ -29,6 +29,6 @@ RSpec.describe "Authentication" do
   end
 
   def then_i_can_access_the_support_interface
-    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 end

--- a/spec/system/publish/auth/support_user_signs_in_spec.rb
+++ b/spec/system/publish/auth/support_user_signs_in_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Authentication" do
   end
 
   def when_i_visit_the_support_interface
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def then_i_am_expected_to_sign_in
@@ -29,6 +29,6 @@ RSpec.describe "Authentication" do
   end
 
   def then_i_can_access_the_support_interface
-    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 end

--- a/spec/system/publish/auth/support_user_signs_in_spec.rb
+++ b/spec/system/publish/auth/support_user_signs_in_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Authentication" do
   end
 
   def when_i_visit_the_support_interface
-    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    visit support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def then_i_am_expected_to_sign_in
@@ -29,6 +29,6 @@ RSpec.describe "Authentication" do
   end
 
   def then_i_can_access_the_support_interface
-    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    expect(page).to have_current_path support_recruitment_cycle_providers_path(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 end

--- a/spec/system/publish/providers/providers_removed_schools_spec.rb
+++ b/spec/system/publish/providers/providers_removed_schools_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe "Publish - Providers - Removed Schools page", service: :publish, 
     end
 
     before do
-      allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2025)
       and_provider_is_linked_to_recruitment_cycle
       and_user_is_signed_in
     end

--- a/spec/system/support/feedbacks_spec.rb
+++ b/spec/system/support/feedbacks_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Support console feedback view", service: :support do
   end
 
   def then_i_am_on_the_support_homepage
-    expect(page).to have_current_path(support_recruitment_cycle_providers_path(Settings.current_recruitment_cycle_year))
+    expect(page).to have_current_path(support_recruitment_cycle_providers_path(Find::CycleTimetable.cycle_year_from_time(Time.zone.now)))
   end
 
   def then_i_see_first_page_of_feedback_with_pagination

--- a/spec/system/support/feedbacks_spec.rb
+++ b/spec/system/support/feedbacks_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Support console feedback view", service: :support do
   end
 
   def then_i_am_on_the_support_homepage
-    expect(page).to have_current_path(support_recruitment_cycle_providers_path(Find::CycleTimetable.cycle_year_for_time(Time.zone.now)))
+    expect(page).to have_current_path(support_recruitment_cycle_providers_path(Find::CycleTimetable.current_year))
   end
 
   def then_i_see_first_page_of_feedback_with_pagination

--- a/spec/system/support/feedbacks_spec.rb
+++ b/spec/system/support/feedbacks_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Support console feedback view", service: :support do
   end
 
   def then_i_am_on_the_support_homepage
-    expect(page).to have_current_path(support_recruitment_cycle_providers_path(Find::CycleTimetable.cycle_year_from_time(Time.zone.now)))
+    expect(page).to have_current_path(support_recruitment_cycle_providers_path(Find::CycleTimetable.cycle_year_for_time(Time.zone.now)))
   end
 
   def then_i_see_first_page_of_feedback_with_pagination

--- a/spec/system/support/filters/provider_course_search_filters_spec.rb
+++ b/spec/system/support/filters/provider_course_search_filters_spec.rb
@@ -83,7 +83,7 @@ private
   end
 
   def when_i_visit_the_providers_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def and_when_i_click_apply_filters

--- a/spec/system/support/filters/provider_course_search_filters_spec.rb
+++ b/spec/system/support/filters/provider_course_search_filters_spec.rb
@@ -83,7 +83,7 @@ private
   end
 
   def when_i_visit_the_providers_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def and_when_i_click_apply_filters

--- a/spec/system/support/filters/provider_course_search_filters_spec.rb
+++ b/spec/system/support/filters/provider_course_search_filters_spec.rb
@@ -83,7 +83,7 @@ private
   end
 
   def when_i_visit_the_providers_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def and_when_i_click_apply_filters

--- a/spec/system/support/filters/provider_filters_spec.rb
+++ b/spec/system/support/filters/provider_filters_spec.rb
@@ -49,7 +49,7 @@ private
   end
 
   def when_i_visit_the_providers_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def then_i_can_search_by_provider_name

--- a/spec/system/support/filters/provider_filters_spec.rb
+++ b/spec/system/support/filters/provider_filters_spec.rb
@@ -49,7 +49,7 @@ private
   end
 
   def when_i_visit_the_providers_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def then_i_can_search_by_provider_name

--- a/spec/system/support/filters/provider_filters_spec.rb
+++ b/spec/system/support/filters/provider_filters_spec.rb
@@ -49,7 +49,7 @@ private
   end
 
   def when_i_visit_the_providers_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def then_i_can_search_by_provider_name

--- a/spec/system/support/filters/user_filters_spec.rb
+++ b/spec/system/support/filters/user_filters_spec.rb
@@ -48,7 +48,7 @@ private
   end
 
   def when_i_visit_the_support_users_index_page
-    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def then_i_can_search_by_first_name

--- a/spec/system/support/filters/user_filters_spec.rb
+++ b/spec/system/support/filters/user_filters_spec.rb
@@ -48,7 +48,7 @@ private
   end
 
   def when_i_visit_the_support_users_index_page
-    support_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def then_i_can_search_by_first_name

--- a/spec/system/support/filters/user_filters_spec.rb
+++ b/spec/system/support/filters/user_filters_spec.rb
@@ -48,7 +48,7 @@ private
   end
 
   def when_i_visit_the_support_users_index_page
-    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def then_i_can_search_by_first_name

--- a/spec/system/support/providers/accredited_partnerships_spec.rb
+++ b/spec/system/support/providers/accredited_partnerships_spec.rb
@@ -139,14 +139,14 @@ private
 
   def then_i_return_to_the_index_page
     expect(page).to have_current_path(support_recruitment_cycle_provider_accredited_partnerships_path(
-                                        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+                                        recruitment_cycle_year: Find::CycleTimetable.current_year,
                                         provider_id: @provider.id,
                                       ))
   end
 
   def and_i_visit_the_index_page
     visit support_recruitment_cycle_provider_accredited_partnerships_path(
-      recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
+      recruitment_cycle_year: Find::CycleTimetable.current_year,
       provider_id: @provider.id,
     )
   end

--- a/spec/system/support/providers/accredited_partnerships_spec.rb
+++ b/spec/system/support/providers/accredited_partnerships_spec.rb
@@ -139,14 +139,14 @@ private
 
   def then_i_return_to_the_index_page
     expect(page).to have_current_path(support_recruitment_cycle_provider_accredited_partnerships_path(
-                                        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+                                        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
                                         provider_id: @provider.id,
                                       ))
   end
 
   def and_i_visit_the_index_page
     visit support_recruitment_cycle_provider_accredited_partnerships_path(
-      recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+      recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
       provider_id: @provider.id,
     )
   end

--- a/spec/system/support/providers/accredited_partnerships_spec.rb
+++ b/spec/system/support/providers/accredited_partnerships_spec.rb
@@ -139,14 +139,14 @@ private
 
   def then_i_return_to_the_index_page
     expect(page).to have_current_path(support_recruitment_cycle_provider_accredited_partnerships_path(
-                                        recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+                                        recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
                                         provider_id: @provider.id,
                                       ))
   end
 
   def and_i_visit_the_index_page
     visit support_recruitment_cycle_provider_accredited_partnerships_path(
-      recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now),
+      recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now),
       provider_id: @provider.id,
     )
   end

--- a/spec/system/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/system/support/providers/courses/editing_a_course_spec.rb
@@ -95,7 +95,7 @@ private
   end
 
   def when_i_visit_the_support_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
   end
 
   def and_click_on_the_first_course_change_link
@@ -105,7 +105,7 @@ private
   alias_method :when_i_return_to_the_edit_page, :and_click_on_the_first_course_change_link
 
   def then_i_am_on_the_support_provider_course_edit_page
-    support_provider_course_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id, course_id: provider.courses.first.id)
+    support_provider_course_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id, course_id: provider.courses.first.id)
   end
 
   def course_code
@@ -149,11 +149,11 @@ private
   end
 
   def valid_date_year
-    @valid_date_year ||= Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i.to_s
+    @valid_date_year ||= Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i.to_s
   end
 
   def invalid_date_year
-    @invalid_date_year ||= (Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i + 3).to_s
+    @invalid_date_year ||= (Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i + 3).to_s
   end
 
   def blank_value
@@ -227,7 +227,7 @@ private
 
   def and_it_contains_invalid_value_errors
     expect(support_provider_course_edit_page.error_summary.text).to include("Course code is already taken")
-    expect(support_provider_course_edit_page.error_summary.text).to include("June #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 3} is not in the #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} cycle")
+    expect(support_provider_course_edit_page.error_summary.text).to include("June #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 3} is not in the #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} cycle")
   end
 
   def and_it_contains_start_date_format_error

--- a/spec/system/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/system/support/providers/courses/editing_a_course_spec.rb
@@ -95,7 +95,7 @@ private
   end
 
   def when_i_visit_the_support_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
   end
 
   def and_click_on_the_first_course_change_link
@@ -105,7 +105,7 @@ private
   alias_method :when_i_return_to_the_edit_page, :and_click_on_the_first_course_change_link
 
   def then_i_am_on_the_support_provider_course_edit_page
-    support_provider_course_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id, course_id: provider.courses.first.id)
+    support_provider_course_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id, course_id: provider.courses.first.id)
   end
 
   def course_code
@@ -149,11 +149,11 @@ private
   end
 
   def valid_date_year
-    @valid_date_year ||= Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i.to_s
+    @valid_date_year ||= Find::CycleTimetable.current_year.to_i.to_s
   end
 
   def invalid_date_year
-    @invalid_date_year ||= (Find::CycleTimetable.cycle_year_for_time(Time.zone.now).to_i + 3).to_s
+    @invalid_date_year ||= (Find::CycleTimetable.current_year.to_i + 3).to_s
   end
 
   def blank_value
@@ -227,7 +227,7 @@ private
 
   def and_it_contains_invalid_value_errors
     expect(support_provider_course_edit_page.error_summary.text).to include("Course code is already taken")
-    expect(support_provider_course_edit_page.error_summary.text).to include("September #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 3} is not in the #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} cycle")
+    expect(support_provider_course_edit_page.error_summary.text).to include("September #{Find::CycleTimetable.current_year + 3} is not in the #{Find::CycleTimetable.current_year} cycle")
   end
 
   def and_it_contains_start_date_format_error

--- a/spec/system/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/system/support/providers/courses/editing_a_course_spec.rb
@@ -95,7 +95,7 @@ private
   end
 
   def when_i_visit_the_support_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
   end
 
   def and_click_on_the_first_course_change_link
@@ -105,7 +105,7 @@ private
   alias_method :when_i_return_to_the_edit_page, :and_click_on_the_first_course_change_link
 
   def then_i_am_on_the_support_provider_course_edit_page
-    support_provider_course_edit_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id, course_id: provider.courses.first.id)
+    support_provider_course_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id, course_id: provider.courses.first.id)
   end
 
   def course_code
@@ -149,11 +149,11 @@ private
   end
 
   def valid_date_year
-    @valid_date_year ||= Settings.current_recruitment_cycle_year.to_i.to_s
+    @valid_date_year ||= Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i.to_s
   end
 
   def invalid_date_year
-    @invalid_date_year ||= (Settings.current_recruitment_cycle_year.to_i + 3).to_s
+    @invalid_date_year ||= (Find::CycleTimetable.cycle_year_from_time(Time.zone.now).to_i + 3).to_s
   end
 
   def blank_value
@@ -227,7 +227,7 @@ private
 
   def and_it_contains_invalid_value_errors
     expect(support_provider_course_edit_page.error_summary.text).to include("Course code is already taken")
-    expect(support_provider_course_edit_page.error_summary.text).to include("September #{Settings.current_recruitment_cycle_year + 3} is not in the #{Settings.current_recruitment_cycle_year} cycle")
+    expect(support_provider_course_edit_page.error_summary.text).to include("June #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 3} is not in the #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} cycle")
   end
 
   def and_it_contains_start_date_format_error

--- a/spec/system/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/system/support/providers/courses/editing_a_course_spec.rb
@@ -227,7 +227,7 @@ private
 
   def and_it_contains_invalid_value_errors
     expect(support_provider_course_edit_page.error_summary.text).to include("Course code is already taken")
-    expect(support_provider_course_edit_page.error_summary.text).to include("June #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 3} is not in the #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} cycle")
+    expect(support_provider_course_edit_page.error_summary.text).to include("September #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 3} is not in the #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} cycle")
   end
 
   def and_it_contains_start_date_format_error

--- a/spec/system/support/providers/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/system/support/providers/courses/editing_visa_sponsorship_spec.rb
@@ -89,15 +89,15 @@ RSpec.describe "Editing visa sponsorship" do
   end
 
   def when_i_navigate_to_the_apprenticeship_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 3, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 3, recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def when_i_navigate_to_the_salaried_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 2, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 2, recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def when_i_navigate_to_the_fee_paying_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 1, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 1, recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   alias_method :and_i_navigate_to_the_same_fee_paying_course, :when_i_navigate_to_the_fee_paying_course

--- a/spec/system/support/providers/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/system/support/providers/courses/editing_visa_sponsorship_spec.rb
@@ -89,15 +89,15 @@ RSpec.describe "Editing visa sponsorship" do
   end
 
   def when_i_navigate_to_the_apprenticeship_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 3, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 3, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def when_i_navigate_to_the_salaried_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 2, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 2, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def when_i_navigate_to_the_fee_paying_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 1, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 1, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   alias_method :and_i_navigate_to_the_same_fee_paying_course, :when_i_navigate_to_the_fee_paying_course

--- a/spec/system/support/providers/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/system/support/providers/courses/editing_visa_sponsorship_spec.rb
@@ -89,15 +89,15 @@ RSpec.describe "Editing visa sponsorship" do
   end
 
   def when_i_navigate_to_the_apprenticeship_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 3, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 3, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def when_i_navigate_to_the_salaried_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 2, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 2, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def when_i_navigate_to_the_fee_paying_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 1, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: provider.id, id: 1, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   alias_method :and_i_navigate_to_the_same_fee_paying_course, :when_i_navigate_to_the_fee_paying_course

--- a/spec/system/support/providers/courses/reverting_a_withdrawal_spec.rb
+++ b/spec/system/support/providers/courses/reverting_a_withdrawal_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Reverting a withdrawal" do
   end
 
   def when_i_navigate_to_the_withdrawn_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: @provider.id, id: @course.id, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: @provider.id, id: @course.id, recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def and_i_click_revert_withdrawal

--- a/spec/system/support/providers/courses/reverting_a_withdrawal_spec.rb
+++ b/spec/system/support/providers/courses/reverting_a_withdrawal_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Reverting a withdrawal" do
   end
 
   def when_i_navigate_to_the_withdrawn_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: @provider.id, id: @course.id, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: @provider.id, id: @course.id, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def and_i_click_revert_withdrawal

--- a/spec/system/support/providers/courses/reverting_a_withdrawal_spec.rb
+++ b/spec/system/support/providers/courses/reverting_a_withdrawal_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Reverting a withdrawal" do
   end
 
   def when_i_navigate_to_the_withdrawn_course
-    visit edit_support_recruitment_cycle_provider_course_path(provider_id: @provider.id, id: @course.id, recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    visit edit_support_recruitment_cycle_provider_course_path(provider_id: @provider.id, id: @course.id, recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def and_i_click_revert_withdrawal

--- a/spec/system/support/providers/courses/viewing_providers_courses_spec.rb
+++ b/spec/system/support/providers/courses/viewing_providers_courses_spec.rb
@@ -46,11 +46,11 @@ private
   end
 
   def when_i_visit_the_support_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
   end
 
   def when_i_visit_the_support_discarded_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: discarded_provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: discarded_provider.id)
   end
 
   def then_i_am_redirected_to_the_providers_page

--- a/spec/system/support/providers/courses/viewing_providers_courses_spec.rb
+++ b/spec/system/support/providers/courses/viewing_providers_courses_spec.rb
@@ -46,11 +46,11 @@ private
   end
 
   def when_i_visit_the_support_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
   end
 
   def when_i_visit_the_support_discarded_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: discarded_provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: discarded_provider.id)
   end
 
   def then_i_am_redirected_to_the_providers_page

--- a/spec/system/support/providers/courses/viewing_providers_courses_spec.rb
+++ b/spec/system/support/providers/courses/viewing_providers_courses_spec.rb
@@ -46,11 +46,11 @@ private
   end
 
   def when_i_visit_the_support_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
   end
 
   def when_i_visit_the_support_discarded_provider_courses_index_page
-    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: discarded_provider.id)
+    support_provider_courses_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: discarded_provider.id)
   end
 
   def then_i_am_redirected_to_the_providers_page

--- a/spec/system/support/providers/editing_a_provider_spec.rb
+++ b/spec/system/support/providers/editing_a_provider_spec.rb
@@ -59,7 +59,7 @@ private
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @provider.id)
   end
 
   def then_i_can_view_provider_details
@@ -81,7 +81,7 @@ private
   end
 
   def then_i_am_on_the_support_provider_edit_contact_details_page
-    expect(URI(current_url).path).to eq("/support/#{Settings.current_recruitment_cycle_year}/providers/#{@provider.id}/contact-details/edit")
+    expect(URI(current_url).path).to eq("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/#{@provider.id}/contact-details/edit")
   end
 
   def when_i_fill_in_a_valid_email

--- a/spec/system/support/providers/editing_a_provider_spec.rb
+++ b/spec/system/support/providers/editing_a_provider_spec.rb
@@ -59,7 +59,7 @@ private
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @provider.id)
   end
 
   def then_i_can_view_provider_details
@@ -81,7 +81,7 @@ private
   end
 
   def then_i_am_on_the_support_provider_edit_contact_details_page
-    expect(URI(current_url).path).to eq("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/#{@provider.id}/contact-details/edit")
+    expect(URI(current_url).path).to eq("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/#{@provider.id}/contact-details/edit")
   end
 
   def when_i_fill_in_a_valid_email

--- a/spec/system/support/providers/editing_a_provider_spec.rb
+++ b/spec/system/support/providers/editing_a_provider_spec.rb
@@ -59,7 +59,7 @@ private
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: @provider.id)
   end
 
   def then_i_can_view_provider_details
@@ -81,7 +81,7 @@ private
   end
 
   def then_i_am_on_the_support_provider_edit_contact_details_page
-    expect(URI(current_url).path).to eq("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/#{@provider.id}/contact-details/edit")
+    expect(URI(current_url).path).to eq("/support/#{Find::CycleTimetable.current_year}/providers/#{@provider.id}/contact-details/edit")
   end
 
   def when_i_fill_in_a_valid_email

--- a/spec/system/support/providers/editing_a_user_from_a_provider_spec.rb
+++ b/spec/system/support/providers/editing_a_user_from_a_provider_spec.rb
@@ -35,7 +35,7 @@ private
   end
 
   def and_i_visit_the_support_provider_user_show_page
-    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.id, provider_id: @provider.id)
+    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: @user.id, provider_id: @provider.id)
   end
 
   def when_i_click_the_change_firstname_link

--- a/spec/system/support/providers/editing_a_user_from_a_provider_spec.rb
+++ b/spec/system/support/providers/editing_a_user_from_a_provider_spec.rb
@@ -35,7 +35,7 @@ private
   end
 
   def and_i_visit_the_support_provider_user_show_page
-    support_provider_user_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.id, provider_id: @provider.id)
+    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.id, provider_id: @provider.id)
   end
 
   def when_i_click_the_change_firstname_link

--- a/spec/system/support/providers/editing_a_user_from_a_provider_spec.rb
+++ b/spec/system/support/providers/editing_a_user_from_a_provider_spec.rb
@@ -35,7 +35,7 @@ private
   end
 
   def and_i_visit_the_support_provider_user_show_page
-    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.id, provider_id: @provider.id)
+    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.id, provider_id: @provider.id)
   end
 
   def when_i_click_the_change_firstname_link

--- a/spec/system/support/providers/onboarding_a_new_provider_spec.rb
+++ b/spec/system/support/providers/onboarding_a_new_provider_spec.rb
@@ -134,7 +134,7 @@ private
   end
 
   def and_i_visit_the_onboarding_a_new_provider_page
-    visit "/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/new"
+    visit "/support/#{Find::CycleTimetable.current_year}/providers/onboarding/new"
   end
 
   def when_i_fill_in_a_valid_provider_contact_details
@@ -212,23 +212,23 @@ private
   end
 
   def then_i_am_redirected_to_provider_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/#{Provider.last.id}")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.current_year}/providers/#{Provider.last.id}")
   end
 
   def then_i_am_redirected_to_check_your_answer_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/check")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.current_year}/providers/onboarding/check")
   end
 
   def then_i_am_redirected_to_the_onboarding_contacts_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/contacts/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.current_year}/providers/onboarding/contacts/new")
   end
 
   def then_i_am_redirected_back_to_the_onboarding_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.current_year}/providers/onboarding/new")
   end
 
   def then_i_am_redirected_back_to_the_support_providers_index_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.current_year}/providers")
   end
 
   def then_i_see_the_error_summary

--- a/spec/system/support/providers/onboarding_a_new_provider_spec.rb
+++ b/spec/system/support/providers/onboarding_a_new_provider_spec.rb
@@ -134,7 +134,7 @@ private
   end
 
   def and_i_visit_the_onboarding_a_new_provider_page
-    visit "/support/#{Settings.current_recruitment_cycle_year}/providers/onboarding/new"
+    visit "/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/new"
   end
 
   def when_i_fill_in_a_valid_provider_contact_details
@@ -212,23 +212,23 @@ private
   end
 
   def then_i_am_redirected_to_provider_page
-    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers/#{Provider.last.id}")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/#{Provider.last.id}")
   end
 
   def then_i_am_redirected_to_check_your_answer_page
-    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers/onboarding/check")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/check")
   end
 
   def then_i_am_redirected_to_the_onboarding_contacts_page
-    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers/onboarding/contacts/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/contacts/new")
   end
 
   def then_i_am_redirected_back_to_the_onboarding_page
-    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers/onboarding/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/new")
   end
 
   def then_i_am_redirected_back_to_the_support_providers_index_page
-    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers")
   end
 
   def then_i_see_the_error_summary

--- a/spec/system/support/providers/onboarding_a_new_provider_spec.rb
+++ b/spec/system/support/providers/onboarding_a_new_provider_spec.rb
@@ -134,7 +134,7 @@ private
   end
 
   def and_i_visit_the_onboarding_a_new_provider_page
-    visit "/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/new"
+    visit "/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/new"
   end
 
   def when_i_fill_in_a_valid_provider_contact_details
@@ -212,23 +212,23 @@ private
   end
 
   def then_i_am_redirected_to_provider_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/#{Provider.last.id}")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/#{Provider.last.id}")
   end
 
   def then_i_am_redirected_to_check_your_answer_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/check")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/check")
   end
 
   def then_i_am_redirected_to_the_onboarding_contacts_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/contacts/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/contacts/new")
   end
 
   def then_i_am_redirected_back_to_the_onboarding_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/new")
   end
 
   def then_i_am_redirected_back_to_the_support_providers_index_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers")
   end
 
   def then_i_see_the_error_summary

--- a/spec/system/support/providers/provider_courses_list_spec.rb
+++ b/spec/system/support/providers/provider_courses_list_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "View provider courses" do
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: provider.id)
   end
 
   def and_click_on_the_courses_tab

--- a/spec/system/support/providers/provider_courses_list_spec.rb
+++ b/spec/system/support/providers/provider_courses_list_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "View provider courses" do
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: provider.id)
   end
 
   def and_click_on_the_courses_tab

--- a/spec/system/support/providers/provider_courses_list_spec.rb
+++ b/spec/system/support/providers/provider_courses_list_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "View provider courses" do
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: provider.id)
   end
 
   def and_click_on_the_courses_tab

--- a/spec/system/support/providers/provider_users_list_spec.rb
+++ b/spec/system/support/providers/provider_users_list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "View provider users" do
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: @provider.id)
   end
 
   def and_click_on_the_users_tab

--- a/spec/system/support/providers/provider_users_list_spec.rb
+++ b/spec/system/support/providers/provider_users_list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "View provider users" do
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @provider.id)
   end
 
   def and_click_on_the_users_tab

--- a/spec/system/support/providers/provider_users_list_spec.rb
+++ b/spec/system/support/providers/provider_users_list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "View provider users" do
   end
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @provider.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @provider.id)
   end
 
   def and_click_on_the_users_tab

--- a/spec/system/support/providers/providers_filter_spec.rb
+++ b/spec/system/support/providers/providers_filter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "View filtered providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def then_i_see_the_providers

--- a/spec/system/support/providers/providers_filter_spec.rb
+++ b/spec/system/support/providers/providers_filter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "View filtered providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def then_i_see_the_providers

--- a/spec/system/support/providers/providers_filter_spec.rb
+++ b/spec/system/support/providers/providers_filter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "View filtered providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def then_i_see_the_providers

--- a/spec/system/support/providers/providers_list_spec.rb
+++ b/spec/system/support/providers/providers_list_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "View providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def then_i_see_the_providers
@@ -33,7 +33,7 @@ RSpec.describe "View providers" do
   end
 
   def then_i_am_on_the_provider_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/new")
   end
 
   def and_i_click_on_add_provider

--- a/spec/system/support/providers/providers_list_spec.rb
+++ b/spec/system/support/providers/providers_list_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "View providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def then_i_see_the_providers
@@ -33,7 +33,7 @@ RSpec.describe "View providers" do
   end
 
   def then_i_am_on_the_provider_page
-    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers/onboarding/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/onboarding/new")
   end
 
   def and_i_click_on_add_provider

--- a/spec/system/support/providers/providers_list_spec.rb
+++ b/spec/system/support/providers/providers_list_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "View providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def then_i_see_the_providers
@@ -33,7 +33,7 @@ RSpec.describe "View providers" do
   end
 
   def then_i_am_on_the_provider_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/onboarding/new")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.current_year}/providers/onboarding/new")
   end
 
   def and_i_click_on_add_provider

--- a/spec/system/support/providers/removing_user_from_provider_spec.rb
+++ b/spec/system/support/providers/removing_user_from_provider_spec.rb
@@ -26,7 +26,7 @@ private
   end
 
   def and_i_visit_the_support_provider_user_show_page
-    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.id, provider_id: @provider.id)
+    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.id, provider_id: @provider.id)
   end
 
   def and_i_click_the_remove_user_link

--- a/spec/system/support/providers/removing_user_from_provider_spec.rb
+++ b/spec/system/support/providers/removing_user_from_provider_spec.rb
@@ -26,7 +26,7 @@ private
   end
 
   def and_i_visit_the_support_provider_user_show_page
-    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.id, provider_id: @provider.id)
+    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: @user.id, provider_id: @provider.id)
   end
 
   def and_i_click_the_remove_user_link

--- a/spec/system/support/providers/removing_user_from_provider_spec.rb
+++ b/spec/system/support/providers/removing_user_from_provider_spec.rb
@@ -26,7 +26,7 @@ private
   end
 
   def and_i_visit_the_support_provider_user_show_page
-    support_provider_user_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.id, provider_id: @provider.id)
+    support_provider_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.id, provider_id: @provider.id)
   end
 
   def and_i_click_the_remove_user_link

--- a/spec/system/support/providers/schools/add_school_to_provider_spec.rb
+++ b/spec/system/support/providers/schools/add_school_to_provider_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe "Adding school to provider as an admin" do
   end
 
   def given_i_visit_the_support_provider_schools_index_page
-    support_provider_schools_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
+    support_provider_schools_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id)
   end
 
   def then_i_am_on_the_school_search_page
-    expect(page).to have_current_path(search_support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id))
+    expect(page).to have_current_path(search_support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id))
   end
 
   def when_i_search_with_an_empty_query

--- a/spec/system/support/providers/schools/add_school_to_provider_spec.rb
+++ b/spec/system/support/providers/schools/add_school_to_provider_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe "Adding school to provider as an admin" do
   end
 
   def given_i_visit_the_support_provider_schools_index_page
-    support_provider_schools_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id)
+    support_provider_schools_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id)
   end
 
   def then_i_am_on_the_school_search_page
-    expect(page).to have_current_path(search_support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id))
+    expect(page).to have_current_path(search_support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id))
   end
 
   def when_i_search_with_an_empty_query

--- a/spec/system/support/providers/schools/add_school_to_provider_spec.rb
+++ b/spec/system/support/providers/schools/add_school_to_provider_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe "Adding school to provider as an admin" do
   end
 
   def given_i_visit_the_support_provider_schools_index_page
-    support_provider_schools_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id)
+    support_provider_schools_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id)
   end
 
   def then_i_am_on_the_school_search_page
-    expect(page).to have_current_path(search_support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id))
+    expect(page).to have_current_path(search_support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id))
   end
 
   def when_i_search_with_an_empty_query

--- a/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Multiple schools" do
   end
 
   def then_i_am_redirected_to_the_school_index
-    expect(page).to have_current_path(support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id))
+    expect(page).to have_current_path(support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id))
   end
 
   def and_i_see_that_all_schools_are_created
@@ -200,16 +200,16 @@ RSpec.describe "Multiple schools" do
   end
 
   def and_i_am_redirected_to_the_multiple_school_check_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
+    expect(page).to have_current_path support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
     expect(page).to have_text "Check your answers"
   end
 
   def when_i_visit_the_multiple_schools_new_page
-    visit new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
+    visit new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
   end
 
   def when_i_visit_a_provider_schools_page
-    visit support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
+    visit support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
   end
 
   def and_i_have_one_existing_school
@@ -279,11 +279,11 @@ RSpec.describe "Multiple schools" do
   end
 
   def when_i_am_redirected_to_the_schools_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
+    expect(page).to have_current_path support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
   end
 
   def and_i_am_on_the_enter_urns_page
-    expect(page).to have_current_path new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
+    expect(page).to have_current_path new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: provider.id)
   end
 
   alias_method :and_i_click_add_schools, :when_i_click_add_schools

--- a/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Multiple schools" do
   end
 
   def then_i_am_redirected_to_the_school_index
-    expect(page).to have_current_path(support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id))
+    expect(page).to have_current_path(support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id))
   end
 
   def and_i_see_that_all_schools_are_created
@@ -200,16 +200,16 @@ RSpec.describe "Multiple schools" do
   end
 
   def and_i_am_redirected_to_the_multiple_school_check_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
+    expect(page).to have_current_path support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
     expect(page).to have_text "Check your answers"
   end
 
   def when_i_visit_the_multiple_schools_new_page
-    visit new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
+    visit new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
   end
 
   def when_i_visit_a_provider_schools_page
-    visit support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
+    visit support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
   end
 
   def and_i_have_one_existing_school
@@ -279,11 +279,11 @@ RSpec.describe "Multiple schools" do
   end
 
   def when_i_am_redirected_to_the_schools_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
+    expect(page).to have_current_path support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
   end
 
   def and_i_am_on_the_enter_urns_page
-    expect(page).to have_current_path new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
+    expect(page).to have_current_path new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: provider.id)
   end
 
   alias_method :and_i_click_add_schools, :when_i_click_add_schools

--- a/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Multiple schools" do
   end
 
   def then_i_am_redirected_to_the_school_index
-    expect(page).to have_current_path(support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id))
+    expect(page).to have_current_path(support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id))
   end
 
   def and_i_see_that_all_schools_are_created
@@ -200,16 +200,16 @@ RSpec.describe "Multiple schools" do
   end
 
   def and_i_am_redirected_to_the_multiple_school_check_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+    expect(page).to have_current_path support_recruitment_cycle_provider_schools_multiple_check_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
     expect(page).to have_text "Check your answers"
   end
 
   def when_i_visit_the_multiple_schools_new_page
-    visit new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+    visit new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
   end
 
   def when_i_visit_a_provider_schools_page
-    visit support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+    visit support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
   end
 
   def and_i_have_one_existing_school
@@ -279,11 +279,11 @@ RSpec.describe "Multiple schools" do
   end
 
   def when_i_am_redirected_to_the_schools_page
-    expect(page).to have_current_path support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+    expect(page).to have_current_path support_recruitment_cycle_provider_schools_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
   end
 
   def and_i_am_on_the_enter_urns_page
-    expect(page).to have_current_path new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: provider.id)
+    expect(page).to have_current_path new_support_recruitment_cycle_provider_schools_multiple_path(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: provider.id)
   end
 
   alias_method :and_i_click_add_schools, :when_i_click_add_schools

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Delete school under provider as an admin" do
   end
 
   def and_i_visit_the_support_provider_school_show_page
-    support_provider_school_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id, id: @site.id)
+    support_provider_school_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id, id: @site.id)
   end
 
   def and_there_is_a_provider_site

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Delete school under provider as an admin" do
   end
 
   def and_i_visit_the_support_provider_school_show_page
-    support_provider_school_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id, id: @site.id)
+    support_provider_school_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id, id: @site.id)
   end
 
   def and_there_is_a_provider_site

--- a/spec/system/support/providers/schools/delete_school_spec.rb
+++ b/spec/system/support/providers/schools/delete_school_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Delete school under provider as an admin" do
   end
 
   def and_i_visit_the_support_provider_school_show_page
-    support_provider_school_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id, id: @site.id)
+    support_provider_school_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id, id: @site.id)
   end
 
   def and_there_is_a_provider_site

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe "Support index" do
   end
 
   def then_i_should_be_on_the_recruitment_cycle_switcher_page
-    expect(support_recruitment_cycle_index_page).to have_link "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} - current"
-    expect(support_recruitment_cycle_index_page).to have_link Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
+    expect(support_recruitment_cycle_index_page).to have_link "#{Find::CycleTimetable.current_year} - current"
+    expect(support_recruitment_cycle_index_page).to have_link Find::CycleTimetable.next_year
   end
 
   def and_should_not_see_the_switch_cycle_link
@@ -66,7 +66,7 @@ RSpec.describe "Support index" do
   end
 
   def i_should_see_the_current_cycle_page
-    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} - current"
+    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.previous_year} to #{Find::CycleTimetable.current_year} - current"
   end
 
   def when_click_the_switch_cycle_link
@@ -74,7 +74,7 @@ RSpec.describe "Support index" do
   end
 
   def i_should_be_on_the_next_cycle_page
-    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1}"
+    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.current_year} to #{Find::CycleTimetable.next_year}"
   end
 
   def and_i_should_see_the_pe_allocations_tab

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe "Support index" do
   end
 
   def then_i_should_be_on_the_recruitment_cycle_switcher_page
-    expect(support_recruitment_cycle_index_page).to have_link "#{Settings.current_recruitment_cycle_year} - current"
-    expect(support_recruitment_cycle_index_page).to have_link Settings.current_recruitment_cycle_year + 1
+    expect(support_recruitment_cycle_index_page).to have_link "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} - current"
+    expect(support_recruitment_cycle_index_page).to have_link Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
   end
 
   def and_should_not_see_the_switch_cycle_link
@@ -72,7 +72,7 @@ RSpec.describe "Support index" do
   end
 
   def i_should_see_the_current_cycle_page
-    expect(support_provider_index_page).to have_text "Recruitment cycle #{Settings.current_recruitment_cycle_year - 1} to #{Settings.current_recruitment_cycle_year} - current"
+    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} - current"
   end
 
   def when_click_the_switch_cycle_link
@@ -80,7 +80,7 @@ RSpec.describe "Support index" do
   end
 
   def i_should_be_on_the_next_cycle_page
-    expect(support_provider_index_page).to have_text "Recruitment cycle #{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}"
+    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1}"
   end
 
   def and_i_should_see_the_pe_allocations_tab

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe "Support index" do
   scenario "viewing support cycles page during rollover", travel: find_closes do
     given_we_have_a_next_cycle
-    and_there_are_two_recruitment_cycles
     and_today_is_before_next_cycle_available_for_support_users_date
     and_i_am_authenticated_as_an_admin_user
     when_i_visit_the_support_index_page
@@ -25,9 +24,8 @@ RSpec.describe "Support index" do
     i_should_be_on_the_next_cycle_page
   end
 
-  scenario "viewing providers page when not in rollover", travel: mid_cycle do
+  scenario "viewing providers page when not in rollover" do
     given_we_have_a_next_cycle
-    and_there_are_two_recruitment_cycles
     and_i_am_authenticated_as_an_admin_user
     and_today_is_before_next_cycle_available_for_support_users_date
     when_i_visit_the_support_index_page
@@ -39,11 +37,6 @@ RSpec.describe "Support index" do
   end
 
   def given_we_have_a_next_cycle
-    find_or_create(:recruitment_cycle, :next)
-  end
-
-  def and_there_are_two_recruitment_cycles
-    find_or_create(:recruitment_cycle, :previous)
     find_or_create(:recruitment_cycle, :next)
   end
 

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe "Support index" do
 
   scenario "viewing providers page when not in rollover" do
     given_we_have_a_next_cycle
-    and_i_am_authenticated_as_an_admin_user
     and_today_is_before_next_cycle_available_for_support_users_date
+    and_i_am_authenticated_as_an_admin_user
     when_i_visit_the_support_index_page
     then_i_should_be_on_the_support_providers_page
   end
 
   def then_i_should_be_on_the_support_providers_page
-    expect(support_provider_index_page).to be_displayed
+    expect(page).to have_current_path "/support/#{RecruitmentCycle.current.year}/providers", ignore_query: true
   end
 
   def given_we_have_a_next_cycle

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe "Support index" do
   end
 
   def then_i_should_be_on_the_recruitment_cycle_switcher_page
-    expect(support_recruitment_cycle_index_page).to have_link "#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} - current"
-    expect(support_recruitment_cycle_index_page).to have_link Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1
+    expect(support_recruitment_cycle_index_page).to have_link "#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} - current"
+    expect(support_recruitment_cycle_index_page).to have_link Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1
   end
 
   def and_should_not_see_the_switch_cycle_link
@@ -73,7 +73,7 @@ RSpec.describe "Support index" do
   end
 
   def i_should_see_the_current_cycle_page
-    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} - current"
+    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) - 1} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} - current"
   end
 
   def when_click_the_switch_cycle_link
@@ -81,7 +81,7 @@ RSpec.describe "Support index" do
   end
 
   def i_should_be_on_the_next_cycle_page
-    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_from_time(Time.zone.now) + 1}"
+    expect(support_provider_index_page).to have_text "Recruitment cycle #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)} to #{Find::CycleTimetable.cycle_year_for_time(Time.zone.now) + 1}"
   end
 
   def and_i_should_see_the_pe_allocations_tab

--- a/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
+++ b/spec/system/support/providers/switching_between_recruitment_cycles_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Support index" do
     given_we_have_a_next_cycle
     and_there_are_two_recruitment_cycles
     and_i_am_authenticated_as_an_admin_user
+    and_today_is_before_next_cycle_available_for_support_users_date
     when_i_visit_the_support_index_page
     then_i_should_be_on_the_support_providers_page
   end
@@ -92,10 +93,10 @@ RSpec.describe "Support index" do
   end
 
   def and_today_is_before_next_cycle_available_for_support_users_date
-    travel_to(1.day.before(RecruitmentCycle.next.available_for_support_users_from))
+    Timecop.travel(1.day.until(RecruitmentCycle.next.available_for_support_users_from))
   end
 
   def and_today_is_after_next_cycle_available_for_support_users_date
-    travel_to(1.day.since(RecruitmentCycle.next.available_for_support_users_from))
+    Timecop.travel(1.day.since(RecruitmentCycle.next.available_for_support_users_from))
   end
 end

--- a/spec/system/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/system/support/providers/users/adding_user_to_provider_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   end
 
   def given_i_visit_the_support_provider_users_index_page
-    support_provider_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id)
+    support_provider_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id)
   end
 
   def given_i_visit_the_support_provider_users_new_page
-    support_provider_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id)
+    support_provider_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id)
   end
 
   def and_i_continue
@@ -67,7 +67,7 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   alias_method :when_i_continue, :and_i_continue
 
   def given_i_visit_the_support_provider_users_new_page
-    support_provider_user_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id)
+    support_provider_user_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, provider_id: @provider.id)
   end
 
   def and_i_fill_in_first_name
@@ -133,7 +133,7 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   end
 
   def and_i_am_still_on_the_same_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/#{@provider.id}/users")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.current_year}/providers/#{@provider.id}/users")
   end
 
   def given_i_am_authenticated_as_an_admin_user

--- a/spec/system/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/system/support/providers/users/adding_user_to_provider_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   end
 
   def given_i_visit_the_support_provider_users_index_page
-    support_provider_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id)
+    support_provider_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id)
   end
 
   def given_i_visit_the_support_provider_users_new_page
-    support_provider_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id)
+    support_provider_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id)
   end
 
   def and_i_continue
@@ -67,7 +67,7 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   alias_method :when_i_continue, :and_i_continue
 
   def given_i_visit_the_support_provider_users_new_page
-    support_provider_user_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id)
+    support_provider_user_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), provider_id: @provider.id)
   end
 
   def and_i_fill_in_first_name
@@ -133,7 +133,7 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   end
 
   def and_i_am_still_on_the_same_page
-    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/#{@provider.id}/users")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_for_time(Time.zone.now)}/providers/#{@provider.id}/users")
   end
 
   def given_i_am_authenticated_as_an_admin_user

--- a/spec/system/support/providers/users/adding_user_to_provider_spec.rb
+++ b/spec/system/support/providers/users/adding_user_to_provider_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   end
 
   def given_i_visit_the_support_provider_users_index_page
-    support_provider_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
+    support_provider_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id)
   end
 
   def given_i_visit_the_support_provider_users_new_page
-    support_provider_users_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
+    support_provider_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id)
   end
 
   def and_i_continue
@@ -67,7 +67,7 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   alias_method :when_i_continue, :and_i_continue
 
   def given_i_visit_the_support_provider_users_new_page
-    support_provider_user_users_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, provider_id: @provider.id)
+    support_provider_user_users_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), provider_id: @provider.id)
   end
 
   def and_i_fill_in_first_name
@@ -133,7 +133,7 @@ RSpec.describe "Adding user to provider as an admin", travel: mid_cycle do
   end
 
   def and_i_am_still_on_the_same_page
-    expect(page).to have_current_path("/support/#{Settings.current_recruitment_cycle_year}/providers/#{@provider.id}/users")
+    expect(page).to have_current_path("/support/#{Find::CycleTimetable.cycle_year_from_time(Time.zone.now)}/providers/#{@provider.id}/users")
   end
 
   def given_i_am_authenticated_as_an_admin_user

--- a/spec/system/support/providers/viewing_a_user_spec.rb
+++ b/spec/system/support/providers/viewing_a_user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Viewing a user" do
 private
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.providers.first.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: @user.providers.first.id)
   end
 
   def and_there_is_a_user(user = nil)
@@ -68,6 +68,6 @@ private
   def and_i_see_the_users_details_with_last_login
     and_i_see_the_users_details
     expect(support_provider_user_show_page.date_last_signed_in.text).to eq(@user.last_login_date_utc.strftime("%d %B %Y at %I:%M%p"))
-    expect(support_provider_user_show_page.remove_user_link["href"]).to eq(delete_support_recruitment_cycle_provider_user_path(Find::CycleTimetable.cycle_year_for_time(Time.zone.now), @user.providers.first, @user))
+    expect(support_provider_user_show_page.remove_user_link["href"]).to eq(delete_support_recruitment_cycle_provider_user_path(Find::CycleTimetable.current_year, @user.providers.first, @user))
   end
 end

--- a/spec/system/support/providers/viewing_a_user_spec.rb
+++ b/spec/system/support/providers/viewing_a_user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Viewing a user" do
 private
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.providers.first.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.providers.first.id)
   end
 
   def and_there_is_a_user(user = nil)
@@ -68,6 +68,6 @@ private
   def and_i_see_the_users_details_with_last_login
     and_i_see_the_users_details
     expect(support_provider_user_show_page.date_last_signed_in.text).to eq(@user.last_login_date_utc.strftime("%d %B %Y at %I:%M%p"))
-    expect(support_provider_user_show_page.remove_user_link["href"]).to eq(delete_support_recruitment_cycle_provider_user_path(Settings.current_recruitment_cycle_year, @user.providers.first, @user))
+    expect(support_provider_user_show_page.remove_user_link["href"]).to eq(delete_support_recruitment_cycle_provider_user_path(Find::CycleTimetable.cycle_year_from_time(Time.zone.now), @user.providers.first, @user))
   end
 end

--- a/spec/system/support/providers/viewing_a_user_spec.rb
+++ b/spec/system/support/providers/viewing_a_user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Viewing a user" do
 private
 
   def when_i_visit_the_support_provider_show_page
-    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.providers.first.id)
+    support_provider_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.providers.first.id)
   end
 
   def and_there_is_a_user(user = nil)
@@ -68,6 +68,6 @@ private
   def and_i_see_the_users_details_with_last_login
     and_i_see_the_users_details
     expect(support_provider_user_show_page.date_last_signed_in.text).to eq(@user.last_login_date_utc.strftime("%d %B %Y at %I:%M%p"))
-    expect(support_provider_user_show_page.remove_user_link["href"]).to eq(delete_support_recruitment_cycle_provider_user_path(Find::CycleTimetable.cycle_year_from_time(Time.zone.now), @user.providers.first, @user))
+    expect(support_provider_user_show_page.remove_user_link["href"]).to eq(delete_support_recruitment_cycle_provider_user_path(Find::CycleTimetable.cycle_year_for_time(Time.zone.now), @user.providers.first, @user))
   end
 end

--- a/spec/system/support/users/creating_a_new_user_spec.rb
+++ b/spec/system/support/users/creating_a_new_user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def when_i_visit_the_user_index_page
-    support_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def and_i_click_on_add_a_user
@@ -41,7 +41,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def then_i_am_taken_to_the_support_user_new_page
-    support_user_new_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_user_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def and_i_fill_in_first_name
@@ -65,7 +65,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def then_i_am_taken_to_the_user_index_page
-    support_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def then_i_should_see_the_error_summary

--- a/spec/system/support/users/creating_a_new_user_spec.rb
+++ b/spec/system/support/users/creating_a_new_user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def when_i_visit_the_user_index_page
-    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def and_i_click_on_add_a_user
@@ -41,7 +41,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def then_i_am_taken_to_the_support_user_new_page
-    support_user_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_user_new_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def and_i_fill_in_first_name
@@ -65,7 +65,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def then_i_am_taken_to_the_user_index_page
-    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def then_i_should_see_the_error_summary

--- a/spec/system/support/users/creating_a_new_user_spec.rb
+++ b/spec/system/support/users/creating_a_new_user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def when_i_visit_the_user_index_page
-    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def and_i_click_on_add_a_user
@@ -41,7 +41,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def then_i_am_taken_to_the_support_user_new_page
-    support_user_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_user_new_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def and_i_fill_in_first_name
@@ -65,7 +65,7 @@ RSpec.describe "Creating a new user" do
   end
 
   def then_i_am_taken_to_the_user_index_page
-    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def then_i_should_see_the_error_summary

--- a/spec/system/support/users/deleting_a_user_spec.rb
+++ b/spec/system/support/users/deleting_a_user_spec.rb
@@ -23,7 +23,7 @@ private
   end
 
   def when_i_visit_the_user_show_page(user_id)
-    support_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: user_id)
+    support_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: user_id)
   end
 
   def when_i_click_the_delete_button

--- a/spec/system/support/users/deleting_a_user_spec.rb
+++ b/spec/system/support/users/deleting_a_user_spec.rb
@@ -23,7 +23,7 @@ private
   end
 
   def when_i_visit_the_user_show_page(user_id)
-    support_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: user_id)
+    support_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: user_id)
   end
 
   def when_i_click_the_delete_button

--- a/spec/system/support/users/deleting_a_user_spec.rb
+++ b/spec/system/support/users/deleting_a_user_spec.rb
@@ -23,7 +23,7 @@ private
   end
 
   def when_i_visit_the_user_show_page(user_id)
-    support_user_show_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: user_id)
+    support_user_show_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: user_id)
   end
 
   def when_i_click_the_delete_button

--- a/spec/system/support/users/deleting_user_from_provider_spec.rb
+++ b/spec/system/support/users/deleting_user_from_provider_spec.rb
@@ -24,7 +24,7 @@ private
   end
 
   def when_i_visit_the_user_show_providers_page
-    support_user_show_providers_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.id)
+    support_user_show_providers_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: @user.id)
   end
 
   def when_i_click_the_remove_user_from_provider_button

--- a/spec/system/support/users/deleting_user_from_provider_spec.rb
+++ b/spec/system/support/users/deleting_user_from_provider_spec.rb
@@ -24,7 +24,7 @@ private
   end
 
   def when_i_visit_the_user_show_providers_page
-    support_user_show_providers_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.id)
+    support_user_show_providers_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.id)
   end
 
   def when_i_click_the_remove_user_from_provider_button

--- a/spec/system/support/users/deleting_user_from_provider_spec.rb
+++ b/spec/system/support/users/deleting_user_from_provider_spec.rb
@@ -24,7 +24,7 @@ private
   end
 
   def when_i_visit_the_user_show_providers_page
-    support_user_show_providers_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.id)
+    support_user_show_providers_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.id)
   end
 
   def when_i_click_the_remove_user_from_provider_button

--- a/spec/system/support/users/editing_a_user_spec.rb
+++ b/spec/system/support/users/editing_a_user_spec.rb
@@ -33,7 +33,7 @@ private
   end
 
   def when_i_visit_the_support_user_edit_page
-    support_user_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.id)
+    support_user_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.id)
   end
 
   def and_i_fill_in_correct_details

--- a/spec/system/support/users/editing_a_user_spec.rb
+++ b/spec/system/support/users/editing_a_user_spec.rb
@@ -33,7 +33,7 @@ private
   end
 
   def when_i_visit_the_support_user_edit_page
-    support_user_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now), id: @user.id)
+    support_user_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year, id: @user.id)
   end
 
   def and_i_fill_in_correct_details

--- a/spec/system/support/users/editing_a_user_spec.rb
+++ b/spec/system/support/users/editing_a_user_spec.rb
@@ -33,7 +33,7 @@ private
   end
 
   def when_i_visit_the_support_user_edit_page
-    support_user_edit_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year, id: @user.id)
+    support_user_edit_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now), id: @user.id)
   end
 
   def and_i_fill_in_correct_details

--- a/spec/system/support/users/providers_list_spec.rb
+++ b/spec/system/support/users/providers_list_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "View providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def then_i_see_the_providers

--- a/spec/system/support/users/providers_list_spec.rb
+++ b/spec/system/support/users/providers_list_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "View providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def then_i_see_the_providers

--- a/spec/system/support/users/providers_list_spec.rb
+++ b/spec/system/support/users/providers_list_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "View providers" do
   end
 
   def when_i_visit_the_support_provider_index_page
-    support_provider_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_provider_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def then_i_see_the_providers

--- a/spec/system/support/users/users_list_spec.rb
+++ b/spec/system/support/users/users_list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "View users" do
   end
 
   def when_i_visit_the_support_users_index_page
-    support_users_index_page.load(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
   end
 
   def and_click_on_the_users_tab

--- a/spec/system/support/users/users_list_spec.rb
+++ b/spec/system/support/users/users_list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "View users" do
   end
 
   def when_i_visit_the_support_users_index_page
-    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_from_time(Time.zone.now))
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
   end
 
   def and_click_on_the_users_tab

--- a/spec/system/support/users/users_list_spec.rb
+++ b/spec/system/support/users/users_list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "View users" do
   end
 
   def when_i_visit_the_support_users_index_page
-    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.cycle_year_for_time(Time.zone.now))
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
   end
 
   def and_click_on_the_users_tab


### PR DESCRIPTION
## Context

Until now, the truth in the system about what the current recruitment cycle year was defined in the Settings.

Settings.current_recruitment_cycle_year

```
# config/settings.yml
current_recruitment_cycle_year: 2025
```

This required us to make a PR to update this hard coded value when we wanted to open Find. "find opens" is the traditional moment for the new cycle to begin.

This change migrates the truth of the cycle year to the CycleTimetable. We take the current system time (Time.zone.now) and find the current cycle year based on that value.

## Test suite
In tests, we only need to travel to the time when a different cycle is active for the year to change. No more mocking `Settings.current_recruitment_cycle_year`. We do need to make sure that the `RecruitmentCycle` model exists in the DB when we time travel like this. (`find_or_create(:recruitment_cycle`)

### Next steps

These changes work for mid cycle, but we need to make further changes to make sure that other components are loaded at the right time.

For example, loading future recruitment cycles, we can get all the cycle years where find_opens is in the future, and use these years to fetch from the DB, instead of updating columns on the `RecruitmentCycle` record.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
