### PR TITLE
Do not try to logout candidate from One Login if there is no session

### DIFF
--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -18,7 +18,8 @@ module Find
         terminate_session
         flash[:success] = t(".sign_out")
 
-        if Settings.one_login.enabled
+        # Double clicking Sign out causes exception when Current.session has already been destroyed
+        if Settings.one_login.enabled && Current.session
           redirect_to(logout_request(Current.session.id_token).redirect_uri, allow_other_host: true)
         else
           redirect_to(find_root_path)


### PR DESCRIPTION
## Context

  Candidates can double click the Sign out button and this wil cause an
  error on the second click when their session has already been
  destroyed.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
