### PR TITLE
Dual write provider schools

### DIFF
--- a/app/controllers/publish/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/publish/providers/schools/check_multiple_controller.rb
@@ -10,7 +10,16 @@ module Publish
         def show; end
 
         def update
-          schools.each(&:save!)
+          schools.each do |site|
+            ActiveRecord::Base.transaction do
+              ::ProviderSchools::LegacySiteCreator.call(site:)
+              ::ProviderSchools::Creator.call(
+                provider:,
+                gias_school_id: gias_schools_by_urn.fetch(site.urn).id,
+                site_code: site.code,
+              )
+            end
+          end
 
           schools_added_message(schools)
 
@@ -66,6 +75,10 @@ module Publish
           end
         end
         alias_method :load_schools, :schools
+
+        def gias_schools_by_urn
+          @gias_schools_by_urn ||= GiasSchool.where(urn: schools.map(&:urn)).index_by(&:urn)
+        end
 
         def unfound_urns
           @unfound_urns = urn_service[:unfound_urns]

--- a/app/controllers/publish/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/publish/providers/schools/check_multiple_controller.rb
@@ -10,18 +10,19 @@ module Publish
         def show; end
 
         def update
-          schools.each do |site|
+          saved_sites = []
+
+          gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
+              provider_school = ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+
+              site = provider.sites.build(gias_school.school_attributes.merge(code: provider_school.site_code))
               ::ProviderSchools::LegacySiteCreator.call(site:)
-              ::ProviderSchools::Creator.call(
-                provider:,
-                gias_school_id: gias_schools_by_urn.fetch(site.urn).id,
-                site_code: site.code,
-              )
+              saved_sites << site
             end
           end
 
-          schools_added_message(schools)
+          schools_added_message(saved_sites)
 
           redirect_to publish_provider_recruitment_cycle_schools_path
         end
@@ -66,19 +67,14 @@ module Publish
           @urn_service ||= ProviderURNIdentificationService.new(provider, urn_form.values || []).call
         end
 
+        def gias_schools
+          @gias_schools ||= GiasSchool.where(urn: urn_service[:new_urns])
+        end
+
         def schools
-          @schools = begin
-            gias_schools = GiasSchool.where(urn: urn_service[:new_urns])
-            gias_schools.map do |gias_school|
-              provider.sites.build(gias_school.school_attributes)
-            end
-          end
+          @schools ||= gias_schools.map { |gias_school| provider.sites.build(gias_school.school_attributes) }
         end
         alias_method :load_schools, :schools
-
-        def gias_schools_by_urn
-          @gias_schools_by_urn ||= GiasSchool.where(urn: schools.map(&:urn)).index_by(&:urn)
-        end
 
         def unfound_urns
           @unfound_urns = urn_service[:unfound_urns]

--- a/app/controllers/publish/providers/schools/checks_controller.rb
+++ b/app/controllers/publish/providers/schools/checks_controller.rb
@@ -10,11 +10,18 @@ module Publish
         def show; end
 
         def update
-          if @site.save
-            redirect_to publish_provider_recruitment_cycle_schools_path, flash: { success_with_body: { title: t(".added"), body: @site.location_name } }
-          else
-            render :show
+          ActiveRecord::Base.transaction do
+            ::ProviderSchools::LegacySiteCreator.call(site: @site)
+            ::ProviderSchools::Creator.call(
+              provider: @site.provider,
+              gias_school_id: school_id,
+              site_code: @site.code,
+            )
           end
+
+          redirect_to publish_provider_recruitment_cycle_schools_path, flash: { success_with_body: { title: t(".added"), body: @site.location_name } }
+        rescue ActiveRecord::RecordInvalid
+          render :show
         end
 
       private

--- a/app/controllers/publish/providers/schools/checks_controller.rb
+++ b/app/controllers/publish/providers/schools/checks_controller.rb
@@ -11,12 +11,10 @@ module Publish
 
         def update
           ActiveRecord::Base.transaction do
+            provider_school = ::ProviderSchools::Creator.call(provider: @provider, gias_school_id: school_id)
+
+            @site.code = provider_school.site_code
             ::ProviderSchools::LegacySiteCreator.call(site: @site)
-            ::ProviderSchools::Creator.call(
-              provider: @site.provider,
-              gias_school_id: school_id,
-              site_code: @site.code,
-            )
           end
 
           redirect_to publish_provider_recruitment_cycle_schools_path, flash: { success_with_body: { title: t(".added"), body: @site.location_name } }

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -39,7 +39,16 @@ module Support
         end
 
         def save
