### PR TITLE
Add rate limiting to Sentry message reporting of OneLogin failure

### DIFF
--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -3,6 +3,37 @@ module Find
     class SessionsController < ApplicationController
       skip_before_action :verify_authenticity_token, only: %i[backchannel_logout]
 
+      KNOWN_ONE_LOGIN_ERROR_TYPES = %w[
+        openid_discovery
+        callback_state_mismatch
+        callback_access_denied
+        callback_invalid_request
+        callback_service_unavailable
+        callback_login_required
+        id_token_request
+        id_token_nonce_mismatch
+        id_token_iss_mismatch
+        id_token_aud_mismatch
+        id_token_iat_mismatch
+        id_token_exp_mismatch
+        id_token_vot_mismatch
+        userinfo_request
+        logout_token_exp_mismatch
+        logout_token_aud_mismatch
+        logout_token_iat_mismatch
+        logout_token_iss_mismatch
+        logout_token_sub_mismatch
+        logout_token_events_claim_mismatch
+        invalid_credentials
+        timeout
+        csrf_detected
+        invalid_response
+        connection_failed
+        invalid_authenticity_token
+      ].freeze
+
+      SAMPLED_ONE_LOGIN_ERROR_TYPES = %w[invalid_authenticity_token other].freeze
+
       def callback
         candidate = Find::CandidateAuthenticator.new(oauth: omniauth).call
 
@@ -31,12 +62,17 @@ module Find
       end
 
       def failure
-        Sentry.capture_message("One Login failure", tags: {
-          error_type: params[:message],
-          provider: params[:provider],
-        }, extra: {
-          session_id: request.session&.id&.public_id,
-        })
+        error_type = normalized_one_login_error_type
+        sampled = SAMPLED_ONE_LOGIN_ERROR_TYPES.include?(error_type)
+
+        if !sampled || ErrorReporting::RateLimiter.report?(key: "one_login:#{error_type}", threshold: 10)
+          Sentry.capture_message("One Login failure", tags: {
+            error_type:,
+            sample_rate: sampled ? 10 : 1,
+          }, extra: {
+            session_id: request.session&.id&.public_id,
+          })
+        end
 
         render "errors/omniauth"
       end
@@ -55,6 +91,11 @@ module Find
       end
 
     private
