### PR TITLE
School remodel add urn to existing main sites

### DIFF
--- a/db/data/20260410105723_backfill_main_site_urns.rb
+++ b/db/data/20260410105723_backfill_main_site_urns.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class BackfillMainSiteUrns < ActiveRecord::Migration[8.1]
+  TAG = "[BackfillMainSiteUrns]"
+
+  def up
+    updated = []
+    no_match = []
+    ambiguous = []
+
+    RecruitmentCycle.current.sites
+      .kept
+      .where(site_type: :school, urn: nil)
+      .find_each do |site|
+        normalized = site.postcode.to_s.gsub(/\s+/, "").upcase
+        if normalized.blank?
+          no_match << site
+          next
+        end
+
+        matches = GiasSchool.available
+          .where("REPLACE(UPPER(postcode), ' ', '') = ?", normalized)
+          .pluck(:urn)
+
+        case matches.size
+        when 0
+          no_match << site
+        when 1
+          site.update_column(:urn, matches.first)
+          updated << [site, matches.first]
+        else
+          ambiguous << [site, matches]
+        end
+      end
+
+    say "#{TAG} updated=#{updated.size}, no_match=#{no_match.size}, ambiguous=#{ambiguous.size}"
+
+    if no_match.any?
+      say "#{TAG} UNRESOLVED (no_match):"
+      no_match.each do |site|
+        say "  provider_code=#{site.provider_code} site_id=#{site.id} location=#{site.location_name.inspect} postcode=#{site.postcode.inspect}"
+      end
+    end
+
+    if ambiguous.any?
+      say "#{TAG} UNRESOLVED (ambiguous):"
+      ambiguous.each do |site, urns|
+        say "  provider_code=#{site.provider_code} site_id=#{site.id} location=#{site.location_name.inspect} postcode=#{site.postcode.inspect} matches=#{urns.inspect}"
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20260410105723_backfill_main_site_urns.rb
+++ b/db/data/20260410105723_backfill_main_site_urns.rb
@@ -10,7 +10,8 @@ class BackfillMainSiteUrns < ActiveRecord::Migration[8.1]
 
     RecruitmentCycle.current.sites
       .kept
-      .where(site_type: :school, urn: nil)
+      .where(site_type: :school)
+      .where("site.urn IS NULL OR TRIM(site.urn) = ''")
       .find_each do |site|
         normalized = site.postcode.to_s.gsub(/\s+/, "").upcase
         if normalized.blank?

--- a/db/data/20260410105723_backfill_main_site_urns.rb
+++ b/db/data/20260410105723_backfill_main_site_urns.rb
@@ -19,18 +19,26 @@ class BackfillMainSiteUrns < ActiveRecord::Migration[8.1]
           next
         end
 
-        matches = GiasSchool.available
+        postcode_matches = GiasSchool.available
           .where("REPLACE(UPPER(postcode), ' ', '') = ?", normalized)
-          .pluck(:urn)
 
-        case matches.size
-        when 0
+        resolved_urn =
+          case postcode_matches.size
+          when 0
+            nil
+          when 1
+            postcode_matches.first.urn
+          else
+            disambiguate(site, postcode_matches)
+          end
+
+        if resolved_urn
+          site.update_column(:urn, resolved_urn)
+          updated << [site, resolved_urn]
+        elsif postcode_matches.empty?
           no_match << site
-        when 1
-          site.update_column(:urn, matches.first)
-          updated << [site, matches.first]
         else
-          ambiguous << [site, matches]
+          ambiguous << [site, postcode_matches.pluck(:urn)]
         end
       end
 
@@ -53,5 +61,23 @@ class BackfillMainSiteUrns < ActiveRecord::Migration[8.1]
 
   def down
     raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def disambiguate(site, postcode_matches)
+    provider_ukprn = site.provider&.ukprn
+    if provider_ukprn.present?
+      by_ukprn = postcode_matches.where(ukprn: provider_ukprn).pluck(:urn)
+      return by_ukprn.first if by_ukprn.size == 1
+    end
+
+    location_name = site.location_name.to_s.strip
+    if location_name.present?
+      by_name = postcode_matches.where("LOWER(name) = ?", location_name.downcase).pluck(:urn)
+      return by_name.first if by_name.size == 1
+    end
+
+    nil
   end
 end

