### PR TITLE
Remove schools from a provider

### DIFF
--- a/app/models/data_hub/remove_provider_schools_process_summary.rb
+++ b/app/models/data_hub/remove_provider_schools_process_summary.rb
@@ -1,0 +1,16 @@
+module DataHub
+  class RemoveProviderSchoolsProcessSummary < ProcessSummary
+    jsonb_accessor :short_summary,
+                   removed_count: :integer,
+                   skipped_with_courses_count: :integer,
+                   kept_present_count: :integer,
+                   kept_missing_count: :integer,
+                   error: :string
+
+    jsonb_accessor :full_summary,
+                   removed: [:jsonb, { array: true, default: [] }],
+                   skipped_with_courses: [:jsonb, { array: true, default: [] }],
+                   kept_present: [:string, { array: true, default: [] }],
+                   kept_missing: [:string, { array: true, default: [] }]
+  end
+end

--- a/app/services/data_hub/remove_provider_schools/dry_run_site_discarder.rb
+++ b/app/services/data_hub/remove_provider_schools/dry_run_site_discarder.rb
@@ -1,0 +1,23 @@
+module DataHub
+  module RemoveProviderSchools
+    class DryRunSiteDiscarder
+      Result = Struct.new(:site_id, :urn, :location_name, keyword_init: true)
+
+      def initialize(site:)
+        @site = site
+      end
+
+      def call
+        Result.new(
+          site_id: site.id,
+          urn: site.urn,
+          location_name: site.location_name,
+        )
+      end
+
+    private
+
+      attr_reader :site
+    end
+  end
+end

--- a/app/services/data_hub/remove_provider_schools/executor.rb
+++ b/app/services/data_hub/remove_provider_schools/executor.rb
@@ -1,0 +1,71 @@
+module DataHub
+  module RemoveProviderSchools
+    class Executor
+      BATCH_SIZE = 100
+
+      attr_reader :provider, :recruitment_cycle
+
+      def initialize(provider_code:, keep_urns:, year:, discarder_class: SiteDiscarder, site_filter: SiteFilter)
+        @recruitment_cycle = RecruitmentCycle.find_by!(year:)
+        @provider = @recruitment_cycle.providers.find_by!(provider_code:)
+        @keep_urns = keep_urns.map(&:to_s)
+        @discarder_class = discarder_class
+        @site_filter = site_filter
+        @removed = []
+        @skipped_with_courses = []
+      end
+
+      def execute
+        process_summary = DataHub::RemoveProviderSchoolsProcessSummary.start!
+
+        remove_schools!
+
+        summary_builder = SummaryBuilder.new(
+          removed: @removed,
+          skipped_with_courses: @skipped_with_courses,
+          kept_present: kept_present,
+          kept_missing: kept_missing,
+        )
+
+        process_summary.finish!(
+          short_summary: summary_builder.short_summary,
+          full_summary: summary_builder.full_summary,
+        )
+      rescue StandardError => e
+        process_summary&.fail!(e)
+        raise e
+      end
+
+    private
+
+      def remove_schools!
+        @site_filter.filter(provider:, keep_urns: @keep_urns).find_each(batch_size: BATCH_SIZE) do |site|
+          if site.has_no_course?
+            result = @discarder_class.new(site:).call
+            @removed << site_payload(result)
+          else
+            @skipped_with_courses << { id: site.id, urn: site.urn, location_name: site.location_name }
+          end
+        end
+      end
+
+      def site_payload(result)
+        { id: result.site_id, urn: result.urn, location_name: result.location_name }
+      end
+
+      # Reconcile the keep list against what is actually on the account so support
+      # can spot data issues (e.g. a URN they expected to keep that is missing).
+      def present_keep_urns
+        @present_keep_urns ||= provider.sites.where(urn: @keep_urns).pluck(:urn).uniq
+      end
+
+      def kept_present
+        present_keep_urns
+      end
+
+      def kept_missing
+        @keep_urns - present_keep_urns
+      end
+    end
+  end
+end

