### PR TITLE
Update accrediting provider description to #about_us from #train_with_us

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -434,7 +434,7 @@ class Course < ApplicationRecord
   end
 
   def ratifying_provider_description
-    accrediting_provider&.train_with_us
+    accrediting_provider&.about_us
   end
 
   def publishable?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1745,13 +1745,13 @@ describe Course do
       let(:course) { create(:course, provider:, accrediting_provider:) }
 
       context "without any provider partnership" do
-        it { is_expected.to eq(accrediting_provider.train_with_us) }
+        it { is_expected.to eq(accrediting_provider.about_us) }
       end
 
       context "with accrediting_provider_enrichments" do
         let(:provider) { create(:provider, accredited_partnerships: [build(:provider_partnership, accredited_provider: accrediting_provider)]) }
 
-        it { is_expected.to eq(accrediting_provider.train_with_us) }
+        it { is_expected.to eq(accrediting_provider.about_us) }
       end
     end
   end

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
 
   it { is_expected.to have_type("courses") }
 
-  it { is_expected.to have_attribute(:about_accredited_body).with_value(course.accrediting_provider.train_with_us) }
+  it { is_expected.to have_attribute(:about_accredited_body).with_value(course.accrediting_provider.about_us) }
   it { is_expected.to have_attribute(:about_course).with_value(course.latest_published_enrichment.about_course) }
   it { is_expected.to have_attribute(:accredited_body_code).with_value(course.accredited_provider_code) }
   it { is_expected.to have_attribute(:age_minimum).with_value(3) }


### PR DESCRIPTION
## Context

The content for the accredited provider is being pulled from the old column `train_with_us` on the course page instead of the `about _us` column.

## Changes proposed in this pull request

Our updates to the Longform content on Courses required us to change the source of the text description for accrediting providers from the `train_with_us` column to the `about_us` column, but we appear to have missed this detail.

Replace the accrediting (ratifying) provider description content on the course in the UI and in the API with the `about_us` column.
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
