### PR TITLE
School Data remodel: Main site migration exception

### DIFF
--- a/app/models/course/school.rb
+++ b/app/models/course/school.rb
@@ -10,4 +10,10 @@ class Course::School < ApplicationRecord
 
   validates :site_code, presence: true
   validates :gias_school_id, uniqueness: { scope: %i[course_id site_code] }
+  validates :gias_school_id,
+            uniqueness: {
+              scope: :course_id,
+              conditions: -> { where.not(site_code: Provider::School::MAIN_SITE_CODE) },
+            },
+            if: -> { site_code != Provider::School::MAIN_SITE_CODE }
 end

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -12,6 +12,12 @@ class Provider::School < ApplicationRecord
 
   validates :site_code, presence: true
   validates :gias_school_id, uniqueness: { scope: %i[provider_id site_code] }
+  validates :gias_school_id,
+            uniqueness: {
+              scope: :provider_id,
+              conditions: -> { where.not(site_code: MAIN_SITE_CODE) },
+            },
+            if: -> { site_code != MAIN_SITE_CODE }
   validates :site_code,
             uniqueness: {
               scope: :provider_id,

--- a/app/models/provider/school.rb
+++ b/app/models/provider/school.rb
@@ -5,6 +5,7 @@ class Provider::School < ApplicationRecord
 
   self.table_name = "provider_school"
 
+  # The main site code is used to identify the main site for a provider. It is used in the uniqueness validation to ensure that there is only one main site per provider.
   MAIN_SITE_CODE = "-"
 
   belongs_to :provider, class_name: "::Provider", inverse_of: :schools

--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -37,15 +37,42 @@ module DataHub
 
       def insert_provider_schools
         inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
+          WITH main_site_provider_schools AS (
+            SELECT DISTINCT ON (site.provider_id)
+                   site.provider_id,
+                   gias_school.id AS gias_school_id,
+                   site.code AS site_code
+            FROM site
+            JOIN gias_school ON gias_school.urn = site.urn
+            WHERE site.site_type = 0
+              AND site.discarded_at IS NULL
+              AND site.urn IS NOT NULL
+              AND site.urn <> ''
+              AND site.code = '-'
+            ORDER BY site.provider_id, site.id
+          ),
+          non_main_provider_schools AS (
+            SELECT DISTINCT ON (site.provider_id, gias_school.id)
+                   site.provider_id,
+                   gias_school.id AS gias_school_id,
+                   site.code AS site_code
+            FROM site
+            JOIN gias_school ON gias_school.urn = site.urn
+            WHERE site.site_type = 0
+              AND site.discarded_at IS NULL
+              AND site.urn IS NOT NULL
+              AND site.urn <> ''
+              AND site.code <> '-'
+            ORDER BY site.provider_id, gias_school.id, site.id
+          ),
+          source_provider_schools AS (
+            SELECT * FROM main_site_provider_schools
+            UNION ALL
+            SELECT * FROM non_main_provider_schools
+          )
           INSERT INTO provider_school (provider_id, gias_school_id, site_code, created_at, updated_at)
-          SELECT DISTINCT ON (site.provider_id, gias_school.id, site.code)
-                 site.provider_id, gias_school.id, site.code, NOW(), NOW()
-          FROM site
-          JOIN gias_school ON gias_school.urn = site.urn
-          WHERE site.site_type = 0
-            AND site.discarded_at IS NULL
-            AND site.urn IS NOT NULL
-            AND site.urn <> ''
+          SELECT provider_id, gias_school_id, site_code, NOW(), NOW()
+          FROM source_provider_schools
           ON CONFLICT DO NOTHING
           RETURNING 1
         SQL
@@ -54,16 +81,44 @@ module DataHub
 
       def insert_course_schools
         inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
+          WITH main_site_course_schools AS (
+            SELECT DISTINCT ON (course_site.course_id, gias_school.id)
+                   course_site.course_id,
+                   gias_school.id AS gias_school_id,
+                   site.code AS site_code
+            FROM course_site
+            JOIN site        ON site.id = course_site.site_id
+            JOIN gias_school ON gias_school.urn = site.urn
+            WHERE site.site_type = 0
+              AND site.discarded_at IS NULL
+              AND site.urn IS NOT NULL
+              AND site.urn <> ''
+              AND site.code = '-'
+            ORDER BY course_site.course_id, gias_school.id, site.id
+          ),
+          non_main_course_schools AS (
+            SELECT DISTINCT ON (course_site.course_id, gias_school.id)
+                   course_site.course_id,
+                   gias_school.id AS gias_school_id,
+                   site.code AS site_code
+            FROM course_site
+            JOIN site        ON site.id = course_site.site_id
+            JOIN gias_school ON gias_school.urn = site.urn
+            WHERE site.site_type = 0
+              AND site.discarded_at IS NULL
+              AND site.urn IS NOT NULL
+              AND site.urn <> ''
+              AND site.code <> '-'
+            ORDER BY course_site.course_id, gias_school.id, site.id
+          ),
+          source_course_schools AS (
+            SELECT * FROM main_site_course_schools
+            UNION ALL
+            SELECT * FROM non_main_course_schools
+          )
           INSERT INTO course_school (course_id, gias_school_id, site_code, created_at, updated_at)
-          SELECT DISTINCT ON (course_site.course_id, gias_school.id, site.code)
-                 course_site.course_id, gias_school.id, site.code, NOW(), NOW()
-          FROM course_site
-          JOIN site        ON site.id = course_site.site_id
-          JOIN gias_school ON gias_school.urn = site.urn
-          WHERE site.site_type = 0
-            AND site.discarded_at IS NULL
-            AND site.urn IS NOT NULL
-            AND site.urn <> ''
+          SELECT course_id, gias_school_id, site_code, NOW(), NOW()
+          FROM source_course_schools
           ON CONFLICT DO NOTHING
           RETURNING 1
         SQL

--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -3,6 +3,13 @@
 module DataHub
   module SchoolsBackfill
     class Executor
+      attr_reader :recruitment_cycle_years, :recruitment_cycle_ids
+
+      def initialize(recruitment_cycle_years: nil)
+        @recruitment_cycle_years = parse_recruitment_cycle_years(recruitment_cycle_years)
+        @recruitment_cycle_ids = resolve_recruitment_cycle_ids
+      end
+
       def execute
         process_summary = DataHub::SchoolsBackfillProcessSummary.start!
 
@@ -34,6 +41,56 @@ module DataHub
       end
 
     private
+
+      def parse_recruitment_cycle_years(raw_years)
+        Array(raw_years)
+          .flat_map { |value| value.to_s.split(",") }
+          .map(&:strip)
+          .reject(&:blank?)
+          .uniq
+      end
+
+      def resolve_recruitment_cycle_ids
+        return [] if recruitment_cycle_years.empty?
+
+        ids_by_year = RecruitmentCycle.where(year: recruitment_cycle_years).pluck(:year, :id).to_h
+        missing_years = recruitment_cycle_years - ids_by_year.keys
+
+        if missing_years.any?
+          raise ArgumentError, "Could not find recruitment cycle(s) for year(s): #{missing_years.join(', ')}"
+        end
+
+        ids_by_year.values
+      end
+
+      def scoped_to_recruitment_cycles?
+        recruitment_cycle_ids.any?
+      end
+
+      def recruitment_cycle_ids_sql
+        recruitment_cycle_ids.join(", ")
+      end
+
+      def site_provider_scope_join_sql
+        return "" unless scoped_to_recruitment_cycles?
+
+        "JOIN provider ON provider.id = site.provider_id"
+      end
+
+      def course_provider_scope_join_sql
+        return "" unless scoped_to_recruitment_cycles?
+
+        <<~SQL.squish
+          JOIN course ON course.id = course_site.course_id
+          JOIN provider ON provider.id = course.provider_id
+        SQL
+      end
+
+      def recruitment_cycle_scope_sql
+        return "" unless scoped_to_recruitment_cycles?
+
+        "AND provider.recruitment_cycle_id IN (#{recruitment_cycle_ids_sql})"
+      end
 
       def insert_provider_schools
         inserted_rows = ActiveRecord::Base.connection.exec_query(provider_schools_insert_sql)
@@ -72,12 +129,14 @@ module DataHub
                    gias_school.id AS gias_school_id,
                    site.code AS site_code
             FROM site
+            #{site_provider_scope_join_sql}
             JOIN gias_school ON gias_school.urn = site.urn
             WHERE site.site_type = 0
               AND site.discarded_at IS NULL
               AND site.urn IS NOT NULL
               AND site.urn <> ''
               AND site.code = '-'
+              #{recruitment_cycle_scope_sql}
             ORDER BY site.provider_id, site.id
           )
         SQL
