### PR TITLE
Add SkilledWorkerVisa step

### DIFF
--- a/app/views/publish/course_wizards/steps/_skilled_worker_visa.html.erb
+++ b/app/views/publish/course_wizards/steps/_skilled_worker_visa.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.skilled_worker_visa.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.skilled_worker_visa.caption")) %>
+  <%= t("course_wizard.steps.skilled_worker_visa.heading") %>
+</h1>
+
+<%= form.govuk_radio_buttons_fieldset :can_sponsor_skilled_worker_visa, legend: { text: t("course_wizard.steps.skilled_worker_visa.question") } do %>
+  <%= form.govuk_radio_button :can_sponsor_skilled_worker_visa, true, label: { text: t("course_wizard.steps.skilled_worker_visa.options.can_sponsor_skilled_worker_visa.label") } %>
+  <%= form.govuk_radio_button :can_sponsor_skilled_worker_visa, false, label: { text: t("course_wizard.steps.skilled_worker_visa.options.cannot_sponsor_skilled_worker_visa.label") } %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.skilled_worker_visa.submit") %>

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -7,7 +7,13 @@ class CourseWizard
 
   delegate :accrediting_provider, to: :accreditation
 
-  delegate :further_education_level?, :primary_level?, :undergraduate_degree_with_qts?, :visa_sponsorship_required?, to: :state_store
+  delegate :further_education_level?,
+           :primary_level?,
+           :undergraduate_degree_with_qts?,
+           :visa_sponsorship_required?,
+           :skilled_worker_visa_required?,
+           :skilled_worker_visa_sponsorship_required?,
+           to: :state_store
 
   def steps_processor
     DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
@@ -25,6 +31,7 @@ class CourseWizard
       graph.add_node :accredited_provider, Steps::AccreditedProvider
       graph.add_node :start_date, Steps::StartDate
       graph.add_node :visa_sponsorship, Steps::VisaSponsorship
+      graph.add_node :skilled_worker_visa, Steps::SkilledWorkerVisa
 
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
@@ -67,9 +74,7 @@ class CourseWizard
           # School-based providers with multiple accredited partners need
           # to choose who is accrediting the course.
           { when: :accredited_provider_selection_required?, then: :accredited_provider },
-
-          # TODO: mirror visa split here:
-          # non-fee courses -> Skilled Worker visa path, fee courses -> Student visa path.
+          { when: :skilled_worker_visa_required?, then: :skilled_worker_visa },
         ],
         default: :visa_sponsorship,
       )
@@ -86,6 +91,14 @@ class CourseWizard
       )
 
       graph.add_edge from: :start_date, to: :courses_index
+
+      graph.add_multiple_conditional_edges(
+        from: :skilled_worker_visa,
+        branches: [
+          { when: :skilled_worker_visa_sponsorship_required?, then: :courses_index },
+        ],
+        default: :start_date,
+      )
     end
   end
 

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -84,6 +84,7 @@ class CourseWizard
       graph.add_multiple_conditional_edges(
         from: :accredited_provider,
         branches: [
+          { when: :undergraduate_degree_with_qts?, then: :start_date },
           { when: :salary_based?, then: :skilled_worker_visa },
           { when: :fee_based?, then: :visa_sponsorship },
         ],

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -11,7 +11,8 @@ class CourseWizard
            :primary_level?,
            :undergraduate_degree_with_qts?,
            :visa_sponsorship_required?,
-           :skilled_worker_visa_required?,
+           :salary_based?,
+           :fee_based?,
            :skilled_worker_visa_sponsorship_required?,
            to: :state_store
 
@@ -74,12 +75,19 @@ class CourseWizard
           # School-based providers with multiple accredited partners need
           # to choose who is accrediting the course.
           { when: :accredited_provider_selection_required?, then: :accredited_provider },
-          { when: :skilled_worker_visa_required?, then: :skilled_worker_visa },
+          { when: :salary_based?, then: :skilled_worker_visa },
         ],
         default: :visa_sponsorship,
       )
 
