### PR TITLE
Implement Course start date step

### DIFF
--- a/app/views/publish/course_wizards/steps/_start_date.html.erb
+++ b/app/views/publish/course_wizards/steps/_start_date.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.start_date.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.start_date.caption")) %>
+  <%= t("course_wizard.steps.start_date.heading") %>
+</h1>
+
+<%= form.govuk_radio_buttons_fieldset :start_date, legend: { hidden: true, text: t("course_wizard.steps.start_date.heading") } do %>
+  <% current_step.start_date_options.each do |option| %>
+    <%= form.govuk_radio_button :start_date, option, label: { text: option } %>
+  <% end %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.start_date.submit") %>

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -20,6 +20,7 @@ class CourseWizard
       graph.add_node :study_pattern, Steps::StudyPattern
       graph.add_node :schools, Steps::Schools
       graph.add_node :study_sites, Steps::StudySites
+      graph.add_node :start_date, Steps::StartDate
 
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
@@ -51,7 +52,20 @@ class CourseWizard
 
       graph.add_edge from: :schools, to: :study_sites
 
-      graph.add_edge from: :study_sites, to: :courses_index
+      graph.add_multiple_conditional_edges(
+        from: :study_sites,
+        branches: [
+          # Further education does not require visa sponsorship in the
+          # existing flow, so it goes straight to start date.
+          { when: :further_education_level?, then: :start_date },
+          # TDA also goes straight to start date.
+          { when: :undergraduate_degree_with_qts?, then: :start_date },
+        ],
+        # TODO: Visa sponsorship steps for other routes will go here.
+        default: :courses_index,
+      )
+
+      graph.add_edge from: :start_date, to: :courses_index
     end
   end
 
@@ -77,5 +91,13 @@ class CourseWizard
         end
       },
     )
+  end
+
+  def provider
+    @provider ||= recruitment_cycle.providers.find_by!(provider_code:)
+  end
+
+  def recruitment_cycle
+    @recruitment_cycle ||= RecruitmentCycle.find_by!(year: recruitment_cycle_year)
   end
 end

--- a/app/wizards/course_wizard/steps/schools.rb
+++ b/app/wizards/course_wizard/steps/schools.rb
@@ -39,15 +39,7 @@ class CourseWizard
       end
 
       def provider_sites
-        provider.sites
-      end
-
-      def provider
-        @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)
-      end
-
-      def recruitment_cycle
-        @recruitment_cycle ||= RecruitmentCycle.find_by!(year: wizard.recruitment_cycle_year)
+        wizard.provider.sites
       end
 
       def funding_type

--- a/app/wizards/course_wizard/steps/start_date.rb
+++ b/app/wizards/course_wizard/steps/start_date.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class StartDate
+      include DfE::Wizard::Step
+
+      attribute :start_date
+
+      validates :start_date, presence: { message: I18n.t("course_wizard.steps.start_date.errors.start_date.blank") }
+
+      def start_date_options
+        cycle_year = wizard.provider.recruitment_cycle.year.to_i
+        options = (1..12).map { |m| "#{Date::MONTHNAMES[m]} #{cycle_year}" } +
+          (1..7).map { |m| "#{Date::MONTHNAMES[m]} #{cycle_year + 1}" }
+
+        return options if persisted?
+
+        index = options.index(sliced_label_for_today(cycle_year))
+
+        index.blank? ? options : options[index..]
+      end
+
+      def self.permitted_params
+        [:start_date]
+      end
+
+    private
+
+      def sliced_label_for_today(cycle_year)
+        today = Time.zone.today
+        january_label = january_label_for(cycle_year)
+
+        if today.year < cycle_year
+          # We're before January starts, so slice at "January <cycle_year>"
+          january_label
+        elsif today.year == cycle_year
+          # In cycle year, slice at the actual month
+          "#{Date::MONTHNAMES[today.month]} #{cycle_year}"
+        else
+          # Default to first month
+          january_label
+        end
+      end
+
+      def january_label_for(cycle_year)
+        "#{Date::MONTHNAMES[1]} #{cycle_year}"
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/start_date.rb
+++ b/app/wizards/course_wizard/steps/start_date.rb
@@ -10,11 +10,12 @@ class CourseWizard
       validates :start_date, presence: { message: I18n.t("course_wizard.steps.start_date.errors.start_date.blank") }
 
       def start_date_options
