### PR TITLE
Refactor search location value object

### DIFF
--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -102,10 +102,17 @@ module Courses
     end
 
     def order
+      # The user's explicit sort choice is preserved across requests EXCEPT
+      # the one-time transition from "no location" to "with location" — at
+      # that moment the carried-over order (course_name_ascending, the
+      # no-location default) should yield to the new location's natural
+      # default. Other incompatible combinations (distance without coords,
+      # fee ordering without fee funding) are still caught inside
+      # OrderingStrategy.
       OrderingStrategy.new(
         search_location: search_location,
         funding: funding,
-        current_order: location_category_changed? ? nil : super,
+        current_order: location_category_first_set? ? nil : super,
       ).call
     end
 
@@ -256,6 +263,18 @@ module Courses
         formatted_address: formatted_address,
         short_address: short_address,
       )
+    end
+
+    # True only when the user is moving from "no location" to "with
+    # location" on this request. Distinct from #location_category_changed?,
+    # which also fires when the category drifts between two location
+    # categories (locality ↔ regional) — that drift can be caused by Google
+    # returning different address_types for the same query and would
+    # otherwise silently override a sort the user just picked.
+    def location_category_first_set?
+      return false if attributes["previous_location_category"].nil?
+
+      previous_location_category.blank? && location_category.present?
     end
 
     def boolean_filter_count(value)

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -277,8 +277,7 @@ module Courses
     end
 
     def ordering_filter_count
-      default_order = search_location.located? ? "distance" : "course_name_ascending"
-      order == default_order ? nil : 1
+      order == OrderingStrategy.default_for(search_location) ? nil : 1
     end
 
     def radius_filter_count

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -103,7 +103,7 @@ module Courses
 
     def order
       OrderingStrategy.new(
-        location: geocoded_location,
+        search_location: search_location,
         funding: funding,
         current_order: location_category_changed? ? nil : super,
       ).call
@@ -248,10 +248,14 @@ module Courses
 
   private
 
-    def geocoded_location
-      return nil unless latitude.present? && longitude.present?
-
-      location
+    def search_location
+      @search_location ||= SearchLocation.new(
+        text: location,
+        latitude: latitude,
+        longitude: longitude,
+        formatted_address: formatted_address,
+        short_address: short_address,
+      )
     end
 
     def boolean_filter_count(value)
@@ -273,7 +277,7 @@ module Courses
     end
 
     def ordering_filter_count
-      default_order = location.present? ? "distance" : "course_name_ascending"
+      default_order = search_location.sortable_by_distance? ? "distance" : "course_name_ascending"
       order == default_order ? nil : 1
     end
 

--- a/app/forms/courses/search_form.rb
+++ b/app/forms/courses/search_form.rb
@@ -277,7 +277,7 @@ module Courses
     end
 
     def ordering_filter_count
-      default_order = search_location.sortable_by_distance? ? "distance" : "course_name_ascending"
+      default_order = search_location.located? ? "distance" : "course_name_ascending"
       order == default_order ? nil : 1
     end
 

--- a/app/services/courses/active_filters/extractor.rb
+++ b/app/services/courses/active_filters/extractor.rb
@@ -26,7 +26,14 @@ module Courses
       def initialize(search_params:, search_form:)
         @search_params = search_params
         @search_form = search_form
-        @param_defaults = Find::SearchParamDefaults.new(search_params)
+        # Defaults are computed from the form's full search_params (which
+        # carry coordinates and the location label) — not from the
+        # constructor-supplied @search_params, which intentionally has
+        # those location keys stripped so they don't show up as chips.
+        # Without this, a geocoded search would not be recognised as a
+        # location-based one when deciding whether "distance" is the
+        # default order.
+        @param_defaults = Find::SearchParamDefaults.new(search_form.search_params)
       end
 
       def call

--- a/app/services/courses/active_filters/hash_extractor.rb
+++ b/app/services/courses/active_filters/hash_extractor.rb
@@ -107,11 +107,11 @@ module Courses
       end
 
       def default_order
-        location_based? ? "distance" : "course_name_ascending"
+        search_location.sortable_by_distance? ? "distance" : "course_name_ascending"
       end
 
-      def location_based?
-        @attrs["location"].present? || @attrs["formatted_address"].present?
+      def search_location
+        @search_location ||= Courses::SearchLocation.from_params(@attrs)
       end
 
       def sort_filters(filters)

--- a/app/services/courses/active_filters/hash_extractor.rb
+++ b/app/services/courses/active_filters/hash_extractor.rb
@@ -107,7 +107,7 @@ module Courses
       end
 
       def default_order
-        search_location.sortable_by_distance? ? "distance" : "course_name_ascending"
+        search_location.located? ? "distance" : "course_name_ascending"
       end
 
       def search_location

--- a/app/services/courses/active_filters/hash_extractor.rb
+++ b/app/services/courses/active_filters/hash_extractor.rb
@@ -107,7 +107,7 @@ module Courses
       end
 
       def default_order
-        search_location.located? ? "distance" : "course_name_ascending"
+        Courses::OrderingStrategy.default_for(search_location)
       end
 
       def search_location

--- a/app/services/courses/ordering_strategy.rb
+++ b/app/services/courses/ordering_strategy.rb
@@ -1,6 +1,14 @@
 module Courses
   class OrderingStrategy
     DEFAULT_ORDER = "course_name_ascending".freeze
