### PR TITLE
Add Age Range page to new course flow

### DIFF
--- a/app/controllers/publish/course_wizards_controller.rb
+++ b/app/controllers/publish/course_wizards_controller.rb
@@ -15,6 +15,8 @@ module Publish
       params[:step]&.to_sym || :level
     end
 
+    helper_method :wizard_repository
+
     def new
       return render_schools_messages unless provider.sites.any?
 
@@ -80,9 +82,10 @@ module Publish
     end
 
     def wizard_repository
-      DfE::Wizard::Repository::Cache.new(
-        cache: Rails.cache,
-        key: "course_wizard_#{params[:provider_code]}_#{params[:recruitment_cycle_year]}_#{state_key}",
+      @wizard_repository ||= CourseWizard::Repositories::Course.new(
+        provider_code: params[:provider_code],
+        recruitment_cycle_year: params[:recruitment_cycle_year],
+        state_key:,
         expires_in: CACHE_EXPIRY,
       )
     end

--- a/app/controllers/publish/course_wizards_controller.rb
+++ b/app/controllers/publish/course_wizards_controller.rb
@@ -15,8 +15,6 @@ module Publish
       params[:step]&.to_sym || :level
     end
 
-    helper_method :wizard_repository
-
     def new
       return render_schools_messages unless provider.sites.any?
 

--- a/app/services/courses/validate_custom_age_range_service.rb
+++ b/app/services/courses/validate_custom_age_range_service.rb
@@ -13,16 +13,16 @@ module Courses
       ages = parse_age_range(age_range_in_years)
 
       if ages.nil?
-        course.errors.add(:age_range_in_years, "^Enter an age range")
+        course.errors.add(:age_range_in_years, "Enter an age range")
         return
       end
 
       from_age, to_age = ages.values_at("from", "to")
 
       if invalid_from_age?(from_age) || invalid_to_age?(to_age)
-        course.errors.add(:age_range_in_years, "^Age range must cover #{MIN_AGE_SPAN} or more school years")
+        course.errors.add(:age_range_in_years, "Age range must cover #{MIN_AGE_SPAN} or more school years")
       elsif (to_age - from_age) < MIN_AGE_SPAN
-        course.errors.add(:age_range_in_years, "^Age range must cover at least #{MIN_AGE_SPAN} years")
+        course.errors.add(:age_range_in_years, "Age range must cover at least #{MIN_AGE_SPAN} years")
       end
     end
 

--- a/app/views/publish/course_wizards/steps/_age_range.html.erb
+++ b/app/views/publish/course_wizards/steps/_age_range.html.erb
@@ -1,0 +1,33 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.age_range.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.age_range.caption")) %>
+  <%= t("course_wizard.steps.age_range.heading") %>
+</h1>
+
+<% preset_options = wizard_repository.read[:level] == "primary" ? current_step.primary_age_range_options : current_step.secondary_age_range_options %>
+
+<%= form.govuk_radio_buttons_fieldset :age_range_in_years, legend: { hidden: true, text: t("course_wizard.steps.age_range.heading") } do %>
+  <% preset_options.each_with_index do |value, index| %>
+    <%= form.govuk_radio_button :age_range_in_years, value,
+          label: { text: value.humanize },
+          link_errors: index.zero? %>
+  <% end %>
+
+  <%= form.govuk_radio_divider %>
+
+  <%= form.govuk_radio_button :age_range_in_years, "other",
+        label: { text: t("edit_options.age_range_in_years.other.label") } do %>
+    <p class="govuk-body"><%= t("course_wizard.steps.age_range.other_hint") %></p>
+
+    <%= form.govuk_text_field :course_age_range_in_years_other_from,
+          label: { text: t("course_wizard.steps.age_range.other_from_label") },
+          class: "govuk-input govuk-input--width-2" %>
+
+    <%= form.govuk_text_field :course_age_range_in_years_other_to,
+          label: { text: t("course_wizard.steps.age_range.other_to_label") },
+          class: "govuk-input govuk-input--width-2" %>
+  <% end %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.age_range.submit") %>

--- a/app/views/publish/course_wizards/steps/_age_range.html.erb
+++ b/app/views/publish/course_wizards/steps/_age_range.html.erb
@@ -5,10 +5,8 @@
   <%= t("course_wizard.steps.age_range.heading") %>
 </h1>
 
-<% preset_options = wizard_repository.read[:level] == "primary" ? current_step.primary_age_range_options : current_step.secondary_age_range_options %>
-
 <%= form.govuk_radio_buttons_fieldset :age_range_in_years, legend: { hidden: true, text: t("course_wizard.steps.age_range.heading") } do %>
-  <% preset_options.each_with_index do |value, index| %>
+  <% current_step.preset_options.each_with_index do |value, index| %>
     <%= form.govuk_radio_button :age_range_in_years, value,
           label: { text: value.humanize },
           link_errors: index.zero? %>

--- a/app/views/publish/course_wizards/steps/_primary_subjects.html.erb
+++ b/app/views/publish/course_wizards/steps/_primary_subjects.html.erb
@@ -5,9 +5,9 @@
   <%= t("course_wizard.steps.primary_subjects.heading") %>
 </h1>
 
-<%= form.govuk_radio_buttons_fieldset :master_subject_id, legend: { hidden: true, text: t("course_wizard.steps.primary_subjects.heading") } do %>
+<%= form.govuk_radio_buttons_fieldset :primary_master_subject_id, legend: { hidden: true, text: t("course_wizard.steps.primary_subjects.heading") } do %>
   <% current_step.selectable_subjects.each do |name, id| %>
-    <%= form.govuk_radio_button :master_subject_id, id, label: { text: name }, link_errors: true %>
+    <%= form.govuk_radio_button :primary_master_subject_id, id, label: { text: name }, link_errors: true %>
   <% end %>
 <% end %>
 

--- a/app/views/publish/course_wizards/steps/_secondary_subjects.html.erb
+++ b/app/views/publish/course_wizards/steps/_secondary_subjects.html.erb
@@ -9,8 +9,8 @@
 <p class="govuk-body">
     <%= govuk_link_to t("course_wizard.steps.secondary_subjects.bursary_and_scholarship_link_text"), t("course_wizard.steps.secondary_subjects.bursary_and_scholarship_link_url") %>
 </p>
-<%= form.govuk_select :master_subject_id,
-      options_for_select(current_step.selectable_subjects, current_step.master_subject_id),
+<%= form.govuk_select :secondary_master_subject_id,
+      options_for_select(current_step.selectable_subjects, current_step.secondary_master_subject_id),
       options: { include_blank: true },
       label: { text: t("course_wizard.steps.secondary_subjects.first_subject_label"), size: "s" } %>
 

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -14,6 +14,8 @@ class CourseWizard
       graph.add_node :level, Steps::Level
       graph.add_node :primary_subjects, Steps::PrimarySubjects
       graph.add_node :secondary_subjects, Steps::SecondarySubjects
+      graph.add_node :age_range, Steps::AgeRange
+
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
       graph.add_multiple_conditional_edges(
@@ -25,8 +27,10 @@ class CourseWizard
         default: :secondary_subjects,
       )
 
-      graph.add_edge from: :primary_subjects, to: :courses_index
-      graph.add_edge from: :secondary_subjects, to: :courses_index
+      graph.add_edge from: :primary_subjects, to: :age_range
+      graph.add_edge from: :secondary_subjects, to: :age_range
+
+      graph.add_edge from: :age_range, to: :courses_index
     end
   end
 

--- a/app/wizards/course_wizard/repositories/course.rb
+++ b/app/wizards/course_wizard/repositories/course.rb
@@ -3,9 +3,7 @@
 class CourseWizard
   module Repositories
     class Course < DfE::Wizard::Repository::Cache
-      CACHE_EXPIRY = 24.hours
-
-      def initialize(provider_code:, recruitment_cycle_year:, state_key:, cache: Rails.cache, expires_in: CACHE_EXPIRY)
+      def initialize(provider_code:, recruitment_cycle_year:, state_key:, expires_in:, cache: Rails.cache)
         super(
           cache:,
           key: self.class.cache_key(provider_code:, recruitment_cycle_year:, state_key:),

--- a/app/wizards/course_wizard/repositories/course.rb
+++ b/app/wizards/course_wizard/repositories/course.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Repositories
+    class Course < DfE::Wizard::Repository::Cache
+      CACHE_EXPIRY = 24.hours
+
+      def initialize(provider_code:, recruitment_cycle_year:, state_key:, cache: Rails.cache, expires_in: CACHE_EXPIRY)
+        super(
+          cache:,
+          key: self.class.cache_key(provider_code:, recruitment_cycle_year:, state_key:),
+          expires_in:,
+        )
+      end
+
+      def self.cache_key(provider_code:, recruitment_cycle_year:, state_key:)
+        "course_wizard_#{provider_code}_#{recruitment_cycle_year}_#{state_key}"
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/age_range.rb
+++ b/app/wizards/course_wizard/steps/age_range.rb
@@ -5,6 +5,8 @@ class CourseWizard
     class AgeRange
       include DfE::Wizard::Step
 
+      CUSTOM_AGE_RANGE_VALIDATOR = Courses::ValidateCustomAgeRangeService
+
       attribute :age_range_in_years, :string
       attribute :course_age_range_in_years_other_from, :string
       attribute :course_age_range_in_years_other_to, :string
@@ -15,14 +17,14 @@ class CourseWizard
         validates :course_age_range_in_years_other_from, numericality: {
           only_integer: true,
           allow_blank: true,
-          greater_than_or_equal_to: 0,
-          less_than_or_equal_to: 46,
+          greater_than_or_equal_to: CUSTOM_AGE_RANGE_VALIDATOR::MIN_FROM_AGE,
+          less_than_or_equal_to: CUSTOM_AGE_RANGE_VALIDATOR::MAX_FROM_AGE,
         }
         validates :course_age_range_in_years_other_to, numericality: {
           only_integer: true,
           allow_blank: true,
-          greater_than_or_equal_to: 4,
-          less_than_or_equal_to: 50,
+          greater_than_or_equal_to: CUSTOM_AGE_RANGE_VALIDATOR::MIN_TO_AGE,
+          less_than_or_equal_to: CUSTOM_AGE_RANGE_VALIDATOR::MAX_TO_AGE,
         }
         validate :age_range_from_and_to_missing
         validate :validate_custom_age_range
@@ -34,6 +36,10 @@ class CourseWizard
 
       def secondary_age_range_options
         %w[11_to_16 11_to_18 14_to_19]
+      end
+
+      def preset_options
+        wizard.state_store.primary_level? ? primary_age_range_options : secondary_age_range_options
       end
 
       def self.permitted_params
@@ -57,7 +63,7 @@ class CourseWizard
       def validate_custom_age_range
         return if errors[:course_age_range_in_years_other_from].present? || errors[:course_age_range_in_years_other_to].present?
 
-        Courses::ValidateCustomAgeRangeService.new.execute(combined_age_range, self)
+        CUSTOM_AGE_RANGE_VALIDATOR.new.execute(combined_age_range, self)
       end
 
       def combined_age_range

--- a/app/wizards/course_wizard/steps/age_range.rb
+++ b/app/wizards/course_wizard/steps/age_range.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class AgeRange
+      include DfE::Wizard::Step
+
+      attribute :age_range_in_years, :string
+      attribute :course_age_range_in_years_other_from, :string
+      attribute :course_age_range_in_years_other_to, :string
+
+      validates :age_range_in_years, presence: { message: I18n.t("course_wizard.steps.age_range.errors.age_range_in_years.blank") }
+
+      with_options if: :age_range_other? do
+        validates :course_age_range_in_years_other_from, numericality: {
+          only_integer: true,
+          allow_blank: true,
+          greater_than_or_equal_to: 0,
+          less_than_or_equal_to: 46,
+        }
+        validates :course_age_range_in_years_other_to, numericality: {
+          only_integer: true,
+          allow_blank: true,
+          greater_than_or_equal_to: 4,
+          less_than_or_equal_to: 50,
+        }
+        validate :age_range_from_and_to_missing
+        validate :validate_custom_age_range
+      end
+
+      def primary_age_range_options
+        %w[3_to_7 5_to_11 7_to_11 7_to_14]
+      end
+
+      def secondary_age_range_options
+        %w[11_to_16 11_to_18 14_to_19]
+      end
+
+      def self.permitted_params
+        %i[age_range_in_years course_age_range_in_years_other_from course_age_range_in_years_other_to]
+      end
+
+    private
+
+      def age_range_other?
+        age_range_in_years == "other"
+      end
+
+      def age_range_from_and_to_missing
+        return unless age_range_in_years == "other"
+
+        errors.add(:course_age_range_in_years_other_from, :blank) if course_age_range_in_years_other_from.blank?
+
+        errors.add(:course_age_range_in_years_other_to, :blank) if course_age_range_in_years_other_to.blank?
+      end
+
+      def validate_custom_age_range
+        return if errors[:course_age_range_in_years_other_from].present? || errors[:course_age_range_in_years_other_to].present?
+
+        Courses::ValidateCustomAgeRangeService.new.execute(combined_age_range, self)
+      end
+
+      def combined_age_range
+        "#{course_age_range_in_years_other_from}_to_#{course_age_range_in_years_other_to}"
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/primary_subjects.rb
+++ b/app/wizards/course_wizard/steps/primary_subjects.rb
@@ -5,17 +5,17 @@ class CourseWizard
     class PrimarySubjects
       include DfE::Wizard::Step
 
-      attribute :master_subject_id, :string
+      attribute :primary_master_subject_id, :string
 
-      validates :master_subject_id,
-                presence: { message: I18n.t("course_wizard.steps.primary_subjects.errors.master_subject_id.blank") }
+      validates :primary_master_subject_id,
+                presence: { message: I18n.t("course_wizard.steps.primary_subjects.errors.primary_master_subject_id.blank") }
 
       def selectable_subjects
         SubjectsCache.new.primary_subjects.map { |subject| [subject.subject_name, subject.id] }
       end
 
       def self.permitted_params
-        [:master_subject_id]
+        [:primary_master_subject_id]
       end
     end
   end

--- a/app/wizards/course_wizard/steps/secondary_subjects.rb
+++ b/app/wizards/course_wizard/steps/secondary_subjects.rb
@@ -11,12 +11,20 @@ class CourseWizard
       validates :master_subject_id,
                 presence: { message: I18n.t("course_wizard.steps.secondary_subjects.errors.master_subject_id.blank") }
 
+      validate :validate_master_subject_id_is_not_same_as_subordinate_subject_id?
+
       def selectable_subjects
         SubjectsCache.new.secondary_subjects.map { |subject| [subject.subject_name, subject.id] }
       end
 
       def self.permitted_params
         %i[master_subject_id subordinate_subject_id]
+      end
+
+      def validate_master_subject_id_is_not_same_as_subordinate_subject_id?
+        if master_subject_id == subordinate_subject_id
+          errors.add(:master_subject_id, I18n.t("course_wizard.steps.secondary_subjects.errors.master_subject_id.same_as_subordinate_subject_id"))
+        end
       end
     end
   end

--- a/app/wizards/course_wizard/steps/secondary_subjects.rb
+++ b/app/wizards/course_wizard/steps/secondary_subjects.rb
@@ -5,25 +5,25 @@ class CourseWizard
     class SecondarySubjects
       include DfE::Wizard::Step
 
-      attribute :master_subject_id, :string
+      attribute :secondary_master_subject_id, :string
       attribute :subordinate_subject_id, :string
 
-      validates :master_subject_id,
-                presence: { message: I18n.t("course_wizard.steps.secondary_subjects.errors.master_subject_id.blank") }
+      validates :secondary_master_subject_id,
+                presence: { message: I18n.t("course_wizard.steps.secondary_subjects.errors.secondary_master_subject_id.blank") }
 
-      validate :validate_master_subject_id_is_not_same_as_subordinate_subject_id?
+      validate :validate_secondary_master_subject_id_is_not_same_as_subordinate_subject_id
 
       def selectable_subjects
         SubjectsCache.new.secondary_subjects.map { |subject| [subject.subject_name, subject.id] }
       end
 
       def self.permitted_params
-        %i[master_subject_id subordinate_subject_id]
+        %i[secondary_master_subject_id subordinate_subject_id]
       end
 
-      def validate_master_subject_id_is_not_same_as_subordinate_subject_id?
-        if master_subject_id == subordinate_subject_id
-          errors.add(:master_subject_id, I18n.t("course_wizard.steps.secondary_subjects.errors.master_subject_id.same_as_subordinate_subject_id"))
+      def validate_secondary_master_subject_id_is_not_same_as_subordinate_subject_id
+        if secondary_master_subject_id == subordinate_subject_id
+          errors.add(:secondary_master_subject_id, I18n.t("course_wizard.steps.secondary_subjects.errors.secondary_master_subject_id.same_as_subordinate_subject_id"))
         end
       end
     end

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -38,7 +38,7 @@ en:
         second_subject_label: Second subject (optional)
         submit: Continue
         errors:
-          master_subject_id:
+          secondary_master_subject_id:
             blank: Select a subject
             same_as_subordinate_subject_id: The second subject must be different to the first subject
       age_range:
@@ -60,13 +60,13 @@ en:
               blank: Enter an age in From
               not_a_number: Enter a valid age in From
               not_an_integer: Enter a valid age in From
-              greater_than_or_equal_to: From age must be between 0 and 46
-              less_than_or_equal_to: From age must be between 0 and 46
+              greater_than_or_equal_to: From age must be between 3 and 15
+              less_than_or_equal_to: From age must be between 3 and 15
               invalid: Enter a valid age in From
             course_age_range_in_years_other_to:
               blank: Enter an age in To
               not_a_number: Enter a valid age in To
               not_an_integer: Enter a valid age in To
-              greater_than_or_equal_to: To age must be between 4 and 50
-              less_than_or_equal_to: To age must be between 4 and 50
+              greater_than_or_equal_to: To age must be between 7 and 19
+              less_than_or_equal_to: To age must be between 7 and 19
               invalid: Enter a valid age in To

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -26,7 +26,7 @@ en:
         heading: Subject
         submit: Continue
         errors:
-          master_subject_id:
+          primary_master_subject_id:
             blank: Select a subject
       secondary_subjects:
         caption: Add course
@@ -40,3 +40,33 @@ en:
         errors:
           master_subject_id:
             blank: Select a subject
+            same_as_subordinate_subject_id: The second subject must be different to the first subject
+      age_range:
+        caption: Add course
+        heading: Age range
+        other_hint: "Enter an age range in years, for example: 5 to 11. The course must cover 4 or more school years."
+        other_from_label: From
+        other_to_label: To
+        submit: Continue
+        errors:
+          age_range_in_years:
+            blank: Select an age range
+  activemodel:
+    errors:
+      models:
+        course_wizard/steps/age_range:
+          attributes:
+            course_age_range_in_years_other_from:
+              blank: Enter an age in From
+              not_a_number: Enter a valid age in From
+              not_an_integer: Enter a valid age in From
+              greater_than_or_equal_to: From age must be between 0 and 46
+              less_than_or_equal_to: From age must be between 0 and 46
+              invalid: Enter a valid age in From
+            course_age_range_in_years_other_to:
+              blank: Enter an age in To
+              not_a_number: Enter a valid age in To
+              not_an_integer: Enter a valid age in To
+              greater_than_or_equal_to: To age must be between 4 and 50
+              less_than_or_equal_to: To age must be between 4 and 50
+              invalid: Enter a valid age in To

--- a/spec/services/courses/validate_custom_age_range_service_spec.rb
+++ b/spec/services/courses/validate_custom_age_range_service_spec.rb
@@ -22,7 +22,7 @@ describe Courses::ValidateCustomAgeRangeService do
   context "an invalid age range" do
     context "with an age range of with a gap of less than 4 years" do
       let(:age_range_in_years) { "5_to_8" }
-      let(:error_message) { "^Age range must cover at least 4 years" }
+      let(:error_message) { "Age range must cover at least 4 years" }
 
       it "returns an error stating valid age ranges must be 4 years or greater" do
         expect(course.errors.messages_for(:age_range_in_years)).to contain_exactly error_message
@@ -31,7 +31,7 @@ describe Courses::ValidateCustomAgeRangeService do
 
     context "with a from value that does not fall within the valid age range" do
       let(:age_range_in_years) { "1_to_15" }
-      let(:error_message) { "^Age range must cover 4 or more school years" }
+      let(:error_message) { "Age range must cover 4 or more school years" }
 
       it "returns an error" do
         expect(course.errors.messages_for(:age_range_in_years)).to contain_exactly error_message
@@ -40,7 +40,7 @@ describe Courses::ValidateCustomAgeRangeService do
 
     context "with a to value that does not fall within the valid age range" do
       let(:age_range_in_years) { "7_to_20" }
-      let(:error_message) { "^Age range must cover 4 or more school years" }
+      let(:error_message) { "Age range must cover 4 or more school years" }
 
       it "returns an error stating valid age ranges must be 4 years or greater" do
         expect(course.errors.messages_for(:age_range_in_years)).to contain_exactly error_message
@@ -49,7 +49,7 @@ describe Courses::ValidateCustomAgeRangeService do
 
     context "with an age range that does not include a valid from age range value" do
       let(:age_range_in_years) { "to_6" }
-      let(:error_message) { "^Enter an age range" }
+      let(:error_message) { "Enter an age range" }
 
       it "returns an error stating that there is an invalid from year" do
         expect(course.errors.messages_for(:age_range_in_years)).to contain_exactly error_message
@@ -58,7 +58,7 @@ describe Courses::ValidateCustomAgeRangeService do
 
     context "with an age range that does not include a valid to age range value" do
       let(:age_range_in_years) { "2_to" }
-      let(:error_message) { "^Enter an age range" }
+      let(:error_message) { "Enter an age range" }
 
       it "returns an error stating that there is an invalid from year" do
         expect(course.errors.messages_for(:age_range_in_years)).to contain_exactly error_message

--- a/spec/system/publish/courses/add_course_wizard/age_range_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/age_range_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Add course wizard age range step", type: :system do
     and_i_choose_other_age_range
     and_i_fill_in_other_age_range(from: "2", to: "11")
     and_i_click_continue
-    then_i_should_see_age_span_school_years_error
+    then_i_should_see_other_from_age_bounds_error
   end
 
   scenario "choosing other with a range shorter than four years shows validation errors" do
@@ -114,6 +114,11 @@ private
   def then_i_should_see_age_span_school_years_error
     expect(page).to have_content("There is a problem")
     expect(page).to have_content("Age range must cover 4 or more school years")
+  end
+
+  def then_i_should_see_other_from_age_bounds_error
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("From age must be between 3 and 15")
   end
 
   def then_i_should_see_age_span_minimum_years_error

--- a/spec/system/publish/courses/add_course_wizard/age_range_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/age_range_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard age range step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user_with_a_school
+    and_primary_subjects_exist
+    and_secondary_subjects_exist
+  end
+
+  scenario "choosing a primary age range and continues to courses index" do
+    when_i_visit_the_wizard_subjects_page_for_primary
+    and_i_choose_primary_subject
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+    and_i_choose_primary_age_range
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_page
+  end
+
+  scenario "choosing a secondary age range and continues to courses index" do
+    when_i_visit_the_wizard_subjects_page_for_secondary
+    and_i_choose_secondary_subject
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+    and_i_choose_secondary_age_range
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_page
+  end
+
+  scenario "choosing no age_range_in_years options renders an error" do
+    when_i_visit_the_wizard_subjects_page_for_secondary
+    and_i_choose_secondary_subject
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+    and_i_click_continue
+    then_i_should_see_an_error_message
+  end
+
+  scenario "choosing other and submitting blank from and to ages shows validation errors" do
+    when_i_visit_the_wizard_subjects_page_for_secondary
+    and_i_choose_secondary_subject
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+    and_i_choose_other_age_range
+    and_i_click_continue
+    then_i_should_see_missing_other_age_range_errors
+  end
+
+  scenario "choosing other with non-numeric ages shows validation errors" do
+    when_i_visit_the_wizard_subjects_page_for_secondary
+    and_i_choose_secondary_subject
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+    and_i_choose_other_age_range
+    and_i_fill_in_other_age_range(from: "abc", to: "11")
+    and_i_click_continue
+    then_i_should_see_invalid_other_from_age_error
+  end
+
+  scenario "choosing other with an out-of-bounds age range shows validation errors" do
+    when_i_visit_the_wizard_subjects_page_for_secondary
+    and_i_choose_secondary_subject
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+    and_i_choose_other_age_range
+    and_i_fill_in_other_age_range(from: "2", to: "11")
+    and_i_click_continue
+    then_i_should_see_age_span_school_years_error
+  end
+
+  scenario "choosing other with a range shorter than four years shows validation errors" do
+    when_i_visit_the_wizard_subjects_page_for_secondary
+    and_i_choose_secondary_subject
+    and_i_click_continue
+    then_i_am_taken_to_the_age_range_page
+    and_i_choose_other_age_range
+    and_i_fill_in_other_age_range(from: "8", to: "11")
+    and_i_click_continue
+    then_i_should_see_age_span_minimum_years_error
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user_with_a_school
+    @user = create(
+      :user,
+      providers: [
+        create(:provider, :accredited_provider, sites: [build(:site)]),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def then_i_should_see_an_error_message
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select an age range")
+  end
+
+  def then_i_should_see_missing_other_age_range_errors
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Enter an age in From")
+    expect(page).to have_content("Enter an age in To")
+  end
+
+  def then_i_should_see_invalid_other_from_age_error
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Enter a valid age in From")
+  end
+
+  def then_i_should_see_age_span_school_years_error
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Age range must cover 4 or more school years")
+  end
+
+  def then_i_should_see_age_span_minimum_years_error
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Age range must cover at least 4 years")
+  end
+
+  def then_i_am_taken_to_the_age_range_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :age_range,
+        state_key: wizard_state_key,
+      ),
+    )
+
+    expect(page).to have_content("Age range")
+  end
+
+  def then_i_am_taken_to_the_courses_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def when_i_visit_the_wizard_subjects_page_for_secondary
+    visit new_publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+    )
+
+    choose "Secondary"
+    choose "No"
+    click_on "Continue"
+  end
+
+  def when_i_visit_the_wizard_subjects_page_for_primary
+    visit new_publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+    )
+
+    choose "Primary"
+    choose "No"
+    click_on "Continue"
+  end
+
+  def and_i_choose_primary_subject
+    choose primary_subject.subject_name
+  end
+
+  def and_i_choose_primary_age_range
+    choose "3 to 7"
+  end
+
+  def and_i_choose_secondary_subject
+    select secondary_subject.subject_name, from: "First subject"
+  end
+
+  def and_i_choose_secondary_age_range
+    choose "11 to 16"
+  end
+
+  def and_i_choose_other_age_range
+    choose "Another age range"
+  end
+
+  def and_i_fill_in_other_age_range(from:, to:)
+    fill_in "From", with: from
+    fill_in "To", with: to
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def primary_subject
+    @primary_subject ||= find_or_create(:primary_subject, :primary_with_english)
+  end
+
+  def secondary_subject
+    @secondary_subject ||= find_or_create(:secondary_subject, :business_studies)
+  end
+
+  def and_primary_subjects_exist
+    primary_subject
+  end
+
+  def and_secondary_subjects_exist
+    secondary_subject
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/subjects_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/subjects_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Add course wizard subjects step", type: :system do
     when_i_visit_the_wizard_subjects_page_for_primary
     and_i_choose_primary_subject
     and_i_click_continue
