### PR TITLE
Remove the ERB output operator for footer with meta

### DIFF
--- a/app/views/layouts/_find_footer.html.erb
+++ b/app/views/layouts/_find_footer.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_footer do |footer| %>
-  <%= footer.with_meta do %>
+  <% footer.with_meta do %>
     <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
       <h2 class="govuk-heading-m">Get help</h2>
 


### PR DESCRIPTION
## Context

  An update to GovUK Components 6.3.0 created a formatting issue.
  In order to maintain our custom footer content we need to stop
  outputting the content of the footer.with_meta and let the library
  print it


https://govuk-components.netlify.app/components/footer/#footer-with-entirely-custom-content

https://github.com/x-govuk/govuk-components/pull/643


## Changes proposed in this pull request

Fix the footer


|Before|After|
|---|---|
|<img width="1910" height="871" alt="image" src="https://github.com/user-attachments/assets/feb07a57-f406-47f4-88d7-52dc742436dd" />|<img width="1922" height="790" alt="image" src="https://github.com/user-attachments/assets/3c315332-0b9b-4d79-b2d4-a6516412236d" />|



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
