### PR TITLE
chore(dependabot): ignore mock_redis updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     ignore:
       - dependency-name: audited
       - dependency-name: sidekiq
+      - dependency-name: mock_redis
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
## Context

Dependabot has been raising updates for `mock_redis`, but we can’t safely take them right now. `mock_redis` is effectively pinned because upgrading it would require upgrading the `redis` gem, which we’re currently unable to do due to Azure constraints.

To reduce noise and avoid repeated failing/blocked upgrade PRs, this change adds `mock_redis` to the Dependabot ignored dependencies list.

## Changes proposed in this pull request

- Update the Dependabot configuration to ignore `mock_redis` dependency updates.

## Guidance to review

- Confirm the Dependabot configuration change is scoped only to `mock_redis`.
- Verify no other dependencies or update schedules are affected.
