### PR TITLE
Implement add course flow wizard setup and Level step

### DIFF
--- a/app/components/add_course_button.html.erb
+++ b/app/components/add_course_button.html.erb
@@ -1,11 +1,7 @@
 <% if required_organisation_details_present? %>
   <%= govuk_button_link_to(
-    t("components.add_course_button.add_course"),
-    new_publish_provider_recruitment_cycle_course_path(
-      provider_code: provider.provider_code,
-      recruitment_cycle_year: provider.recruitment_cycle_year,
-    ),
-    class: "govuk-!-margin-bottom-6",
+    t("components.add_course_button.add_course"), add_course_path,
+    class: "govuk-!-margin-bottom-6"
   ) %>
 
 <% else %>

--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -24,6 +24,7 @@ class AddCourseButton < ViewComponent::Base
       new_publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        state_key: wizard_state_key,
       )
     else
       new_publish_provider_recruitment_cycle_course_path(
@@ -37,6 +38,10 @@ private
 
   def wizard_add_course_flow?
     FeatureFlag.active?(:wizard_add_course_flow)
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
   end
 
   def accredited_provider

--- a/app/components/add_course_button.rb
+++ b/app/components/add_course_button.rb
@@ -19,7 +19,25 @@ class AddCourseButton < ViewComponent::Base
     @incomplete_sections ||= [school, accredited_provider].compact
   end
 
+  def add_course_path
+    if wizard_add_course_flow?
+      new_publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      )
+    else
+      new_publish_provider_recruitment_cycle_course_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      )
+    end
+  end
+
 private
+
+  def wizard_add_course_flow?
+    FeatureFlag.active?(:wizard_add_course_flow)
+  end
 
   def accredited_provider
     return if accredited_partner_present?

--- a/app/controllers/publish/course_wizards_controller.rb
+++ b/app/controllers/publish/course_wizards_controller.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Publish
+  class CourseWizardsController < ApplicationController
+    CACHE_EXPIRY = 1.hour
+
+    before_action :authorize_course_creation
+    before_action :set_wizard, except: [:new]
+
+    helper_method def current_step
+      @wizard.current_step
+    end
+
+    helper_method def current_step_name
+      params[:step]&.to_sym || :level
+    end
+
+    def new
+      return render_schools_messages unless provider.sites.any?
+
+      redirect_to publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: params[:provider_code],
+        recruitment_cycle_year: params[:recruitment_cycle_year],
+        step: :level,
+      )
+    end
+
+    def show; end
+
+    def create
+      update
+    end
+
+    def update
+      if @wizard.save_current_step
+        redirect_to @wizard.next_step_path
+      else
+        render :show
+      end
+    end
+
+  private
+
+    def authorize_course_creation
+      authorize(provider, :can_create_course?)
+    end
+
+    def render_schools_messages
+      flash[:error] = { id: "schools-error", message: "You need to create at least one school before creating a course" }
+
+      redirect_to publish_provider_recruitment_cycle_schools_path(
+        provider.provider_code,
+        provider.recruitment_cycle_year,
+      )
+    end
+
+    def set_wizard
+      state_store = CourseWizard::StateStores::CourseWizardStore.new(
+        repository: DfE::Wizard::Repository::Cache.new(
+          cache: Rails.cache,
+          key: "course_wizard_#{params[:provider_code]}_#{params[:recruitment_cycle_year]}",
+          expires_in: CACHE_EXPIRY,
+        ),
+      )
+
+      @wizard = CourseWizard.new(
+        current_step: current_step_name,
+        current_step_params: step_params,
+        state_store:,
+      ).tap do |wizard|
+        wizard.recruitment_cycle_year = params[:recruitment_cycle_year]
+        wizard.provider_code = params[:provider_code]
+      end
+    end
+
+    def step_params
+      params
+    end
+  end
+end

--- a/app/controllers/publish/course_wizards_controller.rb
+++ b/app/controllers/publish/course_wizards_controller.rb
@@ -22,6 +22,7 @@ module Publish
         provider_code: params[:provider_code],
         recruitment_cycle_year: params[:recruitment_cycle_year],
         step: :level,
