### PR TITLE
Financial Incentives editable by admin

### DIFF
--- a/app/controllers/support/subjects_controller.rb
+++ b/app/controllers/support/subjects_controller.rb
@@ -2,18 +2,33 @@
 
 module Support
   class SubjectsController < ApplicationController
+    FINANCIAL_INCENTIVE_TEXT_FIELDS = %i[bursary_amount scholarship].freeze
+    FINANCIAL_INCENTIVE_BOOLEAN_FIELDS = %i[
+      subject_knowledge_enhancement_course_available
+      non_uk_bursary_eligible
+      non_uk_scholarship_eligible
+    ].freeze
+    FINANCIAL_INCENTIVE_FIELDS = (FINANCIAL_INCENTIVE_TEXT_FIELDS + FINANCIAL_INCENTIVE_BOOLEAN_FIELDS).freeze
+
     before_action :assign_subject, only: %i[show edit update]
 
     def index
       @pagy, @subjects = pagy(filtered_subjects)
     end
 
-    def show; end
+    def show
+      @financial_incentive = @subject.financial_incentive
+    end
 
-    def edit; end
+    def edit
+      @financial_incentive = @subject.financial_incentive || @subject.build_financial_incentive
+    end
 
     def update
-      DataHub::Subjects::UpdateMatchSynonyms.new(subject: @subject, synonyms:).call
+      Subject.transaction do
+        update_match_synonyms
+        update_financial_incentive if should_update_financial_incentive?
+      end
 
       redirect_to support_subject_path(@subject),
                   flash: { success: t("support.flash.updated", resource: Subject.name) }
@@ -50,6 +65,53 @@ module Support
       match_synonyms_text.split(/[\r\n]+/)
                     .map(&:strip)
                     .reject(&:blank?)
+    end
+
+    def update_match_synonyms
+      DataHub::Subjects::UpdateMatchSynonyms.new(subject: @subject, synonyms:).call
+    end
+
+    def update_financial_incentive
+      (@subject.financial_incentive || @subject.build_financial_incentive).update!(financial_incentive_attributes)
+    end
+
+    def should_update_financial_incentive?
+      financial_incentive_params_present? &&
+        (@subject.financial_incentive.present? || financial_incentive_details_provided?)
+    end
+
+    def financial_incentive_details_provided?
+      financial_incentive_attributes.slice(*FINANCIAL_INCENTIVE_TEXT_FIELDS).values.any?(&:present?) ||
+        financial_incentive_attributes.slice(*FINANCIAL_INCENTIVE_BOOLEAN_FIELDS).values.any?
+    end
+
+    def financial_incentive_attributes
+      @financial_incentive_attributes ||= begin
+        attributes = permitted_financial_incentive_params.to_h.symbolize_keys
+
+        FINANCIAL_INCENTIVE_TEXT_FIELDS.each do |field|
+          attributes[field] = attributes[field].presence
+        end
+
+        FINANCIAL_INCENTIVE_BOOLEAN_FIELDS.each do |field|
+          value = attributes[field]
+          value = value.last if value.is_a?(Array)
+          attributes[field] = ActiveModel::Type::Boolean.new.cast(value) || false
+        end
+
+        attributes
+      end
+    end
+
+    def financial_incentive_params_present?
+      params.dig(:subject, :financial_incentive).present?
+    end
+
+    def permitted_financial_incentive_params
+      params
+        .fetch(:subject, ActionController::Parameters.new)
+        .fetch(:financial_incentive, ActionController::Parameters.new)
+        .permit(*FINANCIAL_INCENTIVE_FIELDS)
     end
   end
 end

--- a/app/controllers/support/subjects_controller.rb
+++ b/app/controllers/support/subjects_controller.rb
@@ -2,6 +2,7 @@
 
 module Support
   class SubjectsController < ApplicationController
