### PR TITLE
Exempt salaried courses publish without schools

### DIFF
--- a/app/services/courses/publish_rules/school_presence_exemption.rb
+++ b/app/services/courses/publish_rules/school_presence_exemption.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Single source of truth for "is this course exempt from needing a school
+# attached at publish time?". Support can approve individual salaried or
+# apprenticeship courses to publish without schools (candidates already have
+# their placement arranged) via the `publish_without_schools_allowed` flag.
+#
+# Only applies under the new Course::School data model (the
+# :course_publishing_uses_new_school_model flag), mirroring
+# Courses::PublishRules::SchoolPresence so the flag lives in one place. Never
+# applies to fee-paying courses or to legacy Site data.
+module Courses
+  module PublishRules
+    class SchoolPresenceExemption
+      def self.applies?(course)
+        FeatureFlag.active?(:course_publishing_uses_new_school_model) &&
+          course.publish_without_schools_allowed? &&
+          (course.salary? || course.apprenticeship?)
+      end
+    end
+  end
+end

--- a/app/validators/course_publishable_schools_presence_validator.rb
+++ b/app/validators/course_publishable_schools_presence_validator.rb
@@ -7,6 +7,7 @@
 class CoursePublishableSchoolsPresenceValidator < ActiveModel::Validator
   def validate(course)
     return if Courses::PublishRules::SchoolPresence.any?(course)
+    return if Courses::PublishRules::SchoolPresenceExemption.applies?(course)
 
     course.errors.add(:sites, :blank)
   end

--- a/app/validators/course_publishable_schools_rollover_validator.rb
+++ b/app/validators/course_publishable_schools_rollover_validator.rb
@@ -16,7 +16,7 @@ class CoursePublishableSchoolsRolloverValidator < ActiveModel::Validator
 
     if Courses::PublishRules::SchoolPresence.any?(course)
       course.errors.add(:sites, :check_schools)
-    else
+    elsif !Courses::PublishRules::SchoolPresenceExemption.applies?(course)
       course.errors.add(:sites, :enter_schools)
     end
   end

--- a/spec/services/courses/publish_rules/school_presence_exemption_spec.rb
+++ b/spec/services/courses/publish_rules/school_presence_exemption_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Courses::PublishRules::SchoolPresenceExemption do
+  describe ".applies?" do
+    def course_with(funding:, allowed:)
+      build_stubbed(:course, funding, publish_without_schools_allowed: allowed)
+    end
+
+    context "when the new school model flag is on" do
+      before { allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(true) }
+
+      it "applies to a salaried course with the flag enabled" do
+        expect(described_class.applies?(course_with(funding: :salary, allowed: true))).to be(true)
+      end
+
+      it "applies to an apprenticeship course with the flag enabled" do
+        expect(described_class.applies?(course_with(funding: :apprenticeship, allowed: true))).to be(true)
+      end
+
+      it "does not apply to a fee-paying course even with the flag enabled" do
+        expect(described_class.applies?(course_with(funding: :fee, allowed: true))).to be(false)
+      end
+
+      it "does not apply to a salaried course without the flag enabled" do
+        expect(described_class.applies?(course_with(funding: :salary, allowed: false))).to be(false)
+      end
+
+      it "does not apply to an apprenticeship course without the flag enabled" do
+        expect(described_class.applies?(course_with(funding: :apprenticeship, allowed: false))).to be(false)
+      end
+    end
+
+    context "when the new school model flag is off" do
+      before { allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(false) }
+
+      it "never applies, even for a salaried course with the flag enabled" do
+        expect(described_class.applies?(course_with(funding: :salary, allowed: true))).to be(false)
+      end
+    end
+  end
+end

--- a/spec/validators/course_publishable_schools_presence_validator_spec.rb
+++ b/spec/validators/course_publishable_schools_presence_validator_spec.rb
@@ -50,14 +50,14 @@ describe CoursePublishableSchoolsPresenceValidator do
     before { allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(true) }
 
     {
-      [:salary,         true,  true]  => :no_error,
+      [:salary,         true,  true] => :no_error,
       [:salary,         true,  false] => :no_error,
-      [:salary,         false, true]  => :no_error,
+      [:salary,         false, true] => :no_error,
       [:salary,         false, false] => :blank,
-      [:apprenticeship, false, true]  => :no_error,
+      [:apprenticeship, false, true] => :no_error,
       [:apprenticeship, false, false] => :blank,
-      [:fee,            false, true]  => :blank,
-      [:fee,            true,  true]  => :no_error,
+      [:fee,            false, true] => :blank,
+      [:fee,            true,  true] => :no_error,
       [:fee,            false, false] => :blank,
     }.each do |(funding, has_school, exemption), expected|
       context "#{funding}, #{has_school ? 'with' : 'without'} schools, exemption #{exemption ? 'on' : 'off'}" do

--- a/spec/validators/course_publishable_schools_presence_validator_spec.rb
+++ b/spec/validators/course_publishable_schools_presence_validator_spec.rb
@@ -20,9 +20,62 @@ describe CoursePublishableSchoolsPresenceValidator do
 
   it "adds a :blank error on :sites when SchoolPresence reports no schools" do
     allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(false)
+    allow(Courses::PublishRules::SchoolPresenceExemption).to receive(:applies?).with(course).and_return(false)
 
     run_validator
 
     expect(course.errors.details[:sites]).to include(error: :blank)
