### PR TITLE
Add VisaSponsorshipApplicationDeadlineAt & VisaSponsorshipApplicationDeadlineRequired steps

### DIFF
--- a/app/views/publish/course_wizards/steps/_visa_sponsorship_application_deadline_at.html.erb
+++ b/app/views/publish/course_wizards/steps/_visa_sponsorship_application_deadline_at.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.visa_sponsorship_application_deadline_at.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.visa_sponsorship_application_deadline_at.caption")) %>
+  <%= t("course_wizard.steps.visa_sponsorship_application_deadline_at.heading") %>
+</h1>
+
+<p class="govuk-body"><%= t("course_wizard.steps.visa_sponsorship_application_deadline_at.deadline_advice.it_takes_around_90_days") %></p>
+<p class="govuk-body"><%= t("course_wizard.steps.visa_sponsorship_application_deadline_at.deadline_advice.choose_a_deadline_date") %></p>
+<p class="govuk-body"><%= t("course_wizard.steps.visa_sponsorship_application_deadline_at.deadline_advice.if_you_need_more_time") %></p>
+
+<%= form.govuk_date_field(
+      :visa_sponsorship_application_deadline_at,
+      maxlength_enabled: true,
+      legend: { text: t("course_wizard.steps.visa_sponsorship_application_deadline_at.legend") },
+      hint: lambda {
+        safe_join([
+          tag.p(t("course_wizard.steps.visa_sponsorship_application_deadline_at.hint.hint_date"), class: "govuk-hint"),
+          tag.p(t("course_wizard.steps.visa_sponsorship_application_deadline_at.hint.hint_time"), class: "govuk-hint"),
+        ])
+      },
+    ) %>
+
+<%= form.govuk_submit t("course_wizard.steps.visa_sponsorship_application_deadline_at.submit") %>

