### PR TITLE
Do not show distance to study sites on Course show page

### DIFF
--- a/app/components/find/courses/training_locations/view.rb
+++ b/app/components/find/courses/training_locations/view.rb
@@ -46,9 +46,7 @@ module Find
         def potential_study_sites_text
           return "Not listed yet" if course.study_sites.none?
 
-          if coordinates
-            distance_text
-          elsif course.study_sites.one?
+          if course.study_sites.one?
             "1 study site"
           else
             "#{course.study_sites.size} potential study sites"


### PR DESCRIPTION
## Context

The application is currently showing a distance from the search location to the nearest placement school, but it's also putting this distance beside the study sites - which is misleading.


We have decided not to show distance at all here.

1. We cannot guarantee the geolocation of freely entered addresses in the Study sites



## Changes proposed in this pull request

Remove the distance text for Study Sites on location searches in the Course show page.



## Guidance to review

|0 study sites| 1 study site| many study sites|
|---|---|---|
|<img width="833" height="537" alt="Pasted image 20251118154101" src="https://github.com/user-attachments/assets/9c3ba4a4-6be5-451e-9189-dfd6655c677b" />|<img width="757" height="513" alt="Pasted image 20251118154039" src="https://github.com/user-attachments/assets/32a3ddf4-2b63-4733-a36c-1763bca852d2" />|<img width="731" height="652" alt="Pasted image 20251118154347" src="https://github.com/user-attachments/assets/309197ec-256a-4e6d-a476-d445547ed432" />|

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
