### PR TITLE
Add school experience wizard to Publish salaried/apprenticeship courses

### DIFF
--- a/app/controllers/publish/courses/school_experience/experience_details_controller.rb
+++ b/app/controllers/publish/courses/school_experience/experience_details_controller.rb
@@ -1,0 +1,8 @@
+module Publish
+  module Courses
+    module SchoolExperience
+      class ExperienceDetailsController < SchoolExperienceController
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/school_experience/experience_required_controller.rb
+++ b/app/controllers/publish/courses/school_experience/experience_required_controller.rb
@@ -1,0 +1,38 @@
+module Publish
+  module Courses
+    module SchoolExperience
+      class ExperienceRequiredController < SchoolExperienceController
+        def state_store
+          if submitted_answer
+            # A "yes" answer can't be persisted to the course until the content
+            # arrives on the experience_details step, so it's held in the cache.
+            SchoolExperienceWizard::StateStores::SchoolExperienceWizardStore.new(
+              repository: SchoolExperienceWizard::Repositories::SchoolExperienceCacheRepository.new(
+                provider_code: params[:provider_code],
+                recruitment_cycle_year: params[:recruitment_cycle_year],
+                course_code: params[:course_code],
+              ),
+            )
+          elsif submitted_answer == false || action_name == "new"
+            # A "no" answer is written to the course; the new action reads the
+            # current value from it to pre-select the answer.
+            SchoolExperienceWizard::StateStores::SchoolExperienceWizardStore.new(
+              repository: SchoolExperienceWizard::Repositories::SchoolExperienceRepository.new(
+                record: @course,
+              ),
+            )
+          else
+            # School experience is optional. With no answer there's nothing to
+            # save, so we don't load a repository and let the wizard route back
+            # to the course.
+            SchoolExperienceWizard::StateStores::SchoolExperienceWizardStore.new
+          end
+        end
+
+        def submitted_answer
+          ActiveModel::Type::Boolean.new.cast(params.dig(:experience_required, :experience_required))
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/school_experience/school_experience_controller.rb
+++ b/app/controllers/publish/courses/school_experience/school_experience_controller.rb
@@ -1,0 +1,64 @@
+module Publish
+  module Courses
+    module SchoolExperience
+      class SchoolExperienceController < ApplicationController
+        before_action :assign_course
+        before_action :assign_wizard
+
+        helper_method def current_step
+          @wizard.current_step
+        end
+
+        helper_method def current_step_name
+          controller_name.to_sym
+        end
+
+        def new
+          @wizard.current_step_valid? if params[:display_errors].present?
+        end
+
+        def create
+          if @wizard.save_current_step
+            add_flash_message if @wizard.next_step == :course_edit
+            redirect_to @wizard.next_step_path
+          else
+            render :new
+          end
+        end
+
+        def assign_wizard
+          @wizard = SchoolExperienceWizard.new(
+            current_step: current_step_name,
+            current_step_params: step_params,
+            state_store:,
+          ).tap do |wizard|
+            wizard.recruitment_cycle_year = params[:recruitment_cycle_year]
+            wizard.provider_code = params[:provider_code]
+            wizard.course_code = params[:course_code]
+          end
+        end
+
+        def state_store
+          SchoolExperienceWizard::StateStores::SchoolExperienceWizardStore.new(
+            repository: SchoolExperienceWizard::Repositories::SchoolExperienceRepository.new(
+              record: @course,
+            ),
+          )
+        end
+
+        def step_params
+          params
+        end
+
+        def add_flash_message
+          flash[:success] = t(".flash_success")
+        end
+
+        def assign_course
+          @course ||= provider.courses.find_by!(course_code: params[:course_code])
+          @course_decorator ||= CourseDecorator.new(@course) # rubocop:disable Naming/MemoizedInstanceVariableName
+        end
+      end
+    end
+  end
+end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -434,6 +434,10 @@ class CourseDecorator < ApplicationDecorator
     !teacher_degree_apprenticeship?
   end
 
+  def show_school_experience?
+    recruitment_cycle_after_2026?
+  end
+
   def visa_sponsorship_deadline_required
     visa_sponsorship_application_deadline_at.respond_to?(:to_fs) ? "Yes" : "No"
   end

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -11,7 +11,6 @@ class FeatureFlags
       [:course_sites_updated_email_notification, "Send email notifications when a course's associated schools are updated", "Find and Publish team"],
       [:wizard_add_course_flow, "Enables the wizard add course flow that uses the DfE wizard", "Find and Publish team"],
       [:course_publishing_uses_new_school_model, "Read publish-side school checks from Course::School instead of Site", "Find and Publish team"],
-      [:school_experience, "Enables schools experience requirement feature on courses in Publish", "Find and Publish team"],
     ]
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -447,6 +447,15 @@ class Course < ApplicationRecord
                     .courses.find_by(course_code:)
   end
 
+  # The same course (same provider and course code) in the previous
+  # recruitment cycle, or nil if it does not exist.
+  def in_previous_cycle
+    Course.kept
+          .with_recruitment_cycle((recruitment_cycle_year.to_i - 1).to_s)
+          .merge(Provider.kept)
+          .find_by(course_code:, provider: { provider_code: })
+  end
+
   def generate_name
     Courses::GenerateCourseNameService.call(course: self)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -128,7 +128,7 @@ class Course < ApplicationRecord
   has_many :gias_schools, through: :schools
 
   delegate :recruitment_cycle, :provider_name, :provider_code, to: :provider, allow_nil: true