--- a/app/views/publish/course_wizards/steps/_visa_sponsorship_application_deadline_required.html.erb
+++ b/app/views/publish/course_wizards/steps/_visa_sponsorship_application_deadline_required.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, title_with_error_prefix(t("course_wizard.steps.visa_sponsorship_application_deadline_required.heading"), current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <%= render CaptionText.new(text: t("course_wizard.steps.visa_sponsorship_application_deadline_required.caption")) %>
+  <%= t("course_wizard.steps.visa_sponsorship_application_deadline_required.heading") %>
+</h1>
+
+<p class="govuk-inset-text"><%= t("course_wizard.steps.visa_sponsorship_application_deadline_required.hint") %></p>
+
+<%= form.govuk_radio_buttons_fieldset :visa_sponsorship_application_deadline_required, legend: { hidden: true } do %>
+  <%= form.govuk_radio_button :visa_sponsorship_application_deadline_required, true, label: { text: t("course_wizard.steps.visa_sponsorship_application_deadline_required.options.visa_sponsorship_application_deadline_required.label") } %>
+  <%= form.govuk_radio_button :visa_sponsorship_application_deadline_required, false, label: { text: t("course_wizard.steps.visa_sponsorship_application_deadline_required.options.visa_sponsorship_application_deadline_not_required.label") } %>
+<% end %>
+
+<%= form.govuk_submit t("course_wizard.steps.visa_sponsorship_application_deadline_required.submit") %>

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -35,6 +35,7 @@ class CourseWizard
       graph.add_node :visa_sponsorship, Steps::VisaSponsorship
       graph.add_node :skilled_worker_visa, Steps::SkilledWorkerVisa
       graph.add_node :visa_sponsorship_application_deadline_required, Steps::VisaSponsorshipApplicationDeadlineRequired
+      graph.add_node :visa_sponsorship_application_deadline_at, Steps::VisaSponsorshipApplicationDeadlineAt
 
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
@@ -114,10 +115,12 @@ class CourseWizard
       graph.add_multiple_conditional_edges(
         from: :visa_sponsorship_application_deadline_required,
         branches: [
-          { when: :deadline_for_application_visa_sponsorship_required?, then: :courses_index },
+          { when: :deadline_for_application_visa_sponsorship_required?, then: :visa_sponsorship_application_deadline_at },
         ],
         default: :start_date,
       )
+
+      graph.add_edge from: :visa_sponsorship_application_deadline_at, to: :start_date
     end
   end
 

--- a/app/wizards/course_wizard.rb
+++ b/app/wizards/course_wizard.rb
@@ -14,6 +14,7 @@ class CourseWizard
            :salary_based?,
            :fee_based?,
            :skilled_worker_visa_sponsorship_required?,
+           :deadline_for_application_visa_sponsorship_required?,
            to: :state_store
 
   def steps_processor
@@ -33,6 +34,7 @@ class CourseWizard
       graph.add_node :start_date, Steps::StartDate
       graph.add_node :visa_sponsorship, Steps::VisaSponsorship
       graph.add_node :skilled_worker_visa, Steps::SkilledWorkerVisa
+      graph.add_node :visa_sponsorship_application_deadline_required, Steps::VisaSponsorshipApplicationDeadlineRequired
 
       graph.add_node :courses_index, DfE::Wizard::Core::Redirect
 
@@ -94,8 +96,7 @@ class CourseWizard
       graph.add_multiple_conditional_edges(
         from: :visa_sponsorship,
         branches: [
-          # TODO: when true go to visa sponsorship application deadline page
-          { when: :visa_sponsorship_required?, then: :courses_index },
+          { when: :visa_sponsorship_required?, then: :visa_sponsorship_application_deadline_required },
         ],
         default: :start_date,
       )
@@ -105,8 +106,15 @@ class CourseWizard
       graph.add_multiple_conditional_edges(
         from: :skilled_worker_visa,
         branches: [
-          # TODO: when true go to visa sponsorship application deadline page
-          { when: :skilled_worker_visa_sponsorship_required?, then: :courses_index },
+          { when: :skilled_worker_visa_sponsorship_required?, then: :visa_sponsorship_application_deadline_required },
+        ],
+        default: :start_date,
+      )
+
+      graph.add_multiple_conditional_edges(
+        from: :visa_sponsorship_application_deadline_required,
+        branches: [
+          { when: :deadline_for_application_visa_sponsorship_required?, then: :courses_index },
         ],
         default: :start_date,
       )

--- a/app/wizards/course_wizard/state_stores/course_wizard_store.rb
+++ b/app/wizards/course_wizard/state_stores/course_wizard_store.rb
@@ -33,6 +33,10 @@ class CourseWizard
       def skilled_worker_visa_sponsorship_required?
         ActiveModel::Type::Boolean.new.cast(can_sponsor_skilled_worker_visa)
       end
+
+      def deadline_for_application_visa_sponsorship_required?
+        ActiveModel::Type::Boolean.new.cast(visa_sponsorship_application_deadline_required)
+      end
     end
   end
 end

--- a/app/wizards/course_wizard/steps/visa_sponsorship_application_deadline_at.rb
+++ b/app/wizards/course_wizard/steps/visa_sponsorship_application_deadline_at.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class VisaSponsorshipApplicationDeadlineAt
+      include DfE::Wizard::Step
+
+      DateParts = Struct.new(:year, :month, :day)
+
+      attribute :visa_sponsorship_application_deadline_at
+
+      validate :date_present
+      validate :within_range
+
+      # rubocop:disable Naming/MethodName
+      define_method("visa_sponsorship_application_deadline_at(1i)=") do |value|
+        @deadline_year = value
+        compose_deadline_parts
+      end
+
+      define_method("visa_sponsorship_application_deadline_at(2i)=") do |value|
+        @deadline_month = value
+        compose_deadline_parts
+      end
+
+      define_method("visa_sponsorship_application_deadline_at(3i)=") do |value|
+        @deadline_day = value
+        compose_deadline_parts
+      end
+      # rubocop:enable Naming/MethodName
+
+      def self.permitted_params
+        %i[
+          visa_sponsorship_application_deadline_at
+          visa_sponsorship_application_deadline_at(1i)
+          visa_sponsorship_application_deadline_at(2i)
+          visa_sponsorship_application_deadline_at(3i)
+        ]
+      end
+
+    private
+
+      def date_present
+        error_type = if [year, month, day].all?(&:blank?)
+                       :all_blank
+                     elsif [year, month, day].any?(&:blank?)
+                       :some_blank
+                     elsif [year, month, day].any? { |entry| entry.match?(/\A[a-zA-Z'-]*\z/) }
+                       :not_integers
+                     end
+
+        errors.add(:visa_sponsorship_application_deadline_at, error_type) if error_type.present?
+      end
+
+      def within_range
+        set_date
+
+        unless @date.between?(first_valid_datetime, last_valid_datetime)
+          errors.add(
+            :visa_sponsorship_application_deadline_at,
+            :not_in_range,
+            earliest_date: formatted_first_valid_datetime,
+            apply_deadline: last_valid_datetime.to_fs(:govuk_date_and_time),
+          )
+        end
+      rescue Date::Error
+        errors.add(:visa_sponsorship_application_deadline_at, :invalid_date)
+      end
+
+      def set_date
+        # We use DateTime here instead of Time.zone because DateTime is better at
+        # validating dates.
+        # Time.zone.local(2026, 2, 31) # => => 2026-03-03 00:00:00.000000000 GMT +00:00
+        # DateTime.new(2026, 2, 31) # => Date::Error: invalid date (Date::Error)
+        @date = DateTime.new(year.to_i, month.to_i, day.to_i) # rubocop:disable Style/DateTime
+          .in_time_zone
+          .end_of_day
+      end
+
+      def year
+        visa_sponsorship_application_deadline_at&.year
+      end
+
+      def month
+        visa_sponsorship_application_deadline_at&.month
+      end
+
+      def day
+        visa_sponsorship_application_deadline_at&.day
+      end
+
+      def last_valid_datetime
+        @last_valid_datetime ||= Find::CycleTimetable.date(:apply_deadline, wizard.recruitment_cycle.year.to_i)
+      end
+
+      def first_valid_datetime
+        [Time.zone.now, start_of_cycle].max
+      end
+
+      def formatted_first_valid_datetime
+        if Time.zone.now.after? start_of_cycle
+          "today"
+        else
+          start_of_cycle.to_fs(:govuk_date_and_time)
+        end
+      end
+
+      def start_of_cycle
+        @start_of_cycle ||= wizard.recruitment_cycle.application_start_date.end_of_day.change(hour: 9)
+      end
+
+      def compose_deadline_parts
+        self.visa_sponsorship_application_deadline_at = DateParts.new(
+          @deadline_year,
+          @deadline_month,
+          @deadline_day,
+        )
+      end
+    end
+  end
+end

--- a/app/wizards/course_wizard/steps/visa_sponsorship_application_deadline_at.rb
+++ b/app/wizards/course_wizard/steps/visa_sponsorship_application_deadline_at.rb
@@ -45,7 +45,7 @@ class CourseWizard
                        :all_blank
                      elsif [year, month, day].any?(&:blank?)
                        :some_blank
-                     elsif [year, month, day].any? { |entry| entry.match?(/\A[a-zA-Z'-]*\z/) }
+                     elsif [year, month, day].any? { |entry| entry.present? && !entry.match?(/\A\d+\z/) }
                        :not_integers
                      end
 
@@ -106,7 +106,7 @@ class CourseWizard
       end
 
       def start_of_cycle
-        @start_of_cycle ||= wizard.recruitment_cycle.application_start_date.end_of_day.change(hour: 9)
+        @start_of_cycle ||= wizard.recruitment_cycle.application_start_date.change(hour: 9)
       end
 
       def compose_deadline_parts

--- a/app/wizards/course_wizard/steps/visa_sponsorship_application_deadline_required.rb
+++ b/app/wizards/course_wizard/steps/visa_sponsorship_application_deadline_required.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CourseWizard
+  module Steps
+    class VisaSponsorshipApplicationDeadlineRequired
+      include DfE::Wizard::Step
+
+      attribute :visa_sponsorship_application_deadline_required, :boolean
+
+      validates :visa_sponsorship_application_deadline_required, inclusion: { in: [true, false], message: I18n.t("course_wizard.steps.visa_sponsorship_application_deadline_required.errors.visa_sponsorship_application_deadline_required.blank") }
+
+      def self.permitted_params
+        [:visa_sponsorship_application_deadline_required]
+      end
+    end
+  end
+end

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -182,6 +182,18 @@ en:
         errors:
           visa_sponsorship_application_deadline_required:
             blank: Select if there is a deadline for applications that require visa sponsorship
+      visa_sponsorship_application_deadline_at:
+        caption: Add course
+        heading: Date that applications close for visa sponsored candidates
+        legend: What date will applications that require visa sponsorship close?
+        deadline_advice:
+          it_takes_around_90_days: It takes around 90 days between a candidate that needs visa sponsorship accepting an offer and being recruited.
+          choose_a_deadline_date: Choose a deadline date that gives you at least 3 months to process applications that require a visa so that candidates can start the course on time
+          if_you_need_more_time: If you need more time to process these applications, set an earlier date.
+        hint:
+          hint_date: For example 31 3 2024
+          hint_time: Applications will close at 11:59pm on the date you enter
+        submit: Continue
   activemodel:
     errors:
       models:
@@ -201,3 +213,13 @@ en:
               greater_than_or_equal_to: To age must be between 7 and 19
               less_than_or_equal_to: To age must be between 7 and 19
               invalid: Enter a valid age in To
+        course_wizard/steps/visa_sponsorship_application_deadline_at:
+          attributes:
+            visa_sponsorship_application_deadline_at:
+              all_blank: Select a date that applications close for visa sponsored candidates
+              some_blank: The date that applications which require visa sponsorship will close must contain a day, a month and a year
+              not_integers: The date that applications which require visa sponsorship will close can only contain numbers 0 to 9
+              invalid_date: Enter a real date that applications close for visa sponsored candidates
+              not_in_range: >
+                The date that applications which require visa sponsorship will close must be between %{earliest_date} and
+                the end of the recruitment cycle, %{apply_deadline}

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -168,6 +168,20 @@ en:
         errors:
           can_sponsor_skilled_worker_visa:
             blank: Select if candidates can get a sponsored Skilled Worker visa
+      visa_sponsorship_application_deadline_required:
+        caption: Add course
+        heading: Is there a deadline for applications that require visa sponsorship?
+        question: Is there a deadline for applications that require visa sponsorship?
+        hint: You have told us that you can sponsor visas for this course.
+        submit: Continue
+        options:
+          visa_sponsorship_application_deadline_required:
+            label: "Yes"
+          visa_sponsorship_application_deadline_not_required:
+            label: "No"
+        errors:
+          visa_sponsorship_application_deadline_required:
+            blank: Select if there is a deadline for applications that require visa sponsorship
   activemodel:
     errors:
       models:

--- a/config/locales/en/publish/course_wizard.yml
+++ b/config/locales/en/publish/course_wizard.yml
@@ -171,7 +171,6 @@ en:
       visa_sponsorship_application_deadline_required:
         caption: Add course
         heading: Is there a deadline for applications that require visa sponsorship?
-        question: Is there a deadline for applications that require visa sponsorship?
         hint: You have told us that you can sponsor visas for this course.
         submit: Continue
         options:

--- a/spec/system/publish/courses/add_course_wizard/skilled_worker_visa_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/skilled_worker_visa_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Add course wizard skilled worker visa step", type: :system do
     when_i_visit_the_wizard_skilled_worker_visa_page
     and_i_choose_yes_to_the_skilled_worker_visa_question
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_visa_sponsorship_application_deadline_required_page
   end
 
   scenario "choosing no to skilled worker visa and continues to start date page" do
@@ -70,8 +70,16 @@ private
     expect(page).to have_current_path(publish_provider_recruitment_cycle_course_wizard_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, step: :start_date, state_key: wizard_state_key))
   end
 
-  def then_i_am_taken_to_the_courses_index_page
-    expect(page).to have_current_path(publish_provider_recruitment_cycle_courses_path(provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year))
+  def then_i_am_taken_to_the_visa_sponsorship_application_deadline_required_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :visa_sponsorship_application_deadline_required,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
   end
 
   def provider

--- a/spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_at_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_at_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard visa sponsorship application deadline at step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user_with_a_school
+  end
+
+  scenario "choosing a visa sponsorship application deadline at and continues to start date page" do
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
+    and_i_choose_a_visa_sponsorship_application_deadline_at
+    and_i_click_continue
+    then_i_am_taken_to_the_start_date_page
+  end
+
+  scenario "submitting without selecting a visa sponsorship application deadline at shows validation errors" do
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
+    and_i_click_continue
+    then_i_have_errors_on_the_visa_sponsorship_application_deadline_at_step(
+      "Select a date that applications close for visa sponsored candidates",
+    )
+  end
+
+  scenario "submitting with a date that is not in range shows validation errors" do
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
+    and_i_choose_a_visa_sponsorship_application_deadline_at_that_is_not_in_range
+    and_i_click_continue
+    then_i_have_errors_on_the_visa_sponsorship_application_deadline_at_step(not_in_range_error_message)
+  end
+
+  scenario "submitting with a date that is not a valid date shows validation errors" do
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
+    and_i_choose_a_visa_sponsorship_application_deadline_at_that_is_not_a_valid_date
+    and_i_click_continue
+    then_i_have_errors_on_the_visa_sponsorship_application_deadline_at_step(
+      "Enter a real date that applications close for visa sponsored candidates",
+    )
+  end
+
+  scenario "submitting with letters instead of numbers shows validation errors" do
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
+    and_i_choose_a_visa_sponsorship_application_deadline_at_with_letters
+    and_i_click_continue
+    then_i_have_errors_on_the_visa_sponsorship_application_deadline_at_step(
+      "The date that applications which require visa sponsorship will close can only contain numbers 0 to 9",
+    )
+  end
+
+  scenario "submitting with a date that is not within the recruitment cycle range shows validation errors" do
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
+    and_i_choose_a_visa_sponsorship_application_deadline_at_that_is_not_within_the_recruitment_cycle_range
+    and_i_click_continue
+    then_i_have_errors_on_the_visa_sponsorship_application_deadline_at_step(not_in_range_error_message)
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user_with_a_school
+    @user = create(
+      :user,
+      providers: [create(:provider, :accredited_provider, can_sponsor_student_visa: true, sites: [build(:site)])],
+    )
+
+    given_i_am_authenticated(user: @user)
+    and_i_have_wizard_state_for_visa_sponsorship_application_deadline_at
+  end
+
+  def and_i_have_wizard_state_for_visa_sponsorship_application_deadline_at
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    CourseWizard::StateStores::CourseWizardStore.new(repository:)
+  end
+
+  def when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :visa_sponsorship_application_deadline_at,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def and_i_choose_a_visa_sponsorship_application_deadline_at
+    valid_date = Find::CycleTimetable.date(:apply_deadline, provider.recruitment_cycle_year).to_date - 1.day
+    fill_in "Day", with: valid_date.day
+    fill_in "Month", with: valid_date.month
+    fill_in "Year", with: valid_date.year
+  end
+
+  def and_i_choose_a_visa_sponsorship_application_deadline_at_that_is_not_in_range
+    invalid_date = Find::CycleTimetable.date(:apply_deadline, provider.recruitment_cycle_year).to_date + 1.day
+    fill_in "Day", with: invalid_date.day
+    fill_in "Month", with: invalid_date.month
+    fill_in "Year", with: invalid_date.year
+  end
+
+  def and_i_choose_a_visa_sponsorship_application_deadline_at_that_is_not_a_valid_date
+    fill_in "Day", with: 31
+    fill_in "Month", with: 2
+    fill_in "Year", with: provider.recruitment_cycle_year
+  end
+
+  def and_i_choose_a_visa_sponsorship_application_deadline_at_with_letters
+    fill_in "Day", with: "ab"
+    fill_in "Month", with: "cd"
+    fill_in "Year", with: "efgh"
+  end
+
+  def and_i_choose_a_visa_sponsorship_application_deadline_at_that_is_not_within_the_recruitment_cycle_range
+    fill_in "Day", with: 1
+    fill_in "Month", with: 1
+    fill_in "Year", with: 2000
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_start_date_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :start_date,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_have_errors_on_the_visa_sponsorship_application_deadline_at_step(error_message)
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content(error_message)
+  end
+
+  def not_in_range_error_message
+    apply_deadline = Find::CycleTimetable.date(:apply_deadline, provider.recruitment_cycle_year).to_fs(:govuk_date_and_time)
+    start_of_cycle = provider.recruitment_cycle.application_start_date.end_of_day.change(hour: 9)
+    earliest_date = Time.zone.now.after?(start_of_cycle) ? "today" : start_of_cycle.to_fs(:govuk_date_and_time)
+
+    "The date that applications which require visa sponsorship will close must be between #{earliest_date} and the end of the recruitment cycle, #{apply_deadline}"
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_at_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_at_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe "Add course wizard visa sponsorship application deadline at step"
     )
   end
 
+  scenario "submitting with mixed letters and numbers shows validation errors" do
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
+    and_i_choose_a_visa_sponsorship_application_deadline_at_with_mixed_values
+    and_i_click_continue
+    then_i_have_errors_on_the_visa_sponsorship_application_deadline_at_step(
+      "The date that applications which require visa sponsorship will close can only contain numbers 0 to 9",
+    )
+  end
+
   scenario "submitting with a date that is not within the recruitment cycle range shows validation errors" do
     when_i_visit_the_wizard_visa_sponsorship_application_deadline_at_page
     and_i_choose_a_visa_sponsorship_application_deadline_at_that_is_not_within_the_recruitment_cycle_range
@@ -113,6 +122,12 @@ private
     fill_in "Year", with: "efgh"
   end
 
+  def and_i_choose_a_visa_sponsorship_application_deadline_at_with_mixed_values
+    fill_in "Day", with: "1a"
+    fill_in "Month", with: "2"
+    fill_in "Year", with: provider.recruitment_cycle_year
+  end
+
   def and_i_choose_a_visa_sponsorship_application_deadline_at_that_is_not_within_the_recruitment_cycle_range
     fill_in "Day", with: 1
     fill_in "Month", with: 1
@@ -142,7 +157,7 @@ private
 
   def not_in_range_error_message
     apply_deadline = Find::CycleTimetable.date(:apply_deadline, provider.recruitment_cycle_year).to_fs(:govuk_date_and_time)
-    start_of_cycle = provider.recruitment_cycle.application_start_date.end_of_day.change(hour: 9)
+    start_of_cycle = provider.recruitment_cycle.application_start_date.change(hour: 9)
     earliest_date = Time.zone.now.after?(start_of_cycle) ? "today" : start_of_cycle.to_fs(:govuk_date_and_time)
 
     "The date that applications which require visa sponsorship will close must be between #{earliest_date} and the end of the recruitment cycle, #{apply_deadline}"

--- a/spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_required_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_required_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe "Add course wizard visa sponsorship application deadline required
     given_i_am_authenticated_as_a_provider_user_with_a_school
   end
 
-  scenario "choosing yes to visa sponsorship application deadline required and continues to courses index" do
+  scenario "choosing yes to visa sponsorship application deadline required and continues to visa sponsorship application deadline at page" do
     and_i_have_wizard_state_for_visa_sponsorship_application_deadline_required
     when_i_visit_the_wizard_visa_sponsorship_application_deadline_required_page
     and_i_choose_yes_to_the_visa_sponsorship_application_deadline_required_question
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_visa_sponsorship_application_deadline_at_page
   end
 
   scenario "choosing no to visa sponsorship application deadline required and continues to start date page" do
@@ -71,11 +71,13 @@ private
     click_on "Continue"
   end
 
-  def then_i_am_taken_to_the_courses_index_page
+  def then_i_am_taken_to_the_visa_sponsorship_application_deadline_at_page
     expect(page).to have_current_path(
-      publish_provider_recruitment_cycle_courses_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :visa_sponsorship_application_deadline_at,
+        state_key: wizard_state_key,
       ),
       ignore_query: true,
     )

--- a/spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_required_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_required_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add course wizard visa sponsorship application deadline required step", type: :system do
+  before do
+    FeatureFlag.activate(:wizard_add_course_flow)
+    given_i_am_authenticated_as_a_provider_user_with_a_school
+  end
+
+  scenario "choosing yes to visa sponsorship application deadline required and continues to courses index" do
+    and_i_have_wizard_state_for_visa_sponsorship_application_deadline_required
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_required_page
+    and_i_choose_yes_to_the_visa_sponsorship_application_deadline_required_question
+    and_i_click_continue
+    then_i_am_taken_to_the_courses_index_page
+  end
+
+  scenario "choosing no to visa sponsorship application deadline required and continues to start date page" do
+    and_i_have_wizard_state_for_visa_sponsorship_application_deadline_required
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_required_page
+    and_i_choose_no_to_the_visa_sponsorship_application_deadline_required_question
+    and_i_click_continue
+    then_i_am_taken_to_the_start_date_page
+  end
+
+  scenario "choosing nil to visa sponsorship application deadline required and shows validation errors" do
+    and_i_have_wizard_state_for_visa_sponsorship_application_deadline_required
+    when_i_visit_the_wizard_visa_sponsorship_application_deadline_required_page
+    and_i_click_continue
+    then_i_have_errors_on_the_visa_sponsorship_application_deadline_required_step
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user_with_a_school
+    @user = create(:user, providers: [create(:provider, :accredited_provider, sites: [build(:site)])])
+
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_i_have_wizard_state_for_visa_sponsorship_application_deadline_required
+    repository = CourseWizard::Repositories::Course.new(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      state_key: wizard_state_key,
+      expires_in: 24.hours,
+    )
+
+    CourseWizard::StateStores::CourseWizardStore.new(repository:)
+  end
+
+  def when_i_visit_the_wizard_visa_sponsorship_application_deadline_required_page
+    visit publish_provider_recruitment_cycle_course_wizard_path(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      step: :visa_sponsorship_application_deadline_required,
+      state_key: wizard_state_key,
+    )
+  end
+
+  def and_i_choose_yes_to_the_visa_sponsorship_application_deadline_required_question
+    choose "Yes"
+  end
+
+  def and_i_choose_no_to_the_visa_sponsorship_application_deadline_required_question
+    choose "No"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_am_taken_to_the_courses_index_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_courses_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_am_taken_to_the_start_date_page
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :start_date,
+        state_key: wizard_state_key,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_have_errors_on_the_visa_sponsorship_application_deadline_required_step
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Select if there is a deadline for applications that require visa sponsorship")
+  end
+
+  def provider
+    @provider ||= @user.providers.first
+  end
+
+  def wizard_state_key
+    @wizard_state_key ||= SecureRandom.uuid
+  end
+end

--- a/spec/system/publish/courses/add_course_wizard/visa_sponsorship_spec.rb
+++ b/spec/system/publish/courses/add_course_wizard/visa_sponsorship_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Add course wizard visa sponsorship step", type: :system do
     when_i_visit_the_wizard_visa_sponsorship_page
     and_i_choose_yes_to_the_visa_sponsorship_question
     and_i_click_continue
-    then_i_am_taken_to_the_courses_index_page
+    then_i_am_taken_to_the_visa_sponsorship_application_deadline_required_page
   end
 
   scenario "choosing no to visa sponsorship and continues to start date page" do
@@ -201,11 +201,13 @@ private
     click_on "Continue"
   end
 
-  def then_i_am_taken_to_the_courses_index_page
+  def then_i_am_taken_to_the_visa_sponsorship_application_deadline_required_page
     expect(page).to have_current_path(
-      publish_provider_recruitment_cycle_courses_path(
+      publish_provider_recruitment_cycle_course_wizard_path(
         provider_code: provider.provider_code,
         recruitment_cycle_year: provider.recruitment_cycle_year,
+        step: :visa_sponsorship_application_deadline_required,
+        state_key: wizard_state_key,
       ),
       ignore_query: true,
     )

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -28,9 +28,10 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "site_ids" => %w[1 2] })
       repository.write({ "study_sites_ids" => %w[3 4] })
       repository.write({ "start_date" => "January 2026" })
-      repository.write({ "can_sponsor_student_visa" => true })
       repository.write({ "accredited_provider_code" => "123" })
+      repository.write({ "can_sponsor_student_visa" => true })
       repository.write({ "can_sponsor_skilled_worker_visa" => true })
+      repository.write({ "visa_sponsorship_application_deadline_required" => true })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -47,9 +48,10 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:site_ids]).to eq(%w[1 2])
       expect(data[:study_sites_ids]).to eq(%w[3 4])
       expect(data[:start_date]).to eq("January 2026")
-      expect(data[:can_sponsor_student_visa]).to be(true)
       expect(data[:accredited_provider_code]).to eq("123")
+      expect(data[:can_sponsor_student_visa]).to be(true)
       expect(data[:can_sponsor_skilled_worker_visa]).to be(true)
+      expect(data[:visa_sponsorship_application_deadline_required]).to be(true)
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/repositories/course_spec.rb
+++ b/spec/wizards/add_course_wizard/repositories/course_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe CourseWizard::Repositories::Course do
   let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+  let(:visa_deadline_payload) { { year: "2026", month: "9", day: "1" } }
   let(:repository) do
     described_class.new(
       provider_code: "PROV",
@@ -32,6 +33,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       repository.write({ "can_sponsor_student_visa" => true })
       repository.write({ "can_sponsor_skilled_worker_visa" => true })
       repository.write({ "visa_sponsorship_application_deadline_required" => true })
+      repository.write({ "visa_sponsorship_application_deadline_at" => visa_deadline_payload })
 
       data = repository.read
       expect(data[:level]).to eq("secondary")
@@ -52,6 +54,7 @@ RSpec.describe CourseWizard::Repositories::Course do
       expect(data[:can_sponsor_student_visa]).to be(true)
       expect(data[:can_sponsor_skilled_worker_visa]).to be(true)
       expect(data[:visa_sponsorship_application_deadline_required]).to be(true)
+      expect(data[:visa_sponsorship_application_deadline_at]).to eq(visa_deadline_payload)
 
       expect(data.keys.map(&:class).uniq).to eq([Symbol])
     end

--- a/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
+++ b/spec/wizards/add_course_wizard/state_stores/course_wizard_store_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe CourseWizard::StateStores::CourseWizardStore do
-  subject(:store) { described_class.new(repository:, attribute_names: %w[level qualification can_sponsor_student_visa can_sponsor_skilled_worker_visa funding_type]) }
+  subject(:store) { described_class.new(repository:, attribute_names: %w[level qualification can_sponsor_student_visa can_sponsor_skilled_worker_visa funding_type visa_sponsorship_application_deadline_required]) }
 
   let(:repository) { instance_double(DfE::Wizard::Repository::InMemory) }
 
@@ -81,6 +81,36 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
     end
   end
 
+  describe "#salary_based?" do
+    before do
+      allow(repository).to receive(:read).and_return({ funding_type: })
+    end
+
+    context "when funding type is salary" do
+      let(:funding_type) { "salary" }
+
+      it "returns true" do
+        expect(store.salary_based?).to be true
+      end
+    end
+
+    context "when funding type is apprenticeship" do
+      let(:funding_type) { "apprenticeship" }
+
+      it "returns true" do
+        expect(store.salary_based?).to be true
+      end
+    end
+
+    context "when funding type is fee" do
+      let(:funding_type) { "fee" }
+
+      it "returns false" do
+        expect(store.salary_based?).to be false
+      end
+    end
+  end
+
   describe "#undergraduate_degree_with_qts?" do
     before do
       allow(repository).to receive(:read).and_return({ qualification: })
@@ -141,36 +171,6 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
     end
   end
 
-  describe "#salary_based?" do
-    before do
-      allow(repository).to receive(:read).and_return({ funding_type: })
-    end
-
-    context "when funding type is salary" do
-      let(:funding_type) { "salary" }
-
-      it "returns true" do
-        expect(store.salary_based?).to be true
-      end
-    end
-
-    context "when funding type is apprenticeship" do
-      let(:funding_type) { "apprenticeship" }
-
-      it "returns true" do
-        expect(store.salary_based?).to be true
-      end
-    end
-
-    context "when funding type is fee" do
-      let(:funding_type) { "fee" }
-
-      it "returns false" do
-        expect(store.salary_based?).to be false
-      end
-    end
-  end
-
   describe "#skilled_worker_visa_sponsorship_required?" do
     before do
       allow(repository).to receive(:read).and_return({ can_sponsor_skilled_worker_visa: })
@@ -205,6 +205,44 @@ RSpec.describe CourseWizard::StateStores::CourseWizardStore do
 
       it "returns false" do
         expect(store.skilled_worker_visa_sponsorship_required?).to be false
+      end
+    end
+  end
+
+  describe "#deadline_for_application_visa_sponsorship_required?" do
+    before do
+      allow(repository).to receive(:read).and_return({ visa_sponsorship_application_deadline_required: })
+    end
+
+    context "when visa_sponsorship_application_deadline_required is true" do
+      let(:visa_sponsorship_application_deadline_required) { true }
+
+      it "returns true" do
+        expect(store.deadline_for_application_visa_sponsorship_required?).to be true
+      end
+    end
+
+    context "when visa_sponsorship_application_deadline_required is false" do
+      let(:visa_sponsorship_application_deadline_required) { false }
+
+      it "returns false" do
+        expect(store.deadline_for_application_visa_sponsorship_required?).to be false
+      end
+    end
+
+    context "when visa_sponsorship_application_deadline_required is 'true'" do
+      let(:visa_sponsorship_application_deadline_required) { "true" }
+
+      it "returns true" do
+        expect(store.deadline_for_application_visa_sponsorship_required?).to be true
+      end
+    end
+
+    context "when visa_sponsorship_application_deadline_required is 'false'" do
+      let(:visa_sponsorship_application_deadline_required) { "false" }
+
+      it "returns false" do
+        expect(store.deadline_for_application_visa_sponsorship_required?).to be false
       end
     end
   end

--- a/spec/wizards/add_course_wizard/steps/visa_sponsorship_application_deadline_at_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/visa_sponsorship_application_deadline_at_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe CourseWizard::Steps::VisaSponsorshipApplicationDeadlineAt do
         .to include("The date that applications which require visa sponsorship will close can only contain numbers 0 to 9")
     end
 
+    it "is invalid when date fields contain mixed numeric and non-numeric values" do
+      set_date_parts("2026", "1a", "2")
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:visa_sponsorship_application_deadline_at))
+        .to include("The date that applications which require visa sponsorship will close can only contain numbers 0 to 9")
+    end
+
     it "is invalid when date is not real" do
       set_date_parts("2026", "2", "31")
 

