### PR TITLE
Hide age range for secondary courses in the course list

### DIFF
--- a/app/components/publish/courses/table_component.rb
+++ b/app/components/publish/courses/table_component.rb
@@ -33,6 +33,7 @@ module Publish
       end
 
       def age_range(course)
+        return if course.secondary_course?
         return if course.age_range_in_years.blank?
 
         "Ages #{course.age_range}"

--- a/spec/components/publish/courses/table_component_spec.rb
+++ b/spec/components/publish/courses/table_component_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe Publish::Courses::TableComponent, type: :component do
       end
     end
 
+    context "when the course is secondary" do
+      before do
+        create(:course, :secondary, :published_postgraduate, provider:, name: "Physics", course_code: "P456")
+      end
+
+      it "does not render the age range" do
+        render_component
+
+        expect(page).to have_text("Physics (P456)")
+        expect(page).to have_no_text("Ages 11 to 18")
+      end
+    end
+
     it "renders the course information lines" do
       render_component
 


### PR DESCRIPTION
## Context

Stop showing the age range hint on **secondary** courses in the course list. Primary (and further education) courses keep it.

## Why

Age range was only ever meant for primary courses (original ticket: "add age range to primary courses"), but it was rendering on secondary courses too.

