### PR TITLE
Skip the AssignVisaSponsorshipApplicationDeadlineService without date

### DIFF
--- a/app/services/courses/assign_visa_sponsorship_application_deadline_service.rb
+++ b/app/services/courses/assign_visa_sponsorship_application_deadline_service.rb
@@ -11,6 +11,8 @@ module Courses
     end
 
     def execute(course)
+      return unless deadline_date_params_are_sent
+
       course.visa_sponsorship_application_deadline_at = if visa_sponsorship_application_deadline_required?(course)
                                                           DateTime.new(year.to_i, month.to_i, day.to_i)
                                                                   .in_time_zone("London")
@@ -37,6 +39,10 @@ module Courses
 
     def day
       @course_params["visa_sponsorship_application_deadline_at(3i)"]
+    end
+
+    def deadline_date_params_are_sent
+      @course_params.key?("visa_sponsorship_application_deadline_at(1i)")
     end
   end
 end


### PR DESCRIPTION
## Context

  The AssignVisaSponsorshipApplicationDeadlineService only concerns the
  setting of the visa sponsorship date AFTER the provider decides there
  should be a visa sponsorship deadline date. We can avoid calling this
  service unless the date params are present.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