--- a/spec/wizards/add_course_wizard/steps/visa_sponsorship_application_deadline_at_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/visa_sponsorship_application_deadline_at_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::VisaSponsorshipApplicationDeadlineAt do
+  include_context "add_course_wizard"
+
+  let(:current_step) { :visa_sponsorship_application_deadline_at }
+  let(:visa_sponsorship_application_deadline_at) { nil }
+  let(:wizard_step) { wizard.current_step }
+
+  describe "#valid?" do
+    it "is valid when visa_sponsorship_application_deadline_at is in range" do
+      valid_date = Find::CycleTimetable.date(:apply_deadline, recruitment_cycle_year).to_date - 1.day
+      set_date_parts(valid_date.year.to_s, valid_date.month.to_s, valid_date.day.to_s)
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "is invalid when all date fields are blank" do
+      set_date_parts("", "", "")
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:visa_sponsorship_application_deadline_at))
+        .to include("Select a date that applications close for visa sponsored candidates")
+    end
+
+    it "is invalid when some date fields are blank" do
+      set_date_parts("2026", "", "1")
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:visa_sponsorship_application_deadline_at))
+        .to include("The date that applications which require visa sponsorship will close must contain a day, a month and a year")
+    end
+
+    it "is invalid when date fields contain non-numeric values" do
+      set_date_parts("abcd", "1", "2")
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:visa_sponsorship_application_deadline_at))
+        .to include("The date that applications which require visa sponsorship will close can only contain numbers 0 to 9")
+    end
+
+    it "is invalid when date is not real" do
+      set_date_parts("2026", "2", "31")
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:visa_sponsorship_application_deadline_at))
+        .to include("Enter a real date that applications close for visa sponsored candidates")
+    end
+
+    it "is invalid when date is outside recruitment cycle range" do
+      invalid_date = Find::CycleTimetable.date(:apply_deadline, recruitment_cycle_year).to_date + 1.day
+      set_date_parts(invalid_date.year.to_s, invalid_date.month.to_s, invalid_date.day.to_s)
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:visa_sponsorship_application_deadline_at))
+        .to include("The date that applications which require visa sponsorship will close must be between today and the end of the recruitment cycle, 6pm on 15 September 2026\n")
+    end
+  end
+
+private
+
+  def set_date_parts(year, month, day)
+    wizard_step.public_send("visa_sponsorship_application_deadline_at(1i)=", year)
+    wizard_step.public_send("visa_sponsorship_application_deadline_at(2i)=", month)
+    wizard_step.public_send("visa_sponsorship_application_deadline_at(3i)=", day)
+  end
+end

