### PR TITLE
Various content and UI changes to email alerts

### DIFF
--- a/app/assets/stylesheets/find/components/_active-filters.scss
+++ b/app/assets/stylesheets/find/components/_active-filters.scss
@@ -1,4 +1,16 @@
+.app-active-filters__header {
+  display: flex;
+
+  justify-content: space-between;
+}
+
+.app-c-filter-summary__clear-filters {
+  display: inline-block;
+}
+
 .app-active-filters__heading {
+  display: inline-block;
+
   padding: 0;
   margin: 0 0 govuk-spacing(3);
 

--- a/app/assets/stylesheets/find/components/_email-alert.scss
+++ b/app/assets/stylesheets/find/components/_email-alert.scss
@@ -3,3 +3,7 @@
 
   fill: currentColor;
 }
+
+.app-email-alert__unsubscribe-button {
+  width: 100%;
+}

--- a/app/assets/stylesheets/find/components/_email-alert.scss
+++ b/app/assets/stylesheets/find/components/_email-alert.scss
@@ -3,20 +3,3 @@
 
   fill: currentColor;
 }
-
-.app-email-alert-summary {
-  .app-summary-list__key {
-    display: block;
-
-    width: 100%;
-
-    padding: 0;
-  }
-
-  .app-summary-list__value {
-    display: block;
-
-    padding: 0;
-    margin-bottom: govuk-spacing(3);
-  }
-}

--- a/app/components/find/courses/active_filters/view.html.erb
+++ b/app/components/find/courses/active_filters/view.html.erb
@@ -1,6 +1,10 @@
 <div class="app-active-filters">
-  <h3 class="govuk-heading-s app-active-filters__heading">Active filters</h3>
-
+  <div class="app-active-filters__header">
+    <h3 class="govuk-heading-s app-active-filters__heading">Active filters</h3>
+    <p class="govuk-body">
+      <%= render Find::Courses::ClearAllFilters::View.new(active_filters:, position: :top) %>
+    </p>
+  </div>
   <ul class="app-active-filters__remove-filters">
     <% active_filters.each do |filter| %>
       <li>
@@ -15,8 +19,4 @@
       </li>
     <% end %>
   </ul>
-
-  <p class="govuk-body">
-    <%= render Find::Courses::ClearAllFilters::View.new(active_filters:, position: :top) %>
-  </p>
 </div>

--- a/app/components/find/email_alerts/summary_card_component.html.erb
+++ b/app/components/find/email_alerts/summary_card_component.html.erb
@@ -2,11 +2,11 @@
   <% card.with_action do %>
     <%= govuk_link_to t(".unsubscribe"), unsubscribe_path, class: "govuk-link--no-visited-state" %>
   <% end %>
-  <dl class="govuk-summary-list govuk-summary-list--no-border app-email-alert-summary">
+  <dl class="govuk-summary-list govuk-summary-list--no-border">
     <% filter_rows.each do |row| %>
-      <div class="govuk-summary-list__row app-summary-list__row app-body">
-        <dt class="govuk-summary-list__key app-summary-list__key"><%= row[:label] %></dt>
-        <dd class="govuk-summary-list__value app-summary-list__value"><%= row[:value] %></dd>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= row[:label] %></dt>
+        <dd class="govuk-summary-list__value"><%= row[:value] %></dd>
       </div>
     <% end %>
   </dl>

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -51,6 +51,7 @@ module Find
       def confirm_unsubscribe
         @email_alert = find_alert_by_token
         @filter_tags = extract_filter_tags_from_alert(@email_alert)
+        @summary_rows = build_summary_rows(@email_alert.search_params.to_h, subject_names: Subject.where(subject_code: @email_alert.subjects).pluck(:subject_name))
       end
 
       def unsubscribe_link(alert)
@@ -70,6 +71,7 @@ module Find
 
       def unsubscribe_from_email
         @email_alert = Candidate::EmailAlert.find_signed!(params[:token], purpose: :unsubscribe)
+        @summary_rows = build_summary_rows(@email_alert.search_params.to_h, subject_names: @email_alert.subjects)
         @filter_tags = extract_filter_tags_from_alert(@email_alert)
       rescue ActiveSupport::MessageVerifier::InvalidSignature
         redirect_to find_root_path

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -99,7 +99,7 @@ module Find
       end
 
       def subject_names
-        @subject_names ||= resolve_subject_names(search_params[:subjects])
+        @subject_names ||= resolve_subject_names(subject_codes)
       end
 
       def location_name
@@ -143,6 +143,12 @@ module Find
 
       def search_params_from_request
         Find::SearchParams.permit(params)
