### PR TITLE
Change EmailAlerts schedule back to once a week

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -57,7 +57,7 @@ bg_jobs:
     class: "CleanupRecentSearchesJob"
     queue: default
   send_weekly_email_alerts:
-    cron: "0 3 * * *" # daily at 03:00 (temporarily changed from weekly Friday)
+    cron: "0 3 * * 5" # weekly on Friday at 03:00
     class: "SendWeeklyEmailAlertsJob"
     queue: default
 


### PR DESCRIPTION
## Context


Change EmailAlerts schedule back to once a week. We scheduled it to run once a day for testing but now we're close to release so lets schdule it once a week as planned.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
