### PR TITLE
Email Alert snag list (part two)

### DIFF
--- a/app/assets/stylesheets/components/_stacked_summary_list.scss
+++ b/app/assets/stylesheets/components/_stacked_summary_list.scss
@@ -1,0 +1,24 @@
+// make the summary list look on desktop the way it looks on mobile
+// The list key is stacked on top of the list value instead of side by side
+.govuk-summary-list.govuk-summary-list--stacked {
+  @media (min-width: 40.0625em) {
+    display: block;
+
+    .govuk-summary-list__row {
+      display: block;
+
+      margin-bottom: 15px;
+    }
+
+    .govuk-summary-list__key,
+    .govuk-summary-list__value,
+    .govuk-summary-list__actions {
+      display: block;
+
+      width: 100%;
+
+      padding: 0;
+      margin: 0 0 5px;
+    }
+  }
+}

--- a/app/assets/stylesheets/find/application.scss
+++ b/app/assets/stylesheets/find/application.scss
@@ -17,6 +17,7 @@
 @import "../components/pagination";
 @import "../components/summary-card";
 @import "../components/callout";
+@import "../components/stacked_summary_list";
 
 @import "./components/accordion";
 @import "./components/details-component";

--- a/app/assets/stylesheets/publish/application.scss
+++ b/app/assets/stylesheets/publish/application.scss
@@ -16,6 +16,7 @@ $moj-images-path: "@ministryofjustice/frontend/moj/assets/images/";
 @import "../components/pagination";
 @import "../components/summary-card";
 @import "../components/callout";
+@import "../components/stacked_summary_list";
 
 @import "./components/inset-text";
 @import "./components/link";

--- a/app/components/find/email_alerts/summary_card_component.html.erb
+++ b/app/components/find/email_alerts/summary_card_component.html.erb
@@ -1,8 +1,8 @@
-<%= govuk_summary_card(title: title, classes: "govuk-summary-list--no-border") do |card| %>
+<%= govuk_summary_card(title: title) do |card| %>
   <% card.with_action do %>
     <%= govuk_link_to t(".unsubscribe"), unsubscribe_path, class: "govuk-link--no-visited-state" %>
   <% end %>
-  <dl class="govuk-summary-list govuk-summary-list--no-border">
+  <dl class="govuk-summary-list govuk-summary-list--stacked govuk-summary-list--no-border">
     <% filter_rows.each do |row| %>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><%= row[:label] %></dt>

--- a/app/components/find/email_alerts/summary_card_component.rb
+++ b/app/components/find/email_alerts/summary_card_component.rb
@@ -10,6 +10,7 @@ module Find
         @email_alert = email_alert
         @attrs = email_alert.search_attributes || {}
         @subject_names = subject_names
+        @subject_names << "Further education" if further_education? && @subject_names.exclude?("Further education")
       end
 
       def title
@@ -23,7 +24,7 @@ module Find
 
       def filter_rows
         @filter_rows ||= build_summary_rows(
-          @attrs.merge("radius" => @email_alert.radius, "location" => @email_alert.location_name),
+          @attrs.except("level").merge("radius" => @email_alert.radius, "location" => @email_alert.location_name),
           subject_names: @subject_names,
         )
       end
@@ -31,6 +32,12 @@ module Find
       def unsubscribe_path
         token = @email_alert.signed_id(purpose: :unsubscribe, expires_in: 30.days)
         helpers.find_candidate_confirm_unsubscribe_email_alert_path(token:)
+      end
+
+    private
+
+      def further_education?
+        @attrs["level"] == "further_education"
       end
     end
   end

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -71,7 +71,7 @@ module Find
 
       def unsubscribe_from_email
         @email_alert = Candidate::EmailAlert.find_signed!(params[:token], purpose: :unsubscribe)
-        @summary_rows = build_summary_rows(@email_alert.search_params.to_h, subject_names: @email_alert.subjects)
+        @summary_rows = build_summary_rows(@email_alert.search_params.to_h, subject_names: resolve_subject_names(@email_alert.subjects))
         @filter_tags = extract_filter_tags_from_alert(@email_alert)
       rescue ActiveSupport::MessageVerifier::InvalidSignature
         redirect_to find_root_path

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -20,7 +20,7 @@ module Find
         @title = build_title(subject_names:, search_attributes: search_params.to_h, location_name:, radius: search_params[:radius])
         @summary_rows = build_summary_rows(search_params.to_h, subject_names:)
         @search_params = search_params