+      end
+
+      def subject_codes
+        codes = Array(@search_params[:subjects]).compact_blank
+        codes << @search_params[:subject_code] if @search_params[:subject_code].present?
+        codes.compact_blank.uniq.sort
       end
 
       def resolve_subject_names(codes)

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -36,9 +36,10 @@ module Find
             location_name: alert.location_name,
             radius: alert.radius,
           )
+
           flash[:success_with_body] = {
             "title" => t(".success_title"),
-            "body" => t(".success_body_html", title:),
+            "body" => t(".success_body_html", title:, unsubscribe_link: unsubscribe_link(alert)),
           }
           redirect_to redirect_after_create
         else
@@ -50,6 +51,10 @@ module Find
       def confirm_unsubscribe
         @email_alert = find_alert_by_token
         @filter_tags = extract_filter_tags_from_alert(@email_alert)
+      end
+
+      def unsubscribe_link(alert)
+        helpers.govuk_link_to("unsubscribe", find_candidate_unsubscribe_email_alert_path(token: alert.signed_id(purpose: :unsubscribe, expires_in: 30.days)))
       end
 
       def unsubscribe

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -97,7 +97,7 @@ module Find
       end
 
       def search_params
-        @search_params ||= search_params_from_request
+        @search_params ||= Find::SearchParams.permit(params)
       end
 
       def subject_names
@@ -115,7 +115,7 @@ module Find
 
       def compute_digest_from_params
         Find::FilterKeyDigest.digest(
-          subjects: search_params[:subjects],
+          subjects: subject_codes,
           search_attributes: search_params.to_h,
         )
       end
@@ -143,13 +143,9 @@ module Find
         raise ActiveRecord::RecordNotFound
       end
 
-      def search_params_from_request
-        Find::SearchParams.permit(params)
-      end
-
       def subject_codes
-        codes = Array(@search_params[:subjects]).compact_blank
-        codes << @search_params[:subject_code] if @search_params[:subject_code].present?
+        codes = Array(search_params[:subjects])
+        codes << search_params[:subject_code] if search_params[:subject_code].present?
         codes.compact_blank.uniq.sort
       end
 

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -4,6 +4,8 @@ module Find
   class ResultsController < ApplicationController
     after_action :store_result_fullpath_for_backlinks, :send_analytics_event, :record_recent_search, only: [:index]
 
+    helper_method :show_email_alert_link?
+
     def index
       @address = Geolocation::Address.query(location_params)
 
@@ -51,6 +53,16 @@ module Find
 
     def store_result_fullpath_for_backlinks
       cookies[:results_path] = { value: request.fullpath, httponly: true }
+    end
+
+    def show_email_alert_link?
+      return unless FeatureFlag.active?(:email_alerts)
+
+      filters_applied?
+    end
+
+    def filters_applied?
+      @search_courses_form.active_filters.present?
     end
 
     def page

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -56,18 +56,23 @@ module Find
     end
 
     def show_email_alert_link?
-      return unless FeatureFlag.active?(:email_alerts)
+      return unless current_user.present? && FeatureFlag.active?(:email_alerts)
 
-      filters_applied? && alert_does_not_exist?
+      filters_applied? && alert_does_not_exist? && meaningful_for_recent_search?
     end
 
     def alert_does_not_exist?
-      return if current_user.blank?
+      !current_user.email_alerts.active.exists?(filter_key_digest: search_digest)
+    end
 
-      subjects = [@search_params[:subjects], [@search_params[:subject_code]]].flatten.compact_blank
-      filter_key_digest = Find::FilterKeyDigest.digest(subjects:, search_attributes: @search_params)
+    def search_digest
+      @search_digest ||= Find::FilterKeyDigest.digest(subjects: subject_codes, search_attributes: @search_params)
+    end
 
-      !current_user.email_alerts.active.exists?(filter_key_digest:)
+    def subject_codes
+      codes = Array(params[:subjects])
+      codes << params[:subject_code] if params[:subject_code].present?
+      codes.compact_blank.uniq.sort
     end
 
     def filters_applied?

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -58,7 +58,16 @@ module Find
     def show_email_alert_link?
       return unless FeatureFlag.active?(:email_alerts)
 
-      filters_applied?
+      filters_applied? && alert_does_not_exist?
+    end
+
+    def alert_does_not_exist?
+      return if current_user.blank?
+
+      subjects = [@search_params[:subjects], [@search_params[:subject_code]]].flatten.compact_blank
+      filter_key_digest = Find::FilterKeyDigest.digest(subjects:, search_attributes: @search_params)
+
+      !current_user.email_alerts.active.exists?(filter_key_digest:)
     end
 
     def filters_applied?

