### PR TITLE
Change 'Product technology' to 'Product design' in Design Technology rake task / service

### DIFF
--- a/app/services/subjects/design_technology_subject_creator_service.rb
+++ b/app/services/subjects/design_technology_subject_creator_service.rb
@@ -18,7 +18,7 @@ module Subjects
         { subject_name: "Electronics", subject_code: "DTE" },
         { subject_name: "Engineering", subject_code: "DTEN" },
         { subject_name: "Food technology", subject_code: "DTF" },
-        { subject_name: "Product technology", subject_code: "DTP" },
+        { subject_name: "Product design", subject_code: "DTP" },
         { subject_name: "Textiles", subject_code: "DTT" },
       ]
 

--- a/spec/factories/subjects/secondary_subjects.rb
+++ b/spec/factories/subjects/secondary_subjects.rb
@@ -234,7 +234,7 @@ FactoryBot.define do
     end
 
     trait :product_technology do
-      subject_name { "Product technology" }
+      subject_name { "Product design" }
       subject_code { "DTP" }
     end
 

--- a/spec/services/subjects/design_technology_subject_creator_service_spec.rb
+++ b/spec/services/subjects/design_technology_subject_creator_service_spec.rb
@@ -22,7 +22,7 @@ describe Subjects::DesignTechnologySubjectCreatorService do
     expect(design_technology_model).to have_received(:find_or_create_by!).with(subject_name: "Electronics", subject_code: "DTE")
     expect(design_technology_model).to have_received(:find_or_create_by!).with(subject_name: "Engineering", subject_code: "DTEN")
     expect(design_technology_model).to have_received(:find_or_create_by!).with(subject_name: "Food technology", subject_code: "DTF")
-    expect(design_technology_model).to have_received(:find_or_create_by!).with(subject_name: "Product technology", subject_code: "DTP")
+    expect(design_technology_model).to have_received(:find_or_create_by!).with(subject_name: "Product design", subject_code: "DTP")
     expect(design_technology_model).to have_received(:find_or_create_by!).with(subject_name: "Textiles", subject_code: "DTT")
   end
 


### PR DESCRIPTION
## Context

We recently merged in a PR that adds a service and rake task to populate the Design & Technology subject area and the new specialisms: https://github.com/DFE-Digital/publish-teacher-training/pull/5640

This PR is to rename 'Product technology' to 'Product design'.

## Changes proposed in this pull request

Update `DesignTechnologySubjectCreatorService` and associated specs to replace 'Product technology' with 'Product design'.

## Guidance to review

To add the new Design and technology specialisms:

- you can run the rake task in you terminal with: `bundle exec rake populate_design_technology_subjects`
- or execute the service directly in the rails console: `Subjects::DesignTechnologySubjectCreatorService.new.execute`
- to remove the new D&T specialisms you can run: `CourseSubject.where(subject_id: Subject.where(type: "DesignTechnologySubject").select(:id)).delete_all; Subject.where(type: "DesignTechnologySubject").delete_all`

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