-      graph.add_edge from: :accredited_provider, to: :visa_sponsorship
+      graph.add_multiple_conditional_edges(
+        from: :accredited_provider,
+        branches: [
+          { when: :salary_based?, then: :skilled_worker_visa },
+          { when: :fee_based?, then: :visa_sponsorship },
+        ],
+        default: :start_date,
+      )
 
       graph.add_multiple_conditional_edges(
         from: :visa_sponsorship,

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -70,11 +70,12 @@ class CourseWizard
           # Further education does not require visa sponsorship in the
           # existing flow, so it goes straight to start date.
           { when: :further_education_level?, then: :start_date },
-          # TDA also goes straight to start date.
-          { when: :undergraduate_degree_with_qts?, then: :start_date },
           # School-based providers with multiple accredited partners need
           # to choose who is accrediting the course.
           { when: :accredited_provider_selection_required?, then: :accredited_provider },
+          # TDA goes straight to start date when no accredited provider
+          # selection is required.
+          { when: :undergraduate_degree_with_qts?, then: :start_date },
           { when: :salary_based?, then: :skilled_worker_visa },
         ],
         default: :visa_sponsorship,
@@ -103,6 +104,7 @@ class CourseWizard
       graph.add_multiple_conditional_edges(
         from: :skilled_worker_visa,
         branches: [
+          # TODO: when true go to visa sponsorship application deadline page
           { when: :skilled_worker_visa_sponsorship_required?, then: :courses_index },
         ],
         default: :start_date,

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -13,16 +13,20 @@ class CourseWizard
         level == "primary"
       end
 
+      def fee_based?
+        funding_type == "fee"
+      end
+
+      def salary_based?
+        funding_type.in?(%w[salary apprenticeship])
+      end
+
       def undergraduate_degree_with_qts?
         qualification == "undergraduate_degree_with_qts"
       end
 
       def visa_sponsorship_required?
         ActiveModel::Type::Boolean.new.cast(can_sponsor_student_visa)
-      end
-
-      def skilled_worker_visa_required?
-        funding_type.in?(%w[salary apprenticeship])
       end
 
       def skilled_worker_visa_sponsorship_required?

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -20,6 +20,14 @@ class CourseWizard
       def visa_sponsorship_required?
         ActiveModel::Type::Boolean.new.cast(can_sponsor_student_visa)
       end
+
+      def skilled_worker_visa_required?
+        funding_type.in?(%w[salary apprenticeship])
+      end
+
+      def skilled_worker_visa_sponsorship_required?
+        ActiveModel::Type::Boolean.new.cast(can_sponsor_skilled_worker_visa)
+      end
     end
   end
 end

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -17,6 +17,7 @@ class CourseWizard
         funding_type == "fee"
       end
 
+      # Employment-based funding types are salary and apprenticeship.
       def salary_based?
         funding_type.in?(%w[salary apprenticeship])
       end

--- a/app/wizards/course_wizard/steps/skilled_worker_visa.rb
+++ b/app/wizards/course_wizard/steps/skilled_worker_visa.rb
@@ -9,12 +9,6 @@ class CourseWizard
 
       validates :can_sponsor_skilled_worker_visa, inclusion: { in: [true, false], message: I18n.t("course_wizard.steps.skilled_worker_visa.errors.can_sponsor_skilled_worker_visa.blank") }
 
-      def can_sponsor_skilled_worker_visa
-        return super unless super.nil?
-
-        false
-      end
-
       def self.permitted_params
         [:can_sponsor_skilled_worker_visa]
       end

--- a/app/wizards/course_wizard/steps/skilled_worker_visa.rb
+++ b/app/wizards/course_wizard/steps/skilled_worker_visa.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class SkilledWorkerVisa
+      include DfE::Wizard::Step
+
+      attribute :can_sponsor_skilled_worker_visa, :boolean
+
+      validates :can_sponsor_skilled_worker_visa, inclusion: { in: [true, false], message: I18n.t("course_wizard.steps.skilled_worker_visa.errors.can_sponsor_skilled_worker_visa.blank") }
+
+      def can_sponsor_skilled_worker_visa
+        return super unless super.nil?
+
+        false
+      end
+
+      def self.permitted_params
+        [:can_sponsor_skilled_worker_visa]
+      end
+    end
+  end
+end

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -155,6 +155,19 @@ en:
         errors:
           can_sponsor_student_visa:
             blank: Select if student visas can be sponsored for this course
+      skilled_worker_visa:
+        caption: Add course
+        heading: Skilled Worker visas
+        question: Can your organisation sponsor Skilled Worker visas for this course?
+        submit: Continue
+        options:
+          can_sponsor_skilled_worker_visa:
+            label: "Yes"
+          cannot_sponsor_skilled_worker_visa:
+            label: "No"
+        errors:
+          can_sponsor_skilled_worker_visa:
+            blank: Select if candidates can get a sponsored Skilled Worker visa
   activemodel:
     errors:
       models:

--- a/spec/system/publish/courses/add_course_wizard/accredited_provider_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/accredited_provider_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Add course wizard accredited provider step", type: :system do
     when_i_visit_the_wizard_accredited_provider_page
     and_i_choose_an_accredited_provider
     and_i_click_continue
-    then_i_am_taken_to_the_visa_sponsorship_page
+    then_i_am_taken_to_the_start_date_page
   end
 
   scenario "submitting without selecting an accredited provider shows validation errors" do
@@ -89,12 +89,12 @@ private
     click_on "Continue"
   end
 
-  def then_i_am_taken_to_the_visa_sponsorship_page
+  def then_i_am_taken_to_the_start_date_page
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
-        step: :visa_sponsorship,
+        step: :start_date,
         state_key: wizard_state_key,
       ),
       ignore_query: true,