--- a/app/services/data_hub/remove_provider_schools/site_discarder.rb
+++ b/app/services/data_hub/remove_provider_schools/site_discarder.rb
@@ -1,0 +1,28 @@
+module DataHub
+  module RemoveProviderSchools
+    class SiteDiscarder
+      Result = Struct.new(:site_id, :urn, :location_name, keyword_init: true)
+
+      def initialize(site:)
+        @site = site
+      end
+
+      def call
+        site.transaction do
+          site.update_columns(discarded_via_script: true)
+          site.discard
+        end
+
+        Result.new(
+          site_id: site.id,
+          urn: site.urn,
+          location_name: site.location_name,
+        )
+      end
+
+    private
+
+      attr_reader :site
+    end
+  end
+end

--- a/app/services/data_hub/remove_provider_schools/site_filter.rb
+++ b/app/services/data_hub/remove_provider_schools/site_filter.rb
@@ -1,0 +1,14 @@
+module DataHub
+  module RemoveProviderSchools
+    class SiteFilter
+      # Candidate sites to remove: a provider's school sites, excluding the URNs
+      # we are keeping and the provider's main site (which never carries a keep URN).
+      def self.filter(provider:, keep_urns:)
+        provider
+          .sites # already scoped to site_type: :school and .kept
+          .where.not(urn: keep_urns)
+          .where("TRIM(LOWER(site.location_name)) NOT SIMILAR TO '%main[ -]?site%'")
+      end
+    end
+  end
+end

--- a/app/services/data_hub/remove_provider_schools/summary_builder.rb
+++ b/app/services/data_hub/remove_provider_schools/summary_builder.rb
@@ -1,0 +1,30 @@
+module DataHub
+  module RemoveProviderSchools
+    class SummaryBuilder
+      def initialize(removed:, skipped_with_courses:, kept_present:, kept_missing:)
+        @removed = removed
+        @skipped_with_courses = skipped_with_courses
+        @kept_present = kept_present
+        @kept_missing = kept_missing
+      end
+
+      def short_summary
+        {
+          removed_count: @removed.size,
+          skipped_with_courses_count: @skipped_with_courses.size,
+          kept_present_count: @kept_present.size,
+          kept_missing_count: @kept_missing.size,
+        }
+      end
+
+      def full_summary
+        {
+          removed: @removed,
+          skipped_with_courses: @skipped_with_courses,
+          kept_present: @kept_present,
+          kept_missing: @kept_missing,
+        }
+      end
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -48,6 +48,14 @@
   - course_sites_skipped
   - skipped_sites
   - skipped_course_sites
+  - removed_count
+  - skipped_with_courses_count
+  - kept_present_count
+  - kept_missing_count
+  - removed
+  - skipped_with_courses
+  - kept_present
+  - kept_missing
   - discarded_total_count
   - discarded_lack_urn
   - discarded_invalid_gias_urn

