### PR TITLE
Remove candidate email_address from analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -9,9 +9,9 @@ shared:
     - updated_at
   candidate:
     - id
-    - email_address
     - created_at
     - updated_at
+    # - email_address
   saved_course:
     - id
     - candidate_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -4,6 +4,8 @@
   - id
   - provider_id
   - organisation_id
+  :candidate:
+  - email_address
   :audit:
   - id
   - auditable_id

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -2,8 +2,8 @@
 shared:
   authentication:
     - subject_key
-  candidate:
-    - email_address
+  # candidate:
+  #   - email_address
   user:
     - sign_in_user_id
   session:


### PR DESCRIPTION
## Context

  We are removing the email address until we can confirm beyond doubt
  that our recording of this information is reasonable unter data
  protection policy. We may need to provide a privacy policy before we
  can record such data.


## Changes proposed in this pull request

Remove candidate email address from analytics until we can confirm it is acceptable to record  it with our current data protection guideline adherance.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
