### PR TITLE
Remove SQL command that makes the sanitisation script fail

### DIFF
--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -1,5 +1,4 @@
 DELETE FROM session;
-DELETE FROM access_request;
 DELETE FROM audit;
 
 UPDATE "user"


### PR DESCRIPTION
## Context

  We left this line in to test that the sanitisation script fails when
  one of the commands fails to make sure we don't deploy poorly
  sanitised data to lower environments

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