+    LOCATED_ORDER = "distance".freeze
+
+    # The default order for a given location — used by callers (SearchForm,
+    # SearchParamDefaults, HashExtractor) that need to know "what would the
+    # default be?" without going through the full strategy.
+    def self.default_for(search_location)
+      search_location.located? ? LOCATED_ORDER : DEFAULT_ORDER
+    end
 
     def initialize(search_location:, funding:, current_order:)
       @search_location = search_location
@@ -18,7 +26,7 @@ module Courses
   private
 
     def default_order
-      @search_location.located? ? "distance" : DEFAULT_ORDER
+      self.class.default_for(@search_location)
     end
 
     def should_reset_to_default?
@@ -26,7 +34,7 @@ module Courses
     end
 
     def distance_without_location?
-      @current_order == "distance" && !@search_location.located?
+      @current_order == LOCATED_ORDER && !@search_location.located?
     end
 
     def fee_order_without_fee_funding?

--- a/app/services/courses/ordering_strategy.rb
+++ b/app/services/courses/ordering_strategy.rb
@@ -2,8 +2,8 @@ module Courses
   class OrderingStrategy
     DEFAULT_ORDER = "course_name_ascending".freeze
 
-    def initialize(location:, funding:, current_order:)
-      @location = location
+    def initialize(search_location:, funding:, current_order:)
+      @search_location = search_location
       @funding = funding
       @current_order = current_order
     end
@@ -18,7 +18,7 @@ module Courses
   private
 
     def default_order
-      @location.present? ? "distance" : DEFAULT_ORDER
+      @search_location.sortable_by_distance? ? "distance" : DEFAULT_ORDER
     end
 
     def should_reset_to_default?
@@ -26,7 +26,7 @@ module Courses
     end
 
     def distance_without_location?
-      @current_order == "distance" && @location.blank?
+      @current_order == "distance" && !@search_location.sortable_by_distance?
     end
 
     def fee_order_without_fee_funding?

--- a/app/services/courses/ordering_strategy.rb
+++ b/app/services/courses/ordering_strategy.rb
@@ -18,7 +18,7 @@ module Courses
   private
 
     def default_order
-      @search_location.sortable_by_distance? ? "distance" : DEFAULT_ORDER
+      @search_location.located? ? "distance" : DEFAULT_ORDER
     end
 
     def should_reset_to_default?
@@ -26,7 +26,7 @@ module Courses
     end
 
     def distance_without_location?
-      @current_order == "distance" && !@search_location.sortable_by_distance?
+      @current_order == "distance" && !@search_location.located?
     end
 
     def fee_order_without_fee_funding?

--- a/app/services/courses/search_location.rb
+++ b/app/services/courses/search_location.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Courses
+  # Value object representing the location a candidate provided when
+  # searching for courses. Owns the single question every consumer was
+  # previously re-implementing: "does this search have a location we can
+  # actually sort by distance from?".
+  class SearchLocation
+    def self.from_params(params)
+      params = params.with_indifferent_access
+      new(
+        text: params[:location],
+        latitude: params[:latitude],
+        longitude: params[:longitude],
+        formatted_address: params[:formatted_address],
+        short_address: params[:short_address],
+      )
+    end
+
+    def initialize(text: nil, latitude: nil, longitude: nil,
+                   formatted_address: nil, short_address: nil)
+      @text = text
+      @latitude = latitude
+      @longitude = longitude
+      @formatted_address = formatted_address
+      @short_address = short_address
+    end
+
+    def sortable_by_distance?
+      @latitude.present? && @longitude.present?
+    end
+
+    def blank?
+      [@text, @formatted_address, @short_address].all?(&:blank?) &&
+        !sortable_by_distance?
+    end
+
+    def label
+      [@short_address, @formatted_address, @text].find(&:present?)
+    end
+  end
+end

--- a/app/services/courses/search_location.rb
+++ b/app/services/courses/search_location.rb
@@ -26,13 +26,12 @@ module Courses
       @short_address = short_address
     end
 
-    def sortable_by_distance?
+    def located?
       @latitude.present? && @longitude.present?
     end
 
     def blank?
-      [@text, @formatted_address, @short_address].all?(&:blank?) &&
-        !sortable_by_distance?
+      [@text, @formatted_address, @short_address].all?(&:blank?) && !located?
     end
 
     def label

--- a/app/services/find/search_param_defaults.rb
+++ b/app/services/find/search_param_defaults.rb
@@ -29,7 +29,7 @@ module Find
         "applications_open" => "true",
         "minimum_degree_required" => "show_all_courses",
         "order" => proc { |params|
-          ::Courses::SearchLocation.from_params(params).located? ? "distance" : "course_name_ascending"
+          ::Courses::OrderingStrategy.default_for(::Courses::SearchLocation.from_params(params))
         },
         "level" => "all",
       }

--- a/app/services/find/search_param_defaults.rb
+++ b/app/services/find/search_param_defaults.rb
@@ -29,7 +29,7 @@ module Find
         "applications_open" => "true",
         "minimum_degree_required" => "show_all_courses",
         "order" => proc { |params|
-          ::Courses::SearchLocation.from_params(params).sortable_by_distance? ? "distance" : "course_name_ascending"
+          ::Courses::SearchLocation.from_params(params).located? ? "distance" : "course_name_ascending"
         },
         "level" => "all",
       }