@@ -94,12 +153,14 @@ module DataHub
                    gias_school.id AS gias_school_id,
                    site.code AS site_code
             FROM site
+            #{site_provider_scope_join_sql}
             JOIN gias_school ON gias_school.urn = site.urn
             WHERE site.site_type = 0
               AND site.discarded_at IS NULL
               AND site.urn IS NOT NULL
               AND site.urn <> ''
               AND site.code <> '-'
+              #{recruitment_cycle_scope_sql}
             ORDER BY site.provider_id, gias_school.id, site.id
           )
         SQL
@@ -144,6 +205,7 @@ module DataHub
                    gias_school.id AS gias_school_id,
                    site.code AS site_code
             FROM course_site
+            #{course_provider_scope_join_sql}
             JOIN site        ON site.id = course_site.site_id
             JOIN gias_school ON gias_school.urn = site.urn
             WHERE site.site_type = 0
@@ -151,6 +213,7 @@ module DataHub
               AND site.urn IS NOT NULL
               AND site.urn <> ''
               AND site.code = '-'
+              #{recruitment_cycle_scope_sql}
             ORDER BY course_site.course_id, gias_school.id, site.id
           )
         SQL
@@ -167,6 +230,7 @@ module DataHub
                    gias_school.id AS gias_school_id,
                    site.code AS site_code
             FROM course_site
