### PR TITLE
Add financial incentives support admin UI

### DIFF
--- a/app/controllers/support/financial_incentives_controller.rb
+++ b/app/controllers/support/financial_incentives_controller.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+module Support
+  class FinancialIncentivesController < ApplicationController
+    before_action :set_year
+    before_action :set_financial_incentive, only: %i[edit update]
+
+    def index
+      @subjects = subjects
+      @financial_incentives_by_subject_id = financial_incentives_by_subject_id
+      @missing_subjects = missing_subjects
+      @financial_incentives = financial_incentives
+      @year_options = year_options
+    end
+
+    def create_year
+      redirect_to_index(success: t("support.financial_incentives.create_year.success", count: created_year_count, year:))
+    rescue ::FinancialIncentives::CreateYearService::YearAlreadyExistsError
+      redirect_to_index(warning: t("support.financial_incentives.create_year.already_exists", year:))
+    end
+
+    def create_missing
+      redirect_to_index(create_missing_flash)
+    end
+
+    def create_blank
+      redirect_to_index(create_blank_flash)
+    end
+
+    def confirm_publish
+      @missing_subjects = missing_subjects
+
+      return if @missing_subjects.none?
+
+      redirect_to_index(warning: t("support.financial_incentives.confirm_publish_redirect.missing", year:))
+    end
+
+    def publish
+      ::FinancialIncentives::PublishYearService.call(year:)
+
+      redirect_to_index(success: t("support.financial_incentives.publish.success", year:))
+    rescue ::FinancialIncentives::PublishYearService::IncompleteYearError => e
+      redirect_to_index(warning: t("support.financial_incentives.publish.missing", count: e.missing_subjects.size, year:))
+    end
+
+    def edit
+      @year = financial_incentive.year
+    end
+
+    def update
+      financial_incentive.assign_attributes(financial_incentive_params)
+      @year = financial_incentive.year
+
+      if financial_incentive.invalid?
+        render :edit, status: :unprocessable_entity
+      elsif visible_update_needs_confirmation?
+        render :confirm_update
+      else
+        financial_incentive.save!
+        redirect_to_index(success: t("support.financial_incentives.update.success", subject_name: financial_incentive.subject.subject_name))
+      end
+    end
+
+  private
+
+    attr_reader :financial_incentive, :year
+
+    def subjects
+      @subjects ||= Subject.active.order(:subject_name)
+    end
+
+    def financial_incentives_by_subject_id
+      @financial_incentives_by_subject_id ||= FinancialIncentive
+        .for_year(@year)
+        .where(subject_id: subjects.select(:id))
+        .includes(:subject)
+        .index_by(&:subject_id)
+    end
+
+    def financial_incentives
+      @financial_incentives ||= financial_incentives_by_subject_id.values
+    end
+
+    def missing_subjects
+      @missing_subjects ||= subjects.reject { |subject| financial_incentives_by_subject_id.key?(subject.id) }
+    end
+
+    def set_year
+      @year = requested_year || FinancialIncentive.current_year
+    end
+
+    def set_financial_incentive
+      @financial_incentive = FinancialIncentive.includes(:subject).find(params[:id])
+    end
+
+    def requested_year
+      params[:year].presence&.to_i
+    end
+
+    def year_options
+      @year_options ||= (
+        FinancialIncentive.distinct.pluck(:year) +
+        [FinancialIncentive.current_year, Find::CycleTimetable.next_year, year]
+      ).compact.uniq.sort.reverse
+    end
+
+    def created_year_count
+      @created_year_count ||= ::FinancialIncentives::CreateYearService.call(year:)
+    end
+
+    def created_missing_count
+      @created_missing_count ||= ::FinancialIncentives::CreateMissingService.call(year:)
+    end
+
+    def created_blank_count
+      @created_blank_count ||= ::FinancialIncentives::CreateMissingService.call(year:, subject: blank_subject)
+    end
+
+    def blank_subject
+      @blank_subject ||= Subject.active.find(params[:subject_id])
+    end
+
+    def create_missing_flash
+      if created_missing_count.positive?
+        return { success: t("support.financial_incentives.create_missing.success", count: created_missing_count, year:) }
+      end
+
+      { warning: t("support.financial_incentives.create_missing.none_missing", year:) }
+    end
+
+    def create_blank_flash
+      if created_blank_count.positive?
+        return { success: t("support.financial_incentives.create_blank.success", subject_name: blank_subject.subject_name) }
+      end
+
+      {
+        warning: t(
+          "support.financial_incentives.create_blank.already_exists",
+          subject_name: blank_subject.subject_name,
+          year:,
+        ),
+      }
+    end
+
+    def redirect_to_index(flash)
+      redirect_to support_financial_incentives_path(year:), flash:
+    end
+
+    def visible_update_needs_confirmation?
+      financial_incentive.displayed? && !confirmed_update?
+    end
+
+    def confirmed_update?
+      params[:confirmed] == "true"
+    end
+
+    def financial_incentive_params
+      params.expect(
+        financial_incentive: FinancialIncentive::INCENTIVE_ATTRIBUTES,
+      )
+    end
+  end
+end

--- a/app/controllers/support/financial_incentives_controller.rb
+++ b/app/controllers/support/financial_incentives_controller.rb
@@ -14,9 +14,9 @@ module Support
     end
 
     def create_year
-      redirect_to_index(success: t("support.financial_incentives.create_year.success", count: created_year_count, year:))
+      redirect_to_index(success: t(".success", count: created_year_count, year:))
     rescue ::FinancialIncentives::CreateYearService::YearAlreadyExistsError
-      redirect_to_index(warning: t("support.financial_incentives.create_year.already_exists", year:))
+      redirect_to_index(warning: t(".already_exists", year:))
     end
 
     def create_missing
@@ -32,15 +32,15 @@ module Support
 
       return if @missing_subjects.none?
 
-      redirect_to_index(warning: t("support.financial_incentives.confirm_publish_redirect.missing", year:))
+      redirect_to_index(warning: t(".missing", year:))
     end
 
     def publish
       ::FinancialIncentives::PublishYearService.call(year:)
 
-      redirect_to_index(success: t("support.financial_incentives.publish.success", year:))
+      redirect_to_index(success: t(".success", year:))
     rescue ::FinancialIncentives::PublishYearService::IncompleteYearError => e
-      redirect_to_index(warning: t("support.financial_incentives.publish.missing", count: e.missing_subjects.size, year:))
+      redirect_to_index(warning: t(".missing", count: e.missing_subjects.size, year:))
     end
 
     def edit
@@ -57,7 +57,7 @@ module Support
         render :confirm_update
       else
         financial_incentive.save!
-        redirect_to_index(success: t("support.financial_incentives.update.success", subject_name: financial_incentive.subject.subject_name))
+        redirect_to_index(success: t(".success", subject_name: financial_incentive.subject.subject_name))
       end
     end
 
@@ -86,22 +86,36 @@ module Support
     end
 
     def set_year
-      @year = requested_year || FinancialIncentive.current_year
+      @year = selected_year
     end
 
     def set_financial_incentive
       @financial_incentive = FinancialIncentive.includes(:subject).find(params[:id])
     end
 
-    def requested_year
-      params[:year].presence&.to_i
+    def selected_year
+      requested_year = parsed_requested_year
+      return requested_year if allowed_years.include?(requested_year)
+
+      FinancialIncentive.current_year
+    end
+
+    def parsed_requested_year
+      return if params[:year].blank?
+      return unless params[:year].to_s.match?(/\A\d+\z/)
+
+      params[:year].to_i
+    end
+
+    def allowed_years
+      @allowed_years ||= (
+        FinancialIncentive.distinct.pluck(:year) +
+        [FinancialIncentive.current_year, Find::CycleTimetable.next_year]
+      ).compact.uniq
     end
 
     def year_options
-      @year_options ||= (
-        FinancialIncentive.distinct.pluck(:year) +
-        [FinancialIncentive.current_year, Find::CycleTimetable.next_year, year]
-      ).compact.uniq.sort.reverse
+      @year_options ||= allowed_years.sort.reverse
     end
 
     def created_year_count
@@ -122,20 +136,20 @@ module Support
 
     def create_missing_flash
       if created_missing_count.positive?
-        return { success: t("support.financial_incentives.create_missing.success", count: created_missing_count, year:) }
+        return { success: t(".success", count: created_missing_count, year:) }
       end
 
-      { warning: t("support.financial_incentives.create_missing.none_missing", year:) }
+      { warning: t(".none_missing", year:) }
     end
 
     def create_blank_flash
       if created_blank_count.positive?