-  delegate :after_2021?, :year, :rollover_period_2026?, to: :recruitment_cycle, allow_nil: true, prefix: :recruitment_cycle
+  delegate :after_2021?, :after_2026?, :year, :rollover_period_2026?, to: :recruitment_cycle, allow_nil: true, prefix: :recruitment_cycle
 
   def set_subject_position(course_subject)
     return if course_subject.position.present?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -400,6 +400,7 @@ class Course < ApplicationRecord
   validates :age_range_in_years, presence: true, on: %i[new create publish], unless: :further_education_course?
   validates :level, presence: true, on: %i[new create publish]
   validates :is_send, inclusion: { in: [true, false] }, on: %i[new create publish]
+  validates :school_experience_required_content, absence: true, unless: :school_experience_required
   # TODO: validates :master_subject_id ?
 
   def is_engineers_teach_physics?

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -143,4 +143,8 @@ class RecruitmentCycle < ApplicationRecord
   def after_2025?
     year.to_i > 2025
   end
+
+  def after_2026?
+    year.to_i > 2026
+  end
 end

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -27,7 +27,7 @@
   <% if course.fee_based? %>
     <%= render partial: "publish/courses/fees_and_financial_support", locals: { course: course, summary_list: summary_list } %>
   <% else %>
-      <% enrichment_summary(
+    <% enrichment_summary(
       summary_list,
       :course,
       t("publish.providers.courses.description_content.salary_details_label"),
@@ -43,6 +43,26 @@
 </h2>
 
 <%= govuk_summary_list do |summary_list| %>
+
+  <% if course.show_school_experience? %>
+    <% if course.salaried? %>
+      <% summary_list.with_row do |row|
+        row.with_key { t("publish.providers.courses.description_content.experience_required_key") }
+        if course.school_experience_required.nil?
+          row.with_value(classes: %w[govuk-summary-list__value]) { tag.span(t("value_not_entered"), class: "govuk-hint").html_safe }
+        elsif course.school_experience_required
+          row.with_value(classes: %w[govuk-summary-list__value]) {
+            tag.div(t("publish.providers.courses.description_content.experience_required"), class:"govuk-body")
+            .concat(markdown(course.school_experience_required_content))
+          }
+        else
+          row.with_value(classes: %w[govuk-summary-list__value]) { t("publish.providers.courses.description_content.experience_not_required") }
+        end
+        row.with_action(text: t("change"), href: publish_provider_recruitment_cycle_course_school_experience_required_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <% if course.show_degree_requirements_row? %>
     <% enrichment_summary(
       summary_list,

--- a/app/views/publish/courses/school_experience/experience_details/new.html.erb
+++ b/app/views/publish/courses/school_experience/experience_details/new.html.erb
@@ -6,7 +6,7 @@
 </h1>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(@wizard.previous_step_path) %>
+  <%= govuk_back_link_to(@wizard.resolve_step_path(:experience_required)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish/courses/school_experience/experience_details/new.html.erb
+++ b/app/views/publish/courses/school_experience/experience_details/new.html.erb
@@ -1,0 +1,39 @@
+<% content_for :page_title, title_with_error_prefix(t("publish.courses.#{current_step.model_name.i18n_key}.heading"), current_step.errors && current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+  <%= t("publish.courses.#{current_step.model_name.i18n_key}.page_title") %>
+</h1>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(@wizard.previous_step_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: current_step,
+                  scope: current_step_name,
+                  url: publish_provider_recruitment_cycle_course_school_experience_experience_details_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year,
+                    @course.course_code,
+                  ) do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= render partial: "publish/courses/markdown_formatting" %>
+
+      <%= form.govuk_text_area :experience_details,
+          label: { text: t("publish.courses.#{current_step.model_name.i18n_key}.subtitle"), size: "s" },
+          hint: { text: t("publish.courses.#{current_step.model_name.i18n_key}.hint_html") },
+          rows: 8,
+          max_words: 250,
+          value: "" %>
+
+      <%= form.submit t("publish.courses.#{current_step.model_name.i18n_key}.submit"), class: "govuk-button" %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), @wizard.resolve_step_path(:course_edit)) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/courses/school_experience/experience_required/new.html.erb
+++ b/app/views/publish/courses/school_experience/experience_required/new.html.erb
@@ -1,0 +1,36 @@
+<% content_for :page_title, title_with_error_prefix(t("publish.courses.#{current_step.model_name.i18n_key}.heading"), current_step.errors && current_step.errors.any?) %>
+
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+  <%= t("publish.courses.#{current_step.model_name.i18n_key}.page_title") %>
+</h1>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(@wizard.resolve_step_path(:course_edit)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: current_step,
+                  scope: current_step_name,
+                  url: publish_provider_recruitment_cycle_course_school_experience_experience_required_path(
+                    @provider.provider_code,
+                    @provider.recruitment_cycle_year,
+                    @course.course_code,
+                  ) do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_radio_buttons_fieldset :experience_required, legend: { size: "m", text: t("publish.courses.#{current_step.model_name.i18n_key}.subtitle") } do %>
+
+        <%= form.govuk_radio_button :experience_required, true, label: { text: t("publish.courses.#{current_step.model_name.i18n_key}.yes_label") }, link_errors: true %>
+        <%= form.govuk_radio_button :experience_required, false, label: { text: t("publish.courses.#{current_step.model_name.i18n_key}.no_label") } %>
+      <% end %>
+
+      <%= form.submit t("publish.courses.#{current_step.model_name.i18n_key}.submit"), class: "govuk-button" %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to(t("cancel"), @wizard.resolve_step_path(:course_edit)) %>
+    </p>
+  </div>
+</div>

--- a/app/wizards/school_experience_wizard.rb
+++ b/app/wizards/school_experience_wizard.rb
@@ -7,6 +7,9 @@ class SchoolExperienceWizard
 
   def steps_processor
     DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
+      graph.root(:experience_required)
+
+      graph.add_node :experience_required, Steps::ExperienceRequired
     end
   end
 

--- a/app/wizards/school_experience_wizard.rb
+++ b/app/wizards/school_experience_wizard.rb
@@ -5,11 +5,23 @@ class SchoolExperienceWizard
 
   attr_accessor :recruitment_cycle_year, :provider_code, :course_code
 
+  delegate :experience_is_required?, to: :state_store
+
   def steps_processor
     DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
       graph.root(:experience_required)
 
+      graph.add_conditional_edge(
+        from: :experience_required,
+        when: :experience_is_required?,
+        then: :experience_details,
+        else: :course_edit,
+        label: "Experience is required?",
+      )
+      graph.add_edge from: :experience_details, to: :course_edit
+
       graph.add_node :experience_required, Steps::ExperienceRequired
+      graph.add_node :experience_details, Steps::ExperienceDetails
     end
   end
 

--- a/app/wizards/school_experience_wizard.rb
+++ b/app/wizards/school_experience_wizard.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class SchoolExperienceWizard
+  include DfE::Wizard
+
+  attr_accessor :recruitment_cycle_year, :provider_code, :course_code
+
+  def steps_processor
+    DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
+    end
+  end
+
+  def route_strategy
+    DfE::Wizard::RouteStrategy::ConfigurableRoutes.new(
+      wizard: self,
+      namespace: "publish-provider-recruitment-cycle-course-school-experience",
+    ) do |config|
+      config.default_path_arguments = {
+        recruitment_cycle_year: config.wizard.recruitment_cycle_year,
+        provider_code: config.wizard.provider_code,
+        course_code: config.wizard.course_code,
+      }
+
+      config.map_step :course_edit, to: lambda { |_wizard, options, helpers|
+        options[:code] = options.delete(:course_code)
+        helpers.publish_provider_recruitment_cycle_course_path(**options)
+      }
+    end
+  end
+end

--- a/app/wizards/school_experience_wizard/repositories/school_experience_cache_repository.rb
+++ b/app/wizards/school_experience_wizard/repositories/school_experience_cache_repository.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class SchoolExperienceWizard
+  module Repositories
+    class SchoolExperienceCacheRepository < DfE::Wizard::Repository::Cache
+      CACHE_EXPIRY = 24.hours
+
+      def initialize(provider_code:, recruitment_cycle_year:, course_code:, expires_in: CACHE_EXPIRY, cache: Rails.cache)
+        super(
+          cache:,
+          key: self.class.cache_key(provider_code:, recruitment_cycle_year:, course_code:),
+          expires_in:,
+        )
+      end
+
+      def self.cache_key(provider_code:, recruitment_cycle_year:, course_code:)
+        "school_experience_wizard_#{provider_code}_#{recruitment_cycle_year}_#{course_code}"
+      end
+    end
+  end
+end

--- a/app/wizards/school_experience_wizard/repositories/school_experience_repository.rb
+++ b/app/wizards/school_experience_wizard/repositories/school_experience_repository.rb
@@ -4,10 +4,15 @@ class SchoolExperienceWizard
   module Repositories
     class SchoolExperienceRepository < DfE::Wizard::Repository::Model
       def transform_for_read(step_data)
+        step_data[:experience_required] = step_data[:school_experience_required]
         step_data.deep_symbolize_keys
       end
 
       def transform_for_write(model_data)
+        # This runs when experience_require is "no" on the required step
+        unless model_data[:experience_required].nil?
+          model_data[:school_experience_required] = model_data[:experience_required]
+        end
         model_data
       end
     end

--- a/app/wizards/school_experience_wizard/repositories/school_experience_repository.rb
+++ b/app/wizards/school_experience_wizard/repositories/school_experience_repository.rb
@@ -5,14 +5,27 @@ class SchoolExperienceWizard
     class SchoolExperienceRepository < DfE::Wizard::Repository::Model
       def transform_for_read(step_data)
         step_data[:experience_required] = step_data[:school_experience_required]
+
+        step_data[:experience_details] = step_data[:school_experience_required_content]
+
         step_data.deep_symbolize_keys
       end
 
       def transform_for_write(model_data)
-        # This runs when experience_require is "no" on the required step
-        unless model_data[:experience_required].nil?
-          model_data[:school_experience_required] = model_data[:experience_required]
+        # A "no" answer on the required step (false) is written straight to the
+        # course and clears any content.
+        if model_data[:experience_required] == false
+          model_data[:school_experience_required] = false
+          model_data[:school_experience_required_content] = nil
         end
+
+        # Content arriving on the experience_details step records the "yes"
+        # answer (held in the cache until now) and stores the content.
+        if model_data[:experience_details].present?
+          model_data[:school_experience_required] = true
+          model_data[:school_experience_required_content] = model_data[:experience_details]
+        end
+
         model_data
       end
     end

--- a/app/wizards/school_experience_wizard/repositories/school_experience_repository.rb
+++ b/app/wizards/school_experience_wizard/repositories/school_experience_repository.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SchoolExperienceWizard
+  module Repositories
+    class SchoolExperienceRepository < DfE::Wizard::Repository::Model
+      def transform_for_read(step_data)
+        step_data.deep_symbolize_keys
+      end
+
+      def transform_for_write(model_data)
+        model_data
+      end
+    end
+  end
+end

--- a/app/wizards/school_experience_wizard/state_stores/school_experience_wizard_store.rb
+++ b/app/wizards/school_experience_wizard/state_stores/school_experience_wizard_store.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SchoolExperienceWizard
+  module StateStores
+    class SchoolExperienceWizardStore
+      include DfE::Wizard::StateStore
+
+      def experience_is_required?
+        ActiveModel::Type::Boolean.new.cast(experience_required)
+      end
+    end
+  end
+end

--- a/app/wizards/school_experience_wizard/steps/experience_details.rb
+++ b/app/wizards/school_experience_wizard/steps/experience_details.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SchoolExperienceWizard
+  module Steps
+    class ExperienceDetails
+      include DfE::Wizard::Step
+
+      attribute :experience_details, :string
+
+      validates :experience_details, presence: true, words_count: { maximum: 250 }
+
+      def self.permitted_params
+        %i[experience_details]
+      end
+    end
+  end
+end

--- a/app/wizards/school_experience_wizard/steps/experience_required.rb
+++ b/app/wizards/school_experience_wizard/steps/experience_required.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SchoolExperienceWizard
+  module Steps
+    class ExperienceRequired
+      include DfE::Wizard::Step
+
+      attribute :experience_required, :boolean
+
+      def self.permitted_params
+        %i[experience_required]
+      end
+    end
+  end
+end

--- a/config/locales/en/publish/courses/school_experience.yml
+++ b/config/locales/en/publish/courses/school_experience.yml
@@ -1,0 +1,10 @@
+en:
+  publish:
+    courses:
+      school_experience:
+        experience_required:
+          create:
+            flash_success: School experience updated
+        experience_details:
+          create:
+            flash_success: School experience updated

--- a/config/locales/en/publish/courses/school_experience_wizard.yml
+++ b/config/locales/en/publish/courses/school_experience_wizard.yml
@@ -1,0 +1,17 @@
+en:
+  activemodel:
+    errors:
+      models:
+        school_experience_wizard/steps/experience_required:
+          attributes:
+            experience_required:
+              blank: Pick an option
+  publish:
+    courses:
+      school_experience_wizard/steps/experience_required:
+        page_title: School experience (optional)
+        heading: School experience (optional)
+        subtitle: Is school experience required or strongly recommended for this course? (optional)
+        yes_label: Yes, school experience is required or strongly recommended
+        no_label: No, school experience is not required
+        submit: Continue to add school experience details

--- a/config/locales/en/publish/courses/school_experience_wizard.yml
+++ b/config/locales/en/publish/courses/school_experience_wizard.yml
@@ -6,6 +6,10 @@ en:
           attributes:
             experience_required:
               blank: Pick an option
+        school_experience_wizard/steps/experience_details:
+          attributes:
+            experience_details:
+              blank: Enter the school experience you are looking for
   publish:
     courses:
       school_experience_wizard/steps/experience_required:
@@ -15,3 +19,19 @@ en:
         yes_label: Yes, school experience is required or strongly recommended
         no_label: No, school experience is not required
         submit: Continue to add school experience details
+      school_experience_wizard/steps/experience_details:
+        page_title: School experience
+        heading: School experience
+        label: School experience
+        subtitle: What school experience are you looking for?
+        hint_html: |
+          Candidates have said they would like to know:
+          <ul>
+          <li>Is school experience required or just recommended?</li>
+          <li>How much time should they have spent in a school?</li>
+          <li>What types of activities should they have experience in? For example, observing lessons, teaching classes, behaviour management</li>
+          <li>Must it have been paid work or could it be voluntary?</li>
+          <li>Do they need to have had experience in the particular subject they're applying for?</li>
+          <li>Must their experience have been in a UK school?</li>
+          </ul>
+        submit: Update school experience

--- a/config/locales/en/publish/providers/courses/description_content.yml
+++ b/config/locales/en/publish/providers/courses/description_content.yml
@@ -15,6 +15,9 @@ en:
           course_length_label: Course length
           course_requirements_heading: Requirements and eligibility
           degree_label: Degree
+          experience_required_key: School experience (optional)
+          experience_required: Yes, school experience is required or strongly recommended
+          experience_not_required: No, school experience is not required
           enter_a_levels: Enter A levels and equivalency test requirements
           fee_details_label: Fees and financial support
           fee_for_international_citizens_label: Fee for international citizens

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -245,6 +245,9 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
         get "/school-experience/experience-required", to: "courses/school_experience/experience_required#new", as: :school_experience_required
         post "/school-experience/experience-required", to: "courses/school_experience/experience_required#create"
 
+        get "/school-experience/experience-details", to: "courses/school_experience/experience_details#new", as: :school_experience_details
+        post "/school-experience/experience-details", to: "courses/school_experience/experience_details#create"
+
         get "/degrees/start", on: :member, to: "courses/degrees/start#edit"
         put "/degrees/start", on: :member, to: "courses/degrees/start#update"
 

--- a/config/routes/publish.rb
+++ b/config/routes/publish.rb
@@ -242,6 +242,9 @@ namespace :publish, as: :publish, defaults: { host: URI.parse(Settings.publish_u
         get "/full-part-time", on: :member, to: "courses/study_mode#edit"
         put "/full-part-time", on: :member, to: "courses/study_mode#update"
 
+        get "/school-experience/experience-required", to: "courses/school_experience/experience_required#new", as: :school_experience_required
+        post "/school-experience/experience-required", to: "courses/school_experience/experience_required#create"
+
         get "/degrees/start", on: :member, to: "courses/degrees/start#edit"
         put "/degrees/start", on: :member, to: "courses/degrees/start#update"
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -627,6 +627,27 @@ describe CourseDecorator do
     end
   end
 
+  describe "#show_school_experience?" do
+    let(:cycle_year) { 2027 }
+    let(:provider) { build_stubbed(:provider, recruitment_cycle: build_stubbed(:recruitment_cycle, year: cycle_year)) }
+
+    context "and the course is in the 2027 cycle or later" do
+      let(:cycle_year) { 2027 }
+
+      it "returns true" do
+        expect(decorated_course.show_school_experience?).to be true
+      end
+    end
+
+    context "and the course is in a cycle before 2027" do
+      let(:cycle_year) { 2026 }
+
+      it "returns false" do
+        expect(decorated_course.show_school_experience?).to be false
+      end
+    end
+  end
+
   describe "#a_level_change_path" do
     subject(:a_level_change_path) { course.decorate.a_level_change_path }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -51,6 +51,38 @@ describe Course do
     end
   end
 
+  describe "school experience content validation" do
+    it "is valid with content when school experience is required" do
+      course.school_experience_required = true
+      course.school_experience_required_content = "Spend two weeks in a UK school."
+
+      expect(course).to be_valid
+    end
+
+    it "is valid with no content when school experience is required" do
+      course.school_experience_required = true
+      course.school_experience_required_content = nil
+
+      expect(course).to be_valid
+    end
+
+    it "is invalid with content when school experience is not required" do
+      course.school_experience_required = false
+      course.school_experience_required_content = "Spend two weeks in a UK school."
+
+      expect(course).not_to be_valid
+      expect(course.errors).to be_added(:school_experience_required_content, :present)
+    end
+
+    it "is invalid with content when school experience requirement is unanswered" do
+      course.school_experience_required = nil
+      course.school_experience_required_content = "Spend two weeks in a UK school."
+
+      expect(course).not_to be_valid
+      expect(course.errors).to be_added(:school_experience_required_content, :present)
+    end
+  end
+
   describe "auditing" do
     it { is_expected.to be_audited }
     it { is_expected.to have_associated_audits }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -83,6 +83,32 @@ describe Course do
     end
   end
 
+  describe "#in_previous_cycle" do
+    let(:previous_cycle) { create(:recruitment_cycle, year: "2026") }
+    let(:current_cycle) { create(:recruitment_cycle, year: "2027") }
+    let(:previous_provider) { create(:provider, provider_code: "A1", recruitment_cycle: previous_cycle) }
+    let(:current_provider) { create(:provider, provider_code: "A1", recruitment_cycle: current_cycle) }
+    let(:course) { create(:course, course_code: "B123", provider: current_provider) }
+
+    it "returns the same course in the previous cycle" do
+      previous_course = create(:course, course_code: "B123", provider: previous_provider)
+
+      expect(course.in_previous_cycle).to eq(previous_course)
+    end
+
+    it "returns nil when there is no matching course in the previous cycle" do
+      create(:course, course_code: "B123", provider: create(:provider, provider_code: "Z9", recruitment_cycle: previous_cycle))
+
+      expect(course.in_previous_cycle).to be_nil
+    end
+
+    it "returns nil when the previous-cycle course is discarded" do
+      create(:course, course_code: "B123", provider: previous_provider).discard!
+
+      expect(course.in_previous_cycle).to be_nil
+    end
+  end
+
   describe "auditing" do
     it { is_expected.to be_audited }
     it { is_expected.to have_associated_audits }

--- a/spec/support/shared_contexts/school_experience_wizard.rb
+++ b/spec/support/shared_contexts/school_experience_wizard.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "school_experience_wizard" do
+  subject(:wizard) do
+    SchoolExperienceWizard.new(
+      state_store:,
+      current_step:,
+      current_step_params: { current_step => current_step_params },
+    ).tap do |school_experience_wizard|
+      school_experience_wizard.recruitment_cycle_year = course.recruitment_cycle_year
+      school_experience_wizard.provider_code = course.provider.provider_code
+      school_experience_wizard.course_code = course.course_code
+    end
+  end
+
+  let(:school_experience_required) { nil }
+  let(:school_experience_required_content) { nil }
+  let(:course) do
+    create(
+      :course,
+      school_experience_required:,
+      school_experience_required_content:,
+    )
+  end
+  let(:repository) { SchoolExperienceWizard::Repositories::SchoolExperienceRepository.new(record: course) }
+  let(:state_store) { SchoolExperienceWizard::StateStores::SchoolExperienceWizardStore.new(repository:) }
+  let(:current_step) { :experience_required }
+  let(:current_step_params) { {} }
+end

--- a/spec/system/publish/courses/school_experience/editing_school_experience_spec.rb
+++ b/spec/system/publish/courses/school_experience/editing_school_experience_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe "Editing school experience requirements", travel: mid_cycle, type
 private
 
   def given_i_am_authenticated_as_a_provider_user
-    @user = create(:user, providers: [build(:provider)])
+    # School experience is only shown for courses in the 2027 cycle or later.
+    @user = create(:user, providers: [build(:provider, recruitment_cycle: create(:recruitment_cycle, :next))])
     @provider = @user.providers.first
     given_i_am_authenticated(user: @user)
   end

--- a/spec/system/publish/courses/school_experience/editing_school_experience_spec.rb
+++ b/spec/system/publish/courses/school_experience/editing_school_experience_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Editing school experience requirements", travel: mid_cycle, type: :system do
+  scenario "provider says school experience is required and adds details" do
+    given_i_am_authenticated_as_a_provider_user
+    and_i_have_a_salaried_course
+
+    when_i_visit_the_course_description_tab
+    then_i_see_the_school_experience_row
+
+    when_i_click_to_change_school_experience
+    then_i_am_on_the_experience_required_page
+
+    when_i_choose_that_experience_is_required
+    and_i_click_continue
+    then_i_am_on_the_experience_details_page
+
+    when_i_enter_the_experience_details
+    and_i_click_update
+    then_i_am_back_on_the_course_description_tab
+    and_i_see_the_success_message
+    and_i_see_the_school_experience_requirements
+  end
+
+  scenario "provider says school experience is not required" do
+    given_i_am_authenticated_as_a_provider_user
+    and_i_have_a_salaried_course
+
+    when_i_visit_the_course_description_tab
+    when_i_click_to_change_school_experience
+    then_i_am_on_the_experience_required_page
+
+    when_i_choose_that_experience_is_not_required
+    and_i_click_continue
+    then_i_am_back_on_the_course_description_tab
+    and_i_see_the_success_message
+    and_i_see_that_experience_is_not_required
+  end
+
+  scenario "provider chooses yes then cancels on the details step without leaving orphaned data" do
+    given_i_am_authenticated_as_a_provider_user
+    and_i_have_a_salaried_course
+
+    when_i_visit_the_course_description_tab
+    when_i_click_to_change_school_experience
+    then_i_am_on_the_experience_required_page
+
+    when_i_choose_that_experience_is_required
+    and_i_click_continue
+    then_i_am_on_the_experience_details_page
+
+    when_i_cancel
+    then_i_am_back_on_the_course_description_tab
+    and_the_course_has_no_school_experience_recorded
+  end
+
+  scenario "provider submits the experience required step without choosing an option" do
+    given_i_am_authenticated_as_a_provider_user
+    and_i_have_a_salaried_course
+
+    when_i_visit_the_course_description_tab
+    when_i_click_to_change_school_experience
+    then_i_am_on_the_experience_required_page
+
+    and_i_click_continue
+    then_i_am_back_on_the_course_description_tab
+    and_the_course_has_no_school_experience_recorded
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user
+    @user = create(:user, providers: [build(:provider)])
+    @provider = @user.providers.first
+    given_i_am_authenticated(user: @user)
+  end
+
+  def and_i_have_a_salaried_course
+    @course = create(:course, :with_salary, provider: @provider)
+  end
+
+  def when_i_visit_the_course_description_tab
+    visit publish_provider_recruitment_cycle_course_path(
+      @provider.provider_code,
+      @provider.recruitment_cycle_year,
+      @course.course_code,
+    )
+  end
+
+  def then_i_see_the_school_experience_row
+    expect(page).to have_content("School experience (optional)")
+  end
+
+  def when_i_click_to_change_school_experience
+    click_link "Change", href: experience_required_path
+  end
+
+  def then_i_am_on_the_experience_required_page
+    expect(page).to have_current_path(experience_required_path, ignore_query: true)
+    expect(page).to have_content("Is school experience required or strongly recommended for this course?")
+  end
+
+  def when_i_choose_that_experience_is_required
+    choose "Yes, school experience is required or strongly recommended"
+  end
+
+  def when_i_choose_that_experience_is_not_required
+    choose "No, school experience is not required"
+  end
+
+  def and_i_click_continue
+    click_on "Continue to add school experience details"
+  end
+
+  def then_i_am_on_the_experience_details_page
+    expect(page).to have_current_path(experience_details_path, ignore_query: true)
+    expect(page).to have_content("What school experience are you looking for?")
+  end
+
+  def when_i_enter_the_experience_details
+    fill_in "What school experience are you looking for?", with: "Spend two weeks in a UK school."
+  end
+
+  def and_i_click_update
+    click_on "Update school experience"
+  end
+
+  def then_i_am_back_on_the_course_description_tab
+    expect(page).to have_current_path(
+      publish_provider_recruitment_cycle_course_path(
+        @provider.provider_code,
+        @provider.recruitment_cycle_year,
+        @course.course_code,
+      ),
+      ignore_query: true,
+    )
+  end
+
+  def and_i_see_the_success_message
+    expect(page).to have_content("School experience updated")
+  end
+
+  def and_i_see_the_school_experience_requirements
+    expect(@course.reload.school_experience_required).to be(true)
+    expect(@course.school_experience_required_content).to eq("Spend two weeks in a UK school.")
+    expect(page).to have_content("Spend two weeks in a UK school.")
+  end
+
+  def and_i_see_that_experience_is_not_required
+    expect(@course.reload.school_experience_required).to be(false)
+    expect(page).to have_content("No, school experience is not required")
+  end
+
+  def when_i_cancel
+    click_on "Cancel"
+  end
+
+  def and_the_course_has_no_school_experience_recorded
+    expect(@course.reload.school_experience_required).to be_nil
+    expect(@course.school_experience_required_content).to be_nil
+  end
+
+  def experience_required_path
+    publish_provider_recruitment_cycle_course_school_experience_required_path(
+      @provider.provider_code,
+      @provider.recruitment_cycle_year,
+      @course.course_code,
+    )
+  end
+
+  def experience_details_path
+    publish_provider_recruitment_cycle_course_school_experience_details_path(
+      @provider.provider_code,
+      @provider.recruitment_cycle_year,
+      @course.course_code,
+    )
+  end
+end

--- a/spec/wizards/school_experience_wizard/repositories/school_experience_cache_repository_spec.rb
+++ b/spec/wizards/school_experience_wizard/repositories/school_experience_cache_repository_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolExperienceWizard::Repositories::SchoolExperienceCacheRepository do
+  subject(:repository) do
+    described_class.new(
+      provider_code: "ABC",
+      recruitment_cycle_year: 2025,
+      course_code: "X123",
+      expires_in: 24.hours,
+      cache:,
+    )
+  end
+
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+  describe ".cache_key" do
+    it "namespaces the key by provider, cycle and course" do
+      expect(described_class.cache_key(provider_code: "ABC", recruitment_cycle_year: 2025, course_code: "X123"))
+        .to eq("school_experience_wizard_ABC_2025_X123")
+    end
+  end
+
+  describe "reading and writing" do
+    it "stores the wizard answers without touching any course record" do
+      repository.write(experience_required: true)
+
+      expect(repository.read[:experience_required]).to be(true)
+    end
+
+    it "writes under the namespaced cache key" do
+      repository.write(experience_required: true)
+
+      cached = cache.read("school_experience_wizard_ABC_2025_X123")
+      expect(cached["experience_required"]).to be(true)
+    end
+
+    it "expires the entry after the configured duration" do
+      repository.write(experience_required: true)
+
+      Timecop.travel(25.hours) do
+        expect(repository.read).to eq({})
+      end
+    end
+  end
+end

--- a/spec/wizards/school_experience_wizard/repositories/school_experience_repository_spec.rb
+++ b/spec/wizards/school_experience_wizard/repositories/school_experience_repository_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolExperienceWizard::Repositories::SchoolExperienceRepository do
+  subject(:repository) { described_class.new(record: course) }
+
+  let(:course) { create(:course) }
+
+  describe "#transform_for_read" do
+    it "exposes school_experience_required as the boolean experience_required" do
+      expect(repository.transform_for_read({ school_experience_required: true })[:experience_required]).to be(true)
+      expect(repository.transform_for_read({ school_experience_required: false })[:experience_required]).to be(false)
+    end
+
+    it "leaves experience_required nil when school_experience_required is nil" do
+      result = repository.transform_for_read({ school_experience_required: nil })
+      expect(result[:experience_required]).to be_nil
+    end
+
+    it "exposes school_experience_required_content as experience_details" do
+      result = repository.transform_for_read({ school_experience_required_content: "Spend time in a school" })
+      expect(result[:experience_details]).to eq("Spend time in a school")
+    end
+  end
+
+  describe "#transform_for_write" do
+    # In the live flow only a "no" answer (false) reaches this repository from
+    # the experience_required step; a "yes" answer is held in the cache
+    # repository until the content arrives on the experience_details step.
+    context "when experience_required is answered on the experience_required step" do
+      it "writes false and clears the content for a 'no' answer" do
+        result = repository.transform_for_write({ experience_required: false })
+        expect(result[:school_experience_required]).to be(false)
+        expect(result[:school_experience_required_content]).to be_nil
+      end
+    end
+
+    context "when experience_details is sent on the experience_details step" do
+      it "stores the content and marks school_experience_required true" do
+        result = repository.transform_for_write({ experience_details: "Spend time in a school" })
+        expect(result[:school_experience_required_content]).to eq("Spend time in a school")
+        expect(result[:school_experience_required]).to be(true)
+      end
+    end
+
+    context "when nothing is answered" do
+      it "does not touch the school_experience columns" do
+        result = repository.transform_for_write({ experience_required: nil })
+        expect(result).not_to have_key(:school_experience_required)
+        expect(result).not_to have_key(:school_experience_required_content)
+      end
+    end
+  end
+
+  describe "round trip through the model" do
+    it "persists the content and marks experience required when details are saved" do
+      repository.write(experience_details: "Spend time in a school")
+
+      expect(course.reload.school_experience_required).to be(true)
+      expect(course.school_experience_required_content).to eq("Spend time in a school")
+
+      data = repository.read
+      expect(data[:experience_required]).to be(true)
+      expect(data[:experience_details]).to eq("Spend time in a school")
+    end
+
+    it "persists 'experience not required' answers and clears any content" do
+      course.update!(school_experience_required: true, school_experience_required_content: "stale content")
+
+      repository.write(experience_required: false)
+
+      expect(course.reload.school_experience_required).to be(false)
+      expect(course.school_experience_required_content).to be_nil
+    end
+  end
+end

--- a/spec/wizards/school_experience_wizard/state_stores/school_experience_wizard_store_spec.rb
+++ b/spec/wizards/school_experience_wizard/state_stores/school_experience_wizard_store_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolExperienceWizard::StateStores::SchoolExperienceWizardStore do
+  subject(:store) { described_class.new(repository:, attribute_names: %w[experience_required]) }
+
+  let(:repository) { instance_double(SchoolExperienceWizard::Repositories::SchoolExperienceRepository) }
+
+  describe "#experience_is_required?" do
+    before do
+      allow(repository).to receive(:read).and_return({ experience_required: })
+    end
+
+    context "when experience_required is true" do
+      let(:experience_required) { true }
+
+      it "returns true" do
+        expect(store.experience_is_required?).to be true
+      end
+    end
+
+    context "when experience_required is false" do
+      let(:experience_required) { false }
+
+      it "returns false" do
+        expect(store.experience_is_required?).to be false
+      end
+    end
+
+    context "when experience_required is nil" do
+      let(:experience_required) { nil }
+
+      it "returns nil" do
+        expect(store.experience_is_required?).to be_nil
+      end
+    end
+  end
+end

--- a/spec/wizards/school_experience_wizard/steps/experience_details_spec.rb
+++ b/spec/wizards/school_experience_wizard/steps/experience_details_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolExperienceWizard::Steps::ExperienceDetails do
+  subject(:wizard_step) { described_class.new }
+
+  describe "#valid?" do
+    context "when experience_details is present and within the word limit" do
+      it "is valid" do
+        wizard_step.experience_details = "Applicants should have spent time in a school."
+        expect(wizard_step).to be_valid
+      end
+    end
+
+    context "when experience_details is not present" do
+      it "is not valid" do
+        wizard_step.experience_details = nil
+        expect(wizard_step).not_to be_valid
+        expect(wizard_step.errors.added?(:experience_details, :blank)).to be true
+      end
+    end
+
+    context "when experience_details exceeds 250 words" do
+      it "is not valid" do
+        wizard_step.experience_details = (%w[word] * 251).join(" ")
+        expect(wizard_step).not_to be_valid
+        expect(wizard_step.errors[:experience_details]).to be_present
+      end
+    end
+
+    context "when experience_details is exactly 250 words" do
+      it "is valid" do
+        wizard_step.experience_details = (%w[word] * 250).join(" ")
+        expect(wizard_step).to be_valid
+      end
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq(%i[experience_details])
+    end
+  end
+end

--- a/spec/wizards/school_experience_wizard/steps/experience_required_spec.rb
+++ b/spec/wizards/school_experience_wizard/steps/experience_required_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolExperienceWizard::Steps::ExperienceRequired do
+  subject(:wizard_step) { described_class.new }
+
+  describe "#valid?" do
+    # School experience is optional, so the step does not validate the answer.
+    # An empty submit is allowed and simply returns the user to the course.
+    it "is valid whether or not an answer is given" do
+      wizard_step.experience_required = true
+      expect(wizard_step).to be_valid
+
+      wizard_step.experience_required = false
+      expect(wizard_step).to be_valid
+
+      wizard_step.experience_required = nil
+      expect(wizard_step).to be_valid
+    end
+  end
+
+  describe "boolean casting" do
+    it "casts the submitted radio string values to booleans" do
+      wizard_step.experience_required = "true"
+      expect(wizard_step.experience_required).to be(true)
+
+      wizard_step.experience_required = "false"
+      expect(wizard_step.experience_required).to be(false)
+    end
+  end
+
+  describe ".permitted_params" do
+    it "returns the correct permitted params" do
+      expect(described_class.permitted_params).to eq(%i[experience_required])
+    end
+  end
+end

--- a/spec/wizards/school_experience_wizard/wizard/next_step_spec.rb
+++ b/spec/wizards/school_experience_wizard/wizard/next_step_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "SchoolExperienceWizard#next_step", type: :wizard do
+  include_context "school_experience_wizard"
+
+  context "from experience_required" do
+    let(:current_step) { :experience_required }
+
+    context "when experience is required" do
+      let(:school_experience_required) { true }
+
+      it "branches to experience_details" do
+        expect(wizard).to branch_from(:experience_required).to(:experience_details)
+      end
+    end
+
+    context "when experience is not required" do
+      let(:school_experience_required) { false }
+
+      it "branches to course_edit" do
+        expect(wizard).to branch_from(:experience_required).to(:course_edit)
+      end
+    end
+
+    context "when no answer is given" do
+      let(:school_experience_required) { nil }
+
+      it "branches to course_edit" do
+        expect(wizard).to branch_from(:experience_required).to(:course_edit)
+      end
+    end
+  end
+
+  context "from experience_details" do
+    let(:current_step) { :experience_details }
+    let(:school_experience_required) { true }
+
+    it "proceeds to course_edit" do
+      expect(wizard).to have_next_step(:course_edit)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Add a SchoolExperience DfE Wizard to the course management side in Publish.

This is a slightly non-standard multistep form.  Two steps, first to determine if the course should communicate to the candidate that this course requires or highly recommends school experience. If the course does require experience then the provider must add content to explain the details of this experience.

On the first step, if the user answers "yes", we cannot store this value in the database becuase if they click cancel before completing the second step the database is left in an inconsistent state.

We use a cached backed respository to save "yes" and commit the whole form at the end. If the user answers "no" then we just need to store the "no" in the database directly.

We show the value on the course description page too.

These changes will be followed by the implementation in Find in another PR.

## Changes proposed in this pull request

- Add a DfE Wizard with two repositories
  - one model backed repository for when a step needs to be stored in the database
  - one cached backed repository for when a step needs to be stored temporarily
- This feature is only available in production only if the course in question is in the 2027 cycle or later. This allows us to demonstrate the feature in QA and review apps for now.

## Guidance to review

I did not implement the missing details component on the course edit page because none of the other properties are using it and we should implement them all together

I have not added a "find preview" to the form page. The place this content is displayed is not standard in the way that the preview component currently renders. It is a details component in a two column div so we need feedback as to whether this is the correct content to show in the preview.

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
