### PR TITLE
Correct the dates for find closes screen

### DIFF
--- a/app/views/find/pages/cycle_has_ended.html.erb
+++ b/app/views/find/pages/cycle_has_ended.html.erb
@@ -5,18 +5,18 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Applications are currently closed but you can get ready to apply</h1>
 
-      <p class="govuk-body">Applications for courses starting in the <%= Find::CycleTimetable.cycle_year_range %> academic year are closed.</p>
+      <p class="govuk-body">Applications for courses starting in the <%= Find::CycleTimetable.cycle_year_range(Find::CycleTimetable.previous_year) %> academic year are closed.</p>
 
       <p class="govuk-body">
         You can <%= govuk_link_to("start or continue applying", Settings.apply_base_url) %>
-        for courses starting in the <%= Find::CycleTimetable.next_cycle_year_range %>
+        for courses starting in the <%= Find::CycleTimetable.cycle_year_range %>
         academic year.
       </p>
 
       <p class="govuk-body">You’ll be able to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>find courses from <%= Find::CycleTimetable.find_reopens.to_fs(:govuk_date_and_time) %></li>
-        <li>submit your applications from <%= Find::CycleTimetable.apply_reopens.to_fs(:govuk_date_and_time) %></li>
+        <li>find courses from <%= Find::CycleTimetable.find_opens.to_fs(:govuk_date_and_time) %></li>
+        <li>submit your applications from <%= Find::CycleTimetable.apply_opens.to_fs(:govuk_date_and_time) %></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Context

Find closed is now in the new cycle so the dates in the find down template should reference years one fewer than they did before.

## Changes proposed in this pull request

Deduct 1 year from all the dates in the find closed screen to match it's place in the new cycle.

## Guidance to review

<img width="1151" height="692" alt="image" src="https://github.com/user-attachments/assets/322880af-3126-4920-bdd0-1f79a6e7652a" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
