### PR TITLE
Add publish without schools allowed

### DIFF
--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -32,6 +32,7 @@ module Courses
         end
         new_course.can_sponsor_skilled_worker_visa          = course.can_sponsor_skilled_worker_visa
         new_course.can_sponsor_student_visa                 = course.can_sponsor_student_visa
+        new_course.publish_without_schools_allowed          = course.publish_without_schools_allowed
         new_course.visa_sponsorship_application_deadline_at = nil # We can't currently predict how to carry this value over. Provider must set it again
         new_course.first_published_at                       = nil
         new_course.save!(validate: false)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -81,6 +81,7 @@ shared:
     - schools_validated
     - school_experience_required
     - school_experience_required_content
+    - publish_without_schools_allowed
   course_site:
     - id
     - course_id

--- a/db/migrate/20260616110551_add_publish_without_schools_allowed_to_course.rb
+++ b/db/migrate/20260616110551_add_publish_without_schools_allowed_to_course.rb
@@ -1,0 +1,5 @@
+class AddPublishWithoutSchoolsAllowedToCourse < ActiveRecord::Migration[8.0]
+  def change
+    add_column :course, :publish_without_schools_allowed, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_04_142930) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_16_110551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "btree_gist"
@@ -207,6 +207,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_142930) do
     t.text "profpost_flag"
     t.text "program_type"
     t.integer "provider_id", default: 0, null: false
+    t.boolean "publish_without_schools_allowed", default: false, null: false
     t.integer "qualification", null: false
     t.boolean "school_experience_required"
     t.text "school_experience_required_content"

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -38,6 +38,19 @@ describe Course do
     end
   end
 
+  describe "#publish_without_schools_allowed" do
+    it "defaults to false for a new course" do
+      expect(build(:course).publish_without_schools_allowed?).to be(false)
+      expect(create(:course).reload.publish_without_schools_allowed?).to be(false)
+    end
+
+    it "can be persisted as true" do
+      course.update!(publish_without_schools_allowed: true)
+
+      expect(course.reload.publish_without_schools_allowed?).to be(true)
+    end
+  end
+
   describe "auditing" do
     it { is_expected.to be_audited }
     it { is_expected.to have_associated_audits }

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -73,6 +73,20 @@ RSpec.describe Courses::CopyToProviderService do
     expect(new_course.visa_sponsorship_application_deadline_at).to be_nil
   end
 
+  it "carries over publish_without_schools_allowed when set" do
+    course.update!(publish_without_schools_allowed: true)
+
+    service.execute(course:, new_provider:)
+
+    expect(new_course.publish_without_schools_allowed).to be(true)
+  end
+
+  it "carries over the default publish_without_schools_allowed of false" do
+    service.execute(course:, new_provider:)
+
+    expect(new_course.publish_without_schools_allowed).to be(false)
+  end
+
   context "when the original course has first_published_at set" do
     let(:course) do
       create(:course, :published, accrediting_provider:, subjects: [maths], level: "secondary")


### PR DESCRIPTION
## Context

Adds a `publish_without_schools_allowed` boolean to `course` (default `false`, `null: false`). It records that support has approved an individual salaried course to bypass the missing-schools publish validation. Data layer only — wiring it into the validator is a follow-up.

## Changes

- Migration adding the column (defaults backfill existing rows to `false`)
- Carry the flag over during course rollover
- Register the field with DfE Analytics
- Tests for default, persistence, and rollover carry-over