-        @cancel_path = redirect_after_create
+        @cancel_path = redirect_back
       end
 
       def create
@@ -41,10 +41,10 @@ module Find
             "title" => t(".success_title"),
             "body" => t(".success_body_html", title:, unsubscribe_link: unsubscribe_link(alert)),
           }
-          redirect_to redirect_after_create
+          redirect_to find_candidate_email_alerts_path
         else
           flash[:warning] = t(".create_failed")
-          redirect_to find_candidate_email_alerts_path
+          redirect_to redirect_back
         end
       end
 
@@ -122,7 +122,7 @@ module Find
 
       def redirect_existing_alert
         flash[:info] = t("find.candidates.email_alerts.new.already_subscribed")
-        redirect_to redirect_after_create
+        redirect_to redirect_back
       end
 
       def build_title(subject_names:, search_attributes:, location_name:, radius:)
@@ -185,14 +185,17 @@ module Find
           "title" => t("find.candidates.email_alerts.new.subscription_limit_heading"),
           "body" => t("find.candidates.email_alerts.new.subscription_limit_body_html", link:),
         }
-        redirect_to redirect_after_create
+        redirect_to redirect_back
       end
 
-      def redirect_after_create
-        if params[:return_to] == "recent_searches"
+      def redirect_back
+        case params[:return_to]
+        when "recent_searches"
           find_candidate_recent_searches_path
-        else
+        when "results"
           find_results_path(search_params.except(:return_to))
+        else
+          find_candidate_email_alerts_path
         end
       end
     end

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -18,7 +18,7 @@ module Find
         return redirect_existing_alert if existing_alert?
 
         @title = build_title(subject_names:, search_attributes: search_params.to_h, location_name:, radius: search_params[:radius])
-        @summary_rows = build_summary_rows(search_params.to_h, subject_names:)
+        @summary_rows = build_summary_rows(search_params.to_h.except("level"), subject_names:)
         @search_params = search_params
         @cancel_path = redirect_back
       end
