### PR TITLE
Implement Visa sponsorship and Accredited provider step

### DIFF
--- a/app/views/publish/course_wizards/steps/_accredited_provider.html.erb
+++ b/app/views/publish/course_wizards/steps/_accredited_provider.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.accredited_provider.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.accredited_provider.caption")) %>
+  <%= t("course_wizard.steps.accredited_provider.heading") %>
+</h1>
+
+<%= form.govuk_radio_buttons_fieldset :accredited_provider_code, legend: { hidden: true, text: t("course_wizard.steps.accredited_provider.heading") } do %>
+  <% current_step.accredited_partners.each do |accredited_partner| %>
+    <%= form.govuk_radio_button :accredited_provider_code,
+      accredited_partner.provider_code,
+      label: { text: accredited_partner.provider_name } %>
+  <% end %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.accredited_provider.submit") %>

--- a/app/views/publish/course_wizards/steps/_visa_sponsorship.html.erb
+++ b/app/views/publish/course_wizards/steps/_visa_sponsorship.html.erb
@@ -1,0 +1,35 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.visa_sponsorship.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.visa_sponsorship.caption")) %>
+  <%= t("course_wizard.steps.visa_sponsorship.heading") %>
+</h1>
+
+<% if current_step.show_recruiting_from_overseas_guidance? %>
+  <p class="govuk-body">
+    <%= t("course_wizard.steps.visa_sponsorship.recruiting_from_overseas.prefix") %>
+    <%= govuk_link_to t("course_wizard.steps.visa_sponsorship.recruiting_from_overseas.link_text"), t("course_wizard.steps.visa_sponsorship.recruiting_from_overseas.link_url"), target: "_blank" %>.
+  </p>
+<% end %>
+
+<h2 class="govuk-heading-m">
+  <%= current_step.question %>
+</h2>
+
+<% if current_step.show_accrediting_provider_inset_text? %>
+  <div class="govuk-inset-text">
+    <% if current_step.accrediting_provider_can_sponsor_student_visa? %>
+      <%= t("course_wizard.steps.visa_sponsorship.inset.can_sponsor", provider_name: current_step.accrediting_provider_name) %>
+    <% else %>
+      <p class="govuk-body"><%= t("course_wizard.steps.visa_sponsorship.inset.cannot_sponsor", provider_name: current_step.accrediting_provider_name) %></p>
+      <p class="govuk-body"><%= t("course_wizard.steps.visa_sponsorship.inset.contact_provider", provider_name: current_step.accrediting_provider_name) %></p>
+    <% end %>
+  </div>
+<% end %>
+
+<%= form.govuk_radio_buttons_fieldset :can_sponsor_student_visa, legend: { hidden: true } do %>
+  <%= form.govuk_radio_button :can_sponsor_student_visa, true, label: { text: t("course_wizard.steps.visa_sponsorship.options.can_sponsor_student_visa.label") } %>
+  <%= form.govuk_radio_button :can_sponsor_student_visa, false, label: { text: t("course_wizard.steps.visa_sponsorship.options.cannot_sponsor_student_visa.label") } %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.visa_sponsorship.submit") %>

--- a/app/views/publish/course_wizards/steps/_visa_sponsorship.html.erb
+++ b/app/views/publish/course_wizards/steps/_visa_sponsorship.html.erb
@@ -19,7 +19,7 @@
 <% if current_step.show_accrediting_provider_inset_text? %>
   <div class="govuk-inset-text">
     <% if current_step.accrediting_provider_can_sponsor_student_visa? %>
-      <%= t("course_wizard.steps.visa_sponsorship.inset.can_sponsor", provider_name: current_step.accrediting_provider_name) %>
+      <p class="govuk-body"><%= t("course_wizard.steps.visa_sponsorship.inset.can_sponsor", provider_name: current_step.accrediting_provider_name) %></p>
     <% else %>
       <p class="govuk-body"><%= t("course_wizard.steps.visa_sponsorship.inset.cannot_sponsor", provider_name: current_step.accrediting_provider_name) %></p>
       <p class="govuk-body"><%= t("course_wizard.steps.visa_sponsorship.inset.contact_provider", provider_name: current_step.accrediting_provider_name) %></p>

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -65,6 +65,9 @@ class CourseWizard
           # School-based providers with multiple accredited partners need
           # to choose who is accrediting the course.
           { when: :accredited_provider_selection_required?, then: :accredited_provider },
+
+          # TODO: mirror visa split here:
+          # non-fee courses -> Skilled Worker visa path, fee courses -> Student visa path.
         ],
         default: :visa_sponsorship,
       )

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -121,16 +121,21 @@ class CourseWizard
   end
 
   def accredited_provider_selection_required?
-    !provider.accredited? && provider.accredited_partners.many?
+    !provider.accredited? && accredited_partners.many?
   end
 
   def accrediting_provider
     return if provider.accredited?
 
-    partners = provider.accredited_partners
-    return partners.first if partners.one?
+    @accrediting_provider ||= begin
+      return accredited_partners.first if accredited_partners.one?
 
-    selected_provider_code = state_store.accredited_provider_code
-    partners.find_by(provider_code: selected_provider_code) if selected_provider_code.present?
+      selected_provider_code = state_store.accredited_provider_code
+      accredited_partners.find { |partner| partner.provider_code == selected_provider_code } if selected_provider_code.present?
+    end
+  end
+
+  def accredited_partners
+    @accredited_partners ||= provider.accredited_partners.to_a
   end
 end

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -19,7 +19,8 @@ class CourseWizard
       graph.add_node :funding_type, Steps::FundingType
       graph.add_node :study_pattern, Steps::StudyPattern
       graph.add_node :schools, Steps::Schools
-      graph.add_node :study_sites, Steps::StudySites
+      graph.add_node :study_sites, Steps::StudySites, skip_when: :skip_study_sites?
+      graph.add_node :accredited_provider, Steps::AccreditedProvider
       graph.add_node :start_date, Steps::StartDate
       graph.add_node :visa_sponsorship, Steps::VisaSponsorship
 
@@ -61,9 +62,14 @@ class CourseWizard
           { when: :further_education_level?, then: :start_date },
           # TDA also goes straight to start date.
           { when: :undergraduate_degree_with_qts?, then: :start_date },
+          # School-based providers with multiple accredited partners need
+          # to choose who is accrediting the course.
+          { when: :accredited_provider_selection_required?, then: :accredited_provider },
         ],
         default: :visa_sponsorship,
       )
+
+      graph.add_edge from: :accredited_provider, to: :visa_sponsorship
 
       graph.add_multiple_conditional_edges(
         from: :visa_sponsorship,
@@ -110,9 +116,21 @@ class CourseWizard
     @recruitment_cycle ||= RecruitmentCycle.find_by!(year: recruitment_cycle_year)
   end
 
-  def accrediting_provider
-    return unless provider.accredited_partners.one?
+  def skip_study_sites?
+    provider.study_sites.none?
+  end
 
-    @accrediting_provider ||= provider.accredited_partners.first
+  def accredited_provider_selection_required?
+    !provider.accredited? && provider.accredited_partners.many?
+  end
+
+  def accrediting_provider
+    return if provider.accredited?
+
+    partners = provider.accredited_partners
+    return partners.first if partners.one?
+
+    selected_provider_code = state_store.accredited_provider_code
+    partners.find_by(provider_code: selected_provider_code) if selected_provider_code.present?
   end
 end

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -21,6 +21,7 @@ class CourseWizard
       graph.add_node :schools, Steps::Schools
       graph.add_node :study_sites, Steps::StudySites
       graph.add_node :start_date, Steps::StartDate
+      graph.add_node :visa_sponsorship, Steps::VisaSponsorship
 
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
@@ -61,8 +62,7 @@ class CourseWizard
           # TDA also goes straight to start date.
           { when: :undergraduate_degree_with_qts?, then: :start_date },
         ],
