### PR TITLE
Update location-based course ordering

### DIFF
--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -306,6 +306,7 @@ module Courses
             [
               <<~SQL.squish,
                 course.*,
+                provider.provider_name,
                 MIN(ST_DistanceSphere(
                   ST_SetSRID(ST_MakePoint(site.longitude::float, site.latitude::float), 4326),
                   ST_SetSRID(ST_MakePoint(?::float, ?::float), 4326)
@@ -316,8 +317,8 @@ module Courses
             ],
           ),
         )
-        .group(:id)
-        .order("minimum_distance_to_search_location ASC")
+        .group(:id, "provider.provider_name")
+        .order("minimum_distance_to_search_location ASC, LOWER(provider.provider_name) ASC")
     end
 
     def default_ordering_scope


### PR DESCRIPTION
## Context

Provider feedback identified that location-based ordering on Find felt unfair when several providers shared a placement school. Previously, courses at the same distance sorted by course ID, favoring older database entries. The new requirement is that, for equal distances, results should tie-break by provider name A–Z (case-insensitive).

## What Changed

Updated ordering logic in the location-based search SQL to use provider name as a secondary sort for records with equal distance.

Now: main ordering is still by ascending distance; if multiple records have the same distance (i.e. share a placement school), they are ordered by provider name alphabetically.

Affected only the ordering for location-based (postcode/location) course searches; no change to result set or other search modes.

## How to Test

Create multiple courses sharing the same placement school (i.e. same lat/lng/site), with different provider names.

Perform a location-based search by postcode/coordinates.

Verify that courses with equal distance are listed in case-insensitive A–Z order by provider name, not by course ID or insertion order.

All other search behaviors/filters should remain unaffected.

