### PR TITLE
Implement Funding type step

### DIFF
--- a/app/views/publish/course_wizards/steps/_funding_type.html.erb
+++ b/app/views/publish/course_wizards/steps/_funding_type.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.funding_type.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.funding_type.caption")) %>
+  <%= t("course_wizard.steps.funding_type.heading") %>
+</h1>
+
+<%= form.govuk_radio_buttons_fieldset :funding_type, legend: { hidden: true, text: t("course_wizard.steps.funding_type.heading") } do %>
+  <% current_step.funding_type_options.each_with_index do |value, index| %>
+    <%= form.govuk_radio_button :funding_type, value,
+          label: { text: t("course_wizard.steps.funding_type.options.#{value}.label") },
+          link_errors: index.zero? %>
+  <% end %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.funding_type.submit") %>

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -5,7 +5,7 @@ class CourseWizard
 
   attr_accessor :recruitment_cycle_year, :provider_code, :state_key
 
-  delegate :further_education_level?, :primary_level?, to: :state_store
+  delegate :further_education_level?, :primary_level?, :undergraduate_degree_with_qts?, to: :state_store
 
   def steps_processor
     DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
@@ -16,6 +16,7 @@ class CourseWizard
       graph.add_node :secondary_subjects, Steps::SecondarySubjects
       graph.add_node :age_range, Steps::AgeRange
       graph.add_node :qualifications, Steps::Qualifications
+      graph.add_node :funding_type, Steps::FundingType
 
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
@@ -28,12 +29,20 @@ class CourseWizard
         default: :secondary_subjects,
       )
 
+      graph.add_multiple_conditional_edges(
+        from: :qualifications,
+        branches: [
+          { when: :undergraduate_degree_with_qts?, then: :courses_index },
+        ],
+        default: :funding_type,
+      )
+
       graph.add_edge from: :primary_subjects, to: :age_range
       graph.add_edge from: :secondary_subjects, to: :age_range
 
       graph.add_edge from: :age_range, to: :qualifications
 
-      graph.add_edge from: :qualifications, to: :courses_index
+      graph.add_edge from: :funding_type, to: :courses_index
     end
   end
 

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -12,6 +12,10 @@ class CourseWizard
       def primary_level?
         level == "primary"
       end
+
+      def undergraduate_degree_with_qts?
+        qualification == "undergraduate_degree_with_qts"
+      end
     end
   end
 end

--- a/app/wizards/course_wizard/steps/funding_type.rb
+++ b/app/wizards/course_wizard/steps/funding_type.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class FundingType
+      include DfE::Wizard::Step
+
+      FUNDING_TYPE_OPTIONS = %w[fee salary apprenticeship].freeze
+
+      attribute :funding_type, :string
+
+      validates :funding_type,
+                presence: { message: I18n.t("course_wizard.steps.funding_type.errors.funding_type.blank") }
+
+      validates :funding_type,
+                inclusion: {
+                  in: FUNDING_TYPE_OPTIONS,
+                  message: I18n.t("course_wizard.steps.funding_type.errors.funding_type.blank"),
+                },
+                allow_blank: true
+
+      def funding_type_options
+        FUNDING_TYPE_OPTIONS
+      end
+
+      def self.permitted_params
+        [:funding_type]
+      end
+    end
+  end
+end

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -77,6 +77,21 @@ en:
         errors:
           qualification:
             blank: Select a qualification
+
+      funding_type:
+        caption: Add course
+        heading: Funding type
+        submit: Continue
+        options:
+          fee:
+            label: Fee - no salary
+          salary:
+            label: Salary
+          apprenticeship:
+            label: Teaching apprenticeship - with salary
+        errors:
+          funding_type:
+            blank: Select a funding type
   activemodel:
     errors:
       models:

