### PR TITLE
Remove cycle switcher on Candidates and Users page on support

### DIFF
--- a/app/components/support_title_bar.html.erb
+++ b/app/components/support_title_bar.html.erb
@@ -1,4 +1,4 @@
-<% if rollover_active? && !support_index_page %>
+<% if rollover_active? && !support_index_page && !support_candidates_page && !support_users_page %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <div class="title-bar" aria-label="Organisation switcher">

--- a/app/components/support_title_bar.rb
+++ b/app/components/support_title_bar.rb
@@ -58,4 +58,12 @@ private
   def support_index_page
     request.path == "/support"
   end
+
+  def support_candidates_page
+    request.path == "/support/candidates"
+  end
+
+  def support_users_page
+    request.path == "/support/#{recruitment_cycle_year}/users"
+  end
 end


### PR DESCRIPTION
## Context

It does not make sense to have the cycle switcher on the Users and Candidates pages as these are not affected by switching cycles so should be not show on these pages

## Changes proposed in this pull request

Hide the switcher on those pages

<img width="890" height="214" alt="Screenshot 2025-09-24 at 14 37 14" src="https://github.com/user-attachments/assets/8c94ab2c-b5dd-4f01-ab46-c6f120201400" />
<img width="845" height="214" alt="Screenshot 2025-09-24 at 14 37 18" src="https://github.com/user-attachments/assets/eed28402-56a8-45f6-b4f2-3faee95b7a03" />
<img width="848" height="256" alt="Screenshot 2025-09-24 at 14 37 24" src="https://github.com/user-attachments/assets/910546fc-bef3-44fd-88a5-9cc58f6df0c2" />