+            #{course_provider_scope_join_sql}
             JOIN site        ON site.id = course_site.site_id
             JOIN gias_school ON gias_school.urn = site.urn
             WHERE site.site_type = 0
@@ -174,6 +238,7 @@ module DataHub
               AND site.urn IS NOT NULL
               AND site.urn <> ''
               AND site.code <> '-'
+              #{recruitment_cycle_scope_sql}
             ORDER BY course_site.course_id, gias_school.id, site.id
           )
         SQL
@@ -203,10 +268,12 @@ module DataHub
                    ELSE 'urn_not_in_gias_school'
                  END AS reason
           FROM site
+          #{site_provider_scope_join_sql}
           LEFT JOIN gias_school ON gias_school.urn = site.urn
           WHERE site.site_type = 0
             AND site.discarded_at IS NULL
             AND (site.urn IS NULL OR site.urn = '' OR gias_school.id IS NULL)
+            #{recruitment_cycle_scope_sql}
           ORDER BY site.id
         SQL
       end
@@ -226,14 +293,18 @@ module DataHub
                    ELSE 'urn_not_in_gias_school'
                  END AS reason
           FROM course_site
+          #{course_provider_scope_join_sql}
           LEFT JOIN site        ON site.id = course_site.site_id
           LEFT JOIN gias_school ON gias_school.urn = site.urn
-          WHERE site.id IS NULL
-             OR site.site_type <> 0
-             OR site.discarded_at IS NOT NULL
-             OR site.urn IS NULL
-             OR site.urn = ''
-             OR gias_school.id IS NULL
+          WHERE (
+              site.id IS NULL
+              OR site.site_type <> 0
+              OR site.discarded_at IS NOT NULL
+              OR site.urn IS NULL
+              OR site.urn = ''
+              OR gias_school.id IS NULL
+            )
+            #{recruitment_cycle_scope_sql}
           ORDER BY course_site.course_id, course_site.site_id
         SQL
       end

--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -36,8 +36,37 @@ module DataHub
     private
 
       def insert_provider_schools
-        inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
-          WITH main_site_provider_schools AS (
+        inserted_rows = ActiveRecord::Base.connection.exec_query(provider_schools_insert_sql)
+        inserted_rows.length
+      end
+
+      def insert_course_schools
+        inserted_rows = ActiveRecord::Base.connection.exec_query(course_schools_insert_sql)
+        inserted_rows.length
+      end
+
+      # Builds the provider_school insert from readable CTEs. Main-site rows are
+      # allowed to sit alongside non-main rows, while ordinary non-main rows are
+      # deduplicated before the final idempotent INSERT.
+      def provider_schools_insert_sql
+        <<~SQL
+          WITH #{main_site_provider_schools_cte},
+               #{non_main_provider_schools_cte},
+               #{source_provider_schools_cte}
+          INSERT INTO provider_school (provider_id, gias_school_id, site_code, created_at, updated_at)
+          SELECT provider_id, gias_school_id, site_code, NOW(), NOW()
+          FROM source_provider_schools
+          ON CONFLICT DO NOTHING
+          RETURNING 1
+        SQL
+      end
+
+      # Selects one main-site relationship per provider. Main sites are marked by
+      # site.code = '-', and if legacy data has more than one, the earliest source
+      # site wins to match the one-main-site-per-provider constraint.
+      def main_site_provider_schools_cte
+        <<~SQL.squish
+          main_site_provider_schools AS (
             SELECT DISTINCT ON (site.provider_id)
                    site.provider_id,
                    gias_school.id AS gias_school_id,
@@ -50,7 +79,15 @@ module DataHub
               AND site.urn <> ''
               AND site.code = '-'
             ORDER BY site.provider_id, site.id
-          ),
+          )
+        SQL
+      end
+
+      # Selects ordinary provider-school relationships. The new model permits
+      # only one non-main row for a provider/GIAS pair, so duplicate legacy rows
+      # collapse to the earliest source site.
+      def non_main_provider_schools_cte
+        <<~SQL.squish
           non_main_provider_schools AS (
             SELECT DISTINCT ON (site.provider_id, gias_school.id)
                    site.provider_id,
@@ -64,24 +101,44 @@ module DataHub
               AND site.urn <> ''
               AND site.code <> '-'
             ORDER BY site.provider_id, gias_school.id, site.id
-          ),
+          )
+        SQL
+      end
+
+      # Combines the allowed main-site rows and deduplicated non-main rows into
+      # the source relation used by the provider_school INSERT.
+      def source_provider_schools_cte
+        <<~SQL.squish
           source_provider_schools AS (
             SELECT * FROM main_site_provider_schools
             UNION ALL
             SELECT * FROM non_main_provider_schools
           )