-        return { success: t("support.financial_incentives.create_blank.success", subject_name: blank_subject.subject_name) }
+        return { success: t(".success", subject_name: blank_subject.subject_name) }
       end
 
       {
         warning: t(
-          "support.financial_incentives.create_blank.already_exists",
+          ".already_exists",
           subject_name: blank_subject.subject_name,
           year:,
         ),

--- a/app/helpers/support/financial_incentives_helper.rb
+++ b/app/helpers/support/financial_incentives_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Support
+  module FinancialIncentivesHelper
+    def financial_incentive_amount(amount)
+      amount.present? ? number_to_currency(amount.to_i, precision: 0) : t("support.financial_incentives.shared.none")
+    end
+
+    def financial_incentive_yes_no(value)
+      value ? t("support.financial_incentives.shared.yes") : t("support.financial_incentives.shared.no")
+    end
+
+    def financial_incentive_status_tag(financial_incentive)
+      return govuk_tag(text: t("support.financial_incentives.shared.missing"), colour: "red") if financial_incentive.blank?
+
+      if financial_incentive.displayed?
+        govuk_tag(text: t("support.financial_incentives.shared.visible"), colour: "green")
+      else
+        govuk_tag(text: t("support.financial_incentives.shared.hidden"), colour: "grey")
+      end
+    end
+  end
+end

--- a/app/helpers/support/financial_incentives_helper.rb
+++ b/app/helpers/support/financial_incentives_helper.rb
@@ -2,22 +2,34 @@
 
 module Support
   module FinancialIncentivesHelper
+    STATUS_COLOURS = {
+      hidden: "grey",
+      missing: "red",
+      visible: "green",
+    }.freeze
+
     def financial_incentive_amount(amount)
-      amount.present? ? number_to_currency(amount.to_i, precision: 0) : t("support.financial_incentives.shared.none")
+      amount.present? ? number_to_currency(amount.to_i, precision: 0) : t(".values.none")
     end
 
     def financial_incentive_yes_no(value)
-      value ? t("support.financial_incentives.shared.yes") : t("support.financial_incentives.shared.no")
+      key = value ? :yes : :no
+
+      t(".values.#{key}")
     end
 
     def financial_incentive_status_tag(financial_incentive)
-      return govuk_tag(text: t("support.financial_incentives.shared.missing"), colour: "red") if financial_incentive.blank?
+      status = financial_incentive_status(financial_incentive)
 
-      if financial_incentive.displayed?
-        govuk_tag(text: t("support.financial_incentives.shared.visible"), colour: "green")
-      else
-        govuk_tag(text: t("support.financial_incentives.shared.hidden"), colour: "grey")
-      end
+      govuk_tag(text: t(".statuses.#{status}"), colour: STATUS_COLOURS.fetch(status))
+    end
+
+  private
+
+    def financial_incentive_status(financial_incentive)
+      return :missing if financial_incentive.blank?
+
+      financial_incentive.displayed? ? :visible : :hidden
     end
   end
 end

--- a/app/models/financial_incentive.rb
+++ b/app/models/financial_incentive.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 class FinancialIncentive < ApplicationRecord
+  INCENTIVE_ATTRIBUTES = %i[
+    bursary_amount
+    scholarship
+    early_career_payments
+    non_uk_bursary_eligible
+    non_uk_scholarship_eligible
+    subject_knowledge_enhancement_course_available
+  ].freeze
+
+  DEFAULT_ATTRIBUTES = {
+    bursary_amount: nil,
+    scholarship: nil,
+    early_career_payments: nil,
+    non_uk_bursary_eligible: false,
+    non_uk_scholarship_eligible: false,
+    subject_knowledge_enhancement_course_available: false,
+  }.freeze
+
   attribute :displayed, default: false
   attribute :year, default: -> { FinancialIncentive.current_year }
 

--- a/app/services/financial_incentives/create_missing_service.rb
+++ b/app/services/financial_incentives/create_missing_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module FinancialIncentives
+  # Repairs gaps in an existing financial incentive year.
+  #
+  # This is deliberately different from CreateYearService: missing records are
+  # blank/default rather than copied from the displayed year. It is intended as
+  # a support recovery action for partial years, not as the normal annual setup
+  # path.
+  class CreateMissingService
+    include ServicePattern
+
+    # @param year [Integer, String] target financial incentive year
+    # @param subject [Subject, nil] optional single active subject to repair
+    # @param subject_scope [ActiveRecord::Relation<Subject>] subjects to check for missing records
+    # @param financial_incentive [Class] injectable FinancialIncentive model for persistence
+    def initialize(year:, subject: nil, subject_scope: Subject.active, financial_incentive: FinancialIncentive)
+      @year = year.to_i
+      @subject = subject
+      @subject_scope = subject_scope
+      @financial_incentive = financial_incentive
+    end
+
+    # @return [Integer] number of blank financial incentive records created
+    def call
+      created_count = 0
+
+      @financial_incentive.transaction do
+        subjects_without_incentives.find_each do |subject|
+          @financial_incentive.create!(
+            FinancialIncentive::DEFAULT_ATTRIBUTES.merge(
+              subject:,
+              year: @year,
+              displayed: false,
+            ),
+          )
+          created_count += 1
+        end
+      end
+
+      created_count
+    end
+
+  private
+
+    def subjects_without_incentives
+      subjects.where.not(id: @financial_incentive.for_year(@year).select(:subject_id))
+    end
+
+    def subjects
+      return @subject_scope.where(id: @subject.id) if @subject.present?
+
+      @subject_scope
+    end
+  end
+end

--- a/app/services/financial_incentives/create_year_service.rb
+++ b/app/services/financial_incentives/create_year_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module FinancialIncentives
+  # Creates the initial hidden financial incentive records for a selected year.
+  #
+  # The support UI uses this when a year has no financial incentives yet. Each
+  # active subject gets exactly one hidden target-year record. Values are copied
+  # from that subject's currently displayed incentive, because the displayed
+  # record is the candidate-facing source of truth. Subjects without a displayed
+  # incentive get a blank/default record.
+  class CreateYearService
+    include ServicePattern
+
+    class YearAlreadyExistsError < StandardError; end
+
+    # @param year [Integer, String] target financial incentive year
+    # @param subject_scope [ActiveRecord::Relation<Subject>] subjects to create records for; defaults to active subjects
+    # @param financial_incentive [Class] injectable FinancialIncentive model for persistence
+    def initialize(year:, subject_scope: Subject.active, financial_incentive: FinancialIncentive)
+      @year = year.to_i
+      @subject_scope = subject_scope
+      @financial_incentive = financial_incentive
+    end
+
+    # @return [Integer] number of financial incentive records created
+    # @raise [YearAlreadyExistsError] when any active subject already has a record for the target year
+    def call
+      raise YearAlreadyExistsError if records_for_year_exist?
+
+      created_count = 0
+
+      @financial_incentive.transaction do
+        @subject_scope.includes(:financial_incentive).find_each do |subject|
+          @financial_incentive.create!(
+            attributes_from(subject.financial_incentive).merge(
+              subject:,
+              year: @year,
+              displayed: false,
+            ),
+          )
+          created_count += 1
+        end
+      end
+
+      created_count
+    end
+
+  private
+
+    def records_for_year_exist?
+      @financial_incentive.for_year(@year).where(subject_id: @subject_scope.select(:id)).exists?
+    end
+
+    def attributes_from(source_incentive)
+      return FinancialIncentive::DEFAULT_ATTRIBUTES.dup if source_incentive.blank?
+
+      FinancialIncentive::INCENTIVE_ATTRIBUTES.index_with do |attribute|
+        source_incentive.public_send(attribute)
+      end
+    end
+  end
+end

--- a/app/services/financial_incentives/publish_year_service.rb
+++ b/app/services/financial_incentives/publish_year_service.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module FinancialIncentives
+  # Makes one complete financial incentive year visible for active subjects.
+  #
+  # The public Find/API read paths use each subject's displayed incentive. This
+  # service therefore flips visibility for the whole selected year in one
+  # transaction: existing displayed records for active subjects are hidden, then
+  # the selected year's records are marked displayed. Discontinued subjects are
+  # intentionally outside the default scope.
+  class PublishYearService
+    include ServicePattern
+
+    # Raised when publishing would leave at least one active subject without a
+    # visible incentive for the selected year.
+    class IncompleteYearError < StandardError
+      # @return [Array<Subject>] active subjects missing a target-year financial incentive
+      attr_reader :missing_subjects
+
+      # @param year [Integer] target financial incentive year
+      # @param missing_subjects [Array<Subject>] active subjects missing records for the target year
+      def initialize(year:, missing_subjects:)
+        @missing_subjects = missing_subjects
+        super("Financial incentives for #{year} are missing for #{missing_subjects.size} subjects")
+      end
+    end
+
+    # @param year [Integer, String] target financial incentive year to publish
+    # @param subject_scope [ActiveRecord::Relation<Subject>] subjects whose displayed incentives should be switched
+    # @param financial_incentive [Class] injectable FinancialIncentive model for persistence
+    def initialize(year:, subject_scope: Subject.active, financial_incentive: FinancialIncentive)
+      @year = year.to_i
+      @subject_scope = subject_scope
+      @financial_incentive = financial_incentive
+    end
+
+    # @return [void]
+    # @raise [IncompleteYearError] when any active subject is missing a target-year record
+    def call
+      missing_subjects = subjects_missing_incentives.to_a
+      raise IncompleteYearError.new(year: @year, missing_subjects:) if missing_subjects.any?
+
+      current_time = Time.current
+
+      @financial_incentive.transaction do
+        @financial_incentive.where(subject_id: active_subject_ids, displayed: true).update_all(displayed: false, updated_at: current_time)
+        target_year_incentives.update_all(displayed: true, updated_at: current_time)
+      end
+    end
+
+  private
+
+    def subjects_missing_incentives
+      @subject_scope.where.not(id: target_year_incentives.select(:subject_id)).order(:subject_name)
+    end
+
+    def target_year_incentives
+      @financial_incentive.for_year(@year).where(subject_id: active_subject_ids)
+    end
+
+    def active_subject_ids
+      @active_subject_ids ||= @subject_scope.select(:id)
+    end
+  end
+end

--- a/app/views/support/financial_incentives/confirm_publish.html.erb
+++ b/app/views/support/financial_incentives/confirm_publish.html.erb
@@ -1,0 +1,37 @@
+<% content_for :page_title, t(".page_title", year: @year) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_financial_incentives_path(year: @year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l"><%= t(".heading", year: @year) %></h1>
+
+    <%= govuk_warning_text(text: t(".warning", year: @year)) %>
+
+    <p class="govuk-body">
+      <%= t(".feature_flag_context") %>
+    </p>
+
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { RecruitmentCycle.human_attribute_name(:year) } %>
+        <% row.with_value(text: @year) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t("support.financial_incentives.shared.subjects") } %>
+        <% row.with_value(text: Subject.active.count) %>
+      <% end %>
+    <% end %>
+
+    <%= form_with url: publish_support_financial_incentives_path(year: @year), method: :post, local: true do |form| %>
+      <%= form.govuk_submit t(".submit"), class: "govuk-button--warning" %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t("support.financial_incentives.shared.cancel"), support_financial_incentives_path(year: @year) %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/financial_incentives/confirm_publish.html.erb
+++ b/app/views/support/financial_incentives/confirm_publish.html.erb
@@ -21,7 +21,7 @@
       <% end %>
 
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t("support.financial_incentives.shared.subjects") } %>
+        <% row.with_key { t(".subjects") } %>
         <% row.with_value(text: Subject.active.count) %>
       <% end %>
     <% end %>