-        # TODO: Visa sponsorship steps for other routes will go here.
-        default: :courses_index,
+        default: :visa_sponsorship,
       )
 
       graph.add_edge from: :start_date, to: :courses_index
@@ -99,5 +99,11 @@ class CourseWizard
 
   def recruitment_cycle
     @recruitment_cycle ||= RecruitmentCycle.find_by!(year: recruitment_cycle_year)
+  end
+
+  def accrediting_provider
+    return unless provider.accredited_partners.one?
+
+    @accrediting_provider ||= provider.accredited_partners.first
   end
 end

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -5,6 +5,8 @@ class CourseWizard
 
   attr_accessor :recruitment_cycle_year, :provider_code, :state_key
 
+  delegate :accrediting_provider, to: :accreditation
+
   delegate :further_education_level?, :primary_level?, :undergraduate_degree_with_qts?, :visa_sponsorship_required?, to: :state_store
 
   def steps_processor
@@ -124,21 +126,13 @@ class CourseWizard
   end
 
   def accredited_provider_selection_required?
-    !provider.accredited? && accredited_partners.many?
+    accreditation.selection_required?
   end
 
-  def accrediting_provider
-    return if provider.accredited?
-
-    @accrediting_provider ||= begin
-      return accredited_partners.first if accredited_partners.one?
-
-      selected_provider_code = state_store.accredited_provider_code
-      accredited_partners.find { |partner| partner.provider_code == selected_provider_code } if selected_provider_code.present?
-    end
-  end
-
-  def accredited_partners
-    @accredited_partners ||= provider.accredited_partners.to_a
+  def accreditation
+    @accreditation ||= Accreditation.new(
+      provider:,
+      selected_provider_code: state_store.accredited_provider_code,
+    )
   end
 end

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -5,7 +5,7 @@ class CourseWizard
 
   attr_accessor :recruitment_cycle_year, :provider_code, :state_key
 
-  delegate :further_education_level?, :primary_level?, :undergraduate_degree_with_qts?, to: :state_store
+  delegate :further_education_level?, :primary_level?, :undergraduate_degree_with_qts?, :visa_sponsorship_required?, to: :state_store
 
   def steps_processor
     DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
@@ -63,6 +63,15 @@ class CourseWizard
           { when: :undergraduate_degree_with_qts?, then: :start_date },
         ],
         default: :visa_sponsorship,
+      )
+
+      graph.add_multiple_conditional_edges(
+        from: :visa_sponsorship,
+        branches: [
+          # TODO: when true go to visa sponsorship application deadline page
+          { when: :visa_sponsorship_required?, then: :courses_index },
+        ],
+        default: :start_date,
       )
 
       graph.add_edge from: :start_date, to: :courses_index

--- a/app/wizards/course_wizard/accreditation.rb
+++ b/app/wizards/course_wizard/accreditation.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  class Accreditation
+    def initialize(provider:, selected_provider_code: nil)
+      @provider = provider
+      @selected_provider_code = selected_provider_code
+    end
+
+    def selection_required?
+      requires_partner? && partners.many?
+    end
+
+    def accrediting_provider
+      return unless requires_partner?
+      return partners.first if partners.one?
+
+      selected_partner
+    end
+
+    def partners
+      @partners ||= provider.accredited_partners.sort_by(&:provider_name)
+    end
+
+  private
+
+    attr_reader :provider, :selected_provider_code
+
+    def requires_partner?
+      !provider.accredited?
+    end
+
+    def selected_partner
+      return if selected_provider_code.blank?
+
+      partners.find { |partner| partner.provider_code == selected_provider_code }
+    end
+  end
+end

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -18,7 +18,7 @@ class CourseWizard
       end
 
       def visa_sponsorship_required?
-        ActiveModel::Type::Boolean.new.cast(can_sponsor_student_visa) == true
+        ActiveModel::Type::Boolean.new.cast(can_sponsor_student_visa)
       end
     end
   end

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -16,6 +16,10 @@ class CourseWizard
       def undergraduate_degree_with_qts?
         qualification == "undergraduate_degree_with_qts"
       end
+
+      def visa_sponsorship_required?
+        can_sponsor_student_visa == true
+      end
     end
   end
 end

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -18,7 +18,7 @@ class CourseWizard
       end
 
       def visa_sponsorship_required?
-        can_sponsor_student_visa == true
+        ActiveModel::Type::Boolean.new.cast(can_sponsor_student_visa) == true
       end
     end
   end

--- a/app/wizards/course_wizard/steps/accredited_provider.rb
+++ b/app/wizards/course_wizard/steps/accredited_provider.rb
@@ -10,7 +10,7 @@ class CourseWizard
       validates :accredited_provider_code, presence: { message: I18n.t("course_wizard.steps.accredited_provider.errors.accredited_provider_code.blank") }
 
       def accredited_partners
-        wizard.provider.accredited_partners.sort_by(&:provider_name)
+        wizard.accreditation.partners
       end
 
       def self.permitted_params

--- a/app/wizards/course_wizard/steps/accredited_provider.rb
+++ b/app/wizards/course_wizard/steps/accredited_provider.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class AccreditedProvider
+      include DfE::Wizard::Step
+
+      attribute :accredited_provider_code, :string
+
+      validates :accredited_provider_code, presence: { message: I18n.t("course_wizard.steps.accredited_provider.errors.accredited_provider_code.blank") }
+
+      def accredited_partners
+        wizard.provider.accredited_partners.sort_by(&:provider_name)
+      end
+
+      def self.permitted_params
+        [:accredited_provider_code]
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/visa_sponsorship.rb
+++ b/app/wizards/course_wizard/steps/visa_sponsorship.rb
@@ -50,7 +50,7 @@ class CourseWizard
       end
 
       def accrediting_provider
-        wizard.accrediting_provider
+        wizard.accreditation.accrediting_provider
       end
     end
   end

--- a/app/wizards/course_wizard/steps/visa_sponsorship.rb
+++ b/app/wizards/course_wizard/steps/visa_sponsorship.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class VisaSponsorship
+      include DfE::Wizard::Step
+      VISA_SPONSORSHIP_OPTIONS = %w[yes no].freeze
+
+      attribute :can_sponsor_student_visa
+
+      validates :can_sponsor_student_visa, inclusion: { in: VISA_SPONSORSHIP_OPTIONS, message: I18n.t("course_wizard.steps.visa_sponsorship.errors.can_sponsor_student_visa.blank") }
+
+      def question
+        if wizard.provider.university? || wizard.provider.scitt?
+          I18n.t("course_wizard.steps.visa_sponsorship.questions.organisation")
+        else
+          I18n.t("course_wizard.steps.visa_sponsorship.questions.availability")
+        end
+      end
+
+      def show_recruiting_from_overseas_guidance?
+        (wizard.provider.university? || wizard.provider.scitt?) && !wizard.provider.can_sponsor_student_visa
+      end
+
+      def show_accrediting_provider_inset_text?
+        !wizard.provider.university? && !wizard.provider.scitt? && accrediting_provider.present?
+      end
+
+      def accrediting_provider_name
+        accrediting_provider&.provider_name
+      end
+
+      def accrediting_provider_can_sponsor_student_visa?
+        accrediting_provider&.can_sponsor_student_visa?
+      end
+
+      def self.permitted_params
+        [:can_sponsor_student_visa]
+      end
+
+    private
+
+      def accrediting_provider
+        wizard.accrediting_provider
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/visa_sponsorship.rb
+++ b/app/wizards/course_wizard/steps/visa_sponsorship.rb
@@ -9,6 +9,12 @@ class CourseWizard
 
       validates :can_sponsor_student_visa, inclusion: { in: [true, false], message: I18n.t("course_wizard.steps.visa_sponsorship.errors.can_sponsor_student_visa.blank") }
 
