### PR TITLE
Correct Omniauth failure param

### DIFF
--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -29,7 +29,7 @@ module Find
       def failure
         Sentry.capture_message("One Login failure", extra: {
           error_type: params[:message],
-          provider: params[:provider],
+          strategy: params[:strategy],
         })
 
         render "errors/omniauth"

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -29,6 +29,7 @@ module Find
       def failure
         Sentry.capture_message("One Login failure", extra: {
           error_type: params[:message],
+          session_id: session.id.public_id,
           strategy: params[:strategy],
         })
 

--- a/app/lib/authentications/candidate_omni_auth.rb
+++ b/app/lib/authentications/candidate_omni_auth.rb
@@ -8,6 +8,25 @@ module Authentications
 
     def options
       if one_login?
+        ## Debugging govuk one login session validations
+        unless Rails.env.production?
+          OmniAuth.config.before_request_phase = lambda do |env|
+            r = Rack::Request.new(env)
+            Rails.logger.tagged("DebugOmniAuth::Request") do
+              Rails.logger.info("DebugOmniAuth: session_keys: #{r.session.keys}")
+              Rails.logger.info("DebugOmniAuth: omniauth.params: #{r.session['omniauth.params']}")
+            end
+          end
+          OmniAuth.config.before_callback_phase = lambda do |env|
+            r = Rack::Request.new(env)
+
+            Rails.logger.tagged("DebugOmniAuth::Callback") do
+              Rails.logger.info("DebugOmniAuth: session_keys: #{r.session.keys}")
+              Rails.logger.info("DebugOmniAuth: omniauth.params: #{r.session['omniauth.params']}")
+              Rails.logger.info("DebugOmniAuth: oidc: #{r.session['oidc']}")
+            end
+          end
+        end
         {
           name: :"one-login",
           client_id: Settings.one_login.identifier,


### PR DESCRIPTION
The param we receive to the failure endpoint is called strategy not
  provider.

  https://github.com/omniauth/omniauth/blob/master/lib/omniauth/failure_endpoint.rb#L43## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