+        state_key:,
       )
     end
 
@@ -58,7 +59,7 @@ module Publish
       state_store = CourseWizard::StateStores::CourseWizardStore.new(
         repository: DfE::Wizard::Repository::Cache.new(
           cache: Rails.cache,
-          key: "course_wizard_#{params[:provider_code]}_#{params[:recruitment_cycle_year]}",
+          key: "course_wizard_#{params[:provider_code]}_#{params[:recruitment_cycle_year]}_#{state_key}",
           expires_in: CACHE_EXPIRY,
         ),
       )
@@ -70,7 +71,12 @@ module Publish
       ).tap do |wizard|
         wizard.recruitment_cycle_year = params[:recruitment_cycle_year]
         wizard.provider_code = params[:provider_code]
+        wizard.state_key = state_key
       end
+    end
+
+    def state_key
+      @state_key ||= params[:state_key]
     end
 
     def step_params

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -10,6 +10,7 @@ class FeatureFlags
       [:candidate_accounts, "Enable candidate accounts feature", "Find and Publish team"],
       [:email_alerts, "Enable email alerts for candidates", "Find and Publish team"],
       [:course_sites_updated_email_notification, "Send email notifications when a course's associated schools are updated", "Find and Publish team"],
+      [:wizard_add_course_flow, "Enables the wizard add course flow that uses the DfE wizard", "Find and Publish team"],
     ]
   end
 end

--- a/app/views/publish/course_wizards/show.html.erb
+++ b/app/views/publish/course_wizards/show.html.erb
@@ -13,6 +13,7 @@
             provider_code: params[:provider_code],
             recruitment_cycle_year: params[:recruitment_cycle_year],
             step: current_step_name,
+            state_key: params[:state_key],
           ),
           method: :patch,
         ) do |form| %>

--- a/app/views/publish/course_wizards/show.html.erb
+++ b/app/views/publish/course_wizards/show.html.erb
@@ -1,0 +1,44 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.level.heading"), current_step.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_courses_path(params[:provider_code], params[:recruitment_cycle_year])) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          model: current_step,
+          scope: current_step_name,
+          url: publish_provider_recruitment_cycle_course_wizard_path(
+            provider_code: params[:provider_code],
+            recruitment_cycle_year: params[:recruitment_cycle_year],
+            step: current_step_name,
+          ),
+          method: :patch,
+        ) do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= render CaptionText.new(text: t("course.add_course")) %>
+        <%= t("course_wizard.steps.level.heading") %>
+      </h1>
+
+      <%= form.govuk_radio_buttons_fieldset :level, legend: { text: t("course_wizard.steps.level.level_label"), size: "m" } do %>
+        <%= form.govuk_radio_button :level, t("course_wizard.steps.level.options.primary").downcase, label: { text: t("course_wizard.steps.level.options.primary") } %>
+        <%= form.govuk_radio_button :level, t("course_wizard.steps.level.options.secondary").downcase, label: { text: t("course_wizard.steps.level.options.secondary") } %>
+        <%= form.govuk_radio_button :level, "further_education", label: { text: t("course_wizard.steps.level.options.further_education") } %>
+      <% end %>
+
+      <%= form.govuk_radio_buttons_fieldset :is_send, legend: { text: t("course_wizard.steps.level.send_label"), size: "m" } do %>
+        <%= form.govuk_radio_button :is_send, "true", label: { text: t("course_wizard.steps.level.options.yes_send") } %>
+        <%= form.govuk_radio_button :is_send, "false", label: { text: t("course_wizard.steps.level.options.no_send") } %>
+      <% end %>
+
+      <%= form.govuk_submit t("course_wizard.steps.level.submit") %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("course_wizard.steps.level.cancel"), publish_provider_recruitment_cycle_courses_path(params[:provider_code], params[:recruitment_cycle_year])) %>
+    </p>
+  </div>
+</div>

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -3,7 +3,7 @@
 class CourseWizard
   include DfE::Wizard
 
-  attr_accessor :recruitment_cycle_year, :provider_code
+  attr_accessor :recruitment_cycle_year, :provider_code, :state_key
 
   def steps_processor
     DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
