### PR TITLE
Publish bug: Clicking error summary not focusing on field.

### DIFF
--- a/app/javascript/publish/autocomplete/school.js
+++ b/app/javascript/publish/autocomplete/school.js
@@ -16,6 +16,7 @@ const options = {
 
 function init () {
   initAutocomplete('school-autocomplete', 'publish-providers-schools-search-form-query-field', options)
+  initAutocomplete('school-autocomplete', 'publish-providers-schools-search-form-query-field-error', options)
   initAutocomplete('school-autocomplete', 'support-providers-schools-search-form-query-field', options)
 }
 

--- a/app/views/publish/providers/schools/search/new.html.erb
+++ b/app/views/publish/providers/schools/search/new.html.erb
@@ -1,53 +1,36 @@
 <% content_for :page_title, title_with_error_prefix(t(".title"), @school_search_form.errors.any?) %>
-
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_recruitment_cycle_schools_path) %>
 <% end %>
-
 <div class="govuk-grid-row">
-
   <%= form_with(
     model: @school_search_form,
     url: search_publish_provider_recruitment_cycle_schools_path(@provider.provider_code),
     method: :post,
-    html: { data: { module: "app-schools-autocomplete" } },
+    local: true,
   ) do |f| %>
-
-    <div class="govuk-grid-column-full">
-      <%= f.govuk_error_summary %>
-    </div>
-
-    <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-form-group<% if f.object.errors.present? %> govuk-form-group--error<% end %>">
-        <span class="govuk-caption-l"><%= t(".caption") %></span>
-        <%= f.label :query, { class: "govuk-label govuk-label--l", for: "publish-providers-schools-search-form-query-field" } do %>
-          <%= t(".title") %>
-        <% end %>
-        <div class="govuk-hint"><%= t(".hint") %></div>
-        <% if f.object.errors.present? %>
-          <span class="govuk-error-message" id="publish-providers-schools-search-form-query-field-error">
-            <%= f.object.errors.first.message %>
-          </span>
-        <% end %>
-        <%= f.text_field :query,
-        id: "publish-providers-schools-search-form-query-field",
-        value: params[:query],
-        class: "govuk-input",
-        data: { qa: "schools-search" } %>
-        <div id="school-autocomplete"></div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= f.govuk_error_summary %>
       </div>
-
-      <p class="govuk-body govuk-!-margin-bottom-7">
-        <%= govuk_details(summary_text: t(".help_finding_school")) do %>
-          <%= t(".cannot_find_html", link: t("links.get_information_schools_search")) %>
-        <% end %>
-      </p>
-
-      <%= f.govuk_submit t("continue") %>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <fieldset class="govuk-fieldset">
+        <span class="govuk-caption-l"><%= t(".caption") %></span>
+        <%= f.govuk_text_field :query,
+            value: params[:query],
+            label: { text: t(".title"), size: "l" },
+            hint: { text: t(".hint") }, link_errors: true,
+            form_group: { id: "school-autocomplete" } %>
+        <p class="govuk-body govuk-!-margin-bottom-7">
+          <%= govuk_details(summary_text: t(".help_finding_school")) do %>
+            <%= t(".cannot_find_html", link: t("links.get_information_schools_search")) %>
+          <% end %>
+        </p>
+        <%= f.govuk_submit t("continue") %>
+      </fieldset>
     <% end %>
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_schools_path) %>
+    </p>
   </div>
-</div>
-
-<p class="govuk-body">
-  <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_schools_path) %>
-</p>

--- a/app/views/publish/providers/study_site_search/new.html.erb
+++ b/app/views/publish/providers/study_site_search/new.html.erb
@@ -1,9 +1,7 @@
 <% content_for :page_title, title_with_error_prefix(t(".title"), @study_site_search_form.errors.any?) %>
-
 <% content_for :before_content do %>
   <%= govuk_back_link_to(publish_provider_recruitment_cycle_study_sites_path) %>
 <% end %>
-
 <div class="govuk-grid-row">
   <%= form_with(
     model: @study_site_search_form,
@@ -11,37 +9,22 @@
     method: :post,
     html: { data: { module: "app-schools-autocomplete" } },
   ) do |f| %>
