### PR TITLE
2683 - New GitHub action validate infra workflow - terraform-plan mis…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,8 @@ deploy-init: vendor-modules
 deploy-plan: deploy-init
 	terraform -chdir=terraform/aks plan ${DETAILED_EXITCODE} -var-file=./workspace_variables/$(DEPLOY_ENV).tfvars.json ${TF_VARS}
 
+terraform-plan : deploy-plan
+
 deploy: deploy-init
 	terraform -chdir=terraform/aks apply -var-file=./workspace_variables/$(DEPLOY_ENV).tfvars.json ${TF_VARS} $(AUTO_APPROVE)
 


### PR DESCRIPTION
### Context

Adding a validate infra workflow to detect any changes in SD Infra Terraform 

### Changes proposed in this pull request

The GitHub action workflow validate-infrastructure.yml requires terraform-plan not deploy-plan. The terraform-plan forwarder added to Makefile.

### Guidance to review

To validate the workflow once available. Make a test branch with a change to terraform/aks/workspace_variables/production.tfvars.json **replicas**.
Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**

Manually test changes by altering terraform/aks/workspace_variables/production.tfvars.json **replicas** and running locally the following command.
`make production domains-plan CONFIRM_PRODUCTION=yes`
This will produce a Terraform update in place.

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