-    then_i_am_taken_to_the_courses_page
+    then_i_am_taken_to_the_age_range_page
   end
 
   scenario "submitting primary without selecting a subject shows validation errors" do
@@ -27,13 +27,20 @@ RSpec.describe "Add course wizard subjects step", type: :system do
     when_i_visit_the_wizard_subjects_page_for_secondary
     and_i_choose_secondary_subject
     and_i_click_continue
-    then_i_am_taken_to_the_courses_page
+    then_i_am_taken_to_the_age_range_page
   end
 
   scenario "submitting secondary without selecting a subject shows validation errors" do
     when_i_visit_the_wizard_subjects_page_for_secondary
     and_i_click_continue
     then_i_have_errors_on_the_subjects_step
+  end
+
+  scenario "submitting secondary with a duplicate master and subordinate subject shows validation errors" do
+    when_i_visit_the_wizard_subjects_page_for_secondary
+    and_i_choose_duplicate_master_and_subordinate_subject
+    and_i_click_continue
+    then_i_should_see_a_duplicate_master_and_subordinate_subject_error
   end
 
 private
@@ -55,6 +62,11 @@ private
 
   def and_secondary_subjects_exist
     secondary_subject
+  end
+
+  def and_i_choose_duplicate_master_and_subordinate_subject
+    select secondary_subject.subject_name, from: "First subject"
+    select secondary_subject.subject_name, from: "Second subject"
   end
 
   def when_i_visit_the_wizard_subjects_page_for_primary