--- a/spec/wizards/add_course_wizard/steps/visa_sponsorship_application_deadline_required_spec.rb
+++ b/spec/wizards/add_course_wizard/steps/visa_sponsorship_application_deadline_required_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseWizard::Steps::VisaSponsorshipApplicationDeadlineRequired do
+  include_context "add_course_wizard"
+
+  let(:current_step) { :visa_sponsorship_application_deadline_required }
+  let(:visa_sponsorship_application_deadline_required) { nil }
+  let(:wizard_step) { wizard.current_step }
+
+  describe "#valid?" do
+    it "is valid when visa_sponsorship_application_deadline_required is true" do
+      wizard_step.visa_sponsorship_application_deadline_required = true
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "is valid when visa_sponsorship_application_deadline_required is false" do
+      wizard_step.visa_sponsorship_application_deadline_required = false
+
+      expect(wizard_step).to be_valid
+    end
+
+    it "is invalid when visa_sponsorship_application_deadline_required is nil" do
+      wizard_step.visa_sponsorship_application_deadline_required = nil
+
+      expect(wizard_step).not_to be_valid
+      expect(wizard_step.errors.messages_for(:visa_sponsorship_application_deadline_required)).to contain_exactly("Select if there is a deadline for applications that require visa sponsorship")
+    end
+  end
+end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -347,11 +347,19 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
 
     it "proceeds to courses page when deadline for application visa sponsorship is required" do
       state_store.write(visa_sponsorship_application_deadline_required: true)
