### PR TITLE
Hide accessible-autocomplete status region on mobile

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -4,6 +4,10 @@
   font-family: $govuk-font-family;
 }
 
+.autocomplete__status {
+  @include govuk-visually-hidden;
+}
+
 .govuk-form-group--error {
   .autocomplete__input {
     border-color: $govuk-error-colour;


### PR DESCRIPTION

## Context

Bug: '1 of 3', '2 of 3' etc appears next to location search dropdown - on mobile specifically.

The "1 of N is highlighted" text from accessible-autocomplete's live status region was leaking into the visible layout on mobile in both the location and subject autocompletes, appearing next to the suggestions dropdown.

Upstream, the Status component (node_modules/accessible-autocomplete/ src/status.js) relies solely on inline styles (position: absolute; clip: rect(0 0 0 0); width: 1px; height: 1px; overflow: hidden) to keep the aria-live region visually hidden. The legacy clip property isn't reliable across mobile browsers, so on small viewports the status text becomes visible.

## Solution

Add an explicit rule targeting .autocomplete__status that applies govuk-frontend's govuk-visually-hidden mixin, which uses the modern clip-path-based visually-hidden pattern and works consistently across viewports. Placed in the shared components stylesheet so both find and publish benefit.