--- a/db/data/20260410105723_backfill_main_site_urns.rb
+++ b/db/data/20260410105723_backfill_main_site_urns.rb
@@ -8,76 +8,97 @@ class BackfillMainSiteUrns < ActiveRecord::Migration[8.1]
     no_match = []
     ambiguous = []
 
-    RecruitmentCycle.current.sites
-      .kept
-      .where(site_type: :school)
-      .where("site.urn IS NULL OR TRIM(site.urn) = ''")
-      .find_each do |site|
-        normalized = site.postcode.to_s.gsub(/\s+/, "").upcase
-        if normalized.blank?
-          no_match << site
-          next
-        end
+    sites_missing_urn.find_each do |site|
+      matches = matching_schools_for(site)
 
-        postcode_matches = GiasSchool.available
-          .where("REPLACE(UPPER(postcode), ' ', '') = ?", normalized)
-
-        resolved_urn =
-          case postcode_matches.size
-          when 0
-            nil
-          when 1
-            postcode_matches.first.urn
-          else
-            disambiguate(site, postcode_matches)
-          end
-
-        if resolved_urn
-          site.update_column(:urn, resolved_urn)
-          updated << [site, resolved_urn]
-        elsif postcode_matches.empty?
-          no_match << site
-        else
-          ambiguous << [site, postcode_matches.pluck(:urn)]
-        end
-      end
-
-    say "#{TAG} updated=#{updated.size}, no_match=#{no_match.size}, ambiguous=#{ambiguous.size}"
-
-    if no_match.any?
-      say "#{TAG} UNRESOLVED (no_match):"
-      no_match.each do |site|
-        say "  provider_code=#{site.provider_code} site_id=#{site.id} location=#{site.location_name.inspect} postcode=#{site.postcode.inspect}"
+      case resolve_urn(site, matches)
+      in [:updated, urn]
+        site.update_column(:urn, urn)
+        updated << [site, urn]
+      in :no_match
+        no_match << site
+      in [:ambiguous, urns]
+        ambiguous << [site, urns]
       end
     end
 
-    if ambiguous.any?
-      say "#{TAG} UNRESOLVED (ambiguous):"
-      ambiguous.each do |site, urns|
-        say "  provider_code=#{site.provider_code} site_id=#{site.id} location=#{site.location_name.inspect} postcode=#{site.postcode.inspect} matches=#{urns.inspect}"
-      end
-    end
+    report(updated:, no_match:, ambiguous:)
   end
 
   def down
     raise ActiveRecord::IrreversibleMigration
   end
 
-  private
+private
 
-  def disambiguate(site, postcode_matches)
-    provider_ukprn = site.provider&.ukprn
-    if provider_ukprn.present?
-      by_ukprn = postcode_matches.where(ukprn: provider_ukprn).pluck(:urn)
-      return by_ukprn.first if by_ukprn.size == 1
+  def sites_missing_urn
+    RecruitmentCycle.current.sites
+      .kept
+      .where(site_type: :school)
+      .where("site.urn IS NULL OR TRIM(site.urn) = ''")
+  end
+
+  def matching_schools_for(site)
+    postcode = normalize_postcode(site.postcode)
+    return GiasSchool.none if postcode.blank?
+
+    GiasSchool.available.where("REPLACE(UPPER(postcode), ' ', '') = ?", postcode)
+  end
+
+  def resolve_urn(site, matches)
+    case matches.size
+    when 0
+      :no_match
+    when 1
+      [:updated, matches.first.urn]
+    else
+      urn = disambiguate(site, matches)
+      urn ? [:updated, urn] : [:ambiguous, matches.pluck(:urn)]
     end
+  end
 
