### PR TITLE
Only install playwright on CI for System test groups

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -198,7 +198,7 @@ jobs:
           export PLAYWRIGHT_CLI_VERSION=$(bundle exec ruby -e \
             'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip')
           yarn add --dev playwright@${PLAYWRIGHT_CLI_VERSION}
-          yarn exec playwright install --with-deps chromium
+          yarn exec playwright install chromium --with-deps
 
       - run: bundle exec rails parallel:setup
       - run: bundle exec rails spec:prepare

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -193,6 +193,7 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       - name: Install Playwright
+        if: ${{ startsWith(matrix.tests.name, 'System') }}
         run: |
           export PLAYWRIGHT_CLI_VERSION=$(bundle exec ruby -e \
             'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip')


### PR DESCRIPTION
## Context

We need to install the Playwright javascript library to drive our system tests in ruby.
We don't need to install it for test groups that aren't running a browser.

We now only install it for test matrices whose name starts with 'System'.

Also, pass the `--options` last in the `yarn install playwright` command so we don't install webkit and firefox too.

## Changes proposed in this pull request

|System tests|non-system test|
|---|---|
|<img width="547" height="553" alt="image" src="https://github.com/user-attachments/assets/3df03723-baf1-4742-b290-f2a93b455f6e" />|<img width="625" height="606" alt="image" src="https://github.com/user-attachments/assets/68884c4a-64e5-4075-b327-42da9fa6c4ed" />|



|With --option not last|With --options last|
|---|---|
|<img width="1161" height="873" alt="image" src="https://github.com/user-attachments/assets/6e2a3084-274a-4f1c-9812-4319a5f697bc" />||

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