@@ -93,11 +105,13 @@ private
     click_on "Continue"
   end
 
-  def then_i_am_taken_to_the_courses_page
+  def then_i_am_taken_to_the_age_range_page
     expect(page).to have_current_path(
-      publish_provider_recruitment_cycle_courses_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        step: :age_range,
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        state_key: wizard_state_key,
       ),
       ignore_query: true,
     )
@@ -106,6 +120,11 @@ private
   def then_i_have_errors_on_the_subjects_step
     expect(page).to have_content("There is a problem")
     expect(page).to have_content("Select a subject")
+  end
+
+  def then_i_should_see_a_duplicate_master_and_subordinate_subject_error
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("The second subject must be different to the first subject")
   end
 
   def primary_subject

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Repositories::Course do
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+  let(:repository) do
+    described_class.new(
+      provider_code: "PROV",
+      recruitment_cycle_year: 2026,
+      state_key: "test-state-key",
+      cache:,
+    )
+  end
+
+  describe "#write / #read" do
+    it "keeps a single symbol key when merging string-keyed step writes" do
+      repository.write({ "level" => "secondary" })
+      repository.write({ "is_send" => "false" })
+      repository.write({ "master_subject_id" => "12", "subordinate_subject_id" => "34" })
+      repository.write({ "primary_master_subject_id" => "56" })
+      repository.write({ "age_range_in_years" => "11_to_16" })
+      repository.write({ "course_age_range_in_years_other_from" => "1", "course_age_range_in_years_other_to" => "16" })
+
+      data = repository.read
+      expect(data[:level]).to eq("secondary")
+      expect(data[:is_send]).to eq("false")
+      expect(data[:master_subject_id]).to eq("12")
+      expect(data[:subordinate_subject_id]).to eq("34")
+      expect(data[:primary_master_subject_id]).to eq("56")
+      expect(data[:age_range_in_years]).to eq("11_to_16")
+      expect(data[:course_age_range_in_years_other_from]).to eq("1")
+      expect(data[:course_age_range_in_years_other_to]).to eq("16")
+
+      expect(data.keys.map(&:class).uniq).to eq([Symbol])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       provider_code: "PROV",
       recruitment_cycle_year: 2026,
       state_key: "test-state-key",