-        cycle_year = wizard.provider.recruitment_cycle.year.to_i
+        cycle_year = wizard.recruitment_cycle_year.to_i
+
         options = (1..12).map { |m| "#{Date::MONTHNAMES[m]} #{cycle_year}" } +
           (1..7).map { |m| "#{Date::MONTHNAMES[m]} #{cycle_year + 1}" }
 
-        return options if persisted?
+        return options if start_date.present?
 
         index = options.index(sliced_label_for_today(cycle_year))
 

--- a/app/wizards/course_wizard/steps/study_sites.rb
+++ b/app/wizards/course_wizard/steps/study_sites.rb
@@ -8,21 +8,11 @@ class CourseWizard
       attribute :study_sites_ids
 
       def study_sites
-        provider.study_sites.sort_by(&:location_name)
+        wizard.provider.study_sites.sort_by(&:location_name)
       end
 
       def self.permitted_params
         [{ study_sites_ids: [] }]
-      end
-
-    private
-
-      def provider
-        @provider ||= recruitment_cycle.providers.find_by!(provider_code: wizard.provider_code)
-      end
-
-      def recruitment_cycle
-        @recruitment_cycle ||= RecruitmentCycle.find_by!(year: wizard.recruitment_cycle_year)
       end
     end
   end

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -118,6 +118,13 @@ en:
         heading: Study sites
         submit: Continue
         hint: Select all that apply
+      start_date:
+        caption: Add course
+        heading: Course start date
+        submit: Continue
+        errors:
+          start_date:
+            blank: Select a course start date
   activemodel:
     errors:
       models:

--- a/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/start_date_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard start date step when qualification is undergraduate degree with qts", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user(cycle_year: Date.current.year)
+  end
+
+  scenario "choosing a start date and continues to courses index page" do
+    and_i_have_wizard_state_for_start_date
+    when_i_visit_the_wizard_start_date_page
+    and_i_choose_a_start_date(current_cycle_current_month_label(cycle_year: Date.current.year))
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "submitting start date without selecting an option shows validation errors" do
+    and_i_have_wizard_state_for_start_date
+    when_i_visit_the_wizard_start_date_page
+    and_i_click_continue
+    then_i_have_errors_on_the_start_date_step
+  end
+
+  scenario "shows options from the current month when in the recruitment cycle year" do
+    and_i_have_wizard_state_for_start_date
+    when_i_visit_the_wizard_start_date_page
+
+    expect(page).to have_content("Course start date")
+    expect(page).to have_field(current_cycle_current_month_label(cycle_year: Date.current.year))
+    expect(page).to have_field("July #{Date.current.year + 1}")
+    expect(page).not_to have_field(previous_month_label(cycle_year: Date.current.year)) if Date.current.month > 1
+  end
+
+  scenario "shows options starting from January when provider recruitment cycle is in the future" do
+    given_i_am_authenticated_as_a_provider_user(cycle_year: Date.current.year + 1)
+    and_i_have_wizard_state_for_start_date
+    when_i_visit_the_wizard_start_date_page
+
+    expect(page).to have_content("Course start date")
+    expect(page).to have_field("January #{Date.current.year + 1}")
+    expect(page).not_to have_field("December #{Date.current.year}")
+    expect(page).to have_field("July #{Date.current.year + 2}")
+  end
+
+private
+
+  def when_i_visit_the_wizard_start_date_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :start_date,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def and_i_choose_a_start_date(start_date)
+    choose start_date
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_courses_index_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_have_errors_on_the_start_date_step
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select a course start date")
+  end
+
+  def given_i_am_authenticated_as_a_provider_user(cycle_year:)
+    recruitment_cycle = find_or_create(:recruitment_cycle, year: cycle_year)
+
+    @user = create(
+      :user,
+      providers: [
+        create(:provider, :accredited_provider, recruitment_cycle:),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+
+  def current_cycle_current_month_label(cycle_year:)
+    "#{Date::MONTHNAMES[Date.current.month]} #{cycle_year}"
+  end
+
+  def previous_month_label(cycle_year:)
+    "#{Date::MONTHNAMES[Date.current.month - 1]} #{cycle_year}"
+  end
+
+  def and_i_have_wizard_state_for_start_date
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
+    state_store.write(
+      level: "primary",
+      qualification: "undergraduate_degree_with_qts",
+    )
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
@@ -8,11 +8,27 @@ RSpec.describe "Add course wizard study sites step", type: :system do
     given_i_am_authenticated_as_a_provider_user_with_multiple_schools
   end
 
-  scenario "choosing a study site and continues to courses index page" do
+  scenario "choosing a study site and continues to courses index page when qualification is not TDA or further education" do
     when_i_visit_the_wizard_study_sites_page
     and_i_choose_a_study_site_from_the_list
     and_i_click_continue
     then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "choosing a study site and continues to start date page when qualification is TDA" do
+    and_i_have_wizard_state_for_study_sites(qualification: "undergraduate_degree_with_qts")
+    when_i_visit_the_wizard_study_sites_page
+    and_i_choose_a_study_site_from_the_list
+    and_i_click_continue
+    then_i_am_taken_to_the_start_date_page
+  end
+
+  scenario "choosing a study site and continues to start date page when level is further education" do
+    and_i_have_wizard_state_for_study_sites(level: "further_education")
+    when_i_visit_the_wizard_study_sites_page
+    and_i_choose_a_study_site_from_the_list
+    and_i_click_continue
+    then_i_am_taken_to_the_start_date_page
   end
 
 private
@@ -44,6 +60,18 @@ private
     )
   end
 
+  def then_i_am_taken_to_the_start_date_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :start_date,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
   def given_i_am_authenticated_as_a_provider_user_with_multiple_schools
     @user = create(
       :user,
@@ -70,5 +98,17 @@ private
 
   def wizard_state_key
     @wizard_state_key ||= SecureRandom.uuid
+  end
+
+  def and_i_have_wizard_state_for_study_sites(qualification: nil, level: nil)
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
+    state_store.write(qualification:, level:)
   end
 end

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "study_pattern" => %w[full_time part_time] })
       repository.write({ "site_ids" => %w[1 2] })
       repository.write({ "study_sites_ids" => %w[3 4] })