-          schools.each(&:save!)
+          schools.each do |site|
+            ActiveRecord::Base.transaction do
+              ::ProviderSchools::LegacySiteCreator.call(site:)
+              ::ProviderSchools::Creator.call(
+                provider:,
+                gias_school_id: gias_schools_by_urn.fetch(site.urn).id,
+                site_code: site.code,
+              )
+            end
+          end
 
           schools_added_message(schools)
         end
@@ -59,6 +68,10 @@ module Support
               provider.sites.build(gias_school.school_attributes)
             end
           end
+        end
+
+        def gias_schools_by_urn
+          @gias_schools_by_urn ||= GiasSchool.where(urn: schools.map(&:urn)).index_by(&:urn)
         end
 
         def unfound_urns

--- a/app/controllers/support/providers/schools/check_multiple_controller.rb
+++ b/app/controllers/support/providers/schools/check_multiple_controller.rb
@@ -39,18 +39,19 @@ module Support
         end
 
         def save
-          schools.each do |site|
+          saved_sites = []
+
+          gias_schools.each do |gias_school|
             ActiveRecord::Base.transaction do
+              provider_school = ::ProviderSchools::Creator.call(provider:, gias_school_id: gias_school.id)
+
+              site = provider.sites.build(gias_school.school_attributes.merge(code: provider_school.site_code))
               ::ProviderSchools::LegacySiteCreator.call(site:)
-              ::ProviderSchools::Creator.call(
-                provider:,
-                gias_school_id: gias_schools_by_urn.fetch(site.urn).id,
-                site_code: site.code,
-              )
+              saved_sites << site
             end
           end
 
-          schools_added_message(schools)
+          schools_added_message(saved_sites)
         end
 
         def urn_form
@@ -61,17 +62,12 @@ module Support
           @urn_service ||= ProviderURNIdentificationService.new(provider, urn_form.values || []).call
         end
 
-        def schools
-          @schools = begin
-            gias_schools = GiasSchool.where(urn: urn_service[:new_urns])
-            gias_schools.map do |gias_school|
-              provider.sites.build(gias_school.school_attributes)
-            end
-          end
+        def gias_schools
+          @gias_schools ||= GiasSchool.where(urn: urn_service[:new_urns])
         end
 
-        def gias_schools_by_urn
-          @gias_schools_by_urn ||= GiasSchool.where(urn: schools.map(&:urn)).index_by(&:urn)
+        def schools
+          @schools ||= gias_schools.map { |gias_school| provider.sites.build(gias_school.school_attributes) }
         end
 
         def unfound_urns

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -12,15 +12,13 @@ module Support
           saved = false
 
           ActiveRecord::Base.transaction do
-            saved = @school_form.save!
+            provider_school = ::ProviderSchools::Creator.call(
+              provider: provider,
+              gias_school_id: params[:school_id],
+            )
 
-            if saved
-              ::ProviderSchools::Creator.call(
-                provider: @site.provider,
-                gias_school_id: params[:school_id],
-                site_code: @site.code,
-              )
-            end
+            @school_form.fields[:code] = provider_school.site_code
+            saved = @school_form.save!
           end
 
           if saved

--- a/app/controllers/support/providers/schools/checks_controller.rb
+++ b/app/controllers/support/providers/schools/checks_controller.rb
@@ -9,7 +9,21 @@ module Support
         def show; end
 
         def update
-          if @school_form.save!
+          saved = false
+
+          ActiveRecord::Base.transaction do
+            saved = @school_form.save!
+
+            if saved
+              ::ProviderSchools::Creator.call(
+                provider: @site.provider,
+                gias_school_id: params[:school_id],
+                site_code: @site.code,
+              )
+            end
+          end
+
+          if saved
             redirect_to support_recruitment_cycle_provider_schools_path
             flash[:success] = t(".added")
           else

--- a/app/services/provider_schools/creator.rb
+++ b/app/services/provider_schools/creator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Writes a Provider::School row against the new GIAS-backed data model.
+# Swallows RecordNotUnique so a re-run (e.g. race with the schools backfill
+# executor) is a no-op, matching the backfill's ON CONFLICT DO NOTHING.
+module ProviderSchools
+  class Creator
+    include ServicePattern
+
+    def initialize(provider:, gias_school_id:, site_code:)
+      @provider = provider
+      @gias_school_id = gias_school_id
+      @site_code = site_code
+    end
+
+    def call
+      @provider.schools.find_or_create_by!(gias_school_id: @gias_school_id, site_code: @site_code)
+    rescue ActiveRecord::RecordNotUnique
+      @provider.schools.find_by!(gias_school_id: @gias_school_id, site_code: @site_code)
+    end
+  end
+end

--- a/app/services/provider_schools/creator.rb
+++ b/app/services/provider_schools/creator.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-# Writes a Provider::School row and owns site_code generation so the
-# new model never depends on legacy Site data. Locks the provider row
-# for the duration of the code-pick + insert so two concurrent adds
-# to the same provider can't hand out the same code. Idempotent under
-# RecordNotUnique (race with the backfill or another request).
 module ProviderSchools
