### PR TITLE
School remodel backfill join tables

### DIFF
--- a/app/models/data_hub/schools_backfill_process_summary.rb
+++ b/app/models/data_hub/schools_backfill_process_summary.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DataHub
+  class SchoolsBackfillProcessSummary < ProcessSummary
+    jsonb_accessor :short_summary,
+                   provider_schools_inserted: [:integer, { default: 0 }],
+                   course_schools_inserted: [:integer, { default: 0 }],
+                   sites_skipped: [:integer, { default: 0 }],
+                   course_sites_skipped: [:integer, { default: 0 }]
+
+    jsonb_accessor :full_summary,
+                   skipped_sites_csv_path: :string,
+                   skipped_course_sites_csv_path: :string
+  end
+end

--- a/app/models/data_hub/schools_backfill_process_summary.rb
+++ b/app/models/data_hub/schools_backfill_process_summary.rb
@@ -9,7 +9,7 @@ module DataHub
                    course_sites_skipped: [:integer, { default: 0 }]
 
     jsonb_accessor :full_summary,
-                   skipped_sites_csv_path: :string,
-                   skipped_course_sites_csv_path: :string
+                   skipped_sites: [:jsonb, { array: true, default: [] }],
+                   skipped_course_sites: [:jsonb, { array: true, default: [] }]
   end
 end

--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "csv"
+require "fileutils"
+
+module DataHub
+  module SchoolsBackfill
+    class Executor
+      def initialize(tmp_dir: Rails.root.join("tmp"))
+        @tmp_dir = Pathname.new(tmp_dir)
+      end
+
+      def execute
+        process_summary = DataHub::SchoolsBackfillProcessSummary.start!
+
+        skipped_sites_csv_path        = @tmp_dir.join("schools_backfill_skipped_sites_#{process_summary.id}.csv")
+        skipped_course_sites_csv_path = @tmp_dir.join("schools_backfill_skipped_course_sites_#{process_summary.id}.csv")
+
+        ActiveRecord::Base.transaction do
+          sites_skipped             = write_skipped_sites_csv(skipped_sites_csv_path)
+          provider_schools_inserted = insert_provider_schools
+
+          course_sites_skipped    = write_skipped_course_sites_csv(skipped_course_sites_csv_path)
+          course_schools_inserted = insert_course_schools
+
+          process_summary.finish!(
+            short_summary: {
+              provider_schools_inserted: provider_schools_inserted,
+              course_schools_inserted: course_schools_inserted,
+              sites_skipped: sites_skipped,
+              course_sites_skipped: course_sites_skipped,
+            },
+            full_summary: {
+              skipped_sites_csv_path: skipped_sites_csv_path.to_s,
+              skipped_course_sites_csv_path: skipped_course_sites_csv_path.to_s,
+            },
+          )
+        end
+
+        process_summary
+      rescue StandardError => e
+        process_summary&.fail!(e)
+        raise
+      end
+
+    private
+
+      def insert_provider_schools
+        inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
+          INSERT INTO provider_school (provider_id, gias_school_id, site_code, created_at, updated_at)
+          SELECT DISTINCT ON (site.provider_id, gias_school.id, site.code)
+                 site.provider_id, gias_school.id, site.code, NOW(), NOW()
+          FROM site
+          JOIN gias_school ON gias_school.urn = site.urn
+          WHERE site.site_type = 0
+            AND site.discarded_at IS NULL
+            AND site.urn IS NOT NULL
+            AND site.urn <> ''
+          ON CONFLICT DO NOTHING
+          RETURNING 1
+        SQL
+        inserted_rows.length
+      end
+
+      def insert_course_schools
+        inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
+          INSERT INTO course_school (course_id, gias_school_id, site_code, created_at, updated_at)
+          SELECT DISTINCT ON (course_site.course_id, gias_school.id, site.code)
+                 course_site.course_id, gias_school.id, site.code, NOW(), NOW()
+          FROM course_site
+          JOIN site        ON site.id = course_site.site_id
+          JOIN gias_school ON gias_school.urn = site.urn
+          WHERE site.site_type = 0
+            AND site.discarded_at IS NULL
+            AND site.urn IS NOT NULL
+            AND site.urn <> ''
+          ON CONFLICT DO NOTHING
+          RETURNING 1
+        SQL
+        inserted_rows.length
+      end
+
+      def write_skipped_sites_csv(csv_path)
+        skipped_rows = ActiveRecord::Base.connection.exec_query(<<~SQL).to_a
+          SELECT site.id AS site_id,
+                 site.provider_id,
+                 site.code,
+                 site.urn,
+                 site.location_name,
+                 CASE
+                   WHEN site.urn IS NULL OR site.urn = '' THEN 'no_urn'
+                   ELSE 'urn_not_in_gias_school'
+                 END AS reason
+          FROM site
+          LEFT JOIN gias_school ON gias_school.urn = site.urn
+          WHERE site.site_type = 0
+            AND site.discarded_at IS NULL
+            AND (site.urn IS NULL OR site.urn = '' OR gias_school.id IS NULL)
+          ORDER BY site.id
+        SQL
+        write_csv(csv_path, %w[site_id provider_id code urn location_name reason], skipped_rows)
+        skipped_rows.length
+      end
+
+      def write_skipped_course_sites_csv(csv_path)
+        skipped_rows = ActiveRecord::Base.connection.exec_query(<<~SQL).to_a
+          SELECT course_site.course_id,
+                 course_site.site_id,
+                 site.provider_id,
+                 site.code,
+                 site.urn,
+                 CASE
+                   WHEN site.id IS NULL THEN 'site_missing'
+                   WHEN site.site_type <> 0 THEN 'non_school_site'
+                   WHEN site.discarded_at IS NOT NULL THEN 'site_discarded'
+                   WHEN site.urn IS NULL OR site.urn = '' THEN 'no_urn'
+                   ELSE 'urn_not_in_gias_school'
+                 END AS reason
+          FROM course_site
+          LEFT JOIN site        ON site.id = course_site.site_id
+          LEFT JOIN gias_school ON gias_school.urn = site.urn
+          WHERE site.id IS NULL
+             OR site.site_type <> 0
+             OR site.discarded_at IS NOT NULL
+             OR site.urn IS NULL
+             OR site.urn = ''
+             OR gias_school.id IS NULL
+          ORDER BY course_site.course_id, course_site.site_id
+        SQL
+        write_csv(csv_path, %w[course_id site_id provider_id code urn reason], skipped_rows)
+        skipped_rows.length
+      end
+
+      def write_csv(csv_path, headers, rows)
+        FileUtils.mkdir_p(File.dirname(csv_path))
+        CSV.open(csv_path, "w") do |csv|
+          csv << headers
+          rows.each { |row| csv << headers.map { |header| row[header] } }
+        end
+      end
+    end
+  end
+end

