### PR TITLE
Fix auto publish for description fields

### DIFF
--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -8,7 +8,7 @@ module Find
         include ::ViewHelper
         include PreviewHelper
 
-        attr_reader :course
+        attr_reader :course, :enrichment
 
         delegate :accrediting_provider,
                  :provider,
@@ -26,9 +26,10 @@ module Find
                  :can_sponsor_skilled_worker_visa,
                  :no_fee?, to: :course
 
-        def initialize(course)
+        def initialize(course, enrichment)
           super
           @course = course
+          @enrichment = enrichment
         end
 
         def fee_value
@@ -93,11 +94,11 @@ module Find
 
       private
 
-        def uk_fees(fee_uk = course.enrichment_attribute(:fee_uk_eu))
+        def uk_fees(fee_uk = enrichment&.fee_uk_eu)
           t(".fee_value.fee.uk_fees_html", value: content_tag(:b, number_to_currency(fee_uk.to_f))) if fee_uk.present?
         end
 
-        def international_fees(fee_international = course.enrichment_attribute(:fee_international))
+        def international_fees(fee_international = enrichment&.fee_international)
           t(".fee_value.fee.international_fees_html", value: content_tag(:b, number_to_currency(fee_international.to_f))) if fee_international.present?
         end
 

--- a/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
+++ b/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.html.erb
@@ -7,7 +7,7 @@
   <% end %>
   <% if has_fees? %>
    <% if course.version.to_i == 2 %>
-    <%= render partial: "find/courses/v2/financial_support/fees_and_financials", locals: { course: @course } %>
+    <%= render partial: "find/courses/v2/financial_support/fees_and_financials", locals: { course: @course, enrichment: enrichment } %>
    <% else %>
     <%= render Find::Courses::FeesComponent::View.new(course) %>
    <% end %>

--- a/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.rb
+++ b/app/components/shared/courses/financial_support/fees_and_financial_support_component/view.rb
@@ -7,7 +7,7 @@ module Shared
         class View < ViewComponent::Base
           include PublishHelper
 
-          attr_reader :course
+          attr_reader :course, :enrichment
 
           delegate :salaried?,
                    :excluded_from_bursary?,
@@ -16,9 +16,10 @@ module Shared
                    :has_fees?,
                    :financial_support, to: :course
 
-          def initialize(course)
+          def initialize(course, enrichment)
             super
             @course = course
+            @enrichment = enrichment
           end
         end
       end

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -20,6 +20,8 @@ module Find
       render_not_found unless @course.is_published?
 
       @apply_action_column_class = apply_action_column_class
+
+      @enrichment = @course.latest_published_enrichment
     end
 
     def confirm_apply; end

--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -72,6 +72,8 @@ module Publish
       @provider = provider
       @course = @course.decorate
 
+      @enrichment = @course.latest_draft_enrichment
+
       authorize @course
     end
 

--- a/app/views/find/courses/_v1_components.html.erb
+++ b/app/views/find/courses/_v1_components.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Find::Courses::AboutSchoolsComponent::View.new(course, @coordinates, @distance_from_location, preview: preview?(params)) %>
 
-<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
+<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course, @enrichment) %>
 
 <%= render partial: "find/courses/about_course", locals: { course: course } %>
 

--- a/app/views/find/courses/show.html.erb
+++ b/app/views/find/courses/show.html.erb
@@ -44,7 +44,7 @@
       </div>
     <% end %>
 
-    <%= render Find::Courses::SummaryComponent::View.new(@course) %>
+    <%= render Find::Courses::SummaryComponent::View.new(@course, @enrichment) %>
 
     <%= render Find::Courses::EntryRequirementsComponent::View.new(course: @course) %>
 

--- a/app/views/find/courses/v2/_components.html.erb
+++ b/app/views/find/courses/v2/_components.html.erb
@@ -35,26 +35,26 @@
 
 <%# Where you will train %>
 <% if published_where_you_will_train_present?(course) || preview?(params) %>
