### PR TITLE
Fix untick school on published course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -941,8 +941,12 @@ private
   end
 
   def remove_site!(site:)
-    site_status = site_statuses.find_by!(site:)
-    ucas_status == :new ? site_status.destroy! : site_status.suspend!
+    # Destroy every site_status for this (course, site) pair. The legacy
+    # suspend-then-reuse approach broke when stale duplicate rows existed
+    # (find_by! could return an already-suspended row, AASM raised
+    # InvalidTransition). Audit history is still preserved by the audited
+    # gem on the destroy event.
+    site_statuses.where(site:).destroy_all
   end
 
   def withdraw_latest_enrichment

--- a/app/services/publish/schools/update_course_schools_service.rb
+++ b/app/services/publish/schools/update_course_schools_service.rb
@@ -101,7 +101,12 @@ module Publish
       end
 
       def apply_publish_status_to_site_statuses
-        course.site_statuses.each do |site_status|
+        # Reload + scope to new_or_running so we never touch site_statuses
+        # that sync_schools just suspended or destroyed. Iterating the
+        # cached collection used to flip a freshly-suspended row back to
+        # running, leaving the unticked school still attached on the
+        # rendered page.
+        course.site_statuses.reload.new_or_running.each do |site_status|
           site_status.assign_attributes(site_status_attributes)
         end
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -839,8 +839,8 @@ describe Course do
         expect(second_site_status.reload.status).to eq("running")
       end
 
-      it "sets old site_status to suspended" do
-        expect(first_site_status.reload.status).to eq("suspended")
+      it "destroys the old site_status when its site is removed" do
+        expect(SiteStatus.find_by(id: first_site_status.id)).to be_nil
       end
     end
   end
@@ -1466,15 +1466,19 @@ describe Course do
     context "for running courses" do
       let(:existing_site_status) { create(:site_status, :running, :published, site: existing_site) }
 
-      it "suspends the site when an existing site is removed" do
+      it "destroys the site_status when an existing site is removed" do
         expect { subject.sites = [] }
-          .to change { existing_site_status.reload.status }.from("running").to("suspended")
+          .to change { subject.reload.site_statuses.size }.from(1).to(0)
+        expect(SiteStatus.find_by(id: existing_site_status.id)).to be_nil
       end
 
-      it "adds a new site status and sets it to running when a new site is added" do
-        expect { subject.sites = [new_site] }.to change { subject.reload.site_statuses.size }.from(1).to(2)
+      it "destroys the old site status and creates a running one when sites change" do
+        old_id = existing_site_status.id
+        subject.sites = [new_site]
+        subject.reload
 
-        expect(existing_site_status.reload.status).to eq("suspended")
+        expect(SiteStatus.find_by(id: old_id)).to be_nil
+        expect(subject.site_statuses.size).to eq(1)
         expect(new_site_status.reload.status).to eq("running")
       end
     end
@@ -1499,7 +1503,10 @@ describe Course do
       end
     end
 
-    context "for suspended courses" do
+    context "for courses with a previously-suspended site_status" do
+      # This state is reachable via Course#withdraw (course-level), not via
+      # remove_site! anymore, but the AASM start! event still permits the
+      # suspended → running transition.
       let(:existing_site_status) { create(:site_status, :suspended, site: existing_site) }
 
       it "sets the site to running when a new site is added" do

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -97,6 +97,127 @@ module Publish
           end
         end
 
