### PR TITLE
Find: separate accredited provider organisation content: about_us and value_proposition

### DIFF
--- a/app/views/find/courses/_about_accrediting_provider.html.erb
+++ b/app/views/find/courses/_about_accrediting_provider.html.erb
@@ -2,6 +2,7 @@
   <%= t(".heading", provider_name: course.accrediting_provider.provider_name) %>
 </h1>
 <div data-qa="course__about_accrediting_provider">
-  <%= markdown(course.about_accrediting_provider + course.accrediting_provider_value_proposition) %>
+  <%= markdown(course.about_accrediting_provider) %>
+  <%= markdown(course.accrediting_provider_value_proposition) %>
 </div>
 <%= render Shared::Courses::WhatIsAnAccreditedProviderComponent.new(course: @course) %>


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/UjiVc44t/1220-bug-accredited-provider-organisation-content-aboutus-and-valueproposition-is-not-separated-on-find

After adding the `value_proposition` to the Ratified by page (About us for accredited providers) the content is not separated into paragraphs.

## Changes proposed in this pull request

<img width="907" height="611" alt="Screenshot 2025-10-30 at 15 17 18" src="https://github.com/user-attachments/assets/4635bcd7-9a63-45c0-998f-91007df03576" />


## Guidance to review

Example review app url: https://find-review-5745.test.teacherservices.cloud/courses/2FD/C605/accredited-by

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