@@ -22,9 +22,11 @@ class CourseWizard
       config.default_path_arguments = {
         recruitment_cycle_year: config.wizard.recruitment_cycle_year,
         provider_code: config.wizard.provider_code,
+        state_key: config.wizard.state_key,
       }
 
       config.map_step :courses_index, to: lambda { |_wizard, options, helpers|
+        options = options.except(:state_key)
         helpers.publish_provider_recruitment_cycle_courses_path(**options)
       }
     end

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  include DfE::Wizard
+
+  attr_accessor :recruitment_cycle_year, :provider_code
+
+  def steps_processor
+    DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
+      graph.root :level
+
+      graph.add_node :level, Steps::Level
+      graph.add_edge from: :level, to: :courses_index
+    end
+  end
+
+  def route_strategy
+    DfE::Wizard::RouteStrategy::ConfigurableRoutes.new(
+      wizard: self,
+      namespace: "publish-provider-recruitment-cycle-course-wizard",
+    ) do |config|
+      config.default_path_arguments = {
+        recruitment_cycle_year: config.wizard.recruitment_cycle_year,
+        provider_code: config.wizard.provider_code,
+      }
+
+      config.map_step :courses_index, to: lambda { |_wizard, options, helpers|
+        helpers.publish_provider_recruitment_cycle_courses_path(**options)
+      }
+    end
+  end
+end

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module StateStores
+    class CourseWizardStore
+      include DfE::Wizard::StateStore
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/level.rb
+++ b/app/wizards/course_wizard/steps/level.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class Level
+      include DfE::Wizard::Step
+
+      LEVEL_OPTIONS = %w[primary secondary further_education].freeze
+      SEND_OPTIONS = %w[true false].freeze
+
+      attribute :level, :string
+      attribute :is_send, :string
+
+      validates :level,
+                presence: { message: I18n.t("course_wizard.steps.level.errors.level.blank") },
+                inclusion: { in: LEVEL_OPTIONS, message: I18n.t("course_wizard.steps.level.errors.level.blank") }
+      validates :is_send,
+                presence: { message: I18n.t("course_wizard.steps.level.errors.is_send.blank") },
+                inclusion: { in: SEND_OPTIONS, message: I18n.t("course_wizard.steps.level.errors.is_send.blank") }
+
+      def self.permitted_params
+        %i[level is_send]
+      end
+    end
+  end
+end

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -1,0 +1,20 @@
+en:
+  course_wizard:
+    steps:
+      level:
+        heading: What type of course?
+        level_label: Subject level
+        send_label: Does this course have a special educational needs and disability (SEND) specialism?
+        submit: Continue
+        cancel: Cancel
+        options:
+          primary: Primary
+          secondary: Secondary
+          further_education: Further education
+          yes_send: "Yes"
+          no_send: "No"
+        errors:
+          level:
+            blank: Select a subject level
+          is_send:
+            blank: Select if this course has a special educational needs and disability (SEND) specialism

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -171,8 +171,8 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
       end
 
       resource :course_wizard, only: %i[new], controller: "course_wizards"
-      get "course_wizard/:step", to: "course_wizards#show", as: :course_wizard
-      patch "course_wizard/:step", to: "course_wizards#update"
+      get "course_wizard/:state_key/:step", to: "course_wizards#show", as: :course_wizard
+      patch "course_wizard/:state_key/:step", to: "course_wizards#update"
 
       resources :courses, param: :code, only: %i[index new create show] do
         get "/apply", on: :member, to: "courses#apply", as: :apply

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -170,6 +170,10 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
         get "confirmation"
       end
 
+      resource :course_wizard, only: %i[new], controller: "course_wizards"
+      get "course_wizard/:step", to: "course_wizards#show", as: :course_wizard
+      patch "course_wizard/:step", to: "course_wizards#update"
+
       resources :courses, param: :code, only: %i[index new create show] do
         get "/apply", on: :member, to: "courses#apply", as: :apply
         get "/details", on: :member, to: "courses#details"

