### PR TITLE
Unauthenticated visits to email alerts redirect to custom signin page

### DIFF
--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -43,7 +43,7 @@ module Find
             redirect_to after_auth_find_candidate_saved_courses_path
           else
             flash[:success] = t(".sign_in")
-            redirect_to(session.delete("return_to_after_authenticating") || find_root_path, allow_remote_host: false)
+            redirect_to(request.env["omniauth.origin"] || session.delete("return_to_after_authenticating") || find_root_path, allow_remote_host: false)
           end
         else
           redirect_to find_root_path, flash: { warning: t(".authentication_error") }

--- a/app/controllers/find/authentication/sessions_controller.rb
+++ b/app/controllers/find/authentication/sessions_controller.rb
@@ -43,7 +43,7 @@ module Find
             redirect_to after_auth_find_candidate_saved_courses_path
           else
             flash[:success] = t(".sign_in")
-            redirect_to(request.env["omniauth.origin"] || session.delete("return_to_after_authenticating") || find_root_path, allow_remote_host: false)
+            redirect_to(request.env["omniauth.origin"] || session.delete("return_to_after_authenticating") || find_root_path, allow_other_host: false)
           end
         else
           redirect_to find_root_path, flash: { warning: t(".authentication_error") }

--- a/app/controllers/find/candidates/email_alerts_controller.rb
+++ b/app/controllers/find/candidates/email_alerts_controller.rb
@@ -5,13 +5,23 @@ module Find
     class EmailAlertsController < ApplicationController
       include ::Courses::ActiveFilters::SummaryRowBuilder
 
-      before_action :require_authentication, except: %i[unsubscribe_from_email confirm_unsubscribe_from_email]
+      before_action :require_authentication, except: %i[unsubscribe_from_email confirm_unsubscribe_from_email index sign_in]
       before_action :redirect_if_subscription_limit_reached, only: %i[new create]
 
       def index
+        return redirect_to sign_in_find_candidate_email_alerts_path unless authenticated?
+
         @email_alerts = @candidate.email_alerts.active.order(created_at: :desc)
         all_codes = @email_alerts.flat_map(&:subjects).compact.uniq
         @subject_names_by_code = all_codes.any? ? Subject.where(subject_code: all_codes).pluck(:subject_code, :subject_name).to_h : {}
+      end
+
+      def sign_in
+        @sign_in_url = if Settings.one_login.enabled
+                         "/auth/one-login"
+                       else
+                         "/auth/find-developer"
+                       end
       end
 
       def new

--- a/app/views/find/candidates/email_alerts/sign_in.html.erb
+++ b/app/views/find/candidates/email_alerts/sign_in.html.erb
@@ -1,0 +1,7 @@
+<h1 class="govuk-heading-l">
+  Sign in to view all your email alerts
+</h1>
+
+<%= button_to("#{@sign_in_url}?origin=#{find_candidate_email_alerts_path}", class: %w[govuk-button], method: :post) do
+      tag.span("Sign in")
+    end %>