-
-  <%= f.govuk_error_summary %>
-
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-form-group<% if f.object.errors.present? %> govuk-form-group--error<% end %>">
-      <%= f.label :query, { class: "govuk-label govuk-label--l", for: "publish-providers-schools-search-form-query-field" } do %>
-        <span class="govuk-caption-l">Add study site</span>
-        <%= I18n.t("publish.providers.study_site_search.new.title") %>
-        <% if f.object.errors.present? %>
-          <span class="govuk-error-message" id="publish-providers-schools-search-form-query-field-error">
-            <%= f.object.errors.first.message %>
-          </span>
-        <% end %>
+    <%= f.govuk_error_summary %>
+    <div class="govuk-grid-column-two-thirds">
+      <fieldset class="govuk-fieldset">
+        <span class="govuk-caption-l"><%= t(".caption") %></span>
+          <%= f.govuk_text_field :query,
+            value: params[:query],
+            label: { text: t(".title"), size: "l" },
+            link_errors: true,
+            form_group: { id: "school-autocomplete" } %>
+        <p class="govuk-body govuk-!-margin-bottom-7">
+          <%= govuk_link_to(t(".cannot_find"), new_publish_provider_recruitment_cycle_study_site_path(@provider.provider_code)) %>
+        </p>
+        <%= f.govuk_submit t("continue") %>
       <% end %>
-      <%= f.text_field :query,
-        id: "publish-providers-schools-search-form-query-field",
-        value: params[:query],
-        class: "govuk-input",
-        data: { qa: "study_sites-search" } %>
-      <div id="school-autocomplete"></div>
+      <p class="govuk-body">
+        <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
+      </p>
     </div>
-
-    <p class="govuk-body govuk-!-margin-bottom-7">
-    <%= govuk_link_to(t(".cannot_find"), new_publish_provider_recruitment_cycle_study_site_path(@provider.provider_code)) %>
-    </p>
-
-    <%= f.govuk_submit t("continue") %>
-  <% end %>
-
-  <p class="govuk-body">
-  <%= govuk_link_to(t("cancel"), publish_provider_recruitment_cycle_study_sites_path) %>
-  </p>
   </div>
-</div>

--- a/config/locales/en/publish.yml
+++ b/config/locales/en/publish.yml
@@ -178,6 +178,7 @@ en:
           add_school_to_account: If needed, you can add new schools to your account.
       study_site_search:
         new:
+          caption: Add study site
           title: Enter a school, university, college, URN or postcode
           cannot_find: I cannot find the site - enter manually
       training_partners:

--- a/spec/features/publish/searching_for_a_study_site_spec.rb
+++ b/spec/features/publish/searching_for_a_study_site_spec.rb
@@ -81,7 +81,7 @@ feature "Searching for a study site from the GIAS list" do
   end
 
   def when_i_search_for_a_school_with_a_valid_query
-    fill_in "publish-providers-schools-search-form-query-field", with: @school.name
+    fill_in "publish-providers-schools-search-form-query-field-error", with: @school.name
     click_continue
   end
 


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/t0FT6SAk/1006-bug-clicking-on-error-not-focusing-on-field-all-other-places-do-focus

When clicking on the error summary for the the 'Add a school' and 'Add a study site' in Publish, it does not focus on the input field. 

## Changes proposed in this pull request

- refactor code to use GOV.UK FormBuilder - this fixes the error focus issue
- force autocomplete on error (`publish-providers-schools-search-form-query-field-error`) to ensure autocomplete still works with the error focus/FormBuilder and after a validation error (simply refactoring to use the FormBuilder broke the autocomplete functionality). 

https://github.com/user-attachments/assets/8558f63b-fc59-4758-8d54-c94b67ea619e


## Guidance to review

- Please check the 'add a school' and 'add a study site' flow in Publish to ensure error focus works as expected.
- Please also check that the autocomplete works, especially after the validation error. 
- Are there any other places in Publish that use autocomplete as they will likely be affected by the changes in this PR?

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