@@ -31,7 +31,7 @@ module Find
 
         if alert
           title = build_title(
-            subject_names: resolve_subject_names(alert.subjects),
+            subject_names:,
             search_attributes: alert.search_attributes || {},
             location_name: alert.location_name,
             radius: alert.radius,
@@ -101,7 +101,11 @@ module Find
       end
 
       def subject_names
-        @subject_names ||= resolve_subject_names(subject_codes)
+        @subject_names ||= begin
+          names = resolve_subject_names(subject_codes)
+          names << "Further education" if params["level"] == "further_education"
+          names
+        end
       end
 
       def location_name

--- a/app/helpers/subject_helper.rb
+++ b/app/helpers/subject_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SubjectHelper
+module_function
+
+  def subject_name_in_sentence(name)
+    downcased = name.sub(/^[[:alpha:]]/, &:downcase)
+    Subject::LANGUAGE_PROPER_NOUNS.reduce(downcased) do |memo, proper_noun|
+      memo.gsub(/\b#{Regexp.escape(proper_noun)}\b/i, proper_noun)
+    end
+  end
+end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -48,6 +48,7 @@ class Subject < ApplicationRecord
   end
 
   LANGUAGE_SUBJECT_CODES = %w[Q3 A1 A2 15 18 19 A0 20 21 22 17].freeze
+  LANGUAGE_PROPER_NOUNS = %w[English French German Greek Hebrew Italian Japanese Latin Mandarin Russian Spanish].freeze
   SCIENCE_SUBJECT_NAMES = %w[Physics Chemistry Biology].freeze
 
   def language_subject?

--- a/app/services/courses/active_filters/summary_row_builder.rb
+++ b/app/services/courses/active_filters/summary_row_builder.rb
@@ -6,6 +6,7 @@ module Courses
       VALUE_FORMATTERS = Hash.new(->(values) { values.join(", ") }).merge!(
         funding: ->(values) { values.join(", ").humanize },
         study_types: ->(values) { values.join(", ").humanize },
+        subjects: ->(values) { values.sort.map { |name| SubjectHelper.subject_name_in_sentence(name) }.to_sentence(last_word_connector: ", ").upcase_first },
       ).freeze
 
       FILTER_OPTION_KEYS = {

--- a/app/services/courses/active_filters/summary_row_builder.rb
+++ b/app/services/courses/active_filters/summary_row_builder.rb
@@ -3,6 +3,11 @@
 module Courses
   module ActiveFilters
     module SummaryRowBuilder
+      VALUE_FORMATTERS = Hash.new(->(values) { values.join(", ") }).merge!(
+        funding: ->(values) { values.join(", ").humanize },
+        study_types: ->(values) { values.join(", ").humanize },
+      ).freeze
+
       FILTER_OPTION_KEYS = {
         qualifications: "qualification_options",
         minimum_degree_required: "minimum_degree_required_options",
@@ -27,7 +32,9 @@ module Courses
           values = group.map { |f| resolve_filter_value(id, f) }.compact
           next if values.empty?
 
-          { label:, value: values.join(", ") }
+          value = VALUE_FORMATTERS[id].call(values)
+
+          { label:, value: }
         end
       end
 
@@ -39,8 +46,8 @@ module Courses
           this_year = Find::CycleTimetable.current_year
           next_year = Find::CycleTimetable.next_year
           I18n.t(
-            "find.results.filters.all.#{option_key}.#{filter.raw_value}",
-            recruitment_cycle_year: this_year,
+            "courses.active_filters.#{option_key}.#{filter.raw_value}",
+            current_recruitment_cycle_year: this_year,
             next_recruitment_cycle_year: next_year,
             default: filter.formatted_value,
           )

--- a/app/views/find/results/filters/_all.html.erb
+++ b/app/views/find/results/filters/_all.html.erb
@@ -3,7 +3,7 @@
 <div data-controller="details-component" class="app-c-filter-panel__top">
   <% if show_email_alert_link? %>
     <p class="email-alert-link govuk-body govuk-!-margin-bottom-4">
-      <%= govuk_link_to new_find_candidate_email_alert_path(@search_params.except(:order, :page)), class: "govuk-link--no-visited-state" do %>
+      <%= govuk_link_to new_find_candidate_email_alert_path(@search_params.except(:order, :page).merge(return_to: :results)), class: "govuk-link--no-visited-state" do %>
         <%= render "shared/bell_icon" %>
         <%= t(".set_up_email_alert") %>
       <% end %>

--- a/config/locales/en/find/active_filters.yml
+++ b/config/locales/en/find/active_filters.yml
@@ -8,13 +8,19 @@ en:
       funding:
         fee: Fee-paying courses
         salary: Courses with a salary
-        apprenticeship: Apprenticeships courses
+        apprenticeship: Apprenticeship courses
       interview_location:
         online: Courses with online interviews
       level:
         further_education: Further education
+      minimum_degree_required_options:
+        two_one: "2:1 or First"
+        two_two: "2:2"
+        third_class: "Third"
+        pass: "Pass"
+        no_degree_required: "No degree"
       minimum_degree_required:
-        two_one: "Degree grade: 2:1 or first"
+        two_one: "Degree grade: 2:1 or First"
         two_two: "Degree grade: 2:2"
         third_class: "Degree grade: Third"
         pass: "Degree grade: Pass"
@@ -29,6 +35,9 @@ en:
       qualifications:
         qts: "Qualification: QTS only"
         qts_with_pgce_or_pgde: "Qualification: QTS with PGCE or PGDE"
+      qualification_options:
+        qts: "QTS only"
+        qts_with_pgce_or_pgde: "QTS with PGCE or PGDE"
       radius:
         10: "Search radius: 10 miles"
         20: "Search radius: 20 miles"
@@ -36,6 +45,10 @@ en:
         100: "Search radius: 100 miles"
       send_courses:
         true: Courses with a SEND specialism
+      start_date_options:
+        september: "September %{current_recruitment_cycle_year} only"
+        jan_to_aug: "January to August %{current_recruitment_cycle_year}"
+        oct_to_jul: "October %{current_recruitment_cycle_year} to July %{next_recruitment_cycle_year}"
       start_date:
         september: "Start date: September %{current_recruitment_cycle_year} only"
         jan_to_aug: "Start date: January to August %{current_recruitment_cycle_year}"

--- a/config/locales/en/find/candidates/email_alerts.yml
+++ b/config/locales/en/find/candidates/email_alerts.yml
@@ -28,6 +28,7 @@ en:
             qualifications: Qualification
             minimum_degree_required: Degree required
             can_sponsor_visa: Visa sponsorship
+            interview_location: Online interview
             start_date: Start date
             provider_code: Provider
         create:

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -124,11 +124,11 @@ en:
         subjects_no_location: "%{subject} courses in England"
         many_subjects_no_location: "%{count} subjects in England"
         subjects_with_location: "%{subject} courses within %{radius} miles of %{location}"
-        no_subjects_with_location: "Courses within %{radius} miles of %{location}"
+        no_subjects_with_location: "courses within %{radius} miles of %{location}"
         fallback_with_filters:
-          one: "Courses across England (%{count} filter applied)"
-          other: "Courses across England (%{count} filters applied)"
-        fallback: Courses across England
+          one: "courses across England (%{count} filter applied)"
+          other: "courses across England (%{count} filters applied)"
+        fallback: courses across England
       show:
         back_to_search: Back to search results
         back_to_saved_courses: Back to saved courses

--- a/spec/components/find/courses/search_title_component_spec.rb
+++ b/spec/components/find/courses/search_title_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:location_name) { "Manchester" }
     let(:radius) { 10 }
 
-    it { expect(rendered.text).to eq("Courses within 10 miles of Manchester") }
+    it { expect(rendered.text).to eq("courses within 10 miles of Manchester") }
   end
 
   context "with 1 subject and a location" do
@@ -58,25 +58,25 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:location_name) { "Manchester" }
     let(:radius) { 15 }
 
-    it { expect(rendered.text).to eq("Courses within 15 miles of Manchester") }
+    it { expect(rendered.text).to eq("courses within 15 miles of Manchester") }
   end
 
   context "with a provider name only" do
     let(:search_attributes) { { "provider_name" => "Manchester Metropolitan University (M40)" } }
 
-    it { expect(rendered.text).to eq("Courses across England") }
+    it { expect(rendered.text).to eq("courses across England") }
   end
 
   context "with a provider name and default keys" do
     let(:search_attributes) { { "provider_name" => "Manchester Metropolitan University (M40)", "applications_open" => "true", "order" => "course_name_ascending" } }
 
-    it { expect(rendered.text).to eq("Courses across England") }
+    it { expect(rendered.text).to eq("courses across England") }
   end
 
   context "with a provider name and non-default filter" do
     let(:search_attributes) { { "provider_name" => "Manchester Metropolitan University (M40)", "send_courses" => "true" } }
 
-    it { expect(rendered.text).to eq("Courses across England (1 filter applied)") }
+    it { expect(rendered.text).to eq("courses across England (1 filter applied)") }
   end
 
   context "with no subject/location but visa sponsorship" do
@@ -113,20 +113,20 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
   context "with 1 filter in fallback" do
     let(:search_attributes) { { "level" => "primary" } }
 
-    it { expect(rendered.text).to eq("Courses across England (1 filter applied)") }
+    it { expect(rendered.text).to eq("courses across England (1 filter applied)") }
   end
 
   context "with 2 filters in fallback" do
     let(:search_attributes) { { "level" => "primary", "send_courses" => "true" } }
 
-    it { expect(rendered.text).to eq("Courses across England (2 filters applied)") }
+    it { expect(rendered.text).to eq("courses across England (2 filters applied)") }
   end
 
   context "with provider params excluded from filter count" do
     let(:search_attributes) { { "provider_name" => "Test Provider (TP1)", "provider_code" => "TP1", "send_courses" => "true" } }
 
     it "counts only non-default keys as filters" do
-      expect(rendered.text).to eq("Courses across England (1 filter applied)")
+      expect(rendered.text).to eq("courses across England (1 filter applied)")
     end
   end
 
@@ -134,23 +134,23 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:search_attributes) { { "provider_code" => "TP1", "level" => "secondary" } }
 
     it "excludes provider_code from filter count and uses singular filter" do
-      expect(rendered.text).to eq("Courses across England (1 filter applied)")
+      expect(rendered.text).to eq("courses across England (1 filter applied)")
     end
   end
 
   context "with only default filter values" do
     let(:search_attributes) { { "applications_open" => "true", "minimum_degree_required" => "show_all_courses", "order" => "course_name_ascending" } }
 
-    it { expect(rendered.text).to eq("Courses across England") }
+    it { expect(rendered.text).to eq("courses across England") }
   end
 
   context "with non-default minimum_degree_required" do
     let(:search_attributes) { { "minimum_degree_required" => "two_one", "order" => "course_name_ascending" } }
 
-    it { expect(rendered.text).to eq("Courses across England (1 filter applied)") }
+    it { expect(rendered.text).to eq("courses across England (1 filter applied)") }
   end
 
   context "with no filters at all" do
-    it { expect(rendered.text).to eq("Courses across England") }
+    it { expect(rendered.text).to eq("courses across England") }
   end
 end

--- a/spec/components/find/email_alerts/summary_card_component_spec.rb
+++ b/spec/components/find/email_alerts/summary_card_component_spec.rb
@@ -67,4 +67,36 @@ RSpec.describe Find::EmailAlerts::SummaryCardComponent, type: :component do
       end
     end
   end
+
+  describe "further_education level" do
+    let(:email_alert) do
+      create(
+        :email_alert,
+        candidate:,
+        subjects: [],
+        location_name: nil,
+        radius: nil,
+        search_attributes: { "level" => "further_education" },
+      )
+    end
+
+    it "adds 'Further education' to the subjects shown in the title" do
+      rendered = render_inline(described_class.new(email_alert:, subject_names: []))
+
+      expect(rendered.text).to include("Further education")
+    end
+
+    it "does not duplicate 'Further education' in the subject row when already in subject_names" do
+      rendered = render_inline(described_class.new(email_alert:, subject_names: ["Further education"]))
+
+      expect(rendered.text).not_to include("Further education, Further education")
+    end
+
+    it "does not render a separate level row in the filter list" do
+      rendered = render_inline(described_class.new(email_alert:, subject_names: []))
+
+      keys = rendered.css(".govuk-summary-list__key").map(&:text).map(&:strip)
+      expect(keys).not_to include("Level")
+    end
+  end
 end

--- a/spec/controllers/find/candidates/email_alerts_controller_spec.rb
+++ b/spec/controllers/find/candidates/email_alerts_controller_spec.rb
@@ -82,6 +82,27 @@ module Find
 
             expect(cancel_link_href(response.body)).to eq(find_candidate_recent_searches_path)
           end
+
+          it "treats level=further_education as a subject and omits the level summary row" do
+            get :new, params: { level: "further_education" }
+
+            expect(response.body).to include("Further education")
+            expect(response.body).not_to match(/<dt[^>]*>\s*Level\s*<\/dt>/)
+          end
+
+          it "lists 'Further education' alongside explicit subjects when level=further_education" do
+            subject_area = SubjectArea.find_by!(typename: "SecondarySubject")
+            Subject.find_or_create_by!(subject_code: "C1") do |s|
+              s.subject_name = "Biology"
+              s.type = "SecondarySubject"
+              s.subject_area = subject_area
+            end
+
+            get :new, params: { subjects: %w[C1], level: "further_education" }
+
+            expect(response.body).to include("Biology")
+            expect(response.body).to include("Further education")
+          end
         end
       end
 

--- a/spec/controllers/find/candidates/email_alerts_controller_spec.rb
+++ b/spec/controllers/find/candidates/email_alerts_controller_spec.rb
@@ -15,6 +15,10 @@ module Find
         cookies.signed[Settings.cookies.candidate_session.name] = session_record.session_key
       end
 
+      def cancel_link_href(body)
+        Nokogiri::HTML(body).at_xpath("//a[normalize-space(text())='Cancel']")&.[]("href")
+      end
+
       describe "GET #index" do
         it "renders successfully with active alerts" do
           create(:email_alert, candidate:, subjects: %w[C1])
@@ -58,35 +62,42 @@ module Find
             expect(response.body).not_to include("Start date:")
           end
 
-          it "links cancel to results page by default" do
+          it "links cancel to results page when return_to param is 'results'" do
+            get :new, params: { subjects: %w[C1], level: "secondary", return_to: "results" }
+
+            cancel_href = cancel_link_href(response.body)
+            expect(cancel_href).to start_with("/results?")
+            expect(cancel_href).to include("level=secondary")
+            expect(cancel_href).to include("subjects%5B%5D=C1")
+          end
+
+          it "links cancel to the email alerts index by default" do
             get :new, params: { subjects: %w[C1], level: "secondary" }
 
-            expect(response.body).to include("/results?")
-            expect(response.body).to include("level=secondary")
-            expect(response.body).to include("subjects%5B%5D=C1")
+            expect(cancel_link_href(response.body)).to eq(find_candidate_email_alerts_path)
           end
 
           it "links cancel to recent searches when return_to is recent_searches" do
             get :new, params: { subjects: %w[C1], return_to: "recent_searches" }
 
-            expect(response.body).to include(find_candidate_recent_searches_path)
+            expect(cancel_link_href(response.body)).to eq(find_candidate_recent_searches_path)
           end
         end
       end
 
       describe "POST #create" do
-        it "creates an email alert and redirects with success flash" do
+        it "creates an email alert and redirects to the alerts index with success flash" do
           post :create, params: { subjects: %w[C1], level: "secondary" }
 
           expect(candidate.email_alerts.count).to eq(1)
-          expect(response).to redirect_to(find_results_path(subjects: %w[C1], level: "secondary"))
+          expect(response).to redirect_to(find_candidate_email_alerts_path)
           expect(flash[:success_with_body]["title"]).to eq("Email alert created")
         end
 
-        it "redirects to recent searches when return_to is set" do
+        it "always redirects to the alerts index on success even when return_to is set" do
           post :create, params: { subjects: %w[C1], return_to: "recent_searches" }
 
-          expect(response).to redirect_to(find_candidate_recent_searches_path)
+          expect(response).to redirect_to(find_candidate_email_alerts_path)
         end
       end
 

--- a/spec/helpers/subject_helper_spec.rb
+++ b/spec/helpers/subject_helper_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubjectHelper do
+  describe ".subject_name_in_sentence" do
+    it "down-cases a non-language subject name" do
+      expect(described_class.subject_name_in_sentence("Mathematics")).to eq("mathematics")
+    end
+
+    it "preserves a single-word language proper noun" do
+      expect(described_class.subject_name_in_sentence("French")).to eq("French")
+    end
+
+    it "down-cases descriptive words but preserves the language proper noun" do
+      expect(described_class.subject_name_in_sentence("Ancient Greek")).to eq("ancient Greek")
+      expect(described_class.subject_name_in_sentence("Ancient Hebrew")).to eq("ancient Hebrew")
+    end
+
+    it "leaves a name with no alphabetic first character unchanged" do
+      expect(described_class.subject_name_in_sentence("3D design")).to eq("3D design")
+    end
+  end
+end

--- a/spec/services/courses/active_filter_spec.rb
+++ b/spec/services/courses/active_filter_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Courses::ActiveFilter do
 
       formatted_value = active_filter.formatted_value
 
-      expect(formatted_value).to eq("Degree grade: 2:1 or first")
+      expect(formatted_value).to eq("Degree grade: 2:1 or First")
     end
 
     it "returns nil when translation is missing for non-special ids" do

--- a/spec/services/courses/active_filters/hash_extractor_spec.rb
+++ b/spec/services/courses/active_filters/hash_extractor_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Courses::ActiveFilters::HashExtractor do
       let(:attrs) { { "minimum_degree_required" => "two_one" } }
 
       it "translates via active_filters.yml" do
-        expect(formatted_values).to eq(["Degree grade: 2:1 or first"])
+        expect(formatted_values).to eq(["Degree grade: 2:1 or First"])
       end
     end
 
@@ -209,7 +209,7 @@ RSpec.describe Courses::ActiveFilters::HashExtractor do
           "Courses with a salary",
           "Full time",
           "Qualification: QTS with PGCE or PGDE",
-          "Degree grade: 2:1 or first",
+          "Degree grade: 2:1 or First",
           "Courses with visa sponsorship",
           "Start date: September #{year} only",
         ])