--- a/config/routes/find.rb
+++ b/config/routes/find.rb
@@ -59,7 +59,10 @@ namespace :find, path: "/", defaults: { host: URI.parse(Settings.find_url).host 
       end
 
       constraints ->(_req) { FeatureFlag.active?(:email_alerts) } do
-        resources :email_alerts, only: %i[index new create], path: "email-alerts"
+        resources :email_alerts, only: %i[index new create], path: "email-alerts" do
+          get "sign-in", on: :collection, as: :sign_in
+        end
+
         get "email-alerts/:token/unsubscribe",
             to: "email_alerts#confirm_unsubscribe",
             as: :confirm_unsubscribe_email_alert

--- a/spec/controllers/find/authentication/sessions_controller_spec.rb
+++ b/spec/controllers/find/authentication/sessions_controller_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Find
+  module Authentication
+    describe SessionsController do
+      let(:candidate) { create(:candidate) }
+
+      before do
+        FeatureFlag.activate(:candidate_accounts)
+        request.host = URI(Settings.find_url).host
+      end
+
+      describe "#destroy" do
+        before do
+          CandidateAuthHelper.mock_auth(email_address: candidate.email_address)
+        end
+
+        context "existing database candidate" do
+          before do
+            session_key = SecureRandom.hex(32)
+            candidate.sessions.create!(session_key:, id_token: "id_token")
+            cookies.signed[Settings.cookies.candidate_session.name] = session_key
+          end
+
+          it "redirects to the find root url" do
+            post :destroy
+            expect(response).to redirect_to(find_root_path)
+          end
+
+          it "destroys the candidate's session record" do
+            expect { post :destroy }.to change { candidate.sessions.count }.from(1).to(0)
+          end
+
+          it "sets a sign out flash message" do
+            post :destroy
+            expect(flash[:success]).to eq(I18n.t("find.authentication.sessions.sign_out"))
+          end
+
+          context "when One Login is enabled" do
+            before do
+              allow(Settings.one_login).to receive(:enabled).and_return(true)
+            end
+
+            it "redirects to the One Login end-session endpoint" do
+              post :destroy
+              expect(response).to be_redirect
+              expect(response.location).to start_with(Settings.one_login.logout_url)
+            end
+
+            it "still destroys the candidate's session record" do
+              expect { post :destroy }.to change { candidate.sessions.count }.from(1).to(0)
+            end
+          end
+        end
+
+        context "when there is no active session" do
+          it "redirects to the find root url" do
+            post :destroy
+            expect(response).to redirect_to(find_root_path)
+          end
+
+          it "does not raise" do
+            expect { post :destroy }.not_to raise_error
+          end
+        end
+      end
+
+      describe "#callback" do
+        before do
+          CandidateAuthHelper.mock_auth(email_address: candidate.email_address)
+        end
+
+        let(:request_callback) do
+          request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:"find-developer"]
+          get :callback, params: { provider: "find-developer" }
+        end
+
+        it "protects against redirecting to other hosts" do
+          request.env["omniauth.origin"] = "https://fake.com"
+          expect { request_callback }.to(raise_error(ActionController::Redirecting::OpenRedirectError))
+        end
+
+        context "existing database candidate with authentication" do
+          let(:candidate) { create(:find_developer_candidate) }
+
+          it "does not store candidate data in the cookie session" do
+            request_callback
+            expect(session["candidate"]).to be_nil
+          end
+
+          it "creates a database session record" do
+            expect { request_callback }.to change { candidate.sessions.reload.count }.by(1)
+          end
+
+          it "does not create a new candidate" do
+            candidate
+            expect { request_callback }.not_to change(Candidate, :count)
+          end
+
+          it "stores subject_key in the candidate's authentication" do
+            request_callback
+            expect(candidate.authentications.last.subject_key).to eq("sign_in_user_id")
+          end
+
+          it "redirects to the find root page" do
+            request_callback
+            expect(response).to redirect_to(find_root_path)
+          end
+
+          it "sets a sign in flash message" do
+            request_callback
+            expect(flash[:success]).to eq(I18n.t("find.authentication.sessions.sign_in"))
+          end
+
+          it "redirects to a same-host omniauth origin when present" do
+            request.env["omniauth.origin"] = "#{find_root_url}results"
+            request_callback
+            expect(response).to redirect_to("#{find_root_url}results")
+          end
+
+          it "falls back to the return_to_after_authenticating path when no origin is set" do
+            request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:"find-developer"]
+            get :callback,
+                params: { provider: "find-developer" },
+                session: { "return_to_after_authenticating" => "/results" }
+            expect(response).to redirect_to("/results")
+          end
+        end
+
+        context "candidate without an existing authentication" do
+          let(:candidate) { build(:candidate) }
+
+          it "signs the candidate up by creating a candidate record" do
+            expect { request_callback }.to change(Candidate, :count).by(1)
+          end
+
+          it "creates a database session" do
+            expect { request_callback }.to change(Session, :count).by(1)
+          end
+
+          it "redirects to the find root page" do
+            request_callback
+            expect(response).to redirect_to(find_root_path)
+          end
+
+          it "stores subject_key in the new candidate's authentication" do
+            request_callback
+            new_candidate = Candidate.find_by(email_address: candidate.email_address)
+            expect(new_candidate.authentications.last.subject_key).to eq("sign_in_user_id")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/find/candidates/email_alerts_controller_spec.rb
+++ b/spec/controllers/find/candidates/email_alerts_controller_spec.rb
@@ -31,6 +31,28 @@ module Find
         end
       end
 
