### PR TITLE
[Loadtesting] Update replica and memory for staging pods

### DIFF
--- a/terraform/aks/workspace_variables/staging.tfvars.json
+++ b/terraform/aks/workspace_variables/staging.tfvars.json
@@ -8,8 +8,8 @@
   "resource_group_name": "s189t01-ptt-stg-rg",
   "main_app": {
     "main": {
-      "replicas": 2,
-      "max_memory": "2Gi"
+      "replicas": 6,
+      "max_memory": "3Gi"
     }
   },
   "worker_apps": {


### PR DESCRIPTION
## Context

We would like to test our environment how it handles under stress such as when find opens. In this PR I am increasing the replica count and memory.


## Changes proposed in this pull request

We are going from: 

- 2 -> 6 Replicas
- 2GB -> 3GB Memory each

If we need to we can scale even further