### PR TITLE
Update saved course status tags

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -48,6 +48,25 @@ class CourseDecorator < ApplicationDecorator
     object.open_for_applications? ? "Open" : "Closed"
   end
 
+  def saved_status_tag
+    text, colour = saved_status_text_and_colour
+    h.govuk_tag(text:, colour:)
+  end
+
+  def saved_status_text_and_colour
+    if object.is_withdrawn?
+      %w[Withdrawn red]
+    elsif Find::CycleTimetable.phase_in_time?(:today_is_after_apply_deadline_passed)
+      %w[Closed purple]
+    elsif Find::CycleTimetable.phase_in_time?(:today_is_between_find_opening_and_apply_opening)
+      ["Not yet open", "grey"]
+    elsif object.application_status_closed?
+      %w[Closed purple]
+    else
+      %w[Open turquoise]
+    end
+  end
+
   def a_level_change_path
     return if object.is_withdrawn?
 

--- a/app/views/find/candidates/saved_courses/_saved_course_row.html.erb
+++ b/app/views/find/candidates/saved_courses/_saved_course_row.html.erb
@@ -8,7 +8,7 @@
               <%= saved_course.course.provider_name %>
             </span>
           </strong>
-          <span class="govuk-!-padding-left-2"><%= saved_course.course.decorate.status_tag %></span><br>
+          <span class="govuk-!-padding-left-2"><%= saved_course.course.decorate.saved_status_tag %></span><br>
           <span class="govuk-body-s"><%= saved_course.course.name_and_code %></span>
         </div>
         <%= button_to t(".delete"),
@@ -26,7 +26,7 @@
                 <%= saved_course.course.provider_name %>
               </span>
             </strong>
-            <span class="govuk-!-padding-left-2"><%= saved_course.course.decorate.status_tag %></span><br>
+            <span class="govuk-!-padding-left-2"><%= saved_course.course.decorate.saved_status_tag %></span><br>
             <span class="govuk-body-s"><%= saved_course.course.name_and_code %></span>
           </div>
           <%= button_to t(".delete"),

--- a/spec/system/find/candidates/view_saved_courses_spec.rb
+++ b/spec/system/find/candidates/view_saved_courses_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Viewing my saved courses", service: :find do
 
   scenario "A candidate can view their saved courses" do
     when_i_log_in_as_a_candidate
-    when_i_have_saved_courses
+    and_i_have_saved_courses
 
     then_i_visit_my_saved_courses
 
@@ -31,7 +31,7 @@ RSpec.describe "Viewing my saved courses", service: :find do
   end
 
   def then_i_view_my_saved_courses
-    within(all(".govuk-table__row").first) do
+    within_first_saved_course_row do
       expect(page).to have_content(@course.provider.provider_name)
       expect(page).to have_content(@course.name)
       expect(page).to have_content(@course.course_code)
@@ -44,6 +44,53 @@ RSpec.describe "Viewing my saved courses", service: :find do
           course_code: @course.course_code,
         ),
       )
+    end
+  end
+
+  context "saved status tag across cycle stages" do
+    scenario "Apply has closed but old Find courses are still there shows Closed" do
+      given_a_published_course_exists
+      Timecop.travel(1.day.after(apply_deadline))
+
+      when_i_log_in_as_a_candidate
+      and_i_have_saved_courses
+      then_i_visit_my_saved_courses
+
+      then_i_should_see_in_first_saved_course_row("Closed")
+    end
+
+    scenario "Find has re-opened but Apply hasn’t opened yet shows Not yet open" do
+      given_a_published_course_exists
+      Timecop.travel(1.day.after(find_opens))
+
+      when_i_log_in_as_a_candidate
+      and_i_have_saved_courses
+      then_i_visit_my_saved_courses
+
+      then_i_should_see_in_first_saved_course_row("Not yet open")
+    end
+
+    scenario "Both Find and Apply are open, provider closed course early shows Closed" do
+      given_a_published_course_exists
+      Timecop.travel(1.day.after(apply_opens))
+      @course.update!(application_status: :closed)
+
+      when_i_log_in_as_a_candidate
+      and_i_have_saved_courses
+      then_i_visit_my_saved_courses
+
+      then_i_should_see_in_first_saved_course_row("Closed")
+    end
+
+    scenario "Withdrawn course shows Withdrawn" do
+      given_a_withdrawn_course_exists
+      Timecop.travel(1.day.after(apply_opens))
+
+      when_i_log_in_as_a_candidate
+      and_i_have_saved_courses
+      then_i_visit_my_saved_courses
+
+      then_i_should_see_in_first_saved_course_row("Withdrawn")
     end
   end
 
@@ -62,9 +109,19 @@ RSpec.describe "Viewing my saved courses", service: :find do
     click_link_or_button "Saved courses"
   end
 
-  def when_i_have_saved_courses
+  def and_i_have_saved_courses
     candidate = Candidate.first
     @saved_courses = create(:saved_course, course: @course, candidate: candidate)
+  end
+
+  def within_first_saved_course_row(&block)
+    within(all(".govuk-table__row").first, &block)
+  end
+
+  def then_i_should_see_in_first_saved_course_row(text)
+    within_first_saved_course_row do
+      expect(page).to have_content(text)
+    end
   end
 
   def given_a_published_course_exists
@@ -77,7 +134,21 @@ RSpec.describe "Viewing my saved courses", service: :find do
       :open,
       name: "Art and design (SEND)",
       course_code: "F314",
-      provider: build(:provider, provider_name: "York university", provider_code: "RO1"),
+      provider: build(:provider),
+      subjects: [find_or_create(:secondary_subject, :art_and_design)],
+    )
+  end
+
+  def given_a_withdrawn_course_exists
+    @course = create(
+      :course,
+      :with_full_time_sites,
+      :secondary,
+      :with_special_education_needs,
+      :withdrawn,
+      name: "Art and design (SEND)",
+      course_code: "F315",
+      provider: build(:provider),
       subjects: [find_or_create(:secondary_subject, :art_and_design)],
     )
   end


### PR DESCRIPTION
## Context

The tag on saved courses should vary depending on the stage of the cycle. Most of the time it should be Open, except in these circumstances:

1. Apply has closed but old Find courses are still there. Tag should say Closed
2. Find has re-opened but Apply hasn’t opened yet. Tag should say Not yet open
3. Both Find and Apply are open, but a provider has closed a course early. Tag should say Closed

## Changes proposed in this pull request

Add `saved_status_tag` to fully reflect the saved course status

## Guidance to review

Reviewing locally, as you can alter the CycleTimetable easily and try the 3 variations:

1. Apply has closed but old Find courses are still there. Tag should say Closed
2. Find has re-opened but Apply hasn’t opened yet. Tag should say Not yet open
3. Both Find and Apply are open, but a provider has closed a course early. Tag should say Closed

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