+      describe "GET #sign_in" do
+        context "with rendered views" do
+          render_views
+
+          it "points the sign-in button at one-login when one_login is enabled" do
+            allow(Settings.one_login).to receive(:enabled).and_return(true)
+
+            get :sign_in
+
+            expect(response.body).to include("/auth/one-login")
+          end
+
+          it "points the sign-in button at the find developer strategy when one_login is disabled" do
+            allow(Settings.one_login).to receive(:enabled).and_return(false)
+
+            get :sign_in
+
+            expect(response.body).to include("/auth/find-developer")
+          end
+        end
+      end
+
       describe "GET #new" do
         it "renders the new alert form" do
           get :new, params: { subjects: %w[C1], level: "secondary" }
@@ -131,6 +153,22 @@ module Find
 
           expect(response).to have_http_status(:ok)
         end
+
+        it "returns not found for an invalid token" do
+          get :confirm_unsubscribe, params: { token: "invalid" }
+
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "returns not found for another candidate's alert" do
+          other = create(:candidate)
+          alert = create(:email_alert, candidate: other)
+          token = alert.signed_id(purpose: :unsubscribe, expires_in: 30.days)
+
+          get :confirm_unsubscribe, params: { token: }
+
+          expect(response).to have_http_status(:not_found)
+        end
       end
 
       describe "DELETE #unsubscribe" do
@@ -153,6 +191,13 @@ module Find
           delete :unsubscribe, params: { token: }
 
           expect(alert.reload.unsubscribed_at).to be_nil
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "returns not found for an invalid token" do
+          delete :unsubscribe, params: { token: "invalid" }
+
+          expect(response).to have_http_status(:not_found)
         end
       end
 

--- a/spec/controllers/find/candidates/email_alerts_controller_spec.rb
+++ b/spec/controllers/find/candidates/email_alerts_controller_spec.rb
@@ -245,7 +245,7 @@ module Find
 
         it "redirects unauthenticated users for index" do
           get :index
-          expect(response).to redirect_to(find_root_path)
+          expect(response).to redirect_to(sign_in_find_candidate_email_alerts_path)
         end
 
         it "redirects unauthenticated users for new" do

--- a/spec/system/find/candidates/visit_email_alerts_from_email_spec.rb
+++ b/spec/system/find/candidates/visit_email_alerts_from_email_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Visit Email alerts from email body", service: :find do
+  before do
+    FeatureFlag.activate(:candidate_accounts)
+    FeatureFlag.activate(:email_alerts)
+    CandidateAuthHelper.mock_auth
+  end
+
+  scenario "Viewing email alerts index from email unauthenticated" do
+    when_i_visit_email_alerts
+    then_i_am_shown_a_sign_in_page
+    when_i_click_sign_in_button
+    then_i_am_redirected_to_the_email_alerts
+  end
+
+  def then_i_am_redirected_to_the_email_alerts
+    expect(page).to have_current_path("/candidate/email-alerts")
+  end
+
+  def then_i_am_shown_a_sign_in_page
+    expect(page).to have_content("Sign in to view all your email alerts")
+  end
+
+  def when_i_click_sign_in_button
+    all(:link_or_button, "Sign in").last.click
+    expect(page).to have_content("You have been successfully signed in.")
+  end
+
+  def when_i_visit_email_alerts
+    visit find_candidate_email_alerts_path
+  end
+end


### PR DESCRIPTION
## Context

  - When the user signs in they are then redirected to the email alerts page

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
