### PR TITLE
Strip whitespace from Site#location_name

### DIFF
--- a/db/data/20251119115828_strip_site_location_name.rb
+++ b/db/data/20251119115828_strip_site_location_name.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class StripSiteLocationName < ActiveRecord::Migration[8.0]
+  def up
+    Site.where("location_name ~ '\s$'").find_each do |site|
+      site.skip_geocoding = true
+      site.location_name = site.location_name.strip
+      site.save!(validate: false)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Context

We encountered a bug in Apply service where a candidate was not able to choose some particular preferred placement schools in the application process. We discovered that this was because the Site#location_name had trailing whitespace.

We have since discovered that some School sites that were rolled over from recruitment cycles years ago had traililng white space.

## Changes proposed in this pull request

This PR runs a data migration to strip the whitespace from all Site#location_name that have trailing whitespace.

## Guidance to review

_The remaining two records have a tab character at the end which is matched by postgres `'\s$'` and ruby `String#strip` but for some reason these two records weren't updated_

I'm happy enough to merge as is.

|Before|After|
|---|---|
|<img width="880" height="447" alt="image" src="https://github.com/user-attachments/assets/c4a76a4b-0cb8-499c-b7e4-e1baa965db3b" />|<img width="1132" height="545" alt="image" src="https://github.com/user-attachments/assets/8f943391-5ccd-4bf7-8df7-06c45b68a676" />|




## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
