### PR TITLE
Use London time zone for cycle timetable dates

### DIFF
--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -148,11 +148,11 @@ module Find
 
     def self.phases_in_time
       {
-        today_is_after_find_closes: Time.zone.now.between?(find_closes.in_time_zone("London") - 1.hour, find_reopens.in_time_zone("London") - 1.hour),
-        today_is_after_find_opens: Time.zone.now.between?(find_opens.in_time_zone("London") - 1.hour, apply_deadline),
-        today_is_mid_cycle: Time.zone.now.between?(first_deadline_banner, apply_deadline),
-        today_is_after_apply_deadline_passed: Time.zone.now.between?(apply_deadline, find_closes),
-        today_is_between_find_opening_and_apply_opening: Time.zone.now.between?(find_opens, apply_opens),
+        today_is_after_find_closes: LONDON.now.between?(find_closes, find_reopens),
+        today_is_after_find_opens: LONDON.now.between?(find_opens, apply_deadline),
+        today_is_mid_cycle: LONDON.now.between?(first_deadline_banner, apply_deadline),
+        today_is_after_apply_deadline_passed: LONDON.now.between?(apply_deadline, find_closes),
+        today_is_between_find_opening_and_apply_opening: LONDON.now.between?(find_opens, apply_opens),
       }
     end
 

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -2,59 +2,61 @@
 
 module Find
   class CycleTimetable
