### PR TITLE
Implement Study sites step

### DIFF
--- a/app/views/publish/course_wizards/steps/_schools.html.erb
+++ b/app/views/publish/course_wizards/steps/_schools.html.erb
@@ -21,6 +21,10 @@
   </strong>
 </div>
 
+<p class="govuk-hint">
+  <%= t("course_wizard.steps.schools.hint") %>
+</p>
+
 <%= form.govuk_check_boxes_fieldset :site_ids, legend: { hidden: true, text: heading } do %>
   <% current_step.sites.each_with_index do |site, index| %>
     <%= form.govuk_check_box :site_ids,

--- a/app/views/publish/course_wizards/steps/_study_sites.html.erb
+++ b/app/views/publish/course_wizards/steps/_study_sites.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.study_sites.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.study_sites.caption")) %>
+  <%= t("course_wizard.steps.study_sites.heading") %>
+</h1>
+
+<p class="govuk-hint">
+  <%= t("course_wizard.steps.study_sites.hint") %>
+</p>
+
+<%= form.govuk_check_boxes_fieldset :study_sites_ids, legend: { hidden: true, text: t("course_wizard.steps.study_sites.heading") } do %>
+  <% current_step.study_sites.each_with_index do |study_site, index| %>
+    <%= form.govuk_check_box :study_sites_ids,
+      study_site.id.to_s,
+      label: { text: [study_site.location_name, render(Publish::Schools::NewlyAddedTagComponent.new(school: study_site))].compact_blank.join(" ").html_safe },
+      hint: { text: study_site.full_address },
+      include_hidden: false,
+      link_errors: index.zero? %>
+  <% end %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.study_sites.submit") %>

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -19,6 +19,7 @@ class CourseWizard
       graph.add_node :funding_type, Steps::FundingType
       graph.add_node :study_pattern, Steps::StudyPattern
       graph.add_node :schools, Steps::Schools
+      graph.add_node :study_sites, Steps::StudySites
 
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
@@ -48,7 +49,9 @@ class CourseWizard
 
       graph.add_edge from: :study_pattern, to: :schools
 
-      graph.add_edge from: :schools, to: :courses_index
+      graph.add_edge from: :schools, to: :study_sites
+
+      graph.add_edge from: :study_sites, to: :courses_index
     end
   end
 

--- a/app/wizards/course_wizard/steps/study_sites.rb
+++ b/app/wizards/course_wizard/steps/study_sites.rb
@@ -7,8 +7,6 @@ class CourseWizard
 
       attribute :study_sites_ids
 
-      validate :study_sites_ids_selected
-
       def study_sites
         provider.study_sites.sort_by(&:location_name)
       end
@@ -18,16 +16,6 @@ class CourseWizard
       end
 
     private
-
-      def study_sites_ids_selected
-        return if selected_study_sites_ids.any?
-
-        errors.add(:study_sites_ids, I18n.t("course_wizard.steps.study_sites.errors.study_sites_ids.blank"))
-      end
-
-      def selected_study_sites_ids
-        Array(study_sites_ids).compact_blank
-      end
 
       def provider
         @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)

--- a/app/wizards/course_wizard/steps/study_sites.rb
+++ b/app/wizards/course_wizard/steps/study_sites.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class StudySites
+      include DfE::Wizard::Step
+
+      attribute :study_sites_ids
+
+      validate :study_sites_ids_selected
+
+      def study_sites
+        provider.study_sites.sort_by(&:location_name)
+      end
+
+      def self.permitted_params
+        [{ study_sites_ids: [] }]
+      end
+
+    private
+
+      def study_sites_ids_selected
+        return if selected_study_sites_ids.any?
+
+        errors.add(:study_sites_ids, I18n.t("course_wizard.steps.study_sites.errors.study_sites_ids.blank"))
+      end
+
+      def selected_study_sites_ids
+        Array(study_sites_ids).compact_blank
+      end
+
+      def provider
+        @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)
+      end
+
+      def recruitment_cycle
+        @recruitment_cycle ||= RecruitmentCycle.find_by!(year: wizard.recruitment_cycle_year)
+      end
+    end
+  end
+end

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -106,12 +106,21 @@ en:
             blank: Select a study pattern
       schools:
         caption: Add course
+        hint: Select all that apply
         submit: Continue
         description: The more schools you select, the more searches your course will appear in. You should only add schools that are relevant to this course.
         percentage: 60% of searches are by location.
         errors:
           site_ids:
             blank: Select at least one school
