### PR TITLE
Dont allow discarded users to sign in on publish

### DIFF
--- a/app/controllers/publish/authentication/sessions_controller.rb
+++ b/app/controllers/publish/authentication/sessions_controller.rb
@@ -16,7 +16,7 @@ module Publish
       def callback
         UserSession.begin_session!(session, request.env["omniauth.auth"])
 
-        if current_user
+        if current_user && !current_user.discarded?
           UserSessions::Update.call(user: current_user, user_session:)
 
           redirect_to after_sign_in_path

--- a/spec/controllers/publish/authentication/sessions_controller_spec.rb
+++ b/spec/controllers/publish/authentication/sessions_controller_spec.rb
@@ -70,6 +70,16 @@ module Publish
           end
         end
 
+        context "discarded database user" do
+          let(:user) { create(:user, discarded_at: Time.zone.now) }
+
+          it "does not create a session and redirects to user_not_found" do
+            request_callback
+            expect(session["user"]).to be_nil
+            expect(response).to redirect_to(user_not_found_path)
+          end
+        end
+
         context "non existing database user" do
           let(:user) { build(:user) }
 


### PR DESCRIPTION
## Context

We noticed that in Publish when a user "Deletes" a user the User is then discarded. However the discarded user us still able to sign into Publish. 

## Changes proposed in this pull request

The change is when a user attempts to sign in, we check if there is a user AND if the current_user attempting to sign in is discarded. If it is discarded we terminate their session and redirect to user_not_found_path.

**Note this is a temporary solution to the issue.** As destroying a user has downstream affects one being related to course enrichments so unable to just delete a user

## Guidance to review

Attempt to sign in with a discarded user on Publish

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