@@ -31,7 +31,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to t("support.financial_incentives.shared.cancel"), support_financial_incentives_path(year: @year) %>
+      <%= govuk_link_to t("cancel"), support_financial_incentives_path(year: @year) %>
     </p>
   </div>
 </div>

--- a/app/views/support/financial_incentives/confirm_update.html.erb
+++ b/app/views/support/financial_incentives/confirm_update.html.erb
@@ -1,0 +1,59 @@
+<% content_for :page_title, t(".page_title") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(edit_support_financial_incentive_path(@financial_incentive, year: @year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-l"><%= @financial_incentive.subject.subject_name %></span>
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+    <%= govuk_warning_text(text: t(".warning")) %>
+
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t("support.financial_incentives.shared.bursary_amount") } %>
+        <% row.with_value(text: financial_incentive_amount(@financial_incentive.bursary_amount)) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t("support.financial_incentives.shared.scholarship_amount") } %>
+        <% row.with_value(text: financial_incentive_amount(@financial_incentive.scholarship)) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t("support.financial_incentives.shared.early_career_payments") } %>
+        <% row.with_value(text: financial_incentive_amount(@financial_incentive.early_career_payments)) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t("support.financial_incentives.shared.non_uk_bursary") } %>
+        <% row.with_value(text: financial_incentive_yes_no(@financial_incentive.non_uk_bursary_eligible?)) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t("support.financial_incentives.shared.non_uk_scholarship") } %>
+        <% row.with_value(text: financial_incentive_yes_no(@financial_incentive.non_uk_scholarship_eligible?)) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { t("support.financial_incentives.shared.ske") } %>
+        <% row.with_value(text: financial_incentive_yes_no(@financial_incentive.subject_knowledge_enhancement_course_available?)) %>
+      <% end %>
+    <% end %>
+
+    <%= form_with model: @financial_incentive, url: support_financial_incentive_path(@financial_incentive, year: @year), scope: :financial_incentive, method: :patch, local: true do |form| %>
+      <% FinancialIncentive::INCENTIVE_ATTRIBUTES.each do |attribute| %>
+        <%= form.hidden_field attribute %>
+      <% end %>
+      <%= hidden_field_tag :confirmed, "true" %>
+
+      <%= form.govuk_submit t("support.financial_incentives.shared.confirm_changes") %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t("support.financial_incentives.shared.cancel"), support_financial_incentives_path(year: @year) %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/financial_incentives/confirm_update.html.erb
+++ b/app/views/support/financial_incentives/confirm_update.html.erb
@@ -13,32 +13,32 @@
 
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t("support.financial_incentives.shared.bursary_amount") } %>
+        <% row.with_key { FinancialIncentive.human_attribute_name(:bursary_amount) } %>
         <% row.with_value(text: financial_incentive_amount(@financial_incentive.bursary_amount)) %>
       <% end %>
 
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t("support.financial_incentives.shared.scholarship_amount") } %>
+        <% row.with_key { FinancialIncentive.human_attribute_name(:scholarship) } %>
         <% row.with_value(text: financial_incentive_amount(@financial_incentive.scholarship)) %>
       <% end %>
 
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t("support.financial_incentives.shared.early_career_payments") } %>
+        <% row.with_key { FinancialIncentive.human_attribute_name(:early_career_payments) } %>
         <% row.with_value(text: financial_incentive_amount(@financial_incentive.early_career_payments)) %>
       <% end %>
 
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t("support.financial_incentives.shared.non_uk_bursary") } %>
+        <% row.with_key { FinancialIncentive.human_attribute_name(:non_uk_bursary_eligible) } %>
         <% row.with_value(text: financial_incentive_yes_no(@financial_incentive.non_uk_bursary_eligible?)) %>
       <% end %>
 
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t("support.financial_incentives.shared.non_uk_scholarship") } %>
+        <% row.with_key { FinancialIncentive.human_attribute_name(:non_uk_scholarship_eligible) } %>
         <% row.with_value(text: financial_incentive_yes_no(@financial_incentive.non_uk_scholarship_eligible?)) %>
       <% end %>
 
       <% summary_list.with_row do |row| %>
-        <% row.with_key { t("support.financial_incentives.shared.ske") } %>
+        <% row.with_key { FinancialIncentive.human_attribute_name(:subject_knowledge_enhancement_course_available) } %>
         <% row.with_value(text: financial_incentive_yes_no(@financial_incentive.subject_knowledge_enhancement_course_available?)) %>
       <% end %>
     <% end %>
@@ -49,11 +49,11 @@
       <% end %>
       <%= hidden_field_tag :confirmed, "true" %>
 
-      <%= form.govuk_submit t("support.financial_incentives.shared.confirm_changes") %>
+      <%= form.govuk_submit t(".confirm_changes") %>
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to t("support.financial_incentives.shared.cancel"), support_financial_incentives_path(year: @year) %>
+      <%= govuk_link_to t("cancel"), support_financial_incentives_path(year: @year) %>
     </p>
   </div>
 </div>

--- a/app/views/support/financial_incentives/edit.html.erb
+++ b/app/views/support/financial_incentives/edit.html.erb
@@ -16,9 +16,9 @@
         <%= govuk_warning_text(text: t(".warning")) %>
       <% end %>
 