--- a/app/services/find/search_param_defaults.rb
+++ b/app/services/find/search_param_defaults.rb
@@ -28,13 +28,11 @@ module Find
       {
         "applications_open" => "true",
         "minimum_degree_required" => "show_all_courses",
-        "order" => proc { |params| location_based?(params) ? "distance" : "course_name_ascending" },
+        "order" => proc { |params|
+          ::Courses::SearchLocation.from_params(params).sortable_by_distance? ? "distance" : "course_name_ascending"
+        },
         "level" => "all",
       }
-    end
-
-    def location_based?(params)
-      params["short_address"].present? || params["longitude"].present?
     end
   end
 end

--- a/spec/fixtures/files/google_old_places_api_client/geocode/atlantis.json
+++ b/spec/fixtures/files/google_old_places_api_client/geocode/atlantis.json
@@ -1,0 +1,4 @@
+{
+  "results": [],
+  "status": "ZERO_RESULTS"
+}

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -406,8 +406,11 @@ RSpec.describe Courses::SearchForm do
     end
 
     it "excludes non-filter address fields from active filters" do
+      # No explicit order: a geocoded search defaults to "distance", which is
+      # the natural default for this state — so no order chip surfaces and
+      # the test focuses on what it cares about (address-related fields do
+      # not become chips).
       search_form = described_class.new(
-        order: "course_name_ascending",
         level: "all",
         minimum_degree_required: "show_all_courses",
         applications_open: true,

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -578,7 +578,7 @@ RSpec.describe Courses::SearchForm do
 
     context "with ordering" do
       context "when location is present and order is not distance" do
-        let(:form) { described_class.new(location: "London, UK", order: "course_name_ascending") }
+        let(:form) { described_class.new(location: "London, UK", latitude: 51.5074, longitude: -0.1278, order: "course_name_ascending") }
 
         it "returns 1 for ordering" do
           expect(form.filter_counts[:ordering]).to eq(1)

--- a/spec/forms/courses/search_form_spec.rb
+++ b/spec/forms/courses/search_form_spec.rb
@@ -840,7 +840,7 @@ RSpec.describe Courses::SearchForm do
 
   describe "resetting defaults when location category changes" do
     describe "#order" do
-      context "when location category changed from nil to regional" do
+      context "when the user is adding a location for the first time (no previous location category)" do
         let(:form) do
           described_class.new(
             previous_location_category: "",
@@ -853,23 +853,43 @@ RSpec.describe Courses::SearchForm do
           )
         end
 
-        it "resets to distance (location default)" do
+        it "resets to distance (location default) — the carried-over order was the no-location default" do
           expect(form.order).to eq("distance")
         end
       end
 
-      context "when location category unchanged" do
+      context "when the user already had a location and picks a different order" do
         let(:form) do
           described_class.new(
             previous_location_category: "regional",
             location: "Cornwall, UK",
             formatted_address: "Cornwall, UK",
+            latitude: 50.2660,
+            longitude: -5.0527,
             address_types: %w[administrative_area_level_2 political],
             order: "course_name_ascending",
           )
         end
 
-        it "preserves user selection" do
+        it "preserves the explicit sort choice" do
+          expect(form.order).to eq("course_name_ascending")
+        end
+      end
+
+      context "when the location category drifts between two location categories (e.g. geocoder inconsistency)" do
+        let(:form) do
+          described_class.new(
+            previous_location_category: "regional",
+            location: "BS1 4SB, Bristol",
+            formatted_address: "Bristol BS1 4SB, UK",
+            latitude: 51.4505,
+            longitude: -2.5867,
+            address_types: %w[postal_code],
+            order: "course_name_ascending",
+          )
+        end
+
+        it "preserves the explicit sort choice (does not silently override)" do
           expect(form.order).to eq("course_name_ascending")
         end
       end

--- a/spec/services/courses/active_filters/extractor_spec.rb
+++ b/spec/services/courses/active_filters/extractor_spec.rb
@@ -481,12 +481,6 @@ RSpec.describe Courses::ActiveFilters::Extractor do
 
         expected_filters = [
           Courses::ActiveFilter.new(
-            id: :order,
-            raw_value: "course_name_ascending",
-            value: "course_name_ascending",
-            remove_params: { order: nil },
-          ),
-          Courses::ActiveFilter.new(
             id: :short_address,
             raw_value: "London",
             value: "London",

--- a/spec/services/courses/active_filters/hash_extractor_spec.rb
+++ b/spec/services/courses/active_filters/hash_extractor_spec.rb
@@ -174,7 +174,15 @@ RSpec.describe Courses::ActiveFilters::HashExtractor do
     end
 
     context "with course_name order on a location search" do
-      let(:attrs) { { "order" => "course_name_ascending", "location" => "Manchester", "radius" => "15" } }
+      let(:attrs) do
+        {
+          "order" => "course_name_ascending",
+          "location" => "Manchester",
+          "latitude" => "53.4808",
+          "longitude" => "-2.2426",
+          "radius" => "15",
+        }
+      end
 
       it "shows order because course_name is not the default for location searches" do
         expect(formatted_values).to include("Sort by: Course (a to z)")

--- a/spec/services/courses/search_location_spec.rb
+++ b/spec/services/courses/search_location_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Courses::SearchLocation do
+  describe "#sortable_by_distance?" do
+    it "is true when both coordinates are present" do
+      location = described_class.new(latitude: "51.5074", longitude: "-0.1278")
+      expect(location.sortable_by_distance?).to be true
+    end
+
+    it "is false when latitude is missing" do
+      location = described_class.new(longitude: "-0.1278")
+      expect(location.sortable_by_distance?).to be false
+    end
+
+    it "is false when longitude is missing" do
+      location = described_class.new(latitude: "51.5074")
+      expect(location.sortable_by_distance?).to be false
+    end
+
+    it "is false when both coordinates are missing" do
+      location = described_class.new(text: "London")
+      expect(location.sortable_by_distance?).to be false
+    end
+
+    it "is false when coordinates are empty strings" do
+      location = described_class.new(latitude: "", longitude: "")
+      expect(location.sortable_by_distance?).to be false
+    end
+
+    it "treats display fields (text, short_address, formatted_address) as irrelevant" do
+      location = described_class.new(
+        text: "Atlantis",
+        short_address: "Atlantis",
+        formatted_address: "Atlantis, Ocean",
+      )
+      expect(location.sortable_by_distance?).to be false
+    end
+  end
+
+  describe "#blank?" do
+    it "is true when every field is blank" do
+      expect(described_class.new.blank?).to be true
+    end
+
+    it "is true when only empty strings are passed" do
+      location = described_class.new(text: "", formatted_address: "", short_address: "")
+      expect(location.blank?).to be true
+    end
+
+    it "is false when text is present" do
+      expect(described_class.new(text: "London").blank?).to be false
+    end
+
+    it "is false when formatted_address is present" do
+      expect(described_class.new(formatted_address: "London, UK").blank?).to be false
+    end
+
+    it "is false when short_address is present" do
+      expect(described_class.new(short_address: "London").blank?).to be false
+    end
+
+    it "is false when coordinates are present" do
+      location = described_class.new(latitude: "51.5074", longitude: "-0.1278")
+      expect(location.blank?).to be false
+    end
+  end
+
+  describe "#label" do
+    it "prefers short_address" do
+      location = described_class.new(
+        text: "London NW9, UK",
+        short_address: "London NW9",
+        formatted_address: "London NW9, United Kingdom",
+      )
+      expect(location.label).to eq("London NW9")
+    end
+
+    it "falls back to formatted_address when short_address is blank" do
+      location = described_class.new(
+        text: "London NW9, UK",
+        formatted_address: "London NW9, United Kingdom",
+      )
+      expect(location.label).to eq("London NW9, United Kingdom")
+    end
+
+    it "falls back to text when both short_address and formatted_address are blank" do
+      location = described_class.new(text: "London NW9, UK")
+      expect(location.label).to eq("London NW9, UK")
+    end
+
+    it "is nil when every label-candidate is blank" do
+      expect(described_class.new.label).to be_nil
+    end
+  end
+
+  describe ".from_params" do
+    it "extracts every field from a string-keyed hash" do
+      location = described_class.from_params(
+        "location" => "London, UK",
+        "latitude" => "51.5074",
+        "longitude" => "-0.1278",
+        "formatted_address" => "London, United Kingdom",
+        "short_address" => "London",
+      )
+
+      expect(location.sortable_by_distance?).to be true
+      expect(location.label).to eq("London")
+    end
+
+    it "extracts every field from a symbol-keyed hash" do
+      location = described_class.from_params(
+        location: "London, UK",
+        latitude: "51.5074",
+        longitude: "-0.1278",
+        formatted_address: "London, United Kingdom",
+        short_address: "London",
+      )
+
+      expect(location.sortable_by_distance?).to be true
+      expect(location.label).to eq("London")
+    end
+
+    it "returns a blank location for an empty hash" do
+      expect(described_class.from_params({}).blank?).to be true
+    end
+  end
+end

--- a/spec/services/courses/search_location_spec.rb
+++ b/spec/services/courses/search_location_spec.rb
@@ -3,30 +3,30 @@
 require "rails_helper"
 
 RSpec.describe Courses::SearchLocation do
-  describe "#sortable_by_distance?" do
+  describe "#located?" do
     it "is true when both coordinates are present" do
       location = described_class.new(latitude: "51.5074", longitude: "-0.1278")
-      expect(location.sortable_by_distance?).to be true
+      expect(location.located?).to be true
     end
 
     it "is false when latitude is missing" do
       location = described_class.new(longitude: "-0.1278")
-      expect(location.sortable_by_distance?).to be false
+      expect(location.located?).to be false
     end
 
     it "is false when longitude is missing" do
       location = described_class.new(latitude: "51.5074")
-      expect(location.sortable_by_distance?).to be false
+      expect(location.located?).to be false
     end
 
     it "is false when both coordinates are missing" do
       location = described_class.new(text: "London")
-      expect(location.sortable_by_distance?).to be false
+      expect(location.located?).to be false
     end
 
     it "is false when coordinates are empty strings" do
       location = described_class.new(latitude: "", longitude: "")
-      expect(location.sortable_by_distance?).to be false
+      expect(location.located?).to be false
     end
 
     it "treats display fields (text, short_address, formatted_address) as irrelevant" do
@@ -35,7 +35,7 @@ RSpec.describe Courses::SearchLocation do
         short_address: "Atlantis",
         formatted_address: "Atlantis, Ocean",
       )
-      expect(location.sortable_by_distance?).to be false
+      expect(location.located?).to be false
     end
   end
 
@@ -105,7 +105,7 @@ RSpec.describe Courses::SearchLocation do
         "short_address" => "London",
       )
 
-      expect(location.sortable_by_distance?).to be true
+      expect(location.located?).to be true
       expect(location.label).to eq("London")
     end
 
@@ -118,7 +118,7 @@ RSpec.describe Courses::SearchLocation do
         short_address: "London",
       )
 