-    <%= render partial: "find/courses/v2/where_you_will_train", locals: { course: course } %>
+    <%= render partial: "find/courses/v2/where_you_will_train", locals: { course: course, enrichment: @enrichment } %>
 <% end %>
 
 <%# What you will do on school placements %>
 <% if course.published_placement_school_activities.present? || preview?(params) %>
-  <%= render partial: "find/courses/v2/school_placement", locals: { course: course } %>
+  <%= render partial: "find/courses/v2/school_placement", locals: { course: course, enrichment: @enrichment } %>
 <% end %>
 
 <%# What you will study %>
 <% if course.theoretical_training_activities.present? || preview?(params) %>
-  <%= render partial: "find/courses/v2/what_you_will_study/what_you_will_study", locals: { course: @course } %>
+  <%= render partial: "find/courses/v2/what_you_will_study/what_you_will_study", locals: { course: @course, enrichment: @enrichment } %>
 <% end %>
 
 <%# Interview process %>
 <% if course.published_interview_process.present? || course.published_interview_location.present? || preview?(params) %>
-  <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: course } %>
+  <%= render partial: "find/courses/v2/interview_process/interview_process", locals: { course: course, enrichment: @enrichment } %>
 <% end %>
 
 <%# Financial support %>
-<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course) %>
+<%= render Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View.new(course, @enrichment) %>
 
 <%# Training with disabilities %>
 <% if @provider.train_with_disability.present? || preview?(params) %>

--- a/app/views/find/courses/v2/_school_placement.html.erb
+++ b/app/views/find/courses/v2/_school_placement.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-school-placement"><%= t("find.courses.v2.school_placement.heading") %> </h2>
   <div data-qa="course__school_placement">
-    <% if course.placement_school_activities.present? %>
-      <%= markdown(course.placement_school_activities) %>
-      <% if course.support_and_mentorship.present? %>
-        <%= markdown(course.support_and_mentorship) %>
+    <% if enrichment.present? && enrichment.placement_school_activities.present? %>
+      <%= markdown(enrichment.placement_school_activities) %>
+      <% if enrichment.present? && enrichment.support_and_mentorship.present? %>
+        <%= markdown(enrichment.support_and_mentorship) %>
       <% end %>
       <%= render Shared::Courses::SchoolPlacementActivitiesComponent.new(course:, is_preview: preview?(params)) %>
     <% else %>

--- a/app/views/find/courses/v2/_where_you_will_train.html.erb
+++ b/app/views/find/courses/v2/_where_you_will_train.html.erb
@@ -14,20 +14,20 @@
 
     <% if preview?(course) %>
       <div data-qa="course__school_placement">
-        <% if course.placement_selection_criteria.present? %>
-            <%= markdown(course.placement_selection_criteria) %>
+        <% if enrichment.present? && enrichment.placement_selection_criteria.present? %>
+            <%= markdown(enrichment.placement_selection_criteria) %>
         <% end %>
 
-        <% if course.duration_per_school.present? %>
-            <%= markdown(course.duration_per_school) %>
+        <% if enrichment.present? && enrichment.duration_per_school.present? %>
+            <%= markdown(enrichment.duration_per_school) %>
         <% end %>
 
-        <% if course.theoretical_training_location.present? %>
-            <%= markdown(course.theoretical_training_location) %>
+        <% if enrichment.present? && enrichment.theoretical_training_location.present? %>
+            <%= markdown(enrichment.theoretical_training_location) %>
         <% end %>
 
-        <% if course.theoretical_training_duration.present? %>
-            <%= markdown(course.theoretical_training_duration) %>
+        <% if enrichment.present? && enrichment.theoretical_training_duration.present? %>
+            <%= markdown(enrichment.theoretical_training_duration) %>
         <% end %>
 
         <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :where_you_will_train, is_preview: !where_you_will_train_present?(course)) %>

