### PR TITLE
Fix RecruitmentCycleHelper bug and add specs

### DIFF
--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -14,7 +14,7 @@ module RecruitmentCycleHelper
   end
 
   def previous_recruitment_cycle_period_text
-    "#{Find::CycleTimetable.next_year} to #{Find::CycleTimetable.current_year}"
+    "#{Find::CycleTimetable.previous_year - 1} to #{Find::CycleTimetable.previous_year}"
   end
 
   def hint_text_for_mid_cycle

--- a/spec/helpers/recruitment_cycle_helper_spec.rb
+++ b/spec/helpers/recruitment_cycle_helper_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe RecruitmentCycleHelper do
+  describe "current cycle is 2025 - 2026", travel: mid_cycle(2025) do
+    describe "#current_recruitment_cycle_period_text" do
+      it "returns 2024 to 2025" do
+        expect(helper.current_recruitment_cycle_period_text).to eq("2024 to 2025")
+      end
+    end
+
+    describe "#next_recruitment_cycle_period_text" do
+      it "returns 2025 to 2026" do
+        expect(helper.next_recruitment_cycle_period_text).to eq("2025 to 2026")
+      end
+    end
+
+    describe "#previous_recruitment_cycle_period_text" do
+      it "returns 2023 to 2024" do
+        expect(helper.previous_recruitment_cycle_period_text).to eq("2023 to 2024")
+      end
+    end
+
+    describe "#hint_text_for_mid_cycle" do
+      it "returns text with correct dates" do
+        expect(helper.hint_text_for_mid_cycle).to eq("Candidates can see upcoming application deadlines (9am on 1 October 2024 to 16 September 2025)")
+      end
+    end
+
+    describe "#hint_text_for_after_apply_deadline_passed" do
+      it "returns text with correct dates" do
+        expect(helper.hint_text_for_after_apply_deadline_passed).to eq("Candidates can no longer submit any subsequent applications (16 September 2025 to 29 September 2025)")
+      end
+    end
+
+    describe "#hint_text_for_now_is_before_find_opens" do
+      it "returns text with correct dates" do
+        expect(helper.hint_text_for_now_is_before_find_opens).to eq("Candidates can no longer browse courses on Find (11:59pm on 29 September 2025 to 9am on 30 September 2025)")
+      end
+    end
+
+    describe "#hint_text_for_today_is_after_find_opens" do
+      it "returns text with correct dates" do
+        expect(helper.hint_text_for_today_is_after_find_opens).to eq("Candidates can browse courses on Find. Courses returned are from the next recruitment cycle (30 September 2025)")
+      end
+    end
+
+    describe "#hint_text_for_today_is_between_find_opening_and_apply_opening" do
+      it "returns text with correct dates" do
+        expect(helper.hint_text_for_today_is_between_find_opening_and_apply_opening).to eq("Candidates are able to apply for the courses in the new cycle. (30 September 2025)")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The `previous_recruitment_cycle_period_text` method was returning the wrong text.
No tests for this helper

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
