### PR TITLE
Course list hide uniform course information

### DIFF
--- a/app/assets/stylesheets/publish/components/_table.scss
+++ b/app/assets/stylesheets/publish/components/_table.scss
@@ -32,5 +32,13 @@
     .govuk-body-s {
       margin-bottom: 0;
     }
+
+    // With only one line (or none, when a shown start date is blank for a row)
+    // the cell looks cramped against multi-line rows, so give it more vertical
+    // breathing room.
+    &--sparse {
+      padding-top: 20px;
+      padding-bottom: 20px;
+    }
   }
 }

--- a/app/assets/stylesheets/publish/components/_table.scss
+++ b/app/assets/stylesheets/publish/components/_table.scss
@@ -32,13 +32,25 @@
     .govuk-body-s {
       margin-bottom: 0;
     }
+  }
 
-    // With only one line (or none, when a shown start date is blank for a row)
-    // the cell looks cramped against multi-line rows, so give it more vertical
-    // breathing room.
-    &--sparse {
-      padding-top: 20px;
-      padding-bottom: 20px;
-    }
+  // Sparse rows (0 or 1 course-information line) get more vertical breathing
+  // room across every column so the row stays balanced rather than the
+  // course-information cell looking cramped against multi-line rows.
+  &__row--sparse .govuk-table__cell {
+    padding-top: 20px;
+    padding-bottom: 20px;
+  }
+}
+
+// With no course information at all, the column is dropped: let the Course
+// column take the remaining width and shrink Status to its content on the right.
+.app-table--courses--no-information {
+  table-layout: auto;
+
+  .app-table--courses__status {
+    width: 1%;
+
+    white-space: nowrap;
   }
 }

--- a/app/components/publish/courses/list_component.html.erb
+++ b/app/components/publish/courses/list_component.html.erb
@@ -7,6 +7,10 @@
       </h2>
     <% end %>
 
-    <%= render Publish::Courses::TableComponent.new(courses: group.courses, provider:) %>
+    <%= render Publish::Courses::TableComponent.new(
+          courses: group.courses,
+          provider:,
+          course_information_fields: course_list.visible_course_information_fields,
+        ) %>
   </section>
 <% end %>

--- a/app/components/publish/courses/table_component.html.erb
+++ b/app/components/publish/courses/table_component.html.erb
@@ -22,10 +22,16 @@
           <% end %>
         </td>
         <td class="govuk-table__cell app-table--courses__course-information">
-          <span class="govuk-body-s govuk-!-display-block"><%= funding_label(course) %></span>
-          <span class="govuk-body-s govuk-!-display-block"><%= course.qualifications_summary %></span>
-          <span class="govuk-body-s govuk-!-display-block"><%= study_type_label(course) %></span>
-          <% if start_date(course) %>
+          <% if show_field?(:funding) %>
+            <span class="govuk-body-s govuk-!-display-block"><%= funding_label(course) %></span>
+          <% end %>
+          <% if show_field?(:qualification) %>
+            <span class="govuk-body-s govuk-!-display-block"><%= course.qualifications_summary %></span>
+          <% end %>
+          <% if show_field?(:study_mode) %>
+            <span class="govuk-body-s govuk-!-display-block"><%= study_type_label(course) %></span>
+          <% end %>
+          <% if show_field?(:start_date) && start_date(course) %>
             <span class="govuk-body-s govuk-!-display-block govuk-!-font-size-16"><%= start_date(course) %></span>
           <% end %>
         </td>

--- a/app/components/publish/courses/table_component.html.erb
+++ b/app/components/publish/courses/table_component.html.erb
@@ -2,7 +2,9 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header"><%= t("publish.courses.course_table.course") %></th>
-      <th class="govuk-table__header"><%= t("publish.courses.course_table.course_information") %></th>
+      <% if course_information_column? %>
+        <th class="govuk-table__header"><%= t("publish.courses.course_table.course_information") %></th>
+      <% end %>
       <th class="govuk-table__header"><%= t("publish.courses.course_table.status") %></th>
     </tr>
   </thead>
@@ -21,20 +23,22 @@
             <div class="govuk-hint govuk-!-margin-0"><%= age_range(course) %></div>
           <% end %>
         </td>