+      def can_sponsor_student_visa
+        return super unless super.nil? && default_to_no_from_accrediting_provider?
+
+        false
+      end
+
       def question
         if wizard.provider.accredited?
           I18n.t("course_wizard.steps.visa_sponsorship.questions.organisation")
@@ -38,6 +44,10 @@ class CourseWizard
       end
 
     private
+
+      def default_to_no_from_accrediting_provider?
+        show_accrediting_provider_inset_text? && !accrediting_provider_can_sponsor_student_visa?
+      end
 
       def accrediting_provider
         wizard.accrediting_provider

--- a/app/wizards/course_wizard/steps/visa_sponsorship.rb
+++ b/app/wizards/course_wizard/steps/visa_sponsorship.rb
@@ -4,14 +4,13 @@ class CourseWizard
   module Steps
     class VisaSponsorship
       include DfE::Wizard::Step
-      VISA_SPONSORSHIP_OPTIONS = %w[yes no].freeze
 
-      attribute :can_sponsor_student_visa
+      attribute :can_sponsor_student_visa, :boolean
 
-      validates :can_sponsor_student_visa, inclusion: { in: VISA_SPONSORSHIP_OPTIONS, message: I18n.t("course_wizard.steps.visa_sponsorship.errors.can_sponsor_student_visa.blank") }
+      validates :can_sponsor_student_visa, inclusion: { in: [true, false], message: I18n.t("course_wizard.steps.visa_sponsorship.errors.can_sponsor_student_visa.blank") }
 
       def question
-        if wizard.provider.university? || wizard.provider.scitt?
+        if wizard.provider.accredited?
           I18n.t("course_wizard.steps.visa_sponsorship.questions.organisation")
         else
           I18n.t("course_wizard.steps.visa_sponsorship.questions.availability")
@@ -19,11 +18,11 @@ class CourseWizard
       end
 
       def show_recruiting_from_overseas_guidance?
-        (wizard.provider.university? || wizard.provider.scitt?) && !wizard.provider.can_sponsor_student_visa
+        wizard.provider.accredited? && !wizard.provider.can_sponsor_student_visa
       end
 
       def show_accrediting_provider_inset_text?
-        !wizard.provider.university? && !wizard.provider.scitt? && accrediting_provider.present?
+        !wizard.provider.accredited? && accrediting_provider.present?
       end
 
       def accrediting_provider_name

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -125,6 +125,29 @@ en:
         errors:
           start_date:
             blank: Select a course start date
+      visa_sponsorship:
+        caption: Add course
+        heading: Student visas
+        submit: Continue
+        questions:
+          organisation: Can your organisation sponsor Student visas for this course?
+          availability: Is Student visa sponsorship available for this course?
+        recruiting_from_overseas:
+          prefix: Learn more about
+          link_text: recruiting trainee teachers from overseas
+          link_url: https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers
+        inset:
+          can_sponsor: "%{provider_name} can sponsor Student visas for some of their courses."
+          cannot_sponsor: "%{provider_name} have said they cannot sponsor Student visas so we have defaulted your answer to 'No'."
+          contact_provider: "If your organisation would like to sponsor Student visas, contact %{provider_name}."
+        options:
+          can_sponsor_student_visa:
+            label: "Yes"
+          cannot_sponsor_student_visa:
+            label: "No"
+        errors:
+          can_sponsor_student_visa:
+            blank: Select if student visas can be sponsored for this course
   activemodel:
     errors:
       models:

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -118,6 +118,13 @@ en:
         heading: Study sites
         submit: Continue
         hint: Select all that apply
+      accredited_provider:
+        caption: Add course
+        heading: Accredited provider
+        submit: Continue
+        errors:
+          accredited_provider_code:
+            blank: Select an accredited provider
       start_date:
         caption: Add course
         heading: Course start date

--- a/spec/support/shared_contexts/add_course_wizard.rb
+++ b/spec/support/shared_contexts/add_course_wizard.rb
@@ -23,6 +23,12 @@ RSpec.shared_context "add_course_wizard" do
   let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: recruitment_cycle_year) }
 
   let!(:provider) do
-    create(:provider, :accredited_provider, provider_code:, recruitment_cycle:)
+    create(
+      :provider,
+      :accredited_provider,
+      provider_code:,
+      recruitment_cycle:,
+      sites: [build(:site), build(:site, :study_site)],
+    )
   end
 end

--- a/spec/support/shared_contexts/add_course_wizard.rb
+++ b/spec/support/shared_contexts/add_course_wizard.rb
@@ -20,4 +20,9 @@ RSpec.shared_context "add_course_wizard" do
   let(:provider_code) { "ABC" }
   let(:recruitment_cycle_year) { 2026 }
   let(:state_key) { SecureRandom.uuid }
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle, year: recruitment_cycle_year) }
+
+  let!(:provider) do
+    create(:provider, :accredited_provider, provider_code:, recruitment_cycle:)
+  end
 end

--- a/spec/system/publish/courses/add_course_wizard/accredited_provider_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/accredited_provider_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard accredited provider step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_school_based_provider_user_with_multiple_accredited_partners
+    and_i_have_wizard_state_for_accredited_provider
+  end
+
+  scenario "choosing an accredited provider and continues to visa sponsorship page" do
+    when_i_visit_the_wizard_accredited_provider_page
+    and_i_choose_an_accredited_provider
+    and_i_click_continue
+    then_i_am_taken_to_the_visa_sponsorship_page
+  end
+
+  scenario "submitting without selecting an accredited provider shows validation errors" do
+    when_i_visit_the_wizard_accredited_provider_page
+    and_i_click_continue
+    then_i_have_errors_on_the_accredited_provider_step
+  end
+
+  scenario "shows accredited provider options" do
+    when_i_visit_the_wizard_accredited_provider_page
+    then_i_see_the_accredited_provider_page_content
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_school_based_provider_user_with_multiple_accredited_partners
+    school_provider = create(
+      :provider,
+      provider_type: :lead_school,
+      sites: wizard_sites,
+    )
+    @accredited_partner_one = create(
+      :accredited_provider,
+      provider_name: "Middlesex University",
+      recruitment_cycle: school_provider.recruitment_cycle,
+    )
+    @accredited_partner_two = create(
+      :accredited_provider,
+      provider_name: "University of Hertfordshire",
+      recruitment_cycle: school_provider.recruitment_cycle,
+    )
+    create(
+      :provider_partnership,
+      training_provider: school_provider,
+      accredited_provider: @accredited_partner_one,
+    )
+    create(
+      :provider_partnership,
+      training_provider: school_provider,
+      accredited_provider: @accredited_partner_two,
+    )
+
+    @user = create(:user, providers: [school_provider])
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_i_have_wizard_state_for_accredited_provider
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
+    state_store.write(level: "secondary")
+  end
+
+  def when_i_visit_the_wizard_accredited_provider_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :accredited_provider,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def and_i_choose_an_accredited_provider
+    choose @accredited_partner_one.provider_name
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_visa_sponsorship_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :visa_sponsorship,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_have_errors_on_the_accredited_provider_step
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select an accredited provider")
+  end
+
+  def then_i_see_the_accredited_provider_page_content
+    expect(page).to have_content("Add course")
+    expect(page).to have_content("Accredited provider")
+    expect(page).to have_field(@accredited_partner_one.provider_name, type: "radio")
+    expect(page).to have_field(@accredited_partner_two.provider_name, type: "radio")
+    expect(page).to have_button("Continue")
+  end
+
+  def wizard_sites
+    [
+      build(:site),
+      build(:site),
+    ]
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/schools_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/schools_spec.rb
@@ -127,7 +127,11 @@ private
     @user = create(
       :user,
       providers: [
-        create(:provider, :accredited_provider, sites: [build(:site), build(:site)]),
+        create(
+          :provider,
+          :accredited_provider,
+          sites: [build(:site), build(:site), build(:site, :study_site)],
+        ),
       ],
     )
 