+        # Regression coverage for the QA-reported bug: when a school is
+        # unticked, sync_schools suspends (or destroys) its site_status,
+        # then apply_publish_status_to_site_statuses runs over the remaining
+        # site_statuses. These tests pin down that:
+        #   1. Site_statuses suspended/destroyed during sync stay that way.
+        #   2. Site_statuses still attached after sync get the right
+        #      publish/status applied.
+        describe "site_status state after the apply step" do
+          let(:provider) { create(:provider, sites: [site_one, site_two]) }
+          let(:site_one) { build(:site, location_name: "Site 1") }
+          let(:site_two) { build(:site, location_name: "Site 2") }
+
+          context "when unticking a school on a published course" do
+            let(:course) do
+              create(
+                :course,
+                :published,
+                provider:,
+                site_statuses: [
+                  build(:site_status, :running, :published, site: site_one),
+                  build(:site_status, :running, :published, site: site_two),
+                ],
+              )
+            end
+            let(:params) { { site_ids: [site_two.id] } }
+
+            it "leaves the unticked site_status as :suspended" do
+              described_class.new(course:, params:).call
+
+              site_status = course.reload.site_statuses.find_by!(site: site_one)
+              expect(site_status).to be_status_suspended
+            end
+
+            it "leaves the unticked site_status as :unpublished" do
+              described_class.new(course:, params:).call
+
+              site_status = course.reload.site_statuses.find_by!(site: site_one)
+              expect(site_status).to be_unpublished_on_ucas
+            end
+
+            it "removes the unticked school from course.sites" do
+              described_class.new(course:, params:).call
+
+              expect(course.reload.sites.map(&:id)).to contain_exactly(site_two.id)
+            end
+
+            it "leaves the kept site_status as :running and :published" do
+              described_class.new(course:, params:).call
+
+              site_status = course.reload.site_statuses.find_by!(site: site_two)
+              expect(site_status).to be_status_running
+              expect(site_status).to be_published_on_ucas
+            end
+          end
+
+          context "when an existing suspended site_status is on the course" do
+            let(:course) do
+              create(
+                :course,
+                :published,
+                provider:,
+                site_statuses: [
+                  build(:site_status, :running, :published, site: site_one),
+                  build(:site_status, :suspended, :unpublished, site: site_two),
+                ],
+              )
+            end
+            let(:params) { { site_ids: [site_one.id] } }
+
+            it "does not flip the suspended site_status back to running" do
+              described_class.new(course:, params:).call
+
+              site_status = course.reload.site_statuses.find_by!(site: site_two)
+              expect(site_status).to be_status_suspended
+            end
+
+            it "does not flip the suspended site_status back to published" do
+              described_class.new(course:, params:).call
+
+              site_status = course.reload.site_statuses.find_by!(site: site_two)
+              expect(site_status).to be_unpublished_on_ucas
+            end
+          end
+
+          context "when an existing discontinued site_status is on the course" do
+            let(:course) do
+              create(
+                :course,
+                :published,
+                provider:,
+                site_statuses: [
+                  build(:site_status, :running, :published, site: site_one),
+                  build(:site_status, :discontinued, :unpublished, site: site_two),
+                ],
+              )
+            end
+            let(:params) { { site_ids: [site_one.id] } }
+
+            it "does not touch the discontinued site_status" do
+              described_class.new(course:, params:).call
+
+              site_status = course.reload.site_statuses.find_by!(site: site_two)
+              expect(site_status).to be_status_discontinued
+              expect(site_status).to be_unpublished_on_ucas
+            end
+          end
+
+          context "when adding a school to a draft (unpublished) course" do
+            let(:course) { create(:course, provider:, site_statuses: []) }
+            let(:params) { { site_ids: [site_one.id] } }
+
+            it "the newly attached site_status is :new_status :unpublished" do
+              described_class.new(course:, params:).call
+
+              site_status = course.reload.site_statuses.find_by!(site: site_one)
+              expect(site_status).to be_status_new_status
+              expect(site_status).to be_unpublished_on_ucas
+            end
+          end
+        end
+
         context "dual-write to Course::School" do
           let(:gias_school_one) { create(:gias_school, urn: site_one.urn) }
           let(:gias_school_two) { create(:gias_school, urn: site_two.urn) }

--- a/spec/services/publish/schools/update_course_schools_service_spec.rb
+++ b/spec/services/publish/schools/update_course_schools_service_spec.rb
@@ -123,18 +123,10 @@ module Publish
             end
             let(:params) { { site_ids: [site_two.id] } }
 
-            it "leaves the unticked site_status as :suspended" do
+            it "destroys the unticked site_status" do
               described_class.new(course:, params:).call
 
-              site_status = course.reload.site_statuses.find_by!(site: site_one)
-              expect(site_status).to be_status_suspended
-            end
-
-            it "leaves the unticked site_status as :unpublished" do
-              described_class.new(course:, params:).call
-
-              site_status = course.reload.site_statuses.find_by!(site: site_one)
-              expect(site_status).to be_unpublished_on_ucas
+              expect(course.reload.site_statuses.where(site: site_one)).to be_empty
             end
 
             it "removes the unticked school from course.sites" do