-      expect(wizard).to have_next_step(:courses_index)
+      expect(wizard).to have_next_step(:visa_sponsorship_application_deadline_at)
     end
 
     it "proceeds to start date page when deadline for application visa sponsorship is not required" do
       state_store.write(visa_sponsorship_application_deadline_required: false)
+      expect(wizard).to have_next_step(:start_date)
+    end
+  end
+
+  context "from visa sponsorship application deadline at" do
+    let(:current_step) { :visa_sponsorship_application_deadline_at }
+
+    it "proceeds to start date page" do
       expect(wizard).to have_next_step(:start_date)
     end
   end

--- a/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/next_step_spec.rb
@@ -299,8 +299,8 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
       state_store.write(can_sponsor_student_visa: true)
     end
 
-    it "proceeds to courses page" do
-      expect(wizard).to have_next_step(:courses_index)
+    it "proceeds to visa sponsorship application deadline required page" do
+      expect(wizard).to have_next_step(:visa_sponsorship_application_deadline_required)
     end
   end
 
@@ -324,8 +324,8 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
       state_store.write(can_sponsor_skilled_worker_visa: true)
     end
 
-    it "proceeds to courses page" do
-      expect(wizard).to have_next_step(:courses_index)
+    it "proceeds to visa sponsorship application deadline required page" do
+      expect(wizard).to have_next_step(:visa_sponsorship_application_deadline_required)
     end
   end
 