-          INSERT INTO provider_school (provider_id, gias_school_id, site_code, created_at, updated_at)
-          SELECT provider_id, gias_school_id, site_code, NOW(), NOW()
-          FROM source_provider_schools
+        SQL
+      end
+
+      # Builds the course_school insert from readable CTEs. Course main-site rows
+      # are allowed to sit alongside normal course-school rows for the same GIAS
+      # school; ordinary non-main duplicates are collapsed before insert.
+      def course_schools_insert_sql
+        <<~SQL
+          WITH #{main_site_course_schools_cte},
+               #{non_main_course_schools_cte},
+               #{source_course_schools_cte}
+          INSERT INTO course_school (course_id, gias_school_id, site_code, created_at, updated_at)
+          SELECT course_id, gias_school_id, site_code, NOW(), NOW()
+          FROM source_course_schools
           ON CONFLICT DO NOTHING
           RETURNING 1
         SQL
-        inserted_rows.length
       end
 
-      def insert_course_schools
-        inserted_rows = ActiveRecord::Base.connection.exec_query(<<~SQL)
-          WITH main_site_course_schools AS (
+      # Selects course-level main-site relationships. site.code = '-' is the
+      # marker that lets a main-site course_school row coexist with a normal row
+      # for the same course/GIAS school.
+      def main_site_course_schools_cte
+        <<~SQL.squish
+          main_site_course_schools AS (
             SELECT DISTINCT ON (course_site.course_id, gias_school.id)
                    course_site.course_id,
                    gias_school.id AS gias_school_id,
@@ -95,7 +152,15 @@ module DataHub
               AND site.urn <> ''
               AND site.code = '-'
             ORDER BY course_site.course_id, gias_school.id, site.id
-          ),
+          )
+        SQL
+      end
+
+      # Selects ordinary course-school relationships. The new model permits only
+      # one non-main row for a course/GIAS pair, so duplicate legacy course_site
+      # rows collapse to the earliest source site.
+      def non_main_course_schools_cte
+        <<~SQL.squish
           non_main_course_schools AS (
             SELECT DISTINCT ON (course_site.course_id, gias_school.id)
                    course_site.course_id,
@@ -110,19 +175,20 @@ module DataHub
               AND site.urn <> ''
               AND site.code <> '-'
             ORDER BY course_site.course_id, gias_school.id, site.id
-          ),
+          )
+        SQL
+      end
+
+      # Combines the allowed main-site rows and deduplicated non-main rows into
+      # the source relation used by the course_school INSERT.
+      def source_course_schools_cte
+        <<~SQL.squish
           source_course_schools AS (
             SELECT * FROM main_site_course_schools
             UNION ALL
             SELECT * FROM non_main_course_schools
           )
-          INSERT INTO course_school (course_id, gias_school_id, site_code, created_at, updated_at)
-          SELECT course_id, gias_school_id, site_code, NOW(), NOW()
-          FROM source_course_schools
-          ON CONFLICT DO NOTHING
-          RETURNING 1
         SQL
-        inserted_rows.length
       end
 
       def fetch_skipped_sites

--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -257,7 +257,17 @@ module DataHub
       end
 
       def fetch_skipped_sites
-        ActiveRecord::Base.connection.exec_query(<<~SQL).to_a
+        ActiveRecord::Base.connection.exec_query(skipped_sites_sql).to_a
+      end
+
+      def fetch_skipped_course_sites
+        ActiveRecord::Base.connection.exec_query(skipped_course_sites_sql).to_a
+      end
+
+      # Reports eligible school sites that cannot be backfilled because they
+      # either have no URN or their URN does not resolve to GIAS.
+      def skipped_sites_sql
+        <<~SQL
           SELECT site.id AS site_id,
                  site.provider_id,
                  site.code,
@@ -278,8 +288,11 @@ module DataHub
         SQL
       end
 
-      def fetch_skipped_course_sites
-        ActiveRecord::Base.connection.exec_query(<<~SQL).to_a
+      # Reports course_site rows that cannot produce course_school rows. This
+      # includes broken course_site references, non-school/stale sites, missing
+      # URNs, and URNs that do not resolve to GIAS.
+      def skipped_course_sites_sql
+        <<~SQL
           SELECT course_site.course_id,
                  course_site.site_id,
                  site.provider_id,

--- a/app/services/data_hub/schools_backfill/executor.rb
+++ b/app/services/data_hub/schools_backfill/executor.rb
@@ -110,8 +110,8 @@ module DataHub
           WITH #{main_site_provider_schools_cte},
                #{non_main_provider_schools_cte},
                #{source_provider_schools_cte}
-          INSERT INTO provider_school (provider_id, gias_school_id, site_code, created_at, updated_at)
-          SELECT provider_id, gias_school_id, site_code, NOW(), NOW()
+          INSERT INTO provider_school (provider_id, gias_school_id, site_code, uuid, created_at, updated_at)
+          SELECT provider_id, gias_school_id, site_code, uuid, NOW(), NOW()
           FROM source_provider_schools
           ON CONFLICT DO NOTHING
           RETURNING 1
