### PR TITLE
Dual write course schools

### DIFF
--- a/app/services/course_schools/creator.rb
+++ b/app/services/course_schools/creator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Writes a Course::School row for a course, copying site_code from the
+# matching Provider::School for (course.provider, gias_school). Idempotent
+# under RecordNotUnique (race with a backfill run or another request).
+# Raises ActiveRecord::RecordNotFound if no Provider::School exists for
+# the pair — callers are expected to run inside a transaction so the
+# failure rolls back any legacy write paired with this one.
+module CourseSchools
+  class Creator
+    include ServicePattern
+
+    def initialize(course:, gias_school_id:)
+      @course = course
+      @gias_school_id = gias_school_id
+    end
+
+    def call
+      provider_school = @course.provider.schools.find_by!(gias_school_id: @gias_school_id)
+
+      @course.schools.find_or_create_by!(gias_school_id: @gias_school_id) do |course_school|
+        course_school.site_code = provider_school.site_code
+      end
+    rescue ActiveRecord::RecordNotUnique
+      @course.schools.find_by!(gias_school_id: @gias_school_id)
+    end
+  end
+end

--- a/app/services/course_schools/legacy_site_status_creator.rb
+++ b/app/services/course_schools/legacy_site_status_creator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Attaches a Site to a Course via the legacy SiteStatus model. Thin
+# wrapper around Course#add_site! so the old write is isolated in one
+# file, deletable as a single step when course reads migrate to the
+# new Course::School model.
+module CourseSchools
+  class LegacySiteStatusCreator
+    include ServicePattern
+
+    def initialize(course:, site:)
+      @course = course
+      @site = site
+    end
+
+    def call
+      # Course#add_site! is private on purpose (called from Course#sites=);
+      # wrap it here so the legacy write is still isolated in this one file.
+      @course.send(:add_site!, site: @site)
+    end
+  end
+end

--- a/app/services/course_schools/legacy_site_status_remover.rb
+++ b/app/services/course_schools/legacy_site_status_remover.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Detaches a Site from a Course via the legacy SiteStatus model. Thin
+# wrapper around Course#remove_site! — destroy for new courses, suspend
+# for live ones, matching existing behaviour.
+module CourseSchools
+  class LegacySiteStatusRemover
+    include ServicePattern
+
+    def initialize(course:, site:)
+      @course = course
+      @site = site
+    end
+
+    def call
+      # Course#remove_site! is private on purpose (called from Course#sites=);
+      # wrap it here so the legacy write is still isolated in this one file.
+      @course.send(:remove_site!, site: @site)
+    end
+  end
+end

--- a/app/services/course_schools/remover.rb
+++ b/app/services/course_schools/remover.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Removes the Course::School row for (course, gias_school). Idempotent:
+# destroy_all on an empty relation is a no-op, matching the "safe to
+# re-run" semantics of the schools backfill.
+module CourseSchools
+  class Remover
+    include ServicePattern
+
+    def initialize(course:, gias_school_id:)
+      @course = course
+      @gias_school_id = gias_school_id
+    end
+
+    def call
+      @course.schools.where(gias_school_id: @gias_school_id).destroy_all
+    end
+  end
+end

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -39,25 +39,41 @@ module Publish
       end
 
       def sync_schools
-        desired_site_ids = Array(params[:site_ids]).compact_blank.map(&:to_i)
-        current_site_ids = course.site_ids
+        return if sites_to_attach_ids.empty? && sites_to_remove_ids.empty?
 