-      expect(location.sortable_by_distance?).to be true
+      expect(location.located?).to be true
       expect(location.label).to eq("London")
     end
 

--- a/spec/services/find/search_param_defaults_spec.rb
+++ b/spec/services/find/search_param_defaults_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Find::SearchParamDefaults do
       expect(defaults.default_value?("level", "secondary")).to be false
     end
 
-    context "order default depends on location" do
+    context "order default depends on whether the search has resolved coordinates" do
       it "returns true for order=course_name_ascending without location" do
         defaults = described_class.new(order: "course_name_ascending")
         expect(defaults.default_value?("order", "course_name_ascending")).to be true
@@ -45,19 +45,40 @@ RSpec.describe Find::SearchParamDefaults do
         expect(defaults.default_value?("order", "distance")).to be false
       end
 
-      it "returns true for order=distance with longitude" do
-        defaults = described_class.new(order: "distance", longitude: "-1.5")
+      it "returns true for order=distance with both latitude and longitude" do
+        defaults = described_class.new(order: "distance", latitude: "53.4", longitude: "-1.5")
         expect(defaults.default_value?("order", "distance")).to be true
       end
 
-      it "returns false for order=course_name_ascending with longitude" do
-        defaults = described_class.new(order: "course_name_ascending", longitude: "-1.5")
+      it "returns false for order=course_name_ascending with both coordinates" do
+        defaults = described_class.new(order: "course_name_ascending", latitude: "53.4", longitude: "-1.5")
         expect(defaults.default_value?("order", "course_name_ascending")).to be false
       end
 
