### PR TITLE
Ensure preview back button goes back to the course

### DIFF
--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Preview: #{course.name_and_code} with #{@provider.provider_name}" %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_courses_path(@course.provider_code, @course.recruitment_cycle.year)) %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle.year, @course.course_code)) %>
 <% end %>
 
 <%= govuk_notification_banner(title_text: t("notification_banner.info")) do |notification_banner| %>


### PR DESCRIPTION
## Context

When previewing a course when you click back it took you too the course index page not the actual course

## Changes proposed in this pull request

Change the back link to go to the course page instead of the index page

## Guidance to review

- Vist publish
- Draft a course 
- Preview the course 
- Click the back link
- You should be on the course page NOT index page


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