+      expires_in: 24.hours,
       cache:,
     )
   end
@@ -17,7 +18,7 @@ RSpec.describe CourseWizard::Repositories::Course do
     it "keeps a single symbol key when merging string-keyed step writes" do
       repository.write({ "level" => "secondary" })
       repository.write({ "is_send" => "false" })
-      repository.write({ "master_subject_id" => "12", "subordinate_subject_id" => "34" })
+      repository.write({ "secondary_master_subject_id" => "12", "subordinate_subject_id" => "34" })
       repository.write({ "primary_master_subject_id" => "56" })
       repository.write({ "age_range_in_years" => "11_to_16" })
       repository.write({ "course_age_range_in_years_other_from" => "1", "course_age_range_in_years_other_to" => "16" })
@@ -25,7 +26,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       data = repository.read
       expect(data[:level]).to eq("secondary")
       expect(data[:is_send]).to eq("false")
-      expect(data[:master_subject_id]).to eq("12")
+      expect(data[:secondary_master_subject_id]).to eq("12")
       expect(data[:subordinate_subject_id]).to eq("34")
       expect(data[:primary_master_subject_id]).to eq("56")
       expect(data[:age_range_in_years]).to eq("11_to_16")

--- a/spec/wizards/add_course_wizard/steps/age_range_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/age_range_spec.rb
@@ -11,13 +11,15 @@ RSpec.describe CourseWizard::Steps::AgeRange do
     )
   end
 
