### PR TITLE
Implement Placement/Employment school step

### DIFF
--- a/app/controllers/publish/course_wizards_controller.rb
+++ b/app/controllers/publish/course_wizards_controller.rb
@@ -68,6 +68,8 @@ module Publish
         wizard.recruitment_cycle_year = params[:recruitment_cycle_year]
         wizard.provider_code = params[:provider_code]
         wizard.state_key = state_key
+        wizard.provider = provider
+        wizard.recruitment_cycle = recruitment_cycle
       end
     end
 

--- a/app/controllers/publish/course_wizards_controller.rb
+++ b/app/controllers/publish/course_wizards_controller.rb
@@ -68,8 +68,6 @@ module Publish
         wizard.recruitment_cycle_year = params[:recruitment_cycle_year]
         wizard.provider_code = params[:provider_code]
         wizard.state_key = state_key
-        wizard.provider = provider
-        wizard.recruitment_cycle = recruitment_cycle
       end
     end
 

--- a/app/views/publish/course_wizards/steps/_schools.html.erb
+++ b/app/views/publish/course_wizards/steps/_schools.html.erb
@@ -1,0 +1,35 @@
+<% heading = school_label_for(current_step) %>
+<% content_for :page_title, title_with_error_prefix(heading, current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.schools.caption")) %>
+  <%= heading %>
+</h1>
+
+<p class="govuk-body">
+  <%= t("publish.courses.schools.new.schools_selection") %>
+</p>
+
+<p class="govuk-body">
+  <%= t("publish.courses.schools.new.searches_by_location") %>
+</p>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <%= school_warning_text(current_step) %>
+  </strong>
+</div>
+
+<%= form.govuk_check_boxes_fieldset :site_ids, legend: { hidden: true, text: heading } do %>
+  <% current_step.sites.each_with_index do |site, index| %>
+    <%= form.govuk_check_box :site_ids,
+          site.id.to_s,
+          label: { text: [site.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: site))].compact_blank.join(" ").html_safe },
+          hint: { text: site.full_address },
+          include_hidden: false,
+          link_errors: index.zero? %>
+  <% end %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.schools.submit") %>

--- a/app/views/publish/course_wizards/steps/_schools.html.erb
+++ b/app/views/publish/course_wizards/steps/_schools.html.erb
@@ -7,11 +7,11 @@
 </h1>
 
 <p class="govuk-body">
-  <%= t("publish.courses.schools.new.schools_selection") %>
+  <%= t("course_wizard.steps.schools.description") %>
 </p>
 
 <p class="govuk-body">
-  <%= t("publish.courses.schools.new.searches_by_location") %>
+  <%= t("course_wizard.steps.schools.percentage") %>
 </p>
 
 <div class="govuk-warning-text">

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -18,6 +18,7 @@ class CourseWizard
       graph.add_node :qualifications, Steps::Qualifications
       graph.add_node :funding_type, Steps::FundingType
       graph.add_node :study_pattern, Steps::StudyPattern
+      graph.add_node :schools, Steps::Schools
 
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
@@ -33,7 +34,7 @@ class CourseWizard
       graph.add_multiple_conditional_edges(
         from: :qualifications,
         branches: [
-          { when: :undergraduate_degree_with_qts?, then: :courses_index },
+          { when: :undergraduate_degree_with_qts?, then: :schools },
         ],
         default: :funding_type,
       )
@@ -45,7 +46,9 @@ class CourseWizard
 
       graph.add_edge from: :funding_type, to: :study_pattern
 
-      graph.add_edge from: :study_pattern, to: :courses_index
+      graph.add_edge from: :study_pattern, to: :schools
+
+      graph.add_edge from: :schools, to: :courses_index
     end
   end
 

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -3,7 +3,7 @@
 class CourseWizard
   include DfE::Wizard
 
-  attr_accessor :recruitment_cycle_year, :provider_code, :state_key, :provider, :recruitment_cycle
+  attr_accessor :recruitment_cycle_year, :provider_code, :state_key
 
   delegate :further_education_level?, :primary_level?, :undergraduate_degree_with_qts?, to: :state_store
 

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -3,7 +3,7 @@
 class CourseWizard
   include DfE::Wizard
 
