### PR TITLE
Session timeout

### DIFF
--- a/app/controllers/concerns/find/authentication.rb
+++ b/app/controllers/concerns/find/authentication.rb
@@ -29,7 +29,19 @@ module Find
     end
 
     def find_session_by_cookie
-      Session.find_by(session_key: candidate_session, sessionable_type: "Candidate") if candidate_session
+      return unless candidate_session
+
+      db_session = Session.find_by(session_key: candidate_session, sessionable_type: "Candidate")
+      return unless db_session
+
+      unless db_session.active?
+        db_session.destroy!
+        reset_candidate_session
+        return
+      end
+
+      db_session.touch
+      db_session
     end
 
     def omniauth

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,5 +1,5 @@
 class Session < ApplicationRecord
-  INACTIVITY_TIMEOUT = 2.hours
+  INACTIVITY_TIMEOUT = 30.minutes
 
   belongs_to :sessionable, polymorphic: true
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -6,11 +6,6 @@ class Session < ApplicationRecord
   validates :session_key, presence: true
 
   def active?
-    case sessionable_type
-    when "User"
-      updated_at > INACTIVITY_TIMEOUT.ago
-    else
-      true # Candidate session don't time out yet
-    end
+    updated_at > INACTIVITY_TIMEOUT.ago
   end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,5 +1,5 @@
 class Session < ApplicationRecord
-  USER_TIMEOUT = 2.hours
+  INACTIVITY_TIMEOUT = 2.hours
 
   belongs_to :sessionable, polymorphic: true
 
@@ -8,7 +8,7 @@ class Session < ApplicationRecord
   def active?
     case sessionable_type
     when "User"
-      updated_at > USER_TIMEOUT.ago
+      updated_at > INACTIVITY_TIMEOUT.ago
     else
       true # Candidate session don't time out yet
     end

--- a/spec/controllers/find/candidates/recent_searches_controller_spec.rb
+++ b/spec/controllers/find/candidates/recent_searches_controller_spec.rb
@@ -116,6 +116,32 @@ module Find
           expect(response).to redirect_to(find_root_path)
         end
       end
+
+      context "when the candidate session has timed out" do
+        before do
+          session_record.update_columns(updated_at: Session::INACTIVITY_TIMEOUT.ago)
+        end
+
+        it "destroys the expired session" do
+          get :index
+
+          expect(Session.find_by(id: session_record.id)).to be_nil
+        end
+
+        it "redirects to the find root path" do
+          get :index
+
+          expect(response).to redirect_to(find_root_path)
+        end
+      end
+
+      context "when the candidate session is active" do
+        it "touches the session to reset the inactivity timer" do
+          session_record.update_columns(updated_at: 10.minutes.ago)
+
+          expect { get :index }.to(change { session_record.reload.updated_at })
+        end
+      end
     end
   end
 end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     trait :timed_out do
       updated_at do
         case sessionable_type
-        when "User" then 1.minute.until(Session::USER_TIMEOUT.ago)
+        when "User" then 1.minute.until(Session::INACTIVITY_TIMEOUT.ago)
         end
       end
     end
@@ -18,7 +18,7 @@ FactoryBot.define do
     trait :active do
       updated_at do
         case sessionable_type
-        when "User" then 1.minute.since(Session::USER_TIMEOUT.ago)
+        when "User" then 1.minute.since(Session::INACTIVITY_TIMEOUT.ago)
         end
       end
     end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -8,19 +8,11 @@ FactoryBot.define do
     data { {} }
 
     trait :timed_out do
-      updated_at do
-        case sessionable_type
-        when "User" then 1.minute.until(Session::INACTIVITY_TIMEOUT.ago)
-        end
-      end
+      updated_at { 1.minute.until(Session::INACTIVITY_TIMEOUT.ago) }
     end
 
     trait :active do
-      updated_at do
-        case sessionable_type
-        when "User" then 1.minute.since(Session::INACTIVITY_TIMEOUT.ago)
-        end
-      end
+      updated_at { 1.minute.since(Session::INACTIVITY_TIMEOUT.ago) }
     end
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Session, type: :model do
 
       it "returns false at exactly the timeout boundary" do
         session = create(:session, sessionable: create(:user))
