### PR TITLE
Only show rollover banner until Find opens

### DIFF
--- a/app/views/publish/authentication/sign_in/index.html.erb
+++ b/app/views/publish/authentication/sign_in/index.html.erb
@@ -1,5 +1,5 @@
 <%= render PageTitle.new(title: "sign_in.index") %>
-<% if Date.current >= Date.new(2025, 9, 1) %>
+<% if Find::CycleTimetable.phase_in_time?(:now_is_before_find_opens) %>
   <%= render(NotificationBanner.new(
     text: t("publish.rollover_notification.text"),
     text_body: t(

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
-<% if Date.current >= Date.new(2025, 9, 1) %>
+<% if Find::CycleTimetable.phase_in_time?(:now_is_before_find_opens) %>
   <%= render(NotificationBanner.new(
     text: t("publish.rollover_notification.text"),
     text_body: t(

--- a/spec/requests/publish/banners/rollover_banner_spec.rb
+++ b/spec/requests/publish/banners/rollover_banner_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "Rollover banner spec" do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user, :with_provider) }
+  let(:provider) { user.providers.first }
+
+  before { login_user(user) }
+
+  describe "/courses" do
+    context "when find is closed", travel: 1.hour.before(find_opens) do
+      it "shows the rollover notifiation banner" do
+        get "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/courses"
+
+        expect(response.body).to include(I18n.t("publish.rollover_notification.text"))
+      end
+    end
+
+    context "when find is open", travel: 1.hour.after(find_opens) do
+      it "does not show the rollover notifiation banner" do
+        get "/publish/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}/courses"
+
+        expect(response.body).not_to include(I18n.t("publish.rollover_notification.text"))
+      end
+    end
+  end
+end

--- a/spec/views/publish/authentication/sign_in/index_spec.rb
+++ b/spec/views/publish/authentication/sign_in/index_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "publish/authentication/sign_in/index.html.erb" do
+  before { render }
+
+  context "when find is closed", travel: 1.hour.before(find_opens) do
+    it "rollover notification banner is displayed" do
+      expect(rendered).to have_selector(".govuk-notification-banner", text: t("publish.rollover_notification.text"))
+    end
+  end
+
+  context "when find is open", travel: 1.hour.after(find_opens) do
+    it "rollover notification banner is not displayed" do
+      expect(rendered).to have_no_selector(".govuk-notification-banner", text: t("publish.rollover_notification.text"))
+    end
+  end
+end


### PR DESCRIPTION
## Context

Hide the rollover banner after Find opens

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The banner will appear after find closes until find reopens.
I suspect we'll want to make it appear earlier than that but we can decide that after we hide it with this PR

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
