### PR TITLE
2683 - Makefile changes to stop false positive Terraform plans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ ci:	## Run in automation environment
 	$(eval export AUTO_APPROVE=-auto-approve)
 	$(eval SKIP_CONFIRM=true)
 	$(eval SKIP_AZURE_LOGIN=true)
+	$(eval export NO_IMAGE_TAG_DEFAULT=true)
 
 read-keyvault-config:
 	$(eval export key_vault_name=$(shell jq -r '.key_vault_name' terraform/aks/workspace_variables/$(DEPLOY_ENV).tfvars.json))
@@ -166,7 +167,7 @@ vendor-modules:
 ### Infra Targets From Here
 
 deploy-init: vendor-modules
-	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
+	$(if $(IMAGE_TAG),,$(if $(NO_IMAGE_TAG_DEFAULT),$(eval export IMAGE_TAG=main),$(error Missing environment variable "IMAGE_TAG")))
 	$(eval export TF_VAR_docker_image=ghcr.io/dfe-digital/publish-teacher-training:$(IMAGE_TAG))
 	az account set -s ${AZ_SUBSCRIPTION} && az account show
 	terraform -chdir=terraform/aks init -reconfigure -upgrade -backend-config=./workspace_variables/$(DEPLOY_ENV)_backend.tfvars $(backend_key)


### PR DESCRIPTION
### Context

The validate infra workflow is producing a false positive, reporting a difference between the docker images in live and the workflow run. This is happening because the workflow run is picking up the sha from the latest commit whereas live is from main.

### Changes proposed in this pull request

In Makefile
$(eval export NO_IMAGE_TAG_DEFAULT=true) has been added to ci.
and
$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
has been altered to
$(if $(IMAGE_TAG),,$(if $(NO_IMAGE_TAG_DEFAULT),$(eval export IMAGE_TAG=main),$(error Missing environment variable "IMAGE_TAG")))

The aim is GitHub validation (ci runs) use main, whilst a deploy would use a provided IMAGE_TAG and therefore use the commit SHA and an accidental deploy without IMAGE_TAG would fail safely.

### Guidance to review

There is no real way to test this other than merging to main and running the workflow as that is the only true non-artificial test. If you run against a branch it will use the branch docker image which is definitey going to be different to the live docker image.

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
