### PR TITLE
Admin user filtering

### DIFF
--- a/app/components/filters/user_attributes.html.erb
+++ b/app/components/filters/user_attributes.html.erb
@@ -12,3 +12,15 @@
     </div>
   <% end %>
 </div>
+
+<div class="govuk-form-group">
+  <%= label_tag "status", t("components.filter.users.status"), class: "govuk-label govuk-label--s" %>
+  <div class="govuk-radios">
+    <% [%w[all All], %w[active Active], %w[discarded Deleted]].each do |value, text| %>
+      <div class="govuk-radios__item">
+        <%= radio_button_tag "status", value, (checked?(filters, :status, value) || (filters.blank? && value == "active")), id: "status-#{value}", class: "govuk-radios__input" %>
+        <%= label_tag "status-#{value}", text, class: "govuk-label govuk-radios__label" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/components/paginated_filter.rb
+++ b/app/components/paginated_filter.rb
@@ -18,7 +18,7 @@ private
 
   def allowed_search_params_keys
     {
-      User: %i[text_search user_type],
+      User: %i[text_search user_type status],
       Provider: %i[provider_search course_search accredited provider_type],
       Candidate: %i[text_search],
     }[collection.klass.name.to_sym]

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -63,7 +63,7 @@ module Support
     end
 
     def filter_params
-      @filter_params ||= params.except(:commit, :recruitment_cycle_year).permit(:text_search, :page, :commit, user_type: [])
+      @filter_params ||= params.except(:commit, :recruitment_cycle_year).permit(:text_search, :page, :commit, :status, user_type: [])
     end
   end
 end

--- a/app/services/support/filter.rb
+++ b/app/services/support/filter.rb
@@ -60,6 +60,21 @@ module Support
       records.accredited
     end
 
+    def status_filter(records, status)
+      return records unless status
+
+      case status
+      when "all"
+        records.with_discarded
+      when "discarded"
+        records.discarded
+      when "active"
+        records.kept
+      else
+        records
+      end
+    end
+
     def filter_records
       filtered_records = model_data_scope
 
@@ -69,6 +84,7 @@ module Support
       filtered_records = provider_accredited_type(filtered_records, filter_params[:accredited])
       filtered_records = course_search(filtered_records, filter_params[:course_search]) if filtered_records.respond_to?(:course_search)
       filtered_records = user_type(filtered_records, filter_params[:user_type]) if filtered_records.respond_to?(:admins)
+      filtered_records = status_filter(filtered_records, filter_params[:status]) if filtered_records.respond_to?(:with_discarded) || filtered_records.respond_to?(:kept)
 
       filtered_records
     end

--- a/app/views/support/users/_users.html.erb
+++ b/app/views/support/users/_users.html.erb
@@ -4,6 +4,7 @@
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Email</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Provider count</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
     </tr>
   </thead>
 
@@ -12,7 +13,11 @@
       <tr class="govuk-table__row user-row">
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= govuk_link_to user.full_name, support_recruitment_cycle_user_path(params[:recruitment_cycle_year], user) %>
+            <% if user.discarded? %>
+              <%= user.full_name %>
+            <% else %>
+              <%= govuk_link_to user.full_name, support_recruitment_cycle_user_path(params[:recruitment_cycle_year], user) %>
+            <% end %>
           </span>
         </td>
         <td class="govuk-table__cell">
@@ -23,6 +28,15 @@
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <%= user.providers.in_cycle(@recruitment_cycle).count %>
+          </span>
+        </td>
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <% if user.discarded? %>
+              <%= govuk_tag(text: "Deleted", colour: "red") %>
+            <% else %>
+              <%= govuk_tag(text: "Active", colour: "green") %>
+            <% end %>
           </span>
         </td>
       </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -429,6 +429,11 @@ en:
         user_types:
           admin: "Admin User"
           provider: "Provider User"
+        status: "Status"
+        statuses:
+          all: "All"
+          active: "Active"
+          discarded: "Deleted"
     course:
       financial_incentives:
         none: "None available"