+  # Writes a Provider::School row and owns site_code generation so the
+  # new model never depends on legacy Site data. Locks the provider row
+  # for the duration of the code-pick + insert so two concurrent adds
+  # to the same provider can't hand out the same code. Idempotent under
+  # RecordNotUnique (race with the backfill or another request).
   class Creator
     include ServicePattern
 

--- a/app/services/provider_schools/creator.rb
+++ b/app/services/provider_schools/creator.rb
@@ -1,22 +1,27 @@
 # frozen_string_literal: true
 
-# Writes a Provider::School row against the new GIAS-backed data model.
-# Swallows RecordNotUnique so a re-run (e.g. race with the schools backfill
-# executor) is a no-op, matching the backfill's ON CONFLICT DO NOTHING.
+# Writes a Provider::School row and owns site_code generation so the
+# new model never depends on legacy Site data. Locks the provider row
+# for the duration of the code-pick + insert so two concurrent adds
+# to the same provider can't hand out the same code. Idempotent under
+# RecordNotUnique (race with the backfill or another request).
 module ProviderSchools
   class Creator
     include ServicePattern
 
-    def initialize(provider:, gias_school_id:, site_code:)
+    def initialize(provider:, gias_school_id:)
       @provider = provider
       @gias_school_id = gias_school_id
-      @site_code = site_code
     end
 
     def call
-      @provider.schools.find_or_create_by!(gias_school_id: @gias_school_id, site_code: @site_code)
+      @provider.with_lock do
+        @provider.schools.find_or_create_by!(gias_school_id: @gias_school_id) do |school|
+          school.site_code = Schools::CodeGenerator.call(provider: @provider)
+        end
+      end
     rescue ActiveRecord::RecordNotUnique
-      @provider.schools.find_by!(gias_school_id: @gias_school_id, site_code: @site_code)
+      @provider.schools.find_by!(gias_school_id: @gias_school_id)
     end
   end
 end

--- a/app/services/provider_schools/legacy_site_creator.rb
+++ b/app/services/provider_schools/legacy_site_creator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Writes the legacy Site row for a provider-school addition. Kept isolated
+# from ProviderSchools::Creator so the old write path can be removed in a
+# single step once the new model is switched on.
+module ProviderSchools
+  class LegacySiteCreator
+    include ServicePattern
+
+    def initialize(site:)
+      @site = site
+    end
+
+    def call
+      @site.save!
+      @site
+    end
+  end
+end

--- a/app/services/provider_schools/legacy_site_creator.rb
+++ b/app/services/provider_schools/legacy_site_creator.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# Writes the legacy Site row for a provider-school addition. Kept isolated
-# from ProviderSchools::Creator so the old write path can be removed in a
-# single step once the new model is switched on.
 module ProviderSchools
+  # Writes the legacy Site row for a provider-school addition. Kept isolated
+  # from ProviderSchools::Creator so the old write path can be removed in a
+  # single step once the new model is switched on.
   class LegacySiteCreator
     include ServicePattern
 

--- a/app/services/schools/code_generator.rb
+++ b/app/services/schools/code_generator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Generates a site_code for a provider's next school relationship.
+# Deterministic (first-available) to keep behaviour predictable for
+# users and tests. Excludes "-" because it is reserved for the provider
+# main site under the partial unique index on provider_school
+# (site_code = '-'). Reads used codes from both the legacy site table
+# and the new provider_school table so codes don't collide on either
+# side during the dual-write period. Race safety is the caller's
+# responsibility (see ProviderSchools::Creator).
+module Schools
+  class CodeGenerator
+    include ServicePattern
+
+    SINGLE_CHAR_CODES = (("A".."Z").to_a + ("0".."9").to_a).freeze
+
+    def initialize(provider:)
+      @provider = provider
+    end
+
+    def call
+      first_available_single_char || next_sequential_code
+    end
+
+  private
+
+    def first_available_single_char
+      (SINGLE_CHAR_CODES - used_codes).first
+    end
+
+    def next_sequential_code
+      multi_char_used = used_codes.reject { |c| c.length <= 1 }
+      return "AA" if multi_char_used.empty?
+
+      multi_char_used.max.next
+    end
+
+    def used_codes
+      @used_codes ||= (
+        @provider.sites.pluck(:code) +
+        @provider.schools.pluck(:site_code)
+      ).compact.reject(&:empty?).uniq
+    end
+  end
+end