-  attr_accessor :recruitment_cycle_year, :provider_code, :state_key
+  attr_accessor :recruitment_cycle_year, :provider_code, :state_key, :provider, :recruitment_cycle
 
   delegate :further_education_level?, :primary_level?, :undergraduate_degree_with_qts?, to: :state_store
 

--- a/app/wizards/course_wizard/steps/schools.rb
+++ b/app/wizards/course_wizard/steps/schools.rb
@@ -1,0 +1,57 @@
+class CourseWizard
+  module Steps
+    class Schools
+      include DfE::Wizard::Step
+
+      FUNDING_TYPES_WITH_SALARY = %w[salary apprenticeship].freeze
+
+      attribute :site_ids
+
+      validate :site_ids_selected
+
+      def sites
+        provider_sites.sort_by(&:location_name)
+      end
+
+      def salaried?
+        funding_type.in?(FUNDING_TYPES_WITH_SALARY)
+      end
+
+      def self.permitted_params
+        [{ site_ids: [] }]
+      end
+
+    private
+
+      def site_ids_selected
+        if selected_site_ids.empty? && provider_sites.one?
+          self.site_ids = [provider_sites.first.id.to_s]
+        end
+
+        return if selected_site_ids.any?
+
+        errors.add(:site_ids, I18n.t("course_wizard.steps.schools.errors.site_ids.blank"))
+      end
+
+      def selected_site_ids
+        Array(site_ids).compact_blank
+      end
+
+      def provider_sites
+        provider.sites
+      end
+
+      def provider
+        @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)
+      end
+
+      def recruitment_cycle
+        @recruitment_cycle ||= RecruitmentCycle.find_by!(year: wizard.recruitment_cycle_year)
+      end
+
+      def funding_type
+        wizard.state_store.funding_type
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/schools.rb
+++ b/app/wizards/course_wizard/steps/schools.rb
@@ -4,6 +4,7 @@ class CourseWizard
       include DfE::Wizard::Step
 
       FUNDING_TYPES_WITH_SALARY = %w[salary apprenticeship].freeze
+      QUALIFICATIONS_WITH_SALARY = %w[undergraduate_degree_with_qts].freeze
 
       attribute :site_ids
 
@@ -14,7 +15,7 @@ class CourseWizard
       end
 
       def salaried?
-        funding_type.in?(FUNDING_TYPES_WITH_SALARY)
+        funding_type.in?(FUNDING_TYPES_WITH_SALARY) || qualification.in?(QUALIFICATIONS_WITH_SALARY)
       end
 
       def self.permitted_params
@@ -42,15 +43,19 @@ class CourseWizard
       end
 
       def provider
-        @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)
+        wizard.provider || @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)
       end
 
       def recruitment_cycle
-        @recruitment_cycle ||= RecruitmentCycle.find_by!(year: wizard.recruitment_cycle_year)
+        wizard.recruitment_cycle || @recruitment_cycle ||= RecruitmentCycle.find_by!(year: wizard.recruitment_cycle_year)
       end
 
       def funding_type
         wizard.state_store.funding_type
+      end
+
+      def qualification
+        wizard.state_store.qualification
       end
     end
   end

--- a/app/wizards/course_wizard/steps/schools.rb
+++ b/app/wizards/course_wizard/steps/schools.rb
@@ -43,11 +43,11 @@ class CourseWizard
       end
 
       def provider
-        wizard.provider || @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)
+        @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)
       end
 
       def recruitment_cycle
-        wizard.recruitment_cycle || @recruitment_cycle ||= RecruitmentCycle.find_by!(year: wizard.recruitment_cycle_year)
+        @recruitment_cycle ||= RecruitmentCycle.find_by!(year: wizard.recruitment_cycle_year)
       end
 
       def funding_type

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -106,11 +106,9 @@ en:
             blank: Select a study pattern
       schools:
         caption: Add course
-        heading: Schools
         submit: Continue
         description: The more schools you select, the more searches your course will appear in. You should only add schools that are relevant to this course.
         percentage: 60% of searches are by location.
-        warning_text: If you do not add all relevant placement schools, you may miss out on potential candidates.
         errors:
           site_ids:
             blank: Select at least one school

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -104,6 +104,16 @@ en:
         errors:
           study_pattern:
             blank: Select a study pattern