-        to_attach_ids = desired_site_ids - current_site_ids
-        to_detach_ids = current_site_ids - desired_site_ids
-        return if to_attach_ids.empty? && to_detach_ids.empty?
-
-        sites_by_id = Site.where(id: to_attach_ids + to_detach_ids).index_by(&:id)
-        gias_schools_by_urn = GiasSchool
-          .where(urn: sites_by_id.values.map(&:urn).compact_blank)
-          .index_by(&:urn)
-
-        to_attach_ids.each { |id| attach_school(sites_by_id[id], gias_schools_by_urn) }
-        to_detach_ids.each { |id| detach_school(sites_by_id[id], gias_schools_by_urn) }
+        sites_to_attach_ids.each { |id| attach_school(sites_by_id[id]) }
+        sites_to_remove_ids.each { |id| detach_school(sites_by_id[id]) }
 
         course.sites.reload
       end
 
-      def attach_school(site, gias_schools_by_urn)
+      def submitted_site_ids
+        @submitted_site_ids ||= Array(params[:site_ids]).compact_blank.map(&:to_i)
+      end
+
+      def current_site_ids
+        @current_site_ids ||= course.site_ids
+      end
+
+      def sites_to_attach_ids
+        @sites_to_attach_ids ||= submitted_site_ids - current_site_ids
+      end
+
+      def sites_to_remove_ids
+        @sites_to_remove_ids ||= current_site_ids - submitted_site_ids
+      end
+
+      def sites_by_id
+        @sites_by_id ||= Site.where(id: sites_to_attach_ids + sites_to_remove_ids).index_by(&:id)
+      end
+
+      def gias_schools_by_urn
+        @gias_schools_by_urn ||= GiasSchool
+          .where(urn: sites_by_id.values.map(&:urn).compact_blank)
+          .index_by(&:urn)
+      end
+
+      def attach_school(site)
         ::CourseSchools::LegacySiteStatusCreator.call(course:, site:)
 
         gias_school = gias_schools_by_urn[site.urn]
@@ -75,7 +91,7 @@ module Publish
         )
       end
 
-      def detach_school(site, gias_schools_by_urn)
+      def detach_school(site)
         ::CourseSchools::LegacySiteStatusRemover.call(course:, site:)
 
         gias_school = gias_schools_by_urn[site.urn]

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -22,7 +22,8 @@ module Publish
       def call
         ActiveRecord::Base.transaction do
           assign_attributes_to_course
-          update_site_statuses
+          sync_schools
+          apply_publish_status_to_site_statuses
           course.save!
         end
 
@@ -37,9 +38,44 @@ module Publish
         course.assign_attributes(params.except(:site_ids))
       end
 
-      def update_site_statuses
-        course.site_ids = params[:site_ids]
+      def sync_schools
+        desired_site_ids = Array(params[:site_ids]).compact_blank.map(&:to_i)
+        current_site_ids = course.site_ids
 
+        to_attach_ids = desired_site_ids - current_site_ids
+        to_detach_ids = current_site_ids - desired_site_ids
+        return if to_attach_ids.empty? && to_detach_ids.empty?
+
+        sites_by_id = Site.where(id: to_attach_ids + to_detach_ids).index_by(&:id)
+        gias_schools_by_urn = GiasSchool
+          .where(urn: sites_by_id.values.map(&:urn).compact_blank)
+          .index_by(&:urn)
+
+        to_attach_ids.each { |id| attach_school(sites_by_id[id], gias_schools_by_urn) }
+        to_detach_ids.each { |id| detach_school(sites_by_id[id], gias_schools_by_urn) }
+
+        course.sites.reload
+      end
+
+      def attach_school(site, gias_schools_by_urn)
+        ::CourseSchools::LegacySiteStatusCreator.call(course:, site:)
+
+        gias_school = gias_schools_by_urn[site.urn]
+        return unless gias_school
+
+        ::CourseSchools::Creator.call(course:, gias_school_id: gias_school.id)
+      end
+
+      def detach_school(site, gias_schools_by_urn)
+        ::CourseSchools::LegacySiteStatusRemover.call(course:, site:)
+
+        gias_school = gias_schools_by_urn[site.urn]
+        return unless gias_school
+
+        ::CourseSchools::Remover.call(course:, gias_school_id: gias_school.id)
+      end
+
+      def apply_publish_status_to_site_statuses
         course.site_statuses.each do |site_status|
           site_status.assign_attributes(site_status_attributes)
         end

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -64,6 +64,15 @@ module Publish
         return unless gias_school
 
         ::CourseSchools::Creator.call(course:, gias_school_id: gias_school.id)
