### PR TITLE
Downcase visa sponsorship filter in email alert title

### DIFF
--- a/app/components/find/courses/search_title_component.rb
+++ b/app/components/find/courses/search_title_component.rb
@@ -71,7 +71,7 @@ module Find
       end
 
       def visa_title
-        I18n.t("find.courses.search_title.visa_sponsorship")
+        I18n.t("find.courses.search_title.visa_sponsorship").downcase
       end
 
       def apprenticeship_title

--- a/app/components/find/courses/search_title_component.rb
+++ b/app/components/find/courses/search_title_component.rb
@@ -25,10 +25,13 @@ module Find
 
         named = @subjects.count.between?(1, 2)
 
-        if location?
-          key = named ? "subjects_with_location" : "no_subjects_with_location"
-          I18n.t("find.courses.search_title.#{key}",
+        if location? && named
+          I18n.t("find.courses.search_title.subjects_with_location",
                  subject: @subjects.to_sentence, radius: @radius, location: @location_name)
+        elsif location? && !named
+          I18n.t("find.courses.search_title.no_subjects_with_location",
+                 subject: @subjects.to_sentence, radius: @radius, location: @location_name).upcase_first
+
         elsif named
           I18n.t("find.courses.search_title.subjects_no_location", subject: @subjects.to_sentence)
         else

--- a/app/components/find/courses/search_title_component.rb
+++ b/app/components/find/courses/search_title_component.rb
@@ -95,13 +95,29 @@ module Find
         end
       end
 
-      # These keys represent a specific provider search, not user-selected filters,
-      # so they are excluded from the active filter count displayed in the title.
-      DISPLAY_EXCLUDED_KEYS = %w[provider_code provider_name].freeze
+      # Search attributes that represent candidate-selected filters. Only these
+      # contribute to the active filter count shown in the fallback title. Any
+      # other key — e.g. return_to, the provider_code/provider_name keys of a
+      # provider search, or the location/subject keys handled elsewhere in the
+      # title — is ignored automatically by not appearing in this whitelist.
+      FILTER_KEYS = %w[
+        applications_open
+        can_sponsor_visa
+        engineers_teach_physics
+        funding
+        interview_location
+        level
+        minimum_degree_required
+        order
+        qualifications
+        send_courses
+        start_date
+        study_types
+      ].freeze
 
       def active_filter_count
         defaults = Find::SearchParamDefaults.new(@attrs)
-        @attrs.count { |k, v| v.present? && DISPLAY_EXCLUDED_KEYS.exclude?(k) && defaults.non_default?(k, v) }
+        @attrs.slice(*FILTER_KEYS).count { |k, v| v.present? && defaults.non_default?(k, v) }
       end
     end
   end

--- a/app/components/find/courses/search_title_component.rb
+++ b/app/components/find/courses/search_title_component.rb
@@ -2,6 +2,10 @@
 
 module Find
   module Courses
+    # Builds the search title shown for a set of search criteria.
+    #
+    # All the translations are downcase. When they're at the start of a
+    # sentence in the app we upcase the first char
     class SearchTitleComponent < ViewComponent::Base
       def initialize(subjects:, location_name:, radius:, search_attributes:)
         super()
@@ -14,6 +18,10 @@ module Find
 
       def call
         content_tag(:span, title_text)
+      end
+
+      def heading
+        title_text.upcase_first
       end
 
       def title_text
@@ -31,8 +39,7 @@ module Find
                  subject: @subjects.to_sentence, radius: @radius, location: @location_name)
         elsif location? && !named
           I18n.t("find.courses.search_title.no_subjects_with_location",
-                 subject: @subjects.to_sentence, radius: @radius, location: @location_name).upcase_first
-
+                 subject: @subjects.to_sentence, radius: @radius, location: @location_name)
         elsif named
           I18n.t("find.courses.search_title.subjects_no_location", subject: @subjects.to_sentence)
         else
@@ -75,7 +82,7 @@ module Find
       end
 
       def visa_title
-        I18n.t("find.courses.search_title.visa_sponsorship").downcase
+        I18n.t("find.courses.search_title.visa_sponsorship")
       end
 
       def apprenticeship_title

--- a/app/components/find/courses/search_title_component.rb
+++ b/app/components/find/courses/search_title_component.rb
@@ -24,6 +24,7 @@ module Find
         return fallback_title if @subjects.empty? && no_location?
 
         named = @subjects.count.between?(1, 2)
