### PR TITLE
Set the application Timezone to Europe/London

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -116,7 +116,7 @@ class Provider < ApplicationRecord
 
   scope :changed_since, lambda { |timestamp|
     if timestamp.present?
-      where("provider.changed_at > ?", timestamp)
+      where("provider.changed_at > ?", "'#{timestamp}'::timestamptz")
     else
       where.not(changed_at: nil)
     end.order(:changed_at, :id)

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module ManageCoursesBackend
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Europe/London"
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.active_record.pluralize_table_names = false

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -411,6 +411,7 @@ RSpec.describe API::Public::V1::ProvidersController do
           let(:filter) { { updated_since: (provider2.changed_at - 1.second).iso8601 } }
 
           it "returns 'Second' provider only" do
+            binding.pry
             expect(provider_names_in_response).to eq([provider2.provider_name])
           end
         end


### PR DESCRIPTION
## Context

`Time.zone.now` returns the current time in UTC. If we have code that actions something at 14:00, then during British Summer Time that action will take place an hour later.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
