### PR TITLE
2683 - New GitHub action validate infra workflow

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -1,0 +1,44 @@
+name: Validate Infra
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: ${{ matrix.display }}
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - display: AKS infrastructure
+            validation_plan: aks-infra
+            terraform_base: terraform/aks
+            terraform_version_file: providers.tf
+          - display: Domains infrastructure
+            validation_plan: domains-infra
+            terraform_base: terraform/custom_domains/infrastructure
+            terraform_version_file: terraform.tf
+          - display: Domains environment
+            validation_plan: domains-env
+            terraform_base: terraform/custom_domains/environment_domains
+            terraform_version_file: terraform.tf
+
+    steps:
+      - name: Validate ${{ matrix.display }}
+        uses: DFE-Digital/github-actions/validate-infra@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          environment: production
+          terraform-base: ${{ matrix.terraform_base }}
+          validation-plan: ${{ matrix.validation_plan }}
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ deploy-init: vendor-modules
 	$(eval export TF_VARS=-var config_short=${CONFIG_SHORT} -var service_short=${SERVICE_SHORT} -var service_name=${SERVICE_NAME} -var azure_resource_prefix=${RESOURCE_NAME_PREFIX})
 
 deploy-plan: deploy-init
-	terraform -chdir=terraform/aks plan -var-file=./workspace_variables/$(DEPLOY_ENV).tfvars.json ${TF_VARS}
+	terraform -chdir=terraform/aks plan ${DETAILED_EXITCODE} -var-file=./workspace_variables/$(DEPLOY_ENV).tfvars.json ${TF_VARS}
 
 deploy: deploy-init
 	terraform -chdir=terraform/aks apply -var-file=./workspace_variables/$(DEPLOY_ENV).tfvars.json ${TF_VARS} $(AUTO_APPROVE)
@@ -239,7 +239,7 @@ find-domains-infra-init: find set-production-subscription set-azure-account vend
 		-backend-config=workspace_variables/${DOMAINS_ID}_backend.tfvars
 
 find-domains-infra-plan: find-domains-infra-init
-	terraform -chdir=terraform/custom_domains/infrastructure plan -var-file workspace_variables/${DOMAINS_ID}.tfvars.json
+	terraform -chdir=terraform/custom_domains/infrastructure plan ${DETAILED_EXITCODE} -var-file workspace_variables/${DOMAINS_ID}.tfvars.json
 
 find-domains-infra-apply: find-domains-infra-init
 	terraform -chdir=terraform/custom_domains/infrastructure apply -var-file workspace_variables/${DOMAINS_ID}.tfvars.json ${AUTO_APPROVE}
@@ -249,7 +249,7 @@ publish-domains-infra-init: publish set-production-subscription set-azure-accoun
 		-backend-config=workspace_variables/${DOMAINS_ID}_backend.tfvars
 
 publish-domains-infra-plan: publish-domains-infra-init
-	terraform -chdir=terraform/custom_domains/infrastructure plan -var-file workspace_variables/${DOMAINS_ID}.tfvars.json
+	terraform -chdir=terraform/custom_domains/infrastructure plan ${DETAILED_EXITCODE} -var-file workspace_variables/${DOMAINS_ID}.tfvars.json
 
 publish-domains-infra-apply: publish-domains-infra-init
 	terraform -chdir=terraform/custom_domains/infrastructure apply -var-file workspace_variables/${DOMAINS_ID}.tfvars.json ${AUTO_APPROVE}
@@ -267,7 +267,7 @@ find-domains-init: find set-production-subscription set-azure-account vendor-dom
 	terraform -chdir=terraform/custom_domains/environment_domains init -upgrade -reconfigure -backend-config=workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}_backend.tfvars
 
 find-domains-plan: find-domains-init
-	terraform -chdir=terraform/custom_domains/environment_domains plan -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json
+	terraform -chdir=terraform/custom_domains/environment_domains plan ${DETAILED_EXITCODE} -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json
 
 find-domains-apply: find-domains-init
 	terraform -chdir=terraform/custom_domains/environment_domains apply -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json ${AUTO_APPROVE}
@@ -282,7 +282,7 @@ publish-domains-init: publish set-production-subscription set-azure-account vend
 	terraform -chdir=terraform/custom_domains/environment_domains init -upgrade -reconfigure -backend-config=workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}_backend.tfvars
 
 publish-domains-plan: publish-domains-init
-	terraform -chdir=terraform/custom_domains/environment_domains plan -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json
+	terraform -chdir=terraform/custom_domains/environment_domains plan ${DETAILED_EXITCODE} -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json
 
 publish-domains-apply: publish-domains-init
 	terraform -chdir=terraform/custom_domains/environment_domains apply -var-file workspace_variables/${DOMAINS_ID}_${DEPLOY_ENV}.tfvars.json ${AUTO_APPROVE}


### PR DESCRIPTION
### Context

Adding a validate infra workflow to detect any changes in SD Infra Terraform 

### Changes proposed in this pull request

Add a new GitHub action workflow validate-infrastructure.yml.
${DETAILED_EXITCODE} added to Terraform plan in Makefile.
README.md updated.
TEAMS_WEBHOOK_URL_INFRA added as an Action repository secret.

### Guidance to review

Manually test changes by altering terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json **rate_limit_max** and running locally the following command.
`make production domains-plan CONFIRM_PRODUCTION=yes`
This will produce a Terraform update in place.

To validate the workflow once available. Make a test branch with a change to terraform/custom_domains/environment_domains/workspace_variables/find_production.tfvars.json **rate_limit_max**.

Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
