### PR TITLE
Email column is email_address on candidate table

### DIFF
--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -11,6 +11,6 @@ UPDATE "user"
              AND email NOT LIKE '%@education.gov.uk';
 
 UPDATE "candidate"
-       SET email=concat('anonimized-candidate-',id,'@example.com')
-       WHERE email NOT LIKE '%@digital.education.gov.uk'
-             AND email NOT LIKE '%@education.gov.uk';
+       SET email_address=concat('anonimized-candidate-',id,'@example.com')
+       WHERE email_address NOT LIKE '%@digital.education.gov.uk'
+             AND email_address NOT LIKE '%@education.gov.uk';


### PR DESCRIPTION
## Context

  Correctly sanitize the email_address column on candidate table

 The original attempt to sanitize the candidate email used the wrong column name.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
