### PR TITLE
Remove Settings.current_recruitment_cycle_year from tests

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,7 +70,6 @@ one_login:
   # Then convert them back to newlines for OpenSSL
   private_key: <%= ENV.fetch('ONE_LOGIN_PRIVATE_KEY', 'private_key').gsub("\n", '\n') %>
 
-current_recruitment_cycle_year: 2025
 next_cycle_open_date: 2025-09-30
 
 govuk_notify:

--- a/spec/features/publish/courses/editing_course_start_spec.rb
+++ b/spec/features/publish/courses/editing_course_start_spec.rb
@@ -20,7 +20,9 @@ feature "editing course start date" do
     given_i_am_authenticated(user: create(:user, :with_provider))
   end
 
-  delegate :current_recruitment_cycle_year, to: :Settings
+  def current_recruitment_cycle_year
+    Find::CycleTimetable.current_year
+  end
 
   def and_there_is_a_course_i_want_to_edit
     given_a_course_exists

--- a/spec/features/publish/courses/editing_design_technology_spec.rb
+++ b/spec/features/publish/courses/editing_design_technology_spec.rb
@@ -67,7 +67,7 @@ private
 
   def when_i_visit_the_edit_course_design_technology_page(with_invalid_query: false)
     query = edit_course_design_technology_page_with_query(invalid: with_invalid_query)
-    visit "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/design-technology?#{query.to_query}"
+    visit "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/design-technology?#{query.to_query}"
   end
 
   def when_i_visit_the_edit_course_design_technology_page_with_subordinate(subordinate_key)
@@ -82,7 +82,7 @@ private
       },
     )
 
-    visit "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/design-technology?#{query}"
+    visit "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/design-technology?#{query}"
   end
 
   def and_i_click_continue
@@ -98,7 +98,7 @@ private
   end
 
   def then_i_am_met_with_course_details_page
-    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{course.course_code}/details")
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{course.course_code}/details")
   end
 
   def when_i_select_two_specialisms(first_label, second_label)

--- a/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
+++ b/spec/features/publish/courses/editing_visa_sponsorship_spec.rb
@@ -3,12 +3,9 @@
 require "rails_helper"
 
 feature "Editing visa sponsorship" do
-  before do
-    and_i_am_authenticated_as_a_lead_school_provider_user
-  end
-
   context "fee paying course" do
     scenario "i can update the student visa" do
+      and_i_am_authenticated_as_a_lead_school_provider_user
       given_there_is_a_fee_paying_course_i_want_to_edit_which_cant_sponsor_a_student_visa
       when_i_visit_the_course_publish_courses_student_visa_sponsorship_edit_page
       and_i_choose_yes_to_the_student_sponsorship_question
@@ -24,8 +21,9 @@ feature "Editing visa sponsorship" do
 
   context "salaried course" do
     scenario "i can update the skilled worker visa" do
-      given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
       and_i_am_in_mid_cycle
+      and_i_am_authenticated_as_a_lead_school_provider_user
+      given_there_is_a_salaried_course_i_want_to_edit_which_cant_sponsor_a_skilled_worker_visa
       when_i_visit_the_course_publish_courses_skilled_worker_visa_sponsorship_edit_page
       and_i_choose_yes_to_the_skilled_worker_sponsorship_question
       and_i_continue

--- a/spec/features/publish/courses/new_design_technology_spec.rb
+++ b/spec/features/publish/courses/new_design_technology_spec.rb
@@ -76,11 +76,11 @@ private
   end
 
   def when_i_visit_the_new_course_design_technology_page
-    visit "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/design-technology/new?#{new_course_design_technology_query_params}"
+    visit "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/design-technology/new?#{new_course_design_technology_query_params}"
   end
 
   def when_i_visit_the_new_course_design_technology_page_with_subordinate(subordinate_key)
-    visit "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/design-technology/new?#{new_course_design_technology_with_subordinate_query_params(subordinate_key)}"
+    visit "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/design-technology/new?#{new_course_design_technology_with_subordinate_query_params(subordinate_key)}"
   end
 
   def when_i_visit_the_new_engineers_teach_physics_page_with_subordinate(subordinate_key)
@@ -95,7 +95,7 @@ private
         subjects_ids: [physics.id, subordinate.id],
       },
     )
-    visit "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/engineers-teach-physics/new?#{query}"
+    visit "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/engineers-teach-physics/new?#{query}"
   end
 
   def when_i_select_a_design_technology_specialism
@@ -118,7 +118,7 @@ private
 
   def then_i_am_met_with_the_age_range_page
     expect(page).to have_current_path(
-      "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/age-range/new",
+      "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/age-range/new",
       ignore_query: true,
     )
     expect(page).to have_content("Age range")
@@ -126,7 +126,7 @@ private
 
   def then_i_am_met_with_the_modern_languages_page
     expect(page).to have_current_path(
-      "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/modern-languages/new",
+      "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/modern-languages/new",
       ignore_query: true,
     )
     expect(page).to have_content("Languages")
@@ -134,7 +134,7 @@ private
 
   def then_i_am_met_with_the_engineers_teach_physics_page
     expect(page).to have_current_path(
-      "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/engineers-teach-physics/new",
+      "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/engineers-teach-physics/new",
       ignore_query: true,
     )
     expect(page).to have_content("Engineers Teach Physics")
@@ -142,7 +142,7 @@ private
 
   def then_i_am_met_with_the_design_technology_page
     expect(page).to have_current_path(
-      "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/design-technology/new",
+      "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/design-technology/new",
       ignore_query: true,
     )
     expect(page).to have_content("Specialisms")
@@ -160,7 +160,7 @@ private
 
   def then_the_course_name_shows_just_design_and_technology
     expect(page).to have_current_path(
-      "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{@course.course_code}/details",
+      "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{@course.course_code}/details",
       ignore_query: true,
     )
     within(".govuk-heading-l, h1") do
@@ -181,7 +181,7 @@ private
   end
 
   def when_i_visit_the_edit_course_design_technology_page
-    visit "/publish/organisations/#{provider.provider_code}/#{Settings.current_recruitment_cycle_year}/courses/#{@course.course_code}/design-technology?#{edit_course_design_technology_query_params}"
+    visit "/publish/organisations/#{provider.provider_code}/#{Find::CycleTimetable.current_year}/courses/#{@course.course_code}/design-technology?#{edit_course_design_technology_query_params}"
   end
 
   def edit_course_design_technology_query_params


### PR DESCRIPTION
## Context

We are not using `Settings.current_recruitment_cycle_year` anymore and we need to remove any references from the codebase.

## Changes proposed in this pull request

Remove all `Settings.current_recruitment_cycle_year`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
