### PR TITLE
Publish rules new school model

### DIFF
--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -11,6 +11,7 @@ class FeatureFlags
       [:email_alerts, "Enable email alerts for candidates", "Find and Publish team"],
       [:course_sites_updated_email_notification, "Send email notifications when a course's associated schools are updated", "Find and Publish team"],
       [:wizard_add_course_flow, "Enables the wizard add course flow that uses the DfE wizard", "Find and Publish team"],
+      [:course_publishing_uses_new_school_model, "Read publish-side school checks from Course::School instead of Site", "Find and Publish team"],
     ]
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -365,9 +365,11 @@ class Course < ApplicationRecord
     gcse_science_required? && !recruitment_cycle_after_2021?
   }
 
-  validates :sites, presence: true, on: %i[publish new]
+  validates_with CoursePublishableSchoolsPresenceValidator, on: %i[publish new]
   validates :subjects, presence: true, on: :publish
-  validate :validate_schools, on: :publish, if: -> { recruitment_cycle_rollover_period_2026? }
+  validates_with CoursePublishableSchoolsRolloverValidator,
+                 on: :publish,
+                 if: -> { recruitment_cycle_rollover_period_2026? }
 
   validates :accrediting_provider, presence: true, on: :publish, unless: -> { self_accredited? || further_education_course? }
   validate :validate_enrichment_publishable, on: :publish
@@ -463,15 +465,6 @@ class Course < ApplicationRecord
     return if accredited_provider_code.blank?
 
     errors.add(:accrediting_provider, :partnership_missing) unless provider.accredited_partners.include?(accrediting_provider)
-  end
-
-  def validate_schools
-    return if schools_validated?
-
-    if latest_enrichment&.rolled_over?
-      errors.add(:sites, :check_schools) if sites.school.present?
-      errors.add(:sites, :enter_schools) if sites.school.blank?
-    end
   end
 
   def update_valid?

--- a/app/services/courses/publish_rules/school_presence.rb
+++ b/app/services/courses/publish_rules/school_presence.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Single source of truth for "does this course have any school attached,
+# for the purposes of the :publish validation context?". Flips between
+# legacy Site-based reads and the new Course::School reads based on the
+# :course_publishing_uses_new_school_model flag. Every publish-side
+# school check funnels through here so the flag lives in exactly one place.
+module Courses
+  module PublishRules
+    class SchoolPresence
+      def self.any?(course)
+        if FeatureFlag.active?(:course_publishing_uses_new_school_model)
+          course.schools.any?
+        else
+          # Use Enumerable#any? with a block rather than chaining `.school`
+          # (a scope) so this works on unpersisted courses too — the
+          # presence check runs on the :new validation context where the
+          # course isn't saved yet and its sites are only in memory.
+          course.sites.any?(&:school?)
+        end
+      end
+    end
+  end
+end

--- a/app/validators/course_publishable_schools_presence_validator.rb
+++ b/app/validators/course_publishable_schools_presence_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Publish-context replacement for `validates :sites, presence: true`.
+# Reads the "course has at least one school" decision through
+# Courses::PublishRules::SchoolPresence so flag-on reads from the
+# Course::School model instead of the legacy Site association.
+class CoursePublishableSchoolsPresenceValidator < ActiveModel::Validator
+  def validate(course)
+    return if Courses::PublishRules::SchoolPresence.any?(course)
+
+    course.errors.add(:sites, :blank)
+  end
+end

--- a/app/validators/course_publishable_schools_rollover_validator.rb
+++ b/app/validators/course_publishable_schools_rollover_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Publish-context rollover rule for the 2026 recruitment-cycle migration:
+# when a provider's rolled-over course hits Publish, they must explicitly
+# re-confirm their schools (the `schools_validated` column). Until they
+# do, publishing is blocked with one of two error keys depending on
+# whether any school is currently attached.
+#
+# Reads the "course has at least one school" decision through
+# Courses::PublishRules::SchoolPresence so flag-on reads from the
+# Course::School model instead of the legacy Site association.
+class CoursePublishableSchoolsRolloverValidator < ActiveModel::Validator
+  def validate(course)
+    return if course.schools_validated?
+    return unless course.latest_enrichment&.rolled_over?
+
+    if Courses::PublishRules::SchoolPresence.any?(course)
+      course.errors.add(:sites, :check_schools)
+    else
+      course.errors.add(:sites, :enter_schools)
+    end
+  end
+end

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -84,6 +84,55 @@ describe "#publishable?" do
     end
   end
 