+
+      def normalized_one_login_error_type
+        candidate = params[:message].to_s.demodulize.underscore.sub(/_error\z/, "")
+        KNOWN_ONE_LOGIN_ERROR_TYPES.include?(candidate) ? candidate : "other"
+      end
 
       def logout_request(token)
         logout_utility.build_request(

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -3,6 +3,7 @@ module Find
     class SessionsController < ApplicationController
       skip_before_action :verify_authenticity_token, only: %i[backchannel_logout]
 
+      ERROR_REPORTING_THRESHOLD = 10
       KNOWN_ONE_LOGIN_ERROR_TYPES = %w[
         openid_discovery
         callback_state_mismatch
@@ -65,10 +66,10 @@ module Find
         error_type = normalized_one_login_error_type
         thresholded = THRESHOLDED_ONE_LOGIN_ERROR_TYPES.include?(error_type)
 
-        if !thresholded || ErrorReporting::RateLimiter.report?(key: "one_login:#{error_type}", threshold: 10)
+        if !thresholded || ErrorReporting::RateLimiter.report?(key: "one_login:#{error_type}", threshold: ERROR_REPORTING_THRESHOLD)
           Sentry.capture_message("One Login failure", tags: {
             error_type:,
-            threshold: thresholded ? 10 : 1,
+            threshold: thresholded ? ERROR_REPORTING_THRESHOLD : 1,
           }, extra: {
             session_id: request.session&.id&.public_id,
           })

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -32,7 +32,7 @@ module Find
         invalid_authenticity_token
       ].freeze
 
-      THRESHOLDED_ONE_LOGIN_ERROR_TYPES = %w[invalid_authenticity_token other].freeze
+      THRESHOLDED_ONE_LOGIN_ERROR_TYPES = %w[invalid_authenticity_token].freeze
 
       def callback
         candidate = Find::CandidateAuthenticator.new(oauth: omniauth).call

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -3,6 +3,37 @@ module Find
     class SessionsController < ApplicationController
       skip_before_action :verify_authenticity_token, only: %i[backchannel_logout]
 
+      KNOWN_ONE_LOGIN_ERROR_TYPES = %w[
+        openid_discovery
+        callback_state_mismatch
+        callback_access_denied
+        callback_invalid_request
+        callback_service_unavailable
+        callback_login_required
+        id_token_request
+        id_token_nonce_mismatch
+        id_token_iss_mismatch
+        id_token_aud_mismatch
+        id_token_iat_mismatch
+        id_token_exp_mismatch
+        id_token_vot_mismatch
+        userinfo_request
+        logout_token_exp_mismatch
+        logout_token_aud_mismatch
+        logout_token_iat_mismatch
+        logout_token_iss_mismatch
+        logout_token_sub_mismatch
+        logout_token_events_claim_mismatch
+        invalid_credentials
+        timeout
+        csrf_detected
+        invalid_response
+        connection_failed
+        invalid_authenticity_token
+      ].freeze
+
+      THRESHOLDED_ONE_LOGIN_ERROR_TYPES = %w[invalid_authenticity_token other].freeze
+
       def callback
         candidate = Find::CandidateAuthenticator.new(oauth: omniauth).call
 
@@ -31,12 +62,17 @@ module Find
       end
 
       def failure
-        Sentry.capture_message("One Login failure", tags: {
-          error_type: params[:message],
-          provider: params[:provider],
-        }, extra: {
-          session_id: request.session&.id&.public_id,
-        })
+        error_type = normalized_one_login_error_type
+        thresholded = THRESHOLDED_ONE_LOGIN_ERROR_TYPES.include?(error_type)
+
+        if !thresholded || ErrorReporting::RateLimiter.report?(key: "one_login:#{error_type}", threshold: 10)
+          Sentry.capture_message("One Login failure", tags: {
+            error_type:,
+            threshold: thresholded ? 10 : 1,
+          }, extra: {
+            session_id: request.session&.id&.public_id,
+          })
+        end
 
         render "errors/omniauth"
       end
@@ -55,6 +91,11 @@ module Find
       end
 
     private
+
+      def normalized_one_login_error_type
+        candidate = params[:message].to_s.demodulize.underscore.sub(/_error\z/, "")
+        KNOWN_ONE_LOGIN_ERROR_TYPES.include?(candidate) ? candidate : "other"
+      end
 
       def logout_request(token)
         logout_utility.build_request(

--- a/app/lib/error_reporting/rate_limiter.rb
+++ b/app/lib/error_reporting/rate_limiter.rb
@@ -1,0 +1,29 @@
+module ErrorReporting
+  # Use Redis to keep track of errors reported.
+  # If more than threshold of any error exists then report
+  # Always delete entries older than the window
+  #
+  # Return true if more than threshold entries exist withiing the window
+  class RateLimiter
+    def self.report?(key:, threshold:, window: 1.hour)
+      redis = RedisClient.cache
+      now = Time.zone.now.utc.to_f
+      events_key = "error_reporting:events:#{key}"
+
+      count = redis.multi { |r|
+        # Add one or more members to a sorted set
+        r.zadd(events_key, now, "#{now}-#{SecureRandom.hex(4)}")
+        # Remove all members in a sorted set within the given scores.
+        r.zremrangebyscore(events_key, "-inf", now - window.to_i)
+        # Set a key's time to live in seconds.
+        r.expire(events_key, window.to_i + 60)
+        # Get the number of members in a sorted set.
+        r.zcard(events_key)
+      }.last
+
+      count >= threshold
+    rescue StandardError
+      true
+    end
+  end
+end

--- a/app/lib/error_reporting/rate_limiter.rb
+++ b/app/lib/error_reporting/rate_limiter.rb
@@ -22,7 +22,8 @@ module ErrorReporting
       }.last
 
       count >= threshold
-    rescue StandardError
+    rescue Redis::BaseError => e
+      Rails.logger.tagged("ErrorReporting::RateLimiter") { |l| l.error(e.message) }
       true
     end
   end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,35 +1,8 @@
 # frozen_string_literal: true
 
-class RedisSetting
-  attr_reader :config
-
-  def initialize(config = nil)
-    @config = {
-      url: ENV.fetch("REDIS_WORKER_URL", nil),
-    }.merge(parse_config(config))
-  end
-
-  def url
-    config[:url]
-  end
-
-private
-
-  def parse_config(config)
-    service_config = JSON.parse(config.presence || "{}")
-    redis_config = service_config["redis"]
-    redis_cache_config = redis_config&.select { |r| r["instance_name"].include?("cache") }&.first
-
-    return {} if redis_cache_config.nil?
-
-    redis_credentials = redis_cache_config["credentials"]
-    { url: redis_credentials["uri"] }
-  end
-end
-
 class RedisClient
   def self.current
-    @current ||= Redis.new(url: RedisSetting.new(ENV.fetch("VCAP_SERVICES", nil)).url)
+    @current ||= Redis.new(url: ENV.fetch("REDIS_WORKER_URL", nil))
   end
 
   def self.cache

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -31,4 +31,8 @@ class RedisClient
   def self.current
     @current ||= Redis.new(url: RedisSetting.new(ENV.fetch("VCAP_SERVICES", nil)).url)
   end
+
+  def self.cache
+    @cache ||= Redis.new(url: ENV.fetch("REDIS_CACHE_URL") { ENV.fetch("REDIS_WORKER_URL", nil) })
+  end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ENV.key?("VCAP_SERVICES") || ENV.key?("REDIS_WORKER_URL")
+if ENV.key?("REDIS_WORKER_URL")
   Sidekiq.configure_server do |config|
     config.redis = {
       url: ENV.fetch("REDIS_WORKER_URL"),

--- a/spec/lib/error_reporting/rate_limiter_spec.rb
+++ b/spec/lib/error_reporting/rate_limiter_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe ErrorReporting::RateLimiter do
+  include ActiveSupport::Testing::TimeHelpers
+
+  it "stays silent below the threshold and fires from the threshold onward" do
+    results = 15.times.map { described_class.report?(key: "x", threshold: 10) }
+
+    expect(results).to eq(([false] * 9) + ([true] * 6))
+  end
+
+  it "tracks keys independently" do
+    9.times { described_class.report?(key: "a", threshold: 10) }
+
+    expect(described_class.report?(key: "b", threshold: 10)).to be false
+    expect(described_class.report?(key: "a", threshold: 10)).to be true
+  end
+
+  it "uses a sliding window so old events age out" do
+    freeze_time do
+      10.times { described_class.report?(key: "x", threshold: 10, window: 1.hour) }
+      expect(described_class.report?(key: "x", threshold: 10, window: 1.hour)).to be true
+
+      travel 1.hour + 1.second
+      expect(described_class.report?(key: "x", threshold: 10, window: 1.hour)).to be false
+    end
+  end
+
+  it "fails open if Redis raises" do
+    allow(RedisClient.cache).to receive(:multi).and_raise(StandardError)
+
+    expect(described_class.report?(key: "x", threshold: 10)).to be true
+  end
+end

--- a/spec/lib/error_reporting/rate_limiter_spec.rb
+++ b/spec/lib/error_reporting/rate_limiter_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ErrorReporting::RateLimiter do
-  include ActiveSupport::Testing::TimeHelpers
-
   it "stays silent below the threshold and fires from the threshold onward" do
     results = 15.times.map { described_class.report?(key: "x", threshold: 10) }
 
@@ -17,12 +15,13 @@ RSpec.describe ErrorReporting::RateLimiter do
   end
 
   it "uses a sliding window so old events age out" do
-    freeze_time do
+    Timecop.freeze do
       10.times { described_class.report?(key: "x", threshold: 10, window: 1.hour) }
       expect(described_class.report?(key: "x", threshold: 10, window: 1.hour)).to be true
 
-      travel 1.hour + 1.second
-      expect(described_class.report?(key: "x", threshold: 10, window: 1.hour)).to be false
+      Timecop.travel(1.hour + 1.second) do
+        expect(described_class.report?(key: "x", threshold: 10, window: 1.hour)).to be false
+      end
     end
   end
 

--- a/spec/lib/error_reporting/rate_limiter_spec.rb
+++ b/spec/lib/error_reporting/rate_limiter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ErrorReporting::RateLimiter do
   end
 
   it "fails open if Redis raises" do
-    allow(RedisClient.cache).to receive(:multi).and_raise(StandardError)
+    allow(RedisClient.cache).to receive(:multi).and_raise(Redis::TimeoutError)
 
     expect(described_class.report?(key: "x", threshold: 10)).to be true
   end

--- a/spec/requests/find/authentication_error_spec.rb
+++ b/spec/requests/find/authentication_error_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Authentication error", service: :find, type: :request do
   describe "POST /auth/find-developer/callback" do
     it "triggers an error and renders the error page" do
       allow(Sentry).to receive(:capture_message)
+      allow(ErrorReporting::RateLimiter).to receive(:report?).and_return(true)
 
       post "/auth/find-developer/callback"
       follow_redirect!
@@ -20,6 +21,68 @@ RSpec.describe "Authentication error", service: :find, type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Authentication error")
       expect(Sentry).to have_received(:capture_message)
+    end
+  end
+
+  describe "GET /auth/failure" do
+    before { allow(Sentry).to receive(:capture_message) }
+
+    it "always reports known gem error types without checking the threshold" do
+      expect(ErrorReporting::RateLimiter).not_to receive(:report?)
+
+      get "/auth/failure", params: { message: "callback_state_mismatch" }
+
+      expect(Sentry).to have_received(:capture_message).with(
+        "One Login failure",
+        hash_including(tags: hash_including(error_type: "callback_state_mismatch", sample_rate: 1)),
+      )
+    end
+
+    it "reports invalid_authenticity_token once the threshold is reached" do
+      allow(ErrorReporting::RateLimiter).to receive(:report?)
+        .with(key: "one_login:invalid_authenticity_token", threshold: 10)
+        .and_return(true)
+
+      get "/auth/failure", params: { message: "ActionController::InvalidAuthenticityToken" }
+
+      expect(Sentry).to have_received(:capture_message).with(
+        "One Login failure",
+        hash_including(tags: hash_including(error_type: "invalid_authenticity_token", sample_rate: 10)),
+      )
+    end
+
+    it "stays silent for invalid_authenticity_token below the threshold" do
+      allow(ErrorReporting::RateLimiter).to receive(:report?).and_return(false)
+
+      get "/auth/failure", params: { message: "ActionController::InvalidAuthenticityToken" }
+
+      expect(Sentry).not_to have_received(:capture_message)
+    end
+
+    it "buckets unknown error types as 'other' to bound cardinality, and applies the threshold" do
+      allow(ErrorReporting::RateLimiter).to receive(:report?)
+        .with(key: "one_login:other", threshold: 10)
+        .and_return(true)
+
+      get "/auth/failure", params: { message: "<attacker-controlled>" }
+
+      expect(Sentry).to have_received(:capture_message).with(
+        "One Login failure",
+        hash_including(tags: hash_including(error_type: "other", sample_rate: 10)),
+      )
+    end
+
+    it "treats a blank message as 'other'" do
+      allow(ErrorReporting::RateLimiter).to receive(:report?)
+        .with(key: "one_login:other", threshold: 10)
+        .and_return(true)
+
+      get "/auth/failure"
+
+      expect(Sentry).to have_received(:capture_message).with(
+        "One Login failure",
+        hash_including(tags: hash_including(error_type: "other")),
+      )
     end
   end
 end

--- a/spec/requests/find/authentication_error_spec.rb
+++ b/spec/requests/find/authentication_error_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Authentication error", service: :find, type: :request do
 
       expect(Sentry).to have_received(:capture_message).with(
         "One Login failure",
-        hash_including(tags: hash_including(error_type: "callback_state_mismatch", sample_rate: 1)),
+        hash_including(tags: hash_including(error_type: "callback_state_mismatch", threshold: 1)),
       )
     end
 
@@ -47,7 +47,7 @@ RSpec.describe "Authentication error", service: :find, type: :request do
 
       expect(Sentry).to have_received(:capture_message).with(
         "One Login failure",
-        hash_including(tags: hash_including(error_type: "invalid_authenticity_token", sample_rate: 10)),
+        hash_including(tags: hash_including(error_type: "invalid_authenticity_token", threshold: 10)),
       )
     end
 
@@ -57,19 +57,6 @@ RSpec.describe "Authentication error", service: :find, type: :request do
       get "/auth/failure", params: { message: "ActionController::InvalidAuthenticityToken" }
 
       expect(Sentry).not_to have_received(:capture_message)
-    end
-
-    it "buckets unknown error types as 'other' to bound cardinality, and applies the threshold" do
-      allow(ErrorReporting::RateLimiter).to receive(:report?)
-        .with(key: "one_login:other", threshold: 10)
-        .and_return(true)
-
-      get "/auth/failure", params: { message: "<attacker-controlled>" }
-
-      expect(Sentry).to have_received(:capture_message).with(
-        "One Login failure",
-        hash_including(tags: hash_including(error_type: "other", sample_rate: 10)),
-      )
     end
 
     it "treats a blank message as 'other'" do

--- a/spec/support/mock_redis.rb
+++ b/spec/support/mock_redis.rb
@@ -8,5 +8,6 @@ RSpec.configure do |config|
     allow(Redis).to receive(:new).and_return(mock_redis)
 
     RedisClient.current.flushdb
+    RedisClient.cache.flushdb
   end
 end


### PR DESCRIPTION
## Context

  Omniauth failures happen regularly due to session expiration and other
  normal issues. We want to silence normal occurances of this. We still
  want to report any high levels of this error so genuine issues don't
  get hidden

  We want to maintain a whitelist of error types that correspond the the
  types that the OneLogin strategy will raise. Because the errors
  correspond the the message of the error we keep a list of valid keys
  to create the redis bucket with.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Testing in QA.

I triggered the /auth/failure endpoint with inauthenticity token message 11 times.
Only 2 incitends were reported to Sentry.
This matches our expectations.
Every incident that is above the threshold within the window is reported.

<img width="1119" height="319" alt="image" src="https://github.com/user-attachments/assets/a2e7a671-7262-42db-b7ff-a63d2beca76d" />

<img width="1587" height="646" alt="image" src="https://github.com/user-attachments/assets/c8f8bf77-83a5-4b89-b0bd-72ae1098580e" />



## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.