+      schools:
+        caption: Add course
+        heading: Schools
+        submit: Continue
+        description: The more schools you select, the more searches your course will appear in. You should only add schools that are relevant to this course.
+        percentage: 60% of searches are by location.
+        warning_text: If you do not add all relevant placement schools, you may miss out on potential candidates.
+        errors:
+          site_ids:
+            blank: Select at least one school
   activemodel:
     errors:
       models:

--- a/spec/system/publish/courses/add_course_wizard/qualifications_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/qualifications_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe "Add course wizard qualifications step", type: :system do
     then_i_am_taken_to_the_funding_type_page
   end
 
-  scenario "choosing a qualification with undergraduate degree with QTS and continues to courses index" do
+  scenario "choosing a qualification with undergraduate degree with QTS and continues to schools page" do
     and_i_have_wizard_state_for_qualifications(level: "primary", qualification: "undergraduate_degree_with_qts")
     when_i_visit_the_wizard_qualifications_page
     and_i_choose_qualification(qualification: "Teacher degree apprenticeship (TDA) with QTS")
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_schools_page
   end
 
   scenario "submitting qualifications without selecting a qualification shows validation errors" do
@@ -60,11 +60,13 @@ private
     given_i_am_authenticated(user: @user)
   end
 
-  def then_i_am_taken_to_the_courses_index_page
+  def then_i_am_taken_to_the_schools_page
     expect(page).to have_current_path(
-      publish_provider_recruitment_cycle_courses_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :schools,
+        state_key: wizard_state_key,
       ),
       ignore_query: true,
     )

--- a/spec/system/publish/courses/add_course_wizard/schools_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/schools_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard schools step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user_with_multiple_schools
+  end
+
+  scenario "choosing a salaried school and continues to courses index page" do
+    and_i_have_wizard_state_for_schools(funding_type: "salary")
+    when_i_visit_the_wizard_schools_page
+    and_the_title_and_description_are_displayed_for_a_salaried_school
+    and_i_choose_a_site_from_the_list
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "choosing a non-salaried school and continues to courses index page" do
+    and_i_have_wizard_state_for_schools(funding_type: "fee")
+    when_i_visit_the_wizard_schools_page
+    and_the_title_and_description_are_displayed_for_a_non_salaried_school
+    and_i_choose_a_site_from_the_list
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "submitting schools without selecting a school shows validation errors" do
+    when_i_visit_the_wizard_schools_page
+    and_i_click_continue
+    then_i_have_errors_on_the_schools_step
+  end
+
+private
+
+  def when_i_visit_the_wizard_schools_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :schools,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def and_the_title_and_description_are_displayed_for_a_salaried_school
+    expect(page).to have_content("Employing schools")
+    expect(page).to have_content("If you do not add all relevant employing schools, you may miss out on potential candidates.")
+  end
+
+  def and_the_title_and_description_are_displayed_for_a_non_salaried_school
+    expect(page).to have_content("Placement schools")
+    expect(page).to have_content("If you do not add all relevant placement schools, you may miss out on potential candidates.")
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def and_i_choose_a_site_from_the_list
+    check provider.sites.first.location_name
+  end
+
+  def then_i_have_errors_on_the_schools_step
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select at least one school")
+  end
+
+  def then_i_am_taken_to_the_courses_index_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_multiple_schools
+    @user = create(
+      :user,
+      providers: [
+        create(:provider, :accredited_provider, sites: [build(:site), build(:site)]),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+
+  def and_i_have_wizard_state_for_schools(funding_type:)
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
+    state_store.write(funding_type:)
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/schools_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/schools_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe "Add course wizard schools step", type: :system do
     then_i_have_errors_on_the_schools_step
   end
 
+  scenario "single-school provider continues without explicitly selecting the only school" do
+    given_i_am_authenticated_as_a_provider_user_with_a_school
+    and_i_have_wizard_state_for_schools(funding_type: "fee")
+    when_i_visit_the_wizard_schools_page
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "TDA qualification route continues through schools step to courses index" do
+    and_i_have_wizard_state_for_qualifications(level: "primary")
+    when_i_visit_the_wizard_qualifications_page
+    and_i_choose_qualification("Teacher degree apprenticeship (TDA) with QTS")
+    and_i_click_continue
+    then_i_am_taken_to_the_schools_page
+    and_the_title_and_description_are_displayed_for_a_salaried_school
+    and_i_choose_a_site_from_the_list
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
 private
 
   def when_i_visit_the_wizard_schools_page
@@ -39,6 +59,15 @@ private
       provider_code: provider.provider_code,
       recruitment_cycle_year: provider.recruitment_cycle_year,
       step: :schools,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def when_i_visit_the_wizard_qualifications_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :qualifications,
       state_key: wizard_state_key,
     )
   end
@@ -55,6 +84,10 @@ private
 
   def and_i_click_continue
     click_on "Continue"
+  end
+
+  def and_i_choose_qualification(qualification)
+    choose qualification
   end
 
   def and_i_choose_a_site_from_the_list
@@ -76,11 +109,34 @@ private
     )
   end
 