+        @subjects = @subjects.map { |subject| SubjectHelper.subject_name_in_sentence(subject) }
 
         if location? && named
           I18n.t("find.courses.search_title.subjects_with_location",

--- a/app/components/find/email_alerts/summary_card_component.rb
+++ b/app/components/find/email_alerts/summary_card_component.rb
@@ -19,7 +19,7 @@ module Find
           location_name: @email_alert.location_name,
           radius: @email_alert.radius,
           search_attributes: @attrs,
-        ).title_text
+        ).heading
       end
 
       def filter_rows

--- a/app/components/find/recent_searches/summary_card_component.rb
+++ b/app/components/find/recent_searches/summary_card_component.rb
@@ -12,12 +12,12 @@ module Find
       end
 
       def title
-        render(Find::Courses::SearchTitleComponent.new(
-                 subjects: resolved_subject_names,
-                 location_name: location_display_name,
-                 radius: @recent_search.radius,
-                 search_attributes: @attrs,
-               ))
+        Find::Courses::SearchTitleComponent.new(
+          subjects: resolved_subject_names,
+          location_name: location_display_name,
+          radius: @recent_search.radius,
+          search_attributes: @attrs,
+        ).heading
       end
 
       def filter_tags

--- a/config/locales/en/find/courses.yml
+++ b/config/locales/en/find/courses.yml
@@ -116,11 +116,14 @@ en:
         not_consider_pending_a_level: We will not consider candidates with pending A levels.
         consider_a_level_equivalency: We’ll consider candidates who need to take A level equivalency tests.
         not_consider_a_level_equivalency: We will not consider candidates who need to take A level equivalency tests.
+      # These titles are lower-cased sentence fragments: they read naturally when
+      # interpolated mid-sentence (e.g. "Get email alerts for ..."). Standalone
+      # headings capitalise the first letter via SearchTitleComponent#heading.
       search_title:
-        visa_sponsorship: Courses with visa sponsorship
-        apprenticeship: Apprenticeship courses in England
-        salary: Salaried courses in England
-        further_education: Further education courses across England
+        visa_sponsorship: courses with visa sponsorship
+        apprenticeship: apprenticeship courses in England
+        salary: salaried courses in England
+        further_education: further education courses across England
         subjects_no_location: "%{subject} courses in England"
         many_subjects_no_location: "%{count} subjects in England"
         subjects_with_location: "%{subject} courses within %{radius} miles of %{location}"

--- a/spec/components/find/courses/search_title_component_spec.rb
+++ b/spec/components/find/courses/search_title_component_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:subjects) { %w[Primary] }
     let(:search_attributes) { { "level" => "further_education" } }
 
-    it { expect(rendered.text).to eq("Primary and Further education courses in England") }
+    it { expect(rendered.text).to eq("primary and further education courses in England") }
   end
 
   context "with 1 filter in fallback" do

--- a/spec/components/find/courses/search_title_component_spec.rb
+++ b/spec/components/find/courses/search_title_component_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:location_name) { "Manchester" }
     let(:radius) { 10 }
 
-    it { expect(rendered.text).to eq("courses within 10 miles of Manchester") }
+    # The first letter is upcased so it reads correctly as an email alert card title,
+    # while leaving the location name intact.
+    it { expect(rendered.text).to eq("Courses within 10 miles of Manchester") }
   end
 
   context "with 1 subject and a location" do
@@ -58,7 +60,8 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:location_name) { "Manchester" }
     let(:radius) { 15 }
 
-    it { expect(rendered.text).to eq("courses within 15 miles of Manchester") }
+    # 3+ subjects falls back to the no-subjects-with-location title, which is upcased.
+    it { expect(rendered.text).to eq("Courses within 15 miles of Manchester") }
   end
 
   context "with a provider name only" do
@@ -82,7 +85,7 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
   context "with no subject/location but visa sponsorship" do
     let(:search_attributes) { { "can_sponsor_visa" => "true" } }
 
-    it { expect(rendered.text).to eq("Courses with visa sponsorship") }
+    it { expect(rendered.text).to eq("courses with visa sponsorship") }
   end
 
   context "with no subject/location/visa but apprenticeship funding" do
@@ -135,6 +138,22 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
 
     it "excludes provider_code from filter count and uses singular filter" do
       expect(rendered.text).to eq("courses across England (1 filter applied)")
