### PR TITLE
Update training with disabilities row label

### DIFF
--- a/config/locales/en/publish/providers/providers.yml
+++ b/config/locales/en/publish/providers/providers.yml
@@ -3,6 +3,6 @@ en:
     providers:
       details:
         training_with_disabilities_hidden_text: details about training with disabilities and other needs
-        training_with_disabilities_label: Training with disabilities and other needs
+        training_with_disabilities_label: Training with disabilities
         why_train_with_us_hidden_text: details about training with your organisation
         why_train_with_us_label: Why train with us

--- a/spec/features/publish/edit_provider_details_2026_spec.rb
+++ b/spec/features/publish/edit_provider_details_2026_spec.rb
@@ -57,13 +57,13 @@ feature "Why Train With Us section in 2026 cycle +" do
 
   def then_i_can_edit_info_about_disabilities_and_other_needs
     visit(details_publish_provider_recruitment_cycle_path(provider_code: @provider.provider_code, year: @provider.recruitment_cycle_year))
-    click_link "Change details about training with disabilities and other needs"
+    click_link "Change details about training with disabilities"
 
     page.find("#publish-disability-support-form-train-with-disability-field").set("Updated: training with disabilities")
     click_button "Update training with disabilities"
 
     expect(page).to have_content "Your changes have been published"
-    within_summary_row "Training with disabilities and other needs" do
+    within_summary_row "Training with disabilities" do
       expect(page).to have_content "Updated: training with disabilities"
     end
   end


### PR DESCRIPTION
## Context

The 'Training with disabilities and other needs' row label in the 'Organisation details' tab should be 'Training with disabilities'

## Changes proposed in this pull request

Change label text.

## Guidance to review

<img width="1115" height="434" alt="Screenshot 2025-09-17 at 14 49 20" src="https://github.com/user-attachments/assets/4fe9058b-76b7-413a-8807-e4d10c6b9d2d" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
