### PR TITLE
Fix pg undefined column distance ordering

### DIFF
--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -103,7 +103,7 @@ module Courses
 
     def order
       OrderingStrategy.new(
-        location:,
+        location: geocoded_location,
         funding: funding,
         current_order: location_category_changed? ? nil : super,
       ).call
@@ -247,6 +247,12 @@ module Courses
     end
 
   private
+
+    def geocoded_location
+      return nil unless latitude.present? && longitude.present?
+
+      location
+    end
 
     def boolean_filter_count(value)
       value.presence ? 1 : nil

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -187,10 +187,10 @@ RSpec.describe Courses::SearchForm do
     end
 
     context "when location is present and order is blank" do
-      let(:form) { described_class.new(formatted_address: "London, UK", location: "London, UK") }
+      let(:form) { described_class.new(formatted_address: "London, UK", location: "London, UK", latitude: 51.5074, longitude: -0.1278) }
 
       it "defaults the ordering to distance" do
-        expect(form.search_params).to eq({ minimum_degree_required: "show_all_courses", formatted_address: "London, UK", location: "London, UK", order: "distance", radius: 20 })
+        expect(form.search_params).to eq({ minimum_degree_required: "show_all_courses", formatted_address: "London, UK", location: "London, UK", latitude: 51.5074, longitude: -0.1278, order: "distance", radius: 20 })
       end
     end
 
@@ -233,7 +233,7 @@ RSpec.describe Courses::SearchForm do
     end
 
     context "when location is present, ordered by fee, but fee funding is removed" do
-      let(:form) { described_class.new(formatted_address: "London, UK", location: "London, UK", order: "fee_uk_ascending", funding: %w[salary]) }
+      let(:form) { described_class.new(formatted_address: "London, UK", location: "London, UK", latitude: 51.5074, longitude: -0.1278, order: "fee_uk_ascending", funding: %w[salary]) }
 
       it "resets the ordering to distance" do
         expect(form.search_params[:order]).to eq("distance")
@@ -586,7 +586,7 @@ RSpec.describe Courses::SearchForm do
       end
 
       context "when location is present and order is distance (default)" do
-        let(:form) { described_class.new(location: "London, UK", order: "distance") }
+        let(:form) { described_class.new(location: "London, UK", latitude: 51.5074, longitude: -0.1278, order: "distance") }
 
         it "returns nil for ordering" do
           expect(form.filter_counts[:ordering]).to be_nil
@@ -843,6 +843,8 @@ RSpec.describe Courses::SearchForm do
             previous_location_category: "",
             location: "Cornwall, UK",
             formatted_address: "Cornwall, UK",
+            latitude: 50.2660,
+            longitude: -5.0527,
             address_types: %w[administrative_area_level_2 political],
             order: "course_name_ascending",
           )

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -202,6 +202,28 @@ RSpec.describe Courses::SearchForm do
       end
     end
 
+    context "when location text is present but geocoding produced no coordinates" do
+      # Any free-text location that Geolocation::Address fails to resolve to
+      # latitude/longitude reproduces the bug — the country in the string is
+      # irrelevant. previous_location_category is blank (form re-submitted with
+      # the new location text), so location_category_changed? returns true and
+      # OrderingStrategy defaults to "distance" even though no coordinates
+      # exist for Courses::Query to order by.
+      let(:form) do
+        described_class.new(
+          location: "Unrecognised place ",
+          previous_location_category: "",
+          order: "course_name_ascending",
+          subject_code: "06",
+          can_sponsor_visa: "true",
+        )
+      end
+
+      it "produces a search_params payload that Courses::Query can execute" do
+        expect { ::Courses::Query.call(params: form.search_params.dup).to_a }.not_to raise_error
+      end
+    end
+
     context "when location is blank and order is blank" do
       let(:form) { described_class.new(location: "", order: "") }
 

--- a/spec/services/courses/active_filters/extractor_spec.rb
+++ b/spec/services/courses/active_filters/extractor_spec.rb
@@ -993,6 +993,8 @@ RSpec.describe Courses::ActiveFilters::Extractor do
           short_address: "Locality",
           formatted_address: "Locality",
           postal_code: "SW1A 1AA",
+          latitude: 51.5010,
+          longitude: -0.1419,
           address_types: %w[postal_code],
           radius: 10,
         )
@@ -1050,6 +1052,8 @@ RSpec.describe Courses::ActiveFilters::Extractor do
           location: "Bristol",
           short_address: "Bristol",
           formatted_address: "Bristol, UK",
+          latitude: 51.4545,
+          longitude: -2.5879,
           radius: 50,
         )
         search_params = search_form.search_params


### PR DESCRIPTION
## Summary

Fixes the `PG::UndefinedColumn: column "minimum_distance_to_search_location" does not exist` exception captured in Sentry on the Find results page.

### Root cause

`Courses::Query#distance_ascending_order_scope` orders by `minimum_distance_to_search_location`, which is only added to the SELECT inside `location_scope`. That scope short-circuits when `latitude` / `longitude` are blank, so any call site that reaches the query with `order=distance` and no coordinates triggers `PG::UndefinedColumn`.

The production trigger is a free-text location that fails to geocode (e.g. an address outside the UK):

1. The controller does not add `latitude` / `longitude` to params because `Geolocation::Address` returns no coordinates.
2. `Courses::SearchForm#order` sees `location_category_changed?` is true (un-geocoded text yields `"regional"`, while `previous_location_category` was blank), so the user's `order=course_name_ascending` is dropped and `OrderingStrategy` is called with `current_order: nil`.
3. `OrderingStrategy#default_order` checks `@location.present?` — the text, not coordinates — and returns `"distance"`.
4. `inject_defaults` overwrites params with `order: "distance"` and hands them to `Courses::Query`, where the missing column blows up.

`SavedCourses::Query` already had a defensive guard for exactly this case; `Courses::Query` did not.

### Fix

Add the same guard to `Courses::Query#distance_ascending_order_scope`: when `@applied_scopes[:location]` is blank, reset `params[:order]` to `course_name_ascending` and return the scope so the matching ordering scope runs. This also covers other bypass paths such as `Find::ProcessWeeklyEmailAlertsService` calling `Courses::Query` directly with stored alert params.

### Commits

1. Failing regression specs in `Courses::Query` (`order=distance` without coordinates, plus the subject-filter combination from the Sentry trace).
2. The fix in `app/services/courses/query.rb`.
3. A higher-level `Courses::SearchForm` regression that drives the full form → query path with an un-geocoded location, ensuring the bug stays covered from the form layer if the query-layer guard is ever removed.

### Note for reviewers

There is a deeper smell worth flagging separately: `OrderingStrategy` defaults to `"distance"` based on location *text* presence, when the condition for distance ordering to work is *coordinates* presence. The defensive guard here is the minimal safe fix; threading lat/lng presence into `OrderingStrategy` would be a follow-up.

## Test plan

- [x] `bundle exec rspec spec/services/courses/query/ spec/services/saved_courses/query_spec.rb spec/forms/courses/search_form_spec.rb` — 189 examples pass.
- [x] Commenting out the guard in `distance_ascending_order_scope` reproduces the production `PG::UndefinedColumn` error in all three new specs.
- [x] Confirmed the SearchForm regression triggers with a generic location string ("Unrecognised place") — the bug is not tied to any specific country.