--- a/app/services/schools/code_generator.rb
+++ b/app/services/schools/code_generator.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-# Generates a site_code for a provider's next school relationship.
-# Deterministic (first-available) to keep behaviour predictable for
-# users and tests. Excludes "-" because it is reserved for the provider
-# main site under the partial unique index on provider_school
-# (site_code = '-'). Reads used codes from both the legacy site table
-# and the new provider_school table so codes don't collide on either
-# side during the dual-write period. Race safety is the caller's
-# responsibility (see ProviderSchools::Creator).
 module Schools
+  # Generates a site_code for a provider's next school relationship.
+  # Deterministic (first-available) to keep behaviour predictable for
+  # users and tests. Excludes "-" because it is reserved for the provider
+  # main site under the partial unique index on provider_school
+  # (site_code = '-'). Reads used codes from both the legacy site table
+  # and the new provider_school table so codes don't collide on either
+  # side during the dual-write period. Race safety is the caller's
+  # responsibility (see ProviderSchools::Creator).
   class CodeGenerator
     include ServicePattern
 
@@ -39,7 +39,7 @@ module Schools
       @used_codes ||= (
         @provider.sites.pluck(:code) +
         @provider.schools.pluck(:site_code)
-      ).compact.reject(&:empty?).uniq
+      ).compact_blank.uniq
     end
   end
 end

--- a/spec/services/provider_schools/creator_spec.rb
+++ b/spec/services/provider_schools/creator_spec.rb
@@ -6,48 +6,68 @@ describe ProviderSchools::Creator do
   let(:provider) { create(:provider) }
   let(:gias_school) { create(:gias_school) }
 
-  it "creates a Provider::School row with the given attributes" do
+  it "creates a Provider::School row with the given provider and gias_school" do
     expect {
-      described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+      described_class.call(provider:, gias_school_id: gias_school.id)
     }.to change(Provider::School, :count).by(1)
 
     row = Provider::School.last
     expect(row.provider).to eq(provider)
     expect(row.gias_school_id).to eq(gias_school.id)
-    expect(row.site_code).to eq("A")
+  end
+
+  it "assigns a site_code from Schools::CodeGenerator" do
+    allow(Schools::CodeGenerator).to receive(:call).with(provider:).and_return("Q")
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id)
+
+    expect(result.site_code).to eq("Q")
   end
 
   it "returns the created row" do
-    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "-")
+    result = described_class.call(provider:, gias_school_id: gias_school.id)
 
     expect(result).to be_a(Provider::School)
     expect(result).to be_persisted
   end
 
-  it "is idempotent when called twice with the same attributes" do
-    described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+  it "is idempotent when called twice with the same provider and gias_school" do
+    described_class.call(provider:, gias_school_id: gias_school.id)
 
     expect {
-      described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+      described_class.call(provider:, gias_school_id: gias_school.id)
     }.not_to change(Provider::School, :count)
   end
 
-  it "returns the existing row when a matching row already exists" do
+  it "returns the existing row when one already exists for this (provider, gias_school)" do
     existing = create(:provider_school, provider:, gias_school:, site_code: "A")
 
-    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+    result = described_class.call(provider:, gias_school_id: gias_school.id)
 
     expect(result).to eq(existing)
+    expect(result.site_code).to eq("A")
   end
 
   it "returns the existing row when a RecordNotUnique race fires" do
     existing = create(:provider_school, provider:, gias_school:, site_code: "B")
 
-    allow(provider.schools).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
-    allow(provider).to receive(:schools).and_return(provider.schools)
+    # Simulate a race: between find_or_create_by!'s SELECT and INSERT, another
+    # process inserted the row.
+    allow_any_instance_of(ActiveRecord::Associations::CollectionProxy)
+      .to receive(:find_or_create_by!)
+      .and_raise(ActiveRecord::RecordNotUnique)
 
-    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "B")
+    result = described_class.call(provider:, gias_school_id: gias_school.id)
 
     expect(result).to eq(existing)
+  end
+
+  it "serialises concurrent adds to the same provider via a row-level lock" do
+    expect(provider).to receive(:with_lock).and_call_original.at_least(:once)
+    allow(Provider).to receive(:find).and_return(provider)
+
+    # Can't truly test concurrency in a unit spec, but we verify the lock is
+    # taken around the write.
+    described_class.call(provider:, gias_school_id: gias_school.id)
   end
 end

--- a/spec/services/provider_schools/creator_spec.rb
+++ b/spec/services/provider_schools/creator_spec.rb
@@ -51,11 +51,9 @@ describe ProviderSchools::Creator do
   it "returns the existing row when a RecordNotUnique race fires" do
     existing = create(:provider_school, provider:, gias_school:, site_code: "B")
 
