### PR TITLE
Avoid explictly setting Provider code to avoid uniqueness errors

### DIFF
--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -593,49 +593,54 @@ RSpec.describe Courses::Query do
     end
 
     context "when searching excluding courses" do
-      let(:params) { { excluded_courses: { provider_code: "P12", course_code: "EX12" } } }
+      let(:provider) { create(:provider) }
+      let(:course_code) { "EX12" }
+      let(:params) { { excluded_courses: { provider_code: provider.provider_code, course_code: } } }
 
       it "excludes specified courses from the results" do
         create(:course, :with_full_time_sites,
                name: "Excluded Course",
-               course_code: "EX12",
-               provider: create(:provider, provider_code: "P12"))
+               course_code:,
+               provider:)
 
+        included_course_provider = create(:provider)
         included_course = create(:course, :with_full_time_sites,
                                  name: "Included Course",
-                                 course_code: "IN34",
-                                 provider: create(:provider, provider_code: "P34"))
+                                 provider: included_course_provider)
 
-        same_course_code_different_provider = create(:course, :with_full_time_sites,
-                                                     name: "Included Course with same course code but different provider",
-                                                     course_code: "EX12",
-                                                     provider: create(:provider, provider_code: "P99"))
+        different_provider = create(:provider)
+        same_course_code_different_provider_course = create(:course, :with_full_time_sites,
+                                                            name: "Included Course with same course code but different provider",
+                                                            course_code:,
+                                                            provider: different_provider)
 
         expect(results).to match_collection(
-          [included_course, same_course_code_different_provider],
+          [included_course, same_course_code_different_provider_course],
           attribute_names: %w[name],
         )
       end
     end
 
     context "when searching excluding courses array" do
-      let(:params) { { excluded_courses: [{ provider_code: "P12", course_code: "EX12" }] } }
+      let(:excluded_provider) { create(:provider) }
+      let(:included_course_provider) { create(:provider) }
+      let(:course_code) { "EX12" }
+      let(:params) { { excluded_courses: [{ provider_code: excluded_provider.provider_code, course_code: }] } }
 
       it "excludes specified courses from the results" do
         create(:course, :with_full_time_sites,
                name: "Excluded Course",
-               course_code: "EX12",
-               provider: create(:provider, provider_code: "P12"))
+               course_code:,
+               provider: excluded_provider)
 
         included_course = create(:course, :with_full_time_sites,
                                  name: "Included Course",
-                                 course_code: "IN34",
-                                 provider: create(:provider, provider_code: "P34"))
+                                 provider: included_course_provider)
 
         same_course_code_different_provider = create(:course, :with_full_time_sites,
                                                      name: "Included Course with same course code but different provider",
-                                                     course_code: "EX12",
-                                                     provider: create(:provider, provider_code: "P99"))
+                                                     course_code:,
+                                                     provider: create(:provider))
 
         expect(results).to match_collection(
           [included_course, same_course_code_different_provider],


### PR DESCRIPTION
## Context

The provider code is generated by the factory in the test suite. If we set the provider code on a test subject explicitly we risk conflicting with one that was generated.

```log
Failures:

  1) Courses::Query.call when searching excluding courses excludes specified courses from the results
     Failure/Error: provider: create(:provider, provider_code: "P99"))

     ActiveRecord::RecordInvalid:
       Validation failed: Provider code Provider code already taken
     # ./spec/services/courses/query_spec.rb:612:in 'block (4 levels) in <main>'
     # ./spec/rails_helper.rb:167:in 'block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:97:in 'block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:96:in 'block (2 levels) in <top (required)>'
     # ./spec/support/authentication/mode/magic_link.rb:20:in 'block (2 levels) in <top (required)>'

Finished in 49.64 seconds (files took 9.06 seconds to load)
220 examples, 1 failure

Failed examples:

rspec ./spec/services/courses/query_spec.rb:598 # Courses::Query.call when searching excluding courses excludes specified courses from the results
```

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