@@ -127,7 +127,8 @@ module DataHub
             SELECT DISTINCT ON (site.provider_id)
                    site.provider_id,
                    gias_school.id AS gias_school_id,
-                   site.code AS site_code
+                   site.code AS site_code,
+                   site.uuid AS uuid
             FROM site
             #{site_provider_scope_join_sql}
             JOIN gias_school ON gias_school.urn = site.urn
@@ -151,7 +152,8 @@ module DataHub
             SELECT DISTINCT ON (site.provider_id, gias_school.id)
                    site.provider_id,
                    gias_school.id AS gias_school_id,
-                   site.code AS site_code
+                   site.code AS site_code,
+                   site.uuid AS uuid
             FROM site
             #{site_provider_scope_join_sql}
             JOIN gias_school ON gias_school.urn = site.urn

--- a/db/migrate/20260612120000_add_non_main_uniqueness_to_school_relationships.rb
+++ b/db/migrate/20260612120000_add_non_main_uniqueness_to_school_relationships.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class AddNonMainUniquenessToSchoolRelationships < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_duplicate_non_main_provider_schools
+    remove_duplicate_non_main_course_schools
+
+    add_index :provider_school,
+              %i[provider_id gias_school_id],
+              unique: true,
+              where: "site_code <> '-'",
+              name: "index_provider_school_unique_non_main",
+              algorithm: :concurrently
+
+    add_index :course_school,
+              %i[course_id gias_school_id],
+              unique: true,
+              where: "site_code <> '-'",
+              name: "index_course_school_unique_non_main",
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :course_school, name: "index_course_school_unique_non_main"
+    remove_index :provider_school, name: "index_provider_school_unique_non_main"
+  end
+
+private
+
+  def remove_duplicate_non_main_provider_schools
+    safety_assured do
+      execute <<~SQL.squish
+        DELETE FROM provider_school
+        WHERE id IN (
+          SELECT id
+          FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY provider_id, gias_school_id
+                     ORDER BY id
+                   ) AS duplicate_position
+            FROM provider_school
+            WHERE site_code <> '-'
+          ) ranked_provider_schools
+          WHERE duplicate_position > 1
+        )
+      SQL
+    end
+  end
+
+  def remove_duplicate_non_main_course_schools
+    safety_assured do
+      execute <<~SQL.squish
+        DELETE FROM course_school
+        WHERE id IN (
+          SELECT id
+          FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY course_id, gias_school_id
+                     ORDER BY id
+                   ) AS duplicate_position
+            FROM course_school
+            WHERE site_code <> '-'
+          ) ranked_course_schools
+          WHERE duplicate_position > 1
+        )
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -263,6 +263,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_120100) do
     t.text "site_code", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id", "gias_school_id", "site_code"], name: "index_course_school_unique", unique: true
+    t.index ["course_id", "gias_school_id"], name: "index_course_school_unique_non_main", unique: true, where: "(site_code <> '-'::text)"
     t.index ["gias_school_id"], name: "index_course_school_on_gias_school_id"
   end
 
@@ -467,6 +468,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_120100) do
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.index ["gias_school_id"], name: "index_provider_school_on_gias_school_id"
     t.index ["provider_id", "gias_school_id", "site_code"], name: "index_provider_school_unique", unique: true
+    t.index ["provider_id", "gias_school_id"], name: "index_provider_school_unique_non_main", unique: true, where: "(site_code <> '-'::text)"
     t.index ["provider_id"], name: "index_provider_school_one_main_per_provider", unique: true, where: "(site_code = '-'::text)"
   end
 

--- a/lib/tasks/schools_backfill.rake
+++ b/lib/tasks/schools_backfill.rake
@@ -2,8 +2,11 @@
 
 namespace :schools_backfill do
   desc "Backfill provider_school and course_school from legacy site data"
-  task run: :environment do
-    summary = DataHub::SchoolsBackfill::Executor.new.execute
+  task :run, [:recruitment_cycle_years] => :environment do |_task, args|
+    recruitment_cycle_years = [args[:recruitment_cycle_years], *args.extras].compact
+    recruitment_cycle_years = RecruitmentCycle.pluck(:year) if recruitment_cycle_years.empty?
+
+    summary = DataHub::SchoolsBackfill::Executor.new(recruitment_cycle_years:).execute
     pp summary.short_summary
     pp summary.full_summary
   end

--- a/spec/lib/tasks/schools_backfill_rake_spec.rb
+++ b/spec/lib/tasks/schools_backfill_rake_spec.rb
@@ -6,7 +6,9 @@ require "rake"
 describe "schools_backfill:run" do
   Rails.application.load_tasks if Rake::Task.tasks.empty?
 
-  subject(:run_task) { Rake::Task["schools_backfill:run"].invoke }
+  subject(:run_task) { Rake::Task["schools_backfill:run"].invoke(*task_args) }
+
+  let(:task_args) { [] }
 
   before { Rake::Task["schools_backfill:run"].reenable }
 