--- a/spec/services/courses/active_filters/summary_row_builder_spec.rb
+++ b/spec/services/courses/active_filters/summary_row_builder_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Courses::ActiveFilters::SummaryRowBuilder do
+  describe "VALUE_FORMATTERS" do
+    subject(:formatter) { described_class::VALUE_FORMATTERS[id] }
+
+    context "with an unknown id (default formatter)" do
+      let(:id) { :anything_else }
+
+      it "joins values with a comma" do
+        expect(formatter.call(%w[Alpha Beta])).to eq("Alpha, Beta")
+      end
+
+      it "returns a single value unchanged" do
+        expect(formatter.call(%w[Solo])).to eq("Solo")
+      end
+    end
+
+    context "with :funding" do
+      let(:id) { :funding }
+
+      it "joins values then humanizes (only the first character is capitalised)" do
+        expect(formatter.call(%w[fee salary])).to eq("Fee, salary")
+      end
+
+      it "replaces underscores with spaces" do
+        expect(formatter.call(%w[fee_funded salary])).to eq("Fee funded, salary")
+      end
+    end
+
+    context "with :study_types" do
+      let(:id) { :study_types }
+
+      it "joins values then humanizes" do
+        expect(formatter.call(%w[full_time part_time])).to eq("Full time, part time")
+      end
+    end
+
+    context "with :subjects" do
+      let(:id) { :subjects }
+
+      it "returns a single subject capitalised" do
+        expect(formatter.call(%w[Mathematics])).to eq("Mathematics")
+      end
+
+      it "joins two subjects with 'and'" do
+        expect(formatter.call(%w[Physics Mathematics])).to eq("Mathematics and physics")
+      end
+
+      it "sorts subjects, lowercasing all but the first" do
+        expect(formatter.call(%w[Physics Biology Chemistry])).to eq("Biology, chemistry, physics")
+      end
+
+      it "preserves language proper nouns in their original case" do
+        expect(formatter.call(%w[Physics French Biology])).to eq("Biology, French, physics")
+      end
+
+      it "down-cases the descriptive 'Ancient' but preserves the language proper noun" do
+        expect(formatter.call(["Ancient Greek", "Ancient Hebrew", "Mathematics"]))
+          .to eq("Ancient Greek, ancient Hebrew, mathematics")
+      end
+    end
+  end
+end