@@ -138,7 +142,7 @@ private
     @user = create(
       :user,
       providers: [
-        create(:provider, :accredited_provider, sites: [build(:site)]),
+        create(:provider, :accredited_provider, sites: [build(:site), build(:site, :study_site)]),
       ],
     )
 

--- a/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "Add course wizard study sites step", type: :system do
     given_i_am_authenticated_as_a_provider_user_with_multiple_schools
   end
 
-  scenario "choosing a study site and continues to courses index page when qualification is not TDA or further education" do
+  scenario "choosing a study site and continues to visa sponsorship page when qualification is not TDA or further education" do
     when_i_visit_the_wizard_study_sites_page
     and_i_choose_a_study_site_from_the_list
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_visa_sponsorship_page
   end
 
   scenario "choosing a study site and continues to start date page when qualification is TDA" do
@@ -50,11 +50,13 @@ private
     click_on "Continue"
   end
 
-  def then_i_am_taken_to_the_courses_index_page
+  def then_i_am_taken_to_the_visa_sponsorship_page
     expect(page).to have_current_path(
-      publish_provider_recruitment_cycle_courses_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :visa_sponsorship,
+        state_key: wizard_state_key,
       ),
       ignore_query: true,
     )

--- a/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/study_sites_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe "Add course wizard study sites step", type: :system do
     then_i_am_taken_to_the_start_date_page
   end
 
+  scenario "provider with no study sites skips study sites and continues to accredited provider page" do
+    given_i_am_authenticated_as_a_school_based_provider_user_with_no_study_sites_and_multiple_accredited_partners
+    and_i_have_wizard_state_for_schools
+    when_i_visit_the_wizard_schools_page
+    and_i_choose_a_school_from_the_list
+    and_i_click_continue
+    then_i_am_taken_to_the_accredited_provider_page
+  end
+
 private
 
   def when_i_visit_the_wizard_study_sites_page
@@ -42,8 +51,21 @@ private
     )
   end
 
+  def when_i_visit_the_wizard_schools_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :schools,
+      state_key: wizard_state_key,
+    )
+  end
+
   def and_i_choose_a_study_site_from_the_list
     check provider.study_sites.first.location_name
+  end
+
+  def and_i_choose_a_school_from_the_list
+    check provider.sites.first.location_name
   end
 
   def and_i_click_continue
@@ -74,6 +96,18 @@ private
     )
   end
 
+  def then_i_am_taken_to_the_accredited_provider_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :accredited_provider,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
   def given_i_am_authenticated_as_a_provider_user_with_multiple_schools
     @user = create(
       :user,
@@ -89,6 +123,33 @@ private
           ],
         ),
       ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_i_am_authenticated_as_a_school_based_provider_user_with_no_study_sites_and_multiple_accredited_partners
+    @user = create(
+      :user,
+      providers: [
+        create(
+          :provider,
+          provider_type: :lead_school,
+          sites: [build(:site), build(:site)],
+        ),
+      ],
+    )
+
+    school_provider = @user.providers.first
+    create(
+      :provider_partnership,
+      training_provider: school_provider,
+      accredited_provider: create(:accredited_provider, recruitment_cycle: school_provider.recruitment_cycle),
+    )
+    create(
+      :provider_partnership,
+      training_provider: school_provider,
+      accredited_provider: create(:accredited_provider, recruitment_cycle: school_provider.recruitment_cycle),
     )
 
     given_i_am_authenticated(user: @user)
@@ -112,5 +173,17 @@ private
 
     state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
     state_store.write(qualification:, level:)
+  end
+
+  def and_i_have_wizard_state_for_schools
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
+    state_store.write(funding_type: "fee")
   end
 end