+  end
+
+  it "does not add an error when no schools are attached but the exemption applies" do
+    allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(false)
+    allow(Courses::PublishRules::SchoolPresenceExemption).to receive(:applies?).with(course).and_return(true)
+
+    run_validator
+
+    expect(course.errors[:sites]).to be_empty
+  end
+
+  # Integration of the validator with the real SchoolPresence and
+  # SchoolPresenceExemption rules and real Course::School records, covering the
+  # ticket's publish matrix under the new school model.
+  describe "validation matrix (new school model)" do
+    let(:provider) { create(:provider) }
+    let(:course) { create(:course, funding, provider:, publish_without_schools_allowed: exemption) }
+
+    def attach_school
+      create(:course_school, course:, gias_school: create(:gias_school))
+    end
+
+    before { allow(FeatureFlag).to receive(:active?).with(:course_publishing_uses_new_school_model).and_return(true) }
+
+    {
+      [:salary,         true,  true]  => :no_error,
+      [:salary,         true,  false] => :no_error,
+      [:salary,         false, true]  => :no_error,
+      [:salary,         false, false] => :blank,
+      [:apprenticeship, false, true]  => :no_error,
+      [:apprenticeship, false, false] => :blank,
+      [:fee,            false, true]  => :blank,
+      [:fee,            true,  true]  => :no_error,
+      [:fee,            false, false] => :blank,
+    }.each do |(funding, has_school, exemption), expected|
+      context "#{funding}, #{has_school ? 'with' : 'without'} schools, exemption #{exemption ? 'on' : 'off'}" do
+        let(:funding) { funding }
+        let(:exemption) { exemption }
+
+        it "expects #{expected == :no_error ? 'no :sites error' : "a :sites #{expected} error"}" do
+          attach_school if has_school
+          course.errors.clear
+          described_class.new.validate(course)
+
+          if expected == :no_error
+            expect(course.errors[:sites]).to be_empty
+          else
+            expect(course.errors.details[:sites]).to include(error: expected)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/validators/course_publishable_schools_rollover_validator_spec.rb
+++ b/spec/validators/course_publishable_schools_rollover_validator_spec.rb
@@ -50,11 +50,30 @@ describe CoursePublishableSchoolsRolloverValidator do
     expect(course.errors.details[:sites]).to include(error: :check_schools)
   end
 
-  it "adds an :enter_schools error when no school is attached" do
+  it "adds an :enter_schools error when no school is attached and the exemption does not apply" do
     allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(false)
+    allow(Courses::PublishRules::SchoolPresenceExemption).to receive(:applies?).with(course).and_return(false)
 
     run_validator
 
     expect(course.errors.details[:sites]).to include(error: :enter_schools)
+  end
+
+  it "does not add an :enter_schools error when no school is attached but the exemption applies" do
+    allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(false)
+    allow(Courses::PublishRules::SchoolPresenceExemption).to receive(:applies?).with(course).and_return(true)
+
+    run_validator
+
+    expect(course.errors[:sites]).to be_empty
+  end
+
+  it "still adds a :check_schools error when schools are attached, regardless of the exemption" do
+    allow(Courses::PublishRules::SchoolPresence).to receive(:any?).with(course).and_return(true)
+    allow(Courses::PublishRules::SchoolPresenceExemption).to receive(:applies?).with(course).and_return(true)
+
+    run_validator
+
+    expect(course.errors.details[:sites]).to include(error: :check_schools)
   end
 end


### PR DESCRIPTION
## What

Wires the `publish_without_schools_allowed` flag into publish validation so support-approved **salaried** and **apprenticeship** courses can publish without any schools attached. The exemption bypasses *only* the missing-schools check — every other publish validation still runs.

The exemption applies when all hold: the new `course_school` model is in use (`course_publishing_uses_new_school_model` flag), the course is salaried or apprenticeship, and `publish_without_schools_allowed` is true. It never applies to fee-paying courses or legacy sites data.

## How it decides

```mermaid
flowchart TD
    A[Publish validation: schools present?] -->|Yes| P[Pass — schools attached]
    A -->|No| B{Exemption applies?}
    B -->|"flag on<br/>AND salary? or apprenticeship?<br/>AND publish_without_schools_allowed?"| P2[Pass — exempt]
    B -->|otherwise| F[Block — :sites blank / :enter_schools]

    subgraph Exemption[SchoolPresenceExemption.applies?]
      C1[course_publishing_uses_new_school_model active] --> C2[salary? or apprenticeship?]
      C2 --> C3[publish_without_schools_allowed?]
    end
```

## Changes

- New `Courses::PublishRules::SchoolPresenceExemption` — single source of truth for the exemption decision, sibling to `SchoolPresence`
- `CoursePublishableSchoolsPresenceValidator` — skip `:sites, :blank` when exempt
- `CoursePublishableSchoolsRolloverValidator` — skip the no-schools `:enter_schools` branch when exempt (the `:check_schools` re-confirmation path is untouched)

## Validation matrix

| Funding | Has course_schools? | Exemption | Can publish? |
|---|---|---|---|
| Salaried / Apprenticeship | Yes | any | Yes |
| Salaried / Apprenticeship | No | No | No |
| Salaried / Apprenticeship | No | Yes | Yes |
| Fee | Yes | any | Yes (exemption irrelevant) |
| Fee | No | any | No (exemption ignored) |

## Tests

- New rule spec across flag/funding combinations
- Presence + rollover validator specs extended for the exemption
- Full matrix driven through the real validator + rules with the flag active

## Notes

- Gated on the new-model feature flag (consistent with `SchoolPresence`); legacy sites never qualify
- Builds on the prior data-layer change that added the `publish_without_schools_allowed` column