+      repository.write({ "start_date" => "January 2026" })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -42,6 +43,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:study_pattern]).to eq(%w[full_time part_time])
       expect(data[:site_ids]).to eq(%w[1 2])
       expect(data[:study_sites_ids]).to eq(%w[3 4])
+      expect(data[:start_date]).to eq("January 2026")
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/steps/start_date_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/start_date_spec.rb
@@ -36,24 +36,24 @@ RSpec.describe CourseWizard::Steps::StartDate do
 
   describe "#start_date_options" do
     it "starts from the current month when in the recruitment cycle year" do
-      travel_to Date.new(2026, 6, 15) do
-        options = wizard_step.start_date_options
+      allow(Time.zone).to receive(:today).and_return(Date.new(2026, 6, 15))
 
-        expect(options.first).to eq("June 2026")
-        expect(options).to include("July 2027")
-        expect(options).not_to include("May 2026")
-      end
+      options = wizard_step.start_date_options
+
+      expect(options.first).to eq("June 2026")
+      expect(options).to include("July 2027")
+      expect(options).not_to include("May 2026")
     end
 
     context "when today is after the recruitment cycle year" do
       it "falls back to January of the cycle year" do
-        travel_to Date.new(2027, 2, 1) do
-          options = wizard_step.start_date_options
+        allow(Time.zone).to receive(:today).and_return(Date.new(2027, 2, 1))
 
-          expect(options.first).to eq("January 2026")
-          expect(options).to include("July 2027")
-          expect(options).to include("February 2026")
-        end
+        options = wizard_step.start_date_options
+
+        expect(options.first).to eq("January 2026")
+        expect(options).to include("July 2027")
+        expect(options).to include("February 2026")
       end
     end
 
@@ -61,13 +61,13 @@ RSpec.describe CourseWizard::Steps::StartDate do
       let(:cycle_year) { 2027 }
 
       it "starts from January of the cycle year" do
-        travel_to Date.new(2026, 6, 15) do
-          options = wizard_step.start_date_options
+        allow(Time.zone).to receive(:today).and_return(Date.new(2026, 6, 15))
 
-          expect(options.first).to eq("January 2027")
-          expect(options).to include("July 2028")
-          expect(options).not_to include("December 2026")
-        end
+        options = wizard_step.start_date_options
+
+        expect(options.first).to eq("January 2027")
+        expect(options).to include("July 2028")
+        expect(options).not_to include("December 2026")
       end
     end
   end