--- a/spec/system/publish/courses/add_course_wizard/visa_sponsorship_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/visa_sponsorship_spec.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard visa sponsorship step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+  end
+
+  scenario "choosing yes to visa sponsorship and continues to courses index" do
+    given_i_am_authenticated_as_an_accredited_provider_user
+    and_i_have_wizard_state_for_visa_sponsorship
+    when_i_visit_the_wizard_visa_sponsorship_page
+    and_i_choose_yes_to_the_visa_sponsorship_question
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "choosing no to visa sponsorship and continues to start date page" do
+    given_i_am_authenticated_as_an_accredited_provider_user
+    and_i_have_wizard_state_for_visa_sponsorship
+    when_i_visit_the_wizard_visa_sponsorship_page
+    and_i_choose_no_to_the_visa_sponsorship_question
+    and_i_click_continue
+    then_i_am_taken_to_the_start_date_page
+  end
+
+  scenario "choosing nil to visa sponsorship and shows validation errors" do
+    given_i_am_authenticated_as_an_accredited_provider_user
+    and_i_have_wizard_state_for_visa_sponsorship
+    when_i_visit_the_wizard_visa_sponsorship_page
+    and_i_click_continue
+    then_i_have_errors_on_the_visa_sponsorship_step
+  end
+
+  scenario "accredited provider that cannot sponsor student visas shows organisation question and overseas guidance" do
+    given_i_am_authenticated_as_an_accredited_provider_user(can_sponsor_student_visa: false)
+    when_i_visit_the_wizard_visa_sponsorship_page
+    then_i_see_the_common_visa_sponsorship_page_content
+    and_i_see_the_organisation_question
+    and_i_see_recruiting_from_overseas_guidance
+  end
+
+  scenario "accredited provider that can sponsor student visas shows organisation question without overseas guidance" do
+    given_i_am_authenticated_as_an_accredited_provider_user(can_sponsor_student_visa: true)
+    when_i_visit_the_wizard_visa_sponsorship_page
+    then_i_see_the_common_visa_sponsorship_page_content
+    and_i_see_the_organisation_question
+    and_i_do_not_see_recruiting_from_overseas_guidance
+  end
+
+  scenario "school-based provider shows availability question" do
+    given_i_am_authenticated_as_a_school_based_provider_user
+    when_i_visit_the_wizard_visa_sponsorship_page
+    then_i_see_the_common_visa_sponsorship_page_content
+    and_i_see_the_availability_question
+    and_i_do_not_see_recruiting_from_overseas_guidance
+    and_i_do_not_see_accrediting_provider_inset_text
+  end
+
+  scenario "school-based provider with accrediting partner that cannot sponsor shows inset text" do
+    given_i_am_authenticated_as_a_school_based_provider_user_with_accredited_partner(can_sponsor_student_visa: false)
+    when_i_visit_the_wizard_visa_sponsorship_page
+    then_i_see_the_common_visa_sponsorship_page_content
+    and_i_see_the_availability_question
+    and_i_see_accrediting_partner_cannot_sponsor_inset_text
+  end
+
+  scenario "school-based provider with accrediting partner that can sponsor shows inset text" do
+    given_i_am_authenticated_as_a_school_based_provider_user_with_accredited_partner(can_sponsor_student_visa: true)
+    when_i_visit_the_wizard_visa_sponsorship_page
+    then_i_see_the_common_visa_sponsorship_page_content
+    and_i_see_the_availability_question
+    and_i_see_accrediting_partner_can_sponsor_inset_text
+  end
+
+  scenario "school-based provider with multiple accrediting partners shows availability question only" do
+    given_i_am_authenticated_as_a_school_based_provider_user_with_multiple_accredited_partners
+    when_i_visit_the_wizard_visa_sponsorship_page
+    then_i_see_the_common_visa_sponsorship_page_content
+    and_i_see_the_availability_question
+    and_i_do_not_see_accrediting_provider_inset_text
+  end
+
+private
+
+  def given_i_am_authenticated_as_an_accredited_provider_user(can_sponsor_student_visa: false)
+    @user = create(
+      :user,
+      providers: [
+        create(
+          :provider,
+          :accredited_provider,
+          can_sponsor_student_visa:,
+          sites: wizard_sites,
+        ),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_i_am_authenticated_as_a_school_based_provider_user
+    @user = create(
+      :user,
+      providers: [
+        create(
+          :provider,
+          provider_type: :lead_school,
+          can_sponsor_student_visa: false,
+          sites: wizard_sites,
+        ),
+      ],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_i_am_authenticated_as_a_school_based_provider_user_with_accredited_partner(can_sponsor_student_visa:)
+    school_provider = create(
+      :provider,
+      provider_type: :lead_school,
+      can_sponsor_student_visa: false,
+      sites: wizard_sites,
+    )
+    @accrediting_provider = create(
+      :accredited_provider,
+      can_sponsor_student_visa:,
+      recruitment_cycle: school_provider.recruitment_cycle,
+    )
+    create(
+      :provider_partnership,
+      training_provider: school_provider,
+      accredited_provider: @accrediting_provider,
+    )
+
+    @user = create(:user, providers: [school_provider])
+    given_i_am_authenticated(user: @user)
+  end
+
+  def given_i_am_authenticated_as_a_school_based_provider_user_with_multiple_accredited_partners
+    school_provider = create(
+      :provider,
+      provider_type: :lead_school,
+      can_sponsor_student_visa: false,
+      sites: wizard_sites,
+    )
+    create(
+      :provider_partnership,
+      training_provider: school_provider,
+      accredited_provider: create(:accredited_provider, recruitment_cycle: school_provider.recruitment_cycle),
+    )
+    create(
+      :provider_partnership,
+      training_provider: school_provider,
+      accredited_provider: create(:accredited_provider, recruitment_cycle: school_provider.recruitment_cycle),
+    )
+
+    @user = create(:user, providers: [school_provider])
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_i_have_wizard_state_for_visa_sponsorship
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
+    state_store.write(level: "secondary")
+  end
+
+  def when_i_visit_the_wizard_visa_sponsorship_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :visa_sponsorship,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def and_i_choose_yes_to_the_visa_sponsorship_question
+    choose "Yes"
+  end
+
+  def and_i_choose_no_to_the_visa_sponsorship_question
+    choose "No"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_courses_index_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_am_taken_to_the_start_date_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :start_date,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_have_errors_on_the_visa_sponsorship_step
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select if student visas can be sponsored for this course")
+  end
+
+  def then_i_see_the_common_visa_sponsorship_page_content
+    expect(page).to have_content("Add course")
+    expect(page).to have_content("Student visas")
+    expect(page).to have_field("Yes", type: "radio")
+    expect(page).to have_field("No", type: "radio")
+    expect(page).to have_button("Continue")
+  end
+
+  def and_i_see_the_organisation_question
+    expect(page).to have_content("Can your organisation sponsor Student visas for this course?")
+    expect(page).not_to have_content("Is Student visa sponsorship available for this course?")
+  end
+
+  def and_i_see_the_availability_question
+    expect(page).to have_content("Is Student visa sponsorship available for this course?")
+    expect(page).not_to have_content("Can your organisation sponsor Student visas for this course?")
+  end
+
+  def and_i_see_recruiting_from_overseas_guidance
+    expect(page).to have_content("Learn more about")
+    expect(page).to have_link(
+      "recruiting trainee teachers from overseas",
+      href: "https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers",
+    )
+  end
+
+  def and_i_do_not_see_recruiting_from_overseas_guidance
+    expect(page).not_to have_content("Learn more about")
+    expect(page).not_to have_link("recruiting trainee teachers from overseas")
+  end
+
+  def and_i_see_accrediting_partner_can_sponsor_inset_text
+    expect(page).to have_content(
+      "#{@accrediting_provider.provider_name} can sponsor Student visas for some of their courses.",
+    )
+  end
+
+  def and_i_see_accrediting_partner_cannot_sponsor_inset_text
+    expect(page).to have_content(
+      "#{@accrediting_provider.provider_name} have said they cannot sponsor Student visas so we have defaulted your answer to 'No'.",
+    )
+    expect(page).to have_content(
+      "If your organisation would like to sponsor Student visas, contact #{@accrediting_provider.provider_name}.",
+    )
+  end
+
+  def and_i_do_not_see_accrediting_provider_inset_text
+    expect(page).not_to have_css(".govuk-inset-text")
+  end
+
+  def wizard_sites
+    [
+      build(:site),
+      build(:site),
+      build(:site, :study_site),
+      build(:site, :study_site),
+    ]
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/visa_sponsorship_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/visa_sponsorship_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe "Add course wizard visa sponsorship step", type: :system do
     then_i_see_the_common_visa_sponsorship_page_content
     and_i_see_the_availability_question
     and_i_see_accrediting_partner_cannot_sponsor_inset_text
+    and_i_see_no_selected_by_default
+  end
+
+  scenario "school-based provider with accrediting partner that cannot sponsor and continues without choosing" do
+    given_i_am_authenticated_as_a_school_based_provider_user_with_accredited_partner(can_sponsor_student_visa: false)
+    when_i_visit_the_wizard_visa_sponsorship_page
+    and_i_click_continue
+    then_i_am_taken_to_the_start_date_page
   end
 
   scenario "school-based provider with accrediting partner that can sponsor shows inset text" do
@@ -268,6 +276,11 @@ private
 
   def and_i_do_not_see_accrediting_provider_inset_text
     expect(page).not_to have_css(".govuk-inset-text")
+  end
+
+  def and_i_see_no_selected_by_default
+    expect(page).to have_checked_field("No")
+    expect(page).to have_unchecked_field("Yes")
   end
 
   def wizard_sites

--- a/spec/wizards/add_course_wizard/accreditation_spec.rb
+++ b/spec/wizards/add_course_wizard/accreditation_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Accreditation do
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
+  let(:selected_provider_code) { nil }
+  let(:accreditation) do
+    described_class.new(
+      provider:,
+      selected_provider_code:,
+    )
+  end
+
+  describe "#selection_required?" do
+    context "when provider is accredited" do
+      let(:provider) { create(:provider, :accredited_provider, recruitment_cycle:) }
+
+      it "returns false" do
+        expect(accreditation.selection_required?).to be(false)
+      end
+    end
+
+    context "when school-based provider has one accredited partner" do
+      let(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, recruitment_cycle:)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        school_provider
+      end
+
+      it "returns false" do
+        expect(accreditation.selection_required?).to be(false)
+      end
+    end
+
+    context "when school-based provider has multiple accredited partners" do
+      let(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, recruitment_cycle:)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        school_provider
+      end
+
+      it "returns true" do
+        expect(accreditation.selection_required?).to be(true)
+      end
+    end
+  end
+
+  describe "#accrediting_provider" do
+    context "when provider is accredited" do
+      let(:provider) { create(:provider, :accredited_provider, recruitment_cycle:) }
+
+      it "returns nil" do
+        expect(accreditation.accrediting_provider).to be_nil
+      end
+    end
+
+    context "when school-based provider has one accredited partner" do
+      let(:accredited_partner) { create(:accredited_provider, recruitment_cycle:) }
+      let(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, recruitment_cycle:)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: accredited_partner)
+        school_provider
+      end
+
+      it "returns the only accredited partner" do
+        expect(accreditation.accrediting_provider).to eq(accredited_partner)
+      end
+    end
+
+    context "when school-based provider has multiple accredited partners" do
+      let(:accredited_partner_one) { create(:accredited_provider, provider_name: "Middlesex University", recruitment_cycle:) }
+      let(:accredited_partner_two) { create(:accredited_provider, provider_name: "University of Hertfordshire", recruitment_cycle:) }
+      let(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, recruitment_cycle:)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: accredited_partner_one)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: accredited_partner_two)
+        school_provider
+      end
+
+      context "when selected_provider_code is present" do
+        let(:selected_provider_code) { accredited_partner_two.provider_code }
+
+        it "returns the selected partner" do
+          expect(accreditation.accrediting_provider).to eq(accredited_partner_two)
+        end
+      end
+
+      context "when selected_provider_code is blank" do
+        it "returns nil" do
+          expect(accreditation.accrediting_provider).to be_nil
+        end
+      end
+    end
+  end
+
+  describe "#partners" do
+    let(:provider) do
+      school_provider = create(:provider, provider_type: :lead_school, recruitment_cycle:)
+      create(:provider_partnership, training_provider: school_provider, accredited_provider: accredited_partner_two)
+      create(:provider_partnership, training_provider: school_provider, accredited_provider: accredited_partner_one)
+      school_provider
+    end
+    let(:accredited_partner_one) { create(:accredited_provider, provider_name: "Middlesex University", recruitment_cycle:) }
+    let(:accredited_partner_two) { create(:accredited_provider, provider_name: "University of Hertfordshire", recruitment_cycle:) }
+
+    it "returns partners sorted by provider name" do
+      expect(accreditation.partners).to eq([accredited_partner_one, accredited_partner_two])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "site_ids" => %w[1 2] })
       repository.write({ "study_sites_ids" => %w[3 4] })
       repository.write({ "start_date" => "January 2026" })