-        <td class="govuk-table__cell app-table--courses__course-information">
-          <% if show_field?(:funding) %>
-            <span class="govuk-body-s govuk-!-display-block"><%= funding_label(course) %></span>
-          <% end %>
-          <% if show_field?(:qualification) %>
-            <span class="govuk-body-s govuk-!-display-block"><%= course.qualifications_summary %></span>
-          <% end %>
-          <% if show_field?(:study_mode) %>
-            <span class="govuk-body-s govuk-!-display-block"><%= study_type_label(course) %></span>
-          <% end %>
-          <% if show_field?(:start_date) && start_date(course) %>
-            <span class="govuk-body-s govuk-!-display-block govuk-!-font-size-16"><%= start_date(course) %></span>
-          <% end %>
-        </td>
+        <% if course_information_column? %>
+          <td class="<%= course_information_cell_classes(course) %>">
+            <% if show_field?(:funding) %>
+              <span class="govuk-body-s govuk-!-display-block"><%= funding_label(course) %></span>
+            <% end %>
+            <% if show_field?(:qualification) %>
+              <span class="govuk-body-s govuk-!-display-block"><%= course.qualifications_summary %></span>
+            <% end %>
+            <% if show_field?(:study_mode) %>
+              <span class="govuk-body-s govuk-!-display-block"><%= study_type_label(course) %></span>
+            <% end %>
+            <% if show_field?(:start_date) && start_date(course) %>
+              <span class="govuk-body-s govuk-!-display-block govuk-!-font-size-16"><%= start_date(course) %></span>
+            <% end %>
+          </td>
+        <% end %>
         <td class="govuk-table__cell app-table--courses__status">
           <%= render Publish::Courses::StatusTagComponent.new(course:, recruitment_cycle_year: recruitment_cycle_year(course)) %>
         </td>

--- a/app/components/publish/courses/table_component.html.erb
+++ b/app/components/publish/courses/table_component.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table app-table--courses">
+<table class="govuk-table app-table--courses<%= " app-table--courses--no-information" unless course_information_column? %>">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header"><%= t("publish.courses.course_table.course") %></th>
@@ -10,7 +10,7 @@
   </thead>
   <tbody class="govuk-table__body">
     <% courses.each do |course| %>
-      <tr class="govuk-table__row">
+      <tr class="<%= row_classes(course) %>">
         <td class="govuk-table__cell app-table--courses__course-name">
           <% if on_courses_index_page?(course) %>
             <%= govuk_link_to course.name_and_code, course_path(course), class: "govuk-heading-s govuk-!-margin-bottom-0" %>
@@ -24,7 +24,7 @@
           <% end %>
         </td>
         <% if course_information_column? %>
-          <td class="<%= course_information_cell_classes(course) %>">
+          <td class="govuk-table__cell app-table--courses__course-information">
             <% if show_field?(:funding) %>
               <span class="govuk-body-s govuk-!-display-block"><%= funding_label(course) %></span>
             <% end %>

--- a/app/components/publish/courses/table_component.rb
+++ b/app/components/publish/courses/table_component.rb
@@ -33,9 +33,15 @@ module Publish
         end
       end
 
-      def course_information_cell_classes(course)
-        classes = %w[govuk-table__cell app-table--courses__course-information]
-        classes << "app-table--courses__course-information--sparse" if course_information_line_count(course) <= 1
+      # A row is sparse when it shows at most one course-information line
+      # (including the "column dropped entirely" case, where the count is 0).
+      def sparse_row?(course)
+        course_information_line_count(course) <= 1
+      end
+
+      def row_classes(course)
+        classes = %w[govuk-table__row]
+        classes << "app-table--courses__row--sparse" if sparse_row?(course)
         classes.join(" ")
       end
 

--- a/app/components/publish/courses/table_component.rb
+++ b/app/components/publish/courses/table_component.rb
@@ -24,6 +24,21 @@ module Publish
         course_information_fields.any?
       end
 
