### PR TITLE
Change content for non-UK citizens application date

### DIFF
--- a/config/locales/en/components/find/courses/apply_component.yml
+++ b/config/locales/en/components/find/courses/apply_component.yml
@@ -4,5 +4,5 @@ en:
       apply_component:
         view:
           not_accepting_applications: This course is not accepting applications at the moment. You can contact the provider for more information.
-          visa_sponsorship_deadline_notice_html: Non-UK citizens, apply by <b>%{application_deadline}</b>
+          visa_sponsorship_deadline_notice_html: Non-UK citizens, apply before <b>%{application_deadline}</b>
           apply_to_course: Apply for this course

--- a/spec/components/find/courses/apply_component/view_spec.rb
+++ b/spec/components/find/courses/apply_component/view_spec.rb
@@ -65,7 +65,7 @@ describe Find::Courses::ApplyComponent::View, type: :component do
 
         result = render_inline(described_class.new(course, preview: false))
 
-        expect(result.text).to include "Non-UK citizens, apply by #{deadline.to_fs(:govuk_date)}"
+        expect(result.text).to include "Non-UK citizens, apply before #{deadline.to_fs(:govuk_date)}"
       end
     end
   end


### PR DESCRIPTION
## Context

We have had feedback that some international candidates mis-understand the phrase ‘apply by’. ‘Apply before’ would be better understood.

## Changes proposed in this pull request

See trello for details: https://trello.com/c/KkAL24QE/1233-find-change-content-for-non-uk-citizens-application-date

## Guidance to review

1. Is the content correct?