+    end
+  end
+
+  context "with a non-filter param alongside a filter" do
+    let(:search_attributes) { { "return_to" => "/results", "send_courses" => "true" } }
+
+    it "counts only whitelisted filter keys" do
+      expect(rendered.text).to eq("courses across England (1 filter applied)")
+    end
+  end
+
+  context "with a non-filter param as the only non-default key" do
+    let(:search_attributes) { { "return_to" => "/results" } }
+
+    it "ignores keys that are not in the filter whitelist" do
+      expect(rendered.text).to eq("courses across England")
     end
   end
 

--- a/spec/components/find/courses/search_title_component_spec.rb
+++ b/spec/components/find/courses/search_title_component_spec.rb
@@ -12,16 +12,59 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
   let(:radius) { nil }
   let(:search_attributes) { {} }
 
+  describe "#heading" do
+    subject(:component) { described_class.new(subjects:, location_name:, radius:, search_attributes:) }
+
+    let(:subjects) { %w[Mathematics] }
+
+    it "capitalises the first letter of the lower-cased title" do
+      expect(component.heading).to eq("Mathematics courses in England")
+    end
+
+    it "leaves title_text as a lower-cased sentence fragment" do
+      expect(component.title_text).to eq("mathematics courses in England")
+    end
+  end
+
+  # The component produces a lower-cased, sentence-fragment title so it reads
+  # naturally when interpolated mid-sentence (e.g. "Get email alerts for ...").
+  # The standalone card components capitalise the first letter themselves.
   context "with 1 subject and no location" do
     let(:subjects) { %w[Mathematics] }
 
-    it { expect(rendered.text).to eq("Mathematics courses in England") }
+    it "downcases the non-proper-noun subject" do
+      expect(rendered.text).to eq("mathematics courses in England")
+    end
   end
 
   context "with 2 subjects and no location" do
     let(:subjects) { %w[Mathematics Physics] }
 
-    it { expect(rendered.text).to eq("Mathematics and Physics courses in England") }
+    it { expect(rendered.text).to eq("mathematics and physics courses in England") }
+  end
+
+  context "with a language subject that is a proper noun" do
+    let(:subjects) { %w[French] }
+
+    it "preserves the capitalisation of the proper noun" do
+      expect(rendered.text).to eq("French courses in England")
+    end
+  end
+
+  context "with a mix of proper-noun and non-proper-noun subjects" do
+    let(:subjects) { %w[French Mathematics] }
+
+    it "downcases only the non-proper-noun subject" do
+      expect(rendered.text).to eq("French and mathematics courses in England")
+    end
+  end
+
+  context "with a composite subject embedding a language proper noun" do
+    let(:subjects) { ["Primary with English", "Russian"] }
+
+    it "downcases the subject word by word, preserving embedded proper nouns" do
+      expect(rendered.text).to eq("primary with English and Russian courses in England")
+    end
   end
 
   context "with 3+ subjects and no location" do
@@ -34,9 +77,7 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:location_name) { "Manchester" }
     let(:radius) { 10 }
 
-    # The first letter is upcased so it reads correctly as an email alert card title,
-    # while leaving the location name intact.
-    it { expect(rendered.text).to eq("Courses within 10 miles of Manchester") }
+    it { expect(rendered.text).to eq("courses within 10 miles of Manchester") }
   end
 
   context "with 1 subject and a location" do
@@ -44,7 +85,7 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:location_name) { "Manchester" }
     let(:radius) { 15 }
 
-    it { expect(rendered.text).to eq("Mathematics courses within 15 miles of Manchester") }
+    it { expect(rendered.text).to eq("mathematics courses within 15 miles of Manchester") }
   end
 
   context "with 2 subjects and a location" do
@@ -52,7 +93,7 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:location_name) { "Manchester" }
     let(:radius) { 15 }
 
-    it { expect(rendered.text).to eq("Mathematics and Physics courses within 15 miles of Manchester") }
+    it { expect(rendered.text).to eq("mathematics and physics courses within 15 miles of Manchester") }
   end
 
   context "with 3+ subjects and a location" do
@@ -60,8 +101,8 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
     let(:location_name) { "Manchester" }
     let(:radius) { 15 }
 
-    # 3+ subjects falls back to the no-subjects-with-location title, which is upcased.
-    it { expect(rendered.text).to eq("Courses within 15 miles of Manchester") }
+    # 3+ subjects falls back to the no-subjects-with-location title.
+    it { expect(rendered.text).to eq("courses within 15 miles of Manchester") }
   end
 
   context "with a provider name only" do
