### PR TITLE
The phase banner should show the label not the env name

### DIFF
--- a/app/views/layouts/find.html.erb
+++ b/app/views/layouts/find.html.erb
@@ -53,7 +53,7 @@
 
     <div class="govuk-width-container">
       <% if FeatureFlag.active?(:candidate_accounts) %>
-        <%= render GovukComponent::PhaseBannerComponent.new(tag: { text: Settings.environment.name, colour: phase_colour }, text: t(".feedback", link_to: govuk_link_to(t(".feedback_text"), new_find_feedback_path)).html_safe) %>
+        <%= render GovukComponent::PhaseBannerComponent.new(tag: { text: Settings.environment.label, colour: phase_colour }, text: t(".feedback", link_to: govuk_link_to(t(".feedback_text"), new_find_feedback_path)).html_safe) %>
       <% end %>
       <%= yield :before_content %>
       <main class="govuk-main-wrapper" id="main-content" role="main">


### PR DESCRIPTION
## Context
  We are displaying the environment name where we should be showing the
  phase label i.e. "production" instead of "beta"


<img width="1107" height="356" alt="image" src="https://github.com/user-attachments/assets/d5229c3c-9877-4cc0-9ef2-06b4d561c583" />


## Changes proposed in this pull request

In the PhaseBanner component we should be passing in the `Settings.environment.label` and not `Settings.environment.name`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