--- a/spec/system/find/candidates/email_alerts_spec.rb
+++ b/spec/system/find/candidates/email_alerts_spec.rb
@@ -338,6 +338,8 @@ RSpec.describe "Email alerts", service: :find do
     expect(page).to have_content("Unsubscribe from this email alert")
     expect(page).to have_content("Are you sure you want to unsubscribe?")
     expect(page).to have_button("Unsubscribe")
+    expect(page).to have_content("Biology")
+    expect(page).not_to have_content(/\bC1\b/)
   end
 
   def then_i_see_homepage

--- a/spec/system/find/candidates/email_alerts_spec.rb
+++ b/spec/system/find/candidates/email_alerts_spec.rb
@@ -385,6 +385,7 @@ RSpec.describe "Email alerts", service: :find do
         "can_sponsor_visa" => "true",
         "funding" => %w[salary],
         "send_courses" => "true",
+        "interview_location" => "online",
       },
     )
   end
@@ -395,6 +396,7 @@ RSpec.describe "Email alerts", service: :find do
     expect(page).to have_content("Visa sponsorship")
     expect(page).to have_content("salary")
     expect(page).to have_content("SEND specialism")
+    expect(page).to have_content("Online interview")
   end
 
   def many_filters_search_attributes

--- a/spec/system/find/candidates/email_alerts_spec.rb
+++ b/spec/system/find/candidates/email_alerts_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe "Email alerts", service: :find do
     expect(page).to have_content("Biology")
     expect(page).to have_content("Within 15 miles of Manchester")
     expect(page).to have_content("Visa sponsorship")
