### PR TITLE
Update Provider#changed_at after changes to Provider::School

### DIFF
--- a/app/models/course/school.rb
+++ b/app/models/course/school.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Course::School < ApplicationRecord
+  include TouchCourse
+
   self.table_name = "course_school"
 
   belongs_to :course, class_name: "::Course", inverse_of: :schools

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Provider::School < ApplicationRecord
+  include TouchProvider
+
   self.table_name = "provider_school"
 
   MAIN_SITE_CODE = "-"

--- a/spec/models/course/school_spec.rb
+++ b/spec/models/course/school_spec.rb
@@ -41,6 +41,44 @@ describe Course::School do
     end
   end
 
+  describe "touching the course" do
+    let(:course) { create(:course, changed_at: 1.hour.ago) }
+
+    it "bumps course.changed_at on create" do
+      Timecop.freeze do
+        create(:course_school, course:)
+        expect(course.reload.changed_at).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+
+    it "bumps course.changed_at on update" do
+      course_school = create(:course_school, course:)
+      course.update_columns(changed_at: 1.hour.ago)
+
+      Timecop.freeze do
+        course_school.update!(site_code: "Z")
+        expect(course.reload.changed_at).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+
+    it "does not bump course.changed_at on destroy" do
+      course_school = create(:course_school, course:)
+      course.update_columns(changed_at: 1.hour.ago)
+      before_changed_at = course.reload.changed_at
+
+      course_school.destroy!
+      expect(course.reload.changed_at).to be_within(1.second).of(before_changed_at)
+    end
+
+    it "leaves course.updated_at unchanged" do
+      course.update_columns(updated_at: 1.hour.ago)
+      original_updated_at = course.reload.updated_at
+
+      create(:course_school, course:)
+      expect(course.reload.updated_at).to be_within(1.second).of(original_updated_at)
+    end
+  end
+
   describe "database constraints" do
     let(:course) { create(:course) }
     let(:gias_school) { create(:gias_school) }

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -77,6 +77,44 @@ describe Provider::School do
     end
   end
 
+  describe "touching the provider" do
+    let(:provider) { create(:provider, changed_at: 1.hour.ago) }
+
+    it "bumps provider.changed_at on create" do
+      Timecop.freeze do
+        create(:provider_school, provider:)
+        expect(provider.reload.changed_at).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+
+    it "bumps provider.changed_at on update" do
+      provider_school = create(:provider_school, provider:)
+      provider.update_columns(changed_at: 1.hour.ago)
+
+      Timecop.freeze do
+        provider_school.update!(site_code: "Z")
+        expect(provider.reload.changed_at).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+
+    it "does not bump provider.changed_at on destroy" do
+      provider_school = create(:provider_school, provider:)
+      provider.update_columns(changed_at: 1.hour.ago)
+      before_changed_at = provider.reload.changed_at
+
+      provider_school.destroy!
+      expect(provider.reload.changed_at).to be_within(1.second).of(before_changed_at)
+    end
+
+    it "leaves provider.updated_at unchanged" do
+      provider.update_columns(updated_at: 1.hour.ago)
+      original_updated_at = provider.reload.updated_at
+
+      create(:provider_school, provider:)
+      expect(provider.reload.updated_at).to be_within(1.second).of(original_updated_at)
+    end
+  end
+
   describe "database constraints" do
     let(:provider) { create(:provider) }
     let(:gias_school) { create(:gias_school) }


### PR DESCRIPTION
## Context

When the new (Provider|Course)::School models are updated, we need to touch the associated model `Provider` or `Course`.

## Changes proposed in this pull request

Update `Provider#changed_at` or `Course#changed_at` when the associated school is updated so we can make the model available in the API.

## Guidance to review

The ticket says to touch on destroy, the existing system doesn't touch on destroy. Is this something that is missing from the existing implementation?

**Both Site and Provider::School are now touching the Provider. Do we see any problems coming out of this?**

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