--- a/spec/components/add_course_button_spec.rb
+++ b/spec/components/add_course_button_spec.rb
@@ -12,6 +12,41 @@ describe AddCourseButton do
     render_inline(described_class.new(provider:))
   end
 
+  context "when the wizard add course flow is active" do
+    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], sites: [build(:site)], recruitment_cycle:) }
+
+    it "renders a course wizard link" do
+      component = described_class.new(provider:)
+      allow(component).to receive(:wizard_add_course_flow?).and_return(true)
+
+      render_inline(component)
+
+      expect(rendered_content).to have_link(
+        "Add course",
+        href: new_publish_provider_recruitment_cycle_course_wizard_path(
+          provider.provider_code,
+          provider.recruitment_cycle.year,
+        ),
+      )
+    end
+  end
+
+  context "when the wizard add course flow is not active" do
+    let(:provider) { build(:provider, :accredited_provider, study_sites: [build(:site, :study_site)], sites: [build(:site)], recruitment_cycle:) }
+
+    it "renders a course link" do
+      component = described_class.new(provider:)
+      allow(component).to receive(:wizard_add_course_flow?).and_return(false)
+
+      render_inline(component)
+
+      expect(rendered_content).to have_link(
+        "Add course",
+        href: new_publish_provider_recruitment_cycle_course_path(provider.provider_code, provider.recruitment_cycle.year),
+      )
+    end
+  end
+
   context "when the provider has not filled out any required sections" do
     it "renders an accredited provider link" do
       expect(rendered_content).to have_link(

--- a/spec/components/add_course_button_spec.rb
+++ b/spec/components/add_course_button_spec.rb
@@ -17,15 +17,16 @@ describe AddCourseButton do
 
     it "renders a course wizard link" do
       component = described_class.new(provider:)
-      allow(component).to receive(:wizard_add_course_flow?).and_return(true)
+      allow(component).to receive_messages(wizard_add_course_flow?: true, wizard_state_key: "test-state-key")
 
       render_inline(component)
 
       expect(rendered_content).to have_link(
         "Add course",
         href: new_publish_provider_recruitment_cycle_course_wizard_path(
-          provider.provider_code,
-          provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          state_key: "test-state-key",
         ),
       )
     end

--- a/spec/support/shared_contexts/add_course_wizard.rb
+++ b/spec/support/shared_contexts/add_course_wizard.rb
@@ -9,6 +9,7 @@ RSpec.shared_context "add_course_wizard" do
     ).tap do |course_wizard|
       course_wizard.provider_code = provider_code
       course_wizard.recruitment_cycle_year = recruitment_cycle_year
+      course_wizard.state_key = state_key
     end
   end
 
@@ -18,4 +19,5 @@ RSpec.shared_context "add_course_wizard" do
   let(:current_step_params) { {} }
   let(:provider_code) { "ABC" }
   let(:recruitment_cycle_year) { 2026 }
+  let(:state_key) { SecureRandom.uuid }
 end

--- a/spec/support/shared_contexts/add_course_wizard.rb
+++ b/spec/support/shared_contexts/add_course_wizard.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "add_course_wizard" do
+  subject(:wizard) do
+    CourseWizard.new(
+      state_store:,
+      current_step:,
+      current_step_params: { current_step => current_step_params },
+    ).tap do |course_wizard|
+      course_wizard.provider_code = provider_code
+      course_wizard.recruitment_cycle_year = recruitment_cycle_year
+    end
+  end
+
+  let(:repository) { DfE::Wizard::Repository::InMemory.new }
+  let(:state_store) { CourseWizard::StateStores::CourseWizardStore.new(repository:) }
+  let(:current_step) { :level }
+  let(:current_step_params) { {} }
+  let(:provider_code) { "ABC" }
+  let(:recruitment_cycle_year) { 2026 }
+end

