### PR TITLE
Add fees notice to reflect that fees for courses starting in 2026-27 will be confirmed soon

### DIFF
--- a/app/components/courses/summary_card_component.html.erb
+++ b/app/components/courses/summary_card_component.html.erb
@@ -20,6 +20,9 @@
           <% if fee_hint.present? %>
             <div class="govuk-hint govuk-!-font-size-16"><%= fee_hint %></div>
           <% end %>
+          <% if !course.salary? && !course.apprenticeship? %>
+            <div class="govuk-hint govuk-!-font-size-16"><%= t("find.courses.fee_notice__next_academic_year") %></div>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/app/components/find/courses/fees_component/view.html.erb
+++ b/app/components/find/courses/fees_component/view.html.erb
@@ -31,6 +31,8 @@
       <% end %>
     </div>
 
+    <div class="govuk-body govuk-!-font-weight-bold"><%= t("find.courses.fee_notice__next_academic_year") %></div>
+
     <% if course.fee_details.present? %>
       <div data-qa="course__fee_details">
         <%= markdown(fee_details) %>

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -11,6 +11,9 @@
       <% if fee_hint.present? %>
         <div class="govuk-hint govuk-!-font-size-16"><%= fee_hint %></div>
       <% end %>
+      <% if !course.salaried? && !course.apprenticeship? && !course.no_fee? %>
+        <div class="govuk-hint govuk-!-font-size-16"><%= t("find.courses.fee_notice__next_academic_year") %></div>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/find/courses/v2/financial_support/_fees_and_financials.html.erb
+++ b/app/views/find/courses/v2/financial_support/_fees_and_financials.html.erb
@@ -1,5 +1,6 @@
 <% if course.fee_uk_eu.present? && !course.fee_international.present? %>
   <p class="govuk-body"><%= t(".course_fees", cycle_range: course.cycle_range, fee: number_to_currency(course.fee_uk_eu)) %></p>
+  <div class="govuk-body govuk-!-font-weight-bold"><%= t("find.courses.fee_notice__next_academic_year") %></div>
 <% else %>
   <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :fees_and_financials, is_preview: preview?(params)) %>
 <% end %>
@@ -27,6 +28,7 @@
     </tr>
     </tbody>
   </table>
+  <div class="govuk-body govuk-!-font-weight-bold"><%= t("find.courses.fee_notice__next_academic_year") %></div>
 <% end %>
 
 <% if course.fee_schedule.present? %>

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -1,6 +1,7 @@
 en:
   find:
     courses:
+      fee_notice__next_academic_year: These figures are based on last year. Fees for courses starting in the 2026-2027 academic year will be confirmed soon.
       training_locations:
         view:
           distance: "%{distance} from %{location}"


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/868zJjRg

We have been advised that tuition fees may change for courses starting in 2026-27. So we need to flag this to candidates on Find, until we can confirm the exact changes.

We need to add this content in various places on Find:

**These figures are based on last year. Fees for courses starting in the 2026-2027 academic year will be confirmed soon.**

This content needs to be added in three places:
1. The summary card on the search results page for fee-paying courses
2. The course summary on each course page (fee-paying courses only)
3. The ‘Fees and financial support’ section on each course page for fee-paying courses

## Changes proposed in this pull request

- added notice to above sections on Find.

**1. Summary card on results page (for fee-paying courses)**
<img width="671" height="607" alt="Screenshot 2025-09-29 at 11 46 41" src="https://github.com/user-attachments/assets/2ba160d9-5b0f-435b-abe0-62111215250f" />

**2. Course summary (for fee-paying courses)**
<img width="751" height="476" alt="Screenshot 2025-09-29 at 11 46 22" src="https://github.com/user-attachments/assets/1232fbfe-3e56-4eeb-9311-fd978eed0957" />

**3. The ‘Fees and financial support’ section on each course page for fee-paying courses**

<img width="747" height="608" alt="Screenshot 2025-09-29 at 13 04 26" src="https://github.com/user-attachments/assets/4a8bae69-fd0f-4472-ab74-ac51a1409c22" />

<img width="728" height="494" alt="Screenshot 2025-09-29 at 13 18 28" src="https://github.com/user-attachments/assets/84b4e2bf-e2d0-4bb7-ae5c-d946dc05358a" />


## Guidance to review


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