@@ -18,10 +20,53 @@ describe "schools_backfill:run" do
       full_summary: { "skipped_sites_csv_path" => "tmp/foo.csv" },
     )
 
-    allow(DataHub::SchoolsBackfill::Executor).to receive(:new).and_return(executor)
+    allow(RecruitmentCycle).to receive(:pluck).with(:year).and_return(%w[2026 2025])
+    allow(DataHub::SchoolsBackfill::Executor)
+      .to receive(:new)
+      .with(recruitment_cycle_years: %w[2026 2025])
+      .and_return(executor)
     allow(executor).to receive(:execute).and_return(fake_summary)
 
     expect { run_task }.to output.to_stdout
     expect(executor).to have_received(:execute)
+  end
+
+  it "defaults to every recruitment cycle year" do
+    executor = instance_double(DataHub::SchoolsBackfill::Executor)
+    fake_summary = instance_double(
+      DataHub::SchoolsBackfillProcessSummary,
+      short_summary: {},
+      full_summary: {},
+    )
+
+    allow(RecruitmentCycle).to receive(:pluck).with(:year).and_return(%w[2026 2025])
+    allow(DataHub::SchoolsBackfill::Executor)
+      .to receive(:new)
+      .with(recruitment_cycle_years: %w[2026 2025])
+      .and_return(executor)
+    allow(executor).to receive(:execute).and_return(fake_summary)
+
+    expect { run_task }.to output.to_stdout
+  end
+
+  context "with recruitment cycle years as rake arguments" do
+    let(:task_args) { %w[2026 2025] }
+
+    it "passes the years to the executor" do
+      executor = instance_double(DataHub::SchoolsBackfill::Executor)
+      fake_summary = instance_double(
+        DataHub::SchoolsBackfillProcessSummary,
+        short_summary: {},
+        full_summary: {},
+      )
+
+      allow(DataHub::SchoolsBackfill::Executor)
+        .to receive(:new)
+        .with(recruitment_cycle_years: %w[2026 2025])
+        .and_return(executor)
+      allow(executor).to receive(:execute).and_return(fake_summary)
+
+      expect { run_task }.to output.to_stdout
+    end
   end
 end

--- a/spec/models/course/school_spec.rb
+++ b/spec/models/course/school_spec.rb
@@ -29,7 +29,7 @@ describe Course::School do
       expect(dup.errors[:gias_school_id]).to be_present
     end
 
-    it "allows the same course and gias_school with different site codes" do
+    it "allows the same course and gias_school when one relationship is a main site" do
       existing = create(:course_school, site_code: "-")
       second = build(
         :course_school,
@@ -38,6 +38,18 @@ describe Course::School do
         site_code: "A",
       )
       expect(second).to be_valid
+    end
+
+    it "rejects the same course and gias_school with different non-main site codes" do
+      existing = create(:course_school, site_code: "A")
+      second = build(
+        :course_school,
+        course: existing.course,
+        gias_school: existing.gias_school,
+        site_code: "B",
+      )
+      expect(second).not_to be_valid
+      expect(second.errors[:gias_school_id]).to be_present
     end
   end
 

--- a/spec/models/provider/school_spec.rb
+++ b/spec/models/provider/school_spec.rb
@@ -33,6 +33,40 @@ describe Provider::School do
         expect(duplicate.errors[:gias_school_id]).to be_present
       end
     end
+
+    context "with the same gias_school and different non-main site codes for one provider" do
+      let(:existing) { create(:provider_school, :additional, site_code: "A") }
+      let(:duplicate) do
+        build(
+          :provider_school,
+          :additional,
+          provider: existing.provider,
+          gias_school: existing.gias_school,
+          site_code: "B",
+        )
+      end
+
+      it "is invalid" do
+        duplicate.validate
+        expect(duplicate.errors[:gias_school_id]).to be_present
+      end
+    end
+
+    context "with the same gias_school when one relationship is a main site" do
+      let(:existing) { create(:provider_school, :additional, site_code: "A") }
+      let(:main_site_duplicate) do
+        build(
+          :provider_school,
+          provider: existing.provider,
+          gias_school: existing.gias_school,
+          site_code: "-",
+        )
+      end
+
+      it "is valid" do
+        expect(main_site_duplicate).to be_valid
+      end
+    end
   end
 
   describe "main-site uniqueness (site_code = '-')" do

--- a/spec/services/data_hub/schools_backfill/executor_spec.rb
+++ b/spec/services/data_hub/schools_backfill/executor_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 describe DataHub::SchoolsBackfill::Executor do
   subject(:executor) { described_class.new }
 
+  def create_school_site_without_validation(attributes)
+    build(:site, attributes).tap do |site|
+      site.save!(validate: false)
+    end
+  end
+
   describe "#execute" do
     context "with a provider whose school-type site has a matching GIAS school" do
       let(:provider) { create(:provider) }