--- a/spec/system/publish/courses/add_course_wizard/funding_type_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/funding_type_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard funding type step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user_with_a_school
+  end
+
+  scenario "choosing a funding type and continues to courses index" do
+    when_i_visit_the_wizard_funding_type_page
+    and_i_choose_funding_type
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "submitting funding type without selecting a funding type shows validation errors" do
+    when_i_visit_the_wizard_funding_type_page
+    and_i_click_continue
+    then_i_have_errors_on_the_funding_type_step
+  end
+
+private
+
+  def when_i_visit_the_wizard_funding_type_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :funding_type,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def and_i_choose_funding_type
+    choose "Fee - no salary"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_courses_index_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_have_errors_on_the_funding_type_step
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select a funding type")
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_a_school
+    @user = create(
+      :user,
+      providers: [
+        create(:provider, :accredited_provider, sites: [build(:site)]),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/qualifications_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/qualifications_spec.rb
@@ -8,28 +8,28 @@ RSpec.describe "Add course wizard qualifications step", type: :system do
     given_i_am_authenticated_as_a_provider_user_with_a_school
   end
 
-  scenario "choosing a qualification with primary level and continues to courses index" do
+  scenario "choosing a qualification with primary level and continues to funding type page" do
     and_i_have_wizard_state_for_qualifications(level: "primary")
     when_i_visit_the_wizard_qualifications_page
     and_i_choose_qualification(qualification: "QTS")
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_funding_type_page
   end
 
-  scenario "choosing a qualification with secondary level and continues to courses index" do
+  scenario "choosing a qualification with secondary level and continues to funding type page" do
     and_i_have_wizard_state_for_qualifications(level: "secondary")
     when_i_visit_the_wizard_qualifications_page
     and_i_choose_qualification(qualification: "QTS")
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_funding_type_page
   end
 
-  scenario "choosing a qualification with further education level and continues to courses index" do
+  scenario "choosing a qualification with further education level and continues to funding type page" do
     and_i_have_wizard_state_for_qualifications(level: "further_education")
     when_i_visit_the_wizard_qualifications_page
     and_i_choose_qualification(qualification: "PGDE only (without QTS)")
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_funding_type_page
   end
 
   scenario "submitting qualifications without selecting a qualification shows validation errors" do
@@ -69,11 +69,13 @@ private
     click_on "Continue"
   end
 
-  def then_i_am_taken_to_the_courses_index_page
+  def then_i_am_taken_to_the_funding_type_page
     expect(page).to have_current_path(
-      publish_provider_recruitment_cycle_courses_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :funding_type,
+        state_key: wizard_state_key,
       ),
       ignore_query: true,
     )

--- a/spec/system/publish/courses/add_course_wizard/qualifications_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/qualifications_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe "Add course wizard qualifications step", type: :system do
     then_i_am_taken_to_the_funding_type_page
   end
 
+  scenario "choosing a qualification with undergraduate degree with QTS and continues to courses index" do
+    and_i_have_wizard_state_for_qualifications(level: "primary", qualification: "undergraduate_degree_with_qts")
+    when_i_visit_the_wizard_qualifications_page
+    and_i_choose_qualification(qualification: "Teacher degree apprenticeship (TDA) with QTS")
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
   scenario "submitting qualifications without selecting a qualification shows validation errors" do
     and_i_have_wizard_state_for_qualifications(level: "primary")
     when_i_visit_the_wizard_qualifications_page
@@ -50,6 +58,16 @@ private
     )
 
     given_i_am_authenticated(user: @user)
+  end
+
+  def then_i_am_taken_to_the_courses_index_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      ),
+      ignore_query: true,
+    )
   end
 
   def when_i_visit_the_wizard_qualifications_page
@@ -94,7 +112,7 @@ private
     @wizard_state_key ||= SecureRandom.uuid
   end
 
-  def and_i_have_wizard_state_for_qualifications(level:)
+  def and_i_have_wizard_state_for_qualifications(level: nil, qualification: nil)
     repository = CourseWizard::Repositories::Course.new(
       provider_code: provider.provider_code,
       recruitment_cycle_year: provider.recruitment_cycle_year,
@@ -102,6 +120,6 @@ private
       expires_in: 24.hours,
     )
     state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
-    state_store.write(level:)
+    state_store.write(level:, qualification:)
   end
 end

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "age_range_in_years" => "11_to_16" })
       repository.write({ "course_age_range_in_years_other_from" => "1", "course_age_range_in_years_other_to" => "16" })
       repository.write({ "qualification" => "qts" })
+      repository.write({ "funding_type" => "fee" })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -34,6 +35,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:course_age_range_in_years_other_from]).to eq("1")
       expect(data[:course_age_range_in_years_other_to]).to eq("16")
       expect(data[:qualification]).to eq("qts")
+      expect(data[:funding_type]).to eq("fee")
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
+++ b/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe CourseWizard::StateStores::CourseWizardStore do
-  subject(:store) { described_class.new(repository:, attribute_names: %w[level]) }
+  subject(:store) { described_class.new(repository:, attribute_names: %w[level qualification]) }
 
   let(:repository) { instance_double(DfE::Wizard::Repository::InMemory) }
 
