### PR TITLE
Exit database restore if sanitisation fails

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -104,7 +104,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Clear user data"
-          psql -d ${DATABASE_NAME} -f db/scripts/sanitise.sql
+          psql -d ${DATABASE_NAME} -v ON_ERROR_STOP=1 -f db/scripts/sanitise.sql
             if [ $? -ne 0 ]; then
               echo "db/scripts/sanitise.sql failed" >&2
               exit 1


### PR DESCRIPTION
## Context

A daily recurring script will backup our production database, sanitise it, and restore it to QA. A copy to maintained that will seed any review apps that are created too.

There is a sanitisation script in the repo that deletes sensitive tables and anonymises user information like email address.

If this script does not succeed, it may leave sensitive data in the backup.
psql will not exit immediately when encountering an error, it will continue to execute commands to the end of the file without adding some flags


## Changes proposed in this pull request

The github workflow will fail and halt immediately if the sanitisation script fails, preventing sensitive data from being deployed to QA and review apps.

## Guidance to review

Has this been tested?
- I tested and the script runs successfully under normal circumstances after removing the `DELETE access_request;` command
- In order to test that the script exists in normal execution, we can leave the erroring `DELETE access_request;` command in the script and wait until the next scheduled backup runs to demonstrated it's effectivenes..



## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