--- a/spec/system/publish/courses/add_course_wizard/level_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/level_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard level step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user_with_a_school
+  end
+
+  scenario "choosing a primary level and no SEND and continues to subjects" do
+    when_i_visit_the_wizard_level_page
+    and_i_choose_primary_level
+    and_i_choose_no_for_send_specialism
+    and_i_click_continue
+    then_i_go_back_to_the_school_courses_page
+  end
+
+  scenario "submitting without selecting a level or SEND shows validation errors" do
+    when_i_visit_the_wizard_level_page
+    and_i_click_continue
+    then_i_have_errors_on_the_level_step
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user_with_a_school
+    @user = create(
+      :user,
+      providers: [
+        create(:provider, :accredited_provider, sites: [build(:site)]),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def when_i_visit_the_wizard_level_page
+    visit new_publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+    )
+  end
+
+  def and_i_choose_primary_level
+    choose "Primary"
+  end
+
+  def and_i_choose_no_for_send_specialism
+    choose "No"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_course_wizard_subjects_step
+    expect(page).to have_current_path(
+      new_publish_provider_recruitment_cycle_courses_subjects_path(
+        provider.provider_code,
+        provider.recruitment_cycle_year,
+      ),
+    )
+    expect(page).to have_content("Subject")
+  end
+
+  def then_i_go_back_to_the_school_courses_page
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year))
+  end
+
+  def then_i_have_errors_on_the_level_step
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select a subject level")
+    expect(page).to have_content("Select if this course has a special educational needs and disability (SEND) specialism")
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/level_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/level_spec.rb
@@ -39,6 +39,7 @@ private
     visit new_publish_provider_recruitment_cycle_course_wizard_path(
       provider_code: provider.provider_code,
       recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
     )
   end
 
@@ -65,7 +66,10 @@ private
   end
 
   def then_i_go_back_to_the_school_courses_page
-    expect(page).to have_current_path(publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year))
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(provider.provider_code, provider.recruitment_cycle_year),
+      ignore_query: true,
+    )
   end
 
   def then_i_have_errors_on_the_level_step
@@ -76,5 +80,9 @@ private
 
   def provider
     @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
   end
 end

--- a/spec/wizards/add_course_wizard/steps/level_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/level_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::Level do
+  subject(:wizard_step) { described_class.new }
+
+  describe "#valid?" do
+    context "when level and is_send are present" do
+      it "is valid" do
+        wizard_step.level = "primary"
+        wizard_step.is_send = "true"
+        expect(wizard_step).to be_valid
+
+        wizard_step.level = "secondary"
+        wizard_step.is_send = "true"
+        expect(wizard_step).to be_valid
+
+        wizard_step.level = "further_education"
+        wizard_step.is_send = "true"
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context "when level or is_send are not present" do
+      it "is not valid without a level" do
+        wizard_step.level = nil
+        expect(wizard_step).not_to be_valid
+      end
+
+      it "is not valid without an is_send value" do
+        wizard_step.is_send = nil
+        expect(wizard_step).not_to be_valid
+      end
+    end
+
+    context "when level or is_send are not in the allowed options" do
+      it "is not valid with an unsupported level" do
+        wizard_step.level = "invalid"
+        expect(wizard_step).not_to be_valid
+      end
+
+      it "is not valid with an unsupported is_send value" do
+        wizard_step.is_send = "invalid"
+        expect(wizard_step).not_to be_valid
+      end
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq(%i[level is_send])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CourseWizard#next_step", type: :wizard do
+  include_context "add_course_wizard"
+
+  context "from level" do
+    let(:current_step) { :level }
+
+    it "proceeds to courses page (for now)" do
+      expect(wizard).to have_next_step(:courses_index)
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CourseWizard#previous_step", type: :wizard do
+  include_context "add_course_wizard"
+
+  context "from level" do
+    let(:current_step) { :level }
+
+    it "has no previous step" do
+      expect(wizard).to have_previous_step(nil)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Implement DfE wizard for the add course flow. This PR adds the basic skeleton implementation for add course flow using the DfE wizard as well as the first step of this flow (Level step) 

## Changes proposed in this pull request

- Add `refactored_add_course_flow` feature flag
- Update add course button logic to take user through DfE wizard route if activated
- Implemented the basic structure for the Add Course flow

## Guidance to review

- Check when flag is disabled u are taken through the old flow
- Check when flag is enabled u are taken through the new flow (Only goes up to the Level page)

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