@@ -25,6 +25,50 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
 
       it "returns false" do
         expect(store.further_education_level?).to be false
+      end
+    end
+  end
+
+  describe "#primary_level?" do
+    before do
+      allow(repository).to receive(:read).and_return({ level: })
+    end
+
+    context "when level is 'primary'" do
+      let(:level) { "primary" }
+
+      it "returns true" do
+        expect(store.primary_level?).to be true
+      end
+    end
+
+    context "when level is not 'primary'" do
+      let(:level) { "secondary" }
+
+      it "returns false" do
+        expect(store.primary_level?).to be false
+      end
+    end
+  end
+
+  describe "#undergraduate_degree_with_qts?" do
+    before do
+      allow(repository).to receive(:read).and_return({ qualification: })
+    end
+
+    context "when qualification is 'undergraduate_degree_with_qts'" do
+      let(:qualification) { "undergraduate_degree_with_qts" }
+
+      it "returns true" do
+        expect(store.undergraduate_degree_with_qts?).to be true
+      end
+    end
+
+    context "when qualification is not 'undergraduate_degree_with_qts'" do
+      let(:qualification) { "qts" }
+
+      it "returns false" do
+        expect(store.undergraduate_degree_with_qts?).to be false
       end
     end
   end

--- a/spec/wizards/add_course_wizard/steps/funding_type_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/funding_type_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::FundingType do
+  include_context "add_course_wizard"
+
+  let(:current_step) { :funding_type }
+  let(:current_step_params) { { funding_type: } }
+  let(:funding_type) { nil }
+
+  describe "#valid?" do
+    subject(:wizard_step) { wizard.current_step }
+
+    it "is valid when funding type is present" do
+      wizard_step.funding_type = "fee"
+      expect(wizard_step).to be_valid
+    end
+
+    it "is not valid when funding type is not present" do
+      expect(wizard_step).not_to be_valid
+    end
+
+    it "is not valid when funding type is not in the list of options" do
+      wizard_step.funding_type = "invalid"
+      expect(wizard_step).not_to be_valid
+    end
+  end
+
+  describe "#funding_type_options" do
+    subject(:wizard_step) { wizard.current_step }
+
+    it "returns the funding type options" do
+      expect(wizard_step.funding_type_options).to eq(%w[fee salary apprenticeship])
+    end
+  end
+
+  describe "#self.permitted_params" do
+    it "returns the permitted params" do
+      expect(described_class.permitted_params).to eq([:funding_type])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -79,8 +79,56 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
     end
   end
 
-  context "from qualifications" do
+  context "from qualifications with primary level" do
     let(:current_step) { :qualifications }
+
+    before do
+      state_store.write(level: "primary")
+    end
+
+    it "proceeds to primary subjects page" do
+      expect(wizard).to have_next_step(:funding_type)
+    end
+  end
+
+  context "from qualifications with secondary level" do
+    let(:current_step) { :qualifications }
+
+    before do
+      state_store.write(level: "secondary")
+    end
+
+    it "proceeds to primary subjects page" do
+      expect(wizard).to have_next_step(:funding_type)
+    end
+  end
+
+  context "from qualifications with further education level" do
+    let(:current_step) { :qualifications }
+
+    before do
+      state_store.write(level: "further_education")
+    end
+
+    it "proceeds to funding type page" do
+      expect(wizard).to have_next_step(:funding_type)
+    end
+  end
+
+  context "from qualifications with undergraduate degree with QTS" do
+    let(:current_step) { :qualifications }
+
+    before do
+      state_store.write(qualification: "undergraduate_degree_with_qts")
+    end
+
+    it "proceeds to courses page" do
+      expect(wizard).to have_next_step(:courses_index)
+    end
+  end
+
+  context "from funding type" do
+    let(:current_step) { :funding_type }
 
     it "proceeds to courses page" do
       expect(wizard).to have_next_step(:courses_index)

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -108,4 +108,12 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:level)
     end
   end
+
+  context "from funding type" do
+    let(:current_step) { :funding_type }
+
+    it "goes back to qualifications" do
+      expect(wizard).to have_previous_step(:qualifications)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Add funding type step

## Changes proposed in this pull request

- Add step
- Add view
- Add tests

## Guidance to review

Test that when going from qualifications to funding type this goes to funding type page **UNLESS a user selects `Teacher degree apprenticeship (TDA) with QTS` they should be taken to the course index page, as in the current app (check qa) it takes them to select `Employing schools` page and skips funding type** Which will be implemented when I get to that step.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