--- a/spec/system/publish/courses/editing_course_schools_spec.rb
+++ b/spec/system/publish/courses/editing_course_schools_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     and_no_course_school_row_exists_for_site_one
   end
 
+  scenario "i can detach a school from a published course (regression for QA bug)" do
+    given_the_course_is_published_with_both_sites_running
+    when_i_visit_the_publish_course_school_edit_page
+    when_i_untick_site_one
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_only_site_two_is_attached
+    and_site_one_site_status_is_suspended
+    and_the_basic_details_page_no_longer_lists_site_one
+  end
+
   scenario "updating with invalid data" do
     and_i_submit
     then_i_should_see_an_error_message
@@ -128,6 +139,31 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     site_one = provider.sites.find_by(location_name: "Site 1")
     gias_school_one = GiasSchool.find_by!(urn: site_one.urn)
     expect(course.reload.schools.where(gias_school: gias_school_one)).to be_empty
+  end
+
+  def given_the_course_is_published_with_both_sites_running
+    provider.sites.each do |site|
+      gias_school = GiasSchool.find_by!(urn: site.urn)
+      course.site_statuses.create!(site:, status: :running, publish: :published)
+      create(:course_school, course:, gias_school:, site_code: site.code)
+    end
+    course.update!(first_published_at: 1.day.ago) if course.respond_to?(:first_published_at)
+  end
+
+  def and_site_one_site_status_is_suspended
+    site_one = provider.sites.find_by(location_name: "Site 1")
+    site_status = course.reload.site_statuses.find_by!(site: site_one)
+    expect(site_status).to be_status_suspended
+  end
+
+  def and_the_basic_details_page_no_longer_lists_site_one
+    visit details_publish_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      provider.recruitment_cycle_year,
+      course.course_code,
+    )
+    expect(page).to have_no_content("Site 1")
+    expect(page).to have_content("Site 2")
   end
 
   def provider

--- a/spec/system/publish/courses/editing_course_schools_spec.rb
+++ b/spec/system/publish/courses/editing_course_schools_spec.rb
@@ -35,8 +35,29 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     and_i_submit
     then_i_should_see_a_success_message
     and_only_site_two_is_attached
-    and_site_one_site_status_is_suspended
+    and_site_one_site_status_is_destroyed
     and_the_basic_details_page_no_longer_lists_site_one
+  end
+
+  scenario "untick all then re-tick one school on a published course with three schools" do
+    given_the_provider_has_three_sites
+    given_the_course_is_published_with_all_three_sites_running
+    when_i_visit_the_publish_course_school_edit_page
+    when_i_untick_all_then_tick_only_site_two
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_only_site_two_is_attached_among_the_three
+    and_site_one_and_three_site_statuses_are_destroyed
+  end
+
+  scenario "duplicate stale site_status rows do not break the untick (AASM regression)" do
+    given_the_course_is_published_with_both_sites_running
+    given_site_one_has_an_extra_stale_suspended_site_status
+    when_i_visit_the_publish_course_school_edit_page
+    when_i_untick_site_one
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_only_site_two_is_attached
   end
 
   scenario "updating with invalid data" do
@@ -150,10 +171,18 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     course.update!(first_published_at: 1.day.ago) if course.respond_to?(:first_published_at)
   end
 
-  def and_site_one_site_status_is_suspended
+  def and_site_one_site_status_is_destroyed
     site_one = provider.sites.find_by(location_name: "Site 1")
-    site_status = course.reload.site_statuses.find_by!(site: site_one)
-    expect(site_status).to be_status_suspended
+    expect(course.reload.site_statuses.where(site: site_one)).to be_empty
+  end
+
+  def given_site_one_has_an_extra_stale_suspended_site_status
+    # Mirrors the production data state that triggered AASM::InvalidTransition
+    # for the QA-reported untick: a duplicate suspended row from an earlier
+    # remove sat alongside the running one. find_by!(site:) used to grab the
+    # suspended one and suspend! blew up.
+    site_one = provider.sites.find_by(location_name: "Site 1")
+    SiteStatus.create!(course:, site: site_one, status: :suspended, publish: :unpublished)
   end
 
   def and_the_basic_details_page_no_longer_lists_site_one
