### PR TITLE
Combine subject_code and subjects in create_email_alert_service

### DIFF
--- a/app/services/find/create_email_alert_service.rb
+++ b/app/services/find/create_email_alert_service.rb
@@ -28,7 +28,9 @@ module Find
   private
 
     def extract_subjects
-      Array(@search_params[:subjects]).compact_blank.sort
+      codes = Array(@search_params[:subjects]).compact_blank
+      codes << @search_params[:subject_code] if @search_params[:subject_code].present?
+      codes.compact_blank.uniq.sort
     end
 
     def filter_attributes

--- a/spec/requests/find/email_alerts/create_email_alert_spec.rb
+++ b/spec/requests/find/email_alerts/create_email_alert_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Create Email alert with subjects", service: :find, type: :request do
+  before do
+    create(:find_developer_candidate)
+    FeatureFlag.activate(:email_alerts)
+    FeatureFlag.activate(:candidate_accounts)
+
+    CandidateAuthHelper.mock_auth
+  end
+
+  describe "POST /auth/find-developer" do
+    context "one subject" do
+      it "triggers an error and renders the error page" do
+        post "/auth/find-developer"
+        follow_redirect!
+        follow_redirect!
+
+        expect {
+          post("/candidate/email-alerts", params: {
+            "minimum_degree_required" => "show_all_courses",
+            "subject_code" => "G1",
+            "subject_name" => "Mathematics",
+          })
+        }.to change(Candidate::EmailAlert, :count).from(0).to(1)
+
+        expect(Candidate::EmailAlert.last).to have_attributes({ subjects: %w[G1] })
+
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "two subjects" do
+      it "triggers an error and renders the error page" do
+        post "/auth/find-developer"
+        follow_redirect!
+        follow_redirect!
+
+        expect {
+          post("/candidate/email-alerts", params: {
+            "utm_source" => "results",
+            "previous_location_category" => "",
+            "subject_name" => "French",
+            "subject_code" => "15",
+            "location" => "",
+            "utm_medium" => "search",
+            "order" => "course_name_ascending",
+            "subjects[]" => "17",
+            "minimum_degree_required" => "show_all_courses",
+            "provider_code" => "",
+          })
+        }.to change(Candidate::EmailAlert, :count).from(0).to(1)
+
+        expect(Candidate::EmailAlert.last).to have_attributes({ subjects: %w[15 17] })
+
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

`extract_subjects` in the `CreateEmailAlertService` was not combining the subject autocomplete param `subject_code` with the filter panels subject checkboxes `subjects[]` but now it is.

## Changes proposed in this pull request

In the create email alert controller, we take all the subject parameters and combine them, including the `subject_code`.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