--- a/app/controllers/find/results_controller.rb
+++ b/app/controllers/find/results_controller.rb
@@ -58,7 +58,11 @@ module Find
     def show_email_alert_link?
       return unless current_user.present? && FeatureFlag.active?(:email_alerts)
 
-      filters_applied? && alert_does_not_exist? && meaningful_for_recent_search?
+      filters_applied? && alert_does_not_exist? && meaningful_for_recent_search? && !location_outside_england?
+    end
+
+    def location_outside_england?
+      @address.country.present? && @address.country != "England"
     end
 
     def alert_does_not_exist?

--- a/app/models/candidate/email_alert.rb
+++ b/app/models/candidate/email_alert.rb
@@ -13,17 +13,6 @@ class Candidate
     validate :subscription_limit_not_reached
 
     scope :active, -> { where(unsubscribed_at: nil) }
-    scope :subscribed, -> { active }
-
-    def matches_search?(subjects:, search_attributes:)
-      other_attrs = search_attributes.to_h.stringify_keys
-      self.subjects.sort == Array(subjects).sort &&
-        normalize_filter_attrs(self.search_attributes) == normalize_filter_attrs(other_attrs)
-    end
-
-    def filter_key
-      [subjects.sort, normalize_filter_attrs(search_attributes)]
-    end
 
     def search_params
       params = search_attributes.symbolize_keys

--- a/app/models/candidate/email_alert.rb
+++ b/app/models/candidate/email_alert.rb
@@ -15,7 +15,7 @@ class Candidate
     scope :active, -> { where(unsubscribed_at: nil) }
 
     def search_params
-      params = search_attributes.symbolize_keys
+      params = (search_attributes || {}).symbolize_keys
       params[:subjects] = subjects if subjects.present?
       params[:longitude] = longitude if longitude.present?
       params[:latitude] = latitude if latitude.present?

--- a/app/models/concerns/filter_key_digestable.rb
+++ b/app/models/concerns/filter_key_digestable.rb
@@ -8,7 +8,7 @@ module FilterKeyDigestable
   end
 
   def compute_filter_key_digest
-    Find::FilterKeyDigest.digest(subjects: subjects, search_attributes: search_attributes)
+    Find::FilterKeyDigest.digest(subjects: subjects, search_attributes: search_params)
   end
 
   def normalize_filter_attrs(attrs)

--- a/app/models/recent_search.rb
+++ b/app/models/recent_search.rb
@@ -15,7 +15,7 @@ class RecentSearch < ApplicationRecord
   scope :for_display, -> { active.limit(10) }
 
   def search_params
-    params = search_attributes.symbolize_keys
+    params = (search_attributes || {}).symbolize_keys
     params[:subjects] = subjects if subjects.present?
     params[:longitude] = longitude if longitude.present?
     params[:latitude] = latitude if latitude.present?