--- a/spec/system/publish/courses/add_course_wizard/accredited_provider_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/accredited_provider_spec.rb
@@ -6,14 +6,22 @@ RSpec.describe "Add course wizard accredited provider step", type: :system do
   before do
     FeatureFlag.activate(:wizard_add_course_flow)
     given_i_am_authenticated_as_a_school_based_provider_user_with_multiple_accredited_partners
-    and_i_have_wizard_state_for_accredited_provider
   end
 
-  scenario "choosing an accredited provider and continues to visa sponsorship page" do
+  scenario "choosing an accredited provider and continues to visa sponsorship page when fee based course" do
+    and_i_have_wizard_state_for_accredited_provider(funding_type: "fee")
     when_i_visit_the_wizard_accredited_provider_page
     and_i_choose_an_accredited_provider
     and_i_click_continue
-    then_i_am_taken_to_the_start_date_page
+    then_i_am_taken_to_the_visa_sponsorship_page
+  end
+
+  scenario "choosing an accredited provider and continues to skilled worker visa page when salary based course" do
+    and_i_have_wizard_state_for_accredited_provider(funding_type: "salary")
+    when_i_visit_the_wizard_accredited_provider_page
+    and_i_choose_an_accredited_provider
+    and_i_click_continue
+    then_i_am_taken_to_the_skilled_worker_visa_page
   end
 
   scenario "submitting without selecting an accredited provider shows validation errors" do
@@ -60,7 +68,7 @@ private
     given_i_am_authenticated(user: @user)
   end
 
-  def and_i_have_wizard_state_for_accredited_provider
+  def and_i_have_wizard_state_for_accredited_provider(funding_type: nil)
     repository = CourseWizard::Repositories::Course.new(
       provider_code: provider.provider_code,
       recruitment_cycle_year: provider.recruitment_cycle_year,
@@ -69,7 +77,7 @@ private
     )
 
     state_store = CourseWizard::StateStores::CourseWizardStore.new(repository:)