@@ -338,6 +338,20 @@ RSpec.describe "CourseWizard#next_step", type: :wizard do
     end
 
     it "proceeds to start date page" do
+      expect(wizard).to have_next_step(:start_date)
+    end
+  end
+
+  context "from visa sponsorship application deadline required" do
+    let(:current_step) { :visa_sponsorship_application_deadline_required }
+
+    it "proceeds to courses page when deadline for application visa sponsorship is required" do
+      state_store.write(visa_sponsorship_application_deadline_required: true)
+      expect(wizard).to have_next_step(:courses_index)
+    end
+
+    it "proceeds to start date page when deadline for application visa sponsorship is not required" do
+      state_store.write(visa_sponsorship_application_deadline_required: false)
       expect(wizard).to have_next_step(:start_date)
     end
   end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -262,4 +262,22 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:visa_sponsorship)
     end
   end
+
+  context "from visa sponsorship application deadline at" do
+    let(:current_step) { :visa_sponsorship_application_deadline_at }
+
+    it "goes back to visa sponsorship application deadline required when funding type is fee and can sponsor student visa is true" do
+      state_store.write(funding_type: "fee")
+      state_store.write(can_sponsor_student_visa: true)
+      state_store.write(visa_sponsorship_application_deadline_required: true)
+      expect(wizard).to have_previous_step(:visa_sponsorship_application_deadline_required)
+    end
+
+    it "goes back to visa sponsorship application deadline required when funding type is salary and can sponsor skilled worker visa is true" do
+      state_store.write(funding_type: "salary")
+      state_store.write(can_sponsor_skilled_worker_visa: true)
+      state_store.write(visa_sponsorship_application_deadline_required: true)
+      expect(wizard).to have_previous_step(:visa_sponsorship_application_deadline_required)
+    end
+  end
 end

