### PR TITLE
Data migration to update applications_open_from

### DIFF
--- a/db/data/20250917072746_update_applications_open_from.rb
+++ b/db/data/20250917072746_update_applications_open_from.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class UpdateApplicationsOpenFrom < ActiveRecord::Migration[8.0]
+  def up
+    Course.where(applications_open_from: Date.new(2025, 9, 30))
+      .update_all(applications_open_from: Find::CycleTimetable.apply_opens)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/system/find/courses/apply_for_course_spec.rb
+++ b/spec/system/find/courses/apply_for_course_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Saving a course", service: :find do
   end
 
   scenario "A signed-in candidate can save a course" do
+    Timecop.travel(Find::CycleTimetable.mid_cycle)
     when_i_view_a_course
     when_i_click_apply_for_this_course
 


### PR DESCRIPTION
## Context

Some courses were created when the `RecruitmentCycle.applications_open_date` was set to September 7th.
These courses are now invalid and their dates need to be updated to October 7th 2026, the real date when apply opens.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