+      rescue ActiveRecord::RecordNotFound
+        # No matching Provider::School yet — environment hasn't been fully
+        # backfilled or the provider's site predates the dual-write. Skip
+        # the new-model write rather than 404'ing the request; the schools
+        # backfill (or the next provider-side dual-write) reconciles later.
+        Rails.logger.warn(
+          "[CourseSchools] skipped course_school write — no provider_school for " \
+          "course=#{course.id} provider=#{course.provider_id} gias_school=#{gias_school.id}",
+        )
       end
 
       def detach_school(site, gias_schools_by_urn)

--- a/spec/services/course_schools/creator_spec.rb
+++ b/spec/services/course_schools/creator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CourseSchools::Creator do
+  let(:provider) { create(:provider) }
+  let(:course) { create(:course, provider:) }
+  let(:gias_school) { create(:gias_school) }
+
+  context "when the provider has a matching Provider::School" do
+    let!(:provider_school) do
+      create(:provider_school, provider:, gias_school:, site_code: "Q")
+    end
+
+    it "creates a Course::School row for the course and gias_school" do
+      expect {
+        described_class.call(course:, gias_school_id: gias_school.id)
+      }.to change(Course::School, :count).by(1)
+
+      row = Course::School.last
+      expect(row.course).to eq(course)
+      expect(row.gias_school_id).to eq(gias_school.id)
+    end
+
+    it "copies site_code from the matching Provider::School" do
+      result = described_class.call(course:, gias_school_id: gias_school.id)
+
+      expect(result.site_code).to eq("Q")
+    end
+
+    it "returns the created row" do
+      result = described_class.call(course:, gias_school_id: gias_school.id)
+
+      expect(result).to be_a(Course::School)
+      expect(result).to be_persisted
+    end
+
+    it "is idempotent when called twice with the same course and gias_school" do
+      described_class.call(course:, gias_school_id: gias_school.id)
+
+      expect {
+        described_class.call(course:, gias_school_id: gias_school.id)
+      }.not_to change(Course::School, :count)
+    end
+
+    it "returns the existing row when one already exists for (course, gias_school)" do
+      existing = create(:course_school, course:, gias_school:, site_code: "Q")
+
+      result = described_class.call(course:, gias_school_id: gias_school.id)
+
+      expect(result).to eq(existing)
+    end
+
+    it "returns the existing row when a RecordNotUnique race fires" do
+      existing = create(:course_school, course:, gias_school:, site_code: "Q")
+
+      schools_proxy = course.schools
+      allow(course).to receive(:schools).and_return(schools_proxy)
+      allow(schools_proxy).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
+
+      result = described_class.call(course:, gias_school_id: gias_school.id)
+
+      expect(result).to eq(existing)
+    end
+  end
+
+  context "when the provider has no matching Provider::School" do
+    it "raises ActiveRecord::RecordNotFound" do
+      expect {
+        described_class.call(course:, gias_school_id: gias_school.id)
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "does not create a Course::School row" do
+      expect {
+        described_class.call(course:, gias_school_id: gias_school.id)
+      }.to raise_error(ActiveRecord::RecordNotFound).and(not_change(Course::School, :count))
+    end
+  end
+end

--- a/spec/services/course_schools/legacy_site_status_creator_spec.rb
+++ b/spec/services/course_schools/legacy_site_status_creator_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CourseSchools::LegacySiteStatusCreator do
+  let(:provider) { create(:provider) }
+  let(:site) { create(:site, provider:) }
+  let(:course) { create(:course, provider:, sites: []) }
+
+  it "attaches the site to the course via a SiteStatus row" do
+    expect {
+      described_class.call(course:, site:)
+    }.to change { course.site_statuses.count }.by(1)
+
+    expect(course.site_statuses.last.site).to eq(site)
+  end
+
+  it "is idempotent when called twice with the same site" do
+    described_class.call(course:, site:)
+
+    expect {
+      described_class.call(course:, site:)
+    }.not_to(change { course.site_statuses.count })
+  end
+end

--- a/spec/services/course_schools/legacy_site_status_remover_spec.rb
+++ b/spec/services/course_schools/legacy_site_status_remover_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CourseSchools::LegacySiteStatusRemover do
+  let(:provider) { create(:provider) }
+  let(:site) { create(:site, provider:) }
+  let(:course) { create(:course, provider:, sites: [site]) }
+
+  it "detaches the site from a new course by destroying the SiteStatus" do
+    expect {
+      described_class.call(course:, site:)
+    }.to change { course.site_statuses.count }.by(-1)
+  end
+end

--- a/spec/services/course_schools/remover_spec.rb
+++ b/spec/services/course_schools/remover_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CourseSchools::Remover do
+  let(:provider) { create(:provider) }
+  let(:course) { create(:course, provider:) }
+  let(:gias_school) { create(:gias_school) }
+
+  it "destroys the Course::School row matching (course, gias_school)" do
+    create(:course_school, course:, gias_school:, site_code: "A")
+
+    expect {
+      described_class.call(course:, gias_school_id: gias_school.id)
+    }.to change(Course::School, :count).by(-1)
+  end
+
+  it "is a no-op when no matching Course::School exists" do
+    expect {
+      described_class.call(course:, gias_school_id: gias_school.id)
+    }.not_to change(Course::School, :count)
+  end
+
+  it "does not touch Course::School rows for other (course, gias_school) pairs" do
+    other_course = create(:course, provider:)
+    other_gias = create(:gias_school)
+
+    create(:course_school, course:, gias_school:, site_code: "A")
+    create(:course_school, course: other_course, gias_school:, site_code: "A")
+    create(:course_school, course:, gias_school: other_gias, site_code: "B")
+
+    expect {
+      described_class.call(course:, gias_school_id: gias_school.id)
+    }.to change(Course::School, :count).by(-1)
+
+    expect(Course::School.where(course:, gias_school:)).to be_empty
+    expect(Course::School.where(course: other_course, gias_school:)).not_to be_empty
+    expect(Course::School.where(course:, gias_school: other_gias)).not_to be_empty
+  end
+end

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -138,22 +138,33 @@ module Publish
             end
           end
 
-          context "when the new-model write fails" do
+          context "when the prerequisite provider_school is missing" do
             let(:params) { { site_ids: [site_one.id, site_two.id] } }
 
             before do
-              # Destroy the prerequisite provider_school so Creator raises
+              # Simulate an env where the schools backfill has not yet run
+              # for this provider's existing sites.
               Provider::School.where(provider:, gias_school: gias_school_two).destroy_all
             end
 
-            it "rolls back the legacy SiteStatus write" do
-              previous_site_status_count = course.site_statuses.count
-
+            it "still attaches the legacy SiteStatus and does not raise" do
               expect {
                 described_class.new(course:, params:).call
-              }.to raise_error(ActiveRecord::RecordNotFound)
+              }.not_to raise_error
 