--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -1,38 +1,28 @@
 # frozen_string_literal: true
 
-require "csv"
-require "fileutils"
-
 module DataHub
   module SchoolsBackfill
     class Executor
-      def initialize(tmp_dir: Rails.root.join("tmp"))
-        @tmp_dir = Pathname.new(tmp_dir)
-      end
-
       def execute
         process_summary = DataHub::SchoolsBackfillProcessSummary.start!
 
-        skipped_sites_csv_path        = @tmp_dir.join("schools_backfill_skipped_sites_#{process_summary.id}.csv")
-        skipped_course_sites_csv_path = @tmp_dir.join("schools_backfill_skipped_course_sites_#{process_summary.id}.csv")
-
         ActiveRecord::Base.transaction do
-          sites_skipped             = write_skipped_sites_csv(skipped_sites_csv_path)
+          skipped_sites             = fetch_skipped_sites
           provider_schools_inserted = insert_provider_schools
 
-          course_sites_skipped    = write_skipped_course_sites_csv(skipped_course_sites_csv_path)
+          skipped_course_sites    = fetch_skipped_course_sites
           course_schools_inserted = insert_course_schools
 
           process_summary.finish!(
             short_summary: {
               provider_schools_inserted: provider_schools_inserted,
               course_schools_inserted: course_schools_inserted,
-              sites_skipped: sites_skipped,
-              course_sites_skipped: course_sites_skipped,
+              sites_skipped: skipped_sites.length,
+              course_sites_skipped: skipped_course_sites.length,
             },
             full_summary: {
-              skipped_sites_csv_path: skipped_sites_csv_path.to_s,
-              skipped_course_sites_csv_path: skipped_course_sites_csv_path.to_s,
+              skipped_sites: skipped_sites,
+              skipped_course_sites: skipped_course_sites,
             },
           )
         end
@@ -80,8 +70,8 @@ module DataHub
         inserted_rows.length
       end
 