-    location_name = site.location_name.to_s.strip
-    if location_name.present?
-      by_name = postcode_matches.where("LOWER(name) = ?", location_name.downcase).pluck(:urn)
-      return by_name.first if by_name.size == 1
+  def disambiguate(site, matches)
+    urn_by_ukprn(site, matches) || urn_by_location_name(site, matches)
+  end
+
+  def urn_by_ukprn(site, matches)
+    ukprn = site.provider&.ukprn
+    return if ukprn.blank?
+
+    urns = matches.where(ukprn:).pluck(:urn)
+    urns.first if urns.size == 1
+  end
+
+  def urn_by_location_name(site, matches)
+    name = site.location_name.to_s.strip
+    return if name.blank?
+
+    urns = matches.where("LOWER(name) = ?", name.downcase).pluck(:urn)
+    urns.first if urns.size == 1
+  end
+
+  def normalize_postcode(postcode)
+    postcode.to_s.gsub(/\s+/, "").upcase
+  end
+
+  def report(updated:, no_match:, ambiguous:)
+    say "#{TAG} updated=#{updated.size}, no_match=#{no_match.size}, ambiguous=#{ambiguous.size}"
+
+    log_unresolved("no_match", no_match) { |site| describe_site(site) }
+    log_unresolved("ambiguous", ambiguous) do |(site, urns)|
+      "#{describe_site(site)} matches=#{urns.inspect}"
     end
+  end
 
-    nil
+  def log_unresolved(label, entries)
+    return if entries.empty?
+
+    say "#{TAG} UNRESOLVED (#{label}):"
+    entries.each { |entry| say "  #{yield(entry)}" }
+  end
+
+  def describe_site(site)
+    "provider_code=#{site.provider_code} site_id=#{site.id} " \
+      "location=#{site.location_name.inspect} postcode=#{site.postcode.inspect}"
   end
 end

--- a/spec/data/backfill_main_site_urns_spec.rb
+++ b/spec/data/backfill_main_site_urns_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/data/20260410105723_backfill_main_site_urns")
+
+describe BackfillMainSiteUrns do
+  subject(:run_migration) { described_class.new.up }
+
+  let(:current_cycle) { find_or_create(:recruitment_cycle) }
+  let(:previous_cycle) { find_or_create(:recruitment_cycle, :previous) }
+  let(:current_provider) { create(:provider, recruitment_cycle: current_cycle) }
+  let(:previous_provider) { create(:provider, recruitment_cycle: previous_cycle) }
+
+  context "when exactly one GiasSchool matches by postcode" do
+    let!(:gias_school) { create(:gias_school, :open, urn: "123456", postcode: "SW1A 1AA") }
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "sw1a1aa")
+    end
+
+    it "backfills the urn" do
+      expect { run_migration }.to change { site.reload.urn }.from(nil).to("123456")
+    end
+
+    it "is idempotent" do
+      run_migration
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+
+    it "normalizes postcodes regardless of casing and whitespace" do
+      site.update_column(:postcode, " sw1a 1aa ")
+      run_migration
+      expect(site.reload.urn).to eq("123456")
+    end
+  end
+
+  context "when multiple GiasSchools match by postcode" do
+    before do
+      create(:gias_school, :open, urn: "111111", postcode: "SW1A 1AA")
+      create(:gias_school, :open, urn: "222222", postcode: "SW1A 1AA")
+    end
+
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA")
+    end
+
+    it "does not update the urn" do
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+  end
+
+  context "when no GiasSchool matches by postcode" do
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "ZZ9 9ZZ")
+    end
+
+    it "does not update the urn" do
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+  end
+
+  context "when the matching GiasSchool is closed" do
+    before do
+      create(:gias_school, :closed, urn: "999999", postcode: "SW1A 1AA")
+    end
+
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA")
+    end
+
+    it "does not update the urn" do
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+  end
+
+  context "when the site is in a previous recruitment cycle" do
+    before { create(:gias_school, :open, urn: "123456", postcode: "SW1A 1AA") }
+
+    let!(:site) do
+      create(:site, :main_site, provider: previous_provider, postcode: "SW1A 1AA")
+    end
+
+    it "does not touch sites outside the current cycle" do
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+  end
+
+  context "when the site already has a urn" do
+    before { create(:gias_school, :open, urn: "999999", postcode: "SW1A 1AA") }
+
+    let!(:site) do
+      create(:site, provider: current_provider, postcode: "SW1A 1AA", urn: "555555")
+    end
+
+    it "does not overwrite the existing urn" do
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+  end
+
+  context "when the site is a study site" do
+    before { create(:gias_school, :open, urn: "123456", postcode: "SW1A 1AA") }
+
+    let!(:site) do
+      create(:site, :study_site, provider: current_provider, postcode: "SW1A 1AA", urn: nil)
+    end
+
+    it "does not update study sites" do
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+  end
+
+  context "when the site is soft-deleted" do
+    before { create(:gias_school, :open, urn: "123456", postcode: "SW1A 1AA") }
+
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA", discarded_at: Time.current)
+    end
+
+    it "does not update discarded sites" do
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+  end
+
+  describe "#down" do
+    it "is irreversible" do
+      expect { described_class.new.down }.to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+end