-    state_store.write(level: "secondary")
+    state_store.write(level: "secondary", funding_type:)
   end
 
   def when_i_visit_the_wizard_accredited_provider_page
@@ -89,12 +97,24 @@ private
     click_on "Continue"
   end
 
-  def then_i_am_taken_to_the_start_date_page
+  def then_i_am_taken_to_the_visa_sponsorship_page
     expect(page).to have_current_path(
       publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
-        step: :start_date,
+        step: :visa_sponsorship,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_am_taken_to_the_skilled_worker_visa_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :skilled_worker_visa,
         state_key: wizard_state_key,
       ),
       ignore_query: true,

--- a/spec/system/publish/courses/add_course_wizard/skilled_worker_visa_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/skilled_worker_visa_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe "Add course wizard skilled worker visa step", type: :system do
     then_i_am_taken_to_the_start_date_page
   end
 
+  scenario "choosing nil to skilled worker visa and shows validation errors" do
+    when_i_visit_the_wizard_skilled_worker_visa_page
+    and_i_click_continue
+    then_i_have_errors_on_the_skilled_worker_visa_step
+  end
+
 private
 
   def given_i_am_authenticated_as_a_provider_user_with_a_school
@@ -42,6 +48,10 @@ private
     )
 
     expect(page).to have_content("Can your organisation sponsor Skilled Worker visas for this course?")
+  end
+
+  def then_i_have_errors_on_the_skilled_worker_visa_step
+    expect(page).to have_content("Select if candidates can get a sponsored Skilled Worker visa")
   end
 
   def and_i_choose_yes_to_the_skilled_worker_visa_question

--- a/spec/system/publish/courses/add_course_wizard/skilled_worker_visa_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/skilled_worker_visa_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard skilled worker visa step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user_with_a_school
+  end
+
+  scenario "choosing yes to skilled worker visa and continues to courses index" do
+    when_i_visit_the_wizard_skilled_worker_visa_page
+    and_i_choose_yes_to_the_skilled_worker_visa_question
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "choosing no to skilled worker visa and continues to start date page" do
+    when_i_visit_the_wizard_skilled_worker_visa_page
+    and_i_choose_no_to_the_skilled_worker_visa_question
+    and_i_click_continue
+    then_i_am_taken_to_the_start_date_page
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user_with_a_school
+    @user = create(
+      :user,
+      providers: [create(:provider, :accredited_provider, sites: [build(:site)])],
+    )
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def when_i_visit_the_wizard_skilled_worker_visa_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :skilled_worker_visa,
+      state_key: wizard_state_key,
+    )
+
+    expect(page).to have_content("Can your organisation sponsor Skilled Worker visas for this course?")
+  end
+
+  def and_i_choose_yes_to_the_skilled_worker_visa_question
+    choose "Yes"
+  end
+
+  def and_i_choose_no_to_the_skilled_worker_visa_question
+    choose "No"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_start_date_page
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_course_wizard_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, step: :start_date, state_key: wizard_state_key))
+  end
+
+  def then_i_am_taken_to_the_courses_index_page
+    expect(page).to have_current_path(publish_provider_recruitment_cycle_courses_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year))
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+end

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "start_date" => "January 2026" })
       repository.write({ "can_sponsor_student_visa" => true })
       repository.write({ "accredited_provider_code" => "123" })
+      repository.write({ "can_sponsor_skilled_worker_visa" => true })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -48,6 +49,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:start_date]).to eq("January 2026")
       expect(data[:can_sponsor_student_visa]).to be(true)
       expect(data[:accredited_provider_code]).to eq("123")
+      expect(data[:can_sponsor_skilled_worker_visa]).to be(true)
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
+++ b/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
@@ -56,8 +56,24 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
       allow(repository).to receive(:read).and_return({ funding_type: })
     end
 
-    context "when funding type is not 'fee'" do
+    context "when funding type is 'fee'" do
+      let(:funding_type) { "fee" }
+
+      it "returns true" do
+        expect(store.fee_based?).to be true
+      end
+    end
+
+    context "when funding type is 'apprenticeship'" do
       let(:funding_type) { "apprenticeship" }