+    LONDON = ActiveSupport::TimeZone["London"]
+
     CYCLE_DATES = {
       2021 => {
-        find_opens: Time.zone.local(2020, 10, 6, 9),
-        apply_opens: Time.zone.local(2020, 10, 13, 9),
-        first_deadline_banner: Time.zone.local(2021, 7, 12, 9),
-        apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
-        apply_deadline: Time.zone.local(2021, 9, 21, 18),
-        find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
+        find_opens: LONDON.local(2020, 10, 6, 9),
+        apply_opens: LONDON.local(2020, 10, 13, 9),
+        first_deadline_banner: LONDON.local(2021, 7, 12, 9),
+        apply_1_deadline: LONDON.local(2021, 9, 7, 18),
+        apply_deadline: LONDON.local(2021, 9, 21, 18),
+        find_closes: LONDON.local(2021, 10, 4, 23, 59, 59),
       },
       2022 => {
-        find_opens: Time.zone.local(2021, 10, 5, 9),
-        apply_opens: Time.zone.local(2021, 10, 12, 9),
-        first_deadline_banner: Time.zone.local(2022, 8, 2, 9),
-        apply_1_deadline: Time.zone.local(2022, 9, 6, 18),
-        apply_deadline: Time.zone.local(2022, 9, 20, 18),
-        find_closes: Time.zone.local(2022, 10, 3, 23, 59, 59),
+        find_opens: LONDON.local(2021, 10, 5, 9),
+        apply_opens: LONDON.local(2021, 10, 12, 9),
+        first_deadline_banner: LONDON.local(2022, 8, 2, 9),
+        apply_1_deadline: LONDON.local(2022, 9, 6, 18),
+        apply_deadline: LONDON.local(2022, 9, 20, 18),
+        find_closes: LONDON.local(2022, 10, 3, 23, 59, 59),
       },
       2023 => {
-        find_opens: Time.zone.local(2022, 10, 4, 9),
-        apply_opens: Time.zone.local(2022, 10, 11, 9),
+        find_opens: LONDON.local(2022, 10, 4, 9),
+        apply_opens: LONDON.local(2022, 10, 11, 9),
 
-        first_deadline_banner: Time.zone.local(2023, 8, 1, 9), # 5 weeks before Apply 1 deadline
-        apply_1_deadline: Time.zone.local(2023, 9, 5, 18), # First Tuesday of September
-        apply_deadline: Time.zone.local(2023, 9, 19, 18), # 2 weeks after Apply 1 deadline
-        find_closes: Time.zone.local(2023, 10, 2, 23, 59, 59), # The evening before Find opens in the new cycle
+        first_deadline_banner: LONDON.local(2023, 8, 1, 9), # 5 weeks before Apply 1 deadline
+        apply_1_deadline: LONDON.local(2023, 9, 5, 18), # First Tuesday of September
+        apply_deadline: LONDON.local(2023, 9, 19, 18), # 2 weeks after Apply 1 deadline
+        find_closes: LONDON.local(2023, 10, 2, 23, 59, 59), # The evening before Find opens in the new cycle
       },
       2024 => {
-        find_opens: Time.zone.local(2023, 10, 3, 9), # First Tuesday of October
-        apply_opens: Time.zone.local(2023, 10, 10, 9), # Second Tuesday of October
-        first_deadline_banner: Time.zone.local(2024, 7, 30, 9),
-        apply_deadline: Time.zone.local(2024, 9, 17, 18),
-        find_closes: Time.zone.local(2024, 9, 30, 23, 59, 59), # The evening before Find opens in the new cycle
+        find_opens: LONDON.local(2023, 10, 3, 9), # First Tuesday of October
+        apply_opens: LONDON.local(2023, 10, 10, 9), # Second Tuesday of October
+        first_deadline_banner: LONDON.local(2024, 7, 30, 9),
+        apply_deadline: LONDON.local(2024, 9, 17, 18),
+        find_closes: LONDON.local(2024, 9, 30, 23, 59, 59), # The evening before Find opens in the new cycle
       },
       2025 => {
-        find_opens: Time.zone.local(2024, 10, 1, 9), # CONFIRMED
-        apply_opens: Time.zone.local(2024, 10, 8, 9), # CONFIRMED
-        first_deadline_banner: Time.zone.local(2025, 7, 12, 9), # TBC
-        apply_deadline: Time.zone.local(2025, 9, 16, 18), # CONFIRMED
-        find_closes: Time.zone.local(2025, 9, 29, 23, 59, 59), # CONFIRMED
+        find_opens: LONDON.local(2024, 10, 1, 9), # CONFIRMED
+        apply_opens: LONDON.local(2024, 10, 8, 9), # CONFIRMED
+        first_deadline_banner: LONDON.local(2025, 7, 12, 9), # TBC
+        apply_deadline: LONDON.local(2025, 9, 16, 18), # CONFIRMED
+        find_closes: LONDON.local(2025, 9, 29, 23, 59, 59), # CONFIRMED
       },
       2026 => {
-        find_opens: Time.zone.local(2025, 9, 30, 9), # CONFIRMED
-        apply_opens: Time.zone.local(2025, 10, 7, 9), # CONFIRMED
-        first_deadline_banner: Time.zone.local(2026, 7, 12, 9), # TBC
-        apply_deadline: Time.zone.local(2026, 9, 15, 18), # CONFIRMED
-        find_closes: Time.zone.local(2026, 9, 28, 23, 59, 59), # CONFIRMED
+        find_opens: LONDON.local(2025, 9, 30, 9), # CONFIRMED
+        apply_opens: LONDON.local(2025, 10, 7, 9), # CONFIRMED
+        first_deadline_banner: LONDON.local(2026, 7, 12, 9), # TBC
+        apply_deadline: LONDON.local(2026, 9, 15, 18), # CONFIRMED
+        find_closes: LONDON.local(2026, 9, 28, 23, 59, 59), # CONFIRMED
       },
       2027 => {
-        find_opens: Time.zone.local(2026, 9, 29, 9), # CONFIRMED
-        apply_opens: Time.zone.local(2026, 10, 6, 9), # CONFIRMED
-        first_deadline_banner: Time.zone.local(2027, 7, 12, 9), # TBC
-        apply_deadline: Time.zone.local(2027, 9, 21, 18), # CONFIRMED
-        find_closes: Time.zone.local(2027, 10, 4, 23, 59, 59), # CONFIRMED
+        find_opens: LONDON.local(2026, 9, 29, 9), # CONFIRMED
+        apply_opens: LONDON.local(2026, 10, 6, 9), # CONFIRMED
+        first_deadline_banner: LONDON.local(2027, 7, 12, 9), # TBC
+        apply_deadline: LONDON.local(2027, 9, 21, 18), # CONFIRMED
+        find_closes: LONDON.local(2027, 10, 4, 23, 59, 59), # CONFIRMED
       },
     }.freeze
 

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -48,7 +48,7 @@ module Find
       end
 
       it "returns 2026 for a time just before find opens 2027" do
