### PR TITLE
Enable basic authentication in review apps

### DIFF
--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -28,5 +28,8 @@ authentication:
   secret: secret
   mode: persona
 
+basic_auth:
+  enabled: true
+
 skylight:
   enable: false

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -8,7 +8,7 @@ The Find service is publicly available. We are in the process of looking into ad
 
 ### Basic Auth
 
-The Publish QA environment is protected by basic auth. The username and password can be provided by a Find/Publish team member.
+The Publish QA and Review environments are protected by basic auth. The username and password can be provided by a Find/Publish team member.
 
 ### DfE Sign in
 


### PR DESCRIPTION
## Context

Publish is protected by Basic Authentication when it's deployed to Review Apps.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