-    expect(page).to have_content("Salary")
+    expect(page).to have_content("salary")
     expect(page).to have_content("SEND specialism")
   end
 
@@ -501,9 +501,9 @@ RSpec.describe "Email alerts", service: :find do
   end
 
   def then_i_see_funding_filters_on_confirmation_page
-    expect(page).to have_content("Fee - no salary")
-    expect(page).to have_content("Salary")
-    expect(page).to have_content("Teaching apprenticeship - with salary")
+    expect(page).to have_content("Fee-paying courses")
+    expect(page).to have_content("courses with a salary")
+    expect(page).to have_content("apprenticeship courses")
   end
 
   def then_the_email_alert_has_funding_filters

--- a/spec/system/find/candidates/recent_searches_spec.rb
+++ b/spec/system/find/candidates/recent_searches_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe "Recent searches", service: :find do
     expect(page).to have_content("Courses with a salary")
     expect(page).to have_content("Full time")
     expect(page).to have_content("Qualification: QTS with PGCE or PGDE")
-    expect(page).to have_content("Degree grade: 2:1 or first")
+    expect(page).to have_content("Degree grade: 2:1 or First")
     expect(page).to have_content("Start date: September #{Find::CycleTimetable.current_year} only")
     expect(page).to have_content("Courses with a SEND specialism")
   end

