### PR TITLE
Fix start date options

### DIFF
--- a/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
@@ -147,11 +147,8 @@ describe Courses::EditOptions::StartDateConcern do
         context "September 2026 (2027 cycle course but still in 2026 timetable)" do
           it "returns 2027 cycle options filtered by current 2026 timetable month" do
             travel_to Time.zone.local(2026, 9, 15) do
-              # Still in 2026 cycle according to timetable
               allow(Find::CycleTimetable).to receive(:current_year).and_return(2026)
 
-              # Looking for "September 2026" in 2027 cycle options (Jan 2027 - July 2028)
-              # This won't be found, so falls back to index 0
               expected_options = [
                 "January 2027",
                 "February 2027",
@@ -185,6 +182,15 @@ describe Courses::EditOptions::StartDateConcern do
               allow(Find::CycleTimetable).to receive(:current_year).and_return(2027)
 
               expected_options = [
+                "January 2027",
+                "February 2027",
+                "March 2027",
+                "April 2027",
+                "May 2027",
+                "June 2027",
+                "July 2027",
+                "August 2027",
+                "September 2027",
                 "October 2027",
                 "November 2027",
                 "December 2027",
@@ -227,35 +233,6 @@ describe Courses::EditOptions::StartDateConcern do
                 "May 2028",
                 "June 2028",
                 "July 2028",
-              ]
-
-              expect(example_model.start_date_options).to eq(expected_options)
-            end
-          end
-        end
-      end
-
-      # Real world scenario - today's test
-      context "actual current scenario" do
-        context "October 1, 2025 with 2026 cycle course (real situation)" do
-          it "returns start dates from October 2026 to July 2027" do
-            # This is the actual situation right now
-            travel_to Time.zone.local(2025, 10, 1, 14, 5) do
-              # Current year according to CycleTimetable is 2026
-              allow(Find::CycleTimetable).to receive(:current_year).and_return(2026)
-
-              # We're looking for "October 2026" in the options, and it exists in 2026 cycle
-              expected_options = [
-                "October 2026", # Courses can start in October 2026
-                "November 2026",
-                "December 2026",
-                "January 2027",
-                "February 2027",
-                "March 2027",
-                "April 2027",
-                "May 2027",
-                "June 2027",
-                "July 2027",
               ]
 
               expect(example_model.start_date_options).to eq(expected_options)

--- a/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
+++ b/spec/models/concerns/courses/edit_options/start_date_concern_spec.rb
@@ -3,83 +3,352 @@
 require "rails_helper"
 
 describe Courses::EditOptions::StartDateConcern do
-  let(:example_model) { create(:course) }
+  let(:recruitment_cycle) do
+    RecruitmentCycle.find_by(year: "2026") || create(:recruitment_cycle, year: 2026)
+  end
+  let(:provider) { create(:provider, recruitment_cycle: recruitment_cycle) }
 
-  let(:year) { example_model.provider.recruitment_cycle.year.to_i }
+  after do
+    travel_back
+  end
 
-  context "non persisted course" do
-    context "start_date_options" do
-      it "returns the correct options for the recruitment_cycle" do
-        expect(example_model.start_date_options).to eq(
-          [
-            "January #{year}",
-            "February #{year}",
-            "March #{year}",
-            "April #{year}",
-            "May #{year}",
-            "June #{year}",
-            "July #{year}",
-            "August #{year}",
-            "September #{year}",
-            "October #{year}",
-            "November #{year}",
-            "December #{year}",
-            "January #{year + 1}",
-            "February #{year + 1}",
-            "March #{year + 1}",
-            "April #{year + 1}",
-            "May #{year + 1}",
-            "June #{year + 1}",
-            "July #{year + 1}",
-          ],
-        )
+  describe "#start_date_options" do
+    context "non-persisted course" do
+      let(:example_model) { build(:course, provider: provider) }
+
+      context "2026 cycle course" do
+        context "today (October 1, 2025 - in 2026 cycle)" do
+          it "returns options starting from January 2026 (not October 2026)" do
+            travel_to Time.zone.local(2025, 10, 1, 14, 5) do
+              allow(Find::CycleTimetable).to receive(:current_year).and_return(2026)
+
+              # Since we're in October 2025 but CycleTimetable.current_year is 2026,
+              # we should look for "October 2026" but it doesn't exist in the 2026 cycle options.
+              # The 2026 cycle options are Jan 2026 - July 2027
+              # So we fall back to index 0 (January 2026)
+              expected_options = [
+                "January 2026",
+                "February 2026",
+                "March 2026",
+                "April 2026",
+                "May 2026",
+                "June 2026",
+                "July 2026",
+                "August 2026",
+                "September 2026",
+                "October 2026",
+                "November 2026",
+                "December 2026",
+                "January 2027",
+                "February 2027",
+                "March 2027",
+                "April 2027",
+                "May 2027",
+                "June 2027",
+                "July 2027",
+              ]
+
+              expect(example_model.start_date_options).to eq(expected_options)
+            end
+          end
+        end
+
+        context "January 2026 (mid 2026 cycle)" do
+          it "returns options starting from January 2026" do
+            travel_to Time.zone.local(2026, 1, 15) do
+              allow(Find::CycleTimetable).to receive(:current_year).and_return(2026)
+
+              expected_options = [
+                "January 2026",
+                "February 2026",
+                "March 2026",
+                "April 2026",
+                "May 2026",
+                "June 2026",
+                "July 2026",
+                "August 2026",
+                "September 2026",
+                "October 2026",
+                "November 2026",
+                "December 2026",
+                "January 2027",
+                "February 2027",
+                "March 2027",
+                "April 2027",
+                "May 2027",
+                "June 2027",
+                "July 2027",
+              ]
+
+              expect(example_model.start_date_options).to eq(expected_options)
+            end
+          end
+        end
+
+        context "June 2026 (mid 2026 cycle)" do
+          it "returns options starting from June 2026" do
+            travel_to Time.zone.local(2026, 6, 10) do
+              allow(Find::CycleTimetable).to receive(:current_year).and_return(2026)
+
+              expected_options = [
+                "June 2026",
+                "July 2026",
+                "August 2026",
+                "September 2026",
+                "October 2026",
+                "November 2026",
+                "December 2026",
+                "January 2027",
+                "February 2027",
+                "March 2027",
+                "April 2027",
+                "May 2027",
+                "June 2027",
+                "July 2027",
+              ]
+
+              expect(example_model.start_date_options).to eq(expected_options)
+            end
+          end
+        end
+
+        context "September 2026 (end of 2026 cycle applications)" do
+          it "returns options starting from September 2026" do
+            travel_to Time.zone.local(2026, 9, 15) do
+              allow(Find::CycleTimetable).to receive(:current_year).and_return(2026)
+
+              expected_options = [
+                "September 2026",
+                "October 2026",
+                "November 2026",
+                "December 2026",
+                "January 2027",
+                "February 2027",
+                "March 2027",
+                "April 2027",
+                "May 2027",
+                "June 2027",
+                "July 2027",
+              ]
+
+              expect(example_model.start_date_options).to eq(expected_options)
+            end
+          end
+        end
+      end
+
+      context "2027 cycle course" do
+        let(:recruitment_cycle_2027) do
+          RecruitmentCycle.find_by(year: "2027") || create(:recruitment_cycle, year: 2027)
+        end
+        let(:provider_2027) { create(:provider, recruitment_cycle: recruitment_cycle_2027) }
+        let(:example_model) { build(:course, provider: provider_2027) }
+
+        context "September 2026 (2027 cycle course but still in 2026 timetable)" do
+          it "returns 2027 cycle options filtered by current 2026 timetable month" do
+            travel_to Time.zone.local(2026, 9, 15) do
+              # Still in 2026 cycle according to timetable
+              allow(Find::CycleTimetable).to receive(:current_year).and_return(2026)
+
+              # Looking for "September 2026" in 2027 cycle options (Jan 2027 - July 2028)
+              # This won't be found, so falls back to index 0
+              expected_options = [
+                "January 2027",
+                "February 2027",
+                "March 2027",
+                "April 2027",
+                "May 2027",
+                "June 2027",
+                "July 2027",
+                "August 2027",
+                "September 2027",
+                "October 2027",
+                "November 2027",
+                "December 2027",
+                "January 2028",
+                "February 2028",
+                "March 2028",
+                "April 2028",
+                "May 2028",
+                "June 2028",
+                "July 2028",
+              ]
+
+              expect(example_model.start_date_options).to eq(expected_options)
+            end
+          end
+        end
+
+        context "October 2026 (2027 cycle has opened)" do
+          it "returns options starting from October 2027" do
+            travel_to Time.zone.local(2026, 10, 5) do
+              allow(Find::CycleTimetable).to receive(:current_year).and_return(2027)
+
+              expected_options = [
+                "October 2027",
+                "November 2027",
+                "December 2027",
+                "January 2028",
+                "February 2028",
+                "March 2028",
+                "April 2028",
+                "May 2028",
+                "June 2028",
+                "July 2028",
+              ]
+
+              expect(example_model.start_date_options).to eq(expected_options)
+            end
+          end
+        end
+
+        context "January 2027 (mid 2027 cycle)" do
+          it "returns options starting from January 2027" do
+            travel_to Time.zone.local(2027, 1, 15) do
+              allow(Find::CycleTimetable).to receive(:current_year).and_return(2027)
+
+              expected_options = [
+                "January 2027",
+                "February 2027",
+                "March 2027",
+                "April 2027",
+                "May 2027",
+                "June 2027",
+                "July 2027",
+                "August 2027",
+                "September 2027",
+                "October 2027",
+                "November 2027",
+                "December 2027",
+                "January 2028",
+                "February 2028",
+                "March 2028",
+                "April 2028",
+                "May 2028",
+                "June 2028",
+                "July 2028",
+              ]
+
+              expect(example_model.start_date_options).to eq(expected_options)
+            end
+          end
+        end
+      end
+
+      # Real world scenario - today's test
+      context "actual current scenario" do
+        context "October 1, 2025 with 2026 cycle course (real situation)" do
+          it "returns start dates from October 2026 to July 2027" do
+            # This is the actual situation right now
+            travel_to Time.zone.local(2025, 10, 1, 14, 5) do
+              # Current year according to CycleTimetable is 2026
+              allow(Find::CycleTimetable).to receive(:current_year).and_return(2026)
+
+              # We're looking for "October 2026" in the options, and it exists in 2026 cycle
+              expected_options = [
+                "October 2026", # Courses can start in October 2026
+                "November 2026",
+                "December 2026",
+                "January 2027",
+                "February 2027",
+                "March 2027",
+                "April 2027",
+                "May 2027",
+                "June 2027",
+                "July 2027",
+              ]
+
+              expect(example_model.start_date_options).to eq(expected_options)
+            end
+          end
+        end
+      end
+    end
+
+    context "persisted course" do
+      let(:example_model) { create(:course, provider: provider) }
+
+      shared_examples "returns complete options regardless of time" do |cycle_year|
+        it "returns all start date options for the recruitment cycle" do
+          expected_options = [
+            "January #{cycle_year}",
+            "February #{cycle_year}",
+            "March #{cycle_year}",
+            "April #{cycle_year}",
+            "May #{cycle_year}",
+            "June #{cycle_year}",
+            "July #{cycle_year}",
+            "August #{cycle_year}",
+            "September #{cycle_year}",
+            "October #{cycle_year}",
+            "November #{cycle_year}",
+            "December #{cycle_year}",
+            "January #{cycle_year + 1}",
+            "February #{cycle_year + 1}",
+            "March #{cycle_year + 1}",
+            "April #{cycle_year + 1}",
+            "May #{cycle_year + 1}",
+            "June #{cycle_year + 1}",
+            "July #{cycle_year + 1}",
+          ]
+
+          expect(example_model.start_date_options).to eq(expected_options)
+        end
+      end
+
+      context "2026 cycle course" do
+        context "today (October 1, 2025)" do
+          before do
+            travel_to Time.zone.local(2025, 10, 1)
+          end
+
+          it_behaves_like "returns complete options regardless of time", 2026
+        end
+
+        context "January 2026" do
+          before do
+            travel_to Time.zone.local(2026, 1, 15)
+          end
+
+          it_behaves_like "returns complete options regardless of time", 2026
+        end
+      end
+
+      context "2027 cycle course" do
+        let(:recruitment_cycle_2027) do
+          RecruitmentCycle.find_by(year: "2027") || create(:recruitment_cycle, year: 2027)
+        end
+        let(:provider_2027) { create(:provider, recruitment_cycle: recruitment_cycle_2027) }
+        let(:example_model) { create(:course, provider: provider_2027) }
+
+        context "September 2026" do
+          before do
+            travel_to Time.zone.local(2026, 9, 15)
+          end
+
+          it_behaves_like "returns complete options regardless of time", 2027
+        end
       end
     end
   end
 
-  context "persisted course" do
-    let(:example_model) { build(:course) }
-    let(:month) { [*1..12].sample }
-    let(:expected_starting_options) do
-      [
-        nil,
-        "January #{year}",
-        "February #{year}",
-        "March #{year}",
-        "April #{year}",
-        "May #{year}",
-        "June #{year}",
-        "July #{year}",
-        "August #{year}",
-        "September #{year}",
-        "October #{year}",
-        "November #{year}",
-        "December #{year}",
-      ][month..12].compact
-    end
+  describe "#show_start_date?" do
+    let(:example_model) { build(:course, provider: provider) }
 
-    let(:expected_available_options) do
-      [
+    context "when course is not published" do
+      before { allow(example_model).to receive(:is_published?).and_return(false) }
 
-        *expected_starting_options,
-        "January #{year + 1}",
-        "February #{year + 1}",
-        "March #{year + 1}",
-        "April #{year + 1}",
-        "May #{year + 1}",
-        "June #{year + 1}",
-        "July #{year + 1}",
-      ]
-    end
-
-    around do |example|
-      Timecop.freeze(Time.zone.local(Find::CycleTimetable.current_year, month, 1)) do
-        example.run
+      it "returns true" do
+        expect(example_model.show_start_date?).to be true
       end
     end
 
-    it "returns the available options for the recruitment_cycle" do
-      expect(example_model.start_date_options).to eq(expected_available_options)
+    context "when course is published" do
+      before { allow(example_model).to receive(:is_published?).and_return(true) }
+
+      it "returns false" do
+        expect(example_model.show_start_date?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

This PR fix how start date options are calculated and sliced for `Course` models. 

Previously, the code used the current timetable year for slicing, which caused failures when the current date was before the start of the recruitment cycle or in ambiguous cycle transitions. 

This led to incorrect start months being presented to users.

## How it works now

	•	The available start date options are always built for the course’s recruitment cycle (January–December + January–July of next year).
	•	The slicing logic now considers the current calendar date in context of the cycle boundaries:
	•	If today is before the cycle starts, the options always begin from January of the cycle year - all options are returned.
	•	If today is in the cycle year, slicing starts from today’s month of the cycle year.
	•	Otherwise, all options are returned.