--- a/spec/wizards/add_course_wizard/steps/start_date_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/start_date_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::StartDate do
+  subject(:wizard_step) { wizard.current_step }
+
+  include_context "add_course_wizard"
+
+  let(:current_step) { :start_date }
+  let(:provider_code) { provider.provider_code }
+  let(:recruitment_cycle_year) { provider.recruitment_cycle_year }
+  let(:current_step_params) { { start_date: } }
+  let(:start_date) { nil }
+
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: cycle_year) }
+  let(:cycle_year) { 2026 }
+  let(:provider) { create(:provider, :accredited_provider, recruitment_cycle:) }
+
+  describe "#valid?" do
+    context "when start_date is present" do
+      it "is valid" do
+        wizard_step.start_date = "January 2026"
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context "when start_date is not present" do
+      it "is not valid" do
+        wizard_step.start_date = nil
+        expect(wizard_step).not_to be_valid
+        expect(wizard_step.errors.messages_for(:start_date)).to contain_exactly("Select a course start date")
+      end
+    end
+  end
+
+  describe "#start_date_options" do
+    it "starts from the current month when in the recruitment cycle year" do
+      travel_to Date.new(2026, 6, 15) do
+        options = wizard_step.start_date_options
+
+        expect(options.first).to eq("June 2026")
+        expect(options).to include("July 2027")
+        expect(options).not_to include("May 2026")
+      end
+    end
+
+    context "when today is after the recruitment cycle year" do
+      it "falls back to January of the cycle year" do
+        travel_to Date.new(2027, 2, 1) do
+          options = wizard_step.start_date_options
+
+          expect(options.first).to eq("January 2026")
+          expect(options).to include("July 2027")
+          expect(options).to include("February 2026")
+        end
+      end
+    end
+
+    context "when the recruitment cycle year is in the future" do
+      let(:cycle_year) { 2027 }
+
+      it "starts from January of the cycle year" do
+        travel_to Date.new(2026, 6, 15) do
+          options = wizard_step.start_date_options
+
+          expect(options.first).to eq("January 2027")
+          expect(options).to include("July 2028")
+          expect(options).not_to include("December 2026")
+        end
+      end
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq(%i[start_date])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -154,6 +154,34 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
   context "from study sites" do
     let(:current_step) { :study_sites }
 
+    it "proceeds to courses page by default" do
+      expect(wizard).to have_next_step(:courses_index)
+    end
+
+    context "when qualification is undergraduate degree with qts" do
+      before do
+        state_store.write(qualification: "undergraduate_degree_with_qts")
+      end
+
+      it "proceeds to start date page" do
+        expect(wizard).to have_next_step(:start_date)
+      end
+    end
+
+    context "when level is further education" do
+      before do
+        state_store.write(level: "further_education")
+      end
+
+      it "proceeds to start date page" do
+        expect(wizard).to have_next_step(:start_date)
+      end
+    end
+  end
+
+  context "from start date" do
+    let(:current_step) { :start_date }
+
     it "proceeds to courses page" do
       expect(wizard).to have_next_step(:courses_index)
     end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -152,4 +152,12 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:schools)
     end
   end
+
+  context "from start date" do
+    let(:current_step) { :start_date }
+
+    it "goes back to study sites" do
+      expect(wizard).to have_previous_step(:study_sites)
+    end
+  end
 end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -153,8 +153,24 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
     end
   end
 
-  context "from start date" do
+  context "from start date with undergraduate degree with QTS qualification" do
     let(:current_step) { :start_date }
+
+    before do
+      state_store.write(qualification: "undergraduate_degree_with_qts")
+    end
+
+    it "goes back to study sites" do
+      expect(wizard).to have_previous_step(:study_sites)
+    end
+  end
+
+  context "from start date with further education level" do
+    let(:current_step) { :start_date }
+
+    before do
+      state_store.write(level: "further_education")
+    end
 
     it "goes back to study sites" do
       expect(wizard).to have_previous_step(:study_sites)


### PR DESCRIPTION
## Context

Add Course start date step

## Changes proposed in this pull request

- Add new step
- Add tests
- Update tests
- Refactor `provider` and `recruitment_cycle` to be referenced in `course_wizard.rb` t o reduce repetitive code duplication across steps.

## Guidance to review

Run through the flow compare to QA please note the below. Validate this is working as expected and compare with QA.

```
      graph.add_multiple_conditional_edges(
        from: :study_sites,
        branches: [
          # Further education does not require visa sponsorship in the
          # existing flow, so it goes straight to start date.
          { when: :further_education_level?, then: :start_date },
          # TDA also goes straight to start date.
          { when: :undergraduate_degree_with_qts?, then: :start_date },
        ],
        # TODO: Visa sponsorship steps for other routes will go here.
        default: :courses_index,
      )
```

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
