### PR TITLE
feat(Bursaries)[]: Add a new row for bursary in find

### DIFF
--- a/app/components/courses/summary_card_component.html.erb
+++ b/app/components/courses/summary_card_component.html.erb
@@ -17,12 +17,16 @@
         <% row.with_value do %>
           <%= fee_value %>
 
-          <% if fee_hint.present? %>
-            <div class="govuk-hint govuk-!-font-size-16"><%= fee_hint %></div>
-          <% end %>
           <% if !course.salary? && !course.apprenticeship? %>
             <div class="govuk-hint govuk-!-font-size-16"><%= t("find.courses.fee_notice__next_academic_year") %></div>
           <% end %>
+        <% end %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% if bursary_value.present? %>
+          <% row.with_key(text: bursary_key) %>
+          <% row.with_value(text: bursary_value) %>
         <% end %>
       <% end %>
 

--- a/app/components/courses/summary_card_component.rb
+++ b/app/components/courses/summary_card_component.rb
@@ -78,7 +78,15 @@ module Courses
       end
     end
 
-    def fee_hint
+    def length_key
+      t(".length_key")
+    end
+
+    def bursary_key
+      t(".bursary_key")
+    end
+
+    def bursary_value
       return if course.salary? || course.apprenticeship? || hide_fee_hint?
 
       if financial_incentive.bursary_amount.present? && financial_incentive.scholarship.present?
@@ -98,10 +106,6 @@ module Courses
           scholarship_amount: number_to_currency(financial_incentive.scholarship),
         )
       end
-    end
-
-    def length_key
-      t(".length_key")
     end
 
     def length_value(course_length = enrichment.course_length)

--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -8,12 +8,16 @@
     <% row.with_value do %>
       <%= fee_value %>
 
-      <% if fee_hint.present? %>
-        <div class="govuk-hint govuk-!-font-size-16"><%= fee_hint %></div>
-      <% end %>
       <% if !course.salaried? && !course.apprenticeship? && !course.no_fee? %>
         <div class="govuk-hint govuk-!-font-size-16"><%= t("find.courses.fee_notice__next_academic_year") %></div>
       <% end %>
+    <% end %>
+  <% end %>
+
+  <% if bursary_value.present? %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: bursary_key) %>
+      <% row.with_value(text: bursary_value) %>
     <% end %>
   <% end %>
 

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -39,7 +39,11 @@ module Find
           end
         end
 
-        def fee_hint
+        def bursary_key
+          t(".bursary_key")
+        end
+
+        def bursary_value
           return if course.salary? || course.apprenticeship? || hide_fee_hint?
 
           if financial_incentive.bursary_amount.present? && financial_incentive.scholarship.present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,7 @@ en:
             bursaries_only_html: "Bursaries of %{bursary_amount} are available"
             scholarship_only_html: "Scholarships of %{scholarship_amount} are available"
       length_key: Course length
+      bursary_key: Financial support
       length_value:
         OneYear: 1 year
         TwoYears: Up to 2 years

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -87,6 +87,7 @@ en:
           for_uk_citizens: for UK citizens
           for_non_uk_citizens: for Non-UK citizens
           fee_key: Fee or salary
+          bursary_key: Financial support
           fee_value:
             salary: Salary
             apprenticeship: Salary (apprenticeship)


### PR DESCRIPTION
## Context

I have been asked to add a separate column for bursaries. This is because there will be two grey texts under the fees section once the bursaries are included.

## Changes proposed in this pull request

Move the grey bursary text from the fee row to its own dedicated row.