--- a/app/views/find/courses/v2/financial_support/_fees_and_financials.html.erb
+++ b/app/views/find/courses/v2/financial_support/_fees_and_financials.html.erb
@@ -1,11 +1,11 @@
-<% if course.fee_uk_eu.present? && !course.fee_international.present? %>
+<% if enrichment.fee_uk_eu.present? && !enrichment.fee_international.present? %>
   <p class="govuk-body"><%= t(".course_fees", cycle_range: course.cycle_range, fee: number_to_currency(course.fee_uk_eu)) %></p>
   <div class="govuk-body govuk-!-font-weight-bold"><%= t("find.courses.fee_notice__next_academic_year") %></div>
 <% else %>
   <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :fees_and_financials, is_preview: preview?(params)) %>
 <% end %>
 
-<% if course.fee_international.present? %>
+<% if enrichment.fee_international.present? %>
   <table class="govuk-table app-table--vertical-align-middle">
     <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-!-margin-bottom-4">The course fees
       for <%= course.cycle_range %> are as follows:
@@ -20,25 +20,25 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><%= t(".uk_citizens") %></td>
 
-      <td class="govuk-table__cell"><%= number_to_currency(course.fee_uk_eu) %></td>
+      <td class="govuk-table__cell"><%= number_to_currency(enrichment.fee_uk_eu) %></td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><%= t(".non_uk_citizens") %></td>
-      <td class="govuk-table__cell"><%= number_to_currency(course.fee_international) %></td>
+      <td class="govuk-table__cell"><%= number_to_currency(enrichment.fee_international) %></td>
     </tr>
     </tbody>
   </table>
   <div class="govuk-body govuk-!-font-weight-bold"><%= t("find.courses.fee_notice__next_academic_year") %></div>
 <% end %>
 
-<% if course.fee_schedule.present? %>
-  <%= markdown(course.fee_schedule) %>
+<% if enrichment.fee_schedule.present? %>
+  <%= markdown(enrichment.fee_schedule) %>
 <% end %>
 
-<% if course.additional_fees.present? %>
-  <%= markdown(course.additional_fees) %>
+<% if enrichment.additional_fees.present? %>
+  <%= markdown(enrichment.additional_fees) %>
 <% end %>
 
-<% if course.financial_support.present? %>
-  <%= markdown(course.financial_support) %>
+<% if enrichment.financial_support.present? %>
+  <%= markdown(enrichment.financial_support) %>
 <% end %>

--- a/app/views/find/courses/v2/interview_process/_interview_process.html.erb
+++ b/app/views/find/courses/v2/interview_process/_interview_process.html.erb
@@ -1,26 +1,26 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-interviews"><%= t(".page_title") %></h2>
   <div data-qa="course__interview_process">
-    <% unless course.interview_location == "in person" || course.published_interview_location == "in person" %>
-      <% if course.published_interview_location == "both" || course.interview_location == "both" %>
+    <% unless enrichment.present? && enrichment.interview_location == "in person" || enrichment.present? && enrichment.interview_location == "in person" %>
+      <% if enrichment.present? && enrichment.interview_location == "both" || enrichment.present? && enrichment.interview_location == "both" %>
         <%= govuk_inset_text do %>
           <%= t(".online_interview") %>
           <p class="govuk-hint"><%= t(".individual_circumstances") %></p>
         <% end %>
-      <% elsif course.published_interview_location == "online" || course.interview_location == "online" %>
+      <% elsif enrichment.present? && enrichment.interview_location == "online" || enrichment.present? && enrichment.interview_location == "online" %>
         <%= govuk_inset_text do %>
           <%= t(".online_interview") %>
         <% end %>
       <% end %>
     <% end %>
-    <% if course.interview_process.present? %>
-      <%= markdown(course.interview_process) %>
+    <% if enrichment.present? && enrichment.interview_process.present? %>
+      <%= markdown(enrichment.interview_process) %>
     <% else %>
       <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :interview_process, is_preview: preview?(params)) %>
     <% end %>