+      repository.write({ "can_sponsor_student_visa" => "yes" })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -44,6 +45,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:site_ids]).to eq(%w[1 2])
       expect(data[:study_sites_ids]).to eq(%w[3 4])
       expect(data[:start_date]).to eq("January 2026")
+      expect(data[:can_sponsor_student_visa]).to eq("yes")
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "site_ids" => %w[1 2] })
       repository.write({ "study_sites_ids" => %w[3 4] })
       repository.write({ "start_date" => "January 2026" })
-      repository.write({ "can_sponsor_student_visa" => "yes" })
+      repository.write({ "can_sponsor_student_visa" => true })
       repository.write({ "accredited_provider_code" => "123" })
 
       data = repository.read
@@ -46,7 +46,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:site_ids]).to eq(%w[1 2])
       expect(data[:study_sites_ids]).to eq(%w[3 4])
       expect(data[:start_date]).to eq("January 2026")
-      expect(data[:can_sponsor_student_visa]).to eq("yes")
+      expect(data[:can_sponsor_student_visa]).to be(true)
       expect(data[:accredited_provider_code]).to eq("123")
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "study_sites_ids" => %w[3 4] })
       repository.write({ "start_date" => "January 2026" })
       repository.write({ "can_sponsor_student_visa" => "yes" })
+      repository.write({ "accredited_provider_code" => "123" })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -46,6 +47,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:study_sites_ids]).to eq(%w[3 4])
       expect(data[:start_date]).to eq("January 2026")
       expect(data[:can_sponsor_student_visa]).to eq("yes")
+      expect(data[:accredited_provider_code]).to eq("123")
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
+++ b/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe CourseWizard::StateStores::CourseWizardStore do
-  subject(:store) { described_class.new(repository:, attribute_names: %w[level qualification]) }
+  subject(:store) { described_class.new(repository:, attribute_names: %w[level qualification can_sponsor_student_visa]) }
 
   let(:repository) { instance_double(DfE::Wizard::Repository::InMemory) }
 
@@ -69,6 +69,28 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
 
       it "returns false" do
         expect(store.undergraduate_degree_with_qts?).to be false
+      end
+    end
+  end
+
+  describe "#visa_sponsorship_required?" do
+    before do
+      allow(repository).to receive(:read).and_return({ can_sponsor_student_visa: })
+    end
+
+    context "when can_sponsor_student_visa is true" do
+      let(:can_sponsor_student_visa) { true }
+
+      it "returns true" do
+        expect(store.visa_sponsorship_required?).to be true
+      end
+    end
+
+    context "when can_sponsor_student_visa is false" do
+      let(:can_sponsor_student_visa) { false }
+
+      it "returns false" do
+        expect(store.visa_sponsorship_required?).to be false
       end
     end
   end

--- a/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
+++ b/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
@@ -93,5 +93,21 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
         expect(store.visa_sponsorship_required?).to be false
       end
     end
+
+    context "when can_sponsor_student_visa is 'true'" do
+      let(:can_sponsor_student_visa) { "true" }
+
+      it "returns true" do
+        expect(store.visa_sponsorship_required?).to be true
+      end
+    end
+
+    context "when can_sponsor_student_visa is 'false'" do
+      let(:can_sponsor_student_visa) { "false" }
+
+      it "returns false" do
+        expect(store.visa_sponsorship_required?).to be false
+      end
+    end
   end
 end

--- a/spec/wizards/add_course_wizard/steps/accredited_provider_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/accredited_provider_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::AccreditedProvider do
+  include_context "add_course_wizard"
+
+  let(:current_step) { :accredited_provider }
+  let(:provider) do
+    school_provider = create(:provider, provider_type: :lead_school, provider_code:, recruitment_cycle:)
+    create(:provider_partnership, training_provider: school_provider, accredited_provider: accredited_partner_one)
+    create(:provider_partnership, training_provider: school_provider, accredited_provider: accredited_partner_two)
+    school_provider
+  end
+  let(:accredited_partner_one) { create(:accredited_provider, provider_name: "Middlesex University", recruitment_cycle:) }
+  let(:accredited_partner_two) { create(:accredited_provider, provider_name: "University of Hertfordshire", recruitment_cycle:) }
+  let(:wizard_step) { wizard.current_step }
+
+  describe "#valid?" do
+    it "is valid when accredited_provider_code is present" do
+      wizard_step.accredited_provider_code = accredited_partner_one.provider_code
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "is not valid when accredited_provider_code is blank" do
+      wizard_step.accredited_provider_code = nil
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:accredited_provider_code)).to contain_exactly("Select an accredited provider")
+    end
+  end
+
+  describe "#accredited_partners" do
+    it "returns accredited partners sorted by provider name" do
+      expect(wizard_step.accredited_partners).to eq([accredited_partner_one, accredited_partner_two])
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq([:accredited_provider_code])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/visa_sponsorship_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/visa_sponsorship_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe CourseWizard::Steps::VisaSponsorship do
     end
   end
 