-      def write_skipped_sites_csv(csv_path)
-        skipped_rows = ActiveRecord::Base.connection.exec_query(<<~SQL).to_a
+      def fetch_skipped_sites
+        ActiveRecord::Base.connection.exec_query(<<~SQL).to_a
           SELECT site.id AS site_id,
                  site.provider_id,
                  site.code,
@@ -98,12 +88,10 @@ module DataHub
             AND (site.urn IS NULL OR site.urn = '' OR gias_school.id IS NULL)
           ORDER BY site.id
         SQL
-        write_csv(csv_path, %w[site_id provider_id code urn location_name reason], skipped_rows)
-        skipped_rows.length
       end
 
-      def write_skipped_course_sites_csv(csv_path)
-        skipped_rows = ActiveRecord::Base.connection.exec_query(<<~SQL).to_a
+      def fetch_skipped_course_sites
+        ActiveRecord::Base.connection.exec_query(<<~SQL).to_a
           SELECT course_site.course_id,
                  course_site.site_id,
                  site.provider_id,
@@ -127,16 +115,6 @@ module DataHub
              OR gias_school.id IS NULL
           ORDER BY course_site.course_id, course_site.site_id
         SQL
-        write_csv(csv_path, %w[course_id site_id provider_id code urn reason], skipped_rows)
-        skipped_rows.length
-      end
-
-      def write_csv(csv_path, headers, rows)
-        FileUtils.mkdir_p(File.dirname(csv_path))
-        CSV.open(csv_path, "w") do |csv|
-          csv << headers
-          rows.each { |row| csv << headers.map { |header| row[header] } }
-        end
       end
     end
   end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -46,8 +46,8 @@
   - course_schools_inserted
   - sites_skipped
   - course_sites_skipped
-  - skipped_sites_csv_path
-  - skipped_course_sites_csv_path
+  - skipped_sites
+  - skipped_course_sites
   - discarded_total_count
   - discarded_lack_urn
   - discarded_invalid_gias_urn

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -42,6 +42,12 @@
   - site_statuses_merged
   - site_statuses_removed
   - deduplicated_groups
+  - provider_schools_inserted
+  - course_schools_inserted
+  - sites_skipped
+  - course_sites_skipped
+  - skipped_sites_csv_path
+  - skipped_course_sites_csv_path
   - discarded_total_count
   - discarded_lack_urn
   - discarded_invalid_gias_urn

--- a/lib/tasks/schools_backfill.rake
+++ b/lib/tasks/schools_backfill.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :schools_backfill do
+  desc "Backfill provider_school and course_school from legacy site data"
+  task run: :environment do
+    summary = DataHub::SchoolsBackfill::Executor.new.execute
+    pp summary.short_summary
+    pp summary.full_summary
+  end
+end

--- a/spec/lib/tasks/schools_backfill_rake_spec.rb
+++ b/spec/lib/tasks/schools_backfill_rake_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+describe "schools_backfill:run" do
+  subject(:invoke_task) { Rake::Task["schools_backfill:run"].reenable && Rake::Task["schools_backfill:run"].invoke }
+
+  before { Rails.application.load_tasks if Rake::Task.tasks.empty? }
+
+  it "invokes DataHub::SchoolsBackfill::Executor and prints both summaries" do
+    executor = instance_double(DataHub::SchoolsBackfill::Executor)
+    fake_summary = instance_double(
+      DataHub::SchoolsBackfillProcessSummary,
+      short_summary: { "provider_schools_inserted" => 0 },
+      full_summary: { "skipped_sites_csv_path" => "tmp/foo.csv" },
+    )
+
+    allow(DataHub::SchoolsBackfill::Executor).to receive(:new).and_return(executor)
+    allow(executor).to receive(:execute).and_return(fake_summary)
+
+    expect { invoke_task }.to output.to_stdout
+    expect(executor).to have_received(:execute)
+  end
+end

--- a/spec/lib/tasks/schools_backfill_rake_spec.rb
+++ b/spec/lib/tasks/schools_backfill_rake_spec.rb
@@ -4,9 +4,11 @@ require "rails_helper"
 require "rake"
 
 describe "schools_backfill:run" do
-  subject(:invoke_task) { Rake::Task["schools_backfill:run"].reenable && Rake::Task["schools_backfill:run"].invoke }
+  Rails.application.load_tasks if Rake::Task.tasks.empty?
 