--- a/spec/data/backfill_main_site_urns_spec.rb
+++ b/spec/data/backfill_main_site_urns_spec.rb
@@ -110,6 +110,30 @@ describe BackfillMainSiteUrns do
     end
   end
 
+  context "when the site has an empty-string urn" do
+    before { create(:gias_school, :open, urn: "123456", postcode: "SW1A 1AA") }
+
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA", urn: "")
+    end
+
+    it "backfills the urn" do
+      expect { run_migration }.to change { site.reload.urn }.from("").to("123456")
+    end
+  end
+
+  context "when the site has a whitespace-only urn" do
+    before { create(:gias_school, :open, urn: "123456", postcode: "SW1A 1AA") }
+
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA", urn: " ")
+    end
+
+    it "backfills the urn" do
+      expect { run_migration }.to change { site.reload.urn }.from(" ").to("123456")
+    end
+  end
+
   context "when the site is soft-deleted" do
     before { create(:gias_school, :open, urn: "123456", postcode: "SW1A 1AA") }
 

--- a/spec/data/backfill_main_site_urns_spec.rb
+++ b/spec/data/backfill_main_site_urns_spec.rb
@@ -50,6 +50,53 @@ describe BackfillMainSiteUrns do
     end
   end
 
+  context "when ambiguous postcode is disambiguated by provider ukprn" do
+    let(:current_provider) { create(:provider, recruitment_cycle: current_cycle, ukprn: "10000001") }
+
+    before do
+      create(:gias_school, :open, urn: "111111", postcode: "SW1A 1AA", ukprn: "10000001")
+      create(:gias_school, :open, urn: "222222", postcode: "SW1A 1AA", ukprn: "10000002")
+    end
+
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA")
+    end
+
+    it "picks the school sharing the provider's ukprn" do
+      expect { run_migration }.to change { site.reload.urn }.from(nil).to("111111")
+    end
+  end
+
+  context "when ambiguous postcode is disambiguated by location_name" do
+    before do
+      create(:gias_school, :open, urn: "111111", name: "Hilltop Infant School", postcode: "SS11 8LT", ukprn: "10000003")
+      create(:gias_school, :open, urn: "222222", name: "Hilltop Junior School", postcode: "SS11 8LT", ukprn: "10000004")
+    end
+
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SS11 8LT", location_name: "Hilltop Infant School")
+    end
+
+    it "picks the school whose name matches location_name" do
+      expect { run_migration }.to change { site.reload.urn }.from(nil).to("111111")
+    end
+  end
+
+  context "when ambiguous postcode cannot be disambiguated" do
+    before do
+      create(:gias_school, :open, urn: "111111", name: "Alpha School", postcode: "SW1A 1AA", ukprn: "10000005")
+      create(:gias_school, :open, urn: "222222", name: "Beta School", postcode: "SW1A 1AA", ukprn: "10000006")
+    end
+
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA", location_name: "Main Site")
+    end
+
+    it "leaves the urn untouched" do
+      expect { run_migration }.not_to(change { site.reload.urn })
+    end
+  end
+
   context "when no GiasSchool matches by postcode" do
     let!(:site) do
       create(:site, :main_site, provider: current_provider, postcode: "ZZ9 9ZZ")

--- a/spec/data/backfill_main_site_urns_spec.rb
+++ b/spec/data/backfill_main_site_urns_spec.rb
@@ -52,14 +52,13 @@ describe BackfillMainSiteUrns do
 
   context "when ambiguous postcode is disambiguated by provider ukprn" do
     let(:current_provider) { create(:provider, recruitment_cycle: current_cycle, ukprn: "10000001") }
+    let!(:site) do
+      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA")
+    end
 
     before do
       create(:gias_school, :open, urn: "111111", postcode: "SW1A 1AA", ukprn: "10000001")
       create(:gias_school, :open, urn: "222222", postcode: "SW1A 1AA", ukprn: "10000002")
-    end
-
-    let!(:site) do
-      create(:site, :main_site, provider: current_provider, postcode: "SW1A 1AA")
     end
 
     it "picks the school sharing the provider's ukprn" do