-        session.update_columns(updated_at: Session::USER_TIMEOUT.ago)
+        session.update_columns(updated_at: Session::INACTIVITY_TIMEOUT.ago)
 
         expect(session).not_to be_active
       end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -40,10 +40,16 @@ RSpec.describe Session, type: :model do
     end
 
     context "when the session belongs to a Candidate" do
-      it "returns true regardless of updated_at" do
-        session = create(:session, :timed_out, sessionable: create(:candidate))
+      it "returns true when updated within the timeout period" do
+        session = create(:session, :active, sessionable: create(:candidate))
 
         expect(session).to be_active
+      end
+
+      it "returns false when updated beyond the timeout period" do
+        session = create(:session, :timed_out, sessionable: create(:candidate))
+
+        expect(session).not_to be_active
       end
     end
   end

--- a/spec/requests/publish/sidekiq_authorization_spec.rb
+++ b/spec/requests/publish/sidekiq_authorization_spec.rb
@@ -45,7 +45,7 @@ describe "Sidekiq authorization" do
 
       before do
         login_user(user)
-        user.sessions.last.update_columns(updated_at: 1.minute.until(Session::USER_TIMEOUT.ago))
+        user.sessions.last.update_columns(updated_at: 1.minute.until(Session::INACTIVITY_TIMEOUT.ago))
       end
 
       it "redirects to sign in" do


### PR DESCRIPTION
## Context

Applications where users require authentication to access them need to terminate users' sessions after a defined period of inactivity. Inadequate session timeout, or termination, refers to a security flaw on applications in which an authenticated user session remains active for extensive periods of time, without a lockout function in place for prolonged periods of inactivity.

This was raised in the DfE Publish/Find IT Health Check (FF25-567, pages 13–14). The ITHC recommends a 15–30 minute inactivity window, referencing the OWASP Session Management Cheat Sheet.

Before this PR:
- **Publish** (`User`) sessions timed out after **2 hours** of inactivity.
- **Find** (`Candidate`) sessions had **no inactivity timeout at all** — `Session#active?` returned `true` for candidates regardless of `updated_at`, and `Find::Authentication#find_session_by_cookie` never checked `active?`, destroyed expired records, or touched live ones.

## Solution

Bring both services in line with the ITHC recommendation by enforcing a **30-minute inactivity timeout** for every authenticated session (the upper bound of OWASP's window, chosen to balance security against publisher editing ergonomics).

The change is split into five focused commits:

1. **Rename `Session::USER_TIMEOUT` → `Session::INACTIVITY_TIMEOUT`** — the constant is about to apply to both sessionable types, so the `USER_` prefix is misleading.
2. **Lower the timeout from 2 hours to 30 minutes** — single-line change to satisfy the ITHC recommendation.
3. **Apply the timeout to `Candidate` sessions in `Session#active?`** — removes the special case that treated candidate sessions as eternal; model spec and factory traits updated to exercise both sessionable types.
4. **Enforce the inactivity timeout in `Find::Authentication`** — `find_session_by_cookie` now mirrors the `Publish::Authentication` pattern: if the session is expired it's destroyed and the cookie is reset; otherwise it's `touch`ed so request activity resets the inactivity timer.
5. **Test coverage for the new Find paths** — specs for destroy-on-expiry (session row gone, user redirected) and touch-on-activity (`updated_at` advances on each request).

No configuration changes required — the timeout is a code constant.

## Affected services

- Publish (publishers/support users) — timeout reduced 2h → 30m.
- Find (candidates) — inactivity timeout introduced where none existed.

## Guidance to review

- [ ] Publish: sign in, idle >30 minutes, next request redirects to DfE Sign-in.
- [ ] Publish: sign in, make requests every few minutes for >30 minutes, remain authenticated.
- [ ] Find: sign in as a candidate, idle >30 minutes, next request redirects to `find_root_path` with the sign-in flash.
- [ ] Find: sign in as a candidate, browse continuously, remain authenticated.
- [ ] `bundle exec rspec spec/models/session_spec.rb spec/controllers/find/candidates/recent_searches_controller_spec.rb spec/requests/publish/sidekiq_authorization_spec.rb spec/lib/system_admin_constraint_spec.rb`

## References

- ITHC report FF25-567_DFE_Publish_Find_ITHC_v1, pages 13–14
- https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