--- a/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
+++ b/spec/wizards/add_course_wizard/wizard/previous_step_spec.rb
@@ -240,4 +240,26 @@ RSpec.describe "CourseWizard#previous_step", type: :wizard do
       expect(wizard).to have_previous_step(:study_sites)
     end
   end
+
+  context "from visa sponsorship application deadline required" do
+    let(:current_step) { :visa_sponsorship_application_deadline_required }
+
+    it "goes back to skilled worker visa when funding type is salary and can sponsor skilled worker visa is true" do
+      state_store.write(funding_type: "salary")
+      state_store.write(can_sponsor_skilled_worker_visa: true)
+      expect(wizard).to have_previous_step(:skilled_worker_visa)
+    end
+
+    it "goes back to skilled worker visa when funding type is apprenticeship and can sponsor skilled worker visa is true" do
+      state_store.write(funding_type: "apprenticeship")
+      state_store.write(can_sponsor_skilled_worker_visa: true)
+      expect(wizard).to have_previous_step(:skilled_worker_visa)
+    end
+
+    it "goes back to visa sponsorship when funding type is fee and can sponsor student visa is true" do
+      state_store.write(funding_type: "fee")
+      state_store.write(can_sponsor_student_visa: true)
+      expect(wizard).to have_previous_step(:visa_sponsorship)
+    end
+  end
 end


