### PR TITLE
feat(2717): PTT - upgrade postgis to v3.6 in review

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "6379:6379"
 
   db:
-    image: postgis/postgis:17-3.5-alpine
+    image: postgis/postgis:17-3.6-alpine
     # To preserve data between runs of docker compose, we mount a folder from the host machine.
     volumes:
       - dbdata:/var/lib/postgresql/data

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -56,5 +56,5 @@ module "postgres" {
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_maintenance_window       = var.postgres_azure_maintenance_window
   server_version                 = var.postgres_version
-  server_docker_image            = "postgis/postgis:17-3.5"
+  server_docker_image            = "postgis/postgis:17-3.6"
 }

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -56,5 +56,5 @@ module "postgres" {
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_maintenance_window       = var.postgres_azure_maintenance_window
   server_version                 = var.postgres_version
-  server_docker_image            = "postgis/postgis:17-3.6"
+  server_docker_image            = var.server_docker_image
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -145,3 +145,9 @@ variable "run_as_non_root" {
   default     = true
   description = "Whether to enforce that containers must run as non-root user"
 }
+
+variable "server_docker_image" {
+  type        = string
+  default     = null
+  description = "Docker Hub image for the kubernetes deployment, eg. postgis/postgis:16-3.5. Default is postgres:<server_version>-alpine"
+}

--- a/terraform/aks/workspace_variables/review.tfvars.json
+++ b/terraform/aks/workspace_variables/review.tfvars.json
@@ -19,5 +19,6 @@
   "enable_find": true,
   "enable_monitoring": false,
   "enable_logit": true,
-  "postgres_version": 17
+  "postgres_version": 17,
+  "server_docker_image": "postgis/postgis:17-3.6-alpine"
 }


### PR DESCRIPTION
## Context

- version 17 of postgis requires v3.6 of postgis

https://trello.com/c/Cn5A31Lf/2717-upgrade-ptt-postgres-version-qa-upgrade-azure-supportcall-2604140050004374

## Changes proposed in this pull request

- change version of postgis used in dockerized pg image from v3.5 to v3.6

## Guidance to review
```
make review PR_NUMBER=6065 deploy USE_DB_SETUP_COMMAND=true
```
- tests to be done by app team
- check app is running
- check no errors in db logs

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