+
+      it "returns false" do
+        expect(store.fee_based?).to be false
+      end
+    end
+
+    context "when funding type is 'salary'" do
+      let(:funding_type) { "salary" }
 
       it "returns false" do
         expect(store.fee_based?).to be false

--- a/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
+++ b/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
     end
   end
 
+  describe "#fee_based?" do
+    before do
+      allow(repository).to receive(:read).and_return({ funding_type: })
+    end
+
+    context "when funding type is not 'fee'" do
+      let(:funding_type) { "apprenticeship" }
+
+      it "returns false" do
+        expect(store.fee_based?).to be false
+      end
+    end
+  end
+
   describe "#undergraduate_degree_with_qts?" do
     before do
       allow(repository).to receive(:read).and_return({ qualification: })
@@ -111,7 +125,7 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
     end
   end
 
-  describe "#skilled_worker_visa_required?" do
+  describe "#salary_based?" do
     before do
       allow(repository).to receive(:read).and_return({ funding_type: })
     end
@@ -120,7 +134,7 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
       let(:funding_type) { "salary" }
 
       it "returns true" do
-        expect(store.skilled_worker_visa_required?).to be true
+        expect(store.salary_based?).to be true
       end
     end
 
@@ -128,7 +142,7 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
       let(:funding_type) { "apprenticeship" }
 
       it "returns true" do
-        expect(store.skilled_worker_visa_required?).to be true
+        expect(store.salary_based?).to be true
       end
     end
 
@@ -136,7 +150,7 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
       let(:funding_type) { "fee" }
 
       it "returns false" do
-        expect(store.skilled_worker_visa_required?).to be false
+        expect(store.salary_based?).to be false
       end
     end
   end

--- a/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
+++ b/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe CourseWizard::StateStores::CourseWizardStore do
-  subject(:store) { described_class.new(repository:, attribute_names: %w[level qualification can_sponsor_student_visa]) }
+  subject(:store) { described_class.new(repository:, attribute_names: %w[level qualification can_sponsor_student_visa can_sponsor_skilled_worker_visa funding_type]) }
 
   let(:repository) { instance_double(DfE::Wizard::Repository::InMemory) }
 
@@ -107,6 +107,74 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
 
       it "returns false" do
         expect(store.visa_sponsorship_required?).to be false
+      end
+    end
+  end
+
+  describe "#skilled_worker_visa_required?" do
+    before do
+      allow(repository).to receive(:read).and_return({ funding_type: })
+    end
+
+    context "when funding type is salary" do
+      let(:funding_type) { "salary" }
+
+      it "returns true" do
+        expect(store.skilled_worker_visa_required?).to be true
+      end
+    end
+
+    context "when funding type is apprenticeship" do
+      let(:funding_type) { "apprenticeship" }
+
+      it "returns true" do
+        expect(store.skilled_worker_visa_required?).to be true
+      end
+    end
+
+    context "when funding type is fee" do
+      let(:funding_type) { "fee" }
+
+      it "returns false" do
+        expect(store.skilled_worker_visa_required?).to be false
+      end
+    end
+  end
+
+  describe "#skilled_worker_visa_sponsorship_required?" do
+    before do
+      allow(repository).to receive(:read).and_return({ can_sponsor_skilled_worker_visa: })
+    end
+
+    context "when can_sponsor_skilled_worker_visa is true" do
+      let(:can_sponsor_skilled_worker_visa) { true }
+
+      it "returns true" do
+        expect(store.skilled_worker_visa_sponsorship_required?).to be true
+      end
+    end
+
+    context "when can_sponsor_skilled_worker_visa is false" do
+      let(:can_sponsor_skilled_worker_visa) { false }
+
+      it "returns false" do
+        expect(store.skilled_worker_visa_sponsorship_required?).to be false
+      end
+    end
+
+    context "when can_sponsor_skilled_worker_visa is 'true'" do
+      let(:can_sponsor_skilled_worker_visa) { "true" }
+
+      it "returns true" do
+        expect(store.skilled_worker_visa_sponsorship_required?).to be true
+      end
+    end
+
+    context "when can_sponsor_skilled_worker_visa is 'false'" do
+      let(:can_sponsor_skilled_worker_visa) { "false" }
+
+      it "returns false" do
+        expect(store.skilled_worker_visa_sponsorship_required?).to be false
       end
     end
   end