+  include_context "add_course_wizard"
+
   let(:age_range_in_years) { "other" }
+  let(:from_age) { nil }
+  let(:to_age) { nil }
 
   describe "#valid?" do
     context "when age_range_in_years is not present" do
       let(:age_range_in_years) { nil }
-      let(:from_age) { nil }
-      let(:to_age) { nil }
 
       it "adds the select an age range error" do
         wizard_step.valid?
@@ -39,10 +41,11 @@ RSpec.describe CourseWizard::Steps::AgeRange do
       let(:from_age) { "2" }
       let(:to_age) { "11" }
 
-      it "adds a shared service error to age_range_in_years" do
+      it "adds a field-level bounds error on from age" do
         wizard_step.valid?
 
-        expect(wizard_step.errors.messages_for(:age_range_in_years)).to contain_exactly("Age range must cover 4 or more school years")
+        expect(wizard_step.errors.messages_for(:course_age_range_in_years_other_from)).to include("From age must be between 3 and 15")
+        expect(wizard_step.errors.messages_for(:age_range_in_years)).to be_empty
       end
     end
 
@@ -66,6 +69,45 @@ RSpec.describe CourseWizard::Steps::AgeRange do
 
         expect(wizard_step.errors.messages_for(:course_age_range_in_years_other_from)).to include("Enter a valid age in From")
         expect(wizard_step.errors.messages_for(:age_range_in_years)).to be_empty