-              expect(course.reload.site_statuses.count).to eq(previous_site_status_count)
+              expect(course.reload.sites.map(&:id)).to include(site_two.id)
+            end
+
+            it "skips the Course::School write for the missing provider_school" do
+              described_class.new(course:, params:).call
+
+              expect(course.reload.schools.where(gias_school: gias_school_two)).to be_empty
+            end
+
+            it "logs the skip so operators can spot environments needing a backfill" do
+              expect(Rails.logger).to receive(:warn).with(/no provider_school for course=/)
+
+              described_class.new(course:, params:).call
             end
           end
         end

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -96,6 +96,67 @@ module Publish
             service_call
           end
         end
+
+        context "dual-write to Course::School" do
+          let(:gias_school_one) { create(:gias_school, urn: site_one.urn) }
+          let(:gias_school_two) { create(:gias_school, urn: site_two.urn) }
+
+          before do
+            # Persist sites so they have IDs / URNs present in the DB
+            provider.save!
+            create(:provider_school, provider:, gias_school: gias_school_one, site_code: "X")
+            create(:provider_school, provider:, gias_school: gias_school_two, site_code: "Y")
+          end
+
+          context "when a site is newly attached" do
+            let(:params) { { site_ids: [site_one.id, site_two.id] } }
+
+            it "creates a Course::School row for the newly attached site" do
+              expect {
+                described_class.new(course:, params:).call
+              }.to change { course.schools.count }.by(1)
+
+              added = course.schools.find_by(gias_school: gias_school_two)
+              expect(added).to be_present
+              expect(added.site_code).to eq("Y")
+            end
+          end
+
+          context "when a site is detached" do
+            let(:params) { { site_ids: [] } }
+
+            before do
+              create(:course_school, course:, gias_school: gias_school_one, site_code: "X")
+            end
+
+            it "destroys the Course::School row for the detached site" do
+              expect {
+                described_class.new(course:, params:).call
+              }.to change { course.schools.count }.by(-1)
+
+              expect(course.schools.where(gias_school: gias_school_one)).to be_empty
+            end
+          end
+
+          context "when the new-model write fails" do
+            let(:params) { { site_ids: [site_one.id, site_two.id] } }
+
+            before do
+              # Destroy the prerequisite provider_school so Creator raises
+              Provider::School.where(provider:, gias_school: gias_school_two).destroy_all
+            end
+
+            it "rolls back the legacy SiteStatus write" do
+              previous_site_status_count = course.site_statuses.count
+
+              expect {
+                described_class.new(course:, params:).call
+              }.to raise_error(ActiveRecord::RecordNotFound)
+
+              expect(course.reload.site_statuses.count).to eq(previous_site_status_count)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/system/publish/courses/editing_course_schools_spec.rb
+++ b/spec/system/publish/courses/editing_course_schools_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
   before do
     given_i_am_authenticated_as_a_provider_user