+  context "when the new-school-model flag is on" do
+    let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
+    let(:primary_with_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
+
+    before do
+      allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(true)
+    end
+
+    context "with no Course::School rows" do
+      let(:course) do
+        create(
+          :course,
+          :with_gcse_equivalency,
+          :with_accrediting_provider,
+          subjects: [primary_with_mathematics],
+          enrichments: [enrichment],
+          site_statuses: [site_status], # legacy sites present but flag ignores them
+          study_sites: [study_site],
+        )
+      end
+
+      it "is not publishable and reports the sites :blank error" do
+        expect(course).not_to be_publishable
+        expect(course.errors.details[:sites]).to include(error: :blank)
+      end
+    end
+
+    context "with Course::School rows" do
+      let(:gias_school) { create(:gias_school) }
+      let(:course) do
+        create(
+          :course,
+          :with_gcse_equivalency,
+          :with_accrediting_provider,
+          subjects: [primary_with_mathematics],
+          enrichments: [enrichment],
+          site_statuses: [], # legacy empty but flag reads the new model
+          study_sites: [study_site],
+        )
+      end
+
+      before do
+        create(:course_school, course:, gias_school:, site_code: "A")
+      end
+
+      its(:publishable?) { is_expected.to be_truthy }
+    end
+  end
+
   context "when publishing a NON teacher degree apprenticeship course without A levels" do
     it "does not require A level to be answered" do
       course = create(

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -249,7 +249,11 @@ describe Course do
         .on(%i[create update])
     end
 
-    describe "#validate_schools" do
+    describe "rollover-period schools check on :publish" do
+      # Unit-level rules live in
+      # spec/validators/course_publishable_schools_rollover_validator_spec.rb.
+      # These two cases cover the Course-level wiring: the `if:` guard and
+      # the `schools_validated?` bypass on a real Course instance.
       let(:provider) { create(:provider) }
       let(:recruitment_cycle) { create(:recruitment_cycle, year: 2026, application_start_date: 3.days.ago) }
 
@@ -257,62 +261,20 @@ describe Course do
         provider.update!(recruitment_cycle: recruitment_cycle)
       end
 
-      context "during 2026 rollover period" do
+      context "during 2026 rollover period with schools_validated? true" do
+        let!(:site) { create(:site, provider: provider) }
+        let(:course) { create(:course, schools_validated: true, provider: provider) }
+
         before do
-          # Make sure we're before rollover_end (which is application_start_date + 1.month)
           travel_to(recruitment_cycle.application_start_date + 1.day)
+          course.sites << site
         end
 
         after { travel_back }
 
-        # context "when schools_validated? is false" do
-        #   context "when sites.school is present" do
-        #     let!(:site) { create(:site, provider:) }
-        #     let(:course) { create(:course, provider:, enrichments: [build(:course_enrichment, :rolled_over)]) }
-        #
-        #     before { course.sites << site }
-        #
-        #     it "adds :check_schools error to sites on :publish" do
-        #       expect(course.schools_validated?).to be_falsey
-        #       allow(course.sites).to receive(:school).and_return([site]) unless course.sites.respond_to?(:school)
-        #       course.valid?(:publish)
-        #       expect(course.errors.of_kind?(:sites, :check_schools)).to be true
-        #     end
-        #   end
-        #
-        #   context "when sites.school is blank" do
-        #     let(:course) { create(:course, provider:, enrichments: [build(:course_enrichment, :rolled_over)]) }
-        #
-        #     it "adds :enter_schools error to sites on :publish" do
-        #       allow(course.sites).to receive(:school).and_return([]) unless course.sites.respond_to?(:school)
-        #       course.valid?(:publish)
-        #       expect(course.errors.of_kind?(:sites, :enter_schools)).to be true
-        #     end
-        #   end
-        #
-        #   context "when course is not rolled over" do
-        #     let(:course) { create(:course, provider:, enrichments: [build(:course_enrichment, :draft)]) }
-        #
-        #     it "adds :enter_schools error to sites on :publish" do
-        #       allow(course.sites).to receive(:school).and_return([]) unless course.sites.respond_to?(:school)
-        #       course.valid?(:publish)
-        #       expect(course.errors.of_kind?(:sites, :enter_schools)).to be false
-        #     end
-        #   end
-        # end
-
-        context "when schools_validated? is true" do
-          let!(:site) { create(:site, provider: provider) }
-          let(:course) { create(:course, schools_validated: true, provider: provider) }
-
-          before do
-            course.sites << site
-          end
-
-          it "does not add errors for sites on :publish" do
-            course.valid?(:publish)
-            expect(course.errors[:sites]).to be_empty
-          end
+        it "does not add errors for sites on :publish" do
+          course.valid?(:publish)
+          expect(course.errors[:sites]).to be_empty
         end
       end
 

--- a/spec/services/courses/publish_rules/school_presence_spec.rb
+++ b/spec/services/courses/publish_rules/school_presence_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Courses::PublishRules::SchoolPresence do
+  let(:provider) { create(:provider) }
+  let(:course) { create(:course, provider:) }
+
+  def attach_legacy_site(site)
+    create(:site_status, course:, site:)
+  end
+
+  def attach_new_course_school(gias_school, site_code: "A")
+    create(:course_school, course:, gias_school:, site_code:)
+  end
+
+  describe ".any?" do
+    context "when the flag is off" do
+      before { allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(false) }
+
+      it "returns true when the course has a school-type Site attached" do
+        attach_legacy_site(create(:site, provider:, site_type: :school))
+
+        expect(described_class.any?(course)).to be(true)
+      end
+
+      it "returns false when the course has no Site attached" do
+        expect(described_class.any?(course)).to be(false)
+      end
+
+      it "returns false when the course has only a study-site attached" do
+        attach_legacy_site(create(:site, provider:, site_type: :study_site))
+
+        expect(described_class.any?(course)).to be(false)
+      end
+
+      it "ignores Course::School rows" do
+        attach_new_course_school(create(:gias_school))
+
+        expect(described_class.any?(course)).to be(false)
+      end
+    end
+
+    context "when the flag is on" do
+      before { allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(true) }
+
+      it "returns true when the course has a Course::School row" do
+        attach_new_course_school(create(:gias_school))
+
+        expect(described_class.any?(course)).to be(true)
+      end
+
+      it "returns false when the course has no Course::School row" do
+        expect(described_class.any?(course)).to be(false)
+      end
+
+      it "ignores legacy Sites" do
+        attach_legacy_site(create(:site, provider:, site_type: :school))
+
+        expect(described_class.any?(course)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/validators/course_publishable_schools_presence_validator_spec.rb
+++ b/spec/validators/course_publishable_schools_presence_validator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CoursePublishableSchoolsPresenceValidator do
+  let(:course) { build_stubbed(:course) }
+
+  def run_validator
+    course.errors.clear
+    described_class.new.validate(course)
+  end
+
+  it "does not add an error when SchoolPresence reports schools attached" do
+    allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(true)
+
+    run_validator
+
+    expect(course.errors[:sites]).to be_empty
+  end
+
+  it "adds a :blank error on :sites when SchoolPresence reports no schools" do
+    allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(false)
+
+    run_validator
+
+    expect(course.errors.details[:sites]).to include(error: :blank)
+  end
+end

--- a/spec/validators/course_publishable_schools_rollover_validator_spec.rb
+++ b/spec/validators/course_publishable_schools_rollover_validator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CoursePublishableSchoolsRolloverValidator do
+  let(:course) { build_stubbed(:course) }
+  let(:enrichment) { instance_double(CourseEnrichment, rolled_over?: true) }
+
+  def run_validator
+    course.errors.clear
+    described_class.new.validate(course)
+  end
+
+  before do
+    allow(course).to receive_messages(
+      schools_validated?: false,
+      latest_enrichment: enrichment,
+    )
+  end
+
+  it "is a no-op when schools_validated? is true" do
+    allow(course).to receive(:schools_validated?).and_return(true)
+
+    run_validator
+
+    expect(course.errors[:sites]).to be_empty
+  end
+
+  it "is a no-op when there is no latest enrichment" do
+    allow(course).to receive(:latest_enrichment).and_return(nil)
+
+    run_validator
+
+    expect(course.errors[:sites]).to be_empty
+  end
+
+  it "is a no-op when the latest enrichment is not rolled over" do
+    allow(enrichment).to receive(:rolled_over?).and_return(false)
+
+    run_validator
+
+    expect(course.errors[:sites]).to be_empty
+  end
+
+  it "adds a :check_schools error when a school is attached" do
+    allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(true)
+
+    run_validator
+
+    expect(course.errors.details[:sites]).to include(error: :check_schools)
+  end
+
+  it "adds an :enter_schools error when no school is attached" do
+    allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(false)
+
+    run_validator
+
+    expect(course.errors.details[:sites]).to include(error: :enter_schools)
+  end
+end


### PR DESCRIPTION
## Context

Two `:publish`-context school-related validators on `Course` now read through a single query object that flips data sources by feature flag:

- **Flag off** (default): reads from the legacy `course.sites` association — identical behaviour to today.
- **Flag on**: reads from the new `course.schools` (`Course::School`) association.

Provider-facing publish behaviour is unchanged in either state. The flag (`:course_publishing_uses_new_school_model`) is registered in `app/lib/feature_flags.rb` and toggled at `/support/feature-flags`.

Scope is **publishing rules only** per the ticket — the validation checks that decide "is this course publishable?". Other parts of the publish path that still touch legacy `Site`/`SiteStatus` are surveyed in the audit section below; all are out of scope by the ticket's framing.

## Done-when checklist

- [x] Course publishing rules that depend on schools are switched by feature flag
- [x] Flag off → existing rules use the old data model
- [x] Flag on → equivalent rules use `Course::School`
- [x] Publishing behaviour remains functionally identical for providers (same error keys, same i18n messages, same `publishable?` outcomes given equivalent dual-write data)
- [x] Courses that currently require schools to publish still do
- [x] No support introduced for publishing without schools
- [x] Old-model logic isolated and easy to remove (one `else` branch in one query object)
- [x] Branching is explicit and traceable (single `FeatureFlag.active?` call site)
- [x] Specs cover flag-off, flag-on, publishable, non-publishable
- [x] Implementation note for switchover (below)

## Design

### One query object — single place the flag lives

`Courses::PublishRules::SchoolPresence.any?(course)` (`app/services/courses/publish_rules/school_presence.rb`) is the only file that consults the flag. Two lines of difference at switchover: delete the `else` branch and the flag check, leaving one line.

```ruby
def self.any?(course)
  if FeatureFlag.active?(:course_publishing_uses_new_school_model)
    course.schools.any?
  else
    course.sites.any?(&:school?)
  end
end
```

The flag-off path uses `Enumerable#any? { ... }` (Ruby iteration) rather than chaining the `.school` scope (SQL) so it works on unpersisted courses — the presence rule runs on the `:new` validation context, where `Courses::CreationService` calls `course.valid?(:new)` before saving. Caught this from a regression in `creation_service_spec` during testing.

### Two `ActiveModel::Validator` subclasses

Match the existing `UniqueCourseValidator` / `ALevelCourseValidator` pattern already on `Course`:

- **`CoursePublishableSchoolsPresenceValidator`** replaces `validates :sites, presence: true, on: %i[publish new]`. Adds `:blank` on `:sites` when no school is present.
- **`CoursePublishableSchoolsRolloverValidator`** replaces `Course#validate_schools` (the 2026 rollover rule). Preserves `:check_schools` / `:enter_schools` error keys exactly, so existing i18n messaging and form copy is unchanged. The `schools_validated?` bypass and the `latest_enrichment.rolled_over?` guard live inside the validator now.

Both validators delegate to the query object, so the flag lives in one place and the two rules read the same truth.

`Course` itself shrinks by ~10 lines: the `validate_schools` method body is gone, replaced by two `validates_with` declarations.

## Audit: legacy coupling still in the publish path

I traced the route → controller → service for the publish flow and confirmed nothing else was a school **rule** in disguise. For transparency, here's what still touches `Site` / `SiteStatus` after publish, with my classification:

| Location | What it does | Out of scope because |
|---|---|---|
| `Courses::PublishService#publish_sites` (`app/services/courses/publish_service.rb:37-46`) | `course.site_statuses.status_new_status.update_all(status: :running)` + flips `publish: :published` on running-unpublished rows | Write-side effect of publishing, not a "rule". `Course::School` has no `status` / `publish` columns, so there's nothing to dual-write to. Schema migration first. |
| `NotificationService::CoursePublished#notify_accredited_provider?` (`app/services/notification_service/course_published.rb:33`) | `return false unless course.findable?` — gates the accredited-provider email on at least one running/published site_status | Post-publish filter, not a publishability rule. Moves with the read-path migration. |
| `Publish::CoursesController#fetch_course_with_latest_draft_enrichment_eager_loaded` (`app/controllers/publish/courses_controller.rb:132-146`) | `includes(site_statuses: [:site])` | Perf optimisation that serves the view below. Validators now go through the flag; the eager load stays for the view. |
| `app/views/publish/courses/_basic_details_tab.html.erb:104-116` | Renders `course.sites.length`, `course.sites.first.location_name`, `alphabetically_sorted_sites` on the post-publish page | UI read-path, not a rule. Moves when reads migrate. |
| `Course#validate_site_statuses_publishable` (`app/models/course.rb:1031-1035`) | Iterates `site_statuses.each` and asserts `site_status.valid?` | `:publish` validator, but not a "has schools" rule — it's SiteStatus integrity (vac_status ↔ study_mode). Dies with `Site` itself, not with the schools remodel. |

These are honest legacy reads and writes; none of them are gated by the new flag. The PR doesn't try to move them — the ticket is specifically about publishing **rules**.

## Test plan

- [x] `bundle exec rspec spec/services/courses/publish_rules/school_presence_spec.rb` — 7 cases across the flag-on/flag-off × has-school/no-school × source-divergence matrix.
- [x] `bundle exec rspec spec/validators/course_publishable_schools_presence_validator_spec.rb` — validator unit (stubbed query object).
- [x] `bundle exec rspec spec/validators/course_publishable_schools_rollover_validator_spec.rb` — validator unit covering `schools_validated?` bypass, rollover guard, and both error keys.
- [x] `bundle exec rspec spec/models/course/publishable_spec.rb` — flag-on parity (publishable / non-publishable with `Course::School` rows).
- [x] `bundle exec rspec spec/models/course_spec.rb` — Course-level integration smoke (`if:` guard + `schools_validated` bypass on a real Course).
- [x] `bundle exec rspec spec/services/courses/ spec/system/publish/courses/` — full course service + system sweep, **609 examples, 0 failures**. No regressions.
- [x] Rubocop clean on all touched files.
- [ ] Manual (flag off — default): try to publish a course with no sites → fails with "Select at least one school", same as today.
- [ ] Manual (flag on): `FeatureFlag.activate(:course_publishing_uses_new_school_model)`, repeat — same message when no `Course::School` rows, succeeds when present.
- [ ] Manual (flag on + 2026 rollover period): rolled-over enrichment + `schools_validated = false` + no `Course::School` → `:enter_schools` error; with `Course::School` → `:check_schools`. Identical to today but from the new source.

## Switchover note

> **Which publishing rules were switched**:
> - `Course`'s `:publish` presence check on schools (was `validates :sites, presence: true`; now `validates_with CoursePublishableSchoolsPresenceValidator`).
> - `Course`'s 2026 rollover school check (was `validate :validate_schools`; now `validates_with CoursePublishableSchoolsRolloverValidator`).
>
> Both route through `Courses::PublishRules::SchoolPresence.any?(course)` — the only place the flag is consulted.
>
> **Which old logic is isolated for later removal**:
> - `Courses::PublishRules::SchoolPresence` — delete the `else` branch and the flag check, leaving `course.schools.any?`.
> - The two validator classes keep their names and bodies at switchover; only the query object shrinks.
>
> **Where the feature flag sits**:
> - Registered in `app/lib/feature_flags.rb` as `:course_publishing_uses_new_school_model`.
> - Consulted once, inside `Courses::PublishRules::SchoolPresence.any?`.
> - Admin toggle at `/support/feature-flags`.
>
> **Follow-up cleanup once the old model is removed** (separate tickets, see audit above):
> - Strip the `else` branch from `SchoolPresence`, leaving a one-liner.
> - Remove the `:course_publishing_uses_new_school_model` entry from `FeatureFlags.all`.
> - `Courses::PublishService#publish_sites` needs a schema migration on `Course::School` (`status` / `publish` columns) before it can flip — biggest follow-up.
> - `Course#findable?`, `validate_site_statuses_publishable`, the post-publish view render, and the controller eager-load all retire when `Site` itself goes.


