### PR TITLE
Bump the RAM allocation to review app web pods to 1Gi

### DIFF
--- a/terraform/aks/workspace_variables/review.tfvars.json
+++ b/terraform/aks/workspace_variables/review.tfvars.json
@@ -8,7 +8,7 @@
   "main_app": {
     "main": {
       "replicas": 1,
-      "max_memory": "512Mi"
+      "max_memory": "1Gi"
     }
   },
   "worker_apps": {


### PR DESCRIPTION
## Context

  Our latest Prototype branch is restarting with OOM. We may be able to
  revert this if we find optimisations in that branch


## Changes proposed in this pull request

Increase the max memory for review apps to 1Gi

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