-  before { Rails.application.load_tasks if Rake::Task.tasks.empty? }
+  subject(:run_task) { Rake::Task["schools_backfill:run"].invoke }
+
+  before { Rake::Task["schools_backfill:run"].reenable }
 
   it "invokes DataHub::SchoolsBackfill::Executor and prints both summaries" do
     executor = instance_double(DataHub::SchoolsBackfill::Executor)
@@ -19,7 +21,7 @@ describe "schools_backfill:run" do
     allow(DataHub::SchoolsBackfill::Executor).to receive(:new).and_return(executor)
     allow(executor).to receive(:execute).and_return(fake_summary)
 
-    expect { invoke_task }.to output.to_stdout
+    expect { run_task }.to output.to_stdout
     expect(executor).to have_received(:execute)
   end
 end

--- a/spec/services/data_hub/schools_backfill/executor_spec.rb
+++ b/spec/services/data_hub/schools_backfill/executor_spec.rb
@@ -3,15 +3,7 @@
 require "rails_helper"
 
 describe DataHub::SchoolsBackfill::Executor do
-  subject(:executor) { described_class.new(tmp_dir: tmp_dir) }
-
-  let(:tmp_dir) { Pathname.new(Dir.mktmpdir("schools_backfill_spec")) }
-
-  after { FileUtils.remove_entry(tmp_dir) if tmp_dir.exist? }
-
-  def csv_rows(path)
-    CSV.read(path, headers: true).map(&:to_h)
-  end
+  subject(:executor) { described_class.new }
 
   describe "#execute" do
     context "with a provider whose school-type site has a matching GIAS school" do
@@ -83,11 +75,9 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(Provider::School.where(provider_id: provider.id)).to be_empty
       end
 
-      it "lists the site in the skipped-sites CSV with reason 'no_urn'" do
+      it "records the site in skipped_sites with reason 'no_urn'" do
         summary = executor.execute
-        path = summary.full_summary["skipped_sites_csv_path"]
-        rows = csv_rows(path)
-        skipped = rows.find { |row| row["site_id"] == site.id.to_s }
+        skipped = summary.full_summary["skipped_sites"].find { |row| row["site_id"] == site.id }
         expect(skipped).to include("reason" => "no_urn")
       end
     end
@@ -103,10 +93,9 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(Provider::School.where(provider_id: provider.id)).to be_empty
       end
 
-      it "lists the site in the skipped-sites CSV with reason 'urn_not_in_gias_school'" do
+      it "records the site in skipped_sites with reason 'urn_not_in_gias_school'" do
         summary = executor.execute
-        path = summary.full_summary["skipped_sites_csv_path"]
-        skipped = csv_rows(path).find { |row| row["site_id"] == site.id.to_s }
+        skipped = summary.full_summary["skipped_sites"].find { |row| row["site_id"] == site.id }
         expect(skipped).to include("reason" => "urn_not_in_gias_school")
       end
     end
@@ -129,11 +118,10 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(Provider::School.where(provider_id: provider.id)).to be_empty
       end
 
-      it "does not list the site in the skipped-sites CSV" do
+      it "does not record the site in skipped_sites" do
         summary = executor.execute
-        path = summary.full_summary["skipped_sites_csv_path"]
-        ids = csv_rows(path).map { |row| row["site_id"] }
-        expect(ids).not_to include(site.id.to_s)
+        ids = summary.full_summary["skipped_sites"].map { |row| row["site_id"] }
+        expect(ids).not_to include(site.id)
       end
     end
 
@@ -149,11 +137,10 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(Provider::School.where(provider_id: provider.id)).to be_empty
       end
 
-      it "does not list the site in the skipped-sites CSV" do
+      it "does not record the site in skipped_sites" do
         summary = executor.execute
-        path = summary.full_summary["skipped_sites_csv_path"]
-        ids = csv_rows(path).map { |row| row["site_id"] }
-        expect(ids).not_to include(site.id.to_s)
+        ids = summary.full_summary["skipped_sites"].map { |row| row["site_id"] }
+        expect(ids).not_to include(site.id)
       end
     end
 
@@ -172,7 +159,7 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(first.short_summary["provider_schools_inserted"]).to eq(1)
         expect(first.short_summary["course_schools_inserted"]).to eq(1)
 
-        expect { described_class.new(tmp_dir: tmp_dir).execute }
+        expect { described_class.new.execute }
           .to not_change { Provider::School.count }
           .and(not_change { Course::School.count })
 
