### PR TITLE
Use simple_format to display study site address in publish

### DIFF
--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -5,11 +5,11 @@ class SiteDecorator < Draper::Decorator
   delegate_all
 
   def full_address(join_on_separator = ", ")
-    smart_quotes([object.address1, object.address2, object.address3, object.town, object.address4, object.postcode].compact_blank.join(join_on_separator).html_safe)
+    smart_quotes([object.address1, object.address2, object.address3, object.town, object.address4, object.postcode].compact_blank.join(join_on_separator))
   end
 
   def full_address_on_seperate_lines
-    full_address("<br>")
+    full_address("\n")
   end
 
   def location_name

--- a/app/views/publish/providers/schools/show.html.erb
+++ b/app/views/publish/providers/schools/show.html.erb
@@ -23,7 +23,7 @@
 
             component.with_row do |row|
               row.with_key { t(".address") }
-              row.with_value(text: simple_format(@site.address.compact_blank.join("\n"), {}, wrapper_tag: "div"))
+              row.with_value(text: simple_format(@site.decorate.full_address_on_seperate_lines, {}, wrapper_tag: :div))
             end
           end %>
       <p class="govuk-body">

--- a/app/views/publish/providers/study_sites/show.html.erb
+++ b/app/views/publish/providers/study_sites/show.html.erb
@@ -24,7 +24,7 @@
 
               component.with_row do |row|
                 row.with_key { t("publish.providers.study_sites.address") }
-                row.with_value(text: @site.decorate.full_address_on_seperate_lines)
+                row.with_value(text: simple_format(@site.decorate.full_address_on_seperate_lines, {}, wrapper_tag: :div))
                 row.with_action(text: t("change"), href: edit_publish_provider_recruitment_cycle_study_site_path(@provider.provider_code, @site.recruitment_cycle.year, @site.id), classes: "address", visually_hidden_text: t("publish.providers.study_sites.address"))
               end
             end %>

--- a/app/views/support/providers/schools/show.html.erb
+++ b/app/views/support/providers/schools/show.html.erb
@@ -22,7 +22,7 @@
 
             component.with_row do |row|
               row.with_key { t(".address") }
-              row.with_value(text: simple_format(@site.decorate.full_address_on_seperate_lines.gsub(",", "\n"), nil, wrapper_tag: "span"))
+              row.with_value(text: simple_format(@site.decorate.full_address_on_seperate_lines, nil, wrapper_tag: "div"))
             end
           end %>
 


### PR DESCRIPTION
## Context

The address of study sites are not being formatted in Publish.

## Changes proposed in this pull request

Use consistent approach to displaying Site addresses across Support and Publish.
- use `simple_format`
- use helper to compact_blank address elements and join with "\n" in preparation for `simple_format`

## Guidance to review

[simple_format docs](https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-simple_format)

[Review app link](https://publish-review-5761.test.teacherservices.cloud/publish/organisations/1R3/2026/study-sites/11348233)

|Before|After|
|---|---|
|<img width="1008" height="818" alt="image" src="https://github.com/user-attachments/assets/c257a7ce-ed95-4cd8-b42c-9bea56175c27" />|<img width="999" height="863" alt="image" src="https://github.com/user-attachments/assets/dfb58846-544c-4f1e-b48c-c6b7a1a36386" />|


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
