### PR TITLE
Fix NameError on unauthenticated note requests

### DIFF
--- a/app/controllers/concerns/find/authentication.rb
+++ b/app/controllers/concerns/find/authentication.rb
@@ -82,6 +82,10 @@ module Find
       end
     end
 
+    def reason_for_request
+      :general
+    end
+
     def reason_for_request_from_json
       if request.path.start_with?("/candidate/saved-courses")
         :save_course

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -92,10 +92,6 @@ module Find
 
     private
 
-      def reason_for_request
-        :general
-      end
-
       def search_params
         @search_params ||= Find::SearchParams.permit(params)
       end

--- a/app/controllers/find/candidates/recent_searches_controller.rb
+++ b/app/controllers/find/candidates/recent_searches_controller.rb
@@ -37,12 +37,6 @@ module Find
         @candidate.recent_searches.where(id: ids).find_each(&:undiscard)
         redirect_to find_candidate_recent_searches_path
       end
-
-    private
-
-      def reason_for_request
-        :general
-      end
     end
   end
 end

--- a/app/controllers/find/candidates/saved_courses_controller.rb
+++ b/app/controllers/find/candidates/saved_courses_controller.rb
@@ -211,10 +211,6 @@ module Find
       def saved_courses_filter_params
         params.permit(:location, :order).to_h.compact_blank
       end
-
-      def reason_for_request
-        :general
-      end
     end
   end
 end

--- a/spec/controllers/find/candidates/notes_controller_spec.rb
+++ b/spec/controllers/find/candidates/notes_controller_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Find
+  module Candidates
+    RSpec.describe NotesController, service: :find, type: :controller do
+      let(:candidate) { create(:candidate) }
+      let(:session_record) { create(:session, sessionable: candidate) }
+      let(:saved_course) { create(:saved_course, candidate:) }
+
+      before do
+        FeatureFlag.activate(:candidate_accounts)
+        request.host = URI(Settings.find_url).host
+        cookies.signed[Settings.cookies.candidate_session.name] = session_record.session_key
+      end
+
+      describe "GET #edit" do
+        it "renders successfully" do
+          get :edit, params: { saved_course_id: saved_course.id }
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "when not authenticated" do
+        before do
+          cookies.delete(Settings.cookies.candidate_session.name)
+        end
+
+        it "redirects unauthenticated users for edit" do
+          get :edit, params: { saved_course_id: saved_course.id }
+
+          expect(response).to redirect_to(find_root_path)
+        end
+
+        it "redirects unauthenticated users for update" do
+          patch :update, params: { saved_course_id: saved_course.id, saved_course: { note: "Hi" } }
+
+          expect(response).to redirect_to(find_root_path)
+        end
+
+        it "redirects unauthenticated users for destroy" do
+          delete :destroy, params: { saved_course_id: saved_course.id }
+
+          expect(response).to redirect_to(find_root_path)
+        end
+
+        it "redirects unauthenticated users for undo" do
+          post :undo, params: { saved_course_id: saved_course.id, note: "Hi" }
+
+          expect(response).to redirect_to(find_root_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

`Find::Candidates::NotesController` includes `Find::Authentication` but never defined `reason_for_request`, so unauthenticated HTML requests raised `NameError` in `request_authentication` (Sentry, production).

## Fix

Move the `:general` default into the concern and drop the three identical per-controller overrides. Add a `NotesController` spec covering the unauthenticated redirect path.
