### PR TITLE
Bug: School uniqueness validation on name

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -36,7 +36,8 @@ class Site < ApplicationRecord
                                           conditions: -> { where(discarded_at: nil) },
                                           message: lambda { |object, _data|
                                             "This #{object.site_type.humanize.downcase} has already been added"
-                                          } }
+                                          } },
+                            if: -> { !school? }
   validates :location_name,
             :address1,
             :postcode,


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/qzd4atoN/1135-bug-school-uniqueness-validation-on-name

On the Site table, we have a uniqueness validation on the name column. This was especially useful when providers were adding schools manually but now we fetch the schools from GIAS. Some schools geninely have the same names but different URNs.

We need to remove the uniqueness validation on the site table for schools with the same name per provider.

## Changes proposed in this pull request

- Update the uniqueness validation on `Site#location_name` to only apply to non-school site types.
- Schools can now have the same `location_name` under the same provider, while study sites enforce uniqueness.

## Guidance to review

Schools that have different URNs but the same name (can be used for testing in ass a school flow):
110090
106504

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