-    <% if course.interview_process.present? ||
-          course.interview_location.in?(%w[online both]) ||
-          course.published_interview_location.in?(%w[online both]) %>
+    <% if enrichment.present? &&
+          enrichment.interview_process.present? ||
+          enrichment.present? && enrichment.interview_location.in?(%w[online both]) %>
     <%= render Shared::Courses::InterviewPreparationComponent.new(course:, is_preview: preview?(params)) %>
   <% end %>
 </div>

--- a/app/views/find/courses/v2/what_you_will_study/_what_you_will_study.html.erb
+++ b/app/views/find/courses/v2/what_you_will_study/_what_you_will_study.html.erb
@@ -2,9 +2,9 @@
   <h2 class="govuk-heading-l" id="section-what-you-will-study">
     <%= t(".heading") %>
   </h2>
-  <% if course.theoretical_training_activities.present? || course.assessment_methods.present? %>
-    <%= markdown(course.theoretical_training_activities) %>
-    <%= markdown(course.assessment_methods) %>
+  <% if enrichment.present? && (enrichment.theoretical_training_activities.present? || enrichment.assessment_methods.present? || (preview?(params) && (enrichment.theoretical_training_activities.present? || enrichment.assessment_methods.present?))) %>
+    <%= markdown(enrichment.theoretical_training_activities) %>
+    <%= markdown(enrichment.assessment_methods) %>
     <%= render Shared::Courses::TeacherTrainingExpectationsComponent.new(course:, is_preview: preview?(params)) %>
   <% else %>
     <%= render CoursePreview::MissingInformationComponent.new(course:, information_type: :what_you_will_study, is_preview: preview?(params)) %>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -17,7 +17,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render Find::Courses::SummaryComponent::View.new(course) %>
+    <%= render Find::Courses::SummaryComponent::View.new(course, @enrichment) %>
 
     <!--The reason for the Apply component duplication here is because we want to keep the warning text at the top but Keep the Apply button and end of cycle text at the bottom-->
 

--- a/spec/components/shared/courses/financial_support/fees_and_financial_support_component/view_spec.rb
+++ b/spec/components/shared/courses/financial_support/fees_and_financial_support_component/view_spec.rb
@@ -5,17 +5,19 @@ require "rails_helper"
 describe Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::View, type: :component do
   context "Salaried courses" do
     it "renders salaried course section if the course has a salary" do
-      course = build(:course, funding: "salary").decorate
+      enrichment = create(:course_enrichment)
+      course = create(:course, funding: "salary", enrichments: [enrichment]).decorate
 
-      result = render_inline(described_class.new(course))
+      result = render_inline(described_class.new(course, enrichment))
 
       expect(result.text).to include("How salaried courses work")
     end
 
     it "does not render salaried course section if the course does not have a salary" do
-      course = build(:course, funding: "fee", subjects: [build(:secondary_subject, bursary_amount: "3000")]).decorate
+      enrichment = create(:course_enrichment)
+      course = create(:course, :secondary, funding: "fee", enrichments: [enrichment], subjects: [build(:secondary_subject, bursary_amount: "3000")]).decorate
 
-      result = render_inline(described_class.new(course))
+      result = render_inline(described_class.new(course, enrichment))
 
       expect(result.text).not_to include("How salaried courses work")
     end
@@ -23,9 +25,10 @@ describe Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::Vi
 
   context "Courses excluded from bursary" do
     it "renders the student loans section if the course is excluded from bursary" do
-      course = build(:course, funding: "fee", name: "Drama", subjects: [build(:secondary_subject), build(:secondary_subject)]).decorate
+      enrichment = create(:course_enrichment)
+      course = create(:course, :secondary, funding: "fee", enrichments: [enrichment], name: "Drama", subjects: [build(:secondary_subject), build(:secondary_subject)]).decorate
 
-      result = render_inline(described_class.new(course))
+      result = render_inline(described_class.new(course, enrichment))
 
       expect(result.text).to include("You may be eligible for student loans to cover the cost of your tuition fee or to help with living costs.")
     end