@@ -183,7 +170,7 @@ describe DataHub::SchoolsBackfill::Executor do
     end
 
     context "process summary lifecycle" do
-      it "returns a finished DataHub::SchoolsBackfillProcessSummary with counts and csv paths" do
+      it "returns a finished summary with counts and skipped-row details" do
         provider = create(:provider)
         gias_school = create(:gias_school, urn: "600006")
         create(:site, provider: provider, urn: gias_school.urn, code: "G")
@@ -194,12 +181,12 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(summary.status).to eq("finished")
         expect(summary.finished_at).to be_present
         expect(summary.short_summary["provider_schools_inserted"]).to eq(1)
-        expect(summary.full_summary["skipped_sites_csv_path"]).to include("schools_backfill_skipped_sites_")
-        expect(summary.full_summary["skipped_course_sites_csv_path"]).to include("schools_backfill_skipped_course_sites_")
+        expect(summary.full_summary["skipped_sites"]).to eq([])
+        expect(summary.full_summary["skipped_course_sites"]).to eq([])
       end
 
       it "marks the summary as failed and re-raises on error" do
-        failing_executor = described_class.new(tmp_dir: tmp_dir)
+        failing_executor = described_class.new
         allow(failing_executor).to receive(:insert_course_schools).and_raise(StandardError, "boom")
 
         expect { failing_executor.execute }.to raise_error(StandardError, "boom")
@@ -214,7 +201,7 @@ describe DataHub::SchoolsBackfill::Executor do
         gias_school = create(:gias_school, urn: "700007")
         create(:site, provider: provider, urn: gias_school.urn, code: "H")
 
-        failing_executor = described_class.new(tmp_dir: tmp_dir)
+        failing_executor = described_class.new
         allow(failing_executor).to receive(:insert_course_schools).and_raise(StandardError, "boom")
 
         expect { failing_executor.execute }.to raise_error(StandardError, "boom")

