### PR TITLE
fix: Live Course shows the course length before publishing

### DIFF
--- a/app/components/find/courses/summary_component/view.html.erb
+++ b/app/components/find/courses/summary_component/view.html.erb
@@ -11,11 +11,9 @@
     <% end %>
   <% end %>
 
-  <% if length.present? %>
-    <% summary_list.with_row do |row| %>
-      <% row.with_key(text: t(".course_length")) %>
-      <% row.with_value(text: course_length_with_study_mode_row) %>
-    <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t(".course_length")) %>
+    <% row.with_value(text: course_length_with_study_mode_row) %>
   <% end %>
 
   <% if age_range_in_years.present? %>

--- a/app/components/find/courses/summary_component/view.rb
+++ b/app/components/find/courses/summary_component/view.rb
@@ -12,7 +12,6 @@ module Find
         delegate :accrediting_provider,
                  :provider,
                  :age_range_in_years,
-                 :length,
                  :applications_open_from,
                  :find_outcome,
                  :start_date,
@@ -24,10 +23,20 @@ module Find
                  :can_sponsor_skilled_worker_visa,
                  :no_fee?, to: :course
 
+        delegate :course_length, to: :enrichment
+
         def initialize(course, enrichment)
           super()
           @course = course
           @enrichment = enrichment
+        end
+
+        def course_length_formatted
+          if enrichment.standard_course_length?
+            t("courses.summary_card_component.length_value.#{course_length}")
+          else
+            course_length.to_s
+          end
         end
 
         def fee_value
@@ -47,7 +56,7 @@ module Find
         end
 
         def course_length_with_study_mode_row
-          "#{length} - #{study_mode.humanize.downcase}"
+          "#{course_length_formatted} - #{study_mode.humanize.downcase}"
         end
 
         def visa_sponsorship_row

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -164,4 +164,8 @@ class CourseEnrichment < ApplicationRecord
   def required_qualifications_needed?
     course&.provider&.recruitment_cycle&.year.to_i < Course::STRUCTURED_REQUIREMENTS_REQUIRED_FROM
   end
+
+  def standard_course_length?
+    course_length.in?(%w[OneYear TwoYears ThreeYears FourYears])
+  end
 end

--- a/spec/system/publish/courses/editing_course_length_spec.rb
+++ b/spec/system/publish/courses/editing_course_length_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Editing course length" do
     then_i_an_error_message
   end
 
-  scenario "I update the course length to a standard length (eg Up to two years)" do
+  scenario "I update the course length to a standard length (eg Up to two years)", :js do
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_1_year_course_i_want_to_edit
     when_i_visit_the_course_length_edit_page
@@ -24,6 +24,8 @@ RSpec.describe "Editing course length" do
 
     when_i_visit_the_course_length_edit_page
     then_i_see_two_years_selected
+
+    when_i_view_the_published_course_it_is_not_updated_yet
   end
 
   scenario "I update the course length with a custom length" do
@@ -99,21 +101,31 @@ private
   end
 
   def then_i_see_two_years_selected
-    expect(find_field("Up to 2 years")).to be_checked
+    expect(find_field("Up to 2 years", visible: false)).to be_checked
   end
 
   def then_i_see_one_year_selected
-    expect(find_field("1 year")).to be_checked
+    expect(find_field("1 year", visible: false)).to be_checked
   end
 
   def then_i_see_the_custom_length_of_5_years
-    expect(find_field("Other")).to be_checked
-    expect(find_field("Course length").value).to eq "5 years"
+    expect(find_field("Other", visible: false)).to be_checked
+    expect(find_field("Course length", visible: false).value).to eq "5 years"
   end
 
   def then_i_see_the_custom_length
-    expect(find_field("Other")).to be_checked
-    expect(find_field("Course length").value).to eq "Three years"
+    expect(find_field("Other", visible: false)).to be_checked
+    expect(find_field("Course length", visible: false).value).to eq "Three years"
+  end
+
+  def when_i_view_the_published_course_it_is_not_updated_yet
+    open_new_window
+
+    window = Capybara::Window.new(page, page.driver.window_handles.last)
+    within_window(window) do
+      visit find_course_url(provider_code: provider.provider_code, course_code: course.course_code)
+      expect(page).to have_content("1 year - full time")
+    end
   end
 
   def and_i_submit_the_form


### PR DESCRIPTION
## Context

Updating course Course Length doesn't publish the value until the course is republished.

## Changes proposed in this pull request

Call `course_length_formatted` on the latest published course enrichment passed into the component instead of the course.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