-      <%= f.govuk_text_field :bursary_amount, label: { text: t("support.financial_incentives.shared.bursary_amount"), size: "s" }, width: 10, prefix_text: "£" %>
-      <%= f.govuk_text_field :scholarship, label: { text: t("support.financial_incentives.shared.scholarship_amount"), size: "s" }, width: 10, prefix_text: "£" %>
-      <%= f.govuk_text_field :early_career_payments, label: { text: t("support.financial_incentives.shared.early_career_payments"), size: "s" }, width: 10, prefix_text: "£" %>
+      <%= f.govuk_text_field :bursary_amount, label: { text: FinancialIncentive.human_attribute_name(:bursary_amount), size: "s" }, width: 10, prefix_text: "£" %>
+      <%= f.govuk_text_field :scholarship, label: { text: FinancialIncentive.human_attribute_name(:scholarship), size: "s" }, width: 10, prefix_text: "£" %>
+      <%= f.govuk_text_field :early_career_payments, label: { text: FinancialIncentive.human_attribute_name(:early_career_payments), size: "s" }, width: 10, prefix_text: "£" %>
 
       <%= f.govuk_check_boxes_fieldset :non_uk_bursary_eligible, legend: { text: t(".fields.non_uk_bursary_eligible.legend"), size: "s" }, multiple: false do %>
         <% f.govuk_check_box :non_uk_bursary_eligible, true, false, label: { text: t(".fields.non_uk_bursary_eligible.label") }, multiple: false %>
@@ -36,7 +36,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to t("support.financial_incentives.shared.cancel"), support_financial_incentives_path(year: @year) %>
+      <%= govuk_link_to t("cancel"), support_financial_incentives_path(year: @year) %>
     </p>
   </div>
 </div>

--- a/app/views/support/financial_incentives/edit.html.erb
+++ b/app/views/support/financial_incentives/edit.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title, t(".page_title") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_financial_incentives_path(year: @year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @financial_incentive, url: support_financial_incentive_path(@financial_incentive, year: @year), scope: :financial_incentive, local: true do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= @financial_incentive.subject.subject_name %></span>
+      <h1 class="govuk-heading-l"><%= t(".heading", year: @year) %></h1>
+
+      <% if @financial_incentive.displayed? %>
+        <%= govuk_warning_text(text: t(".warning")) %>
+      <% end %>
+
+      <%= f.govuk_text_field :bursary_amount, label: { text: t("support.financial_incentives.shared.bursary_amount"), size: "s" }, width: 10, prefix_text: "£" %>
+      <%= f.govuk_text_field :scholarship, label: { text: t("support.financial_incentives.shared.scholarship_amount"), size: "s" }, width: 10, prefix_text: "£" %>
+      <%= f.govuk_text_field :early_career_payments, label: { text: t("support.financial_incentives.shared.early_career_payments"), size: "s" }, width: 10, prefix_text: "£" %>
+
+      <%= f.govuk_check_boxes_fieldset :non_uk_bursary_eligible, legend: { text: t(".fields.non_uk_bursary_eligible.legend"), size: "s" }, multiple: false do %>
+        <% f.govuk_check_box :non_uk_bursary_eligible, true, false, label: { text: t(".fields.non_uk_bursary_eligible.label") }, multiple: false %>
+      <% end %>
+
+      <%= f.govuk_check_boxes_fieldset :non_uk_scholarship_eligible, legend: { text: t(".fields.non_uk_scholarship_eligible.legend"), size: "s" }, multiple: false do %>
+        <% f.govuk_check_box :non_uk_scholarship_eligible, true, false, label: { text: t(".fields.non_uk_scholarship_eligible.label") }, multiple: false %>
+      <% end %>
+
+      <%= f.govuk_check_boxes_fieldset :subject_knowledge_enhancement_course_available, legend: { text: t(".fields.subject_knowledge_enhancement_course_available.legend"), size: "s" }, multiple: false do %>
+        <% f.govuk_check_box :subject_knowledge_enhancement_course_available, true, false, label: { text: t(".fields.subject_knowledge_enhancement_course_available.label") }, multiple: false %>
+      <% end %>
+
+      <%= f.govuk_submit t("support.update_record") %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t("support.financial_incentives.shared.cancel"), support_financial_incentives_path(year: @year) %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/financial_incentives/index.html.erb
+++ b/app/views/support/financial_incentives/index.html.erb
@@ -1,0 +1,79 @@
+<% content_for :page_title, t(".page_title") %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(support_subjects_path) %>
+<% end %>
+
+<h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+<%= form_with url: support_financial_incentives_path, method: :get, local: true do %>
+  <div class="govuk-form-group">
+    <%= label_tag :year, t(".financial_incentive_year"), class: "govuk-label" %>
+    <%= select_tag :year, options_for_select(@year_options, @year), class: "govuk-select" %>
+  </div>
+
+  <%= submit_tag t(".apply"), class: "govuk-button govuk-button--secondary" %>
+<% end %>
+
+<% if @financial_incentives.none? %>
+  <div class="govuk-!-text-align-centre govuk-!-padding-6">
+    <h2 class="govuk-heading-m"><%= t(".no_incentives.heading", year: @year) %></h2>
+    <p class="govuk-body"><%= t(".no_incentives.body") %></p>
+    <%= govuk_button_to t(".no_incentives.create", year: @year), create_year_support_financial_incentives_path(year: @year), method: :post %>
+  </div>
+<% else %>
+  <% if @missing_subjects.any? %>
+    <%= govuk_notification_banner(title_text: t("support.financial_incentives.shared.important")) do |notification_banner| %>
+      <% notification_banner.with_heading(text: t(".missing.heading", count: @missing_subjects.size, year: @year)) %>
+      <p class="govuk-body"><%= t(".missing.body") %></p>
+      <%= govuk_button_to t(".missing.create"), create_missing_support_financial_incentives_path(year: @year), method: :post, class: "govuk-button--secondary" %>
+    <% end %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <% if @missing_subjects.none? && @financial_incentives.any? && !@financial_incentives.all?(&:displayed?) %>
+      <%= govuk_button_link_to t(".make_visible", year: @year), confirm_publish_support_financial_incentives_path(year: @year) %>
+    <% elsif @missing_subjects.none? && @financial_incentives.all?(&:displayed?) %>
+      <%= govuk_tag(text: t(".visible_tag", year: @year), colour: "green") %>
+    <% end %>
+  </div>
+
+  <%= govuk_table do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.subject")) %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.bursary")) %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.scholarship")) %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.early_career_payments")) %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.non_uk_bursary")) %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.non_uk_scholarship")) %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.ske")) %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.status")) %>
+        <% row.with_cell(text: t("support.financial_incentives.shared.action")) %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% @subjects.each do |subject| %>
+        <% financial_incentive = @financial_incentives_by_subject_id[subject.id] %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: subject.subject_name) %>
+          <% row.with_cell(text: financial_incentive_amount(financial_incentive&.bursary_amount)) %>
+          <% row.with_cell(text: financial_incentive_amount(financial_incentive&.scholarship)) %>
+          <% row.with_cell(text: financial_incentive_amount(financial_incentive&.early_career_payments)) %>
+          <% row.with_cell(text: financial_incentive_yes_no(financial_incentive&.non_uk_bursary_eligible?)) %>
+          <% row.with_cell(text: financial_incentive_yes_no(financial_incentive&.non_uk_scholarship_eligible?)) %>
+          <% row.with_cell(text: financial_incentive_yes_no(financial_incentive&.subject_knowledge_enhancement_course_available?)) %>
+          <% row.with_cell { financial_incentive_status_tag(financial_incentive) } %>
+          <% row.with_cell do %>
+            <% if financial_incentive.present? %>
+              <%= govuk_link_to t("support.financial_incentives.shared.change"), edit_support_financial_incentive_path(financial_incentive, year: @year) %>
+            <% else %>
+              <%= govuk_button_to t(".create_blank"), create_blank_support_financial_incentives_path(year: @year, subject_id: subject.id), method: :post, class: "govuk-button--secondary govuk-!-margin-bottom-0" %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/support/financial_incentives/index.html.erb
+++ b/app/views/support/financial_incentives/index.html.erb
@@ -23,7 +23,7 @@
   </div>
 <% else %>
   <% if @missing_subjects.any? %>
-    <%= govuk_notification_banner(title_text: t("support.financial_incentives.shared.important")) do |notification_banner| %>
+    <%= govuk_notification_banner(title_text: t(".important")) do |notification_banner| %>
       <% notification_banner.with_heading(text: t(".missing.heading", count: @missing_subjects.size, year: @year)) %>
       <p class="govuk-body"><%= t(".missing.body") %></p>
       <%= govuk_button_to t(".missing.create"), create_missing_support_financial_incentives_path(year: @year), method: :post, class: "govuk-button--secondary" %>
