### PR TITLE
Correct the production OneLogin post logout url

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -35,7 +35,7 @@ one_login:
   # URL we use to end the Onne Login session on behalf of the user
   logout_url: https://oidc.account.gov.uk/logout
   # URL user is redirected to after logging out of One Login
-  post_logout_url: https://find-teacher-training-courses.service.gov.uk/
+  post_logout_url: https://find-teacher-training-courses.service.gov.uk
   # URL of the users profile
   profile_url: https://home.account.gov.uk
 


### PR DESCRIPTION
## Context

  Must remove the trailing slash from the config to match the config on
  OneLogin

  `https://find-teacher-training-courses.service.gov.uk`
  not
  `https://find-teacher-training-courses.service.gov.uk/`

## Changes proposed in this pull request

Logging out of One Login doesn't redirect users successfully to the root url in find unless the urls match exactly

## Guidance to review

<img width="1055" height="454" alt="image" src="https://github.com/user-attachments/assets/7b2a533d-b1d2-4baa-a091-2bb52dfade61" />


```
error_description=client%20registry%20does%20not%20contain%20post_logout_redirect_uri
```
## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
