### PR TITLE
Skip Sentry filtering on One Login failure

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Docs: https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/
 PG_DETAIL_REGEX = /^DETAIL:.*$/
 PG_DETAIL_FILTERED = "[PG DETAIL FILTERED]"
 
@@ -11,9 +12,15 @@ def filter_record_not_unique_exception_messages!(event, hint)
   end
 end
 
+def skip_filter?(event)
+  event[:message] && event[:message][:message] == "One Login failure"
+end
+
 Sentry.init do |config|
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
   config.before_send = lambda do |event, hint|
+    return if skip_filter?(event)
+
     filter_record_not_unique_exception_messages!(event, hint)
     filter.filter(event.to_hash)
   end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -19,7 +19,7 @@ end
 Sentry.init do |config|
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
   config.before_send = lambda do |event, hint|
-    return if skip_filter?(event)
+    return if skip_filter?(event) && !Rails.env.production
 
     filter_record_not_unique_exception_messages!(event, hint)
     filter.filter(event.to_hash)


### PR DESCRIPTION
## Context

The fitlering on our Sentry implementation is filtering out imporant information captured by the Omniauth gem.
Without this logging information we cannot understand the error and so we cannot fix it.



## Changes proposed in this pull request

Removing error filtering on "One Login Error"

<img width="632" height="149" alt="image" src="https://github.com/user-attachments/assets/bb2575bb-a09d-4288-8282-3d1b84778dc6" />

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