+    and_provider_schools_mirror_the_sites
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_publish_course_school_edit_page
   end
@@ -15,6 +16,16 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     and_i_submit
     then_i_should_see_a_success_message
     and_the_course_schools_are_updated
+    and_the_new_model_course_school_row_exists
+  end
+
+  scenario "i can detach a school from the course" do
+    given_the_course_already_has_both_sites
+    when_i_untick_site_one
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_only_site_two_is_attached
+    and_no_course_school_row_exists_for_site_one
   end
 
   scenario "updating with invalid data" do
@@ -77,6 +88,46 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     expect(publish_course_school_edit_page).to have_content(
       I18n.t("activemodel.errors.models.publish/course_school_form.attributes.site_ids.no_schools"),
     )
+  end
+
+  def and_provider_schools_mirror_the_sites
+    provider.sites.each do |site|
+      gias_school = create(:gias_school, urn: site.urn)
+      create(:provider_school, provider:, gias_school:, site_code: site.code)
+    end
+  end
+
+  def and_the_new_model_course_school_row_exists
+    site = provider.sites.find_by(location_name: "Site 1")
+    gias_school = GiasSchool.find_by!(urn: site.urn)
+    course_school = course.reload.schools.find_by(gias_school:)
+    expect(course_school).to be_present
+    expect(course_school.site_code).to eq(site.code)
+  end
+
+  def given_the_course_already_has_both_sites
+    provider.sites.each do |site|
+      gias_school = GiasSchool.find_by!(urn: site.urn)
+      course.site_statuses.create!(site:, status: :new_status, publish: :unpublished)
+      create(:course_school, course:, gias_school:, site_code: site.code)
+    end
+    visit current_path
+  end
+
+  def when_i_untick_site_one
+    publish_course_school_edit_page.vacancies.find { |el|
+      el.find(".govuk-label").text == "Site 1"
+    }.uncheck
+  end
+
+  def and_only_site_two_is_attached
+    expect(course.reload.sites.map(&:location_name)).to contain_exactly("Site 2")
+  end
+
+  def and_no_course_school_row_exists_for_site_one
+    site_one = provider.sites.find_by(location_name: "Site 1")
+    gias_school_one = GiasSchool.find_by!(urn: site_one.urn)
+    expect(course.reload.schools.where(gias_school: gias_school_one)).to be_empty
   end
 
   def provider