+  def then_i_am_taken_to_the_schools_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :schools,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
   def given_i_am_authenticated_as_a_provider_user_with_multiple_schools
     @user = create(
       :user,
       providers: [
         create(:provider, :accredited_provider, sites: [build(:site), build(:site)]),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_a_school
+    @user = create(
+      :user,
+      providers: [
+        create(:provider, :accredited_provider, sites: [build(:site)]),
       ],
     )
 
@@ -105,5 +161,17 @@ private
 
     state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
     state_store.write(funding_type:)
+  end
+
+  def and_i_have_wizard_state_for_qualifications(level:)
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
+    state_store.write(level:)
   end
 end

--- a/spec/system/publish/courses/add_course_wizard/study_pattern_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/study_pattern_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "Add course wizard study pattern step", type: :system do
     given_i_am_authenticated_as_a_provider_user_with_a_school
   end
 
-  scenario "choosing a study pattern and continues to courses index" do
+  scenario "choosing a study pattern and continues to schools page" do
     when_i_visit_the_wizard_study_pattern_page
     and_i_choose_study_pattern
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_schools_page
   end
 
   scenario "submitting study pattern without selecting a study pattern shows validation errors" do
@@ -41,11 +41,13 @@ private
     click_on "Continue"
   end
 
-  def then_i_am_taken_to_the_courses_index_page
+  def then_i_am_taken_to_the_schools_page
     expect(page).to have_current_path(
-      publish_provider_recruitment_cycle_courses_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :schools,
+        state_key: wizard_state_key,
       ),
       ignore_query: true,
     )

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "qualification" => "qts" })
       repository.write({ "funding_type" => "fee" })
       repository.write({ "study_pattern" => %w[full_time part_time] })
+      repository.write({ "site_ids" => %w[1 2] })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -38,6 +39,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:qualification]).to eq("qts")
       expect(data[:funding_type]).to eq("fee")
       expect(data[:study_pattern]).to eq(%w[full_time part_time])
+      expect(data[:site_ids]).to eq(%w[1 2])
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/steps/schools_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/schools_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::Schools do
+  include_context "add_course_wizard"
+
+  let(:current_step) { :schools }
+  let(:provider_code) { provider.provider_code }
+  let(:recruitment_cycle_year) { provider.recruitment_cycle_year }
+  let(:current_step_params) { { site_ids: } }
+  let(:site_ids) { nil }
+
+  let(:provider) { create(:provider, :accredited_provider, recruitment_cycle: find_or_create(:recruitment_cycle)) }
+  let!(:site_a) { create(:site, provider:, location_name: "B School") }
+  let!(:site_b) { create(:site, provider:, location_name: "A School") }
+
+  describe "#valid?" do
+    subject(:wizard_step) { wizard.current_step }
+
+    it "is valid when at least one site is selected" do
+      wizard_step.site_ids = [site_a.id.to_s]
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "is not valid when no sites are selected and provider has multiple sites" do
+      wizard_step.site_ids = nil
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:site_ids)).to contain_exactly("Select at least one school")
+    end
+  end
+
+  describe "#sites" do
+    subject(:wizard_step) { wizard.current_step }
+
+    it "returns provider sites sorted by location name" do
+      expect(wizard_step.sites).to eq(
+        [
+          site_b,
+          site_a,
+        ],
+      )
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq([{ site_ids: [] }])
+    end
+  end
+
+  describe "#salaried?" do
+    subject(:wizard_step) { wizard.current_step }
+
+    context "when funding type is salary" do
+      before do
+        state_store.write(funding_type: "salary")
+      end
+
+      it "returns true" do
+        expect(wizard_step.salaried?).to be(true)
+      end
+    end
+
+    context "when funding type is apprenticeship" do
+      before do
+        state_store.write(funding_type: "apprenticeship")
+      end
+
+      it "returns true" do
+        expect(wizard_step.salaried?).to be(true)
+      end
+    end
+
+    context "when funding type is fee" do
+      before do
+        state_store.write(funding_type: "fee")
+      end
+
+      it "returns false" do
+        expect(wizard_step.salaried?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/schools_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/schools_spec.rb
@@ -54,15 +54,6 @@ RSpec.describe CourseWizard::Steps::Schools do
         ],
       )
     end