@@ -34,10 +37,10 @@ describe Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::Vi
   context "Courses with bursary" do
     it "renders the bursary section if the course has a bursary" do
       FeatureFlag.activate(:bursaries_and_scholarships_announced)
+      enrichment = create(:course_enrichment)
+      course = create(:course, :secondary, funding: "fee", enrichments: [enrichment], name: "History", subjects: [build(:secondary_subject, bursary_amount: "2000"), build(:secondary_subject)]).decorate
 
-      course = build(:course, funding: "fee", name: "History", subjects: [build(:secondary_subject, bursary_amount: "2000"), build(:secondary_subject)]).decorate
-
-      result = render_inline(described_class.new(course))
+      result = render_inline(described_class.new(course, enrichment))
 
       expect(result.text).to include("Bursaries")
       expect(result.text).to include("Bursaries of £2,000 are available to eligible trainees.")
@@ -47,10 +50,10 @@ describe Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::Vi
   context "Courses with scholarship and bursary" do
     it "renders the scholarships and bursary section" do
       FeatureFlag.activate(:bursaries_and_scholarships_announced)
+      enrichment = create(:course_enrichment)
+      course = create(:course, :secondary, funding: "fee", enrichments: [enrichment], name: "History", subjects: [build(:secondary_subject, bursary_amount: "2000", scholarship: "1000"), build(:secondary_subject)]).decorate
 
-      course = build(:course, funding: "fee", name: "History", subjects: [build(:secondary_subject, bursary_amount: "2000", scholarship: "1000"), build(:secondary_subject)]).decorate
-
-      result = render_inline(described_class.new(course))
+      result = render_inline(described_class.new(course, enrichment))
 
       expect(result.text).to include("Bursaries and scholarships")
       expect(result.text).to include("Bursaries of £2,000 and scholarships of £1,000 are available to eligible trainees.")
@@ -59,9 +62,10 @@ describe Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::Vi
 
   context "Courses with student loans" do
     it "renders the student loans section if the course is not salaried, does not have a bursary or scholarship and does not meet bursary exclusion criteria" do
-      course = create(:course, funding: "fee", name: "Drama", subjects: [create(:primary_subject), create(:secondary_subject)]).decorate
+      enrichment = create(:course_enrichment)
+      course = create(:course, :secondary, funding: "fee", enrichments: [enrichment], name: "Drama", subjects: [create(:primary_subject), create(:secondary_subject)]).decorate
 
-      result = render_inline(described_class.new(course))
+      result = render_inline(described_class.new(course, enrichment))
 
       expect(result.text).to include("You may be eligible for student loans to cover the cost of your tuition fee or to help with living costs.")
     end
@@ -69,9 +73,10 @@ describe Shared::Courses::FinancialSupport::FeesAndFinancialSupportComponent::Vi
 
   context "Fee paying courses" do
     it "renders the fees section" do
-      course = create(:course, name: "Music", enrichments: [create(:course_enrichment, fee_uk_eu: "5000", fee_details: "Some fee details")], funding: "fee").decorate
+      enrichment = create(:course_enrichment, fee_uk_eu: "5000", fee_details: "Some fee details")
+      course = create(:course, :secondary, funding: "fee", enrichments: [enrichment], name: "Music").decorate
 
-      result = render_inline(described_class.new(course))
+      result = render_inline(described_class.new(course, enrichment))
 
       expect(result.text).to include("Some fee details")
     end


### PR DESCRIPTION
## Context

When removing the long form course content feature flag I noticed when saving data via the course description fields that it was updating the changes on Find without hitting publish

## Changes proposed in this pull request

Update the view logic to ensure its using the correct field data.

## Guidance to review

- Create a course, when drafting and updating the fields this i updating as expected
- Create a course and publish it
- When updating the description fields data and then viewing the course in Find the fields wont update. Only when you publish then you will see the changes. 

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
