### PR TITLE
Add meta description for find-teacher-training-courses

### DIFF
--- a/app/views/layouts/find.html.erb
+++ b/app/views/layouts/find.html.erb
@@ -14,6 +14,7 @@
     <%= tag.meta(property: "og:url", content: canonical_url) %>
 
     <%= tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
+    <%= tag.meta(name: "description", content: t("find.metadescription")) %>
     <%= tag.meta(property: "og:image", content: image_path("govuk-opengraph-image.png")) %>
     <%= tag.meta(name: "theme-color", content: "#0b0c0c") %>
     <%= tag.meta(name: "format-detection", content: "telephone=no") %>

--- a/config/locales/en/find.yml
+++ b/config/locales/en/find.yml
@@ -1,5 +1,6 @@
 en:
   find:
+    metadescription: Search for teaching courses in England. Search by location, subject, primary, secondary or further education.
     cycles:
       real:
         name: Same as production environment


### PR DESCRIPTION
## Context

Currently Find is looks really bad in Google search results, because there is no metadescription.

Its done when

A metadescription is added to Find so that this appears in google search results.

## Changes proposed in this pull request

Just add a meta tag in the find layout with a description

## Guidance to review

<img width="1440" height="506" alt="image" src="https://github.com/user-attachments/assets/11294575-e76a-4e3a-bd25-a73df6542923" />

https://totheweb.com/learning_center/tool-test-google-title-meta-description-lengths/
https://find-review-5762.test.teacherservices.cloud

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
