### PR TITLE
Preserve gias school coordinates

### DIFF
--- a/lib/gias/importer.rb
+++ b/lib/gias/importer.rb
@@ -37,7 +37,7 @@ module Gias
 
     def preserve_coordinates?(gias_school, school_record)
       gias_school.latitude.present? && gias_school.longitude.present? &&
-        school_record["latitude"].blank? && school_record["longitude"].blank?
+        (school_record["latitude"].blank? || school_record["longitude"].blank?)
     end
   end
 end


### PR DESCRIPTION
## Context

When Gias CSV doesn't have latitude and longitude but we do have on our database, we should preserve the latitude and longitude from the database.

This will guarantee that #5715 task will geocode all blank coordinates and preserve everything after the next day import.