--- a/lib/tasks/remove_provider_schools.rake
+++ b/lib/tasks/remove_provider_schools.rake
@@ -1,0 +1,59 @@
+require "csv"
+
+namespace :remove_provider_schools do
+  usage = "PROVIDER_CODE=XYZ YEAR=2025 KEEP_CSV=/path/to/keep.csv"
+
+  desc "Remove (soft discard) a provider's schools except the URNs to keep (REAL run)"
+  task run: :environment do
+    missing = %w[PROVIDER_CODE YEAR KEEP_CSV].reject { |var| ENV[var].present? }
+    if missing.any?
+      puts "ERROR: You must provide the following environment variables: #{missing.join(', ')}."
+      puts "    Example: #{usage} rake remove_provider_schools:run"
+      exit(1)
+    end
+
+    keep_urns = CSV.read(ENV["KEEP_CSV"], headers: true).map { |row| row["URN"].to_s.strip }.reject(&:blank?)
+    puts "Starting REAL removal for provider #{ENV['PROVIDER_CODE']} (year #{ENV['YEAR']}), keeping #{keep_urns.size} URNs..."
+
+    DataHub::RemoveProviderSchools::Executor.new(
+      provider_code: ENV["PROVIDER_CODE"],
+      keep_urns:,
+      year: ENV["YEAR"],
+      discarder_class: DataHub::RemoveProviderSchools::SiteDiscarder,
+    ).execute
+
+    pp DataHub::RemoveProviderSchoolsProcessSummary.last.short_summary
+    puts "REAL removal completed."
+  rescue StandardError => e
+    puts "ERROR during real removal: #{e.message}"
+    puts e.backtrace
+    raise e
+  end
+
+  desc "Simulate removing a provider's schools without changes (DRY RUN)"
+  task dry_run: :environment do
+    missing = %w[PROVIDER_CODE YEAR KEEP_CSV].reject { |var| ENV[var].present? }
+    if missing.any?
+      puts "ERROR: You must provide the following environment variables: #{missing.join(', ')}."
+      puts "    Example: #{usage} rake remove_provider_schools:dry_run"
+      exit(1)
+    end
+
+    keep_urns = CSV.read(ENV["KEEP_CSV"], headers: true).map { |row| row["URN"].to_s.strip }.reject(&:blank?)
+    puts "Starting DRY RUN removal simulation for provider #{ENV['PROVIDER_CODE']} (year #{ENV['YEAR']}), keeping #{keep_urns.size} URNs..."
+
+    DataHub::RemoveProviderSchools::Executor.new(
+      provider_code: ENV["PROVIDER_CODE"],
+      keep_urns:,
+      year: ENV["YEAR"],
+      discarder_class: DataHub::RemoveProviderSchools::DryRunSiteDiscarder,
+    ).execute
+
+    pp DataHub::RemoveProviderSchoolsProcessSummary.last.short_summary
+    puts "DRY RUN removal simulation completed."
+  rescue StandardError => e
+    puts "ERROR during dry run removal simulation: #{e.message}"
+    puts e.backtrace
+    raise e
+  end
+end

--- a/spec/models/data_hub/remove_provider_schools_process_summary_spec.rb
+++ b/spec/models/data_hub/remove_provider_schools_process_summary_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe DataHub::RemoveProviderSchoolsProcessSummary, type: :model do
+  subject(:summary) do
+    described_class.create!(
+      started_at: Time.zone.now,
+      finished_at: Time.zone.now,
+      status: "finished",
+      short_summary: {
+        removed_count: 2,
+        skipped_with_courses_count: 1,
+        kept_present_count: 1,
+        kept_missing_count: 1,
+      },
+      full_summary: {
+        removed: [{ id: 1, urn: "99999", location_name: "Remove School" }],
+        skipped_with_courses: [{ id: 2, urn: "88888", location_name: "Has Course" }],
+        kept_present: %w[11111],
+        kept_missing: %w[22222],
+      },
+    )
+  end
+
+  it "validates presence and formats" do
+    expect(summary).to be_valid
+    expect(summary.removed_count).to eq(2)
+    expect(summary.skipped_with_courses_count).to eq(1)
+    expect(summary.kept_present_count).to eq(1)
+    expect(summary.kept_missing_count).to eq(1)
+    expect(summary.removed).to eq([{ "id" => 1, "urn" => "99999", "location_name" => "Remove School" }])
+    expect(summary.kept_present).to eq(%w[11111])
+    expect(summary.kept_missing).to eq(%w[22222])
+  end
+end

--- a/spec/services/data_hub/remove_provider_schools/dry_run_site_discarder_spec.rb
+++ b/spec/services/data_hub/remove_provider_schools/dry_run_site_discarder_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe DataHub::RemoveProviderSchools::DryRunSiteDiscarder do
+  let(:provider) { create(:provider) }
+  let(:site) { create(:site, provider:, urn: "99999", location_name: "Remove School") }
+
+  it "reports the site without discarding it", :aggregate_failures do
+    result = described_class.new(site:).call
+
+    expect(result.site_id).to eq site.id
+    expect(result.urn).to eq "99999"
+    expect(result.location_name).to eq "Remove School"
+    expect(site.reload).not_to be_discarded
+  end
+end

