### PR TITLE
Travel to mid cycle so the visa deadline tests pass

### DIFF
--- a/spec/features/publish/courses/editing_visa_sponsorship_deadline_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_deadline_spec.rb
@@ -9,6 +9,7 @@ feature "Editing visa sponsorship deadlines" do
 
   scenario "adds a deadline to a course without one" do
     given_a_course_exists_that_sponsors_visas_but_without_a_deadline
+    and_today_is_mid_cycle
     when_i_visit_the_basic_details_tab
     and_i_change_my_answer_to_require_visa_deadline("Yes")
     and_i_add_a_date
@@ -68,15 +69,16 @@ private
   end
 
   def and_i_add_a_date
-    @valid_date = Find::CycleTimetable.date(
-      :apply_deadline,
-      accrediting_provider.recruitment_cycle.year.to_i,
-    ) - 1.day
+    @valid_date = Find::CycleTimetable.date(:apply_deadline, accrediting_provider.recruitment_cycle.year.to_i) - 1.day
     fill_in "Year", with: @valid_date.year
     fill_in "Month", with: @valid_date.month
     fill_in "Day", with: @valid_date.day
 
     click_on "Update date"
+  end
+
+  def and_today_is_mid_cycle
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
   end
 
   def then_i_see_the_date_on_the_basic_details_tab

--- a/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
@@ -25,6 +25,7 @@ feature "Editing visa sponsorship" do
   context "salaried course" do
     scenario "i can update the skilled worker visa" do
       given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
+      and_i_am_in_mid_cycle
       when_i_visit_the_course_publish_courses_skilled_worker_visa_sponsorship_edit_page
       and_i_choose_yes_to_the_skilled_worker_sponsorship_question
       and_i_continue
@@ -44,6 +45,10 @@ feature "Editing visa sponsorship" do
     @user = create(:user, providers: [build(:provider, sites: [build(:site)])])
     @user.providers.first.courses << create(:course, :with_accrediting_provider)
     given_i_am_authenticated(user: @user)
+  end
+
+  def and_i_am_in_mid_cycle
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
   end
 
   def given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa


### PR DESCRIPTION
## Context

The visa sponsorship deadline tests are failing today. Today is Apply closes.

We cannot set a visa deadline on a course on apply deadline day because the visa sponsorship date time is set to the end of the day and apply deadline is 6pm on deadline day.

## Changes proposed in this pull request

Make the test pass and we can add more fine grained tests later. This is blocking deployment.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
