### PR TITLE
Add to support UI - publish without schools checkbox

### DIFF
--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -46,7 +46,8 @@ module Support
                                    :is_send,
                                    :can_sponsor_student_visa,
                                    :can_sponsor_skilled_worker_visa,
-                                   :accredited_provider_code],
+                                   :accredited_provider_code,
+                                   :publish_without_schools_allowed],
       ).transform_keys { |key| date_field_to_attribute(key) }
     end
 

--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -9,7 +9,7 @@ module Support
       course_code name
     ].freeze
 
-    attr_accessor(*FIELDS, :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_day, :applications_open_from_month, :applications_open_from_year, :is_send, :can_sponsor_student_visa, :can_sponsor_skilled_worker_visa, :accredited_provider_code)
+    attr_accessor(*FIELDS, :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_day, :applications_open_from_month, :applications_open_from_year, :is_send, :can_sponsor_student_visa, :can_sponsor_skilled_worker_visa, :accredited_provider_code, :publish_without_schools_allowed)
 
     validate :validate_start_date_format
     validate :validate_applications_open_from_format
@@ -29,7 +29,8 @@ module Support
         is_send: @course.is_send,
         can_sponsor_student_visa: @course.can_sponsor_student_visa,
         can_sponsor_skilled_worker_visa: @course.can_sponsor_skilled_worker_visa,
-        accredited_provider_code: @course.accredited_provider_code
+        accredited_provider_code: @course.accredited_provider_code,
+        publish_without_schools_allowed: @course.publish_without_schools_allowed
       )
     end
 
@@ -87,6 +88,7 @@ module Support
         can_sponsor_student_visa:,
         can_sponsor_skilled_worker_visa:,
         accredited_provider_code:,
+        publish_without_schools_allowed: publish_without_schools_allowed?,
       }
 
       course.assign_attributes(attributes)
@@ -98,6 +100,13 @@ module Support
 
     def send?
       ActiveModel::Type::Boolean.new.cast(is_send)
+    end
+
+    # Only salaried and apprenticeship courses can be exempted from needing
+    # schools attached at publish time, so refuse to set the flag on any other
+    # funding type even if a value is submitted.
+    def publish_without_schools_allowed?
+      course.decorate.salaried? && ActiveModel::Type::Boolean.new.cast(publish_without_schools_allowed)
     end
 
     def validate_start_date_format

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -52,6 +52,15 @@
 
       <% end %>
 
+      <% if @course.decorate.salaried? %>
+        <%= f.govuk_check_boxes_fieldset :publish_without_schools_allowed,
+              legend: { text: "Publishing this course without schools" },
+              hint: { text: "Only tick this box if you have confirmed that this provider is allowed to publish courses without schools attached." },
+              multiple: false do %>
+          <% f.govuk_check_box :publish_without_schools_allowed, "true", "false", label: { text: "Allow this course to be published without schools attached" }, multiple: false %>
+        <% end %>
+      <% end %>
+
       <%= f.govuk_submit t("support.update_record") %>
     <% end %>
 

--- a/spec/requests/support/courses_spec.rb
+++ b/spec/requests/support/courses_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Support::Courses publish_without_schools_allowed", travel: mid_cycle do
+  include DfESignInUserHelper
+
+  let(:provider) { create(:provider) }
+  let(:year) { provider.recruitment_cycle_year }
+
+  before { host! URI(Settings.base_url).host }
+
+  def update_course(course)
+    patch "/support/#{year}/providers/#{provider.id}/courses/#{course.id}",
+          params: { support_edit_course_form: { publish_without_schools_allowed: "true" } }
+  end
+
+  context "as a support (admin) user" do
+    let(:admin) { create(:user, :admin) }
+
+    it "allows a salaried course to be published without schools" do
+      course = create(:course, :with_salary, provider:)
+      login_user(admin)
+
+      update_course(course)
+
+      expect(course.reload.publish_without_schools_allowed).to be(true)
+    end
+
+    it "allows an apprenticeship course to be published without schools" do
+      course = create(:course, :apprenticeship, provider:)
+      login_user(admin)
+
+      update_course(course)
+
+      expect(course.reload.publish_without_schools_allowed).to be(true)
+    end
+
+    it "ignores the flag for a fee course" do
+      course = create(:course, funding: "fee", provider:)
+      login_user(admin)
+
+      update_course(course)
+
+      expect(course.reload.publish_without_schools_allowed).to be(false)
+    end
+  end
+
+  context "as a provider (non-admin) user" do
+    let(:user) { create(:user, providers: [provider]) }
+
+    it "cannot update the flag through forged params" do
+      course = create(:course, :with_salary, provider:)
+      login_user(user)
+
+      update_course(course)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(course.reload.publish_without_schools_allowed).to be(false)
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider/course_edit.rb
+++ b/spec/support/page_objects/support/provider/course_edit.rb
@@ -14,6 +14,7 @@ module PageObjects
         element :application_open_from_month, "#support_edit_course_form_applications_open_from_2i"
         element :application_open_from_year, "#support_edit_course_form_applications_open_from_1i"
         element :send_specialism_checkbox, "#support-edit-course-form-is-send-true-field"
