### PR TITLE
Add postgis adapter gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem "draper"
 # Custom attributes for endpoints
 gem "active_model_serializers"
 
+# Access to features of the PostGIS geospatial extension
+gem "activerecord-postgis-adapter"
+
 # Pagination for frontend and API
 gem "pagy", "~> 9.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,9 @@ GEM
       activemodel (= 8.0.2.1)
       activesupport (= 8.0.2.1)
       timeout (>= 0.4.0)
+    activerecord-postgis-adapter (11.0.0)
+      activerecord (~> 8.0.0)
+      rgeo-activerecord (~> 8.0.0)
     activestorage (8.0.2.1)
       actionpack (= 8.0.2.1)
       activejob (= 8.0.2.1)
@@ -617,6 +620,10 @@ GEM
       concurrent-ruby (~> 1.0)
     retriable (3.1.2)
     rexml (3.4.1)
+    rgeo (3.0.1)
+    rgeo-activerecord (8.0.0)
+      activerecord (>= 7.0)
+      rgeo (>= 3.0)
     rouge (4.1.2)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
@@ -805,6 +812,7 @@ PLATFORMS
 DEPENDENCIES
   aasm
   active_model_serializers
+  activerecord-postgis-adapter
   amazing_print
   audited (~> 5.4)
   awesome_print

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  adapter: postgresql
+  adapter: postgis
   encoding: unicode
   pool: <%= ENV.fetch('DATABASE_CONNECTION_POOL_SIZE', ENV.fetch('RAILS_MAX_THREADS', 5)) %>
   username: <%= ENV['DB_USERNAME'] %>


### PR DESCRIPTION
## Context

In order to do the optimisations for Find I need to create spatial fields and index them.

So we need to have available the postgis types to active record so the db/schema.rb is generated without problem. 

Otherwise we would have to change the schema format to sql...

This PR adds the postgis as adapter following [postgis readme](https://github.com/rgeo/activerecord-postgis-adapter)