--- a/spec/system/support/users/filtering_users_spec.rb
+++ b/spec/system/support/users/filtering_users_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Filter users by status" do
+  let(:admin_user) { create(:user, :admin) }
+
+  before do
+    given_i_am_authenticated(user: admin_user)
+    and_there_are_users_with_varied_status
+    when_i_visit_the_support_users_index_page
+  end
+
+  scenario "filtering by Active shows only active users" do
+    when_i_select_the_active_status_filter
+    and_i_apply_the_filters
+    then_i_see_only_the_active_user
+  end
+
+  scenario "filtering by Deleted shows only deleted users" do
+    when_i_select_the_deleted_status_filter
+    and_i_apply_the_filters
+    then_i_see_only_the_deleted_user
+  end
+
+  scenario "filtering by All shows both active and deleted users" do
+    when_i_select_the_all_status_filter
+    and_i_apply_the_filters
+    then_i_see_both_users
+  end
+
+  scenario "filtering by user type Provider shows only provider users" do
+    and_there_are_users_for_user_type_filter
+    when_i_select_provider_user_type_filter
+    and_i_apply_the_filters
+    then_i_see_only_provider_users
+  end
+
+  scenario "filtering by user type Admin shows only admin users" do
+    and_there_are_users_for_user_type_filter
+    when_i_select_admin_user_type_filter
+    and_i_apply_the_filters
+    then_i_see_only_admin_users
+  end
+
+private
+
+  def and_there_are_users_with_varied_status
+    @active_user = create(:user, first_name: "Active")
+    @deleted_user = create(:user, first_name: "Deleted")
+    @deleted_user.discard
+  end
+
+  def when_i_visit_the_support_users_index_page
+    support_users_index_page.load(recruitment_cycle_year: Find::CycleTimetable.current_year)
+  end
+
+  def when_i_select_the_active_status_filter
+    choose("status-active")
+  end
+
+  def when_i_select_the_deleted_status_filter
+    choose("status-discarded")
+  end
+
+  def when_i_select_the_all_status_filter
+    choose("status-all")
+  end
+
+  def and_i_apply_the_filters
+    support_users_index_page.apply_filters.click
+  end
+
+  def then_i_see_only_the_active_user
+    expect(page).to have_css(".user-row", text: @active_user.first_name)
+    expect(page).to have_no_css(".user-row", text: @deleted_user.first_name)
+  end
+
+  def then_i_see_only_the_deleted_user
+    expect(page).to have_css(".user-row", text: @deleted_user.first_name)
+    expect(page).to have_no_css(".user-row", text: @active_user.first_name)
+  end
+
+  def then_i_see_both_users
+    expect(page).to have_css(".user-row", text: @active_user.first_name)
+    expect(page).to have_css(".user-row", text: @deleted_user.first_name)
+  end
+
+  def and_there_are_users_for_user_type_filter
+    @provider_user_filter = create(:user, first_name: "ProviderUser")
+    @admin_user_filter = create(:user, :admin, first_name: "AdminUser")
+  end
+
+  def when_i_select_provider_user_type_filter
+    check("user_type-provider")
+  end
+
+  def when_i_select_admin_user_type_filter
+    check("user_type-admin")
+  end
+
+  def then_i_see_only_provider_users
+    expect(page).to have_css(".user-row", text: @provider_user_filter.first_name)
+    expect(page).to have_no_css(".user-row", text: @admin_user_filter.first_name)
+  end
+
+  def then_i_see_only_admin_users
+    expect(page).to have_css(".user-row", text: @admin_user_filter.first_name)
+    expect(page).to have_no_css(".user-row", text: @provider_user_filter.first_name)
+  end
+end


### PR DESCRIPTION
## Context

We need to make it easier to identify "deleted" (discarded) users within the support console top reduce support tickets 

## Changes proposed in this pull request

- Add a status label and column to the users index page to make it easy to see at a glance who is deleted
- Add new filtering options to allow users to filter based on if the user is discarded or not

## Guidance to review

- Visit the support console UI and user new filters to ensure its working correctly

<img width="1119" height="893" alt="Screenshot 2025-11-19 at 07 47 02" src="https://github.com/user-attachments/assets/fc514318-24a8-4b2b-ac69-b4b4e09080cb" />


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