+      end
+    end
+
+    context "when custom ages are outside the valid from and to range" do
+      let(:from_age) { "20" }
+      let(:to_age) { "30" }
+
+      it "adds field-level bounds errors from the shared range limits" do
+        wizard_step.valid?
+
+        expect(wizard_step.errors.messages_for(:course_age_range_in_years_other_from)).to include("From age must be between 3 and 15")
+        expect(wizard_step.errors.messages_for(:course_age_range_in_years_other_to)).to include("To age must be between 7 and 19")
+        expect(wizard_step.errors.messages_for(:age_range_in_years)).to be_empty
+      end
+    end
+  end
+
+  describe "#preset_options" do
+    subject(:wizard_step) { wizard.current_step }
+
+    let(:current_step) { :age_range }
+
+    context "when the selected level is primary" do
+      before do
+        state_store.write(level: "primary")
+      end
+
+      it "returns primary age range options" do
+        expect(wizard_step.preset_options).to eq(%w[3_to_7 5_to_11 7_to_11 7_to_14])
+      end
+    end
+
+    context "when the selected level is secondary" do
+      before do
+        state_store.write(level: "secondary")
+      end
+
+      it "returns secondary age range options" do
+        expect(wizard_step.preset_options).to eq(%w[11_to_16 11_to_18 14_to_19])
       end
     end
   end