-    # Simulate a race: between find_or_create_by!'s SELECT and INSERT, another
-    # process inserted the row.
-    allow_any_instance_of(ActiveRecord::Associations::CollectionProxy)
-      .to receive(:find_or_create_by!)
-      .and_raise(ActiveRecord::RecordNotUnique)
+    schools_proxy = provider.schools
+    allow(provider).to receive(:schools).and_return(schools_proxy)
+    allow(schools_proxy).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
 
     result = described_class.call(provider:, gias_school_id: gias_school.id)
 

--- a/spec/services/provider_schools/creator_spec.rb
+++ b/spec/services/provider_schools/creator_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ProviderSchools::Creator do
+  let(:provider) { create(:provider) }
+  let(:gias_school) { create(:gias_school) }
+
+  it "creates a Provider::School row with the given attributes" do
+    expect {
+      described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+    }.to change(Provider::School, :count).by(1)
+
+    row = Provider::School.last
+    expect(row.provider).to eq(provider)
+    expect(row.gias_school_id).to eq(gias_school.id)
+    expect(row.site_code).to eq("A")
+  end
+
+  it "returns the created row" do
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "-")
+
+    expect(result).to be_a(Provider::School)
+    expect(result).to be_persisted
+  end
+
+  it "is idempotent when called twice with the same attributes" do
+    described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+
+    expect {
+      described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+    }.not_to change(Provider::School, :count)
+  end
+
+  it "returns the existing row when a matching row already exists" do
+    existing = create(:provider_school, provider:, gias_school:, site_code: "A")
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "A")
+
+    expect(result).to eq(existing)
+  end
+
+  it "returns the existing row when a RecordNotUnique race fires" do
+    existing = create(:provider_school, provider:, gias_school:, site_code: "B")
+
+    allow(provider.schools).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
+    allow(provider).to receive(:schools).and_return(provider.schools)
+
+    result = described_class.call(provider:, gias_school_id: gias_school.id, site_code: "B")
+
+    expect(result).to eq(existing)
+  end
+end