@@ -164,6 +193,42 @@ RSpec.describe "Editing course schools", travel: mid_cycle(2026) do
     )
     expect(page).to have_no_content("Site 1")
     expect(page).to have_content("Site 2")
+  end
+
+  def given_the_provider_has_three_sites
+    provider.sites << build(:site, location_name: "Site 3")
+    provider.save!
+    site = provider.sites.find_by(location_name: "Site 3")
+    gias_school = create(:gias_school, urn: site.urn)
+    create(:provider_school, provider:, gias_school:, site_code: site.code)
+  end
+
+  def given_the_course_is_published_with_all_three_sites_running
+    provider.sites.each do |site|
+      gias_school = GiasSchool.find_by!(urn: site.urn)
+      course.site_statuses.create!(site:, status: :running, publish: :published)
+      create(:course_school, course:, gias_school:, site_code: site.code)
+    end
+    course.update!(first_published_at: 1.day.ago) if course.respond_to?(:first_published_at)
+  end
+
+  def when_i_untick_all_then_tick_only_site_two
+    ["Site 1", "Site 2", "Site 3"].each do |label|
+      box = publish_course_school_edit_page.vacancies.find { |el| el.find(".govuk-label").text == label }
+      box.uncheck if box.checked?
+    end
+    publish_course_school_edit_page.vacancies.find { |el| el.find(".govuk-label").text == "Site 2" }.check
+  end
+
+  def and_only_site_two_is_attached_among_the_three
+    expect(course.reload.sites.map(&:location_name)).to contain_exactly("Site 2")
+  end
+
+  def and_site_one_and_three_site_statuses_are_destroyed
+    ["Site 1", "Site 3"].each do |name|
+      site = provider.sites.find_by(location_name: name)
+      expect(course.reload.site_statuses.where(site: site)).to be_empty
+    end
   end
 
   def provider


### PR DESCRIPTION
## Context

On a published course, unticking a placement school and pressing **Update** appeared to do nothing — the school stayed attached. Sometimes it raised a 400 with `AASM::InvalidTransition` in logs.

Both symptoms are the same root cause: `Course#remove_site!` was calling `site_status.suspend!` on a row that the database said was already `:suspended` (a stale duplicate `course_site` row for the same `(course, site)` pair). AASM refused the transition, the transaction rolled back, and from the provider's perspective nothing changed.

## How to reproduce on main

1. Find a published course whose `course_site` table has more than one row for the same `(course_id, site_id)` — at least one running and at least one already-suspended (we have these in the wild; QA hit one on `1CS / 2026 / 2DGY`).
2. Visit `/publish/organisations/{provider}/{year}/courses/{code}/schools`.
3. Untick that school and press **Update**.
4. Either nothing changes (silent rollback) or the page renders 400 with the AASM error in the server log.

The bug is **pre-existing** — it has nothing to do with the recent dual-write work. The legacy `course.site_ids = ...` setter ultimately called the same `remove_site!` with the same `suspend!`. Nobody hit the duplicate-row state until QA did.

## Stack trace from QA

```
AASM::InvalidTransition - Event 'suspend' cannot transition from 'suspended'.
  app/models/course.rb:945:in `remove_site!'
  app/services/course_schools/legacy_site_status_remover.rb:18:in `call'
  app/services/publish/schools/update_course_schools_service.rb:95:in `detach_school'
  app/services/publish/schools/update_course_schools_service.rb:45:in `block in sync_schools'
  app/controllers/publish/courses/schools_controller.rb:30:in `update'
```

`Course#remove_site!` did `site_statuses.find_by!(site:)`, which is a SQL query with `LIMIT 1`. With duplicate rows in `course_site` for the same `(course, site)`, the row returned is non-deterministic — it can be the already-suspended one. Then `site_status.suspend!` raises because AASM `:suspend` only permits `:running → :suspended`.

## The fix

`Course#remove_site!` becomes:

```ruby
def remove_site!(site:)
  site_statuses.where(site:).destroy_all
end
```

- Destroys **every** `site_status` for the `(course, site)` pair — handles duplicates by definition.
- Idempotent: `destroy_all` on an empty relation is a no-op.
- No AASM event, so no transition trap.
- Audit history is preserved by the `audited` gem on the destroy event itself.

### What about `:suspended`?