--- a/spec/wizards/add_course_wizard/steps/age_range_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/age_range_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::AgeRange do
+  subject(:wizard_step) do
+    described_class.new(
+      age_range_in_years:,
+      course_age_range_in_years_other_from: from_age,
+      course_age_range_in_years_other_to: to_age,
+    )
+  end
+
+  let(:age_range_in_years) { "other" }
+
+  describe "#valid?" do
+    context "when age_range_in_years is not present" do
+      let(:age_range_in_years) { nil }
+      let(:from_age) { nil }
+      let(:to_age) { nil }
+
+      it "adds the select an age range error" do
+        wizard_step.valid?
+
+        expect(wizard_step.errors.messages_for(:age_range_in_years)).to contain_exactly("Select an age range")
+      end
+    end
+
+    context "when the custom range is valid" do
+      let(:from_age) { "5" }
+      let(:to_age) { "11" }
+
+      it "is valid" do
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context "when the custom range is outside allowed school year bounds" do
+      let(:from_age) { "2" }
+      let(:to_age) { "11" }
+
+      it "adds a shared service error to age_range_in_years" do
+        wizard_step.valid?
+
+        expect(wizard_step.errors.messages_for(:age_range_in_years)).to contain_exactly("Age range must cover 4 or more school years")
+      end
+    end
+
+    context "when the custom range is shorter than four years" do
+      let(:from_age) { "8" }
+      let(:to_age) { "11" }
+
+      it "adds a shared service error to age_range_in_years" do
+        wizard_step.valid?
+
+        expect(wizard_step.errors.messages_for(:age_range_in_years)).to contain_exactly("Age range must cover at least 4 years")
+      end
+    end
+
+    context "when custom inputs are not numeric" do
+      let(:from_age) { "x" }
+      let(:to_age) { "11" }
+
+      it "keeps field-level numeric validation errors" do
+        wizard_step.valid?
+
+        expect(wizard_step.errors.messages_for(:course_age_range_in_years_other_from)).to include("Enter a valid age in From")
+        expect(wizard_step.errors.messages_for(:age_range_in_years)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/primary_subjects_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/primary_subjects_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe CourseWizard::Steps::PrimarySubjects do
   subject(:wizard_step) { described_class.new }
 
   describe "#valid?" do
-    context "when master_subject_id is present" do
+    context "when primary_master_subject_id is present" do
       it "is valid" do
-        wizard_step.master_subject_id = "1"
+        wizard_step.primary_master_subject_id = "1"
         expect(wizard_step).to be_valid
       end
     end
 
-    context "when master_subject_id is not present" do
-      it "is not valid without a master_subject_id" do
-        wizard_step.master_subject_id = nil
+    context "when primary_master_subject_id is not present" do
+      it "is not valid without a primary_master_subject_id" do
+        wizard_step.primary_master_subject_id = nil
         expect(wizard_step).not_to be_valid
       end
     end
@@ -23,7 +23,7 @@ RSpec.describe CourseWizard::Steps::PrimarySubjects do
 
   describe ".permitted_params" do
     it "returns the correct permitted params" do
-      expect(described_class.permitted_params).to eq([:master_subject_id])
+      expect(described_class.permitted_params).to eq([:primary_master_subject_id])
     end
   end
 end

--- a/spec/wizards/add_course_wizard/steps/secondary_subjects_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/secondary_subjects_spec.rb
@@ -6,23 +6,23 @@ RSpec.describe CourseWizard::Steps::SecondarySubjects do
   subject(:wizard_step) { described_class.new }
 
   describe "#valid?" do
-    context "when master_subject_id is present" do
+    context "when secondary_master_subject_id is present" do
       it "is valid" do
-        wizard_step.master_subject_id = "1"
+        wizard_step.secondary_master_subject_id = "1"
         expect(wizard_step).to be_valid
       end
     end
 
-    context "when master_subject_id is not present" do
-      it "is not valid without a master_subject_id" do
-        wizard_step.master_subject_id = nil
+    context "when secondary_master_subject_id is not present" do
+      it "is not valid without a secondary_master_subject_id" do
+        wizard_step.secondary_master_subject_id = nil
         expect(wizard_step).not_to be_valid
       end
     end
 
-    context "when master_subject_id is the same as the subordinate_subject_id" do
+    context "when secondary_master_subject_id is the same as the subordinate_subject_id" do
       it "is not valid" do
-        wizard_step.master_subject_id = "1"
+        wizard_step.secondary_master_subject_id = "1"
         wizard_step.subordinate_subject_id = "1"
         expect(wizard_step).not_to be_valid
       end
@@ -31,7 +31,7 @@ RSpec.describe CourseWizard::Steps::SecondarySubjects do
 
   describe ".permitted_params" do
     it "returns the correct permitted params" do
-      expect(described_class.permitted_params).to eq(%i[master_subject_id subordinate_subject_id])
+      expect(described_class.permitted_params).to eq(%i[secondary_master_subject_id subordinate_subject_id])
     end
   end
 end

--- a/spec/wizards/add_course_wizard/steps/secondary_subjects_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/secondary_subjects_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe CourseWizard::Steps::SecondarySubjects do
         expect(wizard_step).not_to be_valid
       end
     end
+
+    context "when master_subject_id is the same as the subordinate_subject_id" do
+      it "is not valid" do
+        wizard_step.master_subject_id = "1"
+        wizard_step.subordinate_subject_id = "1"
+        expect(wizard_step).not_to be_valid
+      end
+    end
   end
 
   describe ".permitted_params" do

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -42,13 +42,21 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
   context "from primary subjects" do
     let(:current_step) { :primary_subjects }
 
-    it "proceeds to courses page" do
-      expect(wizard).to have_next_step(:courses_index)
+    it "proceeds to age range page" do
+      expect(wizard).to have_next_step(:age_range)
     end
   end
 
   context "from secondary subjects" do
     let(:current_step) { :secondary_subjects }
+
+    it "proceeds to age range page" do
+      expect(wizard).to have_next_step(:age_range)
+    end
+  end
+
+  context "from age range" do
+    let(:current_step) { :age_range }
 
     it "proceeds to courses page" do
       expect(wizard).to have_next_step(:courses_index)

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -32,4 +32,29 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:level)
     end
   end