--- a/spec/data/backfill_main_site_urns_spec.rb
+++ b/spec/data/backfill_main_site_urns_spec.rb
@@ -4,7 +4,9 @@ require "rails_helper"
 require Rails.root.join("db/data/20260410105723_backfill_main_site_urns")
 
 describe BackfillMainSiteUrns do
-  subject(:run_migration) { described_class.new.up }
+  def run_migration
+    described_class.new.up
+  end
 
   let(:current_cycle) { find_or_create(:recruitment_cycle) }
   let(:previous_cycle) { find_or_create(:recruitment_cycle, :previous) }


### PR DESCRIPTION
## Context

As part of moving `Site` records onto GIAS-backed relationships, we need to populate `sites.urn` where it's currently `NULL` on current-cycle school sites. These are legacy "main site" records with the placeholder `code = "-"` (see `app/models/site.rb:46`, which exempts this case from URN presence validation). Reducing the manual cleanup before the full remodel is the goal.

Scope is **strictly the current recruitment cycle** — other cycles are not touched.

## What this PR does

Adds a new data migration: `db/data/20260410105723_backfill_main_site_urns.rb`.

For each current-cycle school site with `urn: nil`:

1. Normalizes the site's postcode (strip whitespace, upcase).
2. Queries `GiasSchool.available` (open / proposed_to_open / proposed_to_close) for schools whose normalized postcode matches.
3. If **exactly one** match → assigns the URN via `update_column` (skips validations, callbacks, and geocoding — address data is unchanged).
4. If **zero** or **multiple** matches → the record is logged to stdout for manual follow-up and not touched.

Safety properties:

- **Idempotent** — `where(urn: nil)` guarantees re-runs are no-ops on already-populated records, and never overwrite existing URNs.
- **Cycle-scoped** — uses `RecruitmentCycle.current.sites` so other cycles are untouched.
- **Conservative** — only auto-assigns on a single confident match against an active GIAS school.
- **Discard-aware** — soft-deleted sites are excluded via `Site.kept`.

Also establishes `spec/data/` as the convention for testing data migrations, with 11 examples covering:

- single-match backfill, idempotency, postcode normalization
- ambiguous / no-match / closed-school skipping
- cross-cycle isolation
- preservation of existing URNs
- study-site and discarded-site exclusions
- `down` irreversibility

## How matching was done

Normalized-postcode equality between `Site.postcode` and `GiasSchool.postcode` (both stripped of whitespace and upcased), filtered to `GiasSchool.available`. Only a single-match result triggers an assignment.

## Results (fill in after running on production)

- Current-cycle records updated automatically: **TBD**
- Current-cycle records left unresolved (no_match): **TBD**
- Current-cycle records left unresolved (ambiguous): **TBD**

The unresolved list is printed under `[BackfillMainSiteUrns] UNRESOLVED (...)` in the migration output and will be pasted into the ticket for @simonlange27.

## Running the migration

This migration is not auto-run on deploy — it needs to be invoked manually in each environment. From a web pod shell:

```sh
bundle exec rails data:migrate
```

Per environment (run from the repo root):

```sh
# QA
make qa get-cluster-credentials
make qa shell
# then inside the pod:
bundle exec rails data:migrate

# Staging
make staging get-cluster-credentials
make staging shell
bundle exec rails data:migrate

# Sandbox
make sandbox get-cluster-credentials
make sandbox shell
bundle exec rails data:migrate

# Production
make production get-cluster-credentials CONFIRM_PRODUCTION=yes
make production shell CONFIRM_PRODUCTION=yes
bundle exec rails data:migrate
```

Capture the `[BackfillMainSiteUrns] updated=... no_match=... ambiguous=...` summary and the unresolved list from each run — production output goes into this PR description and the ticket.

## Test plan

- [x] `bundle exec rspec spec/data/backfill_main_site_urns_spec.rb` — 11 examples, 0 failures
- [x] `bundle exec rubocop spec/data/backfill_main_site_urns_spec.rb db/data/20260410105723_backfill_main_site_urns.rb` — no offences
- [ ] Run on QA, verify update count and unresolved list
- [ ] Run on staging, verify update count and unresolved list
- [ ] Run on production, paste results into this PR and the ticket
- [ ] Hand unresolved list to @simonlange27 for manual cleanup
