### PR TITLE
FeatureFlags don't raise error in production and send Slack notification

### DIFF
--- a/app/lib/feature_flag.rb
+++ b/app/lib/feature_flag.rb
@@ -51,9 +51,9 @@ class FeatureFlag
     def notify_slack(feature_name, feature_activated)
       return unless Rails.env.production?
 
-      SlackNotificationJob.perform_now(
+      SlackNotificationJob.perform_later(
         I18n.t(slack_notification_i18n_key(feature_activated), feature_name: feature_name.humanize),
-        support_feature_flags_path,
+        Rails.application.routes.url_helpers.support_feature_flags_path,
       )
     end
 

--- a/spec/lib/feature_flag_spec.rb
+++ b/spec/lib/feature_flag_spec.rb
@@ -47,5 +47,15 @@ describe FeatureFlag do
 
       expect(described_class.active?("test_feature")).to be(true)
     end
+
+    context "when the production environment" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "notifies Slack" do
+        expect { described_class.activate("test_feature") }.to have_enqueued_job(SlackNotificationJob)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

  When a FeatureFlag is activated or deactivated in production we send a
  Slack Notification. The URL helper in the FeatureFlag class threw an
  error until we fully scoped it to the routes.url_helpers

Resolve the Sentry error on release
https://dfe-teacher-services.sentry.io/issues/6844627102/?alert_rule_id=11137790&alert_type=issue&notification_uuid=2ea51dc8-936a-4e83-93ed-7628bfd8729b&project=1377944&referrer=slack

## Changes proposed in this pull request

When using route helpers in lib directory, use full namespace

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
