### PR TITLE
Increase feedback shows in support interface

### DIFF
--- a/app/controllers/support/feedbacks_controller.rb
+++ b/app/controllers/support/feedbacks_controller.rb
@@ -1,7 +1,7 @@
 module Support
   class FeedbacksController < ApplicationController
     def index
-      @pagy, @feedbacks = pagy(Feedback.order(created_at: :desc))
+      @pagy, @feedbacks = pagy(Feedback.order(created_at: :desc), limit: 50)
 
       respond_to do |format|
         format.html

--- a/spec/system/support/feedbacks_spec.rb
+++ b/spec/system/support/feedbacks_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Support console feedback view", service: :support do
   end
 
   def then_i_see_recent_feedback_entries
-    Feedback.order(created_at: :desc).limit(10).each do |feedback|
+    Feedback.order(created_at: :desc).limit(50).each do |feedback|
       expect(page).to have_content(feedback.ease_of_use)
       expect(page).to have_content(feedback.experience)
       expect(page).to have_content(feedback.created_at.strftime("%d %B %Y"))

--- a/spec/system/support/feedbacks_spec.rb
+++ b/spec/system/support/feedbacks_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Support console feedback view", service: :support do
   context "with more than one page of feedback" do
     before do
       stub_const("Pagy::DEFAULT", Pagy::DEFAULT.merge(limit: 3))
-      create_list(:feedback, 5) { |feedback, i| feedback.update!(experience: "Pagination feedback #{i + 1}") }
+      create_list(:feedback, 55) { |feedback, i| feedback.update!(experience: "Pagination feedback #{i + 1}") }
       when_i_visit_the_feedback_page
     end
 
@@ -161,12 +161,12 @@ RSpec.describe "Support console feedback view", service: :support do
   end
 
   def then_i_see_first_page_of_feedback_with_pagination
-    expect(page).to have_selector("table tbody tr", count: 3)
+    expect(page).to have_selector("table tbody tr", count: 50)
     expect(page).to have_link("Next")
   end
 
   def then_i_see_second_page_of_feedback_with_pagination
-    expect(page).to have_selector("table tbody tr", count: 2)
+    expect(page).to have_selector("table tbody tr", count: 5)
     expect(page).to have_link("Previous")
   end
 


### PR DESCRIPTION
# Context

This PR increases the number of feedback items shown in the support page feedback list.

The goal is to make it easier for support/admin users to review feedback in larger batches and bulk remove bad feedback more efficiently, instead of having to page through smaller sets of results.

# Guidance to review

- Confirm that the support page feedback list now shows the increased number of items.
- Verify that bulk selection/removal still works correctly with the larger list.
- Check that the page remains usable and performant with more feedback items displayed.
- Confirm there are no regressions to filtering, pagination, or existing feedback management behavior.