### PR TITLE
Fix: Validate provider codes against discarded providers

### DIFF
--- a/app/forms/support/provider_form.rb
+++ b/app/forms/support/provider_form.rb
@@ -63,8 +63,6 @@ module Support
 
   private
 
-    delegate :providers, to: :recruitment_cycle
-
     def scitt?
       provider_type&.to_sym == :scitt
     end
@@ -74,7 +72,9 @@ module Support
     end
 
     def provider_code_taken
-      errors.add(:provider_code, :taken) if providers.exists?(provider_code:)
+      return if provider_code.blank?
+
+      errors.add(:provider_code, :taken) if Provider.exists?(recruitment_cycle:, provider_code: provider_code.upcase)
     end
 
     def provider_type_school_is_an_invalid_accredited_provider

--- a/spec/forms/support/provider_form_spec.rb
+++ b/spec/forms/support/provider_form_spec.rb
@@ -178,7 +178,23 @@ module Support
         end
 
         let(:provider_code) do
-          create(:provider).provider_code
+          create(:provider, recruitment_cycle:).provider_code
+        end
+
+        it "validates the provider code" do
+          expect(subject).not_to be_valid
+
+          expect(subject.errors[:provider_code]).to match_array("Provider code already taken")
+        end
+      end
+
+      context "using a discarded provider_code" do
+        let(:test_params) do
+          { provider_code: }
+        end
+
+        let(:provider_code) do
+          create(:provider, :discarded, recruitment_cycle:).provider_code
         end
 
         it "validates the provider code" do


### PR DESCRIPTION
## Context

Support wasn’t able to add a provider because the form submission failed silently. It turns out that a provider with the same provider code had been discarded in the current cycle.

Interestingly, our Active Record relation between RecruitmentCycle and Provider only includes undiscarded providers. As a result, the existing form validation didn’t catch the collision and no error message was displayed.

I didn’t change the provider relation on RecruitmentCycle, as that could introduce other bugs elsewhere in the application. Instead, I updated the validation in the form object.

## Changes proposed in this pull request

Validate provider codes against discarded providers

## Guidance to review

- Read it, tested it already locally

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