+      # Lines this row actually renders: a shown start-date field still produces
+      # no line when this particular course has no start date, so the count is
+      # decided per row rather than per column.
+      def course_information_line_count(course)
+        course_information_fields.count do |key|
+          key == :start_date ? start_date(course).present? : true
+        end
+      end
+
+      def course_information_cell_classes(course)
+        classes = %w[govuk-table__cell app-table--courses__course-information]
+        classes << "app-table--courses__course-information--sparse" if course_information_line_count(course) <= 1
+        classes.join(" ")
+      end
+
       def course_path(course)
         helpers.publish_provider_recruitment_cycle_course_path(
           provider.provider_code,

--- a/app/components/publish/courses/table_component.rb
+++ b/app/components/publish/courses/table_component.rb
@@ -7,13 +7,22 @@ module Publish
     # the course-information column (funding / qualification / study type / start
     # date) and the status tag. Rows are read-model rows from Publish::Courses::Query.
     class TableComponent < ApplicationComponent
-      def initialize(courses:, provider:, classes: [], html_attributes: {})
+      def initialize(courses:, provider:, course_information_fields: Publish::CourseList::FIELDS.keys, classes: [], html_attributes: {})
         super(classes:, html_attributes:)
         @courses = courses
         @provider = provider
+        @course_information_fields = course_information_fields
       end
 
-      attr_reader :courses, :provider
+      attr_reader :courses, :provider, :course_information_fields
+
+      def show_field?(key)
+        course_information_fields.include?(key)
+      end
+
+      def course_information_column?
+        course_information_fields.any?
+      end
 
       def course_path(course)
         helpers.publish_provider_recruitment_cycle_course_path(

--- a/app/services/publish/course_list.rb
+++ b/app/services/publish/course_list.rb
@@ -18,10 +18,28 @@ module Publish
       end
     end
 
+    # The course-information fields shown per course, in display order. Each maps
+    # to the raw value that drives its displayed text, so uniformity is compared
+    # on that value rather than the rendered label.
+    FIELDS = {
+      funding: ->(course) { course.funding },
+      qualification: ->(course) { course.qualification },
+      study_mode: ->(course) { course.study_mode },
+      start_date: ->(course) { course.start_date.presence&.to_date },
+    }.freeze
+
     delegate :any?, to: :groups
 
     def initialize(provider:)
       @provider = provider
+    end
+
+    # Course-information fields whose value varies across the whole list (all
+    # groups). A field that is identical for every course carries no information
+    # worth showing, so it is omitted from the column.
+    def visible_course_information_fields
+      @visible_course_information_fields ||=
+        FIELDS.keys.select { |key| all_courses.map(&FIELDS.fetch(key)).uniq.size > 1 }
     end
 
     def groups
@@ -37,6 +55,10 @@ module Publish
   private
 
     attr_reader :provider
+
+    def all_courses
+      @all_courses ||= groups.flat_map(&:courses)
+    end
 
     def courses
       @courses ||= Publish::Courses::Query.call(provider:).to_a

--- a/spec/components/publish/courses/list_component_spec.rb
+++ b/spec/components/publish/courses/list_component_spec.rb
@@ -34,6 +34,25 @@ RSpec.describe Publish::Courses::ListComponent, type: :component do
     end
   end
 
+  context "course information column across the whole list" do
+    let(:provider) { create(:provider, :accredited_provider) }
+
+    it "hides the column when every course shares the same information" do
+      create_list(:course, 2, :without_validation, provider:)
+      render_component
+
+      expect(page).to have_no_text("Course information")
+    end
+
+    it "shows the column when course information varies" do
+      create(:course, :without_validation, provider:, study_mode: :full_time)
+      create(:course, :without_validation, provider:, study_mode: :part_time)
+      render_component
+
+      expect(page).to have_text("Course information")
+    end
+  end
+
   context "when the provider has no courses" do
     let(:provider) { create(:provider) }
 

--- a/spec/components/publish/courses/table_component_spec.rb
+++ b/spec/components/publish/courses/table_component_spec.rb
@@ -102,4 +102,48 @@ RSpec.describe Publish::Courses::TableComponent, type: :component do
       expect(page).to have_no_css('span.govuk-\!-font-size-16')
     end
   end
+
+  describe "course information field gating" do
+    subject(:render_with) { render_inline(described_class.new(courses:, provider:, course_information_fields:)) }
+
+    before do
+      create(:course, :published_postgraduate, provider:, name: "Biology", course_code: "B123", start_date: Time.zone.local(2026, 9, 1))
+    end
+
+    context "when only one field is shown" do
+      let(:course_information_fields) { [:funding] }
+
+      it "renders only that field and marks the cell as sparse" do
+        render_with
+
+        within(".app-table--courses__course-information") do
+          expect(page).to have_text("Fee-paying")
+          expect(page).to have_no_text("QTS with PGCE")
+          expect(page).to have_no_text("Full time")
+        end
+        expect(page).to have_css(".app-table--courses__course-information--sparse")
+      end
+    end
+
+    context "when several fields are shown" do
+      let(:course_information_fields) { %i[funding qualification study_mode] }
+
+      it "does not mark the cell as sparse" do
+        render_with
+
+        expect(page).to have_no_css(".app-table--courses__course-information--sparse")
+      end
+    end
+
+    context "when no fields are shown" do
+      let(:course_information_fields) { [] }
+
+      it "drops the Course information column entirely" do
+        render_with
+
+        expect(page.all(".govuk-table__header").map(&:text)).to eq(%w[Course Status])
+        expect(page).to have_no_css(".app-table--courses__course-information")
+      end
+    end
+  end
 end

--- a/spec/components/publish/courses/table_component_spec.rb
+++ b/spec/components/publish/courses/table_component_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Publish::Courses::TableComponent, type: :component do
     context "when only one field is shown" do
       let(:course_information_fields) { [:funding] }
 
-      it "renders only that field and marks the cell as sparse" do
+      it "renders only that field and marks the row as sparse" do
         render_with
 
         within(".app-table--courses__course-information") do
@@ -121,28 +121,30 @@ RSpec.describe Publish::Courses::TableComponent, type: :component do
           expect(page).to have_no_text("QTS with PGCE")
           expect(page).to have_no_text("Full time")
         end
-        expect(page).to have_css(".app-table--courses__course-information--sparse")
+        expect(page).to have_css(".app-table--courses__row--sparse")
       end
     end
 
     context "when several fields are shown" do
       let(:course_information_fields) { %i[funding qualification study_mode] }
 
-      it "does not mark the cell as sparse" do
+      it "does not mark the row as sparse" do
         render_with
 
-        expect(page).to have_no_css(".app-table--courses__course-information--sparse")
+        expect(page).to have_no_css(".app-table--courses__row--sparse")
       end
     end
 
     context "when no fields are shown" do
       let(:course_information_fields) { [] }
 
-      it "drops the Course information column entirely" do
+      it "drops the Course information column and lays out for Course and Status only" do
         render_with
 
         expect(page.all(".govuk-table__header").map(&:text)).to eq(%w[Course Status])
         expect(page).to have_no_css(".app-table--courses__course-information")
+        expect(page).to have_css("table.app-table--courses--no-information")
+        expect(page).to have_css(".app-table--courses__row--sparse")
       end
     end
   end

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -50,6 +50,34 @@ RSpec.describe Publish::CourseList do
         expect(course_list.visible_course_information_fields).to eq(%i[funding study_mode])
       end
     end
+
+    context "when a field is uniform within each group but differs between groups" do
+      before do
+        create(:course, :without_validation, provider:, study_mode: :full_time)
+        create(:course, :without_validation, provider:, study_mode: :part_time,
+                                              accrediting_provider: create(:accredited_provider, provider_name: "Other University"))
+      end
+
+      it "treats uniformity across the whole list, not per group" do
+        expect(course_list.groups.size).to eq(2)
+        expect(course_list.visible_course_information_fields).to eq([:study_mode])
+      end
+    end
+
+    context "with start dates" do
+      it "hides the start date when every course is missing one" do
+        create_list(:course, 2, :without_validation, provider:, start_date: nil)
+
+        expect(course_list.visible_course_information_fields).to eq([])
+      end
+
+      it "shows the start date when some courses have one and others do not" do
+        create(:course, :without_validation, provider:, start_date: nil)
+        create(:course, :without_validation, provider:, start_date: Time.zone.local(2026, 9, 1))
+
+        expect(course_list.visible_course_information_fields).to eq([:start_date])
+      end
+    end
   end
 
   describe "enumerable facade" do

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -18,6 +18,40 @@ RSpec.describe Publish::CourseList do
     end
   end
 
+  describe "#visible_course_information_fields" do
+    let(:provider) { create(:provider, :accredited_provider) }
+
+    context "when every course shares the same values" do
+      before { create_list(:course, 2, :without_validation, provider:) }
+
+      it "returns no fields" do
+        expect(course_list.visible_course_information_fields).to eq([])
+      end
+    end
+
+    context "when only one field varies across the courses" do
+      before do
+        create(:course, :without_validation, provider:, study_mode: :full_time)
+        create(:course, :without_validation, provider:, study_mode: :part_time)
+      end
+
+      it "returns just that field" do
+        expect(course_list.visible_course_information_fields).to eq([:study_mode])
+      end
+    end
+
+    context "when several fields vary" do
+      before do
+        create(:course, :without_validation, provider:, funding: "fee", study_mode: :full_time)
+        create(:course, :without_validation, provider:, funding: "salary", study_mode: :part_time)
+      end
+
+      it "returns the varying fields in display order" do
+        expect(course_list.visible_course_information_fields).to eq(%i[funding study_mode])
+      end
+    end
+  end
+
   describe "enumerable facade" do
     let(:provider) { create(:provider, :accredited_provider) }
 

--- a/spec/services/publish/course_list_spec.rb
+++ b/spec/services/publish/course_list_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Publish::CourseList do
       before do
         create(:course, :without_validation, provider:, study_mode: :full_time)
         create(:course, :without_validation, provider:, study_mode: :part_time,
-                                              accrediting_provider: create(:accredited_provider, provider_name: "Other University"))
+                                             accrediting_provider: create(:accredited_provider, provider_name: "Other University"))
       end
 
       it "treats uniformity across the whole list, not per group" do

--- a/spec/system/publish/viewing_course_information_spec.rb
+++ b/spec/system/publish/viewing_course_information_spec.rb
@@ -25,12 +25,28 @@ RSpec.describe "Viewing course information in the course list" do
   def given_a_course_with_known_information
     create(
       :course,
+      :without_validation,
       provider:,
       accrediting_provider: nil,
+      name: "Known course",
       funding: :fee,
       qualification: :pgce_with_qts,
       study_mode: :full_time,
       start_date: Time.zone.local(2026, 9, 1),
+    )
+    # A contrasting course so every field varies across the list and the column
+    # is shown — uniform values are hidden, so without variation there is nothing
+    # to display.
+    create(
+      :course,
+      :without_validation,
+      provider:,
+      accrediting_provider: nil,
+      name: "Other course",
+      funding: :salary,
+      qualification: :qts,
+      study_mode: :part_time,
+      start_date: Time.zone.local(2027, 1, 1),
     )
   end
 
@@ -46,16 +62,24 @@ RSpec.describe "Viewing course information in the course list" do
   end
 
   def then_i_see_the_course_information_on_separate_lines
-    within ".app-table--courses__course-information" do
-      expect(page).to have_text("Fee-paying")
-      expect(page).to have_text("QTS with PGCE")
-      expect(page).to have_text("Full time")
-      expect(page).to have_text("September 2026")
+    within(course_row("Known course")) do
+      within ".app-table--courses__course-information" do
+        expect(page).to have_text("Fee-paying")
+        expect(page).to have_text("QTS with PGCE")
+        expect(page).to have_text("Full time")
+        expect(page).to have_text("September 2026")
+      end
     end
   end
 
   def and_i_see_the_start_date_in_the_smaller_font
-    expect(page).to have_css('.app-table--courses__course-information .govuk-\!-font-size-16', text: "September 2026")
+    within(course_row("Known course")) do
+      expect(page).to have_css('.app-table--courses__course-information .govuk-\!-font-size-16', text: "September 2026")
+    end
+  end
+
+  def course_row(name)
+    page.find(".govuk-table__row", text: name)
   end
 
   def then_i_see_both_start_dates


### PR DESCRIPTION
## Context

Make the course list's **Course information** column adaptive: hide any value (funding, qualification, study type, start date) that is identical across **all** of a provider's courses. If every value is identical, drop the column heading entirely, leaving Course | Status.

## Why

Providers told us courses in their list "look exactly the same" — repeating the same values down every row makes courses hard to tell apart. Hiding uniform values surfaces only what actually distinguishes one course from another.

## Changes

- `Publish::CourseList#visible_course_information_fields` computes which fields vary across the whole list (all accredited-provider groups).
- `TableComponent` takes that field set and renders only the varying lines; drops the column heading/cell when none vary.
- Cells with 0–1 lines get a `--sparse` modifier (20px top/bottom padding); rows already align to the top.