--- a/app/services/find/filter_key_digest.rb
+++ b/app/services/find/filter_key_digest.rb
@@ -6,7 +6,6 @@ module Find
   class FilterKeyDigest
     # Keys that determine what courses match — excludes display-only keys
     FILTER_KEYS = %w[
-      applications_open
       can_sponsor_visa
       engineers_teach_physics
       funding

--- a/app/services/find/filter_key_digest.rb
+++ b/app/services/find/filter_key_digest.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Find
+  # Functions to hash Find search params
+  # Used to compare live search with RecentSearch and EmailAlert search attributes
   class FilterKeyDigest
     # Keys that determine what courses match — excludes display-only keys
     FILTER_KEYS = %w[
@@ -9,9 +11,15 @@ module Find
       engineers_teach_physics
       funding
       interview_location
+      latitude
       level
+      location
+      longitude
       minimum_degree_required
+      provider_code
+      provider_name
       qualifications
+      radius
       send_courses
       start_date
       study_types

--- a/app/services/find/filter_key_digest.rb
+++ b/app/services/find/filter_key_digest.rb
@@ -34,6 +34,7 @@ module Find
       (attrs || {}).stringify_keys
         .slice(*FILTER_KEYS)
         .transform_values { |v| v.is_a?(Array) ? v.map(&:to_s) : v.to_s }
+        .compact_blank
     end
   end
 end

--- a/app/views/email_alert_mailer/weekly_digest.text.erb
+++ b/app/views/email_alert_mailer/weekly_digest.text.erb
@@ -1,5 +1,3 @@
-<%= @title %>
-
 <%= @body_intro %>
 
 ---

--- a/app/views/email_alert_mailer/weekly_digest.text.erb
+++ b/app/views/email_alert_mailer/weekly_digest.text.erb
@@ -13,7 +13,7 @@
 <% end -%>
 ---
 
-# Your email alert criteria
+## Your email alert criteria
 
 <% @summary_rows.each do |row| -%>
 <%= row[:label] %>: <%= row[:value] %>

--- a/app/views/find/candidates/email_alerts/confirm_unsubscribe.html.erb
+++ b/app/views/find/candidates/email_alerts/confirm_unsubscribe.html.erb
@@ -4,14 +4,16 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-    <ul class="app-recent-search-tags govuk-!-margin-bottom-4">
-      <% @filter_tags.each do |tag_text| %>
-        <li><span class="app-recent-search-tag"><%= tag_text %></span></li>
+    <dl class="govuk-summary-list">
+      <% @summary_rows.each do |row| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><%= row[:label] %></dt>
+          <dd class="govuk-summary-list__value"><%= row[:value] %></dd>
+        </div>
       <% end %>
-    </ul>
+    </dl>
 
     <p class="govuk-body"><%= t(".are_you_sure") %></p>
-
     <div class="govuk-button-group">
       <%= button_to t(".submit"),
           find_candidate_unsubscribe_email_alert_path(token: @email_alert.signed_id(purpose: :unsubscribe, expires_in: 30.days)),

--- a/app/views/find/candidates/email_alerts/confirm_unsubscribe.html.erb
+++ b/app/views/find/candidates/email_alerts/confirm_unsubscribe.html.erb
@@ -16,7 +16,8 @@
       <%= button_to t(".submit"),
           find_candidate_unsubscribe_email_alert_path(token: @email_alert.signed_id(purpose: :unsubscribe, expires_in: 30.days)),
           method: :delete,
-          class: "govuk-button govuk-button--warning" %>
+          class: "govuk-button govuk-button--warning",
+          form_class: "app-email-alert__unsubscribe-button" %>
       <%= govuk_link_to t(".cancel"), find_candidate_email_alerts_path, class: "govuk-link" %>
     </div>
   </div>

--- a/app/views/find/candidates/email_alerts/index.html.erb
+++ b/app/views/find/candidates/email_alerts/index.html.erb
@@ -9,7 +9,7 @@
     </p>
   </div>
 
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <% if @email_alerts.empty? %>
       <%= render Find::EmailAlerts::EmptyStateComponent.new %>
     <% else %>

--- a/app/views/find/candidates/email_alerts/new.html.erb
+++ b/app/views/find/candidates/email_alerts/new.html.erb
@@ -6,11 +6,11 @@
 
     <p class="govuk-body"><%= t(".intro") %></p>
 
-    <dl class="govuk-summary-list app-email-alert-summary">
+    <dl class="govuk-summary-list">
       <% @summary_rows.each do |row| %>
-        <div class="govuk-summary-list__row app-summary-list__row app-body">
-          <dt class="govuk-summary-list__key app-summary-list__key"><%= row[:label] %></dt>
-          <dd class="govuk-summary-list__value app-summary-list__value"><%= row[:value] %></dd>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><%= row[:label] %></dt>
+          <dd class="govuk-summary-list__value"><%= row[:value] %></dd>
         </div>
       <% end %>
     </dl>

--- a/app/views/find/candidates/email_alerts/unsubscribe_from_email.html.erb
+++ b/app/views/find/candidates/email_alerts/unsubscribe_from_email.html.erb
@@ -4,11 +4,14 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-    <ul class="app-recent-search-tags govuk-!-margin-bottom-4">
-      <% @filter_tags.each do |tag_text| %>
-        <li><span class="app-recent-search-tag"><%= tag_text %></span></li>
+    <dl class="govuk-summary-list">
+      <% @summary_rows.each do |row| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><%= row[:label] %></dt>
+          <dd class="govuk-summary-list__value"><%= row[:value] %></dd>
+        </div>
       <% end %>
-    </ul>
+    </dl>
 
     <p class="govuk-body"><%= t(".are_you_sure") %></p>
 

--- a/app/views/find/results/filters/_all.html.erb
+++ b/app/views/find/results/filters/_all.html.erb
@@ -1,6 +1,14 @@
 <%= render Find::Courses::ActiveFilters::View.new(active_filters: form.object.active_filters, search_params: form.object.search_params) %>
 
 <div data-controller="details-component" class="app-c-filter-panel__top">
+  <% if show_email_alert_link? %>
+    <p class="email-alert-link govuk-body govuk-!-margin-bottom-4">
+      <%= govuk_link_to new_find_candidate_email_alert_path(@search_params.except(:order, :page)), class: "govuk-link--no-visited-state" do %>
+        <%= render "shared/bell_icon" %>
+        <%= t(".set_up_email_alert") %>
+      <% end %>
+    </p>
+  <% end %>
   <div class="app-c-filter-section app-c-filter-section__summary" data-action="click->details-component#toggle">
     <div class="app-c-filter-panel__header">
       <button
@@ -12,6 +20,7 @@
          aria-controls="details-component-content">
         <h2 class="app-c-filter-section__summary-heading">Filter and Sort</h2>
       </button>
+
       <span class="govuk-hint app-results-indicator"><%= number_with_delimiter(@courses_count) %> results</span>
     </div>
   </div>
@@ -271,7 +280,7 @@
           <% form.object.qualification_options.each do |qualification_option| %>
             <%= form.govuk_check_box :qualifications, qualification_option, label: { text: t(".qualification_options.#{qualification_option}") }, include_hidden: false, form: form_id %>
           <% end %>
-       <% end %>
+        <% end %>
       </div>
     </details>
 

--- a/app/views/find/results/index.html.erb
+++ b/app/views/find/results/index.html.erb
@@ -75,7 +75,7 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <% if authenticated? && FeatureFlag.active?(:email_alerts) %>
+      <% if show_email_alert_link? %>
         <p class="govuk-body govuk-!-margin-bottom-4">
           <%= govuk_link_to new_find_candidate_email_alert_path(@search_params.except(:order, :page)), class: "govuk-link--no-visited-state" do %>
             <%= render "shared/bell_icon" %>

--- a/app/views/find/results/index.html.erb
+++ b/app/views/find/results/index.html.erb
@@ -75,15 +75,6 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <% if show_email_alert_link? %>
-        <p class="govuk-body govuk-!-margin-bottom-4">
-          <%= govuk_link_to new_find_candidate_email_alert_path(@search_params.except(:order, :page)), class: "govuk-link--no-visited-state" do %>
-            <%= render "shared/bell_icon" %>
-            <%= t(".set_up_email_alert") %>
-          <% end %>
-        </p>
-      <% end %>
-
       <% if @results.present? %>
         <ul class="app-search-results">
           <% @results.each do |course| %>

--- a/config/locales/en/find/candidates/email_alerts.yml
+++ b/config/locales/en/find/candidates/email_alerts.yml
@@ -32,7 +32,9 @@ en:
             provider_code: Provider
         create:
           success_title: Email alert created
-          success_body_html: "You have set up an email alert for %{title}. We'll email you weekly when new courses are added. You can unsubscribe at any time."
+          success_body_html: >
+            <p class="govuk-body">You have set up an email alert for %{title}.</p>
+            <p class="govuk-body">We'll email you weekly when new courses are added. You can %{unsubscribe_link} at any time.</p>
           create_failed: There was a problem creating your email alert. Please try again.
         confirm_unsubscribe:
           page_title: Unsubscribe from this email alert

--- a/config/locales/en/find/results.yml
+++ b/config/locales/en/find/results.yml
@@ -3,7 +3,6 @@ en:
     results:
       index:
         filter_results: Filter results
-        set_up_email_alert: Email me courses like this
       courses_guidance:
         show:
           heading: "Not sure which course is right for you?"

--- a/config/locales/en/find/results/filters/all.yml
+++ b/config/locales/en/find/results/filters/all.yml
@@ -26,6 +26,7 @@ en:
           filter_title_interviews: Online interviews
           filter_title_start_date: Start date
           filter_title_provider: Training provider
+          set_up_email_alert: Email me courses like this
           apply_filter: Apply filters
           sort_by_labels:
             distance: Distance

--- a/spec/mailers/email_alert_mailer_spec.rb
+++ b/spec/mailers/email_alert_mailer_spec.rb
@@ -173,7 +173,7 @@ describe EmailAlertMailer do
         body = mail.govuk_notify_personalisation[:body]
         expect(body).not_to include("](https://evil.com)")
         expect(body).not_to include("[pwned")
-        expect(body).to include("Provider: Evil Corphttps://evil.com pwned")
+        expect(body).to have_content("Provider: Evil Corphttps://evil.com pwned", normalize_ws: true)
       end
     end
   end

--- a/spec/models/candidate/email_alert_spec.rb
+++ b/spec/models/candidate/email_alert_spec.rb
@@ -17,16 +17,6 @@ RSpec.describe Candidate::EmailAlert, type: :model do
         expect(described_class.active).to contain_exactly(active)
       end
     end
-
-    describe ".subscribed" do
-      it "is an alias for active" do
-        active = create(:email_alert)
-        unsubscribed = create(:email_alert)
-        unsubscribed.unsubscribe!
-
-        expect(described_class.subscribed).to contain_exactly(active)
-      end
-    end
   end
 
   describe "validation" do
@@ -78,110 +68,6 @@ RSpec.describe Candidate::EmailAlert, type: :model do
       result = email_alert.search_params
 
       expect(result).to eq(level: "primary")
-    end
-  end
-
-  describe "#matches_search?" do
-    let(:search_attributes) do
-      {
-        "level" => "further_education",
-        "send_courses" => "true",
-        "qualifications" => %w[qts qts_with_pgce_or_pgde],
-        "minimum_degree_required" => "two_one",
-        "can_sponsor_visa" => "true",
-        "interview_location" => "online",
-        "start_date" => %w[jan_to_aug september oct_to_jul],
-      }
-    end
-
-    it "matches when subjects and search_attributes are identical" do
-      alert = build(:email_alert, subjects: %w[C1 F1 W1 L1 13 W3], search_attributes:)
-
-      expect(alert.matches_search?(subjects: %w[C1 F1 W1 L1 13 W3], search_attributes:)).to be true
-    end
-
-    it "matches regardless of subject order" do
-      alert = build(:email_alert, subjects: %w[13 C1 F1 L1 W1 W3], search_attributes:)
-
-      expect(alert.matches_search?(subjects: %w[W3 C1 13 F1 L1 W1], search_attributes:)).to be true
-    end
-
-    it "does not match when subjects differ" do
-      alert = build(:email_alert, subjects: %w[C1 F1], search_attributes:)
-
-      expect(alert.matches_search?(subjects: %w[C1], search_attributes:)).to be false
-    end
-
-    it "does not match when search_attributes differ" do
-      alert = build(:email_alert, subjects: %w[C1], search_attributes:)
-
-      different_attrs = search_attributes.merge("level" => "secondary")
-      expect(alert.matches_search?(subjects: %w[C1], search_attributes: different_attrs)).to be false
-    end
-
-    it "does not match an unsubscribed alert via active scope" do
-      candidate = create(:candidate)
-      alert = create(:email_alert, candidate:, subjects: %w[C1], search_attributes:)
-      alert.unsubscribe!
-
-      expect(
-        candidate.email_alerts.active
-          .pluck(:subjects, :search_attributes)
-          .map { |s, a| [s.sort, a] }
-          .to_set
-          .include?([%w[C1], search_attributes]),
-      ).to be false
-    end
-
-    it "ignores return_to key in search_attributes" do
-      alert = build(:email_alert, subjects: %w[C1], search_attributes:)
-
-      expect(alert.matches_search?(subjects: %w[C1], search_attributes: search_attributes.merge("return_to" => "recent_searches"))).to be true
-    end
-
-    it "matches when alert has string 'true' and recent search has boolean true" do
-      # Email alerts store "true" (string via strong params)
-      # Recent searches store true (boolean via JSONB)
-      alert_attrs = { "can_sponsor_visa" => "true", "send_courses" => "true", "level" => "further_education" }
-      recent_attrs = { "can_sponsor_visa" => true, "send_courses" => true, "level" => "further_education" }
-
-      alert = create(:email_alert, subjects: %w[C1], search_attributes: alert_attrs).reload
-
-      # Verify the type mismatch exists
-      expect(alert.search_attributes["can_sponsor_visa"]).to be_a(String)
-      expect(recent_attrs["can_sponsor_visa"]).to be(true)
-
-      expect(alert.matches_search?(subjects: %w[C1], search_attributes: recent_attrs)).to be true
-    end
-
-    it "matches via filter_key when types differ between alert and recent search" do
-      alert_attrs = { "can_sponsor_visa" => "true", "send_courses" => "true", "level" => "further_education" }
-      recent_attrs = { "can_sponsor_visa" => true, "send_courses" => true, "level" => "further_education" }
-
-      alert = create(:email_alert, subjects: %w[C1], search_attributes: alert_attrs).reload
-
-      alert_key = alert.filter_key
-      normalized_recent_attrs = Find::FilterKeyDigest.normalize(recent_attrs)
-      recent_key = [%w[C1], normalized_recent_attrs]
-
-      expect(Set[alert_key].include?(recent_key)).to be true
-    end
-
-    it "matches when alert is missing a display-only key present in the recent search" do
-      alert = build(:email_alert, subjects: %w[C1], search_attributes: {
-        "level" => "further_education",
-        "can_sponsor_visa" => "true",
-      })
-
-      recent_attrs = {
-        "level" => "further_education",
-        "can_sponsor_visa" => "true",
-        "location" => "Manchester",
-        "radius" => "50",
-        "order" => "distance",
-      }
-
-      expect(alert.matches_search?(subjects: %w[C1], search_attributes: recent_attrs)).to be true
     end
   end
 

--- a/spec/models/concerns/filter_key_digestable_spec.rb
+++ b/spec/models/concerns/filter_key_digestable_spec.rb
@@ -51,17 +51,9 @@ RSpec.describe FilterKeyDigestable do
 
     it "ignores display-only keys in search_attributes" do
       alert1 = create(:email_alert, subjects: %w[C1], search_attributes: { "level" => "secondary" })
-      alert2 = create(:email_alert, subjects: %w[C1], search_attributes: { "level" => "secondary", "location" => "London" })
+      alert2 = create(:email_alert, subjects: %w[C1], search_attributes: { "level" => "secondary", "order" => "course_name_ascending" })
 
       expect(alert1.filter_key_digest).to eq(alert2.filter_key_digest)
-    end
-
-    it "handles nil search_attributes" do
-      alert = build(:email_alert, subjects: %w[C1], search_attributes: nil)
-      # Manually bypass validation to test nil handling
-      alert.instance_variable_set(:@search_attributes_override, true)
-
-      expect(alert.compute_filter_key_digest).to be_present
     end
 
     it "normalizes boolean-like values to strings" do

--- a/spec/services/find/filter_key_digest_spec.rb
+++ b/spec/services/find/filter_key_digest_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Find::FilterKeyDigest do
 
     it "ignores display-only keys" do
       expect(described_class.digest(subjects: %w[C1], search_attributes: { "level" => "secondary" }))
-        .to eq(described_class.digest(subjects: %w[C1], search_attributes: { "level" => "secondary", "location" => "London" }))
+        .to eq(described_class.digest(subjects: %w[C1], search_attributes: { "level" => "secondary", "order" => "course_name_ascending" }))
     end
 
     it "handles nil search_attributes" do
@@ -54,7 +54,7 @@ RSpec.describe Find::FilterKeyDigest do
 
   describe ".normalize" do
     it "only keeps FILTER_KEYS" do
-      result = described_class.normalize("level" => "secondary", "location" => "London", "funding" => "salary")
+      result = described_class.normalize("level" => "secondary", "order" => "course_name_ascending", "funding" => "salary")
 
       expect(result.keys).to contain_exactly("level", "funding")
     end

--- a/spec/system/find/results/email_alert_link_spec.rb
+++ b/spec/system/find/results/email_alert_link_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "./filtering_helper"
+
+RSpec.describe "Email alert link on results page", service: :find do
+  include FilteringHelper
+
+  before do
+    FeatureFlag.activate(:candidate_accounts)
+    FeatureFlag.activate(:email_alerts)
+    CandidateAuthHelper.mock_auth
+    given_there_are_courses_with_secondary_subjects
+  end
+
+  scenario "Signed in user with filters applied sees the email alert link" do
+    when_i_sign_in
+    when_i_visit_results_with_subject_filter
+    then_i_see_the_email_alert_link
+  end
+
+  scenario "Signed out user does not see the email alert link" do
+    when_i_visit_results_with_subject_filter
+    then_i_do_not_see_the_email_alert_link
+  end
+
+  scenario "Email alert link is hidden when feature flag is off" do
+    FeatureFlag.deactivate(:email_alerts)
+    when_i_sign_in
+    when_i_visit_results_with_subject_filter
+    then_i_do_not_see_the_email_alert_link
+  end
+
+  scenario "Email alert link is hidden when no filters are applied" do
+    when_i_sign_in
+    when_i_visit_the_find_results_page
+    then_i_do_not_see_the_email_alert_link
+  end
+
+  scenario "Email alert link is hidden when an active alert exists for the search" do
+    when_i_sign_in
+    and_i_have_an_active_alert_for_the_search
+    when_i_visit_results_with_subject_filter
+    then_i_do_not_see_the_email_alert_link
+  end
+
+  scenario "Email alert link is shown when alert for the search has been unsubscribed" do
+    when_i_sign_in
+    and_i_have_an_unsubscribed_alert_for_the_search
+    when_i_visit_results_with_subject_filter
+    then_i_see_the_email_alert_link
+  end
+
+  def when_i_sign_in
+    visit "/"
+    click_link_or_button "Sign in"
+  end
+
+  def when_i_visit_results_with_subject_filter
+    biology = Subject.find_by(subject_name: "Biology")
+    visit find_results_path(subjects: [biology.subject_code])
+  end
+
+  def then_i_see_the_email_alert_link
+    expect(page).to have_link("Email me courses like this")
+  end
+
+  def then_i_do_not_see_the_email_alert_link
+    expect(page).not_to have_link("Email me courses like this")
+  end
+
+  def candidate
+    Candidate.first
+  end
+
+  def and_i_have_an_active_alert_for_the_search
+    biology = Subject.find_by(subject_name: "Biology")
+
+    create(
+      :email_alert,
+      candidate:,
+      subjects: [biology.subject_code],
+      search_attributes: search_attributes_for_subject_filter,
+    )
+  end
+
+  def and_i_have_an_unsubscribed_alert_for_the_search
+    biology = Subject.find_by(subject_name: "Biology")
+
+    alert = create(
+      :email_alert,
+      candidate:,
+      subjects: [biology.subject_code],
+      search_attributes: search_attributes_for_subject_filter,
+    )
+    alert.unsubscribe!
+  end
+
+  def search_attributes_for_subject_filter
+    { "minimum_degree_required" => "show_all_courses" }
+  end
+end

--- a/spec/system/find/results/email_alert_link_spec.rb
+++ b/spec/system/find/results/email_alert_link_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Email alert link on results page", service: :find do
     FeatureFlag.activate(:email_alerts)
     CandidateAuthHelper.mock_auth
     given_there_are_courses_with_secondary_subjects
+    stub_address_country("England")
   end
 
   scenario "Signed in user with filters applied sees the email alert link" do
@@ -48,6 +49,20 @@ RSpec.describe "Email alert link on results page", service: :find do
   scenario "Email alert link is shown when alert for the search has been unsubscribed" do
     when_i_sign_in
     and_i_have_an_unsubscribed_alert_for_the_search
+    when_i_visit_results_with_subject_filter
+    then_i_see_the_email_alert_link
+  end
+
+  scenario "Email alert link is hidden when the location is outside England" do
+    stub_address_country("Scotland")
+    when_i_sign_in
+    when_i_visit_results_with_subject_filter
+    then_i_do_not_see_the_email_alert_link
+  end
+
+  scenario "Email alert link is shown when no location is resolved" do
+    stub_address_country(nil)
+    when_i_sign_in
     when_i_visit_results_with_subject_filter
     then_i_see_the_email_alert_link
   end
@@ -99,5 +114,11 @@ RSpec.describe "Email alert link on results page", service: :find do
 
   def search_attributes_for_subject_filter
     { "minimum_degree_required" => "show_all_courses" }
+  end
+
+  def stub_address_country(country)
+    allow(Geolocation::Address).to receive(:query).and_return(
+      Geolocation::Address.new(country:),
+    )
   end
 end

--- a/spec/system/find/results/email_alert_link_spec.rb
+++ b/spec/system/find/results/email_alert_link_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe "Email alert link on results page", service: :find do
   end
 
   scenario "Email alert link is hidden when feature flag is off" do
-    FeatureFlag.deactivate(:email_alerts)
+    allow(FeatureFlag).to receive(:active?).and_call_original
+    allow(FeatureFlag).to receive(:active?).with(:email_alerts).and_return(false)
     when_i_sign_in
     when_i_visit_results_with_subject_filter
     then_i_do_not_see_the_email_alert_link


### PR DESCRIPTION
## Context

We have completed 90% of the email alerts feature. We have some snags that need to be corrected before we can launch.

## Changes proposed in this pull request


- [x] Fix email criteria formatting
Remove the Subject text from the email body
- [ ] Unsubscribe button should fill width (email body)
We can't control the Notify email body formatting in the ways we'd like so that item cannot be complete.
- [x] Unsubscribe button should fill width (in service)
Apply 100% width on the button form
- [x] Hide Email courses link when no filters applied
Control when the email subscribe button appears
- [x] Email me courses like this should be in the filter panel
Move the link to the filter panel and move the clear all link next to the heading
- [x] Fix formatting on email alert confirmation summary table
Needs to be QA'd
- [x] Fix formatting in email alert create success flash banner
New lines respected and unsubscribe link added
- [x] Email alert index should be 2/3 width
Done


### Extra
Add coordinates, location and radius to FilterKeyDigest
Remove application_open from filter digest


### Hide 'Email me courses liek this' link conditionally

This is the most complicated part of this PR.


|Condition| Result|
|---|---|
|When a candidate is not logged in| Hide|
|When a search does not have specific filters |Hide|
|When a search contains the same specific filters as an existing email alert| Hide|




## Guidance to review

What if we add a new filter to Find? What affect would that have on the email alert digest?
## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
