### PR TITLE
Fix TypeError when geocoding returns nil coordinates

### DIFF
--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -32,6 +32,8 @@ module Find
 
     def distance_from_location
       @address = Geolocation::Address.query(location_params)
+      return if @address.latitude.nil? || @address.longitude.nil?
+
       @distance_from_location ||= ::Courses::NearestSchoolQuery.new(
         courses: [@course],
         latitude: @address.latitude,

--- a/app/controllers/find/courses_controller.rb
+++ b/app/controllers/find/courses_controller.rb
@@ -32,7 +32,7 @@ module Find
 
     def distance_from_location
       @address = Geolocation::Address.query(location_params)
-      return if @address.latitude.nil? || @address.longitude.nil?
+      return unless @address.coordinates?
 
       @distance_from_location ||= ::Courses::NearestSchoolQuery.new(
         courses: [@course],

--- a/app/services/geolocation/address.rb
+++ b/app/services/geolocation/address.rb
@@ -162,6 +162,10 @@ module Geolocation
       landmark? || (postcode_area? && route.present?)
     end
 
+    def coordinates?
+      latitude.present? && longitude.present?
+    end
+
   private
 
     def full_postcode?

--- a/spec/controllers/find/courses_controller_spec.rb
+++ b/spec/controllers/find/courses_controller_spec.rb
@@ -71,6 +71,33 @@ module Find
 
         expect(response).to be_not_found
       end
+
+      context "when a location param is given but geocoding returns no coordinates" do
+        let(:published_course) do
+          create(
+            :course,
+            enrichments: [build(:course_enrichment, :published)],
+            sites: [create(:site, latitude: 51.5, longitude: -0.1)],
+            provider:,
+          )
+        end
+
+        before do
+          allow(Geolocation::Address).to receive(:query).and_return(
+            Geolocation::Address.new(latitude: nil, longitude: nil, formatted_address: nil),
+          )
+        end
+
+        it "does not raise a TypeError from Float(nil)" do
+          expect {
+            get :show, params: {
+              provider_code: provider.provider_code,
+              course_code: published_course.course_code,
+              location: "somewhere unresolvable",
+            }
+          }.not_to raise_error
+        end
+      end
     end
   end
 end

--- a/spec/services/geolocation/address_spec.rb
+++ b/spec/services/geolocation/address_spec.rb
@@ -3,6 +3,28 @@
 require "rails_helper"
 
 RSpec.describe Geolocation::Address do
+  describe "#coordinates?" do
+    it "returns true when both latitude and longitude are present" do
+      address = described_class.new(latitude: 51.5, longitude: -0.1)
+      expect(address.coordinates?).to be(true)
+    end
+
+    it "returns false when latitude is nil" do
+      address = described_class.new(latitude: nil, longitude: -0.1)
+      expect(address.coordinates?).to be(false)
+    end
+
+    it "returns false when longitude is nil" do
+      address = described_class.new(latitude: 51.5, longitude: nil)
+      expect(address.coordinates?).to be(false)
+    end
+
+    it "returns false when both are nil" do
+      address = described_class.new
+      expect(address.coordinates?).to be(false)
+    end
+  end
+
   describe "#short_address" do
     context "when full postcode" do
       let(:address) do


### PR DESCRIPTION

## Context

When a user visits a course page with a `location` query param that Google Places fails to resolve (blank query, API error, or missing coordinates), `Geolocation::Address.query` returns an Address with `latitude: nil` and `longitude: nil`. `Find::CoursesController#distance_from_location` then passed these straight to `Courses::NearestSchoolQuery`, whose `select_sql` interpolates `Float(@longitude)` / `Float(@latitude)` into the `ST_MakePoint` call. `Float(nil)` raises `TypeError: can't convert nil into Float`, 500ing the course show page.

Guard the controller with an early return when the resolved address has no coordinates. The existing `Find::Courses::TrainingLocations::View` component already falls back to the "no address" branch when `@distance_from_location` is unset, so no view changes are needed.

Adds a regression spec that stubs `Geolocation::Address.query` to return nil coordinates and asserts `#show` does not raise.


