### PR TITLE
Restrict provider users to their own cycle

### DIFF
--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -91,7 +91,7 @@ module Publish
       @providers ||= if current_user.admin?
                        RecruitmentCycle.current.providers
                      else
-                       RecruitmentCycle.current.providers.where(id: current_user.providers)
+                       RecruitmentCycle.current.providers.where(id: current_user.providers.available_to_provider_user)
                      end
     end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -138,7 +138,8 @@ class Provider < ApplicationRecord
       .or(where(provider_code: Course.findable.select(:accredited_provider_code)))
   }
 
-  scope :in_current_cycle, -> { where(recruitment_cycle: RecruitmentCycle.current_recruitment_cycle) }
+  scope :in_current_cycle, -> { where(recruitment_cycle: RecruitmentCycle.current_cycle) }
+  scope :available_to_provider_user, -> { where(recruitment_cycle: RecruitmentCycle.current_and_upcoming_cycles_open_to_publish) }
 
   scope :in_next_cycle, -> { where(recruitment_cycle: RecruitmentCycle.next_recruitment_cycle) }
 

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -34,6 +34,7 @@ class RecruitmentCycle < ApplicationRecord
     where(year: Find::CycleTimetable.current_year).or(upcoming_cycles_open_to_publish)
   end
 
+  scope :current_cycle, -> { where(year: Find::CycleTimetable.current_year) }
   # Old cycle closes for providers the moment the new cycle starts
   scope :upcoming_cycles_open_to_publish, lambda {
     where(":now >= available_in_publish_from AND year > :current_year",

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -15,7 +15,7 @@ class ProviderPolicy
       if user.admin?
         scope.all
       else
-        scope.where(id: user.providers)
+        scope.where(id: user.providers.available_to_provider_user)
       end
     end
   end
@@ -34,7 +34,7 @@ class ProviderPolicy
   end
 
   def show?
-    user.admin? || user.providers.include?(provider)
+    user.admin? || user.providers.available_to_provider_user.include?(provider)
   end
 
   def show_any?
@@ -53,7 +53,7 @@ class ProviderPolicy
     return true if user.admin?
 
     accredited_partners_codes = provider.accredited_partners.pluck(:provider_code)
-    user_provider_codes = user.providers.pluck(:provider_code)
+    user_provider_codes = user.providers.available_to_provider_user.pluck(:provider_code)
 
     !(accredited_partners_codes & user_provider_codes).compact.empty?
   end


### PR DESCRIPTION
## Context

Providers only ever have access to the current recruitment cycle and the next recruitment cycle when rollover is happening and it's available to provider users.

Our routes allow for anyone to put any valid year in the URL, and there's nothing to prevent providers from doing that.

## Changes proposed in this pull request

- Add new providers scope to return only current and future providers, this will be used to get providers for users.
- Add `RecruitmentCycle.current_cycle` which returns a scope instead of executing a query. This makes efficient queries possible

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