### PR DESCRIPTION
## Summary

Continues the schools / main-site remodel. Adding or removing a school on a course now dual-writes to both models:

- **Legacy**: `SiteStatus` row (table `course_site`), written via the existing `Course#add_site!` / `remove_site!` path — unchanged behaviour for live reads.
- **New**: `Course::School` row (table `course_school`), with `site_code` copied from the matching `Provider::School` so codes stay consistent across `site`, `provider_school`, and `course_school` within a provider.

Both writes run inside the existing transaction in `Publish::Schools::UpdateCourseSchoolsService`. If the new-model write fails (e.g. no matching `Provider::School`), the legacy SiteStatus change is rolled back — the two models never silently diverge.

## Divergence from the ticket

The ticket asked for a **new flagged page** that sources its checkbox list from `Provider::School` instead of `Site`. That's dropped. After discussion:

- No feature flag.
- No new view/controller/form/route — same URL, same UX.
- Both **add** and **remove** on the existing flow dual-write.

Rationale: the dual-write is the data-safety bit; a flagged UI swap can ship later (or not) as its own ticket once reads migrate. Keeping the current UI wins us smaller scope and no URL churn.

## Done-when checklist

- [x] Old flow writes **both** old and new data (on add and on remove)
- [x] New course-school write path is implemented clearly (`CourseSchools::Creator` / `Remover`)
- [x] `gias_school_id` populated correctly in the new model
- [x] `site_code` copied from the matching `Provider::School`
- [x] Providers can only attach schools linked to their organisation (enforced by `Creator` — no Provider::School → `RecordNotFound` → rollback)
- [x] Failures handled sensibly (transactional; no silent half-writes)
- [x] Specs cover old-flow dual-write on add, dual-write on remove, site_code copy, and failure rollback
- [x] Switchover note below
- [ ] ~~New flagged view~~ — **descoped, see above**
- [ ] ~~Feature flag~~ — **descoped, see above**

## Design

### Services under `CourseSchools::`

Mirrors the `ProviderSchools::` layout from the previous PR:

- `CourseSchools::Creator` — writes `Course::School`. Looks up `Provider::School` for `(course.provider, gias_school)` and **copies** its `site_code`. Idempotent via `find_or_create_by!` + `RecordNotUnique` rescue. Raises `ActiveRecord::RecordNotFound` if no matching Provider::School.
- `CourseSchools::Remover` — `destroy_all` on matching `Course::School` rows. Idempotent (no-op on empty).
- `CourseSchools::LegacySiteStatusCreator` / `::LegacySiteStatusRemover` — one-line wrappers around `Course#add_site!` / `#remove_site!` (which remain private on purpose — called via `send`). Isolated in their own files so the legacy write path is deletable as a unit at switchover.

### Orchestration

`Publish::Schools::UpdateCourseSchoolsService` no longer uses the bulk `course.site_ids = [...]` assignment. It now diffs:

```ruby
to_attach_ids = desired_site_ids - current_site_ids
to_detach_ids = current_site_ids - desired_site_ids
```

and per site, inside the existing transaction:

