### PR TITLE
infra(K8S)[]: Reduce main app replicas from 18 to 6 in prod

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -8,7 +8,7 @@
   "resource_group_name": "s189p01-ptt-pd-rg",
   "main_app": {
     "main": {
-      "replicas": 9,
+      "replicas": 6,
       "max_memory": "4Gi"
     }
   },


### PR DESCRIPTION
## Context

As we currently only use 5-10% max of our pods resources, I'm looking to reduce main app replicas from 18 to 9 in production configuration

## Changes proposed in this pull request

Reducing replica count from 18 to 6