+      study_sites:
+        caption: Add course
+        heading: Study sites
+        submit: Continue
+        hint: Select all that apply
+        errors:
+          study_sites_ids:
+            blank: Select at least one study site
   activemodel:
     errors:
       models:

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -118,9 +118,6 @@ en:
         heading: Study sites
         submit: Continue
         hint: Select all that apply
-        errors:
-          study_sites_ids:
-            blank: Select at least one study site
   activemodel:
     errors:
       models:

--- a/spec/system/publish/courses/add_course_wizard/schools_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/schools_spec.rb
@@ -8,22 +8,22 @@ RSpec.describe "Add course wizard schools step", type: :system do
     given_i_am_authenticated_as_a_provider_user_with_multiple_schools
   end
 
-  scenario "choosing a salaried school and continues to courses index page" do
+  scenario "choosing a salaried school and continues to study sites page" do
     and_i_have_wizard_state_for_schools(funding_type: "salary")
     when_i_visit_the_wizard_schools_page
     and_the_title_and_description_are_displayed_for_a_salaried_school
     and_i_choose_a_site_from_the_list
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_study_sites_page
   end
 
-  scenario "choosing a non-salaried school and continues to courses index page" do
+  scenario "choosing a non-salaried school and continues to study sites page" do
     and_i_have_wizard_state_for_schools(funding_type: "fee")
     when_i_visit_the_wizard_schools_page
     and_the_title_and_description_are_displayed_for_a_non_salaried_school
     and_i_choose_a_site_from_the_list
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_study_sites_page
   end
 
   scenario "submitting schools without selecting a school shows validation errors" do
@@ -32,15 +32,15 @@ RSpec.describe "Add course wizard schools step", type: :system do
     then_i_have_errors_on_the_schools_step
   end
 
-  scenario "single-school provider continues without explicitly selecting the only school" do
+  scenario "single-school provider continues to study sites page without explicitly selecting the only school" do
     given_i_am_authenticated_as_a_provider_user_with_a_school
     and_i_have_wizard_state_for_schools(funding_type: "fee")
     when_i_visit_the_wizard_schools_page
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_study_sites_page
   end
 
-  scenario "TDA qualification route continues through schools step to courses index" do
+  scenario "TDA qualification route continues through schools step to study sites page" do
     and_i_have_wizard_state_for_qualifications(level: "primary")
     when_i_visit_the_wizard_qualifications_page
     and_i_choose_qualification("Teacher degree apprenticeship (TDA) with QTS")
@@ -49,7 +49,7 @@ RSpec.describe "Add course wizard schools step", type: :system do
     and_the_title_and_description_are_displayed_for_a_salaried_school
     and_i_choose_a_site_from_the_list
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_study_sites_page
   end
 
 private
@@ -99,11 +99,13 @@ private
     expect(page).to have_content("Select at least one school")
   end
 
-  def then_i_am_taken_to_the_courses_index_page
+  def then_i_am_taken_to_the_study_sites_page
     expect(page).to have_current_path(
-      publish_provider_recruitment_cycle_courses_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :study_sites,
+        state_key: wizard_state_key,
       ),
       ignore_query: true,
     )

--- a/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe "Add course wizard study sites step", type: :system do
     then_i_am_taken_to_the_courses_index_page
   end
 
-  scenario "submitting study sites without selecting a study site shows validation errors" do
-    when_i_visit_the_wizard_study_sites_page
-    and_i_click_continue
-    then_i_have_errors_on_the_study_sites_step
-  end
-
 private
 
   def when_i_visit_the_wizard_study_sites_page
@@ -48,11 +42,6 @@ private
       ),
       ignore_query: true,
     )
-  end
-
-  def then_i_have_errors_on_the_study_sites_step
-    expect(page).to have_content("There is a problem")
-    expect(page).to have_content("Select at least one study site")
   end
 
   def given_i_am_authenticated_as_a_provider_user_with_multiple_schools

--- a/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard study sites step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user_with_multiple_schools
+  end
+
+  scenario "choosing a study site and continues to courses index page" do
+    when_i_visit_the_wizard_study_sites_page
+    and_i_choose_a_study_site_from_the_list
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "submitting study sites without selecting a study site shows validation errors" do
+    when_i_visit_the_wizard_study_sites_page
+    and_i_click_continue
+    then_i_have_errors_on_the_study_sites_step
+  end
+
+private
+
+  def when_i_visit_the_wizard_study_sites_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :study_sites,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def and_i_choose_a_study_site_from_the_list
+    check provider.study_sites.first.location_name
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_courses_index_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_have_errors_on_the_study_sites_step
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select at least one study site")
+  end
+
+  def given_i_am_authenticated_as_a_provider_user_with_multiple_schools
+    @user = create(
+      :user,
+      providers: [
+        create(
+          :provider,
+          :accredited_provider,
+          sites: [
+            build(:site),
+            build(:site),
+            build(:site, :study_site),
+            build(:site, :study_site),
+          ],
+        ),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+end

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "funding_type" => "fee" })
       repository.write({ "study_pattern" => %w[full_time part_time] })
       repository.write({ "site_ids" => %w[1 2] })