@@ -41,15 +41,15 @@
   <%= govuk_table do |table| %>
     <% table.with_head do |head| %>
       <% head.with_row do |row| %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.subject")) %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.bursary")) %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.scholarship")) %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.early_career_payments")) %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.non_uk_bursary")) %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.non_uk_scholarship")) %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.ske")) %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.status")) %>
-        <% row.with_cell(text: t("support.financial_incentives.shared.action")) %>
+        <% row.with_cell(text: t(".table.subject")) %>
+        <% row.with_cell(text: t(".table.bursary")) %>
+        <% row.with_cell(text: t(".table.scholarship")) %>
+        <% row.with_cell(text: t(".table.early_career_payments")) %>
+        <% row.with_cell(text: t(".table.non_uk_bursary")) %>
+        <% row.with_cell(text: t(".table.non_uk_scholarship")) %>
+        <% row.with_cell(text: t(".table.ske")) %>
+        <% row.with_cell(text: t(".table.status")) %>
+        <% row.with_cell(text: t(".table.action")) %>
       <% end %>
     <% end %>
 
@@ -67,7 +67,7 @@
           <% row.with_cell { financial_incentive_status_tag(financial_incentive) } %>
           <% row.with_cell do %>
             <% if financial_incentive.present? %>
-              <%= govuk_link_to t("support.financial_incentives.shared.change"), edit_support_financial_incentive_path(financial_incentive, year: @year) %>
+              <%= govuk_link_to t("change"), edit_support_financial_incentive_path(financial_incentive, year: @year) %>
             <% else %>
               <%= govuk_button_to t(".create_blank"), create_blank_support_financial_incentives_path(year: @year, subject_id: subject.id), method: :post, class: "govuk-button--secondary govuk-!-margin-bottom-0" %>
             <% end %>

--- a/app/views/support/subjects/index.html.erb
+++ b/app/views/support/subjects/index.html.erb
@@ -2,6 +2,10 @@
   <%= t(".page_title") %>
 </h1>
 
+<div class="govuk-button-group">
+  <%= link_to t(".financial_incentives"), support_financial_incentives_path, class: "govuk-button govuk-button--primary" %>
+</div>
+
 <%= render PaginatedFilter.new(filter_params: @filter_params, collection: @subjects, pagy: @pagy) do %>
   <%= govuk_table do |table| %>
     <% table.with_head do |head| %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -14,6 +14,13 @@ en:
         ease_of_use: Ease of use
         experience: User experience
         created_at: Created at
+      financial_incentive:
+        bursary_amount: Bursary amount
+        early_career_payments: Early career payments
+        non_uk_bursary_eligible: Non-UK bursary
+        non_uk_scholarship_eligible: Non-UK scholarship
+        scholarship: Scholarship amount
+        subject_knowledge_enhancement_course_available: SKE
     errors:
       models:
         site:

--- a/config/locales/en/support/financial_incentives.yml
+++ b/config/locales/en/support/financial_incentives.yml
@@ -1,33 +1,19 @@
 en:
   support:
     financial_incentives:
-      shared:
-        action: Action
-        bursary: Bursary
-        bursary_amount: Bursary amount
-        cancel: Cancel
-        change: Change
-        confirm_changes: Confirm changes
-        early_career_payments: Early career payments
-        hidden: Hidden
-        important: Important
-        missing: Missing
-        "no": "No"
-        non_uk_bursary: Non-UK bursary
-        non_uk_scholarship: Non-UK scholarship
-        none: None
-        scholarship: Scholarship
-        scholarship_amount: Scholarship amount
-        ske: SKE
-        status: Status
-        subject: Subject
-        subjects: Subjects
-        visible: Visible
-        "yes": "Yes"
       index:
         page_title: Financial incentives
         financial_incentive_year: Financial incentive year
         apply: Apply
+        important: Important
+        statuses:
+          hidden: Hidden
+          missing: Missing
+          visible: Visible
+        values:
+          "no": "No"
+          none: None
+          "yes": "Yes"
         no_incentives:
           heading: There are no financial incentives for %{year}
           body: Create hidden financial incentives for every active subject by copying the currently visible incentive for each subject.
@@ -41,6 +27,16 @@ en:
         make_visible: Make %{year} incentives visible
         visible_tag: "%{year} incentives are visible"
         create_blank: Create blank incentive
+        table:
+          action: Action
+          bursary: Bursary
+          early_career_payments: Early career payments
+          non_uk_bursary: Non-UK bursary
+          non_uk_scholarship: Non-UK scholarship
+          scholarship: Scholarship
+          ske: SKE
+          status: Status
+          subject: Subject
       edit:
         page_title: Edit financial incentive
         heading: Edit %{year} financial incentive
@@ -61,10 +57,17 @@ en:
         warning: This will hide the currently visible incentives and make all %{year} incentives visible for active subjects.
         feature_flag_context: Find and the public API will only show these incentives while the bursaries and scholarships feature flag is active.
         submit: Make financial incentives visible
+        subjects: Subjects
+        missing: Create missing financial incentives before making %{year} visible
       confirm_update:
         page_title: Confirm financial incentive changes
         heading: Confirm changes to this visible financial incentive
         warning: These changes will be visible to candidates when the feature flag is active.
+        confirm_changes: Confirm changes
+        values:
+          "no": "No"
+          none: None
+          "yes": "Yes"
       create_year:
         success: "%{count} financial incentives for %{year} created"
         already_exists: Financial incentives for %{year} already exist
@@ -74,8 +77,6 @@ en:
       create_blank:
         success: Blank financial incentive for %{subject_name} created
         already_exists: "%{subject_name} already has a financial incentive for %{year}"
-      confirm_publish_redirect:
-        missing: Create missing financial incentives before making %{year} visible
       publish:
         success: Financial incentives for %{year} are now visible
         missing:

--- a/config/locales/en/support/financial_incentives.yml
+++ b/config/locales/en/support/financial_incentives.yml
@@ -1,0 +1,85 @@
+en:
+  support:
+    financial_incentives:
+      shared:
+        action: Action
+        bursary: Bursary
+        bursary_amount: Bursary amount
+        cancel: Cancel
+        change: Change
+        confirm_changes: Confirm changes
+        early_career_payments: Early career payments
+        hidden: Hidden
+        important: Important
+        missing: Missing
+        "no": "No"
+        non_uk_bursary: Non-UK bursary
+        non_uk_scholarship: Non-UK scholarship
+        none: None
+        scholarship: Scholarship
+        scholarship_amount: Scholarship amount
+        ske: SKE
+        status: Status
+        subject: Subject
+        subjects: Subjects
+        visible: Visible
+        "yes": "Yes"
+      index:
+        page_title: Financial incentives
+        financial_incentive_year: Financial incentive year
+        apply: Apply
+        no_incentives:
+          heading: There are no financial incentives for %{year}
+          body: Create hidden financial incentives for every active subject by copying the currently visible incentive for each subject.
+          create: Create financial incentives for %{year}
+        missing:
+          heading:
+            one: "%{count} subject missing financial incentives for %{year}"
+            other: "%{count} subjects missing financial incentives for %{year}"
+          body: Create blank hidden financial incentives for missing subjects before making this year visible.
+          create: Create blank incentives for missing subjects
+        make_visible: Make %{year} incentives visible
+        visible_tag: "%{year} incentives are visible"
+        create_blank: Create blank incentive
+      edit:
+        page_title: Edit financial incentive
+        heading: Edit %{year} financial incentive
+        warning: Changes to this incentive will be visible to candidates when the feature flag is active.
+        fields:
+          non_uk_bursary_eligible:
+            legend: Non-UK bursary eligibility
+            label: Eligible for non-UK bursary
+          non_uk_scholarship_eligible:
+            legend: Non-UK scholarship eligibility
+            label: Eligible for non-UK scholarship
+          subject_knowledge_enhancement_course_available:
+            legend: Subject knowledge enhancement
+            label: SKE course available
+      confirm_publish:
+        page_title: Make %{year} financial incentives visible
+        heading: Make %{year} financial incentives visible?
+        warning: This will hide the currently visible incentives and make all %{year} incentives visible for active subjects.
+        feature_flag_context: Find and the public API will only show these incentives while the bursaries and scholarships feature flag is active.
+        submit: Make financial incentives visible
+      confirm_update:
+        page_title: Confirm financial incentive changes
+        heading: Confirm changes to this visible financial incentive
+        warning: These changes will be visible to candidates when the feature flag is active.
+      create_year:
+        success: "%{count} financial incentives for %{year} created"
+        already_exists: Financial incentives for %{year} already exist
+      create_missing:
+        success: "%{count} blank financial incentives for %{year} created"
+        none_missing: There are no missing financial incentives for %{year}
+      create_blank:
+        success: Blank financial incentive for %{subject_name} created
+        already_exists: "%{subject_name} already has a financial incentive for %{year}"
+      confirm_publish_redirect:
+        missing: Create missing financial incentives before making %{year} visible
+      publish:
+        success: Financial incentives for %{year} are now visible
+        missing:
+          one: Financial incentives for %{year} are missing for %{count} subject
+          other: Financial incentives for %{year} are missing for %{count} subjects
+      update:
+        success: Financial incentive for %{subject_name} updated

