### PR TITLE
next_recruitment_cycle_year returns Find::CycleTimetable.next_year

### DIFF
--- a/app/components/title_bar.rb
+++ b/app/components/title_bar.rb
@@ -55,7 +55,7 @@ private
   end
 
   def next_recruitment_cycle_year
-    Find::CycleTimetable.current_year
+    Find::CycleTimetable.next_year
   end
 
   def recruitment_label

--- a/spec/components/title_bar_spec.rb
+++ b/spec/components/title_bar_spec.rb
@@ -23,17 +23,35 @@ describe TitleBar do
     end
   end
 
-  context "single org users during rollover" do
+  context "single org users during rollover", travel: 1.day.before(find_closes) do
+    subject { described_class.new(title:, current_user:, provider: provider_code) }
+
     before do
-      allow(RecruitmentCycle).to receive(:upcoming_cycles_open_to_publish?).and_return(true)
-      render_inline(described_class.new(title:, current_user:, provider: provider_code))
+      find_or_create(:recruitment_cycle, :next)
     end
 
-    it "renders the provided title" do
-      expect(component).to have_text("BAT School")
+    context "when viewing the current cycle" do
+      it "renders the provided title" do
+        # stub recruitment_cycle_year - hard to test params outside controller
+        allow(subject).to receive(:recruitment_cycle_year).and_return(Find::CycleTimetable.current_year) # rubocop:disable RSpec/SubjectStub
+        render_inline(subject)
+        expect(component).to have_text("BAT School")
+        expect(component).to have_text("- #{RecruitmentCycle.current_recruitment_cycle.year_range} - current")
+      end
+    end
+
+    context "when viewing the next cycle" do
+      it "renders the provided title" do
+        # stub recruitment_cycle_year - hard to test params outside controller
+        allow(subject).to receive(:recruitment_cycle_year).and_return(Find::CycleTimetable.next_year) # rubocop:disable RSpec/SubjectStub
+        render_inline(subject)
+        expect(component).to have_text("BAT School")
+        expect(component).to have_text("- #{RecruitmentCycle.current_recruitment_cycle.next.year_range}")
+      end
     end
 
     it "renders the recruitment cycle link" do
+      render_inline(subject)
       expect(component.has_link?("Change recruitment cycle", href: "/publish/organisations/1BJ?switcher=true")).to be true
     end
   end


### PR DESCRIPTION
## Context

Typo in the TitleBar component.

`recruitment_cycle_year` should return `Find::CycleTimetable.next_year` not `Find::CycleTimetable.current_year`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
