### PR TITLE
impr(k8s)[]: Update max_memory for staging

### DIFF
--- a/terraform/aks/workspace_variables/staging.tfvars.json
+++ b/terraform/aks/workspace_variables/staging.tfvars.json
@@ -9,7 +9,7 @@
   "main_app": {
     "main": {
       "replicas": 2,
-      "max_memory": "2Gi"
+      "max_memory": "3Gi"
     }
   },
   "worker_apps": {


### PR DESCRIPTION
## Context

We have been receiving error messages due to memory usage reaching its maximum limit in the staging environment.

## Changes proposed in this pull request

To resolve this issue and prevent future alerts in Slack, we propose increasing the maximum memory from 2GB to 3GB.