-      it "returns true for order=distance with short_address" do
+      it "returns false for order=distance when only longitude is present" do
+        defaults = described_class.new(order: "distance", longitude: "-1.5")
+        expect(defaults.default_value?("order", "distance")).to be false
+      end
+
+      it "returns false for order=distance when only latitude is present" do
+        defaults = described_class.new(order: "distance", latitude: "53.4")
+        expect(defaults.default_value?("order", "distance")).to be false
+      end
+
+      # Locks in the explicit behaviour change in this refactor: a search that
+      # only has the display label (short_address) and no resolved coordinates
+      # — e.g. a stored email alert whose lat/lng columns were never populated
+      # — is no longer treated as if distance ordering were the default. The
+      # query cannot sort by distance without coordinates, so a "Sort by"
+      # filter chip would be misleading.
+      it "returns false for order=distance when short_address is present but coordinates are not" do
         defaults = described_class.new(order: "distance", short_address: "Manchester")
-        expect(defaults.default_value?("order", "distance")).to be true
+        expect(defaults.default_value?("order", "distance")).to be false
+      end
+
+      it "returns true for order=course_name_ascending when short_address is present but coordinates are not" do
+        defaults = described_class.new(order: "course_name_ascending", short_address: "Manchester")
+        expect(defaults.default_value?("order", "course_name_ascending")).to be true
       end
     end
 

--- a/spec/system/find/results/filter_chip_consistency_spec.rb
+++ b/spec/system/find/results/filter_chip_consistency_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../results_helper"
+
+# Cross-cuts the active-filter chip extractor and the form's order
+# resolution to assert they *agree* on whether an ordering is "default"
+# or "applied" for every realistic state. The pre-refactor codebase had
+# four sites independently answering "is this a location-based search?"
+# with conflicting predicates — that disagreement would silently produce
+# wrong chips. These specs lock in consistency end-to-end through the
+# real controller and view.
+RSpec.describe "Filter chip consistency for order across location states", service: :find do
+  include ResultsHelper
+
+  let!(:provider) { create(:provider, provider_name: "Alpha University") }
+
+  let!(:course) do
+    create(
+      :course,
+      :secondary,
+      :open,
+      :published,
+      :with_full_time_sites,
+      name: "Mathematics",
+      provider: provider,
+    )
+  end
+
+  before do
+    stub_atlantis_geocode_zero_results
+  end
+
+  context "with geocoded coordinates" do
+    let(:london) { build(:location, :london) }
+
+    before do
+      stub_london_location_search
+    end
+
+    scenario "no explicit order — no order chip (distance IS the default)" do
+      visit find_results_path(
+        location: "London, UK",
+        latitude: london.latitude,
+        longitude: london.longitude,
+      )
+
+      expect(page).not_to have_content("Sort by: distance")
+      expect(page).not_to have_content("Sort by: Course (a to z)")
+    end
+
+    scenario "explicit order=course_name_ascending — chip appears (it is NOT the default for geocoded searches)" do
+      visit find_results_path(
+        location: "London, UK",
+        latitude: london.latitude,
+        longitude: london.longitude,
+        order: "course_name_ascending",
+      )
+
+      expect(page).to have_content("Sort by: Course (a to z)")
+    end
+  end
+
+  context "with un-geocoded location text" do
+    scenario "no explicit order — no order chip (form fell back to course_name_ascending, which IS the default)" do
+      visit find_results_path(location: "Atlantis")
+
+      expect(page).not_to have_content("Sort by: distance")
+      expect(page).not_to have_content("Sort by: Course (a to z)")
+    end
+
+    scenario "explicit order=distance — form normalises away from distance, no 'Sort by: distance' chip surfaces" do
+      visit find_results_path(location: "Atlantis", order: "distance")
+
+      expect(page).not_to have_content("Sort by: distance")
+    end
+  end
+
+  context "with no location at all" do
+    scenario "order=course_name_ascending — no chip (this is the default)" do
+      visit find_results_path(order: "course_name_ascending")
+
+      expect(page).not_to have_content("Sort by: Course (a to z)")
+      expect(page).not_to have_content("Sort by: distance")
+    end
+
+    scenario "order=provider_name_ascending — chip appears (not the default)" do
+      visit find_results_path(order: "provider_name_ascending")
+
+      expect(page).to have_content(/Sort by: Provider/i)
+    end
+  end
+end

