### PR TITLE
Bug: Duplicated Site Code

### DIFF
--- a/spec/services/data_hub/rollover/study_site_code_orchestrator_spec.rb
+++ b/spec/services/data_hub/rollover/study_site_code_orchestrator_spec.rb
@@ -28,13 +28,16 @@ RSpec.describe DataHub::Rollover::StudySiteCodeOrchestrator, type: :service do
         create(:site, :study_site, provider: new_provider, code: "A1")
       end
 
-      it "returns the original codes unchanged" do
+      it "reassigns conflicting codes to keep target provider codes unique" do
         assignments = described_class.new(
           target_provider: new_provider,
           sites_to_copy: sites_to_copy,
         ).call
 
-        expect(assignments.map { |a| a[:code] }).to contain_exactly("A1", "B2")
+        codes = assignments.map { |a| a[:code] }
+        expect(codes).to include("B2")
+        expect(codes).not_to include("A1")
+        expect(codes.uniq.size).to eq(2)
       end
     end
 

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -132,6 +132,29 @@ describe Providers::CopyToRecruitmentCycleService do
             new_recruitment_cycle: new_recruitment_cycle,
           )
       end
+
+      context "when a site code already exists on the target provider" do
+        before do
+          create(:site, :school, provider: new_provider, code: site.code)
+          create(:site, :study_site, provider: new_provider, code: study_site.code)
+        end
+
+        it "skips school code collisions and reassigns study site collisions" do
+          result = service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
+
+          expect(mocked_copy_site_service).not_to have_received(:execute).with(site: site, new_provider: new_provider)
+          expect(mocked_copy_site_service).to have_received(:execute).with(
+            site: study_site,
+            new_provider: new_provider,
+            assigned_code: satisfy { |code| code != study_site.code },
+          )
+
+          expect(result[:sites_skipped]).to include(
+            { site_code: site.code, reason: "Site code already exists on provider" },
+          )
+          expect(result[:study_sites_skipped]).to be_empty
+        end
+      end
     end
 
     it "assigns the new provider to organisation" do

--- a/spec/services/sites/code_generator_spec.rb
+++ b/spec/services/sites/code_generator_spec.rb
@@ -41,4 +41,15 @@ describe Sites::CodeGenerator do
       expect(subject).to eq("AD")
     end
   end
+
+  context "when only a study site holds the final available UCAS code" do
+    before do
+      (Site::POSSIBLE_CODES - ["A"]).each { |code| create(:site, code:, provider:) }
+      create(:site, :study_site, code: "A", provider:)
+    end
+
+    it "does not reuse the study site code" do
+      expect(subject).to eq("AA")
+    end
+  end
 end

--- a/spec/services/sites/code_generator_spec.rb
+++ b/spec/services/sites/code_generator_spec.rb
@@ -44,7 +44,7 @@ describe Sites::CodeGenerator do
 
   context "when only a study site holds the final available UCAS code" do
     before do
-      (Site::POSSIBLE_CODES - ["A"]).each { |code| create(:site, code:, provider:) }
+      (Site::POSSIBLE_CODES - %w[A]).each { |code| create(:site, code:, provider:) }
       create(:site, :study_site, code: "A", provider:)
     end
 


### PR DESCRIPTION
Ensure unique site codes by reassigning duplicates in StudySiteCodeOrchestrator and preventing reuse in CodeGenerator

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
