### PR TITLE
The link in support to a provider in publish scopes the cycle

### DIFF
--- a/app/views/support/providers/show.html.erb
+++ b/app/views/support/providers/show.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 <div class="govuk-caption-l"><%= Provider.human_attribute_name(@provider.provider_type) %></div>
 <h1 class="govuk-heading-l">
-  <%= govuk_link_to @provider.name_and_code, publish_provider_path(@provider.provider_code), no_visited_state: true %>
+  <%= govuk_link_to @provider.name_and_code, publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle.year), no_visited_state: true %>
 </h1>
 <%= render "support/providers/navigation" %>
 <%= render Providers::ProviderList::View.new(provider: @provider) %>


### PR DESCRIPTION
## Context

The link in the support console that takes the support user to a provider in publish is not scoped to the recruitment cycle.
If a new provider is created in the next before the next cycle begins, the link will default to looking for the provider in the current cycle, but returns a 404.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