-
-    it "uses provider/recruitment cycle from the wizard when available" do
-      wizard.provider = provider
-      wizard.recruitment_cycle = provider.recruitment_cycle
-
-      expect(RecruitmentCycle).not_to receive(:find_by!)
-
-      wizard_step.sites
-    end
   end
 
   describe ".permitted_params" do

--- a/spec/wizards/add_course_wizard/steps/schools_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/schools_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe CourseWizard::Steps::Schools do
       expect(wizard_step).not_to be_valid
       expect(wizard_step.errors.messages_for(:site_ids)).to contain_exactly("Select at least one school")
     end
+
+    context "when provider has only one site" do
+      let!(:site_b) { nil }
+
+      it "auto-selects the only site and is valid when no site is submitted" do
+        wizard_step.site_ids = nil
+
+        expect(wizard_step).to be_valid
+        expect(wizard_step.site_ids).to eq([site_a.id.to_s])
+      end
+    end
   end
 
   describe "#sites" do
@@ -42,6 +53,15 @@ RSpec.describe CourseWizard::Steps::Schools do
           site_a,
         ],
       )
+    end
+
+    it "uses provider/recruitment cycle from the wizard when available" do
+      wizard.provider = provider
+      wizard.recruitment_cycle = provider.recruitment_cycle
+
+      expect(RecruitmentCycle).not_to receive(:find_by!)
+
+      wizard_step.sites
     end
   end
 
@@ -81,6 +101,16 @@ RSpec.describe CourseWizard::Steps::Schools do
 
       it "returns false" do
         expect(wizard_step.salaried?).to be(false)
+      end
+    end
+
+    context "when qualification is undergraduate degree with qts and funding type is nil" do
+      before do
+        state_store.write(qualification: "undergraduate_degree_with_qts")
+      end
+
+      it "returns true" do
+        expect(wizard_step.salaried?).to be(true)
       end
     end
   end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -122,21 +122,29 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
       state_store.write(qualification: "undergraduate_degree_with_qts")
     end
 
-    it "proceeds to courses page" do
-      expect(wizard).to have_next_step(:courses_index)
+    it "proceeds to schools page" do
+      expect(wizard).to have_next_step(:schools)
     end
   end
 
   context "from funding type" do
     let(:current_step) { :funding_type }
 
-    it "proceeds to courses page" do
+    it "proceeds to study pattern page" do
       expect(wizard).to have_next_step(:study_pattern)
     end
   end
 
   context "from study pattern" do
     let(:current_step) { :study_pattern }
+
+    it "proceeds to schools page" do
+      expect(wizard).to have_next_step(:schools)
+    end
+  end
+
+  context "from schools" do
+    let(:current_step) { :schools }
 
     it "proceeds to courses page" do
       expect(wizard).to have_next_step(:courses_index)

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -124,4 +124,24 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:funding_type)
     end
   end
+
+  context "from schools" do
+    let(:current_step) { :schools }
+
+    it "goes back to study pattern" do
+      expect(wizard).to have_previous_step(:study_pattern)
+    end
+  end
+
+  context "from schools with undergraduate degree with QTS qualification" do
+    let(:current_step) { :schools }
+
+    before do
+      state_store.write(qualification: "undergraduate_degree_with_qts")
+    end
+
+    it "goes back to qualifications" do
+      expect(wizard).to have_previous_step(:qualifications)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Implement Placement/Employment school step

## Changes proposed in this pull request

- Add new step
- Add new view
- Add new school specs
- Update existing specs 

## Guidance to review

Compare the flow within QA and within the review app to ensure consistency. Keep in mind if on the `qualifications' step and you select `undergraduate_degree_with_qts` you will jump straight to the `schools` step. Other than that the flow should be sequential for any other sections  in previous steps.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
