### PR TITLE
Allow deduplication of sites with blank URN if code is '-'

### DIFF
--- a/app/services/data_hub/sites/deduplication/deduplicator.rb
+++ b/app/services/data_hub/sites/deduplication/deduplicator.rb
@@ -62,7 +62,7 @@ module DataHub
 
           site_scope.find_each do |site|
             next unless site.school?
-            next if site.urn.blank?
+            next if site.urn.blank? && site.code != "-"
 
             grouped[deduplication_key_for(site)] << site
           end


### PR DESCRIPTION
## Context

Extend the DataHub::Deduplication service by allowing it to deduplicate sites without URNs if they are Main sites (code "-")

## Changes proposed in this pull request

If a provider has multiple sites that have no URN, we can deduplicate the ones that have code: "-". This is how we can be confident that those sites should be in a deduplication group.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