@@ -61,6 +67,89 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(Course::School.where(course_id: course.id).count).to eq(0)
         executor.execute
         expect(Course::School.where(course_id: course.id).count).to eq(1)
+      end
+    end
+
+    context "with a normal site and main site linked to the same GIAS school" do
+      let(:provider) { create(:provider) }
+      let(:gias_school) { create(:gias_school, urn: "210002") }
+      let(:course) { create(:course, provider: provider) }
+      let!(:normal_site) do
+        create(:site, provider: provider, urn: gias_school.urn, code: "A")
+      end
+      let!(:main_site) do
+        create_school_site_without_validation(
+          provider: provider,
+          urn: gias_school.urn,
+          code: "-",
+          location_name: "Main site",
+        )
+      end
+
+      before do
+        create(:site_status, course: course, site: normal_site)
+        create(:site_status, course: course, site: main_site)
+      end
+
+      it "creates separate provider_school rows for the normal and main-site relationships" do
+        executor.execute
+
+        expect(
+          Provider::School.where(provider_id: provider.id, gias_school_id: gias_school.id).pluck(:site_code),
+        ).to contain_exactly("A", "-")
+      end
+
+      it "creates separate course_school rows for the normal and main-site relationships" do
+        executor.execute
+
+        expect(
+          Course::School.where(course_id: course.id, gias_school_id: gias_school.id).pluck(:site_code),
+        ).to contain_exactly("A", "-")
+      end
+
+      it "does not duplicate the main-site rows on a rerun" do
+        executor.execute
+
+        expect { described_class.new.execute }
+          .to not_change { Provider::School.count }
+          .and(not_change { Course::School.count })
+      end
+    end
+
+    context "with multiple non-main sites linked to the same GIAS school" do
+      let(:provider) { create(:provider) }
+      let(:gias_school) { create(:gias_school, urn: "220002") }
+      let(:course) { create(:course, provider: provider) }
+      let!(:first_site) do
+        create(:site, provider: provider, urn: gias_school.urn, code: "A")
+      end
+      let!(:second_site) do
+        create_school_site_without_validation(
+          provider: provider,
+          urn: gias_school.urn,
+          code: "B",
+        )
+      end
+
+      before do
+        create(:site_status, course: course, site: first_site)
+        create(:site_status, course: course, site: second_site)
+      end
+
+      it "creates one provider_school row using the first source site" do
+        executor.execute
+
+        expect(
+          Provider::School.where(provider_id: provider.id, gias_school_id: gias_school.id).pluck(:site_code),
+        ).to contain_exactly("A")
+      end
+
+      it "creates one course_school row using the first source site" do
+        executor.execute
+
+        expect(
+          Course::School.where(course_id: course.id, gias_school_id: gias_school.id).pluck(:site_code),
+        ).to contain_exactly("A")
       end
     end
 

--- a/spec/services/data_hub/schools_backfill/executor_spec.rb
+++ b/spec/services/data_hub/schools_backfill/executor_spec.rb
@@ -320,6 +320,80 @@ describe DataHub::SchoolsBackfill::Executor do
           Provider::School.where(provider_id: current_provider.id, gias_school_id: current_gias_school.id),
         ).to exist
       end