--- a/spec/system/find/candidates/recent_searches_spec.rb
+++ b/spec/system/find/candidates/recent_searches_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe "Recent searches", service: :find do
   end
 
   def then_i_see_the_provider_search_title
-    expect(page).to have_content("Courses across England")
+    expect(page).to have_content("courses across England")
   end
 
   def then_i_see_the_provider_filter_tag

--- a/spec/system/find/results/active_filters_spec.rb
+++ b/spec/system/find/results/active_filters_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe "Courses search with active filters", :js, service: :find do
   end
 
   def then_two_one_degree_filter_is_displayed
-    expect(active_filters).to include("Degree grade: 2:1 or first")
+    expect(active_filters).to include("Degree grade: 2:1 or First")
   end
 
   def then_online_interview_location_filter_is_displayed
@@ -533,7 +533,7 @@ RSpec.describe "Courses search with active filters", :js, service: :find do
   end
 
   def then_all_expected_filters_are_displayed
-    expect(active_filters).to contain_exactly("Primary", "Primary with English", "Art and design", "Further education", "Fee-paying courses", "Courses with a salary", "Full time", "Part time", "Qualification: QTS only", "Qualification: QTS with PGCE or PGDE", "Degree grade: 2:1 or first", "Courses with visa sponsorship", "Courses with online interviews", "London", "Courses with a SEND specialism", "Biology")
+    expect(active_filters).to contain_exactly("Primary", "Primary with English", "Art and design", "Further education", "Fee-paying courses", "Courses with a salary", "Full time", "Part time", "Qualification: QTS only", "Qualification: QTS with PGCE or PGDE", "Degree grade: 2:1 or First", "Courses with visa sponsorship", "Courses with online interviews", "London", "Courses with a SEND specialism", "Biology")
   end
 
   def when_user_search_main_subject(subject)


### PR DESCRIPTION
## Context

The latest list of snags in the Email Alerts feature. 6 items in total which are listed and described in the Trello ticket.

## Changes proposed in this pull request

- [x] Lowercase on "Courses" in titles and notification text
- [x] Redirect to email alert index after creating an email alert
- [x] Show Further Education in the Subject row instead of the Level row
  - This is a bit hacky. Any suggestions are welcome.
- [x] Summary row values should match the pill text
  - used xxx_options to remove the key prefix from the pill text
- [x] Add Online Interview to summary rows
- [x] Style email alert summary box as if it’s on mobile when on desktop


## Guidance to review

Formatting the subject names when they are displayed in the sentence like list requires downcasing the first letter of the subject name unless it's a proper noun. I've put this functionality in the SubjectHelper for now. I think we need to discuss our options for presenting model data.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