It stays in the model. **`Course#withdraw`** still legitimately uses `:suspended` to mark a withdrawn course's site_statuses (a course-level "no longer live" concept, distinct from "this school was removed"). The AASM `start!` event also still permits `:suspended → :running` for legacy data that's already in `:suspended` state. We're only changing the *remove-a-school-from-course* path.

`:discontinued` is genuinely vestigial — nothing in the codebase ever transitions into it — and is a separate cleanup ticket.

### Why not keep suspend and just guard against duplicates?

We considered three options:

| Option | Verdict |
|---|---|
| `find_by!`-then-skip-if-already-suspended | Still leaves the duplicate-row state untouched; cleans up nothing; another callsite hitting the same data trips again. |
| Iterate, suspend each running, skip suspended | Cleans up partially; ends up with mixed running/suspended rows for the same pair; complicates re-add. |
| **Destroy_all** | Cleans up the whole pair, no AASM, no duplicates left behind, audit log retains history. |

Destroy is the smallest, most defensible change. `:suspended`-from-`remove_site!` was never a feature anyone relied on — it just happened to be the soft-delete strategy.

## Defensive secondary fix included

While debugging I also tightened `Publish::Schools::UpdateCourseSchoolsService#apply_publish_status_to_site_statuses` so it can never flip a `:suspended` or `:discontinued` row back to `:running` via `assign_attributes`:

```ruby
def apply_publish_status_to_site_statuses
  course.site_statuses.reload.new_or_running.each do |site_status|
    site_status.assign_attributes(site_status_attributes)
  end
end
```

`reload` to get DB truth, `new_or_running` so we never touch suspended/discontinued. This isn't strictly required given the destroy switch, but it stops `Course#withdraw`-induced suspended rows from being clobbered if `UpdateCourseSchoolsService` ever runs against a withdrawn-then-edited course.

## Test plan

### New system spec (drives the actual UI)

`spec/system/publish/courses/editing_course_schools_spec.rb` adds three scenarios:

- *I can detach a school from a published course (regression for QA bug)* — published course with two running site_statuses, untick one, assert site is gone, site_status row destroyed, basic-details page reflects the change.
- *Untick all then re-tick one school on a published course with three schools* — exact scenario you walked me through.
- *Duplicate stale site_status rows do not break the untick (AASM regression)* — seeds a duplicate `:suspended` row for the site about to be unticked. **This one fails on main with the same `AASM::InvalidTransition` you saw in logs**, and passes with the fix.

### Specs updated for new destroy semantics

- `spec/models/course_spec.rb` — the "suspends old site_status" assertions become "destroys old site_status".
- `spec/services/publish/schools/update_course_schools_service_spec.rb` — the regression context for unticking on a published course asserts row destruction.
- The "pre-existing suspended site_status doesn't get clobbered by apply" test stays — it now exercises the secondary defensive fix in `apply_publish_status_to_site_statuses`.

### Wider sweep

- `bundle exec rspec spec/services/publish/schools/ spec/services/courses/ spec/models/course/ spec/models/course_spec.rb spec/system/publish/courses/editing_course_schools_spec.rb` — 868 examples, 0 relevant failures (one pre-existing `geokit-rails/adapters/postgis` env load issue unrelated to this branch).
- Rubocop clean on all touched files.

### Manual verification on QA

After deploying this branch:

- [ ] Visit `/publish/organisations/1CS/2026/courses/2DGY/schools`, untick everything except one school, press Update — the page reflects only that one school attached.
- [ ] Run the duplicate-row scenario in rails console first (`SiteStatus.create!(course:, site:, status: :suspended, publish: :unpublished)` for a site that's already attached running) and repeat the untick — should still succeed.

## Risk

- **Low.** The change is to one method on `Course`. The legacy `course.site_ids = ...` flow that some other callers may rely on now destroys instead of suspends. Re-adding a previously-removed school works the same as before — `find_or_initialize_by(site:)` finds nothing, builds new, `start!` to `:running`. Audit log gets a destroy event in place of a suspend update event.
- The only behavioural change a downstream consumer could notice is that the row in `course_site` is gone instead of having `status='S'`. Nothing in the UI or in queries currently filters on `:suspended` from the remove path (verified by grep), and the only non-test reads of `:suspended` are from `Course#withdraw`, which is untouched.