+
+      it "can be scoped to one recruitment cycle" do
+        previous_cycle = create(:recruitment_cycle, :previous)
+        current_cycle = find_or_create(:recruitment_cycle)
+
+        previous_provider = create(:provider, recruitment_cycle: previous_cycle)
+        current_provider = create(:provider, recruitment_cycle: current_cycle)
+        previous_gias_school = create(:gias_school, urn: "830008")
+        current_gias_school = create(:gias_school, urn: "840008")
+        previous_site = create(:site, provider: previous_provider, urn: previous_gias_school.urn, code: "P")
+        current_site = create(:site, provider: current_provider, urn: current_gias_school.urn, code: "Q")
+        previous_course = create(:course, provider: previous_provider)
+        current_course = create(:course, provider: current_provider)
+        create(:site_status, course: previous_course, site: previous_site)
+        create(:site_status, course: current_course, site: current_site)
+
+        described_class.new(recruitment_cycle_years: current_cycle.year).execute
+
+        expect(
+          Provider::School.where(provider_id: current_provider.id, gias_school_id: current_gias_school.id),
+        ).to exist
+        expect(
+          Course::School.where(course_id: current_course.id, gias_school_id: current_gias_school.id),
+        ).to exist
+        expect(
+          Provider::School.where(provider_id: previous_provider.id, gias_school_id: previous_gias_school.id),
+        ).to be_empty
+        expect(
+          Course::School.where(course_id: previous_course.id, gias_school_id: previous_gias_school.id),
+        ).to be_empty
+      end
+
+      it "accepts comma-separated recruitment cycle years" do
+        previous_cycle = create(:recruitment_cycle, :previous)
+        current_cycle = find_or_create(:recruitment_cycle)
+
+        previous_provider = create(:provider, recruitment_cycle: previous_cycle)
+        current_provider = create(:provider, recruitment_cycle: current_cycle)
+        previous_gias_school = create(:gias_school, urn: "850008")
+        current_gias_school = create(:gias_school, urn: "860008")
+
+        create(:site, provider: previous_provider, urn: previous_gias_school.urn, code: "P")
+        create(:site, provider: current_provider, urn: current_gias_school.urn, code: "Q")
+
+        described_class.new(recruitment_cycle_years: "#{previous_cycle.year}, #{current_cycle.year}").execute
+
+        expect(
+          Provider::School.where(provider_id: previous_provider.id, gias_school_id: previous_gias_school.id),
+        ).to exist
+        expect(
+          Provider::School.where(provider_id: current_provider.id, gias_school_id: current_gias_school.id),
+        ).to exist
+      end
+
+      it "scopes skipped-row reporting to the selected recruitment cycle" do
+        previous_cycle = create(:recruitment_cycle, :previous)
+        current_cycle = find_or_create(:recruitment_cycle)
+        previous_provider = create(:provider, recruitment_cycle: previous_cycle)
+        current_provider = create(:provider, recruitment_cycle: current_cycle)
+        previous_site = create_school_site_without_validation(provider: previous_provider, urn: nil, code: "P")
+        current_site = create_school_site_without_validation(provider: current_provider, urn: nil, code: "Q")
+
+        summary = described_class.new(recruitment_cycle_years: current_cycle.year).execute
+
+        skipped_site_ids = summary.full_summary["skipped_sites"].map { |row| row["site_id"] }
+        expect(skipped_site_ids).to contain_exactly(current_site.id)
+        expect(skipped_site_ids).not_to include(previous_site.id)
+      end
+
+      it "raises when a requested recruitment cycle year does not exist" do
+        expect {
+          described_class.new(recruitment_cycle_years: "1900").execute
+        }.to raise_error(ArgumentError, "Could not find recruitment cycle(s) for year(s): 1900")
+      end
     end
   end
 end

--- a/spec/services/data_hub/schools_backfill/executor_spec.rb
+++ b/spec/services/data_hub/schools_backfill/executor_spec.rb
@@ -29,6 +29,16 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(provider_school.site_code).to eq("A")
       end
 
+      it "copies the legacy site uuid into provider_school" do
+        executor.execute
+
+        provider_school = Provider::School.find_by!(
+          provider_id: provider.id,
+          gias_school_id: gias_school.id,
+        )
+        expect(provider_school.uuid).to eq(site.uuid)
+      end
+
       it "does not insert provider_school for a different gias_school" do
         other_gias_school = create(:gias_school, urn: "999999")
         executor.execute
@@ -99,6 +109,20 @@ describe DataHub::SchoolsBackfill::Executor do
         ).to contain_exactly("A", "-")
       end
 
+      it "copies the source site uuid for each provider_school relationship" do
+        executor.execute
+
+        provider_school_uuids_by_site_code = Provider::School
+          .where(provider_id: provider.id, gias_school_id: gias_school.id)
+          .pluck(:site_code, :uuid)
+          .to_h
+
+        expect(provider_school_uuids_by_site_code).to eq(
+          "A" => normal_site.uuid,
+          "-" => main_site.uuid,
+        )
+      end
+
       it "creates separate course_school rows for the normal and main-site relationships" do
         executor.execute
 
@@ -142,6 +166,17 @@ describe DataHub::SchoolsBackfill::Executor do
         expect(
           Provider::School.where(provider_id: provider.id, gias_school_id: gias_school.id).pluck(:site_code),
         ).to contain_exactly("A")
+      end
+
+      it "copies the uuid from the first source site" do
+        executor.execute
+
+        provider_school = Provider::School.find_by!(
+          provider_id: provider.id,
+          gias_school_id: gias_school.id,
+        )
+
+        expect(provider_school.uuid).to eq(first_site.uuid)
       end
 
       it "creates one course_school row using the first source site" do


### PR DESCRIPTION
## Context

This is a follow-up to the school relationship backfill work.

Main sites are now staying in the remodel and can be linked to GIAS schools. That creates a valid edge case where a provider or course can have both:

- a normal school relationship for a GIAS school
- a main-site relationship for the same GIAS school

Main-site relationships are identified by site_code = "-". They should be allowed as a separate row, but duplicate protection should not be relaxed for ordinary non-main school rows.

## Changes proposed in this pull request

- Adds stricter uniqueness for non-main school relationships:
	- one non-main provider_school per provider and GIAS school
	- one non-main course_school per course and GIAS school
- Keeps the allowed main-site duplicate case where site_code = "-".
- Updates model validations to match the new database constraints.
- Updates the school backfill SQL so it:
	- carries matched main-site rows into the new relationship tables
	- creates separate normal and main-site rows for the same GIAS school
	- collapses multiple non-main rows to the first source site.id
	- remains idempotent on rerun
- Adds specs for provider-school and course-school main-site duplicate behaviour.

## Guidance to review

Check the code, the validation, the backfill

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
