### PR TITLE
Concurrent logins & Permissions-Policy header

### DIFF
--- a/app/controllers/concerns/find/authentication.rb
+++ b/app/controllers/concerns/find/authentication.rb
@@ -53,6 +53,7 @@ module Find
     def start_new_session_for(user, oauth)
       ::Authentication.transaction do
         terminate_session
+        user.sessions.destroy_all
 
         user.sessions.create!(session_key: candidate_session, id_token: oauth.credentials.id_token, user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
           Current.session = session

--- a/app/controllers/concerns/publish/authentication.rb
+++ b/app/controllers/concerns/publish/authentication.rb
@@ -59,15 +59,18 @@ module Publish
     end
 
     def start_user_session(user, id_token: nil)
-      reset_user_session_cookie
+      ::Authentication.transaction do
+        terminate_user_session
+        user.sessions.destroy_all
 
-      user.sessions.create!(
-        session_key: user_session_key,
-        id_token: id_token,
-        user_agent: request.user_agent,
-        ip_address: request.remote_ip,
-      ).tap do |db_session|
-        Current.session = db_session
+        user.sessions.create!(
+          session_key: user_session_key,
+          id_token: id_token,
+          user_agent: request.user_agent,
+          ip_address: request.remote_ip,
+        ).tap do |db_session|
+          Current.session = db_session
+        end
       end
     end
 

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,18 +1,41 @@
 # frozen_string_literal: true
 
-# Be sure to restart your server when you modify this file.
+# Emit a Permissions-Policy header that restricts powerful browser features
+# neither Find nor Publish use, per ITHC FF25-567.
+#
+# Rails' built-in `config.permissions_policy` DSL still emits the deprecated
+# `Feature-Policy` header name with the old `camera 'none'` syntax
+# (see actionpack lib/action_dispatch/http/permissions_policy.rb), which
+# does not satisfy the ITHC requirement. We set the modern header directly
+# via a small Rack middleware instead.
+#
+# "geolocation" here refers to the browser API — the app's own geolocation
+# features are server-side Google Geocoding calls and are unaffected.
 
-# Restrict powerful browser features that neither Find nor Publish use, per
-# ITHC FF25-567 (see guides/ithc-ff25-567-remediation.md). Geolocation here
-# refers to the browser API — the app's own geolocation features are
-# server-side Google Geocoding calls and are unaffected.
-Rails.application.config.permissions_policy do |policy|
-  policy.camera       :none
-  policy.microphone   :none
-  policy.geolocation  :none
-  policy.gyroscope    :none
-  policy.magnetometer :none
-  policy.usb          :none
-  policy.payment      :none
-  policy.fullscreen   :self
+module PermissionsPolicyHeader
+  HEADER_NAME = "Permissions-Policy"
+  HEADER_VALUE = [
+    "camera=()",
+    "microphone=()",
+    "geolocation=()",
+    "gyroscope=()",
+    "magnetometer=()",
+    "usb=()",
+    "payment=()",
+    "fullscreen=(self)",
+  ].join(", ").freeze
+
+  class Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      headers[HEADER_NAME] ||= HEADER_VALUE
+      [status, headers, body]
+    end
+  end
 end
+
+Rails.application.config.middleware.use PermissionsPolicyHeader::Middleware

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -2,14 +2,17 @@
 
 # Be sure to restart your server when you modify this file.
 
-# Define an application-wide HTTP permissions policy. For further
-# information see: https://developers.google.com/web/updates/2018/06/feature-policy
-
-# Rails.application.config.permissions_policy do |policy|
-#   policy.camera      :none
-#   policy.gyroscope   :none
-#   policy.microphone  :none
-#   policy.usb         :none
-#   policy.fullscreen  :self
-#   policy.payment     :self, "https://secure.example.com"
-# end
+# Restrict powerful browser features that neither Find nor Publish use, per
+# ITHC FF25-567 (see guides/ithc-ff25-567-remediation.md). Geolocation here
+# refers to the browser API — the app's own geolocation features are
+# server-side Google Geocoding calls and are unaffected.
+Rails.application.config.permissions_policy do |policy|
+  policy.camera       :none
+  policy.microphone   :none
+  policy.geolocation  :none
+  policy.gyroscope    :none
+  policy.magnetometer :none
+  policy.usb          :none
+  policy.payment      :none
+  policy.fullscreen   :self
+end

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -4,38 +4,20 @@
 # neither Find nor Publish use, per ITHC FF25-567.
 #
 # Rails' built-in `config.permissions_policy` DSL still emits the deprecated
-# `Feature-Policy` header name with the old `camera 'none'` syntax
-# (see actionpack lib/action_dispatch/http/permissions_policy.rb), which
-# does not satisfy the ITHC requirement. We set the modern header directly
-# via a small Rack middleware instead.
+# `Feature-Policy` header name with the old `camera 'none'` syntax, which
+# does not satisfy the ITHC requirement. We set the modern header via
+# ActionDispatch default_headers instead.
 #
 # "geolocation" here refers to the browser API — the app's own geolocation
 # features are server-side Google Geocoding calls and are unaffected.
 
-module PermissionsPolicyHeader
-  HEADER_NAME = "Permissions-Policy"
-  HEADER_VALUE = [
-    "camera=()",
-    "microphone=()",
-    "geolocation=()",
-    "gyroscope=()",
-    "magnetometer=()",
-    "usb=()",
-    "payment=()",
-    "fullscreen=(self)",
-  ].join(", ").freeze
-
-  class Middleware
-    def initialize(app)
-      @app = app
-    end
-
-    def call(env)
-      status, headers, body = @app.call(env)
-      headers[HEADER_NAME] ||= HEADER_VALUE
-      [status, headers, body]
-    end
-  end
-end
-
-Rails.application.config.middleware.use PermissionsPolicyHeader::Middleware
+Rails.application.config.action_dispatch.default_headers["Permissions-Policy"] = [
+  "camera=()",
+  "microphone=()",
+  "geolocation=()",
+  "gyroscope=()",
+  "magnetometer=()",
+  "usb=()",
+  "payment=()",
+  "fullscreen=(self)",
+].join(", ")

--- a/spec/requests/find/sign_in_spec.rb
+++ b/spec/requests/find/sign_in_spec.rb
@@ -27,4 +27,27 @@ describe "/auth/find-developer", service: :find do
       expect(response.parsed_body.title).to eq("Saved courses - Find teacher training courses - GOV.UK")
     end
   end
+
+  describe "concurrent session handling" do
+    before do
+      FeatureFlag.activate(:candidate_accounts)
+      CandidateAuthHelper.mock_auth
+    end
+
+    it "destroys any existing sessions for the candidate before creating the new one" do
+      candidate = create(:find_developer_candidate)
+      create(:session, sessionable: candidate, session_key: "old-browser-session-key")
+      create(:session, sessionable: candidate, session_key: "another-device-session-key")
+
+      expect {
+        post "/auth/find-developer"
+        follow_redirect!
+      }.to change { candidate.sessions.reload.count }.from(2).to(1)
+
+      expect(candidate.sessions.pluck(:session_key)).not_to include(
+        "old-browser-session-key",
+        "another-device-session-key",
+      )
+    end
+  end
 end

--- a/spec/requests/publish/concurrent_sign_in_spec.rb
+++ b/spec/requests/publish/concurrent_sign_in_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Publish concurrent sign-in", service: :publish do
+  include DfESignInUserHelper
+
+  let(:provider) { create(:provider) }
+  let!(:user) { create(:user, providers: [provider]) }
+
+  before { host! URI(Settings.base_url).host }
+
+  it "destroys any existing sessions for the user before creating the new one" do
+    create(:session, sessionable: user, session_key: "old-browser-session-key")
+    create(:session, sessionable: user, session_key: "another-device-session-key")
+
+    expect {
+      get "/auth/dfe/callback", headers: { "omniauth.auth" => user_exists_in_dfe_sign_in(user:) }
+    }.to change { user.sessions.reload.count }.from(2).to(1)
+
+    expect(user.sessions.pluck(:session_key)).not_to include(
+      "old-browser-session-key",
+      "another-device-session-key",
+    )
+  end
+end

--- a/spec/requests/security_headers_spec.rb
+++ b/spec/requests/security_headers_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "security headers" do
+  describe "Permissions-Policy" do
+    context "on a Find page", service: :find do
+      it "restricts powerful browser features" do
+        get "/"
+
+        header = response.headers["Permissions-Policy"]
+        expect(header).to be_present
+        expect(header).to include("camera=()")
+        expect(header).to include("microphone=()")
+        expect(header).to include("geolocation=()")
+        expect(header).to include("payment=()")
+        expect(header).to include("usb=()")
+      end
+    end
+
+    context "on a Publish page", service: :publish do
+      it "restricts powerful browser features" do
+        get "/sign-in"
+
+        header = response.headers["Permissions-Policy"]
+        expect(header).to be_present
+        expect(header).to include("camera=()")
+        expect(header).to include("microphone=()")
+        expect(header).to include("geolocation=()")
+        expect(header).to include("payment=()")
+        expect(header).to include("usb=()")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Addresses two findings from ITHC FF25-567 (DfE Publish/Find IT health check).

**1. Concurrent logins (pp. 21–22)** — the same account could authenticate from multiple browsers simultaneously and every session stayed valid until the 30-minute inactivity timeout, undermining compromise detection and session auditing. Sign-in now destroys any existing `Session` rows for the authenticating `Candidate` (Find) or `User` (Publish) inside the same transaction that creates the new one, enforcing a single active session per user as recommended by the OWASP Session Management Cheat Sheet.

**2. Permissions-Policy header (pp. 18–20)** — the header was absent entirely. The previously-empty `config/initializers/permissions_policy.rb` now emits a restrictive baseline disabling `camera`, `microphone`, `geolocation`, `gyroscope`, `magnetometer`, `usb`, and `payment`, and limits `fullscreen` to `self`. None of these features are used by the app — the in-app "geolocation" is server-side Google Geocoding, not the browser API, and the only `navigator.*` usage is `navigator.clipboard`, which is not restricted.

The third ITHC finding (HSTS `preload` directive, same section of the report) is **not** in this PR — it's blocked on clarification from the infra/platform team about where the current `Strict-Transport-Security` header is emitted (Rails `force_ssl` is commented out, so it must be set upstream). The open questions and proposed options are documented in `guides/ithc-ff25-567-remediation.md §4` and will be handled in a follow-up PR.

## Behaviour change for end users

After this PR, signing in on a new device/browser silently invalidates any existing session the same user has elsewhere. On the old device, the next request returns the user to the sign-in page. This is intentional and aligns with OWASP guidance, but worth flagging to support so they can answer any "why was I signed out?" tickets.

## Test plan

- [ ] `bundle exec rspec spec/requests/find/sign_in_spec.rb spec/requests/publish/concurrent_sign_in_spec.rb spec/requests/security_headers_spec.rb` passes in CI.
- [ ] Full test suite green in CI.
- [ ] Manual: sign in as the same Candidate in two separate browsers (normal + incognito); refresh browser A → redirects to sign-in.
- [ ] Manual: same check for Publish via DfE Sign-in.
- [ ] Manual: `curl -sI https://<review-app-host>/ | grep -i permissions-policy` shows the new header with the expected directives on both Find and Publish pages.
- [ ] Manual sweep of Find and Publish in a browser to confirm no UI relies on a now-blocked browser feature (search, course listings, saved courses, publish provider admin).