@@ -91,19 +132,19 @@ RSpec.describe Find::Courses::SearchTitleComponent, type: :component do
   context "with no subject/location/visa but apprenticeship funding" do
     let(:search_attributes) { { "funding" => %w[apprenticeship] } }
 
-    it { expect(rendered.text).to eq("Apprenticeship courses in England") }
+    it { expect(rendered.text).to eq("apprenticeship courses in England") }
   end
 
   context "with no subject/location/visa but salary funding" do
     let(:search_attributes) { { "funding" => %w[salary] } }
 
-    it { expect(rendered.text).to eq("Salaried courses in England") }
+    it { expect(rendered.text).to eq("salaried courses in England") }
   end
 
   context "with no subject/location/visa but further education level" do
     let(:search_attributes) { { "level" => "further_education" } }
 
-    it { expect(rendered.text).to eq("Further education courses across England") }
+    it { expect(rendered.text).to eq("further education courses across England") }
   end
 
   context "with primary subjects and further education level" do

--- a/spec/components/find/email_alerts/summary_card_component_spec.rb
+++ b/spec/components/find/email_alerts/summary_card_component_spec.rb
@@ -68,6 +68,24 @@ RSpec.describe Find::EmailAlerts::SummaryCardComponent, type: :component do
     end
   end
 
+  describe "card title capitalisation" do
+    let(:email_alert) do
+      create(
+        :email_alert,
+        candidate:,
+        subjects: [],
+        location_name: nil,
+        radius: nil,
+      )
+    end
+
+    it "capitalises the first letter of the lower-cased shared title" do
+      rendered = render_inline(described_class.new(email_alert:, subject_names: %w[Mathematics]))
+
+      expect(rendered.text).to include("Mathematics courses in England")
+    end
+  end
+
   describe "further_education level" do
     let(:email_alert) do
       create(

--- a/spec/components/find/recent_searches/summary_card_component_spec.rb
+++ b/spec/components/find/recent_searches/summary_card_component_spec.rb
@@ -18,6 +18,15 @@ module Find
 
         expect(page).to have_link("Search again", href: /utm_source=recent_searches/)
       end
+
+      it "capitalises the first letter of the lower-cased shared title" do
+        recent_search = create(:recent_search, subjects: %w[C1])
+        component = described_class.new(recent_search:, subject_names_by_code: { "C1" => "Mathematics" })
+
+        render_inline(component)
+
+        expect(page).to have_text("Mathematics courses in England")
+      end
     end
   end
 end

--- a/spec/controllers/find/candidates/email_alerts_controller_spec.rb
+++ b/spec/controllers/find/candidates/email_alerts_controller_spec.rb
@@ -123,7 +123,7 @@ module Find
             get :new, params: { subjects: %w[C1], level: "further_education" }
 
             expect(response.body).to include("Biology")
-            expect(response.body).to include("Further education")
+            expect(response.body).to include("further education")
           end
         end
       end

--- a/spec/system/find/candidates/recent_searches_spec.rb
+++ b/spec/system/find/candidates/recent_searches_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe "Recent searches", service: :find do
   end
 
   def then_i_see_the_provider_search_title
-    expect(page).to have_content("courses across England")
+    expect(page).to have_content("Courses across England")
   end
 
   def then_i_see_the_provider_filter_tag


### PR DESCRIPTION
## Context

Some issues with email alerts feature from the bug party

## Changes proposed in this pull request

#### Capitalise email alert summary card title when the search has no subjects but uses location

<img width="722" height="280" alt="image" src="https://github.com/user-attachments/assets/5817b485-ce63-44d8-b42e-e16f41873ce9" />


#### Filter out irrelevant params when counting how many filters are being used in the search

<img width="763" height="439" alt="image" src="https://github.com/user-attachments/assets/104f0a2c-29d6-4fb3-91b7-812b030d869c" />


#### Downcase visa sponsorship filter in email alert title

<img width="811" height="449" alt="image" src="https://github.com/user-attachments/assets/0807137b-0b4a-441f-a2e2-789102ec869f" />


#### Lowercase non-proper noun subjects in create alert success notice 

<img width="1065" height="337" alt="image" src="https://github.com/user-attachments/assets/20f7d8eb-39de-484f-95ef-753e47418342" />


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Checklist

- [ ] I have moved hard-coded strings to locale files.
- [ ] I have removed the usage of `data-qa` attributes in HTML files and updated the corresponding tests.