+
+  context "from age range with primary level" do
+    let(:current_step) { :age_range }
+
+    before do
+      state_store.write(primary_master_subject_id: "123")
+      state_store.write(level: "primary")
+    end
+
+    it "goes back to primary subjects" do
+      expect(wizard).to have_previous_step(:primary_subjects)
+    end
+  end
+
+  context "from age range with secondary level" do
+    let(:current_step) { :age_range }
+
+    before do
+      state_store.write(master_subject_id: "123", subordinate_subject_id: "456")
+    end
+
+    it "goes back to secondary subjects" do
+      expect(wizard).to have_previous_step(:secondary_subjects)
+    end
+  end
 end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -50,7 +50,22 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
     let(:current_step) { :age_range }
 
     before do
-      state_store.write(master_subject_id: "123", subordinate_subject_id: "456")
+      state_store.write(level: "secondary")
+      state_store.write(secondary_master_subject_id: "123", subordinate_subject_id: "456")
+    end
+
+    it "goes back to secondary subjects" do
+      expect(wizard).to have_previous_step(:secondary_subjects)
+    end
+  end
+
+  context "from age range with secondary level when primary and secondary subjects are both present" do
+    let(:current_step) { :age_range }
+
+    before do
+      state_store.write(level: "secondary")
+      state_store.write(primary_master_subject_id: "123")
+      state_store.write(secondary_master_subject_id: "456", subordinate_subject_id: "789")
     end
 
     it "goes back to secondary subjects" do


### PR DESCRIPTION
## Context

Implement Age Range step for Primary and Secondary courses

## Changes proposed in this pull request

- Add age range step to the add course wizard
- Add specs for updated flow
- Add validation to the age range step

## Guidance to review


## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
