### PR TITLE
Adjust Find and Apply open time to 8am in cycle timetable to account for BST

### DIFF
--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -40,11 +40,11 @@ module Find
         apply_opens: Time.zone.local(2024, 10, 8, 9), # CONFIRMED
         first_deadline_banner: Time.zone.local(2025, 7, 12, 9), # TBC
         apply_deadline: Time.zone.local(2025, 9, 16, 18), # CONFIRMED
-        find_closes: Time.zone.local(2025, 9, 29, 23, 59, 59), # CONFIRMED
+        find_closes: Time.zone.local(2025, 9, 29, 22, 59, 59), # CONFIRMED: Find closes at 11:59pm, adjusted to 10:59pm here to account for BST
       },
       2026 => {
-        find_opens: Time.zone.local(2025, 9, 30, 9), # CONFIRMED
-        apply_opens: Time.zone.local(2025, 10, 7, 9), # CONFIRMED
+        find_opens: Time.zone.local(2025, 9, 30, 8), # CONFIRMED: Find opens at 9am, adjusted to 8am here to account for BST
+        apply_opens: Time.zone.local(2025, 10, 7, 8), # CONFIRMED: Apply opens at 9am, adjusted to 8am here to account for BST
         first_deadline_banner: Time.zone.local(2026, 7, 12, 9), # TBC
         apply_deadline: Time.zone.local(2026, 9, 15, 18), # CONFIRMED
         find_closes: Time.zone.local(2026, 9, 28, 23, 59, 59), # CONFIRMED


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/IfHs3UJt/1053-banner-start-of-cycle-apply-will-be-open-soon

The banners on Find are set to change dynamically depending on the time/date set in the cycle timetable. We recently noticed that the last banner switched over an hour later than expected due to the fact that the app/cycle timetable operates in UTC; locally we are currently in BST which is 1 hour ahead.

We initially tried to rectify this by setting the application TimeZone to 'Europe/London', however we encountered a test failure that we wouldn't have expected to fail after making this change: https://github.com/DFE-Digital/publish-teacher-training/pull/5639

With Find opening shortly, this PR is a short term fix and sets the opening time to 8am UTC (9am BST).

## Changes proposed in this pull request

Change `find_opens` and `apply_opens` to 8am in `cycle_timetable`. 

## Guidance to review

change the local date/time of your computer to the following and the banners on the Find homepage should change to reflect find opening / apply opening at the right time i.e. 9am:

Find opens: 30 September 2025, 09:00
Apply opens: 07 October 2025, 09:00

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
