### PR TITLE
Lock Sidekiq version below 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,9 +75,8 @@ gem "discard"
 # Gov Notify
 gem "govuk_notify_rails"
 
-# Run jobs in the background. Good enough until we know we need more firepower
-# (i.e. SideKiq)
-gem "sidekiq"
+# Run jobs in the background.
+gem "sidekiq", "~> 6.5"
 gem "sidekiq-cron"
 
 # Semantic Logger makes logs pretty

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -903,7 +903,7 @@ DEPENDENCIES
   sentry-ruby
   sentry-sidekiq
   shoulda-matchers (~> 6.5)
-  sidekiq
+  sidekiq (~> 6.5)
   sidekiq-cron
   simplecov (< 0.23)
   site_prism (~> 5.1)


### PR DESCRIPTION
## Context

  Sidekiq v7 requires Redis v7+ which we don't currently have access to.
  This is a precautionary version locking.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