--- a/spec/services/provider_schools/legacy_site_creator_spec.rb
+++ b/spec/services/provider_schools/legacy_site_creator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ProviderSchools::LegacySiteCreator do
+  let(:provider) { create(:provider) }
+  let(:gias_school) { create(:gias_school) }
+  let(:site) { provider.sites.build(gias_school.school_attributes) }
+
+  it "persists the site" do
+    expect {
+      described_class.call(site:)
+    }.to change(Site, :count).by(1)
+  end
+
+  it "returns the saved site" do
+    result = described_class.call(site:)
+
+    expect(result).to eq(site)
+    expect(result).to be_persisted
+  end
+
+  it "raises when the site is invalid" do
+    invalid_site = provider.sites.build
+
+    expect {
+      described_class.call(site: invalid_site)
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/services/schools/code_generator_spec.rb
+++ b/spec/services/schools/code_generator_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Schools::CodeGenerator do
+  let(:provider) { create(:provider) }
+
+  def seed_site(code)
+    create(:site, provider:, code:)
+  end
+
+  def seed_provider_school(site_code)
+    create(:provider_school, provider:, site_code:)
+  end
+
+  describe "#call" do
+    it "returns 'A' for a provider with no sites or schools" do
+      expect(described_class.call(provider:)).to eq("A")
+    end
+
+    it "returns the first alphabetical code not yet used" do
+      seed_site("A")
+
+      expect(described_class.call(provider:)).to eq("B")
+    end
+
+    it "fills the lowest free slot, not sequentially after the highest" do
+      seed_site("B")
+      seed_site("C")
+
+      expect(described_class.call(provider:)).to eq("A")
+    end
+
+    it "reads used codes from both legacy sites and new provider_schools" do
+      seed_site("A")
+      seed_provider_school("B")
+
+      expect(described_class.call(provider:)).to eq("C")
+    end
+
+    it "treats the same code appearing in both tables as used-once" do
+      seed_site("A")
+      seed_provider_school("A")
+
+      expect(described_class.call(provider:)).to eq("B")
+    end
+
+    it "moves into the numeric range after A-Z are used" do
+      ("A".."Z").each { |c| seed_site(c) }
+
+      expect(described_class.call(provider:)).to eq("0")
+    end
+
+    it "returns 'AA' once all single-char codes are exhausted" do
+      (("A".."Z").to_a + ("0".."9").to_a).each { |c| seed_site(c) }
+
+      expect(described_class.call(provider:)).to eq("AA")
+    end
+
+    it "never returns '-' even when it is the only single-char code missing from used set" do
+      # seed everything BUT "-"; the legacy generator could pick "-" here, we must not
+      (("A".."Z").to_a + ("0".."9").to_a).each { |c| seed_site(c) }
+
+      expect(described_class.call(provider:)).not_to eq("-")
+    end
+
+    it "tolerates a seeded '-' main-site code in provider_school without letting it affect picks" do
+      seed_provider_school("-")
+
+      expect(described_class.call(provider:)).to eq("A")
+    end
+
+    it "returns the next sequential code after the highest multi-char in use" do
+      (("A".."Z").to_a + ("0".."9").to_a).each { |c| seed_site(c) }
+      seed_site("AA")
+      seed_site("AB")
+
+      expect(described_class.call(provider:)).to eq("AC")
+    end
+
+    it "wraps from 'AZ' to 'BA'" do
+      (("A".."Z").to_a + ("0".."9").to_a).each { |c| seed_site(c) }
+      seed_site("AZ")
+
+      expect(described_class.call(provider:)).to eq("BA")
+    end
+
+    it "ignores codes used by other providers" do
+      other = create(:provider)
+      create(:site, provider: other, code: "A")
+
+      expect(described_class.call(provider:)).to eq("A")
+    end
+
+    it "ignores nil and blank codes in the union" do
+      # guard against rogue data; we can't seed nil/blank via the Site factory cleanly
+      # because Site validations enforce presence, but we can stub .pluck to simulate
+      allow(provider.sites).to receive(:pluck).with(:code).and_return([nil, "", "A"])
+      allow(provider.schools).to receive(:pluck).with(:site_code).and_return([nil, "", "B"])
+
+      expect(described_class.call(provider:)).to eq("C")
+    end
+  end
+end

--- a/spec/services/schools/code_generator_spec.rb
+++ b/spec/services/schools/code_generator_spec.rb
@@ -4,9 +4,14 @@ require "rails_helper"
 
 describe Schools::CodeGenerator do
   let(:provider) { create(:provider) }
+  let(:all_single_chars) { ("A".."Z").to_a + ("0".."9").to_a }
 
   def seed_site(code)
     create(:site, provider:, code:)
+  end
+
+  def seed_sites(codes)
+    Site.insert_all(codes.map { |code| { provider_id: provider.id, code: } })
   end
 
   def seed_provider_school(site_code)
@@ -46,20 +51,20 @@ describe Schools::CodeGenerator do
     end
 
     it "moves into the numeric range after A-Z are used" do
-      ("A".."Z").each { |c| seed_site(c) }
+      seed_sites(("A".."Z").to_a)
 
       expect(described_class.call(provider:)).to eq("0")
     end
 
     it "returns 'AA' once all single-char codes are exhausted" do
-      (("A".."Z").to_a + ("0".."9").to_a).each { |c| seed_site(c) }
+      seed_sites(all_single_chars)
 
       expect(described_class.call(provider:)).to eq("AA")
     end
 
     it "never returns '-' even when it is the only single-char code missing from used set" do
       # seed everything BUT "-"; the legacy generator could pick "-" here, we must not
-      (("A".."Z").to_a + ("0".."9").to_a).each { |c| seed_site(c) }
+      seed_sites(all_single_chars)
 
       expect(described_class.call(provider:)).not_to eq("-")
     end
@@ -71,16 +76,13 @@ describe Schools::CodeGenerator do
     end
 
     it "returns the next sequential code after the highest multi-char in use" do
-      (("A".."Z").to_a + ("0".."9").to_a).each { |c| seed_site(c) }
-      seed_site("AA")
-      seed_site("AB")
+      seed_sites(all_single_chars + %w[AA AB])
 
       expect(described_class.call(provider:)).to eq("AC")
     end
 
     it "wraps from 'AZ' to 'BA'" do
-      (("A".."Z").to_a + ("0".."9").to_a).each { |c| seed_site(c) }
-      seed_site("AZ")
+      seed_sites(all_single_chars + %w[AZ])
 
       expect(described_class.call(provider:)).to eq("BA")
     end

--- a/spec/system/publish/providers/schools/add_school_spec.rb
+++ b/spec/system/publish/providers/schools/add_school_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
     when_i_click_add_school
     then_i_see_a_confirmation_message
     and_the_school_is_in_the_database
+    and_the_provider_school_row_is_created
   end
 
   scenario "attempting to add a school with duplicate URN" do
@@ -48,6 +49,7 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
     when_i_click_add_school
     then_i_see_a_duplicate_urn_error
     and_the_school_is_not_added_to_the_database
+    and_no_provider_school_row_is_created
   end
 
   def and_there_are_gias_schools
@@ -172,5 +174,16 @@ RSpec.describe "Adding a provider's schools", travel: mid_cycle(2026) do
     added_school = provider.sites.find_by(urn: @gias_school.urn)
     expect(added_school).to be_present
     expect(added_school.location_name).to eq(@gias_school.name)
+  end
+
+  def and_the_provider_school_row_is_created
+    added_site = provider.sites.find_by(urn: @gias_school.urn)
+    provider_school = provider.schools.find_by(gias_school_id: @gias_school.id)
+    expect(provider_school).to be_present
+    expect(provider_school.site_code).to eq(added_site.code)
+  end
+
+  def and_no_provider_school_row_is_created
+    expect(provider.schools.where(gias_school_id: @gias_school.id)).to be_empty
   end
 end

--- a/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/publish/providers/schools/creating_multiple_schools_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Multiple schools" do
     when_i_click_add_schools
     then_i_am_redirected_to_the_school_index
     and_i_see_that_all_schools_are_created
+    and_provider_school_rows_are_created_for_each
     and_i_see_the_success_message
   end
 
@@ -125,6 +126,15 @@ RSpec.describe "Multiple schools" do
   def and_i_see_that_all_schools_are_created
     @gias_schools.each do |school|
       expect(page).to have_css(".school-row", text: /#{school.name}.*#{school.urn}/)
+    end
+  end
+
+  def and_provider_school_rows_are_created_for_each
+    @gias_schools.each do |gias_school|
+      site = provider.sites.find_by(urn: gias_school.urn)
+      provider_school = provider.schools.find_by(gias_school_id: gias_school.id)
+      expect(provider_school).to be_present
+      expect(provider_school.site_code).to eq(site.code)
     end
   end
 

--- a/spec/system/support/providers/schools/add_school_to_provider_spec.rb
+++ b/spec/system/support/providers/schools/add_school_to_provider_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "Adding school to provider as an admin" do
       when_i_click_add_school
       then_i_see_a_confirmation_message
       and_the_school_is_in_the_database
+      and_the_provider_school_row_is_created
     end
 
     scenario "attempting to add a school with duplicate URN" do
@@ -165,5 +166,12 @@ RSpec.describe "Adding school to provider as an admin" do
     added_school = @provider.sites.find_by(urn: @gias_school.urn)
     expect(added_school).to be_present
     expect(added_school.location_name).to eq(@gias_school.name)
+  end
+
+  def and_the_provider_school_row_is_created
+    added_site = @provider.sites.find_by(urn: @gias_school.urn)
+    provider_school = @provider.schools.find_by(gias_school_id: @gias_school.id)
+    expect(provider_school).to be_present
+    expect(provider_school.site_code).to eq(added_site.code)
   end
 end

--- a/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
+++ b/spec/system/support/providers/schools/creating_multiple_schools_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Multiple schools" do
     when_i_click_add_schools
     then_i_am_redirected_to_the_school_index
     and_i_see_that_all_schools_are_created
+    and_provider_school_rows_are_created_for_each
     and_i_see_the_success_message
   end
 
@@ -116,6 +117,15 @@ RSpec.describe "Multiple schools" do
   def and_i_see_that_all_schools_are_created
     @gias_schools.each do |school|
       expect(page).to have_css(".school-row", text: /#{school.name}.*#{school.urn}/)
+    end
+  end
+
+  def and_provider_school_rows_are_created_for_each
+    @gias_schools.each do |gias_school|
+      site = @provider.sites.find_by(urn: gias_school.urn)
+      provider_school = @provider.schools.find_by(gias_school_id: gias_school.id)
+      expect(provider_school).to be_present
+      expect(provider_school.site_code).to eq(site.code)
     end
   end
 


### PR DESCRIPTION
## Summary

As part of the schools / main-site remodel, providers adding schools to their organisation now dual-write to both the legacy and new data models:

- **Legacy**: `Site` (unchanged — existing validations, geocoding, `Site#code` via `Sites::CodeGenerator` all behave as today).
- **New**: `Provider::School` (GIAS-backed join) — populated with the correct `gias_school_id` and `site_code` (`"-"` for the provider main site).

Scope is the **two user-facing flows** the ticket calls out:

1. **Single-school add** — provider or support user searches GIAS, confirms.
2. **Bulk URN add** — user pastes a URN list, confirms.

Each has a Publish (provider-facing) and Support (admin) controller, so four call sites total. The `DataHub::RegisterSchoolImporter` rake task is **out of scope**; anything it writes before switchover is picked up by `DataHub::SchoolsBackfill::Executor`.

## Done-when checklist

- [x] Adding a school to a provider writes to both data models (single-add)
- [x] Bulk URN import writes to both data models
- [x] Old and new write paths live in **separate service objects** (`ProviderSchools::LegacySiteCreator` and `ProviderSchools::Creator`) — the new path never reads legacy Site data
- [x] Code is structured so the old write path can be removed cleanly later (see *Switchover* below)
- [x] Old data model behaves exactly as today
- [x] New data model gets the correct `gias_school_id` and `site_code`
- [x] Failures are transactional — a failure in either write rolls back both, so we never silently create data in only one model
- [x] Specs cover both single-add and bulk URN flows, asserting rows exist in **both** tables
- [x] Switchover steps documented (below)

## Design

### Three services under `ProviderSchools::` and one shared utility under `Schools::`

- `ProviderSchools::LegacySiteCreator` — takes a built Site and saves it. One-file legacy island, deleted at switchover.
- `ProviderSchools::Creator` — takes `provider:` and `gias_school_id:`, writes the `Provider::School` row. Wraps in `@provider.with_lock` so concurrent adds to the same provider serialise instead of racing for the same code. Idempotent under `RecordNotUnique`. Uses `find_or_create_by!(gias_school_id:)` — a provider-school relationship is uniquely keyed by `(provider, gias_school)`.
- `Schools::CodeGenerator` — deterministic, provider-scoped site_code generator shared with the upcoming `CourseSchools::` work in the next PR. Reads the union of `provider.sites` + `provider.schools` so codes don't collide on either side during dual-write.

### Controller pattern (all four call sites)

```ruby
ActiveRecord::Base.transaction do
  provider_school = ::ProviderSchools::Creator.call(provider:, gias_school_id:)

  site.code = provider_school.site_code   # new → legacy, never the reverse
  ::ProviderSchools::LegacySiteCreator.call(site:)
end
```

The new write runs **first** and owns code generation; the legacy Site is set from the Provider::School's `site_code`. This is what keeps new-path inputs completely free of legacy-Site data — grep `@site.code | site.code` across the four controllers returns only the one *assignment* line above, which is the very line removed at switchover.

### Improvements over the legacy `Sites::CodeGenerator`

| Legacy | New `Schools::CodeGenerator` |
|---|---|
| `.sample` (non-deterministic) | First-available alphabetical (deterministic, predictable for users and tests) |
| Can hand out `"-"` | `"-"` hard-excluded (reserved for the main-site partial unique index) |
| Reads `provider.sites` only | Union of `provider.sites` + `provider.schools` |
| References `Site::POSSIBLE_CODES` etc. | Self-contained constants |
| `"Z"` sentinel in sequential branch | Explicit `"AA"` seed |
| No race protection | Caller (`ProviderSchools::Creator`) holds `@provider.with_lock` |

## Test plan

- [x] `bundle exec rspec spec/services/schools/code_generator_spec.rb` — 13 cases covering: empty provider, first-available pick, gap-filling, union read, numeric fallback, sequential fallback, `"AZ"→"BA"` wrap, `"-"` never emitted, nil/blank tolerance.
- [x] `bundle exec rspec spec/services/provider_schools/` — Creator + LegacySiteCreator unit specs.
- [x] `bundle exec rspec spec/system/publish/providers/schools/ spec/system/support/providers/schools/` — every add-school system spec asserts a matching `Provider::School` row exists with the correct `site_code` and `gias_school_id`.
- [x] Full sweep: `bundle exec rspec spec/system/publish/providers/ spec/system/support/providers/` — 110 examples, 0 failures.
- [x] Grep check: no leakage from legacy `Site` data into `ProviderSchools::Creator` inputs.
- [ ] Manual: add a school via Publish single-search, confirm `Site.last.code == Provider::School.last.site_code` and matching `urn`/`gias_school_id`.
- [ ] Manual: bulk URN paste (3+ URNs), confirm N `Site` rows and N `Provider::School` rows.
- [ ] Manual failure path: stub a `Provider::School` validation to fail, confirm no `Site` row is created either (transactional rollback).

## Switchover (when the new model goes live)

1. Delete `app/services/provider_schools/legacy_site_creator.rb` and its spec.
2. In each of the four schools/check controllers:
   - Remove the `ActiveRecord::Base.transaction` wrapper.
   - Remove the `@site.code = provider_school.site_code` (or `@school_form.fields[:code] = ...`) assignment.
   - Remove the `::ProviderSchools::LegacySiteCreator.call(...)` line.
   - For bulk flows, remove the legacy `schools` helper and the Site-building inside `update`. Rework the check-page view to iterate `gias_schools`.
   - For Support single-add, drop `@school_form.save!` (and the form itself, if unused elsewhere).
3. In `Schools::CodeGenerator`, drop the `provider.sites.pluck(:code)` term from the union.
4. Delete `Sites::CodeGenerator` along with the `Site` model.

`ProviderSchools::Creator` is untouched at switchover — it never read legacy Site data. `Schools::CodeGenerator` survives and continues to serve `CourseSchools::Creator` from the follow-up PR.

## Next PR

A follow-up will mirror this work for **course schools**: adding a school to a course will dual-write `CourseSite` (legacy) and `Course::School` (new). It will introduce `CourseSchools::Creator` and `CourseSchools::LegacyCourseSiteCreator`, reusing `Schools::CodeGenerator` unchanged.