-        time = Time.zone.local(2026, 9, 29, 8, 59, 58)
+        time = Find::CycleTimetable::LONDON.local(2026, 9, 29, 8, 59, 58)
         expect(described_class.cycle_year_for_time(time)).to eq(2026)
       end
 
@@ -85,16 +85,16 @@ module Find
     describe ".find_opens(year)" do
       context "when no argument is passed" do
         it "returns find_opens date for 2021" do
-          Timecop.travel(Time.zone.local(2021, 1, 1, 12, 0, 0)) do
-            expect(described_class.find_opens).to eq(Time.zone.local(2020, 10, 6, 9))
+          Timecop.travel(Find::CycleTimetable::LONDON.local(2021, 1, 1, 12, 0, 0)) do
+            expect(described_class.find_opens).to eq(Find::CycleTimetable::LONDON.local(2020, 10, 6, 9))
           end
         end
       end
 
       context "when passing 2024 as argument" do
         it "returns find_opens date for 2024" do
-          Timecop.travel(Time.zone.local(2021, 11, 1, 12, 0, 0)) do
-            expect(described_class.find_opens(2024)).to eq(Time.zone.local(2023, 10, 3, 9))
+          Timecop.travel(Find::CycleTimetable::LONDON.local(2021, 11, 1, 12, 0, 0)) do
+            expect(described_class.find_opens(2024)).to eq(Find::CycleTimetable::LONDON.local(2023, 10, 3, 9))
           end
         end
       end
@@ -102,13 +102,13 @@ module Find
 
     describe ".preview_mode?" do
       it "returns true when it is after the Apply deadline but before Find closes" do
-        Timecop.travel(Time.zone.local(2021, 9, 21, 19, 0, 0)) do
+        Timecop.travel(Find::CycleTimetable::LONDON.local(2021, 9, 21, 19, 0, 0)) do
           expect(described_class.preview_mode?).to be true
         end
       end
 
       it "returns false before the Apply deadline" do
-        Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
+        Timecop.travel(Find::CycleTimetable::LONDON.local(2021, 9, 21, 17, 0, 0)) do
           expect(described_class.preview_mode?).to be false
         end
       end
@@ -195,7 +195,7 @@ module Find
       end
 
       it "returns false before the apply_deadline" do
-        Timecop.travel(Time.zone.local(2021, 9, 21, 17, 0, 0)) do
+        Timecop.travel(Find::CycleTimetable::LONDON.local(2021, 9, 21, 17, 0, 0)) do
           expect(described_class.show_cycle_closed_banner?).to be false
         end
       end


### PR DESCRIPTION
## Context

The banners on Find are set to change dynamically depending on the time/date set in the cycle timetable. We recently noticed that the last banner switched over an hour later than expected due to the fact that the app/cycle timetable operates in UTC; locally we are currently in BST which is 1 hour ahead. 

We initially tried to rectify this by setting the application TimeZone to 'Europe/London', however we encountered a test failure that we wouldn't have expected to fail after making this change: https://github.com/DFE-Digital/publish-teacher-training/pull/5639

This PR updates the cycle timetable to use London local time for all key dates.

## Changes proposed in this pull request

- Switch cycle timetable dates to `ActiveSupport::TimeZone["London"]` to ensure deadlines follow UK local time (BST/GMT) while the app continues to run in UTC.

## Guidance to review

change the local date/time of your computer to the following and the banners on the Find homepage should change to reflect find opening / apply opening at the right time i.e. 9am:
- Find opens: 30 September 2025, 09:00
- Apply opens: 07 October 2025, 09:00

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