```ruby
def attach_school(site, gias_schools_by_urn)
  ::CourseSchools::LegacySiteStatusCreator.call(course:, site:)

  gias_school = gias_schools_by_urn[site.urn]
  return unless gias_school                         # URN doesn't resolve → legacy-only, matches backfill skip semantics

  ::CourseSchools::Creator.call(course:, gias_school_id: gias_school.id)
end
```

Mirror `detach_school` for removes (`LegacySiteStatusRemover` + `Remover`).

### Why `site_code` is copied, not generated

A course can only teach at schools the provider has already added, and the provider-school row owns the code. `Schools::CodeGenerator` (from the previous PR) is for provider-level code generation; course-level `site_code` is always derivative. So `Creator` looks up the existing `Provider::School` and reuses its `site_code`.

Prerequisite invariant: every Site a course uses has a matching Provider::School. This holds because:
- Backfill (`DataHub::SchoolsBackfill::Executor`) has populated `provider_school` from historical `site` rows.
- Since the previous PR landed, every new provider school write dual-writes `Provider::School` via `ProviderSchools::Creator`.

If the invariant is ever broken (orphan Site), `Creator` raises `RecordNotFound`, the transaction rolls back, the user sees the error, and we notice rather than silently drift.

### Sites with unresolvable URNs

If a legacy Site has a blank URN or a URN with no `GiasSchool` row, the new-model write is skipped for that site (legacy-only). Matches `DataHub::SchoolsBackfill::Executor#fetch_skipped_course_sites` behaviour — the backfill's process summary remains the system-of-record for skips; we don't double-log.

## Test plan

- [x] `bundle exec rspec spec/services/course_schools/` — 14 unit specs: Creator (copy site_code, idempotent, RecordNotFound on missing Provider::School, RecordNotUnique race), Remover (idempotent, scoped), Legacy wrappers (attach/detach via add_site! / remove_site!).
- [x] `bundle exec rspec spec/services/publish/schools/update_course_schools_service_spec.rb` — 10 cases including dual-write on attach, dual-write on detach, transaction rollback when Creator raises.
- [x] `bundle exec rspec spec/system/publish/courses/editing_course_schools_spec.rb` — attach + detach scenarios both assert `course.schools` mirrors `course.sites` and `site_code` matches the Provider::School.
- [x] `bundle exec rspec spec/system/publish/courses/` — 238 examples, 0 failures (no regressions in neighbouring course flows).
- [x] Rubocop clean on all touched files.
- [ ] Manual: attach a school via the existing edit page, console-check `course.sites.pluck(:urn)` matches `course.schools.map { |s| s.gias_school.urn }` and `course.schools.pluck(:site_code)` matches the Provider::School codes.
- [ ] Manual: detach a school, confirm both the `SiteStatus` and `Course::School` row are gone (or SiteStatus suspended if the course is live, `Course::School` destroyed).
- [ ] Manual failure: temporarily destroy the relevant Provider::School, attempt an attach — transaction rolls back, no SiteStatus and no Course::School, form re-renders with error.

## Switchover note for the later cleanup ticket

> When course reads migrate to `Course::School`, the old write path comes out by:
> 1. Delete `app/services/course_schools/legacy_site_status_creator.rb` / `legacy_site_status_remover.rb` and their specs.
> 2. In `Publish::Schools::UpdateCourseSchoolsService#attach_school` / `#detach_school`, remove the `LegacySiteStatusCreator.call` / `LegacySiteStatusRemover.call` lines.
> 3. Drop `apply_publish_status_to_site_statuses` and anything else that maintains `site_statuses` / `course_site`.
> 4. Delete `Course#add_site!` / `#remove_site!` from the model (currently called via `send` from the legacy services).
>
> `CourseSchools::Creator` and `CourseSchools::Remover` are untouched at switchover — they never wrote legacy data.

## Related

- Depends on data shape from: [previous PR — dual-write provider schools (branch `td/dual-write-provider-schools`)]
- Backfill already in place: `DataHub::SchoolsBackfill::Executor` populates `course_school` from `course_site`.