--- a/spec/wizards/add_course_wizard/steps/skilled_worker_visa_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/skilled_worker_visa_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::SkilledWorkerVisa do
+  include_context "add_course_wizard"
+
+  let(:current_step) { :skilled_worker_visa }
+  let(:can_sponsor_skilled_worker_visa) { nil }
+  let(:wizard_step) { wizard.current_step }
+
+  describe "#valid?" do
+    it "is valid when can_sponsor_skilled_worker_visa is true" do
+      wizard_step.can_sponsor_skilled_worker_visa = true
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "is valid when can_sponsor_skilled_worker_visa is false" do
+      wizard_step.can_sponsor_skilled_worker_visa = false
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "defaults to false when can_sponsor_skilled_worker_visa is nil" do
+      wizard_step.can_sponsor_skilled_worker_visa = nil
+
+      expect(wizard_step.can_sponsor_skilled_worker_visa).to be(false)
+      expect(wizard_step).to be_valid
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/skilled_worker_visa_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/skilled_worker_visa_spec.rb
@@ -29,4 +29,10 @@ RSpec.describe CourseWizard::Steps::SkilledWorkerVisa do
       expect(wizard_step).to be_valid
     end
   end
+
+  describe ".permitted_params" do
+    it "returns [:can_sponsor_skilled_worker_visa]" do
+      expect(described_class.permitted_params).to eq(%i[can_sponsor_skilled_worker_visa])
+    end
+  end
 end

--- a/spec/wizards/add_course_wizard/steps/skilled_worker_visa_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/skilled_worker_visa_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe CourseWizard::Steps::SkilledWorkerVisa do
       expect(wizard_step).to be_valid
     end
 
-    it "defaults to false when can_sponsor_skilled_worker_visa is nil" do
+    it "is invalid when can_sponsor_skilled_worker_visa is nil" do
       wizard_step.can_sponsor_skilled_worker_visa = nil
 
-      expect(wizard_step.can_sponsor_skilled_worker_visa).to be(false)
-      expect(wizard_step).to be_valid
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:can_sponsor_skilled_worker_visa)).to contain_exactly("Select if candidates can get a sponsored Skilled Worker visa")
     end
   end
 

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -257,6 +257,17 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
   context "from accredited provider" do
     let(:current_step) { :accredited_provider }
 
+    it "proceeds to start date page for undergraduate degree with qts when funding type is not set" do
+      state_store.write(qualification: "undergraduate_degree_with_qts")
+      expect(wizard).to have_next_step(:start_date)
+    end
+
+    it "proceeds to start date page for undergraduate degree with qts even when funding type is set" do
+      state_store.write(qualification: "undergraduate_degree_with_qts")
+      state_store.write(funding_type: "salary")
+      expect(wizard).to have_next_step(:start_date)
+    end
+
     it "proceeds to visa sponsorship page when fee based course" do
       state_store.write(funding_type: "fee")
       expect(wizard).to have_next_step(:visa_sponsorship)

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -239,8 +239,19 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
   context "from accredited provider" do
     let(:current_step) { :accredited_provider }
 
-    it "proceeds to visa sponsorship page" do
+    it "proceeds to visa sponsorship page when fee based course" do
+      state_store.write(funding_type: "fee")
       expect(wizard).to have_next_step(:visa_sponsorship)