+  describe "boolean casting" do
+    it "casts 'true' to true in serializable data" do
+      wizard_step.can_sponsor_student_visa = "true"
+
+      expect(wizard_step.serializable_data["can_sponsor_student_visa"]).to be(true)
+    end
+
+    it "casts 'false' to false in serializable data" do
+      wizard_step.can_sponsor_student_visa = "false"
+
+      expect(wizard_step.serializable_data["can_sponsor_student_visa"]).to be(false)
+    end
+  end
+
   describe "#question" do
     it "returns the organisation question for university or scitt providers" do
       expect(wizard_step.question).to eq("Can your organisation sponsor Student visas for this course?")
@@ -166,6 +180,18 @@ RSpec.describe CourseWizard::Steps::VisaSponsorship do
 
       it "returns nil for accrediting provider sponsorship capability" do
         expect(wizard_step.accrediting_provider_can_sponsor_student_visa?).to be_nil
+      end
+    end
+
+    context "when there is a single accredited partner that cannot sponsor student visas" do
+      let(:accredited_partner_can_sponsor_student_visa) { false }
+
+      it "defaults can_sponsor_student_visa to false" do
+        expect(wizard_step.can_sponsor_student_visa).to be(false)
+      end
+
+      it "is valid without explicitly setting can_sponsor_student_visa" do
+        expect(wizard_step).to be_valid
       end
     end
   end

--- a/spec/wizards/add_course_wizard/steps/visa_sponsorship_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/visa_sponsorship_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::VisaSponsorship do
+  include_context "add_course_wizard"
+
+  let(:current_step) { :visa_sponsorship }
+  let(:provider_code) { provider.provider_code }
+  let(:recruitment_cycle_year) { provider.recruitment_cycle_year }
+  let(:provider) do
+    create(
+      :provider,
+      :accredited_provider,
+      can_sponsor_student_visa: can_sponsor_student_visa,
+      recruitment_cycle: find_or_create(:recruitment_cycle),
+    )
+  end
+  let(:can_sponsor_student_visa) { false }
+  let(:wizard_step) { wizard.current_step }
+
+  describe "#question" do
+    it "returns the organisation question for university or scitt providers" do
+      expect(wizard_step.question).to eq("Can your organisation sponsor Student visas for this course?")
+    end
+
+    context "when provider is not university or scitt" do
+      let(:provider) do
+        create(
+          :provider,
+          provider_type: :lead_school,
+          can_sponsor_student_visa: false,
+          recruitment_cycle: find_or_create(:recruitment_cycle),
+        )
+      end
+
+      it "returns the sponsorship availability question" do
+        expect(wizard_step.question).to eq("Is Student visa sponsorship available for this course?")
+      end
+    end
+  end
+
+  describe "#show_recruiting_from_overseas_guidance?" do
+    it "returns true for university or scitt providers that cannot sponsor student visas" do
+      expect(wizard_step.show_recruiting_from_overseas_guidance?).to be(true)
+    end
+
+    context "when provider can sponsor student visas" do
+      let(:can_sponsor_student_visa) { true }
+
+      it "returns false" do
+        expect(wizard_step.show_recruiting_from_overseas_guidance?).to be(false)
+      end
+    end
+
+    context "when provider is not university or scitt" do
+      let(:provider) do
+        create(
+          :provider,
+          provider_type: :lead_school,
+          can_sponsor_student_visa: false,
+          recruitment_cycle: find_or_create(:recruitment_cycle),
+        )
+      end
+
+      it "returns false" do
+        expect(wizard_step.show_recruiting_from_overseas_guidance?).to be(false)
+      end
+    end
+  end
+
+  describe "#show_accrediting_provider_inset_text?" do
+    let(:provider) do
+      create(
+        :provider,
+        provider_type: :lead_school,
+        can_sponsor_student_visa: false,
+        recruitment_cycle: find_or_create(:recruitment_cycle),
+      )
+    end
+    let(:accredited_partner) do
+      create(
+        :accredited_provider,
+        can_sponsor_student_visa: accredited_partner_can_sponsor_student_visa,
+        recruitment_cycle: provider.recruitment_cycle,
+      )
+    end
+    let(:accredited_partner_can_sponsor_student_visa) { false }
+    let(:create_partnership) { true }
+
+    before do
+      if create_partnership
+        create(:provider_partnership, training_provider: provider, accredited_provider: accredited_partner)
+      end
+    end
+
+    it "returns true when there is a single accredited partner" do
+      expect(wizard_step.show_accrediting_provider_inset_text?).to be(true)
+    end
+
+    it "returns the accredited partner name" do
+      expect(wizard_step.accrediting_provider_name).to eq(accredited_partner.provider_name)
+    end
+
+    it "returns false for accredited partner visa sponsorship capability" do
+      expect(wizard_step.accrediting_provider_can_sponsor_student_visa?).to be(false)
+    end
+
+    context "when accredited partner can sponsor student visas" do
+      let(:accredited_partner_can_sponsor_student_visa) { true }
+
+      it "returns true for accredited partner visa sponsorship capability" do
+        expect(wizard_step.accrediting_provider_can_sponsor_student_visa?).to be(true)
+      end
+    end
+
+    context "when there are multiple accredited partners" do
+      before do
+        create(:provider_partnership, training_provider: provider, accredited_provider: create(:accredited_provider, recruitment_cycle: provider.recruitment_cycle))
+      end
+
+      it "returns false" do
+        expect(wizard_step.show_accrediting_provider_inset_text?).to be(false)
+      end
+
+      it "returns nil for accrediting provider name" do
+        expect(wizard_step.accrediting_provider_name).to be_nil
+      end
+
+      it "returns nil for accrediting provider sponsorship capability" do
+        expect(wizard_step.accrediting_provider_can_sponsor_student_visa?).to be_nil
+      end
+    end
+
+    context "when there are no accredited partners" do
+      let(:create_partnership) { false }
+
+      it "returns false" do
+        expect(wizard_step.show_accrediting_provider_inset_text?).to be(false)
+      end
+
+      it "returns nil for accrediting provider name" do
+        expect(wizard_step.accrediting_provider_name).to be_nil
+      end
+
+      it "returns nil for accrediting provider sponsorship capability" do
+        expect(wizard_step.accrediting_provider_can_sponsor_student_visa?).to be_nil
+      end
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq([:can_sponsor_student_visa])
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/visa_sponsorship_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/visa_sponsorship_spec.rb
@@ -19,6 +19,27 @@ RSpec.describe CourseWizard::Steps::VisaSponsorship do
   let(:can_sponsor_student_visa) { false }
   let(:wizard_step) { wizard.current_step }
 
+  describe "#valid?" do
+    it "is valid when can_sponsor_student_visa is true" do
+      wizard_step.can_sponsor_student_visa = true
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "is valid when can_sponsor_student_visa is false" do
+      wizard_step.can_sponsor_student_visa = false
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "is not valid when can_sponsor_student_visa is nil" do
+      wizard_step.can_sponsor_student_visa = nil
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:can_sponsor_student_visa)).to contain_exactly("Select if student visas can be sponsored for this course")
+    end
+  end
+
   describe "#question" do
     it "returns the organisation question for university or scitt providers" do
       expect(wizard_step.question).to eq("Can your organisation sponsor Student visas for this course?")

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -154,8 +154,8 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
   context "from study sites" do
     let(:current_step) { :study_sites }
 