+    BOOLEAN_TYPE = ActiveModel::Type::Boolean.new
     FINANCIAL_INCENTIVE_TEXT_FIELDS = %i[bursary_amount scholarship].freeze
     FINANCIAL_INCENTIVE_BOOLEAN_FIELDS = %i[
       subject_knowledge_enhancement_course_available
@@ -86,21 +87,32 @@ module Support
     end
 
     def financial_incentive_attributes
-      @financial_incentive_attributes ||= begin
-        attributes = permitted_financial_incentive_params.to_h.symbolize_keys
+      @financial_incentive_attributes ||= normalize_financial_incentive_attributes(
+        permitted_financial_incentive_params.to_h.symbolize_keys,
+      )
+    end
 
-        FINANCIAL_INCENTIVE_TEXT_FIELDS.each do |field|
-          attributes[field] = attributes[field].presence
-        end
+    def normalize_financial_incentive_attributes(attributes)
+      normalize_text_fields!(attributes)
+      normalize_boolean_fields!(attributes)
+      attributes
+    end
 
-        FINANCIAL_INCENTIVE_BOOLEAN_FIELDS.each do |field|
-          value = attributes[field]
-          value = value.last if value.is_a?(Array)
-          attributes[field] = ActiveModel::Type::Boolean.new.cast(value) || false
-        end
-
-        attributes
+    def normalize_text_fields!(attributes)
+      FINANCIAL_INCENTIVE_TEXT_FIELDS.each do |field|
+        attributes[field] = attributes[field].presence
       end
+    end
+
+    def normalize_boolean_fields!(attributes)
+      FINANCIAL_INCENTIVE_BOOLEAN_FIELDS.each do |field|
+        attributes[field] = cast_to_boolean(attributes[field])
+      end
+    end
+
+    def cast_to_boolean(value)
+      raw_value = value.is_a?(Array) ? value.last : value
+      BOOLEAN_TYPE.cast(raw_value) || false
     end
 
     def financial_incentive_params_present?

--- a/app/views/support/subjects/edit.html.erb
+++ b/app/views/support/subjects/edit.html.erb
@@ -13,6 +13,36 @@
           rows: 8,
           value: @subject.match_synonyms_text %>
 
+      <h2 class="govuk-heading-m">Financial incentives</h2>
+
+      <% if @subject.financial_incentive.blank? %>
+        <p class="govuk-body">No financial incentive exists for this subject yet. Enter details below to create one.</p>
+      <% end %>
+
+      <%= f.fields_for :financial_incentive, @financial_incentive do |financial_incentive_fields| %>
+        <%= financial_incentive_fields.govuk_text_field :bursary_amount,
+            label: { text: "Bursary amount", size: "s" },
+            hint: { text: "Enter numbers only, for example 26000." },
+            width: 10 %>
+
+        <%= financial_incentive_fields.govuk_text_field :scholarship,
+            label: { text: "Scholarship amount", size: "s" },
+            hint: { text: "Enter numbers only, for example 28000." },
+            width: 10 %>
+
+        <%= financial_incentive_fields.govuk_check_boxes_fieldset :subject_knowledge_enhancement_course_available, legend: { text: "Subject knowledge enhancement course" }, multiple: false do %>
+          <% financial_incentive_fields.govuk_check_box :subject_knowledge_enhancement_course_available, true, false, label: { text: "Subject knowledge enhancement course available" }, multiple: false %>
+        <% end %>
+
+        <%= financial_incentive_fields.govuk_check_boxes_fieldset :non_uk_bursary_eligible, legend: { text: "Non-UK bursary eligibility" }, multiple: false do %>
+          <% financial_incentive_fields.govuk_check_box :non_uk_bursary_eligible, true, false, label: { text: "Eligible for non-UK bursary" }, multiple: false %>
+        <% end %>
+
+        <%= financial_incentive_fields.govuk_check_boxes_fieldset :non_uk_scholarship_eligible, legend: { text: "Non-UK scholarship eligibility" }, multiple: false do %>
+          <% financial_incentive_fields.govuk_check_box :non_uk_scholarship_eligible, true, false, label: { text: "Eligible for non-UK scholarship" }, multiple: false %>
+        <% end %>
+      <% end %>
+
       <%= f.govuk_submit t("support.update_resource", resource: "subject") %>
     <% end %>
 

--- a/app/views/support/subjects/show.html.erb
+++ b/app/views/support/subjects/show.html.erb
@@ -32,4 +32,39 @@
         row.with_value(text: @subject.match_synonyms)
         row.with_action(text: "Change", href: edit_support_subject_path(@subject), visually_hidden_text: Subject.human_attribute_name(:match_synonyms))
       end
+
+      component.with_row do |row|
+        row.with_key { "Bursary amount" }
+        row.with_value(text: @financial_incentive&.bursary_amount.presence || t("govuk_component.summary_list_component.not_available"))
+        row.with_action(text: "Change", href: edit_support_subject_path(@subject), visually_hidden_text: "bursary amount")
+      end
+
+      component.with_row do |row|
+        row.with_key { "Scholarship amount" }
+        row.with_value(text: @financial_incentive&.scholarship.presence || t("govuk_component.summary_list_component.not_available"))
+        row.with_action(text: "Change", href: edit_support_subject_path(@subject), visually_hidden_text: "scholarship amount")
+      end
+
+      component.with_row do |row|
+        row.with_key { "Early career payments" }
+        row.with_value(text: @financial_incentive&.early_career_payments.presence || t("govuk_component.summary_list_component.not_available"))
+      end
+
+      component.with_row do |row|
+        row.with_key { "Subject knowledge enhancement course available" }
+        row.with_value(text: @financial_incentive&.subject_knowledge_enhancement_course_available ? "Yes" : "No")
+        row.with_action(text: "Change", href: edit_support_subject_path(@subject), visually_hidden_text: "subject knowledge enhancement course availability")
+      end
+
+      component.with_row do |row|
+        row.with_key { "Non-UK bursary eligible" }
+        row.with_value(text: @financial_incentive&.non_uk_bursary_eligible ? "Yes" : "No")
+        row.with_action(text: "Change", href: edit_support_subject_path(@subject), visually_hidden_text: "non-UK bursary eligibility")
+      end
+
+      component.with_row do |row|
+        row.with_key { "Non-UK scholarship eligible" }
+        row.with_value(text: @financial_incentive&.non_uk_scholarship_eligible ? "Yes" : "No")
+        row.with_action(text: "Change", href: edit_support_subject_path(@subject), visually_hidden_text: "non-UK scholarship eligibility")
+      end
     end %>

--- a/spec/system/support/subjects/editing_financial_incentives_spec.rb
+++ b/spec/system/support/subjects/editing_financial_incentives_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Support subjects financial incentives" do
+  include DfESignInUserHelper
+
+  before do
+    given_a_support_user_exists
+    sign_in_system_test(user: @user)
+  end
+
+  scenario "updating an existing financial incentive" do
+    given_mathematics_has_financial_incentive
+    given_i_visit_the_support_subjects_page
+    when_i_search_for_mathematics
+    when_i_click_on_the_mathematics_subject
+    when_i_click_change_financial_incentive
+    and_i_enter_financial_incentive_values(
+      bursary_amount: "26000",
+      scholarship: "28000",
+      non_uk_bursary_eligible: true,
+      non_uk_scholarship_eligible: true,
+      subject_knowledge_enhancement_course_available: true,
+    )
+    and_i_click_update_subject
+    then_i_am_redirected_to_the_subject_page
+    and_i_see_the_success_message
+    and_i_see_updated_financial_incentive_details
+  end
+
+  scenario "creating a financial incentive when one does not exist" do
+    given_mathematics_has_no_financial_incentive
+    given_i_visit_the_support_subjects_page
+    when_i_search_for_mathematics
+    when_i_click_on_the_mathematics_subject
+    when_i_click_change_financial_incentive
+    and_i_enter_financial_incentive_values(
+      bursary_amount: "15000",
+      scholarship: "",
+      non_uk_bursary_eligible: true,
+      non_uk_scholarship_eligible: false,
+      subject_knowledge_enhancement_course_available: false,
+    )
+    and_i_click_update_subject
+    then_i_am_redirected_to_the_subject_page
+    and_i_see_the_success_message
+    and_i_see_created_financial_incentive_details
+  end
+
+  scenario "not creating a financial incentive when one does not exist and no details are entered" do
+    given_mathematics_has_no_financial_incentive
+    given_i_visit_the_support_subjects_page
+    when_i_search_for_mathematics
+    when_i_click_on_the_mathematics_subject
+    when_i_click_change_financial_incentive
+    and_i_click_update_subject
+    then_i_am_redirected_to_the_subject_page
+    and_i_see_the_success_message
+    and_i_see_no_financial_incentive_was_created
+  end
+
+  def given_a_support_user_exists
+    @user = create(:user, :admin)
+  end
+
+  def given_mathematics_has_financial_incentive
+    mathematics.financial_incentive&.destroy!
+    create(
+      :financial_incentive,
+      subject: mathematics,
+      bursary_amount: "1000",
+      scholarship: "2000",
+      early_career_payments: "3000",
+      non_uk_bursary_eligible: false,
+      non_uk_scholarship_eligible: false,
+      subject_knowledge_enhancement_course_available: false,
+    )
+  end
+
+  def given_mathematics_has_no_financial_incentive
+    mathematics.financial_incentive&.destroy!
+  end
+
+  def given_i_visit_the_support_subjects_page
+    visit support_subjects_path
+  end
+
+  def when_i_search_for_mathematics
+    fill_in "text_search", with: "Mathematics"
+    click_link_or_button "Apply filters"
+  end
+
+  def when_i_click_on_the_mathematics_subject
+    click_link_or_button "Mathematics"
+  end
+
+  def when_i_click_change_financial_incentive
+    within(".govuk-summary-list__row", text: "Bursary amount") do
+      click_link_or_button "Change"
+    end
+  end
+
+  def and_i_enter_financial_incentive_values(
+    bursary_amount:,
+    scholarship:,
+    non_uk_bursary_eligible:,
+    non_uk_scholarship_eligible:,
+    subject_knowledge_enhancement_course_available:
+  )
+    fill_in "subject[financial_incentive][bursary_amount]", with: bursary_amount
+    fill_in "subject[financial_incentive][scholarship]", with: scholarship
+
+    set_checkbox("Eligible for non-UK bursary", non_uk_bursary_eligible)
+    set_checkbox("Eligible for non-UK scholarship", non_uk_scholarship_eligible)
+    set_checkbox("Subject knowledge enhancement course available", subject_knowledge_enhancement_course_available)
+  end
+
+  def and_i_click_update_subject
+    click_link_or_button "Update subject"
+  end
+
+  def then_i_am_redirected_to_the_subject_page
+    expect(page).to have_current_path(support_subject_path(mathematics), ignore_query: true)
+  end
+
+  def and_i_see_the_success_message
+    expect(page).to have_content("Subject successfully updated")
+  end
+
+  def and_i_see_updated_financial_incentive_details
+    within(".govuk-summary-list") do
+      expect(page).to have_content("26000")
+      expect(page).to have_content("28000")
+      expect(page).to have_content("Non-UK bursary eligible")
+      expect(page).to have_content("Non-UK scholarship eligible")
+      expect(page).to have_content("Subject knowledge enhancement course available")
+    end
+
+    financial_incentive = mathematics.reload.financial_incentive
+
+    expect(financial_incentive.bursary_amount).to eq("26000")
+    expect(financial_incentive.scholarship).to eq("28000")
+    expect(financial_incentive.early_career_payments).to eq("3000")
+    expect(financial_incentive.non_uk_bursary_eligible).to be(true)
+    expect(financial_incentive.non_uk_scholarship_eligible).to be(true)
+    expect(financial_incentive.subject_knowledge_enhancement_course_available).to be(true)
+  end
+
+  def and_i_see_created_financial_incentive_details
+    within(".govuk-summary-list") do
+      expect(page).to have_content("15000")
+      expect(page).to have_content("Not available")
+      expect(page).to have_content("Non-UK bursary eligible")
+    end
+
+    financial_incentive = mathematics.reload.financial_incentive
+
+    expect(financial_incentive).to be_present
+    expect(financial_incentive.bursary_amount).to eq("15000")
+    expect(financial_incentive.scholarship).to be_nil
+    expect(financial_incentive.early_career_payments).to be_nil
+    expect(financial_incentive.non_uk_bursary_eligible).to be(true)
+    expect(financial_incentive.non_uk_scholarship_eligible).to be(false)
+    expect(financial_incentive.subject_knowledge_enhancement_course_available).to be(false)
+  end
+
+  def and_i_see_no_financial_incentive_was_created
+    within(".govuk-summary-list") do
+      expect(page).to have_content("Not available")
+    end
+
+    expect(mathematics.reload.financial_incentive).to be_nil
+  end
+
+  def set_checkbox(label, checked)
+    checked ? check(label, allow_label_click: true) : uncheck(label, allow_label_click: true)
+  end
+
+  def mathematics
+    @mathematics ||= Subject.find_by(subject_name: "Mathematics")
+  end
+end

--- a/spec/system/support/subjects/editing_match_synonyms_spec.rb
+++ b/spec/system/support/subjects/editing_match_synonyms_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Add match synonyms to subjects" do
+RSpec.describe "Support subjects match synonyms" do
   include DfESignInUserHelper
 
   before do
@@ -55,10 +55,6 @@ RSpec.describe "Add match synonyms to subjects" do
 
   def given_a_support_user_exists
     @user = create(:user, :admin)
-  end
-
-  def given_mathematics_has_synonyms
-    mathematics.update!(match_synonyms: %w[Maths Math Numeracy])
   end
 
   def given_i_visit_the_support_subjects_page


### PR DESCRIPTION
## Context

Support users could edit subject match synonyms, but there was no admin interface to create or update `FinancialIncentive` data for a subject.

That meant FI changes required non-UI intervention, and support users could not manage bursary/scholarship eligibility data directly in the support console.

This PR introduces that missing capability in support subject management.

## Changes proposed in this pull request

- Added financial incentive management to support subject editing.
- Support users can now update FI data for a subject from the existing support subject edit page.
- If a subject has no `FinancialIncentive`, one is created when FI details are submitted.

- Added FI display on support subject details page.
- FI values are now visible in the subject summary list.
- “Change” actions are available for editable FI fields.

- Refactored `Support::SubjectsController` to support FI edit/create flow cleanly.
- Applies FI updates only when FI params are present.
- Prevents creating empty FI records when no FI details are submitted.

## Guidance to review

1. Functional behavior
- In support subjects, confirm FI fields are editable as listed above.
- Confirm a subject without FI gets an FI record when FI details are submitted.
- Confirm no FI record is created when no FI details are submitted.

2. UI behavior
- On support subject show page, verify FI values are shown in the summary list.
- Verify “Change” links route to the subject edit form.

3. Regression/safety
- Confirm synonym editing behavior remains unchanged.

4. Tests
- Run: `bundle exec rspec spec/system/support/subjects`
- Expected: all examples pass.