--- a/config/locales/en/support/subjects.yml
+++ b/config/locales/en/support/subjects.yml
@@ -3,6 +3,7 @@ en:
     subjects:
       index:
         page_title: 'Subjects'
+        financial_incentives: 'Financial Incentives'
       show:
         page_title: 'Subject'
         back_link_text: 'All subjects records'

--- a/config/locales/en/support/subjects.yml
+++ b/config/locales/en/support/subjects.yml
@@ -3,7 +3,7 @@ en:
     subjects:
       index:
         page_title: 'Subjects'
-        financial_incentives: 'Financial Incentives'
+        financial_incentives: 'Financial incentives'
       show:
         page_title: 'Subject'
         back_link_text: 'All subjects records'

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -12,6 +12,15 @@ namespace :support, constraints: { host: Settings.publish_hosts }, defaults: { h
   resources :providers_onboarding_form_requests, only: %i[index new create show update], path: "providers-onboarding-form-requests", as: :providers_onboarding_form_requests
 
   resources :subjects, except: %i[create destroy]
+  resources :financial_incentives, path: "financial-incentives", only: %i[index edit update] do
+    collection do
+      post :create_year, path: "create-year"
+      post :create_missing, path: "create-missing"
+      post :create_blank, path: "create-blank"
+      get :confirm_publish, path: "confirm-publish"
+      post :publish
+    end
+  end
 
   resources :recruitment_cycle, only: %i[index], param: :year, constraints: CycleYearConstraint.new, path: "" do
     namespace :providers do

--- a/guides/adr/0015-store-financial-incentives-by-year-with-display-control.md
+++ b/guides/adr/0015-store-financial-incentives-by-year-with-display-control.md
@@ -89,14 +89,32 @@ The application keeps `Subject#financial_incentive` as the displayed incentive a
 
 The financial incentive import service creates or updates incentives for a specific year and defaults new imported incentives to hidden. A later operational step can flip the displayed flag when the new incentives should be released.
 
+### Support management workflow
+
+Support users can manage financial incentives by year through the support UI. This is the operational workflow for preparing, checking, repairing, editing, and publishing year-specific incentives.
+
+The support workflow follows these rules:
+
+- Financial incentive years are selected by the plain integer year stored on `FinancialIncentive`.
+- Creating a new year creates hidden financial incentives for every active subject. Discontinued subjects are excluded.
+- New year records copy values from each subject's currently displayed incentive. If a subject has no displayed incentive, the new record is created with blank/default incentive values.
+- The index view shows all active subjects for the selected year, including subjects with missing records.
+- Missing records can be repaired by creating blank hidden incentives, either one subject at a time or for all missing active subjects.
+- Making a year visible requires a confirmation step.
+- A year can only be made visible when every active subject has a financial incentive for that year.
+- Publishing a year happens in a transaction: currently displayed active-subject incentives are hidden, then the selected year's active-subject incentives are marked as displayed.
+- Editing an incentive that is already displayed requires confirmation because the change affects candidate-facing data when the feature flag is active.
+
+The `displayed` flag and the `bursaries_and_scholarships_announced` feature flag remain separate controls. `displayed` chooses which year-specific records are candidate-facing; the feature flag controls whether bursary and scholarship content is shown at all.
+
 ## Consequences
 
 Future financial incentives can be imported, validated, and tested before they are visible to candidates. This reduces the risk of timed annual updates and keeps the published values stable until the team chooses to release the new records.
 
-The release process now needs to update display state correctly: each subject should have the previous displayed incentive hidden and the new incentive shown. The database partial unique index prevents two displayed incentives for the same subject, but it does not decide which incentive should be displayed.
+The release process needs to update display state correctly: each active subject should have the previous displayed incentive hidden and the new incentive shown. The database partial unique index prevents two displayed incentives for the same subject, but it does not decide which incentive should be displayed. The support workflow provides a transaction-backed publishing action for this.
 
 Code that previously assumed one incentive per subject must now choose between the displayed association and the full incentive history. This is intentional: public candidate-facing paths should use the displayed incentive, while import and maintenance code can work with year-specific records.
 
 Using an integer year means the database does not enforce a direct relationship between a financial incentive and a recruitment cycle record. Any requirement for incentive years to align with active recruitment cycles should be enforced in the import or management workflow rather than by coupling the data model to recruitment cycle rollover.
 
-Automating the release process, adding admin controls, or recording scheduled release dates can be considered later if the manual flip becomes difficult to operate.
+Automating the release process or recording scheduled release dates can be considered later if the manual support workflow becomes difficult to operate.

--- a/spec/services/financial_incentives/create_missing_service_spec.rb
+++ b/spec/services/financial_incentives/create_missing_service_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FinancialIncentives::CreateMissingService, :without_subjects do
+  subject(:create_missing) { described_class.call(**service_arguments) }
+
+  let(:target_year) { 2026 }
+  let(:service_arguments) { { year: target_year } }
+  let(:existing_subject) { create(:primary_subject, :primary) }
+  let(:missing_subject) { create(:primary_subject, :primary_with_english) }
+  let(:discontinued_subject) { create(:discontinued_subject, :humanities) }
+
+  describe ".call" do
+    before do
+      given_subject_areas_exist
+      and_subjects_exist
+    end
+
+    context "when an existing year is missing incentives for active subjects" do
+      before do
+        given_one_active_subject_already_has_an_incentive
+      end
+
+      it "creates blank hidden incentives only for the missing active subjects" do
+        expect { @created_count = create_missing }
+          .to change(target_year_incentives, :count).by(1)
+
+        expect(@created_count).to eq(1)
+        expect(missing_incentive).to have_attributes(blank_incentive_attributes)
+        expect(existing_subject_target_year_incentives.count).to eq(1)
+        expect(discontinued_target_year_incentives).to be_empty
+      end
+    end
+
+    context "when repairing one active subject" do
+      let(:service_arguments) { { year: target_year, subject: missing_subject } }
+
+      it "creates a blank hidden incentive for only that subject" do
+        expect { @created_count = create_missing }
+          .to change(target_year_incentives, :count).by(1)
+
+        expect(@created_count).to eq(1)
+        expect(missing_incentive).to have_attributes(blank_incentive_attributes)
+        expect(existing_subject_target_year_incentives).to be_empty
+      end
+    end
+  end
+
+private
+
+  def given_subject_areas_exist
+    find_or_create(:subject_area, :primary)
+    find_or_create(:subject_area, :discontinued)
+  end
+
+  def and_subjects_exist
+    existing_subject
+    missing_subject
+    discontinued_subject
+  end
+
+  def given_one_active_subject_already_has_an_incentive
+    create(:financial_incentive, :hidden, subject: existing_subject, year: target_year)
+  end
+
+  def missing_incentive
+    missing_subject.financial_incentive_records.find_by!(year: target_year)
+  end
+
+  def target_year_incentives
+    FinancialIncentive.for_year(target_year)
+  end
+
+  def existing_subject_target_year_incentives
+    existing_subject.financial_incentive_records.for_year(target_year)
+  end
+
+  def discontinued_target_year_incentives
+    discontinued_subject.financial_incentive_records.for_year(target_year)
+  end
+
+  def blank_incentive_attributes
+    FinancialIncentive::DEFAULT_ATTRIBUTES.merge(displayed: false)
+  end
+end

--- a/spec/services/financial_incentives/create_year_service_spec.rb
+++ b/spec/services/financial_incentives/create_year_service_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FinancialIncentives::CreateYearService, :without_subjects do
+  subject(:create_year) { described_class.call(year: target_year) }
+
+  let(:source_year) { 2025 }
+  let(:target_year) { 2026 }
+  let(:subject_with_displayed_incentive) { create(:primary_subject, :primary) }
+  let(:subject_without_incentive) { create(:primary_subject, :primary_with_english) }
+  let(:discontinued_subject) { create(:discontinued_subject, :humanities) }
+
+  describe ".call" do
+    before do
+      given_subject_areas_exist
+      and_subjects_exist
+    end
+
+    context "when the target year has no financial incentives" do
+      before do
+        given_the_subject_has_a_displayed_incentive
+      end
+
+      it "creates hidden target-year records for active subjects" do
+        expect { @created_count = create_year }
+          .to change(target_year_incentives, :count).by(2)
+
+        expect(@created_count).to eq(2)
+        expect(copied_incentive).to have_attributes(copied_incentive_attributes)
+        expect(blank_incentive).to have_attributes(blank_incentive_attributes)
+        expect(discontinued_target_year_incentives).to be_empty
+      end
+    end
+
+    context "when an active subject already has a target-year incentive" do
+      before do
+        create(:financial_incentive, :hidden, subject: subject_with_displayed_incentive, year: target_year)
+      end
+
+      it "does not overwrite the year" do
+        expect { create_year }
+          .to raise_error(described_class::YearAlreadyExistsError)
+
+        expect(target_year_incentives.count).to eq(1)
+      end
+    end
+  end
+
+private
+
+  def given_subject_areas_exist
+    find_or_create(:subject_area, :primary)
+    find_or_create(:subject_area, :discontinued)
+  end
+
+  def and_subjects_exist
+    subject_with_displayed_incentive
+    subject_without_incentive
+    discontinued_subject
+  end
+
+  def given_the_subject_has_a_displayed_incentive
+    create(:financial_incentive, displayed_incentive_attributes)
+  end
+
+  def displayed_incentive_attributes
+    copied_incentive_attributes.merge(
+      subject: subject_with_displayed_incentive,
+      year: source_year,
+      displayed: true,
+    )
+  end
+
+  def copied_incentive
+    subject_with_displayed_incentive.financial_incentive_records.find_by!(year: target_year)
+  end
+
+  def blank_incentive
+    subject_without_incentive.financial_incentive_records.find_by!(year: target_year)
+  end
+
+  def target_year_incentives
+    FinancialIncentive.for_year(target_year)
+  end
+
+  def discontinued_target_year_incentives
+    discontinued_subject.financial_incentive_records.for_year(target_year)
+  end
+
+  def copied_incentive_attributes
+    {
+      bursary_amount: "10000",
+      scholarship: "12000",
+      early_career_payments: "2000",
+      non_uk_bursary_eligible: true,
+      non_uk_scholarship_eligible: true,
+      subject_knowledge_enhancement_course_available: true,
+      displayed: false,
+    }
+  end
+
+  def blank_incentive_attributes
+    FinancialIncentive::DEFAULT_ATTRIBUTES.merge(displayed: false)
+  end
+end

--- a/spec/services/financial_incentives/publish_year_service_spec.rb
+++ b/spec/services/financial_incentives/publish_year_service_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FinancialIncentives::PublishYearService, :without_subjects do
+  subject(:publish_year) { described_class.call(year: target_year) }
+
+  let(:previous_year) { 2025 }
+  let(:target_year) { 2026 }
+  let(:first_subject) { create(:primary_subject, :primary) }
+  let(:second_subject) { create(:primary_subject, :primary_with_english) }
+  let(:discontinued_subject) { create(:discontinued_subject, :humanities) }
+
+  describe ".call" do
+    before do
+      given_subject_areas_exist
+      and_subjects_exist
+    end
+
+    context "when the target year is complete" do
+      before do
+        given_the_previous_year_is_visible
+        and_the_target_year_is_hidden_for_active_subjects
+        and_a_discontinued_subject_has_a_hidden_target_year_incentive
+      end
+
+      it "switches visibility for active subjects only" do
+        publish_year
+
+        expect(first_target_incentive.reload).to be_displayed
+        expect(second_target_incentive.reload).to be_displayed
+        expect(first_previous_incentive.reload).not_to be_displayed
+        expect(second_previous_incentive.reload).not_to be_displayed
+        expect(discontinued_target_incentive.reload).not_to be_displayed
+      end
+    end
+
+    context "when the target year is missing an active subject" do
+      before do
+        create(:financial_incentive, :hidden, subject: first_subject, year: target_year)
+      end
+
+      it "raises an error with the missing subjects" do
+        expect { publish_year }
+          .to raise_error(described_class::IncompleteYearError) do |error|
+            expect(error.missing_subjects).to contain_exactly(second_subject)
+          end
+      end
+    end
+  end
+
+private
+
+  def given_subject_areas_exist
+    find_or_create(:subject_area, :primary)
+    find_or_create(:subject_area, :discontinued)
+  end
+
+  def and_subjects_exist
+    first_subject
+    second_subject
+    discontinued_subject
+  end
+
+  def given_the_previous_year_is_visible
+    create(:financial_incentive, subject: first_subject, year: previous_year, displayed: true)
+    create(:financial_incentive, subject: second_subject, year: previous_year, displayed: true)
+  end
+
+  def and_the_target_year_is_hidden_for_active_subjects
+    create(:financial_incentive, :hidden, subject: first_subject, year: target_year)
+    create(:financial_incentive, :hidden, subject: second_subject, year: target_year)
+  end
+
+  def and_a_discontinued_subject_has_a_hidden_target_year_incentive
+    create(:financial_incentive, :hidden, subject: discontinued_subject, year: target_year)
+  end
+
+  def first_previous_incentive
+    financial_incentive_for(first_subject, previous_year)
+  end
+
+  def second_previous_incentive
+    financial_incentive_for(second_subject, previous_year)
+  end
+
+  def first_target_incentive
+    financial_incentive_for(first_subject, target_year)
+  end
+
+  def second_target_incentive
+    financial_incentive_for(second_subject, target_year)
+  end
+
+  def discontinued_target_incentive
+    financial_incentive_for(discontinued_subject, target_year)
+  end
+
+  def financial_incentive_for(subject, year)
+    subject.financial_incentive_records.find_by!(year:)
+  end
+end

--- a/spec/system/support/financial_incentives_spec.rb
+++ b/spec/system/support/financial_incentives_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe "Financial incentives support" do
     then_the_physics_financial_incentive_is_updated
   end
 
+  scenario "visiting the page with an invalid or unsupported year" do
+    when_i_visit_the_financial_incentives_page_with_year("not-a-year")
+    then_i_see_the_current_financial_incentive_year
+    and_i_do_not_see_year_option("0")
+
+    when_i_visit_the_financial_incentives_page_with_year("9999")
+    then_i_see_the_current_financial_incentive_year
+    and_i_do_not_see_year_option("9999")
+  end
+
 private
 
   attr_reader :support_user, :mathematics, :physics_incentive
@@ -64,7 +74,7 @@ private
   end
 
   def when_i_click_financial_incentives
-    click_link_or_button "Financial Incentives"
+    click_link_or_button "Financial incentives"
   end
 
   def then_i_see_the_financial_incentives_page
@@ -82,6 +92,7 @@ private
 
   def then_financial_incentives_are_created_for_all_active_subjects
     expect(page).to have_content("financial incentives for #{current_year} created")
+    expect(page).to have_no_content("translation missing")
     expect(FinancialIncentive.for_year(current_year).where(subject: Subject.active).count).to eq(Subject.active.count)
   end
 
@@ -96,6 +107,20 @@ private
 
   def when_i_visit_the_financial_incentives_page
     visit support_financial_incentives_path(year: current_year)
+  end
+
+  def when_i_visit_the_financial_incentives_page_with_year(year)
+    visit support_financial_incentives_path(year:)
+  end
+
+  def then_i_see_the_current_financial_incentive_year
+    expect(page).to have_select("Financial incentive year", selected: current_year.to_s)
+    expect(page).to have_content("There are no financial incentives for #{current_year}")
+    expect(page).to have_no_content("There are no financial incentives for 0")
+  end
+
+  def and_i_do_not_see_year_option(year)
+    expect(page).to have_no_css("select#year option[value='#{year}']")
   end
 
   def then_i_see_mathematics_is_missing_a_financial_incentive
@@ -129,6 +154,7 @@ private
   def then_i_see_the_publish_confirmation_page
     expect(page).to have_content("Make #{current_year} financial incentives visible?")
     expect(page).to have_content("This will hide the currently visible incentives")
+    expect(page).to have_no_content("translation missing")
   end
 
   def when_i_confirm_the_year_should_be_visible
@@ -158,6 +184,7 @@ private
   def then_i_see_the_visible_incentive_confirmation_page
     expect(page).to have_content("Confirm changes to this visible financial incentive")
     expect(page).to have_content("£12,345")
+    expect(page).to have_no_content("translation missing")
   end
 
   def when_i_confirm_the_financial_incentive_changes

--- a/spec/system/support/financial_incentives_spec.rb
+++ b/spec/system/support/financial_incentives_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Financial incentives support" do
+  include DfESignInUserHelper
+
+  before do
+    given_a_support_user_exists
+    sign_in_system_test(user: support_user)
+    and_the_current_year_has_no_financial_incentives
+  end
+
+  scenario "creating a new year and repairing a missing incentive" do
+    given_i_visit_the_support_subjects_page
+    when_i_click_financial_incentives
+    then_i_see_the_financial_incentives_page
+    and_i_see_there_are_no_incentives_for_the_current_year
+
+    when_i_create_financial_incentives_for_the_current_year
+    then_financial_incentives_are_created_for_all_active_subjects
+    and_discontinued_subjects_do_not_get_financial_incentives
+
+    given_mathematics_is_missing_a_financial_incentive
+    when_i_visit_the_financial_incentives_page
+    then_i_see_mathematics_is_missing_a_financial_incentive
+
+    when_i_create_a_blank_financial_incentive_for_mathematics
+    then_mathematics_has_a_blank_hidden_financial_incentive
+  end
+
+  scenario "publishing a year and confirming edits to a visible incentive" do
+    given_the_current_year_has_hidden_financial_incentives
+    when_i_visit_the_financial_incentives_page
+    and_i_choose_to_make_the_current_year_visible
+    then_i_see_the_publish_confirmation_page
+
+    when_i_confirm_the_year_should_be_visible
+    then_the_current_year_is_visible
+    and_physics_has_a_visible_financial_incentive
+
+    when_i_edit_the_physics_financial_incentive
+    and_i_change_the_bursary_amount
+    then_i_see_the_visible_incentive_confirmation_page
+
+    when_i_confirm_the_financial_incentive_changes
+    then_the_physics_financial_incentive_is_updated
+  end
+
+private
+
+  attr_reader :support_user, :mathematics, :physics_incentive
+
+  def given_a_support_user_exists
+    @support_user = create(:user, :admin)
+  end
+
+  def and_the_current_year_has_no_financial_incentives
+    FinancialIncentive.for_year(current_year).delete_all
+  end
+
+  def given_i_visit_the_support_subjects_page
+    visit support_subjects_path
+  end
+
+  def when_i_click_financial_incentives
+    click_link_or_button "Financial Incentives"
+  end
+
+  def then_i_see_the_financial_incentives_page
+    expect(page).to have_current_path(support_financial_incentives_path, ignore_query: true)
+    expect(page).to have_content("Financial incentives")
+  end
+
+  def and_i_see_there_are_no_incentives_for_the_current_year
+    expect(page).to have_content("There are no financial incentives for #{current_year}")
+  end
+
+  def when_i_create_financial_incentives_for_the_current_year
+    click_link_or_button "Create financial incentives for #{current_year}"
+  end
+
+  def then_financial_incentives_are_created_for_all_active_subjects
+    expect(page).to have_content("financial incentives for #{current_year} created")
+    expect(FinancialIncentive.for_year(current_year).where(subject: Subject.active).count).to eq(Subject.active.count)
+  end
+
+  def and_discontinued_subjects_do_not_get_financial_incentives
+    expect(FinancialIncentive.for_year(current_year).where(subject_id: DiscontinuedSubject.select(:id))).to be_empty
+  end
+
+  def given_mathematics_is_missing_a_financial_incentive
+    @mathematics = Subject.find_by!(subject_name: "Mathematics")
+    FinancialIncentive.find_by!(subject: mathematics, year: current_year).destroy!
+  end
+
+  def when_i_visit_the_financial_incentives_page
+    visit support_financial_incentives_path(year: current_year)
+  end
+
+  def then_i_see_mathematics_is_missing_a_financial_incentive
+    expect(page).to have_content("1 subject missing financial incentives for #{current_year}")
+
+    within("tr", text: mathematics.subject_name) do
+      expect(page).to have_content("Missing")
+      expect(page).to have_button("Create blank incentive")
+    end
+  end
+
+  def when_i_create_a_blank_financial_incentive_for_mathematics
+    within("tr", text: mathematics.subject_name) do
+      click_link_or_button "Create blank incentive"
+    end
+  end
+
+  def then_mathematics_has_a_blank_hidden_financial_incentive
+    expect(page).to have_content("Blank financial incentive for Mathematics created")
+    expect(financial_incentive_for(mathematics)).not_to be_displayed
+  end
+
+  def given_the_current_year_has_hidden_financial_incentives
+    FinancialIncentives::CreateYearService.call(year: current_year)
+  end
+
+  def and_i_choose_to_make_the_current_year_visible
+    click_link_or_button "Make #{current_year} incentives visible"
+  end
+
+  def then_i_see_the_publish_confirmation_page
+    expect(page).to have_content("Make #{current_year} financial incentives visible?")
+    expect(page).to have_content("This will hide the currently visible incentives")
+  end
+
+  def when_i_confirm_the_year_should_be_visible
+    click_link_or_button "Make financial incentives visible"
+  end
+
+  def then_the_current_year_is_visible
+    expect(page).to have_content("Financial incentives for #{current_year} are now visible")
+  end
+
+  def and_physics_has_a_visible_financial_incentive
+    @physics_incentive = financial_incentive_for(physics)
+    expect(physics_incentive).to be_displayed
+  end
+
+  def when_i_edit_the_physics_financial_incentive
+    within("tr", text: physics.subject_name) do
+      click_link_or_button "Change"
+    end
+  end
+
+  def and_i_change_the_bursary_amount
+    fill_in "Bursary amount", with: "12345"
+    click_link_or_button "Update"
+  end
+
+  def then_i_see_the_visible_incentive_confirmation_page
+    expect(page).to have_content("Confirm changes to this visible financial incentive")
+    expect(page).to have_content("£12,345")
+  end
+
+  def when_i_confirm_the_financial_incentive_changes
+    click_link_or_button "Confirm changes"
+  end
+
+  def then_the_physics_financial_incentive_is_updated
+    expect(page).to have_content("Financial incentive for Physics updated")
+    expect(physics_incentive.reload.bursary_amount).to eq("12345")
+  end
+
+  def current_year
+    @current_year ||= FinancialIncentive.current_year
+  end
+
+  def physics
+    @physics ||= Subject.find_by!(subject_name: "Physics")
+  end
+
+  def financial_incentive_for(subject)
+    FinancialIncentive.find_by!(subject:, year: current_year)
+  end
+end


### PR DESCRIPTION
## Context

### What

Adds a Support admin UI for managing financial incentives by year.

### Why

Financial incentives are now stored by year and controlled with a `displayed` flag. Support users need a way to prepare, repair, edit, and publish yearly incentive data without relying on manual database changes.

## Changes proposed in this pull request

- Adds `/support/financial-incentives`.
- Adds a `Financial Incentives` button to `/support/subjects`.
- Shows all active, non-discontinued subjects for the selected year.
- Supports year switching.
- Allows support users to:
  - create a new hidden year by copying each subject’s currently displayed incentive
  - create blank hidden incentives for missing subjects
  - create a single blank incentive from a missing row
  - edit incentive values
  - confirm edits to currently visible incentives
  - confirm publishing a complete year
- Publishes a year transactionally by hiding currently displayed active-subject incentives and making the selected year visible.
- Blocks publishing if any active subject is missing an incentive.
- Keeps feature flag behaviour separate.
- Adds translated support UI copy.
- Adds service and system coverage.

## Screenshots
<img width="1001" height="853" alt="Screenshot 2026-05-12 at 18 56 11" src="https://github.com/user-attachments/assets/2ade37fb-1eb7-45c6-beb3-b402ad7499e4" />
<img width="652" height="870" alt="Screenshot 2026-05-12 at 18 56 30" src="https://github.com/user-attachments/assets/3a1fb435-7602-44ae-8359-97707a6483cf" />
<img width="1030" height="819" alt="Screenshot 2026-05-12 at 18 56 47" src="https://github.com/user-attachments/assets/12ad1da0-09a1-42e6-a6b3-926af39aa521" />


## Guidance to review

- Check the new UI
- Run the specs
- Review the code

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