+    end
+
+    it "proceeds to skilled worker visa page when salary based course" do
+      state_store.write(funding_type: "salary")
+      expect(wizard).to have_next_step(:skilled_worker_visa)
+    end
+
+    it "proceeds to skilled worker visa page when apprenticeship based course" do
+      state_store.write(funding_type: "apprenticeship")
+      expect(wizard).to have_next_step(:skilled_worker_visa)
     end
   end
 

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -181,6 +181,24 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
       end
     end
 
+    context "when qualification is undergraduate degree with qts and provider has multiple accredited partners" do
+      let!(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, provider_code:, recruitment_cycle:)
+        create(:site, :study_site, provider: school_provider)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        school_provider
+      end
+
+      before do
+        state_store.write(qualification: "undergraduate_degree_with_qts")
+      end
+
+      it "proceeds to accredited provider page" do
+        expect(wizard).to have_next_step(:accredited_provider)
+      end
+    end
+
     context "when level is further education" do
       before do
         state_store.write(level: "further_education")

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -204,6 +204,36 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
         expect(wizard).to have_next_step(:accredited_provider)
       end
     end
+
+    context "when funding type is salary" do
+      before do
+        state_store.write(funding_type: "salary")
+      end
+
+      it "proceeds to skilled worker visa page" do
+        expect(wizard).to have_next_step(:skilled_worker_visa)
+      end
+    end
+
+    context "when funding type is apprenticeship" do
+      before do
+        state_store.write(funding_type: "apprenticeship")
+      end
+
+      it "proceeds to skilled worker visa page" do
+        expect(wizard).to have_next_step(:skilled_worker_visa)
+      end
+    end
+
+    context "when funding type is fee" do
+      before do
+        state_store.write(funding_type: "fee")
+      end
+
+      it "proceeds to visa sponsorship page" do
+        expect(wizard).to have_next_step(:visa_sponsorship)
+      end
+    end
   end
 
   context "from accredited provider" do
@@ -243,6 +273,30 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
 
     it "proceeds to start date page" do
       expect(wizard).to have_next_step(:start_date)
+    end
+  end
+
+  context "from skilled worker visa when funding type is salary" do
+    let(:current_step) { :skilled_worker_visa }
+
+    before do
+      state_store.write(funding_type: "salary")
+    end
+
+    it "proceeds to courses page" do
+      expect(wizard).to have_next_step(:courses_index)
+    end
+  end
+
+  context "from skilled worker visa when funding type is apprenticeship" do
+    let(:current_step) { :skilled_worker_visa }
+
+    before do
+      state_store.write(funding_type: "apprenticeship")
+    end
+
+    it "proceeds to start date page" do
+      expect(wizard).to have_next_step(:courses_index)
     end
   end
 end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -276,11 +276,12 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
     end
   end
 
-  context "from skilled worker visa when funding type is salary" do
+  context "from skilled worker visa when funding type is salary and can sponsor skilled worker visa is true" do
     let(:current_step) { :skilled_worker_visa }
 
     before do
       state_store.write(funding_type: "salary")
+      state_store.write(can_sponsor_skilled_worker_visa: true)
     end
 
     it "proceeds to courses page" do
@@ -288,15 +289,16 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
     end
   end
 
-  context "from skilled worker visa when funding type is apprenticeship" do
+  context "from skilled worker visa when funding type is apprenticeship and can sponsor skilled worker visa is false" do
     let(:current_step) { :skilled_worker_visa }
 
     before do
       state_store.write(funding_type: "apprenticeship")
+      state_store.write(can_sponsor_skilled_worker_visa: false)
     end
 
     it "proceeds to start date page" do
-      expect(wizard).to have_next_step(:courses_index)
+      expect(wizard).to have_next_step(:start_date)
     end
   end
 end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -213,4 +213,16 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:study_sites)
     end
   end
+
+  context "from skilled worker visa" do
+    let(:current_step) { :skilled_worker_visa }
+
+    before do
+      state_store.write(funding_type: "salary")
+    end
+
+    it "goes back to study sites" do
+      expect(wizard).to have_previous_step(:study_sites)
+    end
+  end
 end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -193,7 +193,34 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
         school_provider
       end
 