--- a/spec/services/data_hub/schools_backfill/executor_spec.rb
+++ b/spec/services/data_hub/schools_backfill/executor_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DataHub::SchoolsBackfill::Executor do
+  subject(:executor) { described_class.new(tmp_dir: tmp_dir) }
+
+  let(:tmp_dir) { Pathname.new(Dir.mktmpdir("schools_backfill_spec")) }
+
+  after { FileUtils.remove_entry(tmp_dir) if tmp_dir.exist? }
+
+  def csv_rows(path)
+    CSV.read(path, headers: true).map(&:to_h)
+  end
+
+  describe "#execute" do
+    context "with a provider whose school-type site has a matching GIAS school" do
+      let(:provider) { create(:provider) }
+      let(:gias_school) { create(:gias_school, urn: "100001") }
+      let!(:site) do
+        create(:site, provider: provider, urn: gias_school.urn, code: "A")
+      end
+
+      it "inserts one provider_school row matching the source site" do
+        executor.execute
+
+        provider_school = Provider::School.find_by!(
+          provider_id: provider.id,
+          gias_school_id: gias_school.id,
+        )
+        expect(provider_school.site_code).to eq("A")
+      end
+
+      it "does not insert provider_school for a different gias_school" do
+        other_gias_school = create(:gias_school, urn: "999999")
+        executor.execute
+
+        expect(
+          Provider::School.where(
+            provider_id: provider.id,
+            gias_school_id: other_gias_school.id,
+          ),
+        ).to be_empty
+      end
+    end
+
+    context "with a course_site linked to a school whose URN matches GIAS" do
+      let(:provider) { create(:provider) }
+      let(:gias_school) { create(:gias_school, urn: "200002") }
+      let(:site) do
+        create(:site, provider: provider, urn: gias_school.urn, code: "B")
+      end
+      let(:course) { create(:course, provider: provider) }
+      let!(:site_status) do
+        create(:site_status, course: course, site: site)
+      end
+
+      it "inserts one course_school row with the correct site_code" do
+        executor.execute
+
+        course_school = Course::School.find_by!(
+          course_id: course.id,
+          gias_school_id: gias_school.id,
+        )
+        expect(course_school.site_code).to eq("B")
+      end
+
+      it "copies unpublished course_site rows too (parity with source)" do
+        expect(Course::School.where(course_id: course.id).count).to eq(0)
+        executor.execute
+        expect(Course::School.where(course_id: course.id).count).to eq(1)
+      end
+    end
+
+    context "with a site whose URN is nil" do
+      let(:provider) { create(:provider) }
+      let!(:site) do
+        create(:site, provider: provider, urn: nil, code: "-", location_name: "Main")
+      end
+
+      it "does not insert a provider_school row" do
+        executor.execute
+        expect(Provider::School.where(provider_id: provider.id)).to be_empty
+      end
+
+      it "lists the site in the skipped-sites CSV with reason 'no_urn'" do
+        summary = executor.execute
+        path = summary.full_summary["skipped_sites_csv_path"]
+        rows = csv_rows(path)
+        skipped = rows.find { |row| row["site_id"] == site.id.to_s }
+        expect(skipped).to include("reason" => "no_urn")
+      end
+    end
+
+    context "with a site whose URN does not match any GIAS school" do
+      let(:provider) { create(:provider) }
+      let!(:site) do
+        create(:site, provider: provider, urn: "900009", code: "C")
+      end
+
+      it "does not insert a provider_school row" do
+        executor.execute
+        expect(Provider::School.where(provider_id: provider.id)).to be_empty
+      end
+
+      it "lists the site in the skipped-sites CSV with reason 'urn_not_in_gias_school'" do
+        summary = executor.execute
+        path = summary.full_summary["skipped_sites_csv_path"]
+        skipped = csv_rows(path).find { |row| row["site_id"] == site.id.to_s }
+        expect(skipped).to include("reason" => "urn_not_in_gias_school")
+      end
+    end
+
+    context "with a discarded school-type site" do
+      let(:provider) { create(:provider) }
+      let(:gias_school) { create(:gias_school, urn: "300003") }
+      let!(:site) do
+        create(
+          :site,
+          provider: provider,
+          urn: gias_school.urn,
+          code: "D",
+          discarded_at: 1.day.ago,
+        )
+      end
+
+      it "does not insert a provider_school row" do
+        executor.execute
+        expect(Provider::School.where(provider_id: provider.id)).to be_empty
+      end
+
+      it "does not list the site in the skipped-sites CSV" do
+        summary = executor.execute
+        path = summary.full_summary["skipped_sites_csv_path"]
+        ids = csv_rows(path).map { |row| row["site_id"] }
+        expect(ids).not_to include(site.id.to_s)
+      end
+    end
+
+    context "with a study site" do
+      let(:provider) { create(:provider) }
+      let(:gias_school) { create(:gias_school, urn: "400004") }
+      let!(:site) do
+        create(:site, :study_site, provider: provider, urn: gias_school.urn, code: "E")
+      end
+
+      it "does not insert a provider_school row" do
+        executor.execute
+        expect(Provider::School.where(provider_id: provider.id)).to be_empty
+      end
+
+      it "does not list the site in the skipped-sites CSV" do
+        summary = executor.execute
+        path = summary.full_summary["skipped_sites_csv_path"]
+        ids = csv_rows(path).map { |row| row["site_id"] }
+        expect(ids).not_to include(site.id.to_s)
+      end
+    end
+
+    context "idempotency — executing twice" do
+      let(:provider) { create(:provider) }
+      let(:gias_school) { create(:gias_school, urn: "500005") }
+
+      before do
+        site = create(:site, provider: provider, urn: gias_school.urn, code: "F")
+        course = create(:course, provider: provider)
+        create(:site_status, course: course, site: site)
+      end
+
+      it "does not duplicate rows and reports zero inserts on the second run" do
+        first = executor.execute
+        expect(first.short_summary["provider_schools_inserted"]).to eq(1)
+        expect(first.short_summary["course_schools_inserted"]).to eq(1)
+
+        expect { described_class.new(tmp_dir: tmp_dir).execute }
+          .to not_change { Provider::School.count }
+          .and(not_change { Course::School.count })
+
+        second = DataHub::SchoolsBackfillProcessSummary.order(:started_at).last
+        expect(second.short_summary["provider_schools_inserted"]).to eq(0)
+        expect(second.short_summary["course_schools_inserted"]).to eq(0)
+      end
+    end
+
+    context "process summary lifecycle" do
+      it "returns a finished DataHub::SchoolsBackfillProcessSummary with counts and csv paths" do
+        provider = create(:provider)
+        gias_school = create(:gias_school, urn: "600006")
+        create(:site, provider: provider, urn: gias_school.urn, code: "G")
+
+        summary = executor.execute
+
+        expect(summary).to be_a(DataHub::SchoolsBackfillProcessSummary)
+        expect(summary.status).to eq("finished")
+        expect(summary.finished_at).to be_present
+        expect(summary.short_summary["provider_schools_inserted"]).to eq(1)
+        expect(summary.full_summary["skipped_sites_csv_path"]).to include("schools_backfill_skipped_sites_")
+        expect(summary.full_summary["skipped_course_sites_csv_path"]).to include("schools_backfill_skipped_course_sites_")
+      end
+
+      it "marks the summary as failed and re-raises on error" do
+        allow(executor).to receive(:insert_course_schools).and_raise(StandardError, "boom")
+
+        expect { executor.execute }.to raise_error(StandardError, "boom")
+
+        summary = DataHub::SchoolsBackfillProcessSummary.order(:started_at).last
+        expect(summary.status).to eq("failed")
+        expect(summary.short_summary["error_message"]).to eq("boom")
+      end
+
+      it "rolls back provider_school inserts when course_school insert fails" do
+        provider = create(:provider)
+        gias_school = create(:gias_school, urn: "700007")
+        create(:site, provider: provider, urn: gias_school.urn, code: "H")
+
+        allow(executor).to receive(:insert_course_schools).and_raise(StandardError, "boom")
+
+        expect { executor.execute }.to raise_error(StandardError, "boom")
+        expect(Provider::School.where(provider_id: provider.id)).to be_empty
+      end
+    end
+
+    context "across multiple recruitment cycles" do
+      it "backfills sites and course_sites from every cycle" do
+        previous_cycle = create(:recruitment_cycle, :previous)
+        current_cycle = find_or_create(:recruitment_cycle)
+
+        previous_provider = create(:provider, recruitment_cycle: previous_cycle)
+        current_provider = create(:provider, recruitment_cycle: current_cycle)
+        previous_gias_school = create(:gias_school, urn: "810008")
+        current_gias_school = create(:gias_school, urn: "820008")
+
+        create(:site, provider: previous_provider, urn: previous_gias_school.urn, code: "P")
+        create(:site, provider: current_provider, urn: current_gias_school.urn, code: "Q")
+
+        executor.execute
+
+        expect(
+          Provider::School.where(provider_id: previous_provider.id, gias_school_id: previous_gias_school.id),
+        ).to exist
+        expect(
+          Provider::School.where(provider_id: current_provider.id, gias_school_id: current_gias_school.id),
+        ).to exist
+      end
+    end
+  end
+end

--- a/spec/services/data_hub/schools_backfill/executor_spec.rb
+++ b/spec/services/data_hub/schools_backfill/executor_spec.rb
@@ -199,9 +199,10 @@ describe DataHub::SchoolsBackfill::Executor do
       end
 
       it "marks the summary as failed and re-raises on error" do
-        allow(executor).to receive(:insert_course_schools).and_raise(StandardError, "boom")
+        failing_executor = described_class.new(tmp_dir: tmp_dir)
+        allow(failing_executor).to receive(:insert_course_schools).and_raise(StandardError, "boom")
 
-        expect { executor.execute }.to raise_error(StandardError, "boom")
+        expect { failing_executor.execute }.to raise_error(StandardError, "boom")
 
         summary = DataHub::SchoolsBackfillProcessSummary.order(:started_at).last
         expect(summary.status).to eq("failed")
@@ -213,9 +214,10 @@ describe DataHub::SchoolsBackfill::Executor do
         gias_school = create(:gias_school, urn: "700007")
         create(:site, provider: provider, urn: gias_school.urn, code: "H")
 
-        allow(executor).to receive(:insert_course_schools).and_raise(StandardError, "boom")
+        failing_executor = described_class.new(tmp_dir: tmp_dir)
+        allow(failing_executor).to receive(:insert_course_schools).and_raise(StandardError, "boom")
 
-        expect { executor.execute }.to raise_error(StandardError, "boom")
+        expect { failing_executor.execute }.to raise_error(StandardError, "boom")
         expect(Provider::School.where(provider_id: provider.id)).to be_empty
       end
     end


### PR DESCRIPTION
## Summary

Implements a bulk SQL backfill that populates the new `provider_school` and `course_school` join tables from the existing `site` / `course_site` data model. School URNs on `site` are resolved to `gias_school.id` via a direct join on `urn`. The backfill is wrapped in a `DataHub::SchoolsBackfillProcessSummary` for observability and invoked via a rake task.

