### PR TITLE
Revert to old One Login issues banner

### DIFF
--- a/app/components/find/maintenance_banner_component.html.erb
+++ b/app/components/find/maintenance_banner_component.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
   <% notification_banner.with_heading(
-    text: "Important",
+    text: "Login issues",
   ) %>
-  <p class="govuk-body">The service will be unavailable from 5pm to 7pm on Tuesday 28 April 2026.</p>
+  <p class="govuk-body">Some users with non-UK mobile numbers may not be able to sign in at the moment. We’re aware of the issue and will remove this message once it’s resolved.</p>
 <% end %>

--- a/spec/components/find/maintenance_banner_component_spec.rb
+++ b/spec/components/find/maintenance_banner_component_spec.rb
@@ -9,7 +9,7 @@ module Find
         FeatureFlag.activate(:maintenance_banner)
         result = render_inline(described_class.new)
 
-        expect(result.text).to have_content "Important"
+        expect(result.text).to have_content "Login issues"
       end
     end
 

--- a/spec/system/find/maintainance_page_spec.rb
+++ b/spec/system/find/maintainance_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Maintenance mode" do
       visit find_root_path
 
       expect(page).to have_current_path find_maintenance_path
-      expect(page).to have_content "Important"
+      expect(page).to have_content "Login issues"
     end
   end
 

--- a/spec/system/find/maintainance_page_spec.rb
+++ b/spec/system/find/maintainance_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Maintenance mode" do
       visit find_root_path
 
       expect(page).to have_current_path find_maintenance_path
-      expect(page).to have_content "Login issues"
+      expect(page).to have_content "This service is currently down for maintenance"
     end
   end
 

--- a/spec/system/find/maintenance_banner_spec.rb
+++ b/spec/system/find/maintenance_banner_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Maintenance banner" do
 
       visit find_root_path
 
-      expect(page).to have_content "The service will be unavailable from 5pm to 7pm on Tuesday 28 April 2026."
+      expect(page).to have_content "Some users with non-UK mobile numbers may not be able to sign in at the moment."
     end
   end
 
@@ -20,7 +20,7 @@ RSpec.describe "Maintenance banner" do
       visit find_root_path
 
       expect(page).to have_content "Find teacher training courses"
-      expect(page).to have_no_content "The service will be unavailable from 5pm to 7pm on Tuesday 28 April 2026."
+      expect(page).to have_no_content "Some users with non-UK mobile numbers may not be able to sign in at the moment."
     end
   end
 end


### PR DESCRIPTION
## Context

One Login still has issues with foreign numbers. So we have to put the banner back up.

## Changes proposed in this pull request

New banner text

## Guidance to review

Check and approve 