--- a/spec/services/data_hub/remove_provider_schools/executor_spec.rb
+++ b/spec/services/data_hub/remove_provider_schools/executor_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe DataHub::RemoveProviderSchools::Executor do
+  subject(:executor) do
+    described_class.new(provider_code: provider.provider_code, keep_urns:, year:, discarder_class:)
+  end
+
+  let(:recruitment_cycle) { RecruitmentCycle.current }
+  let(:year) { recruitment_cycle.year }
+  let!(:provider) { create(:provider, recruitment_cycle:) }
+  let(:keep_urns) { %w[11111 22222] }
+
+  let!(:keep_site) { create(:site, provider:, urn: "11111", location_name: "Keep School") }
+  let!(:remove_site)          { create(:site, provider:, urn: "99999", location_name: "Remove School") }
+  let!(:remove_with_course)   { create(:site, provider:, urn: "77777", location_name: "Has Course School") }
+
+  before do
+    # Attach remove_with_course to a kept course so it must be skipped.
+    course = create(:course, provider:)
+    create(:site_status, status: "running", site: remove_with_course, course:)
+  end
+
+  context "with real discarder" do
+    let(:discarder_class) { DataHub::RemoveProviderSchools::SiteDiscarder }
+
+    it "discards only schools that are not kept and have no course" do
+      expect { executor.execute }.to change { Site.discarded.count }.by(1)
+
+      expect(remove_site.reload).to be_discarded
+      expect(keep_site.reload).not_to be_discarded
+      expect(remove_with_course.reload).not_to be_discarded
+    end
+
+    it "records a summary with removed, skipped and keep-list reconciliation" do
+      executor.execute
+
+      summary = DataHub::RemoveProviderSchoolsProcessSummary.last
+      expect(summary.removed_count).to eq(1)
+      expect(summary.skipped_with_courses_count).to eq(1)
+      expect(summary.kept_present_count).to eq(1)
+      expect(summary.kept_missing_count).to eq(1)
+      expect(summary.kept_present).to eq(%w[11111])
+      expect(summary.kept_missing).to eq(%w[22222])
+    end
+  end
+
+  context "with dry run discarder" do
+    let(:discarder_class) { DataHub::RemoveProviderSchools::DryRunSiteDiscarder }
+
+    it "does NOT discard any sites" do
+      expect { executor.execute }.not_to(change { Site.discarded.count })
+    end
+
+    it "still records what would be removed" do
+      executor.execute
+
+      summary = DataHub::RemoveProviderSchoolsProcessSummary.last
+      expect(summary.removed_count).to eq(1)
+      expect(summary.skipped_with_courses_count).to eq(1)
+    end
+  end
+end

--- a/spec/services/data_hub/remove_provider_schools/site_discarder_spec.rb
+++ b/spec/services/data_hub/remove_provider_schools/site_discarder_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe DataHub::RemoveProviderSchools::SiteDiscarder do
+  let(:provider) { create(:provider) }
+  let(:site) { create(:site, provider:, urn: "99999", location_name: "Remove School") }
+
+  it "discards the site and flags it as discarded via script", :aggregate_failures do
+    result = described_class.new(site:).call
+
+    expect(result.site_id).to eq site.id
+    expect(result.urn).to eq "99999"
+    expect(result.location_name).to eq "Remove School"
+    expect(site.reload).to be_discarded
+    expect(site.reload.discarded_via_script).to be true
+  end
+end