+      repository.write({ "study_sites_ids" => %w[3 4] })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -40,6 +41,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:funding_type]).to eq("fee")
       expect(data[:study_pattern]).to eq(%w[full_time part_time])
       expect(data[:site_ids]).to eq(%w[1 2])
+      expect(data[:study_sites_ids]).to eq(%w[3 4])
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/steps/schools_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/schools_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe CourseWizard::Steps::Schools do
   let(:current_step) { :schools }
   let(:provider_code) { provider.provider_code }
   let(:recruitment_cycle_year) { provider.recruitment_cycle_year }
-  let(:current_step_params) { { site_ids: } }
   let(:site_ids) { nil }
 
   let(:provider) { create(:provider, :accredited_provider, recruitment_cycle: find_or_create(:recruitment_cycle)) }

--- a/spec/wizards/add_course_wizard/steps/study_site_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/study_site_spec.rb
@@ -22,12 +22,6 @@ RSpec.describe CourseWizard::Steps::StudySites do
       wizard_step.study_sites_ids = %w[1 2]
       expect(wizard_step).to be_valid
     end
-
-    it "is not valid when no study sites are selected" do
-      wizard_step.study_sites_ids = nil
-      expect(wizard_step).not_to be_valid
-      expect(wizard_step.errors.messages_for(:study_sites_ids)).to contain_exactly("Select at least one study site")
-    end
   end
 
   describe "#study_sites" do

--- a/spec/wizards/add_course_wizard/steps/study_site_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/study_site_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::StudySites do
+  include_context "add_course_wizard"
+
+  let(:current_step) { :study_sites }
+  let(:provider_code) { provider.provider_code }
+  let(:recruitment_cycle_year) { provider.recruitment_cycle_year }
+  let(:study_sites_ids) { nil }
+
+  let(:provider) { create(:provider, :accredited_provider, recruitment_cycle: find_or_create(:recruitment_cycle)) }
+  let!(:study_site_b) { create(:site, :study_site, provider:, location_name: "B Study Site") }
+  let!(:study_site_z) { create(:site, :study_site, provider:, location_name: "Z Study Site") }
+  let!(:study_site_a) { create(:site, :study_site, provider:, location_name: "A Study Site") }
+
+  describe "#valid?" do
+    subject(:wizard_step) { wizard.current_step }
+
+    it "is valid when at least one study site is selected" do
+      wizard_step.study_sites_ids = %w[1 2]
+      expect(wizard_step).to be_valid
+    end
+
+    it "is not valid when no study sites are selected" do
+      wizard_step.study_sites_ids = nil
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:study_sites_ids)).to contain_exactly("Select at least one study site")
+    end
+  end
+
+  describe "#study_sites" do
+    subject(:wizard_step) { wizard.current_step }
+
+    it "returns provider study sites sorted by location name" do
+      expect(wizard_step.study_sites).to eq(
+        [
+          study_site_a,
+          study_site_b,
+          study_site_z,
+        ],
+      )
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the permitted params" do
+      expect(described_class.permitted_params).to eq([{ study_sites_ids: [] }])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
   context "from schools" do
     let(:current_step) { :schools }
 
+    it "proceeds to study sites page" do
+      expect(wizard).to have_next_step(:study_sites)
+    end
+  end
+
+  context "from study sites" do
+    let(:current_step) { :study_sites }
+
     it "proceeds to courses page" do
       expect(wizard).to have_next_step(:courses_index)
     end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -144,4 +144,12 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:qualifications)
     end
   end
+
+  context "from study sites" do
+    let(:current_step) { :study_sites }
+
+    it "goes back to schools" do
+      expect(wizard).to have_previous_step(:schools)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Implement Study sites step

## Changes proposed in this pull request

Add new step
Add new view
Add new study site specs
Update existing specs

## Guidance to review

Go through the flow and after the schools page you should always land on the study sites page


**_Small note: In the current version users can skip the study sites page, will confirm if this is meant to happen as in this PR we validate a user must select a study site._**

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