- **SQL-first**: two `INSERT ... SELECT ... ON CONFLICT DO NOTHING` statements do all the work — no Ruby per-row loops, no ActiveRecord instantiation
- **Idempotent by construction**: `ON CONFLICT DO NOTHING` covers both the composite unique index and the partial unique index (one main site per provider), so reruns are free
- **Parity with source**: all `course_site` rows are copied regardless of `publish` / `status` — the new `course_school` table has no publish/status column, so filtering here would destroy history; retrieval logic is a separate ticket
- **Skip reporting**: sites with no URN or an unresolvable URN are written to CSV files under `tmp/`, with paths and counts recorded on the process summary

### Approach — why bulk SQL

The dev DB holds 100k+ site rows and 600k+ course_site rows. 

A Ruby `.each` loop with individual `create!` calls would instantiate hundreds of thousands of ActiveRecord objects and run for minutes. The two SQL statements complete in seconds and use constant memory. `ON CONFLICT DO NOTHING` makes the process safely repeatable without needing to check for existing rows first.

### How to run

```
bundle exec rails schools_backfill:run
```

Outputs `short_summary` (counts) and `full_summary` (CSV paths) to stdout. The run is also recorded as a `DataHub::SchoolsBackfillProcessSummary` row (STI on `data_hub_process_summary`), observable via:

```ruby
DataHub::SchoolsBackfillProcessSummary.last.short_summary
# => {"provider_schools_inserted"=>108176, "course_schools_inserted"=>685256, "sites_skipped"=>..., "course_sites_skipped"=>...}
```

### What gets backfilled

| Source | Target | Join condition | Filters |
|--------|--------|---------------|---------|
| `site` | `provider_school` | `gias_school.urn = site.urn` | `site_type = 0` (school), not discarded, URN present and non-blank |
| `course_site → site` | `course_school` | `gias_school.urn = site.urn` | Same site filters; all course_site rows regardless of publish/status |

`site.code` maps directly to `site_code` on the new tables (no transformation). `site_code = '-'` represents the provider main site, enforced by the partial unique index from the previous PR.

### What gets skipped (and logged)

- Sites with `urn IS NULL` or `urn = ''` → reason: `no_urn`
- Sites whose URN doesn't match any `gias_school` row → reason: `urn_not_in_gias_school`
- Discarded sites and study sites are excluded from both inserts **and** from the skipped CSVs (they're expected exclusions, not actionable gaps)

### Performance trade-offs

- Single transaction wraps both tables — if the course_school insert fails, provider_school inserts roll back too. Acceptable because ON CONFLICT makes the full re-run cheap.
- `course_site` has no timestamps; `created_at` / `updated_at` on new rows are set to `NOW()` at insert time — downstream code should not use these as "when was the relationship established".
- CSVs live in `tmp/` — on containerised hosts they vanish on pod restart. Read them before cycling the pod, or pipe them to blob storage in a follow-up if needed.

## New files

| File | Purpose |
|------|---------|
| `app/models/data_hub/schools_backfill_process_summary.rb` | STI subclass with `jsonb_accessor` typed fields for counts + CSV paths |
| `app/services/data_hub/schools_backfill/executor.rb` | Core service: skip CSVs → bulk insert → finish summary |
| `lib/tasks/schools_backfill.rake` | `schools_backfill:run` thin wrapper |
| `spec/services/data_hub/schools_backfill/executor_spec.rb` | 13 examples: happy path, skipped rows, idempotency, process summary lifecycle, rollback on error, multi-cycle coverage |
| `spec/lib/tasks/schools_backfill_rake_spec.rb` | Smoke test for the rake task |

## Test plan

- [ ] `bundle exec rspec spec/services/data_hub/schools_backfill/executor_spec.rb spec/lib/tasks/schools_backfill_rake_spec.rb` — all green
- [ ] Run `bundle exec rails schools_backfill:run` on a seeded dev DB — confirm non-zero `provider_schools_inserted` / `course_schools_inserted`
- [ ] Re-run the rake task — confirm a second summary with both inserted counts at `0` (idempotency)
- [ ] Inspect a skipped-rows CSV: `head tmp/schools_backfill_skipped_sites_<id>.csv`
- [ ] `DataHub::SchoolsBackfillProcessSummary.last` shows `status: "finished"` with populated summaries
- [ ] `git diff db/schema.rb` is empty — no schema changes in this PR
