### PR TITLE
Update test to make sure test subjects created in the right cycle

### DIFF
--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -367,7 +367,7 @@ RSpec.describe API::Public::V1::ProvidersController do
         end
       end
 
-      context "with filter" do
+      context "with filter", travel: 2.days.before(find_closes) do
         let(:provider2) do
           Timecop.freeze(Time.zone.today + 1) do
             create(:accredited_provider,


### PR DESCRIPTION
## Context
    Travel to point in time where test creates provider in recruitment cycle
    
      When some tests run we travel one day to create a provider. If the
      current day is 1 day before the next cycle, that provider gets created
      in the next cycle.

## Changes proposed in this pull request

    
      In order for the tests to pass, we need to travel 2 days before the
      start of the cycle so the provider is created in the cycle under test


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