--- a/spec/system/find/results/sort_choice_respected_spec.rb
+++ b/spec/system/find/results/sort_choice_respected_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../results_helper"
+
+# Reproduces the report: a user searches for a subject + postcode on the
+# homepage, lands on the results page, picks "Sort by Course name (a to z)"
+# from the dropdown — but no "Sort by" chip appears in the active filters.
+# A second click on the same sort option works.
+#
+# Root cause: the previous render's hidden `previous_location_category`
+# was captured as "regional", while the geocoder returns "postal_code"
+# address_types on this request — making the location category effectively
+# "locality". SearchForm#order then sees location_category_changed? as true
+# and silently drops the explicit user choice, resetting the order to the
+# location default ("distance"). The chip extractor then sees
+# order == default → no chip surfaces.
+#
+# The deeper question is whether `location_category_changed?` should ever
+# override an explicit user sort. This spec locks in the answer: no.
+RSpec.describe "Sort choice respected after location category drift", service: :find do
+  include ResultsHelper
+
+  let!(:provider) { create(:provider, provider_name: "Alpha University") }
+
+  let!(:mathematics) do
+    create(
+      :course,
+      :secondary,
+      :open,
+      :published,
+      :with_full_time_sites,
+      name: "Mathematics",
+      provider: provider,
+      subjects: [find_or_create(:secondary_subject, :mathematics)],
+    )
+  end
+
+  before do
+    # Geocode result with `postal_code` in address_types → DefaultRadius
+    # computes location_category = "locality" on this render.
+    allow(Geolocation::Address).to receive(:query).with("BS1 4SB, Bristol").and_return(
+      Geolocation::Address.new(
+        formatted_address: "Bristol BS1 4SB, UK",
+        latitude: 51.4505,
+        longitude: -2.5867,
+        country: "United Kingdom",
+        postal_code: "BS1 4SB",
+        postal_town: "Bristol",
+        address_types: %w[postal_code],
+      ),
+    )
+  end
+
+  scenario "explicit Sort by course name (a to z) surfaces a chip even when previous_location_category drifted" do
+    # Mirrors the exact URL the user lands on after picking Sort from the
+    # dropdown — the offending bit is `previous_location_category=regional`
+    # while the geocoder reports a locality category for this request.
+    visit find_results_path(
+      previous_location_category: "regional",
+      subject_name: "Mathematics",
+      subject_code: "G1",
+      location: "BS1 4SB, Bristol",
+      order: "course_name_ascending",
+      radius: 50,
+      subjects: %w[G1],
+      minimum_degree_required: "show_all_courses",
+    )
+
+    expect(page).to have_http_status(:ok)
+    expect(page).to have_content("Sort by: Course (a to z)")
+  end
+end