--- a/spec/services/data_hub/remove_provider_schools/site_filter_spec.rb
+++ b/spec/services/data_hub/remove_provider_schools/site_filter_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe DataHub::RemoveProviderSchools::SiteFilter do
+  let(:recruitment_cycle) { create(:recruitment_cycle, year: "2025") }
+  let(:provider) { create(:provider, recruitment_cycle:) }
+  let(:keep_urns) { %w[11111 22222] }
+
+  let!(:keep_site_a)  { create(:site, provider:, urn: "11111", location_name: "Keep School A") }
+  let!(:keep_site_b)  { create(:site, provider:, urn: "22222", location_name: "Keep School B") }
+  let!(:remove_site)  { create(:site, provider:, urn: "99999", location_name: "Remove School") }
+  let!(:main_site)    { create(:site, :main_site, provider:, location_name: "Main Site") }
+
+  it "returns school sites to remove, excluding kept URNs and the main site" do
+    result = described_class.filter(provider:, keep_urns:)
+
+    expect(result).to contain_exactly(remove_site)
+    expect(result).not_to include(keep_site_a, keep_site_b, main_site)
+  end
+
+  it "does not return another provider's schools" do
+    other_provider = create(:provider, recruitment_cycle:)
+    create(:site, provider: other_provider, urn: "88888", location_name: "Other Provider School")
+
+    result = described_class.filter(provider:, keep_urns:)
+
+    expect(result).to contain_exactly(remove_site)
+  end
+
+  it "does not return study sites" do
+    create(:site, :study_site, provider:, location_name: "Study Site")
+
+    result = described_class.filter(provider:, keep_urns:)
+
+    expect(result).to contain_exactly(remove_site)
+  end
+end

--- a/spec/services/data_hub/remove_provider_schools/summary_builder_spec.rb
+++ b/spec/services/data_hub/remove_provider_schools/summary_builder_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe DataHub::RemoveProviderSchools::SummaryBuilder do
+  subject(:builder) do
+    described_class.new(
+      removed: [{ id: 1, urn: "99999", location_name: "Remove School" }],
+      skipped_with_courses: [{ id: 2, urn: "88888", location_name: "Has Course" }],
+      kept_present: %w[11111],
+      kept_missing: %w[22222],
+    )
+  end
+
+  it "builds the short summary with counts" do
+    expect(builder.short_summary).to eq(
+      removed_count: 1,
+      skipped_with_courses_count: 1,
+      kept_present_count: 1,
+      kept_missing_count: 1,
+    )
+  end
+
+  it "builds the full summary with details" do
+    expect(builder.full_summary).to eq(
+      removed: [{ id: 1, urn: "99999", location_name: "Remove School" }],
+      skipped_with_courses: [{ id: 2, urn: "88888", location_name: "Has Course" }],
+      kept_present: %w[11111],
+      kept_missing: %w[22222],
+    )
+  end
+end


### PR DESCRIPTION
## What this does

NITE had about 1,250 schools added to their account by the Register import, but they only use 25. The long list makes it hard for them (and the support team) to manage schools and add them to courses. Removing schools one at a time in Publish would take far too long.

This adds a task that removes all of a provider's schools except the ones we want to keep.

## How it works

A new rake task, `remove_provider_schools`, takes:

- `PROVIDER_CODE` – the provider to clean up
- `YEAR` – the recruitment cycle
- `KEEP_CSV` – a CSV file listing the school URNs to keep

For NITE, the keep list is the 25 schools they have attached to courses.

For every school the provider has (in that year), it:

- keeps any school whose URN is in the CSV
- keeps the provider's main site
- skips and reports any school still attached to a course, so we never break a live course by accident
- removes the rest

Removal is a soft delete (discard). The schools disappear from Publish straight away but can be brought back if needed. Every removal is recorded in the audit log.

It also checks the keep list against the account and reports which of the 25 URNs were actually found and which were missing, so support can spot any data problems.

## Safety

- There is a dry run (`remove_provider_schools:dry_run`) that shows exactly what would happen without changing anything. Always run this first.
- A summary is saved for every run with counts and details (removed, skipped, kept).
- Nothing is hard deleted, so it can be undone.

## How to run

```
PROVIDER_CODE=XYZ YEAR=2026 KEEP_CSV=/path/to/keep.csv rake remove_provider_schools:dry_run
PROVIDER_CODE=XYZ YEAR=2026 KEEP_CSV=/path/to/keep.csv rake remove_provider_schools:run
```

Check the dry run summary first: removed count should be about 1,225, kept count should be 25 (look into anything missing), and review the skipped-with-courses list before doing the real run.

## Tests

New specs cover the filter, the discard, the dry run, the summary, the keep-list check, and the rake flow. All green.