+        element :publish_without_schools_allowed_checkbox, "#support-edit-course-form-publish-without-schools-allowed-true-field"
         element :error_summary, ".govuk-error-summary"
         element :continue, ".govuk-button", text: "Update"
       end

--- a/spec/system/support/providers/courses/editing_publish_without_schools_spec.rb
+++ b/spec/system/support/providers/courses/editing_publish_without_schools_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Editing publish without schools as support", travel: mid_cycle do
+  before do
+    given_i_am_authenticated_as_an_admin_user
+  end
+
+  context "with a salaried course" do
+    scenario "I can approve the course to publish without schools" do
+      when_i_visit_the_edit_page_for(salaried_course)
+      then_i_see_the_publish_without_schools_checkbox
+      when_i_tick_the_publish_without_schools_checkbox
+      and_i_click_the_update_button
+      then_the_course_is_allowed_to_publish_without_schools(salaried_course)
+      when_i_visit_the_edit_page_for(salaried_course)
+      then_the_publish_without_schools_checkbox_is_ticked
+    end
+  end
+
+  context "with an apprenticeship course" do
+    scenario "I see the publish without schools checkbox" do
+      when_i_visit_the_edit_page_for(apprenticeship_course)
+      then_i_see_the_publish_without_schools_checkbox
+    end
+  end
+
+  context "with a fee course" do
+    scenario "the publish without schools checkbox is not available" do
+      when_i_visit_the_edit_page_for(fee_course)
+      then_i_do_not_see_the_publish_without_schools_checkbox
+    end
+  end
+
+private
+
+  def given_i_am_authenticated_as_an_admin_user
+    Timecop.travel(1.second.from_now)
+    given_i_am_authenticated(user: create(:user, :admin))
+  end
+
+  def provider
+    @provider ||= create(:provider)
+  end
+
+  def salaried_course
+    @salaried_course ||= create(:course, :with_salary, provider:)
+  end
+
+  def apprenticeship_course
+    @apprenticeship_course ||= create(:course, :apprenticeship, provider:)
+  end
+
+  def fee_course
+    @fee_course ||= create(:course, funding: "fee", provider:)
+  end
+
+  def when_i_visit_the_edit_page_for(course)
+    support_provider_course_edit_page.load(
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      provider_id: provider.id,
+      course_id: course.id,
+    )
+  end
+
+  def then_i_see_the_publish_without_schools_checkbox
+    expect(support_provider_course_edit_page).to have_publish_without_schools_allowed_checkbox
+    expect(support_provider_course_edit_page).to have_text("Publishing this course without schools")
+    expect(support_provider_course_edit_page).to have_text("Only tick this box if you have confirmed that this provider is allowed to publish courses without schools attached.")
+    expect(support_provider_course_edit_page).to have_text("Allow this course to be published without schools attached")
+  end
+
+  def then_i_do_not_see_the_publish_without_schools_checkbox
+    expect(support_provider_course_edit_page).to have_no_publish_without_schools_allowed_checkbox
+    expect(support_provider_course_edit_page).to have_no_text("Publishing this course without schools")
+  end
+
+  def when_i_tick_the_publish_without_schools_checkbox
+    support_provider_course_edit_page.publish_without_schools_allowed_checkbox.check
+  end
+
+  def and_i_click_the_update_button
+    support_provider_course_edit_page.continue.click
+  end
+
+  def then_the_course_is_allowed_to_publish_without_schools(course)
+    expect(course.reload.publish_without_schools_allowed).to be(true)
+  end
+
+  def then_the_publish_without_schools_checkbox_is_ticked
+    expect(support_provider_course_edit_page.publish_without_schools_allowed_checkbox).to be_checked
+  end
+end


### PR DESCRIPTION
## Context

Some providers are permitted to publish courses before they have schools attached. This adds a support-only toggle so we can grant that exemption on a per-course basis, rather than blocking publication for these providers.

## Changes proposed in this pull request

- Add a `publish_without_schools_allowed` checkbox to the support "Edit course" page, shown only for salaried/apprenticeship courses.
- Permit the new field in `Support::CoursesController` and the `Support::EditCourseForm`.
- Guard the flag in the form so it can only ever be set on salaried courses, even if a value is submitted for an ineligible course.
- Carry the flag over during course rollover and register it with DfE Analytics (column/migration already on main).

## Guidance to review

- Edit a salaried/apprenticeship course in support, tick the box, and confirm the value persists.
- Confirm the checkbox is hidden for non-salaried courses and that the flag cannot be set on them.