--- a/spec/system/find/results/un_geocoded_location_spec.rb
+++ b/spec/system/find/results/un_geocoded_location_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../results_helper"
+
+# These specs cover the production scenario that produced
+# `PG::UndefinedColumn: column "minimum_distance_to_search_location" does
+# not exist` on the Find results page: the user reaches the page with a
+# location string in the URL, but the controller could not resolve it to
+# coordinates (geocoding returned ZERO_RESULTS, an old email-alert search
+# carried only short_address, etc.). In all cases the page must render,
+# results must come back sorted by course name, and no misleading
+# "Sort by" filter chip should appear.
+RSpec.describe "Results page with an un-geocoded location", service: :find do
+  include ResultsHelper
+
+  let(:primary_subject) { find_or_create(:primary_subject, :primary) }
+  let(:biology_subject) { find_or_create(:secondary_subject, :biology) }
+
+  let!(:apple_provider) { create(:provider, provider_name: "Apple University") }
+  let!(:zebra_provider) { create(:provider, provider_name: "Zebra University") }
+
+  let!(:biology_course) do
+    create(
+      :course,
+      :secondary,
+      :open,
+      :published,
+      :with_full_time_sites,
+      name: "Biology",
+      provider: zebra_provider,
+      subjects: [biology_subject],
+    )
+  end
+
+  let!(:primary_course) do
+    create(
+      :course,
+      :primary,
+      :open,
+      :published,
+      :with_full_time_sites,
+      name: "Primary",
+      provider: apple_provider,
+      subjects: [primary_subject],
+    )
+  end
+
+  before do
+    stub_atlantis_geocode_zero_results
+  end
+
+  scenario "location alone — page renders, sorted by course name, no 'Sort by' chip" do
+    visit find_results_path(location: "Atlantis")
+
+    expect(page).to have_http_status(:ok)
+    expect(page).to have_css("h1", text: /courses/i)
+    expect(page).not_to have_content("Sort by: distance")
+    expect(page).not_to have_content("Sort by: Course (a to z)")
+  end
+
+  scenario "location + subject filter (mirrors the Sentry payload) — subject chip present, no order chip, no crash" do
+    visit find_results_path(location: "Atlantis", subjects: [biology_subject.subject_code])
+
+    expect(page).to have_http_status(:ok)
+    expect(page).to have_content("Biology")
+    expect(page).not_to have_content("Sort by: distance")
+    expect(page).not_to have_content("Sort by: Course (a to z)")
+  end
+
+  scenario "location + funding filter — funding chip present, no order chip" do
+    visit find_results_path(location: "Atlantis", funding: %w[salary])
+
+    expect(page).to have_http_status(:ok)
+    expect(page).not_to have_content("Sort by: distance")
+    expect(page).not_to have_content("Sort by: Course (a to z)")
+  end
+
+  scenario "location + explicit order=course_name_ascending — no order chip (it IS the default)" do
+    visit find_results_path(location: "Atlantis", order: "course_name_ascending")
+
+    expect(page).to have_http_status(:ok)
+    expect(page).not_to have_content("Sort by: Course (a to z)")
+  end
+
+  scenario "location + explicit order=distance — page renders (no PG::UndefinedColumn), no 'Sort by: distance' chip" do
+    visit find_results_path(location: "Atlantis", order: "distance")
+
+    expect(page).to have_http_status(:ok)
+    expect(page).not_to have_content("Sort by: distance")
+  end
+
+  scenario "location + start_date filter — page renders" do
+    visit find_results_path(location: "Atlantis", start_date: %w[september])
+
+    expect(page).to have_http_status(:ok)
+    expect(page).not_to have_content("Sort by: distance")
+  end
+
+  # Locks in the SearchParamDefaults behaviour change: when only the
+  # display label (short_address) is present and no coordinates,
+  # `order=distance` is no longer considered "the default for this
+  # state" — so the chip would surface and look misleading. The form's
+  # order resolution prevents the crash; the chip extractor agrees
+  # there's nothing default about an un-runnable distance ordering.
+  scenario "direct URL with short_address + order=distance, no coordinates — no 'Sort by: distance' chip" do
+    visit find_results_path(short_address: "Manchester", order: "distance")
+
+    expect(page).to have_http_status(:ok)
+    expect(page).not_to have_content("Sort by: distance")
+  end
+end

--- a/spec/system/find/results_helper.rb
+++ b/spec/system/find/results_helper.rb
@@ -634,6 +634,17 @@ module ResultsHelper
       )
   end
 
