### PR TITLE
Remove Settings.next_cycle_open_date

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -34,7 +34,7 @@ class CourseDecorator < ApplicationDecorator
     if current_open_cycle?
       h.govuk_link_to("View live course", h.find_course_url(provider.provider_code, object.course_code))
     else
-      "No - live on #{govuk_short_ordinal(Settings.next_cycle_open_date)}"
+      "No - live on #{govuk_short_ordinal(Find::CycleTimetable.next_find_opens.to_date)}"
     end
   end
 

--- a/app/services/find/cycle_timetable.rb
+++ b/app/services/find/cycle_timetable.rb
@@ -125,6 +125,18 @@ module Find
       date(:find_opens, next_year)
     end
 
+    # Next date find opens (either this cycle or next)
+    # return nil if no date is found
+    def self.next_find_opens
+      cycle = CYCLE_DATES.values.find do |year|
+        year[:find_opens] > LONDON.now
+      end
+
+      return nil if cycle.blank?
+
+      cycle[:find_opens]
+    end
+
     def self.apply_opens(year = current_year)
       date(:apply_opens, year)
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,8 +70,6 @@ one_login:
   # Then convert them back to newlines for OpenSSL
   private_key: <%= ENV.fetch('ONE_LOGIN_PRIVATE_KEY', 'private_key').gsub("\n", '\n') %>
 
-next_cycle_open_date: 2025-09-30
-
 govuk_notify:
   api_key: please_change_me
   welcome_email_template_id: 42a9723d-b5a1-413a-89e6-bbdd073373ab

--- a/spec/services/find/cycle_timetable_spec.rb
+++ b/spec/services/find/cycle_timetable_spec.rb
@@ -230,5 +230,27 @@ module Find
         end
       end
     end
+
+    describe ".next_find_opens" do
+      context "when find is closed in the 2025 cycle" do
+        it "returns find_opens(2025)", travel: 1.hour.after(find_closes(2024)) do
+          expect(described_class.next_find_opens).to eq(find_opens(2025))
+        end
+      end
+
+      context "before find is closed in the 2024 cycle" do
+        it "returns find_opens(2025)", travel: 1.hour.before(find_closes(2024)) do
+          expect(described_class.next_find_opens).to eq(find_opens(2025))
+        end
+      end
+
+      context "before find is closed in the 2050 cycle" do
+        it "returns nil" do
+          Timecop.travel(Time.local(2050, 10, 10, 9)) do
+            expect(described_class.next_find_opens).to be_nil
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

We use `Settings.next_cycle_open_date` to communicate to publishers when their courses will be live.
We can use the CycleTimetable to calculate this instead and avoid a deployment to update.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<img width="1167" height="799" alt="image" src="https://github.com/user-attachments/assets/453af999-a331-42fb-83c2-24a40a345ed4" />

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