### PR DESCRIPTION
## Context

This change completes the visa sponsorship branch in the add-course wizard so providers can explicitly set whether they need a visa-related application deadline, and if so, enter that deadline date.  
It replaces the previous direct jump to the next section with a clearer decision path and adds date validation to prevent invalid or out-of-window deadlines.

## Changes proposed in this pull request

- Adds a new `visa_sponsorship_application_deadline_required` step (yes/no) shown when visa sponsorship is required.
- Adds a new `visa_sponsorship_application_deadline_at` date step, including validation for:
  - blank/partial dates
  - non-numeric values
  - invalid calendar dates
  - out-of-range dates (must be between start-of-cycle/today and cycle apply deadline)
- Updates wizard navigation so visa sponsorship paths now route through these steps before `start_date`.
- Persists new state keys in the wizard store/repository:
  - `visa_sponsorship_application_deadline_required`
  - `visa_sponsorship_application_deadline_at`
- Adds/updates locale strings for both new pages and validation messages.
- Expands test coverage across:
  - step specs
  - system specs
  - wizard next/previous step specs
  - repository/state store specs

## Guidance to review

- Walk through add-course flows where visa sponsorship is required:
  - fee-funded route (`visa_sponsorship`)
  - salary/apprenticeship route (`skilled_worker_visa`)
- Verify routing:
  - sponsorship required -> deadline required step
  - deadline required = yes -> deadline date step
  - deadline required = no -> `start_date`
- On date step, test edge cases:
  - empty fields, partial fields, letters, invalid date (e.g. 31/02), and after apply deadline
- Confirm copy/errors come from locale entries and match expected content.
- Suggested checks:
  - `bundle exec rspec spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_required_spec.rb`
  - `bundle exec rspec spec/system/publish/courses/add_course_wizard/visa_sponsorship_application_deadline_at_spec.rb`
  - `bundle exec rspec spec/wizards/add_course_wizard/wizard/next_step_spec.rb spec/wizards/add_course_wizard/wizard/previous_step_spec.rb`

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.