### PR TITLE
Update this content on Find now that Apply has closed

### DIFF
--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -18,6 +18,8 @@ module Find
       @saved_course = @candidate&.saved_courses&.find_by(course_id: @course.id)
 
       render_not_found unless @course.is_published?
+
+      @apply_action_column_class = apply_action_column_class
     end
 
     def confirm_apply; end
@@ -89,6 +91,16 @@ module Find
     end
 
   private
+
+    def apply_action_column_class
+      if FeatureFlag.active?(:candidate_accounts) && CycleTimetable.apply_deadline_passed
+        "govuk-grid-column-full"
+      elsif FeatureFlag.active?(:candidate_accounts) && !CycleTimetable.apply_deadline_passed
+        "govuk-grid-column-one-third-from-desktop"
+      else
+        "govuk-grid-column-one-half"
+      end
+    end
 
     def set_course
       @course = provider.courses.includes(

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -133,6 +133,8 @@ module Find
 
     def self.show_apply_deadline_banner? = phase_in_time?(:today_is_mid_cycle)
 
+    def self.apply_deadline_passed = phase_in_time?(:today_is_after_apply_deadline_passed)
+
     def self.show_cycle_closed_banner?
       phase_in_time?(:today_is_after_apply_deadline_passed) &&
         !phase_in_time?(:today_is_between_find_opening_and_apply_opening)

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -28,7 +28,7 @@
 
     <% if @course.application_status_open? || !Find::CycleTimetable.mid_cycle? %>
       <div class="govuk-grid-row govuk-!-margin-bottom-6">
-        <div class="<%= FeatureFlag.active?(:candidate_accounts) ? "govuk-grid-column-one-third-from-desktop" : "govuk-grid-column-one-half" %>">
+        <div class="<%= @apply_action_column_class %>">
           <%= render Find::Courses::ApplyComponent::View.new(
                 @course,
                 preview: preview?(params),


### PR DESCRIPTION
## Context

Since Find closed the `govuk-grid-column` is displaying incorrectly. This is due to now having the save course button

## Changes proposed in this pull request

Update the `govuk-grid-column` styling based on if the cycle time and `FeatureFlag.active?(:candidate_accounts)` to ensure the page looks correct

## Guidance to review
- Visit when Find is closed and application are not open
- Visit when Find is open and application are open
- Visit when Find is open and application are closed

<img width="738" height="427" alt="Screenshot 2025-09-24 at 08 24 53" src="https://github.com/user-attachments/assets/d28faabe-64b7-4437-90ba-903b0235655c" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