-    it "proceeds to courses page by default" do
-      expect(wizard).to have_next_step(:courses_index)
+    it "proceeds to visa sponsorship page by default" do
+      expect(wizard).to have_next_step(:visa_sponsorship)
     end
 
     context "when qualification is undergraduate degree with qts" do
@@ -184,6 +184,30 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
 
     it "proceeds to courses page" do
       expect(wizard).to have_next_step(:courses_index)
+    end
+  end
+
+  context "from visa sponsorship when visa sponsorship is required" do
+    let(:current_step) { :visa_sponsorship }
+
+    before do
+      state_store.write(can_sponsor_student_visa: true)
+    end
+
+    it "proceeds to courses page" do
+      expect(wizard).to have_next_step(:courses_index)
+    end
+  end
+
+  context "from visa sponsorship when visa sponsorship is not required" do
+    let(:current_step) { :visa_sponsorship }
+
+    before do
+      state_store.write(can_sponsor_student_visa: false)
+    end
+
+    it "proceeds to start date page" do
+      expect(wizard).to have_next_step(:start_date)
     end
   end
 end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -149,6 +149,19 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
     it "proceeds to study sites page" do
       expect(wizard).to have_next_step(:study_sites)
     end
+
+    context "when provider has no study sites and multiple accredited partners" do
+      let!(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, provider_code:, recruitment_cycle:)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        school_provider
+      end
+
+      it "skips study sites and proceeds to accredited provider page" do
+        expect(wizard).to have_next_step(:accredited_provider)
+      end
+    end
   end
 
   context "from study sites" do
@@ -176,6 +189,28 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
       it "proceeds to start date page" do
         expect(wizard).to have_next_step(:start_date)
       end
+    end
+
+    context "when provider has multiple accredited partners" do
+      let!(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, provider_code:, recruitment_cycle:)
+        create(:site, :study_site, provider: school_provider)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        school_provider
+      end
+
+      it "proceeds to accredited provider page" do
+        expect(wizard).to have_next_step(:accredited_provider)
+      end
+    end
+  end
+
+  context "from accredited provider" do
+    let(:current_step) { :accredited_provider }
+
+    it "proceeds to visa sponsorship page" do
+      expect(wizard).to have_next_step(:visa_sponsorship)
     end
   end
 

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -176,4 +176,12 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:study_sites)
     end
   end
+
+  context "from visa sponsorship" do
+    let(:current_step) { :visa_sponsorship }
+
+    it "goes back to study sites" do
+      expect(wizard).to have_previous_step(:study_sites)
+    end
+  end
 end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -201,6 +201,13 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
 
   context "from accredited provider" do
     let(:current_step) { :accredited_provider }
+    let!(:provider) do
+      school_provider = create(:provider, provider_type: :lead_school, provider_code:, recruitment_cycle:)
+      create(:site, :study_site, provider: school_provider)
+      create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+      create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+      school_provider
+    end
 
     it "goes back to study sites" do
       expect(wizard).to have_previous_step(:study_sites)

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -183,5 +183,27 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
     it "goes back to study sites" do
       expect(wizard).to have_previous_step(:study_sites)
     end
+
+    context "when provider has multiple accredited partners" do
+      let!(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, provider_code:, recruitment_cycle:)
+        create(:site, :study_site, provider: school_provider)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        school_provider
+      end
+
+      it "goes back to accredited provider" do
+        expect(wizard).to have_previous_step(:accredited_provider)
+      end
+    end
+  end
+
+  context "from accredited provider" do
+    let(:current_step) { :accredited_provider }
+
+    it "goes back to study sites" do
+      expect(wizard).to have_previous_step(:study_sites)
+    end
   end
 end


### PR DESCRIPTION
## Context

The add-course wizard previously sent most providers straight from study sites to the courses index. The legacy publish flow already asks about student visa sponsorship, and for school-based providers with multiple accredited partners it also asks them to choose an accredited provider.

This PR adds the **Student visas** step and aligns post-study-sites behavior with the legacy flow, including the accredited-provider selection path and study-sites skipping behavior when no study sites exist.

**Note:** If the user answers **Yes** to sponsoring student visas, they are sent to the **courses index** for now. A dedicated visa application deadline step is still a TODO in `course_wizard.rb`.

## Changes proposed in this pull request

- Add `CourseWizard::Steps::VisaSponsorship` with validation for `can_sponsor_student_visa`
- Add `_visa_sponsorship.html.erb` (Yes/No radios, conditional overseas guidance, accrediting-provider inset)
- Add locale strings under `course_wizard.steps.visa_sponsorship`
- Route study sites → **visa sponsorship** by default (TDA and FE still go to start date)
- Route visa sponsorship → **start date** when No, or **courses index** when Yes (`visa_sponsorship_required?` in state store)
- Add/expand wizard helper logic for `accrediting_provider` so it supports:
  - single partner auto-selection
  - selected `accredited_provider_code` when multiple partners
- Add `CourseWizard::Steps::AccreditedProvider` and `_accredited_provider.html.erb`
- Route school-based providers with multiple accredited partners:
  - study sites → **accredited provider** → visa sponsorship
- Add `skip_when` behavior for study sites in the wizard graph and `skip_study_sites?` rule for providers with no study sites
- Add locale strings under `course_wizard.steps.accredited_provider`
- Update/add specs for:
  - visa sponsorship step and navigation/content permutations
  - accredited provider wizard step (unit + system)
  - updated graph next/previous step behavior
  - study-sites skip and routing cases
  - shared wizard test context/provider setup updates

## Guidance to review

- **`app/wizards/course_wizard.rb`**  
  Confirm graph transitions match legacy expectations:
  - study sites → start date (TDA/FE)
  - study sites → accredited provider (school-based + multiple partners)
  - study sites → visa sponsorship (default)
  - accredited provider → visa sponsorship
  - visa sponsorship → courses index/start date based on answer
  - study sites skipped when provider has no study sites

- **`app/wizards/course_wizard/steps/visa_sponsorship.rb`**, **`app/views/publish/course_wizards/steps/_visa_sponsorship.html.erb`**  
  Validate conditional copy/UI behavior for accredited vs school-based providers and accrediting partner messaging.

- **`app/wizards/course_wizard/steps/accredited_provider.rb`**, **`app/views/publish/course_wizards/steps/_accredited_provider.html.erb`**  
  Validate provider-selection UI and validation matches legacy “Accredited provider” behavior.

- **`app/wizards/course_wizard/state_stores/course_wizard_store.rb`**  
  Confirm `visa_sponsorship_required?` behavior is still correct for interim routing.

- **Specs**
  - `spec/system/publish/courses/add_course_wizard/visa_sponsorship_spec.rb`
  - `spec/system/publish/courses/add_course_wizard/accredited_provider_spec.rb`
  - `spec/system/publish/courses/add_course_wizard/study_sites_spec.rb`
  - `spec/wizards/add_course_wizard/steps/visa_sponsorship_spec.rb`
  - `spec/wizards/add_course_wizard/steps/accredited_provider_spec.rb`
  - `spec/wizards/add_course_wizard/wizard/next_step_spec.rb`
  - `spec/wizards/add_course_wizard/wizard/previous_step_spec.rb`