+  def stub_atlantis_geocode_zero_results
+    stub_request(
+      :get,
+      %r{https://maps.googleapis.com/maps/api/geocode/json.*address=Atlantis},
+    ).to_return(
+      status: 200,
+      body: file_fixture("google_old_places_api_client/geocode/atlantis.json").read,
+      headers: { "Content-Type" => "application/json" },
+    )
+  end
+
   def stub_london_location_search
     stub_request(
       :get,


### PR DESCRIPTION
## Summary

The question *"does this search have a usable location?"* was being answered in four different files, each with a slightly different definition. This consolidates it into one place — a small `Courses::SearchLocation` value object — and updates the four sites to ask it the same way.

## Why this matters

The recent `PG::UndefinedColumn` crash on the Find results page (hot-fixed in `td/fix-pg-undefined-column-distance-ordering`) was the loudest symptom of this. That fix patched one of the four places. The others kept producing quieter wrong-UI bugs:

- A confusing "Sort by: Course (a to z)" chip would appear after searching a non-UK location.
- The "Sort by" chip would not show up when a user picked a non-default sort on a geocoded search.

## What's in the box

**New:** `Courses::SearchLocation` — small value object. Its public method is `#located?`, which returns true only when both `latitude` and `longitude` are present.

**Updated** — the four sites that previously implemented the rule themselves now delegate to the value object:
- `Courses::OrderingStrategy`
- `Courses::SearchForm#ordering_filter_count`
- `Find::SearchParamDefaults`
- `Courses::ActiveFilters::HashExtractor`

**Bonus fix:** `Courses::ActiveFilters::Extractor` was being handed `search_params` with coordinates stripped (so they wouldn't render as filter chips), but it then used those stripped params to compute which order counted as "default" — so it could no longer tell a geocoded search apart. Pointed it at the form's full `search_params` for the defaults check only.

## Behaviour change to call out

Previously, a search with `short_address: "Manchester"` but no resolved coordinates (think: a stored email alert whose lat/lng columns were never populated) was treated as if `"distance"` were the natural default order. After this PR, only resolved coordinates count. The filter chip extractor is now honest: it won't claim `"distance"` is the default for a search the query can't actually run by distance.

A dedicated unit spec in `search_param_defaults_spec.rb` locks this in.

## Tests

- New unit specs for `Courses::SearchLocation`.
- New unit specs pinning down the `SearchParamDefaults` behaviour change.
- 7 new system specs in `spec/system/find/results/un_geocoded_location_spec.rb` covering the production trigger (`Atlantis` geocoding to ZERO_RESULTS) and six variations — page renders, no `PG::UndefinedColumn`, no misleading "Sort by" chip.
- 6 new system specs in `spec/system/find/results/filter_chip_consistency_spec.rb` asserting the form and the chip extractor agree on default-vs-applied across geocoded, un-geocoded, and no-location states.

To confirm the new system specs actually exercise the rule, I temporarily broke `SearchLocation#located?` to return the wrong answer and ran them — 8 of 13 went red. Restored.

## Object mapping

## Class diagram — `Courses::SearchLocation` + `Courses::OrderingStrategy` and their callers

```mermaid
classDiagram
    direction LR

    class SearchLocation {
      +text: String
      +latitude
      +longitude
      +formatted_address: String
      +short_address: String
      +located?() Boolean
      +blank?() Boolean
      +label() String
      <<value object>>
      $from_params(params) SearchLocation
    }

    class OrderingStrategy {
      DEFAULT_ORDER = "course_name_ascending"
      LOCATED_ORDER = "distance"
      +call() String
      $default_for(search_location) String
      <<strategy>>
    }

    class SearchForm {
      +order() String
      +ordering_filter_count() Integer
      -search_location() SearchLocation
    }

    class SearchParamDefaults {
      +default_value?(key, value) Boolean
      -defaults() Hash
    }

    class HashExtractor {
      +call() Array~ActiveFilter~
      -default_order() String
      -search_location() SearchLocation
    }

    class Extractor {
      +call() Array~ActiveFilter~
      -param_defaults: SearchParamDefaults
    }

    SearchForm        --> SearchLocation   : builds (memoised)
    HashExtractor     --> SearchLocation   : builds from @attrs
    SearchParamDefaults ..> SearchLocation : builds inside defaults proc

    SearchForm           --> OrderingStrategy : .new(...).call  (resolves order)
    SearchForm           --> OrderingStrategy : .default_for     (ordering_filter_count)
    SearchParamDefaults  --> OrderingStrategy : .default_for     (defaults proc)
    HashExtractor        --> OrderingStrategy : .default_for     (default_order)

    OrderingStrategy --> SearchLocation : asks .located?
    Extractor       --> SearchParamDefaults : uses for default checks
    SearchForm      --> Extractor : passes form into Extractor.new
```

---

## Sequence diagram — "user searches with un-geocoded text" (the production trigger)

```mermaid
sequenceDiagram
    autonumber
    actor U as User
    participant C as Find::ResultsController
    participant F as SearchForm
    participant L as SearchLocation
    participant O as OrderingStrategy
    participant Q as Courses::Query
    participant E as ActiveFilters::Extractor
    participant D as SearchParamDefaults

    U->>C: GET /results?location=Atlantis
    C->>F: SearchForm.new(params + geocode result)
    Note over C,F: geocode returned ZERO_RESULTS → no latitude/longitude

    F->>L: build SearchLocation (text, no coords)
    F->>O: OrderingStrategy.new(search_location:, ...).call
    O->>L: located?
    L-->>O: false
    O-->>F: "course_name_ascending"  (DEFAULT_ORDER)

    F->>Q: Courses::Query.call(params: ...order=course_name_ascending)
    Q-->>F: results sorted by course name (no PG::UndefinedColumn)

    F->>E: build active_filters (passes self)
    E->>D: SearchParamDefaults.new(form.search_params)
    Note over D: defaults proc uses<br/>OrderingStrategy.default_for(SearchLocation.from_params(params))
    D->>L: built inside proc → located?
    L-->>D: false
    D-->>E: default order = "course_name_ascending"
    Note over E: order = default → suppress "Sort by" chip

    E-->>F: chips (no order chip)
    F-->>C: render
    C-->>U: 200 OK, no misleading chip
```

---

## What changed structurally

- One **predicate** — `SearchLocation#located?` — replaces four different definitions of "is this a location-based search?".
- One **mapping** — `OrderingStrategy.default_for(search_location)` — replaces four duplicates of `located? ? "distance" : "course_name_ascending"`.
- `Extractor` now sources defaults from `search_form.search_params` (full) so it can see coords that were intentionally stripped from chip iteration.
- `Courses::Query` / `SavedCourses::Query` still implement the same default-order rule via internal scope state — already correct, deliberately out of scope for this PR.


## Test plan

- [x] `bundle exec rspec spec/services/courses/ spec/services/find/ spec/services/saved_courses/ spec/forms/courses/` (677 examples)
- [x] `bundle exec rspec spec/system/find/results/un_geocoded_location_spec.rb spec/system/find/results/filter_chip_consistency_spec.rb` (13 examples)
- [x] Smoke check by breaking `SearchLocation#located?` and confirming the new system specs go red.