-      it "goes back to accredited provider" do
+      it "goes back to accredited provider when fee based course" do
+        state_store.write(funding_type: "fee")
+        expect(wizard).to have_previous_step(:accredited_provider)
+      end
+    end
+  end
+
+  context "from skilled worker visa" do
+    let(:current_step) { :skilled_worker_visa }
+
+    before do
+      state_store.write(funding_type: "salary")
+    end
+
+    it "goes back to study sites" do
+      expect(wizard).to have_previous_step(:study_sites)
+    end
+
+    context "when provider has multiple accredited partners" do
+      let!(:provider) do
+        school_provider = create(:provider, provider_type: :lead_school, provider_code:, recruitment_cycle:)
+        create(:site, :study_site, provider: school_provider)
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
+        school_provider
+      end
+
+      it "goes back to accredited provider when provider has multiple accredited partners" do
         expect(wizard).to have_previous_step(:accredited_provider)
       end
     end
@@ -207,18 +234,6 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
       create(:provider_partnership, training_provider: school_provider, accredited_provider: create(:accredited_provider, recruitment_cycle:))
       school_provider
-    end
-
-    it "goes back to study sites" do
-      expect(wizard).to have_previous_step(:study_sites)
-    end
-  end
-
-  context "from skilled worker visa" do
-    let(:current_step) { :skilled_worker_visa }
-
-    before do
-      state_store.write(funding_type: "salary")
     end
 
     it "goes back to study sites" do


### PR DESCRIPTION
## Context

This change introduces a dedicated Skilled Worker visa step in the add-course wizard for funding types that require it (`salary` and `apprenticeship`), instead of relying only on the existing student visa flow.

The key behaviour to note is:
- the step defaults to **No** when unset
- routing now depends on the answer:
  - **Yes** → courses index
  - **No** → start date

## Changes proposed in this pull request

- Added new wizard step class: `CourseWizard::Steps::SkilledWorkerVisa`
  - boolean attribute `can_sponsor_skilled_worker_visa`
  - inclusion validation for `[true, false]` with custom error
  - default getter behaviour to `false` when nil
  - permitted params defined
- Added new view partial for the step:
  - question + yes/no radios + continue CTA
- Added i18n content for heading/question/options/errors in `course_wizard.yml`
- Updated wizard graph to include the new step and branching:
  - from `study_sites` to `skilled_worker_visa` when required
  - from `skilled_worker_visa` to `courses_index` when true, else `start_date`
- Extended `CourseWizardStore` with skilled-worker predicates:
  - `skilled_worker_visa_required?`
  - `skilled_worker_visa_sponsorship_required?`
- Added/updated test coverage:
  - system spec for skilled worker step
  - step spec
  - state store spec
  - next/previous step wizard specs
  - repository spec support updates
- Added explicit spec assertion for `.permitted_params` on `SkilledWorkerVisa`
- Updated next-step wizard tests to include `can_sponsor_skilled_worker_visa` state and assert:
  - sponsored path goes to `courses_index`
  - non-sponsored path goes to `start_date`

## Guidance to review

- Start with wizard graph/state changes:
  - `app/wizards/course_wizard.rb`
  - `app/wizards/course_wizard/state_stores/course_wizard_store.rb`
- Then review step behaviour and validation:
  - `app/wizards/course_wizard/steps/skilled_worker_visa.rb`
  - `app/views/publish/course_wizards/steps/_skilled_worker_visa.html.erb`
- Finally validate coverage:
  - `spec/system/publish/courses/add_course_wizard/skilled_worker_visa_spec.rb`
  - `spec/wizards/add_course_wizard/wizard/next_step_spec.rb`
  - `spec/wizards/add_course_wizard/steps/skilled_worker_visa_spec.rb`
  - `spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb`